### PR TITLE
WT-9466 Rework cppsuite-hs-cleanup code

### DIFF
--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -23,7 +23,8 @@ metrics_monitor=
     stat_cache_size=
     (
         # FIXME-WT-9339
-        # Add the runtime check once we better manager the cache.
+        # Re-enable the runtime check once we manage cache better.
+        max=200,
         runtime=false,
     ),
     stat_db_size=

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -23,9 +23,8 @@ metrics_monitor=
     stat_cache_size=
     (
         # FIXME-WT-9339
-        # one day maybe we'll stop blowing out the cache.
-        max=200,
-        runtime=true,
+        # Add the runtime check once we better manager the cache.
+        runtime=false,
     ),
     stat_db_size=
     (

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -215,8 +215,7 @@ database_operation::insert_operation(thread_worker *tc)
         testutil_assert(counter < collections_per_thread);
     }
     /* Make sure the last transaction is rolled back now the work is finished. */
-    if (tc->txn.active())
-        tc->txn.rollback();
+    tc->txn.try_rollback();
 }
 
 void
@@ -257,8 +256,7 @@ database_operation::read_operation(thread_worker *tc)
         testutil_check(cursor->reset(cursor.get()));
     }
     /* Make sure the last transaction is rolled back now the work is finished. */
-    if (tc->txn.active())
-        tc->txn.rollback();
+    tc->txn.try_rollback();
 }
 
 void
@@ -341,8 +339,7 @@ database_operation::remove_operation(thread_worker *tc)
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */
-    if (tc->txn.active())
-        tc->txn.rollback();
+    tc->txn.try_rollback();
 }
 
 void
@@ -401,8 +398,7 @@ database_operation::update_operation(thread_worker *tc)
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */
-    if (tc->txn.active())
-        tc->txn.rollback();
+    tc->txn.try_rollback();
 }
 
 void

--- a/test/cppsuite/src/main/transaction.cpp
+++ b/test/cppsuite/src/main/transaction.cpp
@@ -122,7 +122,7 @@ transaction::rollback(const std::string &config)
 void
 transaction::try_rollback(const std::string &config)
 {
-    if (can_rollback())
+    if (_in_txn)
         rollback(config);
 }
 
@@ -156,12 +156,6 @@ transaction::set_needs_rollback(bool rollback)
 bool
 transaction::can_commit()
 {
-    return (!_needs_rollback && can_rollback());
-}
-
-bool
-transaction::can_rollback()
-{
-    return (_in_txn && _op_count >= _target_op_count);
+    return (!_needs_rollback && _in_txn && _op_count >= _target_op_count);
 }
 } // namespace test_harness

--- a/test/cppsuite/src/main/transaction.h
+++ b/test/cppsuite/src/main/transaction.h
@@ -66,11 +66,6 @@ class transaction {
      * the transaction.
      */
     bool can_commit();
-    /*
-     * Returns true if a transaction can be rolled back as determined by the op count and the state
-     * of the transaction.
-     */
-    bool can_rollback();
     /* Get the number of operations this transaction needs before it can commit */
     int64_t get_target_op_count() const;
 

--- a/test/cppsuite/tests/burst_inserts.cpp
+++ b/test/cppsuite/tests/burst_inserts.cpp
@@ -146,8 +146,7 @@ class burst_inserts : public test {
             tc->sleep();
         }
         /* Make sure the last transaction is rolled back now the work is finished. */
-        if (tc->txn.active())
-            tc->txn.rollback();
+        tc->txn.try_rollback();
     }
 
     private:

--- a/test/cppsuite/tests/cache_resize.cpp
+++ b/test/cppsuite/tests/cache_resize.cpp
@@ -163,8 +163,7 @@ class cache_resize : public test {
         }
 
         /* Make sure the last transaction is rolled back now the work is finished. */
-        if (tc->txn.active())
-            tc->txn.rollback();
+        tc->txn.try_rollback();
     }
 
     void

--- a/test/cppsuite/tests/cursor_bound_01.cpp
+++ b/test/cppsuite/tests/cursor_bound_01.cpp
@@ -584,8 +584,7 @@ class cursor_bound_01 : public test {
             testutil_check(cursor->reset(cursor.get()));
         }
         /* Rollback any transaction that could not commit before the end of the test. */
-        if (tc->txn.active())
-            tc->txn.rollback();
+        tc->txn.try_rollback();
     }
 
     void
@@ -649,8 +648,7 @@ class cursor_bound_01 : public test {
         }
 
         /* Rollback any transaction that could not commit before the end of the test. */
-        if (tc->txn.active())
-            tc->txn.rollback();
+        tc->txn.try_rollback();
     }
 
     void
@@ -734,8 +732,7 @@ class cursor_bound_01 : public test {
             normal_cursor->reset(normal_cursor.get());
         }
         /* Roll back the last transaction if still active now the work is finished. */
-        if (tc->txn.active())
-            tc->txn.commit();
+        tc->txn.try_rollback();
     }
 
     void
@@ -783,7 +780,6 @@ class cursor_bound_01 : public test {
             normal_cursor->reset(normal_cursor.get());
         }
         /* Roll back the last transaction if still active now the work is finished. */
-        if (tc->txn.active())
-            tc->txn.rollback();
+        tc->txn.try_rollback();
     }
 };

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -26,6 +26,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include "src/common/logger.h"
 #include "src/common/random_generator.h"
 #include "src/main/test.h"
 
@@ -52,43 +53,34 @@ class hs_cleanup : public test {
         logger::log_msg(
           LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
-        const char *key_tmp;
         const uint64_t MAX_ROLLBACKS = 100;
         uint32_t rollback_retries = 0;
 
-        collection &coll = tc->db.get_collection(tc->id);
-
         /* In this test each thread gets a single collection. */
         testutil_assert(tc->db.get_collection_count() == tc->thread_count);
+
+        collection &coll = tc->db.get_collection(tc->id);
         scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
 
-        /* We don't know the keyrange we're operating over here so we can't be much smarter here. */
+        /*
+         * We don't know the key range we're operating over here so we can't be much smarter here.
+         */
         while (tc->running()) {
             tc->sleep();
 
-            auto ret = cursor->next(cursor.get());
-            if (ret != 0) {
-                if (ret == WT_NOTFOUND) {
-                    testutil_check(cursor->reset(cursor.get()));
-                    continue;
-                }
-                if (ret == WT_ROLLBACK) {
-                    /*
-                     * As a result of the logic in this test its possible that the previous next
-                     * call can happen outside the context of a transaction. Assert that we are in
-                     * one if we got a rollback.
-                     */
-                    testutil_check(tc->txn.can_rollback());
-                    tc->txn.rollback();
-                    continue;
-                }
-                testutil_die(ret, "Unexpected error returned from cursor->next()");
-            }
-
-            testutil_check(cursor->get_key(cursor.get(), &key_tmp));
-
             /* Start a transaction if possible. */
             tc->txn.try_begin();
+
+            auto ret = cursor->next(cursor.get());
+            if (ret != 0) {
+                testutil_assert(ret == WT_NOTFOUND || ret == WT_ROLLBACK);
+                testutil_check(cursor->reset(cursor.get()));
+                tc->txn.rollback();
+                continue;
+            }
+
+            const char *key_tmp;
+            testutil_check(cursor->get_key(cursor.get(), &key_tmp));
 
             /*
              * The retrieved key needs to be passed inside the update function. However, the update
@@ -111,7 +103,6 @@ class hs_cleanup : public test {
             testutil_assert(rollback_retries < MAX_ROLLBACKS);
         }
         /* Ensure our last transaction is resolved. */
-        if (tc->txn.active())
-            tc->txn.rollback();
+        tc->txn.try_rollback();
     }
 };

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -73,9 +73,9 @@ class hs_cleanup : public test {
 
             auto ret = cursor->next(cursor.get());
             if (ret != 0) {
-                if(ret == WT_NOTFOUND)
+                if (ret == WT_NOTFOUND)
                     testutil_check(cursor->reset(cursor.get()));
-                else if(ret == WT_ROLLBACK)
+                else if (ret == WT_ROLLBACK)
                     tc->txn.rollback();
                 else
                     testutil_die(ret, "Unexpected error returned from cursor->next()");

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -73,9 +73,12 @@ class hs_cleanup : public test {
 
             auto ret = cursor->next(cursor.get());
             if (ret != 0) {
-                testutil_assert(ret == WT_NOTFOUND || ret == WT_ROLLBACK);
-                testutil_check(cursor->reset(cursor.get()));
-                tc->txn.rollback();
+                if(ret == WT_NOTFOUND)
+                    testutil_check(cursor->reset(cursor.get()));
+                else if(ret == WT_ROLLBACK)
+                    tc->txn.rollback();
+                else
+                    testutil_die(ret, "Unexpected error returned from cursor->next()");
                 continue;
             }
 

--- a/test/cppsuite/tests/search_near_02.cpp
+++ b/test/cppsuite/tests/search_near_02.cpp
@@ -133,8 +133,7 @@ class search_near_02 : public test {
             }
 
             /* Rollback any transaction that could not commit before the end of the test. */
-            if (tc->txn.active())
-                tc->txn.rollback();
+            tc->txn.try_rollback();
 
             /* Reset our cursor to avoid pinning content. */
             testutil_check(cc.cursor->reset(cc.cursor.get()));
@@ -219,8 +218,7 @@ class search_near_02 : public test {
             testutil_check(cursor_prefix->reset(cursor_prefix.get()));
         }
         /* Roll back the last transaction if still active now the work is finished. */
-        if (tc->txn.active())
-            tc->txn.rollback();
+        tc->txn.try_rollback();
     }
 
     private:


### PR DESCRIPTION
The changes include:

- A rework of the cppsuite-hs-cleanup code
- The deactivation of the cache size runtime check
- The removal of the `can_rollback()` function