### PR TITLE
WT-9647 Correct the pointer return arguments in the mmap call chain

### DIFF
--- a/src/block_cache/block_map.c
+++ b/src/block_cache/block_map.c
@@ -13,15 +13,15 @@
  *     Map a segment of the file in, if possible.
  */
 int
-__wt_blkcache_map(WT_SESSION_IMPL *session, WT_BLOCK *block, void *mapped_regionp, size_t *lengthp,
-  void *mapped_cookiep)
+__wt_blkcache_map(WT_SESSION_IMPL *session, WT_BLOCK *block, void **mapped_regionp, size_t *lengthp,
+  void **mapped_cookiep)
 {
     WT_DECL_RET;
     WT_FILE_HANDLE *handle;
 
-    *(void **)mapped_regionp = NULL;
+    *mapped_regionp = NULL;
     *lengthp = 0;
-    *(void **)mapped_cookiep = NULL;
+    *mapped_cookiep = NULL;
 
     /* Map support is configurable. */
     if (!S2C(session)->mmap)
@@ -54,7 +54,7 @@ __wt_blkcache_map(WT_SESSION_IMPL *session, WT_BLOCK *block, void *mapped_region
      */
     ret = handle->fh_map(handle, (WT_SESSION *)session, mapped_regionp, lengthp, mapped_cookiep);
     if (ret == EBUSY || ret == ENOTSUP) {
-        *(void **)mapped_regionp = NULL;
+        *mapped_regionp = NULL;
         ret = 0;
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -86,8 +86,8 @@ extern int __wt_bad_object_type(WT_SESSION_IMPL *session, const char *uri)
   WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_blkcache_get_handle(WT_SESSION_IMPL *session, WT_BLOCK *orig, uint32_t objectid,
   WT_BLOCK **blockp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_blkcache_map(WT_SESSION_IMPL *session, WT_BLOCK *block, void *mapped_regionp,
-  size_t *lengthp, void *mapped_cookiep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_blkcache_map(WT_SESSION_IMPL *session, WT_BLOCK *block, void **mapped_regionp,
+  size_t *lengthp, void **mapped_cookiep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_blkcache_map_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr,
   size_t addr_size, bool *foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_blkcache_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],

--- a/src/include/extern_posix.h
+++ b/src/include/extern_posix.h
@@ -28,8 +28,8 @@ extern int __wt_posix_directory_list_single(WT_FILE_SYSTEM *file_system, WT_SESS
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_posix_file_extend(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session,
   wt_off_t offset) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_posix_map(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, void *mapped_regionp,
-  size_t *lenp, void *mapped_cookiep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_posix_map(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, void **mapped_regionp,
+  size_t *lenp, void **mapped_cookiep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_posix_map_discard(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, void *map,
   size_t length, void *mapped_cookie) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_posix_map_preload(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, const void *map,

--- a/src/include/extern_win.h
+++ b/src/include/extern_win.h
@@ -46,8 +46,8 @@ extern int __wt_win_directory_list_single(WT_FILE_SYSTEM *file_system, WT_SESSIO
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_win_fs_size(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *name,
   wt_off_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_win_map(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_regionp,
-  size_t *lenp, void *mapped_cookiep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_win_map(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void **mapped_regionp,
+  size_t *lenp, void **mapped_cookiep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_win_unmap(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_region,
   size_t length, void *mapped_cookie) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uintmax_t __wt_process_id(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4847,7 +4847,7 @@ struct __wt_file_handle {
 	 *    which is subsequently passed to WT_FILE_HANDLE::unmap.
 	 */
 	int (*fh_map)(WT_FILE_HANDLE *file_handle, WT_SESSION *session,
-	    void *mapped_regionp, size_t *lengthp, void *mapped_cookiep);
+	    void **mapped_regionp, size_t *lengthp, void **mapped_cookiep);
 
 	/*!
 	 * Unmap part of a memory mapped file, based on the POSIX 1003.1

--- a/src/os_posix/os_map.c
+++ b/src/os_posix/os_map.c
@@ -13,8 +13,8 @@
  *     Map a file into memory.
  */
 int
-__wt_posix_map(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, void *mapped_regionp, size_t *lenp,
-  void *mapped_cookiep)
+__wt_posix_map(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, void **mapped_regionp, size_t *lenp,
+  void **mapped_cookiep)
 {
     WT_FILE_HANDLE_POSIX *pfh;
     WT_SESSION_IMPL *session;
@@ -52,7 +52,7 @@ __wt_posix_map(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, void *mapped_regionp,
            pfh->fd, (wt_off_t)0)) == MAP_FAILED)
         WT_RET_MSG(session, __wt_errno(), "%s: memory-map: mmap", fh->name);
 
-    *(void **)mapped_regionp = map;
+    *mapped_regionp = map;
     *lenp = len;
     return (0);
 }

--- a/src/os_win/os_map.c
+++ b/src/os_win/os_map.c
@@ -13,8 +13,8 @@
  *     Map a file into memory.
  */
 int
-__wt_win_map(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_regionp,
-  size_t *lenp, void *mapped_cookiep)
+__wt_win_map(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void **mapped_regionp,
+  size_t *lenp, void **mapped_cookiep)
 {
     WT_DECL_RET;
     WT_FILE_HANDLE_WIN *win_fh;
@@ -58,8 +58,8 @@ __wt_win_map(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, void *mapped_r
         return (ret);
     }
 
-    *(void **)mapped_cookiep = mapped_cookie;
-    *(void **)mapped_regionp = map;
+    *mapped_cookiep = mapped_cookie;
+    *mapped_regionp = map;
     *lenp = len;
     return (0);
 }


### PR DESCRIPTION
Correct the pointer-return argument types in the mmap call chain.

Note: the use of `void *` instead of `void **` to accept a pointer to an arbitrary pointer occurs because because if `x` is a `foo *` rather than a `void *`, passing `&x` to an argument of type `void **` is rejected by the compiler. Declaring the argument as `void *` prevents this check, and works on all real machines (as opposed to those run only by comp.lang.c contributors). That's why it was the way it was.

However, it's unsafe (in that you can accidentally pass `x` instead of `&x `and it won't be caught) and also hiding formally undefined behavior (at least with strict-aliasing enabled) and that might eventually lead to problems. Furthermore, the call sites we have are already passing the address of a `void *`, so there's no particular need for this leeway.

The change technically changes the signatures of the affected functions, but I know of no real machine where this change will actually affect the function call ABI, so as best I know it won't break binary compatibility.

However: the change also affects the WT_FILE_HANDLE map call, which is published in the extension API. This should still not break the build of any formally correct usage calling it, but if we think someone out there is taking advantage of the leeway, or providing their own file handles with map support (the latter seems pretty unlikely, granted) maybe we shouldn't do this.

For these reasons this change should get plenty of scrutiny.

(Also, I don't have a Windows machine so haven't actually tested the Windows build yet.)