### PR TITLE
WT-9366 Adding cursor bounds stress test to evergreen

### DIFF
--- a/test/cppsuite/configs/cursor_bound_01_stress.txt
+++ b/test/cppsuite/configs/cursor_bound_01_stress.txt
@@ -7,7 +7,7 @@
 #   - P threads will continuously update random keys.
 #   - Q threads will utilize the custom operation and will execute next() and prev() calls with
 # random bounds.
-duration_seconds=600,
+duration_seconds=3600,
 cache_size_mb=1500,
 reverse_collator=false,
 timestamp_manager=
@@ -22,7 +22,7 @@ workload_manager=
     populate_config=
     (
         collection_count=100,
-        key_count_per_collection=1,
+        key_count_per_collection=10000,
         value_size=100000,
         thread_count=50,
     ),

--- a/test/cppsuite/configs/cursor_bound_01_stress.txt
+++ b/test/cppsuite/configs/cursor_bound_01_stress.txt
@@ -1,0 +1,70 @@
+# Configuration for cursor_bound_01 default test.
+# During the test duration:
+#   - M threads will keep inserting new random keys.
+#   - N threads will execute search_near calls with random bounds set. Each search_near
+# call with bounds set is verified against the default search_near.
+#   - O threads will continuously remove random keys.
+#   - P threads will continuously update random keys.
+#   - Q threads will utilize the custom operation and will execute next() and prev() calls with
+# random bounds.
+duration_seconds=600,
+cache_size_mb=1500,
+reverse_collator=false,
+timestamp_manager=
+(
+    # This will let us randomly pick a read timestamp in a bigger range to trigger visibility
+    # checks.
+    stable_lag=25,
+    oldest_lag=25,
+),
+workload_manager=
+(
+    populate_config=
+    (
+        collection_count=100,
+        key_count_per_collection=1,
+        value_size=100000,
+        thread_count=50,
+    ),
+    #100MB/s insert rate
+    insert_config=
+    (
+        key_size=100,
+        op_rate=100ms,
+        thread_count=10,
+        value_size=1000000,
+        ops_per_transaction=(max=20,min=0)
+    ),
+    read_config=
+    (
+        op_rate=3ms,
+        thread_count=30
+    ),
+    #100MB/s remove reate
+    remove_config=
+    (
+        op_rate=10ms,
+        thread_count=10,
+        ops_per_transaction=(max=20,min=0)
+    ),
+    #100MB/s update rate
+    update_config=
+    (
+        op_rate=100ms,
+        thread_count=10,
+        value_size=1000000,
+        ops_per_transaction=(max=20,min=0)
+    ),
+    custom_config=
+    (
+        thread_count=10
+    ),
+    checkpoint_config=
+    (
+        op_rate=240s,
+    )
+),
+operation_tracker=
+(
+    enabled=false,
+)

--- a/test/cppsuite/tests/cursor_bound_01.cpp
+++ b/test/cppsuite/tests/cursor_bound_01.cpp
@@ -63,7 +63,8 @@ class cursor_bound_01 : public test {
             _inclusive = random_generator::instance().generate_integer(0, 1);
         }
 
-        bound(uint64_t key_size_max, bool lower_bound, char start) : bound(key_size_max, lower_bound)
+        bound(uint64_t key_size_max, bool lower_bound, char start)
+            : bound(key_size_max, lower_bound)
         {
             _key[0] = start;
         }
@@ -266,7 +267,8 @@ class cursor_bound_01 : public test {
         if (bound_choice == LOWER_BOUND_SET || bound_choice == ALL_BOUNDS_SET) {
             lower_bound = bound(tc->key_size, true);
             range_cursor->set_key(range_cursor.get(), lower_bound.get_key().c_str());
-            testutil_check(range_cursor->bound(range_cursor.get(), lower_bound.get_config().c_str()));
+            testutil_check(
+              range_cursor->bound(range_cursor.get(), lower_bound.get_config().c_str()));
         }
 
         if (bound_choice == UPPER_BOUND_SET || bound_choice == ALL_BOUNDS_SET) {
@@ -276,7 +278,8 @@ class cursor_bound_01 : public test {
                 upper_bound = bound(tc->key_size, false);
             }
             range_cursor->set_key(range_cursor.get(), upper_bound.get_key().c_str());
-            testutil_check(range_cursor->bound(range_cursor.get(), upper_bound.get_config().c_str()));
+            testutil_check(
+              range_cursor->bound(range_cursor.get(), upper_bound.get_config().c_str()));
         }
 
         if (bound_choice == ALL_BOUNDS_SET) {
@@ -557,7 +560,8 @@ class cursor_bound_01 : public test {
 
                 /* Generate a random key. */
                 auto key = random_generator::instance().generate_random_string(tc->key_size);
-                auto value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+                auto value =
+                  random_generator::instance().generate_pseudo_random_string(tc->value_size);
                 /* Insert a key/value pair. */
                 if (tc->insert(cursor, coll.id, key, value)) {
                     if (tc->txn.can_commit()) {
@@ -621,7 +625,8 @@ class cursor_bound_01 : public test {
                 testutil_check(rnd_cursor->get_key(rnd_cursor.get(), &key));
 
                 /* Update the found key with a randomized value. */
-                auto value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
+                auto value =
+                  random_generator::instance().generate_pseudo_random_string(tc->value_size);
                 if (tc->update(cursor, coll.id, key, value)) {
                     if (tc->txn.can_commit()) {
                         /* We are not checking the result of commit as it is not necessary. */

--- a/test/cppsuite/tests/cursor_bound_01.cpp
+++ b/test/cppsuite/tests/cursor_bound_01.cpp
@@ -63,6 +63,11 @@ class cursor_bound_01 : public test {
             _inclusive = random_generator::instance().generate_integer(0, 1);
         }
 
+        bound(uint64_t key_size_max, bool lower_bound, char start) : bound(key_size_max, lower_bound)
+        {
+            _key[0] = start;
+        }
+
         std::string
         get_config() const
         {
@@ -170,7 +175,7 @@ class cursor_bound_01 : public test {
                 normal_ret = normal_cursor->prev(normal_cursor.get());
         }
 
-        if (normal_ret == WT_NOTFOUND)
+        if (normal_ret == WT_NOTFOUND || normal_ret == WT_ROLLBACK)
             return;
 
         const char *normal_key;
@@ -189,6 +194,9 @@ class cursor_bound_01 : public test {
             }
             return;
         }
+        if (range_ret == WT_ROLLBACK) {
+            return;
+        }
         testutil_assert(range_ret == 0 && normal_ret == 0);
 
         /* Retrieve the key the cursor is pointing at. */
@@ -204,6 +212,10 @@ class cursor_bound_01 : public test {
                 normal_ret = normal_cursor->prev(normal_cursor.get());
                 range_ret = range_cursor->prev(range_cursor.get());
             }
+
+            if (normal_ret == WT_ROLLBACK || range_ret == WT_ROLLBACK)
+                break;
+
             testutil_assert(normal_ret == 0 || normal_ret == WT_NOTFOUND);
             testutil_assert(range_ret == 0 || range_ret == WT_NOTFOUND);
 
@@ -223,17 +235,16 @@ class cursor_bound_01 : public test {
                 }
                 break;
             }
-
+            /* Make sure that records match between both cursors. */
+            testutil_check(normal_cursor->get_key(normal_cursor.get(), &normal_key));
+            testutil_check(range_cursor->get_key(range_cursor.get(), &range_key));
+            testutil_assert(std::string(normal_key).compare(range_key) == 0);
             if (next && !upper_key.empty())
                 testutil_assert(custom_lexicographical_compare(
                   range_key, upper_key, upper_bound.get_inclusive()));
             else if (!next && !lower_key.empty())
                 testutil_assert(custom_lexicographical_compare(
                   lower_key, range_key, lower_bound.get_inclusive()));
-            /* Make sure that records match between both cursors. */
-            testutil_check(normal_cursor->get_key(normal_cursor.get(), &normal_key));
-            testutil_check(range_cursor->get_key(range_cursor.get(), &range_key));
-            testutil_assert(std::string(normal_key).compare(range_key) == 0);
         }
     }
 
@@ -245,47 +256,32 @@ class cursor_bound_01 : public test {
     std::pair<bound, bound>
     set_random_bounds(thread_worker *tc, scoped_cursor &range_cursor)
     {
-        int ret;
         bound lower_bound, upper_bound;
 
-        auto set_random_bounds = random_generator::instance().generate_integer(0, 3);
-        if (set_random_bounds == NO_BOUNDS)
+        testutil_check(range_cursor->reset(range_cursor.get()));
+        auto bound_choice = random_generator::instance().generate_integer(0, 3);
+        if (bound_choice == NO_BOUNDS)
             testutil_check(range_cursor->bound(range_cursor.get(), "action=clear"));
 
-        if (set_random_bounds == LOWER_BOUND_SET || set_random_bounds == ALL_BOUNDS_SET) {
+        if (bound_choice == LOWER_BOUND_SET || bound_choice == ALL_BOUNDS_SET) {
             lower_bound = bound(tc->key_size, true);
             range_cursor->set_key(range_cursor.get(), lower_bound.get_key().c_str());
-            ret = range_cursor->bound(range_cursor.get(), lower_bound.get_config().c_str());
-            testutil_assert(ret == 0 || ret == EINVAL);
-
-            /*
-             * It is possible that the new lower bound overlaps with the upper bound. In that case,
-             * just clear the lower bound and continue with test.
-             */
-            if (ret == EINVAL)
-                lower_bound.clear();
+            testutil_check(range_cursor->bound(range_cursor.get(), lower_bound.get_config().c_str()));
         }
 
-        if (set_random_bounds == UPPER_BOUND_SET || set_random_bounds == ALL_BOUNDS_SET) {
-            upper_bound = bound(tc->key_size, false);
+        if (bound_choice == UPPER_BOUND_SET || bound_choice == ALL_BOUNDS_SET) {
+            if (bound_choice == ALL_BOUNDS_SET) {
+                upper_bound = bound(tc->key_size, false, lower_bound.get_key()[0] + 1);
+            } else {
+                upper_bound = bound(tc->key_size, false);
+            }
             range_cursor->set_key(range_cursor.get(), upper_bound.get_key().c_str());
-            ret = range_cursor->bound(range_cursor.get(), upper_bound.get_config().c_str());
-            testutil_assert(ret == 0 || ret == EINVAL);
-
-            /*
-             * It is possible that the new upper bound overlaps with the lower bound. In that case,
-             * just clear the upper bound and continue with test.
-             */
-            if (ret == EINVAL)
-                upper_bound.clear();
+            testutil_check(range_cursor->bound(range_cursor.get(), upper_bound.get_config().c_str()));
         }
 
-        /*
-         * It is possible that upper bound and lower bound both get EINVAL, in that case clear all
-         * bounds.
-         */
-        if (upper_bound.get_key().empty() && lower_bound.get_key().empty())
-            testutil_check(range_cursor->bound(range_cursor.get(), "action=clear"));
+        if (bound_choice == ALL_BOUNDS_SET) {
+            testutil_assert(upper_bound.get_key().compare(lower_bound.get_key()) > 0);
+        }
 
         return std::make_pair(lower_bound, upper_bound);
     }
@@ -504,6 +500,9 @@ class cursor_bound_01 : public test {
         } else
             ret = normal_cursor->next(normal_cursor.get());
 
+        if (ret == WT_ROLLBACK)
+            return;
+
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
 
         /*
@@ -552,13 +551,13 @@ class cursor_bound_01 : public test {
 
             collection &coll = tc->db.get_random_collection();
             scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
-            tc->txn.begin();
+            tc->txn.try_begin();
 
             while (tc->txn.active() && tc->running()) {
 
                 /* Generate a random key. */
                 auto key = random_generator::instance().generate_random_string(tc->key_size);
-                auto value = random_generator::instance().generate_random_string(tc->value_size);
+                auto value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
                 /* Insert a key/value pair. */
                 if (tc->insert(cursor, coll.id, key, value)) {
                     if (tc->txn.can_commit()) {
@@ -578,13 +577,12 @@ class cursor_bound_01 : public test {
                 tc->sleep();
             }
 
-            /* Rollback any transaction that could not commit before the end of the test. */
-            if (tc->txn.active())
-                tc->txn.rollback();
-
             /* Reset our cursor to avoid pinning content. */
             testutil_check(cursor->reset(cursor.get()));
         }
+        /* Rollback any transaction that could not commit before the end of the test. */
+        if (tc->txn.active())
+            tc->txn.rollback();
     }
 
     void
@@ -601,13 +599,13 @@ class cursor_bound_01 : public test {
             scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
             scoped_cursor rnd_cursor =
               tc->session.open_scoped_cursor(coll.name, "next_random=true");
-            tc->txn.begin();
+            tc->txn.try_begin();
 
             while (tc->txn.active() && tc->running()) {
                 int ret = rnd_cursor->next(rnd_cursor.get());
 
                 /* It is possible not to find anything if the collection is empty. */
-                testutil_assert(ret == 0 || ret == WT_NOTFOUND);
+                testutil_assert(ret == 0 || ret == WT_NOTFOUND || ret == WT_ROLLBACK);
                 if (ret == WT_NOTFOUND) {
                     /*
                      * If we cannot find any record, finish the current transaction as we might be
@@ -615,13 +613,15 @@ class cursor_bound_01 : public test {
                      */
                     WT_IGNORE_RET_BOOL(tc->txn.commit());
                     continue;
+                } else if (ret == WT_ROLLBACK) {
+                    break;
                 }
 
                 const char *key;
                 testutil_check(rnd_cursor->get_key(rnd_cursor.get(), &key));
 
                 /* Update the found key with a randomized value. */
-                auto value = random_generator::instance().generate_random_string(tc->value_size);
+                auto value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
                 if (tc->update(cursor, coll.id, key, value)) {
                     if (tc->txn.can_commit()) {
                         /* We are not checking the result of commit as it is not necessary. */
@@ -640,13 +640,14 @@ class cursor_bound_01 : public test {
                 tc->sleep();
             }
 
-            /* Rollback any transaction that could not commit before the end of the test. */
-            if (tc->txn.active())
-                tc->txn.rollback();
-
-            /* Reset our cursor to avoid pinning content. */
+            /* Reset our cursors to avoid pinning content. */
+            testutil_check(rnd_cursor->reset(rnd_cursor.get()));
             testutil_check(cursor->reset(cursor.get()));
         }
+
+        /* Rollback any transaction that could not commit before the end of the test. */
+        if (tc->txn.active())
+            tc->txn.rollback();
     }
 
     void
@@ -661,34 +662,17 @@ class cursor_bound_01 : public test {
           LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
         std::map<uint64_t, scoped_cursor> cursors;
-        /* Maintain the lower and upper bound for each cursor held in the cursors map. */
-        std::map<uint64_t, std::pair<bound, bound>> bounds;
         while (tc->running()) {
             /* Get a random collection to work on. */
             collection &coll = tc->db.get_random_collection();
 
             /* Find a cached cursor or create one if none exists. */
-            if (cursors.find(coll.id) == cursors.end()) {
-                bound lower_bound, upper_bound;
+            if (cursors.find(coll.id) == cursors.end())
                 cursors.emplace(coll.id, std::move(tc->session.open_scoped_cursor(coll.name)));
-                bounds.emplace(coll.id, std::move(std::make_pair(lower_bound, upper_bound)));
-            }
 
             /* Set random bounds on cached range cursor. */
             auto &range_cursor = cursors[coll.id];
-            auto &bound_pair = bounds[coll.id];
-            auto new_bound_pair = set_random_bounds(tc, range_cursor);
-            /* Only update the bounds when the bounds have a key. */
-            if (!new_bound_pair.first.get_key().empty())
-                bound_pair.first = new_bound_pair.first;
-            if (!new_bound_pair.second.get_key().empty())
-                bound_pair.second = new_bound_pair.second;
-
-            /* Clear all bounds if both bounds don't have a key. */
-            if (new_bound_pair.first.get_key().empty() && new_bound_pair.second.get_key().empty()) {
-                bound_pair.first.clear();
-                bound_pair.second.clear();
-            }
+            auto bound_pair = set_random_bounds(tc, range_cursor);
 
             scoped_cursor normal_cursor = tc->session.open_scoped_cursor(coll.name);
             wt_timestamp_t ts = tc->tsm->get_valid_read_ts();
@@ -698,7 +682,6 @@ class cursor_bound_01 : public test {
              */
             tc->txn.begin(
               "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
-
             while (tc->txn.active() && tc->running()) {
                 /* Generate a random string. */
                 auto key_size = random_generator::instance().generate_integer(
@@ -709,7 +692,9 @@ class cursor_bound_01 : public test {
                 int exact = 0;
                 range_cursor->set_key(range_cursor.get(), srch_key.c_str());
                 auto ret = range_cursor->search_near(range_cursor.get(), &exact);
-                testutil_assert(ret == 0 || ret == WT_NOTFOUND);
+                testutil_assert(ret == 0 || ret == WT_NOTFOUND || ret == WT_ROLLBACK);
+                if (ret == WT_ROLLBACK)
+                    continue;
 
                 /* Verify the bound search_near result using the normal cursor. */
                 validate_bound_search_near(ret, exact, range_cursor, normal_cursor, srch_key,
@@ -722,23 +707,27 @@ class cursor_bound_01 : public test {
                 if (ret == 0) {
                     const char *range_srch_key;
                     testutil_check(range_cursor->get_key(range_cursor.get(), &range_srch_key));
-
-                    range_cursor->set_key(range_cursor.get(), range_srch_key);
+                    std::string range_key_copy(range_srch_key);
+                    range_cursor->set_key(range_cursor.get(), range_key_copy.c_str());
                     ret = range_cursor->search(range_cursor.get());
 
-                    testutil_assert(ret == 0 || ret == WT_NOTFOUND);
+                    testutil_assert(ret == 0 || ret == WT_NOTFOUND || ret == WT_ROLLBACK);
+                    if (ret == WT_ROLLBACK)
+                        continue;
                     validate_bound_search(
-                      ret, range_cursor, srch_key, bound_pair.first, bound_pair.second);
+                      ret, range_cursor, range_key_copy, bound_pair.first, bound_pair.second);
                 }
 
                 tc->txn.add_op();
-                tc->txn.try_rollback();
+                tc->txn.commit();
                 tc->sleep();
             }
+            range_cursor->reset(range_cursor.get());
+            normal_cursor->reset(normal_cursor.get());
         }
         /* Roll back the last transaction if still active now the work is finished. */
         if (tc->txn.active())
-            tc->txn.rollback();
+            tc->txn.commit();
     }
 
     void
@@ -753,34 +742,17 @@ class cursor_bound_01 : public test {
           LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
         std::map<uint64_t, scoped_cursor> cursors;
-        /* Maintain the lower and upper bound for each cursor held in the cursors map. */
-        std::map<uint64_t, std::pair<bound, bound>> bounds;
         while (tc->running()) {
             /* Get a random collection to work on. */
             collection &coll = tc->db.get_random_collection();
 
             /* Find a cached cursor or create one if none exists. */
-            if (cursors.find(coll.id) == cursors.end()) {
-                bound lower_bound, upper_bound;
+            if (cursors.find(coll.id) == cursors.end())
                 cursors.emplace(coll.id, std::move(tc->session.open_scoped_cursor(coll.name)));
-                bounds.emplace(coll.id, std::move(std::make_pair(lower_bound, upper_bound)));
-            }
 
             /* Set random bounds on cached range cursor. */
             auto &range_cursor = cursors[coll.id];
-            auto &bound_pair = bounds[coll.id];
-            auto new_bound_pair = set_random_bounds(tc, range_cursor);
-            /* Only update the bounds when the bounds have a key. */
-            if (!new_bound_pair.first.get_key().empty())
-                bound_pair.first = new_bound_pair.first;
-            if (!new_bound_pair.second.get_key().empty())
-                bound_pair.second = new_bound_pair.second;
-
-            /* Clear all bounds if both bounds don't have a key. */
-            if (new_bound_pair.first.get_key().empty() && new_bound_pair.second.get_key().empty()) {
-                bound_pair.first.clear();
-                bound_pair.second.clear();
-            }
+            auto bound_pair = set_random_bounds(tc, range_cursor);
 
             scoped_cursor normal_cursor = tc->session.open_scoped_cursor(coll.name);
             wt_timestamp_t ts = tc->tsm->get_valid_read_ts();
@@ -800,6 +772,8 @@ class cursor_bound_01 : public test {
                 tc->txn.try_rollback();
                 tc->sleep();
             }
+            normal_cursor->reset(normal_cursor.get());
+            range_cursor->reset(range_cursor.get());
         }
         /* Roll back the last transaction if still active now the work is finished. */
         if (tc->txn.active())

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1217,6 +1217,16 @@ tasks:
           test_config_filename: configs/burst_inserts_stress.txt
           test_name: burst_inserts
 
+  - name: cppsuite-cursor-bound-01-stress
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "cppsuite test"
+        vars:
+          test_config_filename: configs/cursor_bound_01_stress.txt
+          test_name: cursor_bound_01
+
   - name: cppsuite-search-near-01-stress
     depends_on:
       - name: compile
@@ -4262,6 +4272,7 @@ buildvariants:
     - name: compile
     - name: cppsuite-operations-test-stress
     - name: cppsuite-burst-inserts-stress
+    - name: cppsuite-cursor-bound-01-stress
     - name: cppsuite-hs-cleanup-stress
     - name: cppsuite-search-near-01-stress
     - name: cppsuite-search-near-02-stress


### PR DESCRIPTION
This is a Draft PR as I have spotted an interesting issue in the FTDC where cursor->next traversals are happening 1/10 as much as cursor->prev traversals. Additionally the reverse collator test hasn't yet been added. 

Please review the code changes and the stressful configuration file.