### PR TITLE
WT-9643 Fix pthread_mutex_destroy() failure during test_checkpoint.

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -86,17 +86,17 @@ end_threads(void)
         testutil_check(__wt_thread_join(NULL, &g.flush_thread));
         __wt_rwlock_destroy(NULL, &g.flush_lock);
     }
-    if (g.use_timestamps)
-        /* Don't destroy the clock lock yet, it is also used by the checkpoint thread */
-        testutil_check(__wt_thread_join(NULL, &g.clock_thread));
-
-    /*
-     * Shutdown checkpoint after flush thread completes because flush depends on checkpoint. Then we
-     * can destroy the clock lock too.
-     */
+    /* Shutdown checkpoint after flush thread completes because flush depends on checkpoint. */
     testutil_check(__wt_thread_join(NULL, &g.checkpoint_thread));
-    if (g.use_timestamps)
+
+    if (g.use_timestamps) {
+        /*
+         * The clock lock is also used by the checkpoint thread. Now that it has exited it is safe
+         * to destroy that lock.
+         */
+        testutil_check(__wt_thread_join(NULL, &g.clock_thread));
         __wt_rwlock_destroy(NULL, &g.clock_lock);
+    }
 }
 
 /*


### PR DESCRIPTION
We need to wait to destroy the lock protecting the stable timestamp
until all threads using that lock have exited.