### PR TITLE
WT-9610 Unable to set HAVE_BUILTIN_EXTENSION_ZSTD: Failed to find zstd library

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -40,7 +40,7 @@ if(NOT HAVE_BUILTIN_EXTENSION_ZLIB)
     set(default_enable_zlib ${HAVE_LIBZ})
 endif()
 if(NOT HAVE_BUILTIN_EXTENSION_ZSTD)
-    set(default_enable_zstd ${HAVE_LIBTCMALLOC})
+    set(default_enable_zstd ${HAVE_LIBZSTD})
 endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -124,6 +124,12 @@ functions:
           ${SPINLOCK_TYPE|} \
           ${CC_OPTIMIZE_LEVEL|}"
 
+        # This is a workaround until WT-8981 is resolved and we can remove this. The Ubuntu PPC platform does not have ZSTD.
+        # Strip it out.
+        if [ "${build_variant|}" = "ubuntu1804-ppc" ] && [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_ZSTD=1) ]]; then
+          DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
+        fi
+
         if [ "$OS" = "Windows_NT" ]; then
           # Use the Windows powershell script to configure the CMake build.
           # We execute it in a powershell environment as its easier to detect and source the Visual Studio
@@ -4131,7 +4137,7 @@ buildvariants:
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
       LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_BUILDDIR/test/utility/
-    CC_OPTIMIZE_LEVEL: -O3
+    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O3
     HAVE_DIAGNOSTIC: -DHAVE_DIAGNOSTIC=0
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
     CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL

--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -84,7 +84,7 @@ build_branch()
         config=""
         config+="-DENABLE_SNAPPY=1 "
         # Need to disable configs since WT-9455
-	config+="-DENABLE_LZ4=0 -DENABLE_ZLIB=0 -DENABLE_ZSTD=0 "
+        config+="-DENABLE_LZ4=0 -DENABLE_ZLIB=0 -DENABLE_ZSTD=0 "
         config+="-DWT_STANDALONE_BUILD=0 "
         (mkdir -p build && cd build &&
             $CMAKE $config ../. && make -j $(grep -c ^processor /proc/cpuinfo)) > /dev/null

--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -83,7 +83,7 @@ build_branch()
         . ./test/evergreen/find_cmake.sh
         config=""
         config+="-DENABLE_SNAPPY=1 "
-	# Need to disable configs since WT-9455
+        # Need to disable configs since WT-9455
 	config+="-DENABLE_LZ4=0 -DENABLE_ZLIB=0 -DENABLE_ZSTD=0 "
         config+="-DWT_STANDALONE_BUILD=0 "
         (mkdir -p build && cd build &&

--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -83,6 +83,8 @@ build_branch()
         . ./test/evergreen/find_cmake.sh
         config=""
         config+="-DENABLE_SNAPPY=1 "
+	# Need to disable configs since WT-9455
+	config+="-DENABLE_LZ4=0 -DENABLE_ZLIB=0 -DENABLE_ZSTD=0 "
         config+="-DWT_STANDALONE_BUILD=0 "
         (mkdir -p build && cd build &&
             $CMAKE $config ../. && make -j $(grep -c ^processor /proc/cpuinfo)) > /dev/null

--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -83,7 +83,8 @@ build_branch()
         . ./test/evergreen/find_cmake.sh
         config=""
         config+="-DENABLE_SNAPPY=1 "
-        # Need to disable configs since WT-9455
+        # Need to disable configs since WT-9455 enabled additional items by default.
+        # Old releases didn't have these enabled, need to make it consistent.
         config+="-DENABLE_LZ4=0 -DENABLE_ZLIB=0 -DENABLE_ZSTD=0 "
         config+="-DWT_STANDALONE_BUILD=0 "
         (mkdir -p build && cd build &&


### PR DESCRIPTION
Fixing fallout of WT-9455. Fixing optimization for perf tests (typo). Fixing Ubuntu PPC tests with removing ZSTD as its not supported. Fixing compatibility tests by disabling extensions