### PR TITLE
WT-9473 Update s_mentions to exclude build directories.

### DIFF
--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -15,17 +15,12 @@ fi
 # Get what could be the ticket id.
 ticket_id=$(echo "$branch_name" | cut -d "-" -f-2)
 
-search_function="grep -Iinr --exclude-dir=.git $ticket_id ../ 2>&1"
+# Find the name of the build folder WiredTiger has been compiled in.
+# Users can name this folder anything, but it needs to be in the rootdir and to contain CMakeFiles
+cmake_file=$(find ../ -maxdepth 2 -name CMakeFiles)
+build_folder=$(basename $(dirname $cmake_file))
 
-# The wiredtiger file path needs to be relative to $HOME as some scripts strip $HOME from the path.
-wt_src_path=$(readlink -f ../)
-wt_src_path=${wt_src_path#"$(readlink -f "$HOME")/"}
-
-if [[ $wt_src_path =~ .*${wt_ticket_regex}.* ]]; then
-    # If the wiredtiger filepath contains $ticket_id (e.g. ~/src/$ticket_id/wiredtiger) then we will
-    # match generated build scripts containing this path. Filter these results from the search.
-    search_function="$search_function | grep -v $wt_src_path 2>&1"
-fi
+search_function="grep -Iinr --exclude-dir=.git --exclude-dir=$build_folder $ticket_id ../ 2>&1"
 
 # Check for comments related to the ticket.
 if eval "$search_function >/dev/null" ; then


### PR DESCRIPTION
After compiling WiredTiger the build folder will contain full paths to the WiredTiger directory, and if that path contains the ticket number `s_mentions` is looking for then `s_mentions` will raise a warning incorrectly. There was existing code to check for this, but it didn't handle symlinks correctly. 

Now that build_posix is deprecated we can also simplify the code and just ignore the build folder.