### PR TITLE
WT-9639 doc-update fails due to missing python folder

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2225,6 +2225,7 @@ tasks:
       - func: "compile wiredtiger docs"
 
   - name: doc-update
+    patchable: false
     stepback: false
     commands:
       - func: "get project"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2225,7 +2225,6 @@ tasks:
       - func: "compile wiredtiger docs"
 
   - name: doc-update
-    patchable: false
     stepback: false
     commands:
       - func: "get project"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -256,7 +256,8 @@ functions:
               if [ -d cmake_build ]; then rm -r cmake_build; fi
               mkdir -p cmake_build
               pushd cmake_build
-              $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" ../.
+              # Adding -DENABLE_PYTHON=1 -DENABLE_STRICT=1 as 6.0 does not default these like develop.
+              $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" -DENABLE_PYTHON=1 -DENABLE_STRICT=1 ../.
               make -C lang/python ${smp_command|}
             fi
             # Pop to root project directory.


### PR DESCRIPTION
Adding back enabling python and strict for doc compile for 6.0