### PR TITLE
WT-9556 Clean up code used by the cppsuite example test

### DIFF
--- a/test/cppsuite/configs/test_template_default.txt
+++ b/test/cppsuite/configs/test_template_default.txt
@@ -1,4 +1,3 @@
-# Example configuration file, as default are added automatically only non default configurations
-# need to be defined.
+# Example configuration file, as default are added automatically only non default configurations need to be defined.
 duration_seconds=5,
 cache_size_mb=250

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -406,10 +406,10 @@ database_operation::update_operation(thread_worker *tc)
 }
 
 void
-database_operation::validate(const std::string &operation_table_name,
-  const std::string &schema_table_name, const std::vector<uint64_t> &known_collection_ids)
+database_operation::validate(
+  const std::string &operation_table_name, const std::string &schema_table_name, database &db)
 {
     validator wv;
-    wv.validate(operation_table_name, schema_table_name, known_collection_ids);
+    wv.validate(operation_table_name, schema_table_name, db);
 }
 } // namespace test_harness

--- a/test/cppsuite/src/main/database_operation.h
+++ b/test/cppsuite/src/main/database_operation.h
@@ -65,8 +65,8 @@ class database_operation {
     /* Basic update operation that chooses a random key and updates it. */
     virtual void update_operation(thread_worker *tc);
 
-    virtual void validate(const std::string &operation_table_name,
-      const std::string &schema_table_name, const std::vector<uint64_t> &known_collection_ids);
+    virtual void validate(
+      const std::string &operation_table_name, const std::string &schema_table_name, database &db);
 
     virtual ~database_operation() = default;
 };

--- a/test/cppsuite/src/main/test.cpp
+++ b/test/cppsuite/src/main/test.cpp
@@ -170,8 +170,7 @@ test::run()
     if (_operation_tracker->enabled()) {
         std::unique_ptr<configuration> tracking_config(_config->get_subconfig(OPERATION_TRACKER));
         this->validate(_operation_tracker->get_operation_table_name(),
-          _operation_tracker->get_schema_table_name(),
-          _workload_manager->get_database().get_collection_ids());
+          _operation_tracker->get_schema_table_name(), _workload_manager->get_database());
     }
 
     /* Log perf stats. */

--- a/test/cppsuite/src/main/transaction.cpp
+++ b/test/cppsuite/src/main/transaction.cpp
@@ -126,6 +126,12 @@ transaction::try_rollback(const std::string &config)
         rollback(config);
 }
 
+int64_t
+transaction::get_target_op_count()
+{
+    return _target_op_count;
+}
+
 /*
  * FIXME: WT-9198 We're concurrently doing a transaction that contains a bunch of operations while
  * moving the stable timestamp. Eat the occasional EINVAL from the transaction's first commit

--- a/test/cppsuite/src/main/transaction.cpp
+++ b/test/cppsuite/src/main/transaction.cpp
@@ -127,7 +127,7 @@ transaction::try_rollback(const std::string &config)
 }
 
 int64_t
-transaction::get_target_op_count()
+transaction::get_target_op_count() const
 {
     return _target_op_count;
 }

--- a/test/cppsuite/src/main/transaction.h
+++ b/test/cppsuite/src/main/transaction.h
@@ -72,7 +72,7 @@ class transaction {
      */
     bool can_rollback();
     /* Get the number of operations this transaction needs before it can commit */
-    int64_t get_target_op_count();
+    int64_t get_target_op_count() const;
 
     private:
     bool _in_txn = false;

--- a/test/cppsuite/src/main/transaction.h
+++ b/test/cppsuite/src/main/transaction.h
@@ -71,6 +71,8 @@ class transaction {
      * of the transaction.
      */
     bool can_rollback();
+    /* Get the number of operations this transaction needs before it can commit */
+    int64_t get_target_op_count();
 
     private:
     bool _in_txn = false;

--- a/test/cppsuite/src/main/validator.cpp
+++ b/test/cppsuite/src/main/validator.cpp
@@ -35,8 +35,8 @@
 
 namespace test_harness {
 void
-validator::validate(const std::string &operation_table_name, const std::string &schema_table_name,
-  const std::vector<uint64_t> &known_collection_ids)
+validator::validate(
+  const std::string &operation_table_name, const std::string &schema_table_name, database &db)
 {
     WT_DECL_RET;
     wt_timestamp_t tracked_timestamp;
@@ -50,6 +50,8 @@ validator::validate(const std::string &operation_table_name, const std::string &
 
     scoped_session session = connection_manager::instance().create_session();
     scoped_cursor cursor = session.open_scoped_cursor(operation_table_name);
+
+    const std::vector<uint64_t> known_collection_ids = db.get_collection_ids();
 
     /*
      * Default validation depends on specific fields being present in the tracking table. If the

--- a/test/cppsuite/src/main/validator.h
+++ b/test/cppsuite/src/main/validator.h
@@ -54,8 +54,8 @@ class validator {
      * - operation_table_name: Table that contains all the operations performed on keys.
      * - schema_table_name: Table that contains all the schema operations performed.
      */
-    void validate(const std::string &operation_table_name, const std::string &schema_table_name,
-      const std::vector<uint64_t> &known_collection_ids);
+    void validate(
+      const std::string &operation_table_name, const std::string &schema_table_name, database &db);
 
     private:
     /*

--- a/test/cppsuite/tests/cache_resize.cpp
+++ b/test/cppsuite/tests/cache_resize.cpp
@@ -168,8 +168,8 @@ class cache_resize : public test {
     }
 
     void
-    validate(const std::string &operation_table_name, const std::string &,
-      const std::vector<uint64_t> &) override final
+    validate(
+      const std::string &operation_table_name, const std::string &, database &) override final
     {
         bool first_record = true;
         int ret;

--- a/test/cppsuite/tests/test_template.cpp
+++ b/test/cppsuite/tests/test_template.cpp
@@ -115,7 +115,7 @@ class test_template : public test {
     }
 
     void
-    validate(const std::string &, const std::string &, const std::vector<uint64_t> &) override final
+    validate(const std::string &, const std::string &, database &) override final
     {
         logger::log_msg(LOG_WARN, "validate: nothing done");
     }


### PR DESCRIPTION
A couple of fixes Identified when writing the example test in the cppsuite docs:
- Pass the database into `validate` so we can check against its contents
- Make the comment in test_template_default.txt a single line. Otherwise the sed command in `create_test` only deletes the first line
- Allow the user to access the number of operations per transaction when writing tests