### PR TITLE
WT-9555 Add dedicated mirror config and trace arguments to test/format

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -445,7 +445,7 @@ functions:
         set -o errexit
         set -o verbose
         for i in $(seq ${times|1}); do
-          ./t -c ${config|../../../test/format/CONFIG.stress} ${extra_args|} || ( [ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG ) 2>&1
+          ./t -c ${config|../../../test/format/CONFIG.stress} ${trace_args|-T bulk,txn,retain=100} ${extra_args|} || ( [ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG ) 2>&1
         done
   "format test script":
     command: shell.exec
@@ -2577,7 +2577,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "format test"
         vars:
-          config: CONFIG.mirror
+          config: ../../../test/format/CONFIG.mirror
           trace_args: -T all
 
   - name: format-stress-pull-request-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2571,6 +2571,15 @@ tasks:
 
             RW_LOCK_FILE=$(pwd)/../../cmake_build/test/csuite/rwlock/test_rwlock ./time_shift_test.sh /usr/local/lib/faketime/libfaketimeMT.so.1 0-1 2>&1
 
+  - name: format-mirror-test
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "format test"
+        vars:
+          config: CONFIG.mirror
+          trace_args: -T all
+
   - name: format-stress-pull-request-test
     tags: ["pull_request"]
     commands:
@@ -3934,6 +3943,7 @@ buildvariants:
     - name: static-wt-build-test
     - name: linux-directio
       distros: ubuntu2004-build
+    - name: format-mirror-test
     - name: format-smoke-test
     - name: format-failure-configs-test
     - name: data-validation-stress-test-checkpoint

--- a/test/format/CONFIG.mirror
+++ b/test/format/CONFIG.mirror
@@ -1,0 +1,8 @@
+# Similar to the stress config, with the addition of mirroring.
+btree.huffman_value=0
+cache.minimum=20
+runs.mirror=1
+runs.rows=1000000:5000000
+runs.tables=3:10
+runs.threads=4:32
+runs.timer=6:30


### PR DESCRIPTION
This changes all Evergreen test/format configurations to have some amount of tracing by default. It also adds a dedicated `format-mirror-test` task that's basically the stress config but with all tracing enabled.

There are a couple of linked patch builds on the Jira ticket. These two patch builds run every single test-format configuration I could find, so I believe the new tracing defaults are safe to add.

There's a failure for `format-abort-recovery-stress-test` in `table_verify_mirror`, so there's clearly an issue elsewhere in this branch, but I don't believe it's related to this tracing change. I'll investigate it, but I don't think it should block me from getting some feedback on this PR.