### PR TITLE
WT-9584 Fixed verification logic in table_verify_mirror

### DIFF
--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -309,7 +309,8 @@ page_dump:
                  * We can't continue if the keys don't match, otherwise, optionally continue showing
                  * failures, up to 20.
                  */
-                testutil_assert(base_keyno == table_keyno && g.trace_mirror_fail && failures < 20);
+                testutil_assert(
+                  base_keyno == table_keyno || (g.trace_mirror_fail && failures < 20));
             }
         }
 


### PR DESCRIPTION
Logic in the assert doesn't match the comment above it in `table_verify_mirror`. This PR fixes the assert to match the comment.