### PR TITLE
WT-9393 Reading fast truncated pages in a readonly database can lead to cache stuck

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -426,7 +426,7 @@ static int
 __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
 {
     WT_REF *child;
-    bool active;
+    bool visible;
 
     /*
      * There may be cursors in the tree walking the list of child pages. The parent is locked, so
@@ -488,9 +488,24 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
                               */
             if (!__wt_atomic_casv8(&child->state, WT_REF_DELETED, WT_REF_LOCKED))
                 return (__wt_set_return(session, EBUSY));
-            active = __wt_page_del_active(session, child, true);
+            /*
+             * We can evict any truncation that's committed. However, restrictions in reconciliation
+             * mean that it needs to be visible to us when we get there. And unfortunately we are
+             * upstream of the point where eviction threads get snapshots. So, use the following
+             * logic:
+             *     1. If we already have a snapshot, use it to check visibility.
+             *     2. If we do not but we're an eviction thread, check if the operation is resolved.
+             *        We will get a snapshot shortly and any committed operation will be visible.
+             *     3. Otherwise, check if it is globally visible.
+             */
+            if (F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT))
+                visible = __wt_page_del_visible(session, child->ft_info.del, false);
+            else if (F_ISSET(session, WT_SESSION_EVICTION))
+                visible = __wt_page_del_committed(child->ft_info.del);
+            else
+                visible = __wt_page_del_visible(session, child->ft_info.del, true);
             child->state = WT_REF_DELETED;
-            if (active)
+            if (!visible)
                 return (__wt_set_return(session, EBUSY));
             break;
         default:

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1608,6 +1608,28 @@ __wt_page_del_active(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
 }
 
 /*
+ * __wt_page_del_committed --
+ *     Return if a truncate operation is resolved. (Since truncations that abort are removed
+ *     immediately, "resolved" and "committed" are equivalent here.) The caller should have already
+ *     locked the ref and confirmed that the ref's previous state was WT_REF_DELETED. The page_del
+ *     argument should be the ref's ft_info.del member.
+ */
+static inline bool
+__wt_page_del_committed(WT_PAGE_DELETED *page_del)
+{
+    /*
+     * There are two possible cases: either page_del is NULL (in which case the deletion is globally
+     * visible and must have been committed) or it is not, in which case page_del->committed tells
+     * us what we want to know.
+     */
+
+    if (page_del == NULL)
+        return (true);
+
+    return (page_del->committed);
+}
+
+/*
  * __wt_btree_syncing_by_other_session --
  *     Returns true if the session's current btree is being synced by another thread.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1988,6 +1988,8 @@ static inline bool __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bo
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_page_del_active(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_page_del_committed(WT_PAGE_DELETED *page_del)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_page_del_visible(WT_SESSION_IMPL *session, WT_PAGE_DELETED *page_del,
   bool visible_all) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_page_evict_clean(WT_PAGE *page)

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -208,10 +208,6 @@ class test_truncate15(wttest.WiredTigerTestCase):
             else:
                 raise e
 
-        # Move the stable timestamp forward before exiting so we don't waste time rolling
-        # back the changes during shutdown.
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
-
 if __name__ == '__main__':
     wttest.run()
 

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_truncate15.py
+#
+# Check that readonly database reading fast truncated pages doesn't lead to cache stuck.
+
+class test_truncate15(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all)'
+    session_config = 'isolation=snapshot'
+
+    # Hook to run using remove instead of truncate for reference. This should not alter the
+    # behavior... but may if things are broken. Disable the reference version by default as it's
+    # only useful when investigating behavior changes. This list is first in the make_scenarios
+    # call so the additional cases don't change the scenario numbering.
+    trunc_values = [
+        ('truncate', dict(trunc_with_remove=False)),
+        #('remove', dict(trunc_with_remove=True)),
+    ]
+
+    format_values = [
+        # Do not run against VLCS or FLCS until/unless they get fast-truncate support.
+        # The issue at hand is specific to fast-truncate pages and is not relevant to slow-truncate.
+        #('column', dict(key_format='r', value_format='S', extraconfig='')),
+        #('column_fix', dict(key_format='r', value_format='8t',
+        #    extraconfig=',allocation_size=512,leaf_page_max=512')),
+        ('integer_row', dict(key_format='i', value_format='S', extraconfig='')),
+    ]
+
+    scenarios = make_scenarios(trunc_values, format_values)
+
+    def truncate(self, uri, make_key, keynum1, keynum2):
+        if self.trunc_with_remove:
+            cursor = self.session.open_cursor(uri)
+            err = 0
+            for k in range(keynum1, keynum2 + 1):
+                cursor.set_key(k)
+                try:
+                    err = cursor.remove()
+                except WiredTigerError as e:
+                    if wiredtiger_strerror(WT_ROLLBACK) in str(e):
+                        err = WT_ROLLBACK
+                    else:
+                        raise e
+                if err != 0:
+                    break
+            cursor.close()
+        else:
+            lo_cursor = self.session.open_cursor(uri)
+            hi_cursor = self.session.open_cursor(uri)
+            lo_cursor.set_key(make_key(keynum1))
+            hi_cursor.set_key(make_key(keynum2))
+            try:
+                err = self.session.truncate(None, lo_cursor, hi_cursor, None)
+            except WiredTigerError as e:
+                if wiredtiger_strerror(WT_ROLLBACK) in str(e):
+                    err = WT_ROLLBACK
+                else:
+                    raise e
+            lo_cursor.close()
+            hi_cursor.close()
+        return err
+
+    def check(self, uri, make_key, nrows, nzeros, value, ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
+        seen = 0
+        zseen = 0
+        for k, v in cursor:
+            if self.value_format == '8t' and v == 0:
+                zseen += 1
+            else:
+                self.assertEqual(v, value)
+                seen += 1
+        self.assertEqual(seen, nrows)
+        self.assertEqual(zseen, nzeros if self.value_format == '8t' else 0)
+        self.session.rollback_transaction()
+        cursor.close()
+
+    def evict_cursor(self, uri, ds, nrows, ts):
+        s = self.conn.open_session()
+        s.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
+        # Configure debug behavior on a cursor to evict the page positioned on when reset is called.
+        evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(ds.key(i))
+            evict_cursor.search()
+            evict_cursor.reset()
+        s.rollback_transaction()
+        evict_cursor.close()
+
+    def test_truncate15(self):
+        # Note: 50000 is not large enough to trigger the problem.
+        nrows = 100000
+
+        uri = "table:truncate15"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config='log=(enabled=false)' + self.extraconfig)
+        ds.populate()
+
+        if self.value_format == '8t':
+            value_a = 97
+            value_b = 98
+        else:
+            value_a = "aaaaa" * 500
+            value_b = "bbbbb" * 500
+
+        # Pin oldest and stable timestamps to 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        # Write a bunch of data at time 10.
+        cursor = self.session.open_cursor(ds.uri)
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = value_a
+            # Commit every 101 rows to avoid overflowing the cache.
+            if i % 101 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        # Mark it stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+
+        # Reopen the connection so nothing is in memory and we can fast-truncate.
+        self.reopen_conn()
+
+        # Truncate the data at time 25, but prepare at 20 and make durable 30.
+        self.session.begin_transaction()
+        err = self.truncate(ds.uri, ds.key, nrows // 4 + 1, nrows // 4 + nrows // 2)
+        self.assertEqual(err, 0)
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(25))
+        self.session.commit_transaction('durable_timestamp=' + self.timestamp_str(30))
+
+        # Make sure we did at least one fast-delete. For columns, there's no fast-delete
+        # support (yet) so assert we didn't.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        if self.key_format == 'r':
+            self.assertEqual(fastdelete_pages, 0)
+        else:
+            self.assertGreater(fastdelete_pages, 0)
+
+        # Advance stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
+        self.session.checkpoint()
+
+        # Reopen the connection so nothing is in memory.
+        self.reopen_conn(".", "cache_size=1MB,eviction_dirty_target=90,eviction_dirty_trigger=100" +
+            ",eviction_updates_target=90,eviction_updates_trigger=100,readonly=true")
+
+        # Validate the data.
+        try:
+            # At time 10 we should see all value_a.
+            self.check(ds.uri, ds.key, nrows, 0, value_a, 10)
+            #self.evict_cursor(ds.uri, ds, nrows, 10)
+
+            # At time 20 we should still see all value_a.
+            self.check(ds.uri, ds.key, nrows, 0, value_a, 20)
+            #self.evict_cursor(ds.uri, ds, nrows, 20)
+
+            # At time 25 we should still see half value_a, and for FLCS, half zeros.
+            self.check(ds.uri, ds.key, nrows // 2, nrows // 2, value_a, 25)
+            #self.evict_cursor(ds.uri, ds, nrows // 2, 25)
+
+            # At time 30 we should also see half value_a, and for FLCS, half zeros.
+            self.check(ds.uri, ds.key, nrows // 2, nrows // 2, value_a, 30)
+            #self.evict_cursor(ds.uri, ds, nrows // 2, 30)
+        except WiredTigerError as e:
+            # If we get WT_ROLLBACK while reading, assume it's because we overflowed the
+            # cache, and fail. (If we don't trap this explicitly, the test harness retries
+            # the whole test, which is not what we want.)
+            if wiredtiger_strerror(WT_ROLLBACK) in str(e):
+                self.assertTrue(False)
+            else:
+                raise e
+
+        # Move the stable timestamp forward before exiting so we don't waste time rolling
+        # back the changes during shutdown.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
+
+if __name__ == '__main__':
+    wttest.run()
+


### PR DESCRIPTION
Evict any committed truncate, not just globally-visible ones.

This turns out to be more than a one-line change because for eviction threads the check happens before we get the snapshot that we'll be using to check for visibility. So in that case we want to check explicitly if the truncate's committed. Otherwise, if we have a snapshot, use it; otherwise fall back to a global visibility check.

Include the test Hari posted in the ticket as test_truncate15, with a few adjustments. Most notably, the cache overflow condition now results in reads failing with WT_ROLLBACK, so catch that and fail if we see it.

(Otherwise the test harness retries the whole test, and that isn't what we want.)

Also, I had to make it larger to get it to fail reliably.

Note 1: the transition from page_del_active to page_del_visible is not a functional change; page_del_active() returns !page_del_visible() and is going to go away.

Note 2: test_truncate13/14 are pending in WT-9603.