### PR TITLE
WT-9573 Ignore "explicit declaration of ret" false positive in s_style

### DIFF
--- a/dist/s_style
+++ b/dist/s_style
@@ -208,7 +208,9 @@ else
 	   ! expr "$f" : 'examples/.*' > /dev/null &&
 	   ! expr "$f" : 'test/.*' > /dev/null &&
 	   ! expr "$f" : 'ext/.*' > /dev/null; then
-		egrep -w ret $f | egrep 'int.*[, ]ret[,;]' > $t
+	   # This regex can return false positives on functions that take ret as
+	   # an argument. Filter out matches that contain brackets.
+		egrep -w ret $f | egrep 'int.*[, ]ret[,;]' | egrep -v '[()]' > $t
 		test -s $t && {
 			echo "$f: explicit declaration of \"ret\""
 			cat $t


### PR DESCRIPTION
s_style checks for explicit declarations of ret using the regex `int.*[, ]ret[,;]`, but this is too broad and will also match against functions that contain "int" in their name and take `ret` as an argument. For example __wt_call_log_pr**int**_return(conn, session, **ret**, "")

Add a filter to the regex above to ignore lines that contain brackets as this indicates the line is a function call and not a variable declaration.