### PR TITLE
WT-9596 verify-datafile-little-endian test couldn't open lz4 compressor extension

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4414,6 +4414,8 @@ buildvariants:
     cmake_generator: Ninja
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
     CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL
+    # Must disable ZSTD as its not available on the big endian platform (we generate the data files used for those tests here).
+    posix_configure_flags: -DENABLE_ZSTD=0
   tasks:
     - name: compile
     - name: generate-datafile-little-endian


### PR DESCRIPTION
Disabling ZSTD on little endian as big endian doesn't support it.