### PR TITLE
WT-9494 Remove references of NEWS file from dist scripts and changelog from documentation

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -21,16 +21,6 @@ export PYTHONDONTWRITEBYTECODE=1
 
 e=0
 
-changelog()
-{
-	# convert the top-level NEWS file into a change log page in the docs
-	(echo "WiredTiger Change Log"
-	 echo "====================="
-	 echo
-	 sed -e 's, \([0-9a-f]\{7\}\) , [\1](https://github.com/wiredtiger/wiredtiger/commit/\1) ,g' \
-	     -e 's,\(\(WT\|SERVER\)-[0-9]*\),[\1](https://jira.mongodb.org/browse/\1),g' ../NEWS) > ../src/docs/changelog.md
-}
-
 wtperf_config()
 {
 	# The Linux ed command writes line numbers to stderr, redirect both
@@ -243,9 +233,6 @@ while :
 		break;;
 	esac
 done
-
-# Generate the change log
-changelog
 
 # Generate the list of wtperf configuration options.
 wtperf_config

--- a/dist/s_release
+++ b/dist/s_release
@@ -39,7 +39,7 @@ echo "Packing release into $RELEASE_DIR/$PKG.tar.bz2"
 (cd "$RELEASE_DIR" && tar cf - $PKG | bzip2 -9 > $PKG.tar.bz2)
 
 echo "Packing documentation into $RELEASE_DIR/$PKG-docs.tar.bz2"
-(cd "$RELEASE_DIR" && tar cf - $PKG/LICENSE $PKG/NEWS $PKG/README $PKG/docs | \
+(cd "$RELEASE_DIR" && tar cf - $PKG/LICENSE $PKG/README $PKG/docs | \
     bzip2 -9 > $PKG-docs.tar.bz2)
 
 rm -r $DEST

--- a/dist/s_string
+++ b/dist/s_string
@@ -75,10 +75,4 @@ for f in $l; do
 	check "--mode=ccpp" $f
 done
 
-l="NEWS"
-# Check other files.
-for f in $l; do
-	check "" $f
-done
-
 exit 0

--- a/src/docs/introduction.dox
+++ b/src/docs/introduction.dox
@@ -38,9 +38,8 @@ For more information about administrating WiredTiger databases, see:
 - @subpage command_line
 - @subpage admin
 
-For release change logs and upgrading information, see:
+For release upgrading information, see:
 
-- @subpage md_changelog
 - @subpage upgrading
 
 WiredTiger is distributed under Open Source licenses; for more information, see:


### PR DESCRIPTION
In [WT-9310](https://jira.mongodb.org/browse/WT-9310) we decided to deprecate/remove the NEWS file. However, the references to the NEWS file in those dist scripts were not fully removed, including the changelog in the WiredTiger documentation. This PR is to get them cleaned up.