### PR TITLE
WT-8903 Convert all GDB references to explicitly use the v3 toolchain

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -558,7 +558,7 @@ functions:
         wt_hang_analyzer_option="-c -o file -o stdout"
 
         echo "Calling the wt hang analyzer ..."
-        PATH="/opt/mongodbtoolchain/gdb/bin:$PATH" ${python_binary|python3} ../test/wt_hang_analyzer/wt_hang_analyzer.py $wt_hang_analyzer_option
+        PATH="/opt/mongodbtoolchain/v3/gdb/bin:$PATH" ${python_binary|python3} ../test/wt_hang_analyzer/wt_hang_analyzer.py $wt_hang_analyzer_option
 
   "save wt hang analyzer core/debugger files":
     - command: archive.targz_pack


### PR DESCRIPTION
Change the `/opt/mongodbtoolchain/` path in evergreen to `/opt/mongodbtoolchain/v3` as the former is a symlink to v3 will be deprecated in future.