### PR TITLE
WT-9634 s_export on a clean WT checkout complains about unit-test function

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -99,7 +99,7 @@ There are a number of additional configuration options you can pass to the CMake
 * `-DENABLE_SODIUM=1` : Build the libsodium encryptor extension
 * `-DHAVE_DIAGNOSTIC=1` : Enable WiredTiger diagnostics (enabled by default for non Release build types)
 * `-DHAVE_REF_TRACK=1` : Enable WiredTiger to track recent state transitions for WT_REF structures (always enabled in diagnostic build)
-* `-DHAVE_UNITTEST=1` : Enable WiredTiger unit tests (enabled by default)
+* `-DHAVE_UNITTEST=1` : Enable WiredTiger C++ Catch2 based unit tests
 * `-DHAVE_ATTACH=1` : Enable to pause for debugger attach on failure
 * `-DENABLE_PYTHON=1` : Compile the python API (enabled by default if python is available)
 * `-DCMAKE_INSTALL_PREFIX=<path-to-install-directory>` : Path to install directory

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -12,17 +12,9 @@ set(default_enable_tcmalloc ${HAVE_LIBTCMALLOC})
 set(default_enable_debug_info ON)
 set(default_enable_static OFF)
 set(default_enable_shared ON)
-set(default_have_unittest ON)
 
 if("${CMAKE_BUILD_TYPE}" MATCHES "^(Release|RelWithDebInfo)$")
     set(default_have_diagnostics OFF)
-endif()
-
-# Disable unittests when building MSan, reports an use-of-uninitalized-value error due
-# libstdc++ not being built with the sanitizer.
-# See https://github.com/catchorg/Catch2/issues/899.
-if("${CMAKE_BUILD_TYPE}" STREQUAL "MSan")
-    set(default_have_unittest OFF)
 endif()
 
 # Enable python if we have the minimum version.
@@ -118,8 +110,8 @@ config_bool(
 
 config_bool(
     HAVE_UNITTEST
-    "Enable WiredTiger unit tests"
-    DEFAULT ${default_have_unittest}
+    "Enable C++ Catch2 based WiredTiger unit tests"
+    DEFAULT OFF
 )
 
 config_bool(

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -102,7 +102,6 @@ functions:
 
         # Define common config flags for the tasks to make it cleaner when configuring the tasks.
         # Note that the config flags are resolved prior to changing to cmake_build directory.
-        # Unittest is enabled by default in cmake but disabled here because it causes failures in the s_all processing.
         DEFINED_EVERGREEN_CONFIG_FLAGS="${CMAKE_BUILD_TYPE|} \
           ${CMAKE_INSTALL_PREFIX|} \
           ${CMAKE_PREFIX_PATH|} \
@@ -114,7 +113,7 @@ functions:
           ${HAVE_BUILTIN_EXTENSION_ZLIB|} \
           ${HAVE_BUILTIN_EXTENSION_ZSTD|} \
           ${HAVE_FTRUNCATE|} \
-          ${HAVE_UNITTEST|-DHAVE_UNITTEST=0} \
+          ${HAVE_UNITTEST} \
           ${NON_BARRIER_DIAGNOSTIC_YIELDS|} \
           ${HAVE_DIAGNOSTIC|} \
           ${GNU_C_VERSION|} \


### PR DESCRIPTION
Disabling Catch2 C++ tests by default as it exposes additional symbols and downloads a 3rd party package