### PR TITLE
WT-9635 Fix Cursor bound fuzz taking too long to run

### DIFF
--- a/test/suite/test_cursor_bound_fuzz.py
+++ b/test/suite/test_cursor_bound_fuzz.py
@@ -368,7 +368,7 @@ class test_cursor_bound_fuzz(wttest.WiredTigerTestCase):
     # generate N values and keep them in memory.
     value_array = []
     iteration_count = 200 if wttest.islongtest() else 50
-    value_size = 1000000 if wttest.islongtest() else 100
+    value_size = 100000 if wttest.islongtest() else 100
     value_array_size = 20
     key_count = 10000 if wttest.islongtest() else 1000
     min_key = 1


### PR DESCRIPTION
With this change, the unit-test-long takes 1hr now. Previously the unit-test-long would take 3 hrs.