### PR TITLE
WT-9493 Update 3rd party license paths to match source code

### DIFF
--- a/src/docs/license.dox
+++ b/src/docs/license.dox
@@ -39,9 +39,9 @@ of the WiredTiger library should comply with these copyrights.
 
 <table>
 @hrow{Distribution Files, Copyright Holder, License}
-@row{\c src/include/bitstring.i, University of California\, Berkeley, <a href="http://www.opensource.org/licenses/BSD-3-Clause">BSD-3-Clause License</a>}
+@row{\c src/include/bitstring_inline.h, University of California\, Berkeley, <a href="http://www.opensource.org/licenses/BSD-3-Clause">BSD-3-Clause License</a>}
 @row{\c src/include/queue.h, University of California\, Berkeley, <a href="http://www.opensource.org/licenses/BSD-3-Clause">BSD-3-Clause License</a>}
-@row{\c src/os_posix/os_getopt.c, University of California\, Berkeley, <a href="http://www.opensource.org/licenses/BSD-3-Clause">BSD-3-Clause License</a>}
+@row{\c src/os_common/os_getopt.c, University of California\, Berkeley, <a href="http://www.opensource.org/licenses/BSD-3-Clause">BSD-3-Clause License</a>}
 @row{\c src/support/hash_city.c, Google\, Inc., <a href="http://www.opensource.org/licenses/MIT">The MIT License</a>}
 @row{\c src/support/hash_fnv.c, Authors, Public Domain}
 </table>
@@ -55,7 +55,7 @@ copyrights.
 
 <table>
 @hrow{Distribution Files, Copyright Holder, License}
-@row{\c src/support/power8/*, Anton Blanchard\, IBM Corp., <a href="http://opensource.org/licenses/Apache-2.0">Apache License\, Version 2.0</a> or the <a href="http://www.gnu.org/licenses/gpl-2.0-standalone.html">GNU General Public License\, version 2 or later</a>}
+@row{\c src/checksum/power8/*, Anton Blanchard\, IBM Corp., <a href="http://opensource.org/licenses/Apache-2.0">Apache License\, Version 2.0</a> or the <a href="http://www.gnu.org/licenses/gpl-2.0-standalone.html">GNU General Public License\, version 2 or later</a>}
 </table>
 
 @section license_crc32-zseries 3rd party software optionally included in the WiredTiger library: s390x
@@ -66,7 +66,7 @@ of the WiredTiger library z13 builds should comply with these copyrights.
 
 <table>
 @hrow{Distribution Files, Copyright Holder, License}
-@row{\c src/support/zseries/*, IBM Corp., <a href="http://opensource.org/licenses/Apache-2.0">Apache License\, Version 2.0</a> or the <a href="http://www.gnu.org/licenses/gpl-2.0-standalone.html">GNU General Public License\, version 2 or later</a>}
+@row{\c src/checksum/zseries/*, IBM Corp., <a href="http://opensource.org/licenses/Apache-2.0">Apache License\, Version 2.0</a> or the <a href="http://www.gnu.org/licenses/gpl-2.0-standalone.html">GNU General Public License\, version 2 or later</a>}
 </table>
 
 @section license_distribution 3rd party software included in the WiredTiger distribution


### PR DESCRIPTION
Update locations of separately-licensed code in license.dox.