### PR TITLE
WT-9497 Wrong ifdef in the zlib compressor extension

### DIFF
--- a/ext/compressors/zlib/zlib_compress.c
+++ b/ext/compressors/zlib/zlib_compress.c
@@ -300,7 +300,7 @@ zlib_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *config)
  * We have to remove this symbol when building as a builtin extension otherwise it will conflict
  * with other builtin libraries.
  */
-#ifndef HAVE_BUILTIN_EXTENSION_SNAPPY
+#ifndef HAVE_BUILTIN_EXTENSION_ZLIB
 /*
  * wiredtiger_extension_init --
  *     WiredTiger zlib compression extension.


### PR DESCRIPTION
Use the right ifdef to build in the zlib compressor.