### PR TITLE
WT-9710 Re-enable tcmalloc usage in evergreen

### DIFF
--- a/cmake/define_libwiredtiger.cmake
+++ b/cmake/define_libwiredtiger.cmake
@@ -72,9 +72,6 @@ macro(define_wiredtiger_library target type)
     if(ENABLE_MEMKIND)
         target_link_libraries(${target} PRIVATE wt::memkind)
     endif()
-    if(ENABLE_TCMALLOC)
-        target_link_libraries(${target} PRIVATE wt::tcmalloc)
-    endif()
 
     # We want to capture any transitive dependencies associated with the builtin library
     # target and ensure we are explicitly linking the 3rd party libraries.

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -138,6 +138,11 @@ target_compile_options(${swig_wt_target}
 
 swig_link_libraries(wiredtiger_python ${wiredtiger_target} ${python_libs})
 
+if(ENABLE_TCMALLOC)
+    # Order matters on linking as WT lib depends on tcmalloc when enabled.
+    swig_link_libraries(wiredtiger_python ${wiredtiger_target} wt::tcmalloc)
+endif()
+
 # Setup our output 'wiredtiger' directory to hold the python module sources.
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/wiredtiger
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -35,7 +35,7 @@ target_include_directories(wt
 target_link_libraries(wt wt::wiredtiger)
 
 if(ENABLE_TCMALLOC)
-    target_link_libraries(wt wt::tcmalloc)
+    target_link_libraries(wt wt::wiredtiger wt::tcmalloc)
 endif()
 
 # Our test suite expects `wt` to sit at the top level build directory.

--- a/test/cppsuite/CMakeLists.txt
+++ b/test/cppsuite/CMakeLists.txt
@@ -55,11 +55,6 @@ create_test_executable(csuite_style_example_test
     CXX
 )
 
-if(ENABLE_TCMALLOC)
-    target_link_libraries(run wt::tcmalloc)
-    target_link_libraries(csuite_style_example_test wt::tcmalloc)
-endif()
-
 # Test definitions.
 add_test(NAME cppsuite COMMAND ${CMAKE_CURRENT_BINARY_DIR}/run)
 

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -105,6 +105,11 @@ function(create_test_executable target)
         target_link_libraries(${target} windows_shim)
     endif()
 
+    if(ENABLE_TCMALLOC)
+        # Order matters on linking as WT lib depends on tcmalloc when enabled.
+        target_link_libraries(${target} wt::wiredtiger wt::tcmalloc)
+    endif()
+
     # Install any additional files, scripts, etc in the output test binary
     # directory. Useful if we need to setup an additional wrappers needed to run the test
     # executable.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4082,7 +4082,7 @@ buildvariants:
     - name: format-abort-recovery-stress-test
 
 # When running the Python tests on this variant tcmalloc must be preloaded otherwise the wiredtiger library
-# fails to load and resolve its dependency..
+# fails to load and resolve its dependency.
 - name: ubuntu2004-stress-tests-arm64
   display_name: Ubuntu 20.04 Stress tests (ARM64)
   run_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4081,6 +4081,8 @@ buildvariants:
     - name: ".stress-test-sanitizer-4"
     - name: format-abort-recovery-stress-test
 
+# When running the Python tests on this variant tcmalloc must be preloaded otherwise the wiredtiger library
+# fails to load and resolve its dependency..
 - name: ubuntu2004-stress-tests-arm64
   display_name: Ubuntu 20.04 Stress tests (ARM64)
   run_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -104,6 +104,7 @@ functions:
         # Note that the config flags are resolved prior to changing to cmake_build directory.
         DEFINED_EVERGREEN_CONFIG_FLAGS="${CMAKE_BUILD_TYPE|} \
           ${CMAKE_INSTALL_PREFIX|} \
+          ${CMAKE_PREFIX_PATH|} \
           ${CMAKE_TOOLCHAIN_FILE|} \
           ${ENABLE_SHARED|} \
           ${ENABLE_STATIC|} \
@@ -4091,7 +4092,7 @@ buildvariants:
       PATH=/opt/mongodbtoolchain/v3/bin:$PATH
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
-      LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libeatmydata.so
+      LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libeatmydata.so:$WT_TOPDIR/TCMALLOC_LIB/lib/libtcmalloc.so.4
       LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib
     CMAKE_PREFIX_PATH: -DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"
     CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -37,9 +37,6 @@ target_compile_options(
 )
 
 target_link_libraries(unittests Catch2::Catch2)
-if(ENABLE_TCMALLOC)
-    target_link_libraries(unittests wt::tcmalloc)
-endif()
 
 add_test(NAME unittest COMMAND ${CMAKE_CURRENT_BINARY_DIR}/unittests)
 set_tests_properties(unittest PROPERTIES LABELS "check;unittest")


### PR DESCRIPTION
Re-enabled tcmalloc usage in evergreen. Updated linking of tcmalloc from at the shared object level to the executable level which should prevent running multiple allocators which is known to introduce issues.