### PR TITLE
WT-9388 Pass thread worker session into set_tracking_cursor

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -91,7 +91,7 @@ run "python test_tag.py"
 # The s_mentions script requires bash.
 run "./s_mentions" "--warning-only"
 if command -v evergreen > /dev/null; then
-	run "evergreen validate ../test/evergreen.yml"
+	run "evergreen validate -p wiredtiger ../test/evergreen.yml"
 fi
 
 COMMANDS="

--- a/dist/s_all
+++ b/dist/s_all
@@ -91,7 +91,7 @@ run "python test_tag.py"
 # The s_mentions script requires bash.
 run "./s_mentions" "--warning-only"
 if command -v evergreen > /dev/null; then
-	run "evergreen validate -p wiredtiger ../test/evergreen.yml"
+	run "evergreen validate ../test/evergreen.yml"
 fi
 
 COMMANDS="

--- a/test/cppsuite/configs/cache_resize_default.txt
+++ b/test/cppsuite/configs/cache_resize_default.txt
@@ -37,5 +37,5 @@ operation_tracker=
     # Timestamp, transaction id,
     tracking_key_format=QQ,
     # Operation type, cache size
-    tracking_value_format=iS
+    tracking_value_format=iQ
 )

--- a/test/cppsuite/src/component/operation_tracker.cpp
+++ b/test/cppsuite/src/component/operation_tracker.cpp
@@ -216,7 +216,7 @@ operation_tracker::save_operation(WT_SESSION *session, const tracking_operation 
     return (ret);
 }
 
-/* Note that the transaction id is not used in the default implementation of the tracking table. */
+/* Note that session is not used in the default implementation of the tracking table. */
 void
 operation_tracker::set_tracking_cursor(WT_SESSION *session, const tracking_operation &operation,
   const uint64_t &collection_id, const std::string &key, const std::string &value,

--- a/test/cppsuite/src/component/operation_tracker.cpp
+++ b/test/cppsuite/src/component/operation_tracker.cpp
@@ -193,7 +193,7 @@ operation_tracker::save_schema_operation(
 }
 
 int
-operation_tracker::save_operation(const uint64_t txn_id, const tracking_operation &operation,
+operation_tracker::save_operation(WT_SESSION *session, const tracking_operation &operation,
   const uint64_t &collection_id, const std::string &key, const std::string &value,
   wt_timestamp_t ts, scoped_cursor &op_track_cursor)
 {
@@ -210,7 +210,7 @@ operation_tracker::save_operation(const uint64_t txn_id, const tracking_operatio
           "save_operation: invalid operation " + std::to_string(static_cast<int>(operation));
         testutil_die(EINVAL, error_message.c_str());
     } else {
-        set_tracking_cursor(txn_id, operation, collection_id, key, value, ts, op_track_cursor);
+        set_tracking_cursor(session, operation, collection_id, key, value, ts, op_track_cursor);
         ret = op_track_cursor->insert(op_track_cursor.get());
     }
     return (ret);
@@ -218,7 +218,7 @@ operation_tracker::save_operation(const uint64_t txn_id, const tracking_operatio
 
 /* Note that the transaction id is not used in the default implementation of the tracking table. */
 void
-operation_tracker::set_tracking_cursor(const uint64_t txn_id, const tracking_operation &operation,
+operation_tracker::set_tracking_cursor(WT_SESSION *session, const tracking_operation &operation,
   const uint64_t &collection_id, const std::string &key, const std::string &value,
   wt_timestamp_t ts, scoped_cursor &op_track_cursor)
 {

--- a/test/cppsuite/src/component/operation_tracker.h
+++ b/test/cppsuite/src/component/operation_tracker.h
@@ -75,11 +75,11 @@ class operation_tracker : public component {
     void save_schema_operation(
       const tracking_operation &operation, const uint64_t &collection_id, wt_timestamp_t ts);
 
-    virtual void set_tracking_cursor(const uint64_t txn_id, const tracking_operation &operation,
+    virtual void set_tracking_cursor(WT_SESSION *session, const tracking_operation &operation,
       const uint64_t &collection_id, const std::string &key, const std::string &value,
       wt_timestamp_t ts, scoped_cursor &op_track_cursor);
 
-    int save_operation(const uint64_t txn_id, const tracking_operation &operation,
+    int save_operation(WT_SESSION *session, const tracking_operation &operation,
       const uint64_t &collection_id, const std::string &key, const std::string &value,
       wt_timestamp_t ts, scoped_cursor &op_track_cursor);
 

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -120,9 +120,8 @@ thread_worker::update(
             testutil_die(ret, "unhandled error while trying to update a key");
     }
 
-    uint64_t txn_id = ((WT_SESSION_IMPL *)session.get())->txn->id;
     ret = op_tracker->save_operation(
-      txn_id, tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
+      session.get(), tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
 
     if (ret == 0)
         txn.add_op();
@@ -162,9 +161,8 @@ thread_worker::insert(
             testutil_die(ret, "unhandled error while trying to insert a key");
     }
 
-    uint64_t txn_id = ((WT_SESSION_IMPL *)session.get())->txn->id;
     ret = op_tracker->save_operation(
-      txn_id, tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
+      session.get(), tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
 
     if (ret == 0)
         txn.add_op();
@@ -200,9 +198,8 @@ thread_worker::remove(scoped_cursor &cursor, uint64_t collection_id, const std::
             testutil_die(ret, "unhandled error while trying to remove a key");
     }
 
-    uint64_t txn_id = ((WT_SESSION_IMPL *)session.get())->txn->id;
     ret = op_tracker->save_operation(
-      txn_id, tracking_operation::DELETE_KEY, collection_id, key, "", ts, op_track_cursor);
+      session.get(), tracking_operation::DELETE_KEY, collection_id, key, "", ts, op_track_cursor);
 
     if (ret == 0)
         txn.add_op();

--- a/test/cppsuite/tests/test_template.cpp
+++ b/test/cppsuite/tests/test_template.cpp
@@ -42,13 +42,13 @@ class operation_tracker_template : public operation_tracker {
     }
 
     void
-    set_tracking_cursor(const uint64_t txn_id, const tracking_operation &operation,
+    set_tracking_cursor(WT_SESSION *session, const tracking_operation &operation,
       const uint64_t &collection_id, const std::string &key, const std::string &value,
       wt_timestamp_t ts, scoped_cursor &op_track_cursor) override final
     {
         /* You can replace this call to define your own tracking table contents. */
         operation_tracker::set_tracking_cursor(
-          txn_id, operation, collection_id, key, value, ts, op_track_cursor);
+          session, operation, collection_id, key, value, ts, op_track_cursor);
     }
 };
 


### PR DESCRIPTION
`set_tracking_cursor` now takes session as an argument to allow greater flexibility in what can be saved to the tracking cursor without users needing to update the function interface.
Initially I also looked at reducing the number of arguments passed in, but these changes lead to issues in other areas of the code and so the arguments have been left as is.