### PR TITLE
WT-9614 Improve required compiler and python support in cmake/doc

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -97,7 +97,7 @@ There are a number of additional configuration options you can pass to the CMake
 * `-DENABLE_ZLIB=1` : Build the zlib compressor extension (enabled by default if the ZLIB library is present)
 * `-DENABLE_ZSTD=1` : Build the libzstd compressor extension (enabled by default if the ZSTD library is present)
 * `-DENABLE_SODIUM=1` : Build the libsodium encryptor extension
-* `-DHAVE_DIAGNOSTIC=1` : Enable WiredTiger diagnostics
+* `-DHAVE_DIAGNOSTIC=1` : Enable WiredTiger diagnostics (enabled by default for non Release build types)
 * `-DHAVE_REF_TRACK=1` : Enable WiredTiger to track recent state transitions for WT_REF structures (always enabled in diagnostic build)
 * `-DHAVE_UNITTEST=1` : Enable WiredTiger unit tests (enabled by default)
 * `-DHAVE_ATTACH=1` : Enable to pause for debugger attach on failure

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -8,8 +8,8 @@ To build with CMake we **require** the following dependencies:
   * `gcc` : Version 8.5 or later, or 
   * `clang`: Version 7.01 or later, or
   * `Visual Studio 2017`: If compiling on Windows
-* `cmake` : Official CMake install instructions found here: https://cmake.org/install/
-  * *WiredTiger supports CMake 3.10+*
+  * `cmake` : Official CMake install instructions found here: https://cmake.org/install/ (*WiredTiger supports CMake 3.10+*)
+  * `python` : Version 3 or later for building the Python API or running the tests
 
 We also suggest the following dependencies are also installed (for improved build times):
 

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -3,7 +3,7 @@ include(cmake/configs/version.cmake)
 
 # Setup defaults based on the build type and available libraries.
 set(default_have_diagnostics ON)
-set(default_enable_python ON)
+set(default_enable_python OFF)
 set(default_enable_lz4 OFF)
 set(default_enable_snappy OFF)
 set(default_enable_zlib OFF)
@@ -52,6 +52,16 @@ if(WT_WIN)
     # additionally generate a dll file using a *DEF file.
     set(default_enable_static ON)
     set(default_enable_shared OFF)
+endif()
+
+# Enable python if we have the minimum version.
+set(python_libs)
+set(python_version)
+set(python_executable)
+source_python3_package(python_libs python_version python_executable)
+
+if("${python_version}" VERSION_GREATER_EQUAL "3")
+  set(default_enable_python ON)
 endif()
 
 # WiredTiger-related configuration options.

--- a/cmake/define_libwiredtiger.cmake
+++ b/cmake/define_libwiredtiger.cmake
@@ -43,9 +43,11 @@ macro(define_wiredtiger_library target type)
     #   of a 'SHARED' wiredtiger library would conflict.
     # NO_SYSTEM_FROM_IMPORTED - don't treat include interface directories consumed on an imported target as system
     #   directories.
+    # C_STANDARD - require C11 from the compiler.
     set_target_properties(${target} PROPERTIES
         OUTPUT_NAME "wiredtiger"
         NO_SYSTEM_FROM_IMPORTED TRUE
+        C_STANDARD 11
     )
 
     # Ensure we link any available library dependencies to our wiredtiger target.

--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -10,7 +10,7 @@ To build from the WiredTiger GitHub repository requires
 <a href="https://gcc.gnu.org/">GCC 8.5 or later</a> or
 <a href="https://clang.llvm.org/">Clang 7.01 or later</a>, and
 <a href="https://cmake.org/">CMake 3.10.0 or later</a>, and
-<a href="https://python.org/">Python 3 or later</a> (if building to support the Python API or running the tests), and
+<a href="https://python.org/">Python 3 or later</a> (if building to support the Python API), and
 <a href="http://www.swig.org/">SWIG</a> (if building to support the Python API).
 We also suggest <a href="https://ninja-build.org/">Ninja</a> and
 <a href="https://ccache.dev/">ccache</a> for improved incremental build times.
@@ -103,7 +103,7 @@ Configure WiredTiger to sleep and wait for a debugger to attach on failure.
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DHAVE_DIAGNOSTIC=1
-Configure WiredTiger to perform various run-time diagnostic tests (enabled by default).
+Configure WiredTiger to perform various run-time diagnostic tests (enabled by default for non Release build types).
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DNON_BARRIER_DIAGNOSTIC_YIELDS=1

--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -10,6 +10,7 @@ To build from the WiredTiger GitHub repository requires
 <a href="https://gcc.gnu.org/">GCC 8.5 or later</a> or
 <a href="https://clang.llvm.org/">Clang 7.01 or later</a>, and
 <a href="https://cmake.org/">CMake 3.10.0 or later</a>, and
+<a href="https://python.org/">Python 3 or later</a> (if building to support the Python API or running the tests), and
 <a href="http://www.swig.org/">SWIG</a> (if building to support the Python API).
 We also suggest <a href="https://ninja-build.org/">Ninja</a> and
 <a href="https://ccache.dev/">ccache</a> for improved incremental build times.
@@ -102,7 +103,7 @@ Configure WiredTiger to sleep and wait for a debugger to attach on failure.
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DHAVE_DIAGNOSTIC=1
-Configure WiredTiger to perform various run-time diagnostic tests.
+Configure WiredTiger to perform various run-time diagnostic tests (enabled by default).
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
@@ -112,23 +113,23 @@ Requires that HAVE_DIAGNOSTIC is also enabled.
 
 @par \c -DENABLE_LZ4=1
 Configure WiredTiger for <a href="https://github.com/Cyan4973/lz4">LZ4</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the LZ4 library is present); see @ref compression for more information.
 
 @par \c -DENABLE_PYTHON=1
 Build the WiredTiger <a href="http://www.python.org">Python</a> API;
-requires <a href="http://swig.org">SWIG</a>.
+requires <a href="http://swig.org">SWIG</a> (enabled by default if python is available).
 
 @par \c -DENABLE_SNAPPY=1
 Configure WiredTiger for <a href="http://code.google.com/p/snappy/">snappy</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the SNAPPY library is present); see @ref compression for more information.
 
 @par \c -DENABLE_ZLIB=1
 Configure WiredTiger for <a href="http://www.zlib.net/">zlib</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the ZLIB library is present); see @ref compression for more information.
 
 @par \c -DENABLE_ZSTD=1
 Configure WiredTiger for <a href="https://github.com/facebook/zstd">Zstd</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the ZSTD library is present); see @ref compression for more information.
 
 @par \c -DWT_STANDALONE_BUILD=0
 Configure WiredTiger to disable standalone build. Standalone build is enabled

--- a/src/docs/build-windows.dox
+++ b/src/docs/build-windows.dox
@@ -94,7 +94,7 @@ Configure WiredTiger to sleep and wait for a debugger to attach on failure.
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DHAVE_DIAGNOSTIC=1
-Configure WiredTiger to perform various run-time diagnostic tests.
+Configure WiredTiger to perform various run-time diagnostic tests (enabled by default).
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
@@ -104,23 +104,23 @@ Requires that HAVE_DIAGNOSTIC is also enabled.
 
 @par \c -DENABLE_LZ4=1
 Configure WiredTiger for <a href="https://github.com/Cyan4973/lz4">LZ4</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the LZ4 library is present); see @ref compression for more information.
 
 @par \c -DENABLE_PYTHON=1
 Build the WiredTiger <a href="http://www.python.org">Python</a> API;
-requires <a href="http://swig.org">SWIG</a>.
+requires <a href="http://swig.org">SWIG</a> (enabled by default if python is available).
 
 @par \c -DENABLE_SNAPPY=1
 Configure WiredTiger for <a href="http://code.google.com/p/snappy/">snappy</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the SNAPPY library is present); see @ref compression for more information.
 
 @par \c -DENABLE_ZLIB=1
 Configure WiredTiger for <a href="http://www.zlib.net/">zlib</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the ZLIB library is present); see @ref compression for more information.
 
 @par \c -DENABLE_ZSTD=1
 Configure WiredTiger for <a href="https://github.com/facebook/zstd">Zstd</a>
-compression; see @ref compression for more information.
+compression (enabled by default if the ZSTD library is present); see @ref compression for more information.
 
 @par \c -DWT_STANDALONE_BUILD=0
 Configure WiredTiger to disable standalone build. Standalone build is enabled

--- a/src/docs/build-windows.dox
+++ b/src/docs/build-windows.dox
@@ -94,7 +94,7 @@ Configure WiredTiger to sleep and wait for a debugger to attach on failure.
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DHAVE_DIAGNOSTIC=1
-Configure WiredTiger to perform various run-time diagnostic tests (enabled by default).
+Configure WiredTiger to perform various run-time diagnostic tests (enabled by default for non Release build types).
 <b>DO NOT</b> configure this option in production environments.
 
 @par \c -DNON_BARRIER_DIAGNOSTIC_YIELDS=1

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -135,7 +135,7 @@ functions:
           # We execute it in a powershell environment as its easier to detect and source the Visual Studio
           # toolchain in a native Windows environment. We can't easily execute the build in a cygwin environment.
           echo "Using config flags $DEFINED_EVERGREEN_CONFIG_FLAGS ${windows_configure_flags|}"
-          powershell.exe  -NonInteractive '.\test\evergreen\build_windows.ps1' -configure 1 $DEFINED_EVERGREEN_CONFIG_FLAGS ${windows_configure_flags|}
+          ${configure_env_vars|} powershell.exe  -NonInteractive '.\test\evergreen\build_windows.ps1' -configure 1 $DEFINED_EVERGREEN_CONFIG_FLAGS ${windows_configure_flags|}
         else
           echo "Using config flags $DEFINED_EVERGREEN_CONFIG_FLAGS ${posix_configure_flags|}"
           # Fetch the gperftools library if needed. This will also get tcmalloc.
@@ -153,7 +153,7 @@ functions:
           mkdir -p cmake_build
           cd cmake_build
 
-          $CMAKE $DEFINED_EVERGREEN_CONFIG_FLAGS ${posix_configure_flags|} -G "${cmake_generator|Ninja}" ./..
+          ${configure_env_vars|} $CMAKE $DEFINED_EVERGREEN_CONFIG_FLAGS ${posix_configure_flags|} -G "${cmake_generator|Ninja}" ./..
         fi
   "make wiredtiger": &make_wiredtiger
     command: shell.exec
@@ -4363,6 +4363,8 @@ buildvariants:
   - windows-64-vs2017-test
   expansions:
     python_binary: '/cygdrive/c/Python39/python'
+    configure_env_vars:
+      PATH=/cygdrive/c/Python39:/cygdrive/c/Python39/Scripts:$PATH
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build


### PR DESCRIPTION
Updating cmake to default python enable/disable based on presence. Requiring C11 standard for compiler. Improving doc around tool requirements and cmake features.