### PR TITLE
WT-9587 Fix Windows status reporting in evergreen

### DIFF
--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -20,9 +20,9 @@ $ErrorActionPreference = "Stop"
 # Source the vcvars to ensure we have access to the Visual Studio toolchain
 cmd /c "`"$vcvars_bat`"&set" |
 foreach {
-  if ($_ -match "=") {
-    $v = $_.split("="); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
-  }
+    if ($_ -match "=") {
+        $v = $_.split("="); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
+    }
 }
 
 # Ensure the PROCESSOR_ARCHITECTURE environment variable is set. This is sometimes not set
@@ -39,14 +39,14 @@ if (-not (Test-Path cmake_build)) {
 cd cmake_build
 
 # Configure build with CMake.
-if( $configure -eq $true) {
+if ($configure -eq $true) {
     # Note that ${args} are all the command line options that are not automatically parsed by the param function.
     C:\cmake\bin\cmake --no-warn-unused-cli -DSWIG_DIR='C:\swigwin-3.0.2' -DSWIG_EXECUTABLE='C:\swigwin-3.0.2\swig.exe' -DCMAKE_BUILD_TYPE='None' -DENABLE_PYTHON=1 -DENABLE_STRICT=1 -DCMAKE_TOOLCHAIN_FILE='..\cmake\toolchains\cl.cmake' ${args} -G "Ninja" ..\.
     Die-On-Failure($LastExitCode)
 }
 
 # Execute Ninja build.
-if( $build -eq $true) {
+if ($build -eq $true) {
     ninja
     Die-On-Failure($LastExitCode)
 }

--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -4,6 +4,19 @@ param (
     [string]$vcvars_bat = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvars64.bat"
 )
 
+function Die-On-Failure {
+    param (
+        $Result
+    )
+
+    if ($Result -ne 0) {
+        throw("Task failed: " + $Result)
+    }
+}
+
+# This script should fail when a cmdlet fails.
+$ErrorActionPreference = "Stop"
+
 # Source the vcvars to ensure we have access to the Visual Studio toolchain
 cmd /c "`"$vcvars_bat`"&set" |
 foreach {
@@ -29,9 +42,11 @@ cd cmake_build
 if( $configure -eq $true) {
     # Note that ${args} are all the command line options that are not automatically parsed by the param function.
     C:\cmake\bin\cmake --no-warn-unused-cli -DSWIG_DIR='C:\swigwin-3.0.2' -DSWIG_EXECUTABLE='C:\swigwin-3.0.2\swig.exe' -DCMAKE_BUILD_TYPE='None' -DENABLE_PYTHON=1 -DENABLE_STRICT=1 -DCMAKE_TOOLCHAIN_FILE='..\cmake\toolchains\cl.cmake' ${args} -G "Ninja" ..\.
+    Die-On-Failure($LastExitCode)
 }
 
 # Execute Ninja build.
 if( $build -eq $true) {
     ninja
+    Die-On-Failure($LastExitCode)
 }


### PR DESCRIPTION
This also fixes a couple of whitespace oddities I found.

I was tossing up between this and a version that let you write `Die-On-Failure(cmake ...)` but it got a little weird. The function calls don't actually return an exit code - they return some opaque type that we'd have to extract the exit code from somehow, and I'm not confident that every binary returns the same type of object.

Hopefully this doesn't result in a cascade of Evergreen failures...