### PR TITLE
WT-9222 Process the call log for open_session()

### DIFF
--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -68,19 +68,22 @@ call_log_manager::process_call_log_entry(json call_log_entry)
         _conn = &connection_simulator::get_connection();
         break;
     case api_method::open_session:
-        if (_conn == nullptr){
-            std::cerr << "Could not open session, connection does not exist." << std::endl;
+        const std::string session_id = call_log_entry["session_id"].get<std::string>();
+
+        if (_conn == nullptr) {
+            throw std::runtime_error("Could not open session, connection does not exist");
+            break;
+        } else if (_session_map.find(session_id) != _session_map.end()) {
+            std::cerr << "Could not open duplicate session, session already exists." << std::endl;
             break;
         }
 
         session_simulator *session = _conn->open_session();
-        /* 
-        * Insert this session into the mapping between the simulator session object and the
-        * wiredtiger session object. 
-        */
-       const std::string session_id = call_log_entry["session_id"].get<std::string>();
-        _session_map.insert(std::pair<std::string, session_simulator *>(
-            session_id, session));
+        /*
+         * Insert this session into the mapping between the simulator session object and the
+         * wiredtiger session object.
+         */
+        _session_map.insert(std::pair<std::string, session_simulator *>(session_id, session));
         break;
     }
 }

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -32,7 +32,7 @@
 
 #include "call_log_manager.h"
 
-call_log_manager::call_log_manager(const std::string& call_log_file)
+call_log_manager::call_log_manager(const std::string &call_log_file)
 {
     std::ifstream file(call_log_file);
     if (file.fail()) {
@@ -62,13 +62,25 @@ call_log_manager::process_call_log()
 void
 call_log_manager::process_call_log_entry(json call_log_entry)
 {
-    const std::string method_name = call_log_entry["MethodName"].get<std::string>();
-    switch (_api_map.at(method_name)) {
-    case api_method::wiredtiger_open:
-        /* conn = &connection_simulator::get_connection(); */
-        break;
-    case api_method::open_session:
-        break;
+    try {
+        const std::string method_name = call_log_entry["MethodName"].get<std::string>();
+        std::cout << "Processing entry " << method_name << std::endl;
+        switch (_api_map.at(method_name)) {
+        case api_method::wiredtiger_open:
+            _conn = &connection_simulator::get_connection();
+            break;
+        case api_method::open_session:
+            session_simulator *session = _conn->open_session();
+            /* Insert this session into the mapping between the simulator session object and the
+             * wiredtiger session object. */
+            _session_map.insert(std::pair<std::string, session_simulator *>(
+              call_log_entry["Output"]["objectId"], session));
+            break;
+        }
+    } catch (const std::exception &e) {
+        std::cerr << "process_call_log_entry: Cannot process call log entry. " << e.what()
+                  << std::endl;
+        return;
     }
 }
 

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -63,7 +63,7 @@ void
 call_log_manager::process_call_log_entry(json call_log_entry)
 {
     try {
-        const std::string method_name = call_log_entry["MethodName"].get<std::string>();
+        const std::string method_name = call_log_entry["method_name"].get<std::string>();
         std::cout << "Processing entry " << method_name << std::endl;
         switch (_api_map.at(method_name)) {
         case api_method::wiredtiger_open:
@@ -74,7 +74,7 @@ call_log_manager::process_call_log_entry(json call_log_entry)
             /* Insert this session into the mapping between the simulator session object and the
              * wiredtiger session object. */
             _session_map.insert(std::pair<std::string, session_simulator *>(
-              call_log_entry["Output"]["objectId"], session));
+              call_log_entry["output"]["session_id"], session));
             break;
         }
     } catch (const std::exception &e) {

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -62,26 +62,21 @@ call_log_manager::process_call_log()
 void
 call_log_manager::process_call_log_entry(json call_log_entry)
 {
-    try {
-        const std::string method_name = call_log_entry["method_name"].get<std::string>();
-        std::cout << "Processing entry " << method_name << std::endl;
-        switch (_api_map.at(method_name)) {
-        case api_method::wiredtiger_open:
-            _conn = &connection_simulator::get_connection();
-            break;
-        case api_method::open_session:
-            session_simulator *session = _conn->open_session();
-            /* 
-             * Insert this session into the mapping between the simulator session object and the
-             * wiredtiger session object. 
-             */
-            _session_map.insert(std::pair<std::string, session_simulator *>(
-              call_log_entry["output"]["session_id"], session));
-            break;
-        }
-    } catch (const std::exception &e) {
-        std::cerr << "process_call_log_entry: Cannot process call log entry. " << e.what()
-                  << std::endl;
+    const std::string method_name = call_log_entry["method_name"].get<std::string>();
+    std::cout << "Processing entry " << method_name << std::endl;
+    switch (_api_map.at(method_name)) {
+    case api_method::wiredtiger_open:
+        _conn = &connection_simulator::get_connection();
+        break;
+    case api_method::open_session:
+        session_simulator *session = _conn->open_session();
+        /* 
+        * Insert this session into the mapping between the simulator session object and the
+        * wiredtiger session object. 
+        */
+        _session_map.insert(std::pair<std::string, session_simulator *>(
+            call_log_entry["session_id"], session));
+        break;
     }
 }
 

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -70,10 +70,14 @@ call_log_manager::process_call_log_entry(json call_log_entry)
     case api_method::open_session:
         const std::string session_id = call_log_entry["session_id"].get<std::string>();
 
-        if (_conn == nullptr) {
+        /*
+         * Not having a valid connection is a fatal error since no other operations can happen
+         * without a connection.
+         */
+        if (_conn == nullptr)
             throw std::runtime_error("Could not open session, connection does not exist");
-            break;
-        } else if (_session_map.find(session_id) != _session_map.end()) {
+        /* We should not open sessions with an ID that is already in use. */
+        else if (_session_map.find(session_id) != _session_map.end()) {
             std::cerr << "Could not open duplicate session, session already exists." << std::endl;
             break;
         }

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -63,19 +63,24 @@ void
 call_log_manager::process_call_log_entry(json call_log_entry)
 {
     const std::string method_name = call_log_entry["method_name"].get<std::string>();
-    std::cout << "Processing entry " << method_name << std::endl;
     switch (_api_map.at(method_name)) {
     case api_method::wiredtiger_open:
         _conn = &connection_simulator::get_connection();
         break;
     case api_method::open_session:
+        if (_conn == nullptr){
+            std::cerr << "Could not open session, connection does not exist." << std::endl;
+            break;
+        }
+
         session_simulator *session = _conn->open_session();
         /* 
         * Insert this session into the mapping between the simulator session object and the
         * wiredtiger session object. 
         */
+       const std::string session_id = call_log_entry["session_id"].get<std::string>();
         _session_map.insert(std::pair<std::string, session_simulator *>(
-            call_log_entry["session_id"], session));
+            session_id, session));
         break;
     }
 }

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -71,8 +71,10 @@ call_log_manager::process_call_log_entry(json call_log_entry)
             break;
         case api_method::open_session:
             session_simulator *session = _conn->open_session();
-            /* Insert this session into the mapping between the simulator session object and the
-             * wiredtiger session object. */
+            /* 
+             * Insert this session into the mapping between the simulator session object and the
+             * wiredtiger session object. 
+             */
             _session_map.insert(std::pair<std::string, session_simulator *>(
               call_log_entry["output"]["session_id"], session));
             break;
@@ -80,7 +82,6 @@ call_log_manager::process_call_log_entry(json call_log_entry)
     } catch (const std::exception &e) {
         std::cerr << "process_call_log_entry: Cannot process call log entry. " << e.what()
                   << std::endl;
-        return;
     }
 }
 

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.h
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.h
@@ -47,7 +47,7 @@ class call_log_manager {
 
     /* Member variables */
     private:
-    connection_simulator *_conn;
+    connection_simulator *_conn = nullptr;
     json _call_log;
     std::map<std::string, api_method> _api_map;
     std::map<std::string, session_simulator *> _session_map;

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.h
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.h
@@ -38,7 +38,7 @@ enum class api_method { open_session, wiredtiger_open };
 class call_log_manager {
     /* Methods */
     public:
-    call_log_manager(const std::string&);
+    call_log_manager(const std::string &);
     void process_call_log();
 
     private:
@@ -50,4 +50,5 @@ class call_log_manager {
     connection_simulator *_conn;
     json _call_log;
     std::map<std::string, api_method> _api_map;
+    std::map<std::string, session_simulator *> _session_map;
 };


### PR DESCRIPTION
The call log for open session is processed by creating a new session object in connection and adding it to the session map along with the session id.