### PR TITLE
WT-9209 Cannot build Release build with ENABLE_STRICT enabled

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1052,7 +1052,7 @@ monitor(void *arg)
 
     wtperf = (WTPERF *)arg;
     opts = wtperf->opts;
-    assert(opts->sample_interval != 0);
+    testutil_assert(opts->sample_interval != 0);
 
     fp = jfp = NULL;
     first = true;

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -31,7 +31,6 @@
 
 #include "test_util.h"
 
-#include <assert.h>
 #include <math.h>
 
 #include "config_opt.h"

--- a/ext/test/fail_fs/CMakeLists.txt
+++ b/ext/test/fail_fs/CMakeLists.txt
@@ -9,8 +9,10 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/src/include
         ${CMAKE_BINARY_DIR}/include
         ${CMAKE_BINARY_DIR}/config
+	${CMAKE_SOURCE_DIR}/test/utility
 )
 target_compile_options(
     wiredtiger_fail_fs
     PRIVATE ${COMPILER_DIAGNOSTIC_C_FLAGS}
 )
+target_link_libraries(wiredtiger_fail_fs test_util)

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -38,8 +38,8 @@
 #include <execinfo.h>
 
 #include <wiredtiger_ext.h>
-#include "misc.h"
 #include "queue.h"
+#include "test_util.h"
 
 #define FAIL_FS_GIGABYTE (1024 * 1024 * 1024)
 
@@ -116,37 +116,25 @@ static int fail_fs_terminate(WT_FILE_SYSTEM *, WT_SESSION *);
 static void
 fail_fs_allocate_lock(pthread_rwlock_t *lockp)
 {
-    int ret;
-    ret = pthread_rwlock_init(lockp, NULL);
-    assert(ret == 0);
-    WT_UNUSED(ret); /* Marking unused for release builds. */
+    testutil_assert(pthread_rwlock_init(lockp, NULL) == 0);
 }
 
 static void
 fail_fs_destroy_lock(pthread_rwlock_t *lockp)
 {
-    int ret;
-    ret = pthread_rwlock_destroy(lockp);
-    assert(ret == 0);
-    WT_UNUSED(ret); /* Marking unused for release builds. */
+    testutil_assert(pthread_rwlock_destroy(lockp) == 0);
 }
 
 static void
 fail_fs_lock(pthread_rwlock_t *lockp)
 {
-    int ret;
-    ret = pthread_rwlock_wrlock(lockp);
-    assert(ret == 0);
-    WT_UNUSED(ret); /* Marking unused for release builds. */
+    testutil_assert(pthread_rwlock_wrlock(lockp) == 0);
 }
 
 static void
 fail_fs_unlock(pthread_rwlock_t *lockp)
 {
-    int ret;
-    ret = pthread_rwlock_unlock(lockp);
-    assert(ret == 0);
-    WT_UNUSED(ret); /* Marking unused for release builds. */
+    testutil_assert(pthread_rwlock_unlock(lockp) == 0);
 }
 
 /*

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -38,6 +38,7 @@
 #include <execinfo.h>
 
 #include <wiredtiger_ext.h>
+#include "misc.h"
 #include "queue.h"
 
 #define FAIL_FS_GIGABYTE (1024 * 1024 * 1024)
@@ -115,25 +116,37 @@ static int fail_fs_terminate(WT_FILE_SYSTEM *, WT_SESSION *);
 static void
 fail_fs_allocate_lock(pthread_rwlock_t *lockp)
 {
-    assert(pthread_rwlock_init(lockp, NULL) == 0);
+    int ret;
+    ret = pthread_rwlock_init(lockp, NULL);
+    assert(ret == 0);
+    WT_UNUSED(ret); /* Marking unused for release builds. */
 }
 
 static void
 fail_fs_destroy_lock(pthread_rwlock_t *lockp)
 {
-    assert(pthread_rwlock_destroy(lockp) == 0);
+    int ret;
+    ret = pthread_rwlock_destroy(lockp);
+    assert(ret == 0);
+    WT_UNUSED(ret); /* Marking unused for release builds. */
 }
 
 static void
 fail_fs_lock(pthread_rwlock_t *lockp)
 {
-    assert(pthread_rwlock_wrlock(lockp) == 0);
+    int ret;
+    ret = pthread_rwlock_wrlock(lockp);
+    assert(ret == 0);
+    WT_UNUSED(ret); /* Marking unused for release builds. */
 }
 
 static void
 fail_fs_unlock(pthread_rwlock_t *lockp)
 {
-    assert(pthread_rwlock_unlock(lockp) == 0);
+    int ret;
+    ret = pthread_rwlock_unlock(lockp);
+    assert(ret == 0);
+    WT_UNUSED(ret); /* Marking unused for release builds. */
 }
 
 /*

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -6,7 +6,6 @@
  * See the file LICENSE for redistribution information.
  */
 
-#include <assert.h>
 #include "util.h"
 #include "util_dump.h"
 
@@ -422,8 +421,8 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor, char
 
             /* copy names of projected values */
             p = strchr(cursor->uri, '(');
-            assert(p != NULL);
-            assert(p[strlen(p) - 1] == ')');
+            WT_ASSERT((WT_SESSION_IMPL *)session, p != NULL);
+            WT_ASSERT((WT_SESSION_IMPL *)session, p[strlen(p) - 1] == ')');
             p++;
             if (*p != ')')
                 WT_RET(dump_add_config(session, &newconfig, &len, "%s", ","));
@@ -437,7 +436,7 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor, char
     if (ret != WT_NOTFOUND)
         return (util_err(session, ret, "WT_CONFIG_PARSER.next"));
 
-    assert(len > 0);
+    WT_ASSERT((WT_SESSION_IMPL *)session, len > 0);
     if ((ret = parser->close(parser)) != 0)
         return (util_err(session, ret, "WT_CONFIG_PARSER.close"));
 

--- a/test/fuzz/config/fuzz_config.c
+++ b/test/fuzz/config/fuzz_config.c
@@ -27,8 +27,6 @@
  */
 #include "fuzz_util.h"
 
-#include <assert.h>
-
 int LLVMFuzzerTestOneInput(const uint8_t *, size_t);
 
 /*
@@ -50,7 +48,7 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     if (!fuzzutil_sliced_input_init(&input, data, size, separator, sizeof(separator), 2))
         return (0);
 
-    assert(input.num_slices == 2);
+    testutil_assert(input.num_slices == 2);
     key = fuzzutil_slice_to_cstring(input.slices[0], input.sizes[0]);
     if (key == NULL)
         testutil_die(ENOMEM, "Failed to allocate key");

--- a/test/fuzz/fuzz_util.c
+++ b/test/fuzz/fuzz_util.c
@@ -27,7 +27,6 @@
  */
 #include "fuzz_util.h"
 
-#include <assert.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -61,7 +60,7 @@ fuzzutil_setup(void)
     char home[100];
 
     if (fuzz_state.conn != NULL) {
-        assert(fuzz_state.session != NULL);
+        testutil_assert(fuzz_state.session != NULL);
         return;
     }
 

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -28,8 +28,6 @@
 
 #include "test_util.h"
 
-#include <assert.h>
-
 #define HOME "WT_TEST"
 #define DUMP "WT_TEST/__slvg.dump"   /* Dump file */
 #define LOAD "WT_TEST/__slvg.load"   /* Build file */
@@ -545,7 +543,7 @@ build(int ikey, int ivalue, int cnt)
           PSIZE, PSIZE, PSIZE, OSIZE, OSIZE));
         break;
     default:
-        assert(0);
+        testutil_assert(0);
     }
     testutil_check(session->create(session, LOAD_URI, config));
     testutil_check(session->open_cursor(session, LOAD_URI, NULL, "bulk,append", &cursor));


### PR DESCRIPTION
Cleaning up usage of assert from assert.h and enabling compile with Release build type. Updated fail fs to use test_util.