### PR TITLE
WT-9729 Fix data modification operations with bounds cursor

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1547,11 +1547,8 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
     session = CUR2S(cbt);
     yield_count = sleep_usecs = 0;
 
-    /* It's no longer possible to bulk-load into the tree. */
-    __wt_btree_disable_bulk(session);
-
     /*
-     * Check that the provided insert key is within bounds. If not, return WT_NOTFOUND and early
+     * Check that the provided update key is within bounds. If not, return WT_NOTFOUND and early
      * exit.
      */
     if (WT_CURSOR_BOUNDS_SET(cursor)) {
@@ -1565,6 +1562,9 @@ __btcur_update(WT_CURSOR_BTREE *cbt, WT_ITEM *value, u_int modify_type)
         if (key_out_of_bounds)
             WT_ERR(WT_NOTFOUND);
     }
+
+    /* It's no longer possible to bulk-load into the tree. */
+    __wt_btree_disable_bulk(session);
 
     /* Save the cursor state. */
     __cursor_state_save(cursor, &state);

--- a/test/suite/test_cursor_bound14.py
+++ b/test/suite/test_cursor_bound14.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+from wtbound import bound_base
+
+# test_cursor_bound14.py
+# Test the next() and prev() calls in the cursor bound API. Test general use cases of bound API,
+# including setting lower bounds and upper bounds.
+class test_cursor_bound14(bound_base):
+    file_name = 'test_cursor_bound14'
+
+    types = [
+        ('file', dict(uri='file:', use_colgroup=False)),
+        ('table', dict(uri='table:', use_colgroup=False)),
+        # FIXME-WT-9738: Uncomment once bug with remove operations on a bounded cursor with colgroups is fixed.
+        #('colgroup', dict(uri='table:', use_colgroup=True))
+    ]
+
+    key_formats = [
+        ('string', dict(key_format='S')),
+        ('var', dict(key_format='r')),
+        ('int', dict(key_format='i')),
+        ('bytes', dict(key_format='u')),
+        ('composite_string', dict(key_format='SSS')),
+        ('composite_int_string', dict(key_format='iS')),
+        ('composite_complex', dict(key_format='iSru')),
+    ]
+
+    value_formats = [
+        ('string', dict(value_format='S')),
+        # FIX-ME-WT-9589: Fix bug complex colgroups not returning records within bounds.
+        # ('complex-string', dict(value_format='SS')),
+    ]
+
+    cursor_config = [
+        ('overwrite', dict(cursor_config="")),
+        ('no-overwrite', dict(cursor_config="overwrite=false")),
+    ]
+    config = [
+        ('lower-bounds-evict', dict(lower_bounds=True,upper_bounds=False,evict=True)),
+        ('upper-bounds-evict', dict(lower_bounds=False,upper_bounds=True,evict=True)),
+        ('both-bounds-evict', dict(lower_bounds=True,upper_bounds=True,evict=True)),
+        ('lower-bounds-no-evict', dict(lower_bounds=True,upper_bounds=False,evict=True)),
+        ('upper-bounds-no-evict', dict(lower_bounds=False,upper_bounds=True,evict=True)),  
+        ('both-bounds-no-evict', dict(lower_bounds=True,upper_bounds=True,evict=False)),
+    ]
+
+    scenarios = make_scenarios(types, key_formats, value_formats, config, cursor_config)
+
+    def test_bound_data_operations(self):
+        cursor = self.create_session_and_cursor(self.cursor_config)
+
+        cursor.set_key(self.gen_key(10))
+        cursor.set_value(self.gen_val(100))
+        self.assertEqual(cursor.insert(), 0)
+
+        cursor.set_key(self.gen_key(95))
+        cursor.set_value(self.gen_val(100))
+        self.assertEqual(cursor.insert(), 0)
+        
+        if (self.lower_bounds):
+            self.set_bounds(cursor, 45, "lower", self.lower_inclusive)
+        if (self.upper_bounds):
+            self.set_bounds(cursor, 50, "upper", self.upper_inclusive)
+
+        # Test bound API: test inserting key outside of bounds.
+        cursor.set_key(self.gen_key(15))
+        cursor.set_value(self.gen_val(120))
+        if (self.lower_bounds):
+            self.assertRaisesHavingMessage(
+                wiredtiger.WiredTigerError, lambda: cursor.insert(), '/item not found/')
+        else:
+            self.assertEqual(cursor.insert(), 0)
+
+        cursor.set_key(self.gen_key(90))
+        cursor.set_value(self.gen_val(120))
+        if (self.upper_bounds):
+            self.assertRaisesHavingMessage(
+                wiredtiger.WiredTigerError, lambda: cursor.insert(), '/item not found/')
+        else:
+            self.assertEqual(cursor.insert(), 0)
+
+        # Test bound API: test updating an existing key outside of bounds.
+        cursor.set_key(self.gen_key(10))
+        cursor.set_value(self.gen_val(120))
+        if (self.lower_bounds):
+            self.assertEqual(cursor.update(), wiredtiger.WT_NOTFOUND)
+        else:
+            self.assertEqual(cursor.update(), 0)
+        
+
+        cursor.set_key(self.gen_key(95))
+        cursor.set_value(self.gen_val(120))
+        if (self.upper_bounds):
+            self.assertEqual(cursor.update(), wiredtiger.WT_NOTFOUND)
+        else:
+            self.assertEqual(cursor.update(), 0)
+
+        # Test bound API: test reserve on an existing key with bounds.
+        self.session.begin_transaction()
+        cursor.set_key(self.gen_key(10))
+        if (self.lower_bounds):
+            self.assertRaisesHavingMessage(
+                wiredtiger.WiredTigerError, lambda: cursor.reserve(), '/item not found/')
+        else:
+            self.assertEqual(cursor.reserve(), 0)
+
+        cursor.set_key(self.gen_key(95))
+        if (self.upper_bounds):
+            self.assertRaisesHavingMessage(
+                wiredtiger.WiredTigerError, lambda: cursor.reserve(), '/item not found/')
+        else:
+            self.assertEqual(cursor.reserve(), 0)
+        self.session.commit_transaction()
+
+        # Test bound API: test modifies on an existing key outside of bounds.
+        if (not self.use_colgroup):
+            self.session.begin_transaction()
+            cursor.set_key(self.gen_key(10))
+            mods = [wiredtiger.Modify("2", 0, 1)]
+            if (self.lower_bounds):
+                self.assertEqual(cursor.modify(mods), wiredtiger.WT_NOTFOUND)
+            else:
+                self.assertEqual(cursor.modify(mods), 0)
+
+            cursor.set_key(self.gen_key(95))
+            mods = [wiredtiger.Modify("2", 0, 1)]
+            if (self.upper_bounds):
+                self.assertEqual(cursor.modify(mods), wiredtiger.WT_NOTFOUND)
+            else:
+                self.assertEqual(cursor.modify(mods), 0)
+            self.session.commit_transaction()
+        
+        # Test bound API: test removing on an existing key outside of bounds.
+        cursor.set_key(self.gen_key(10))
+        if (self.lower_bounds):
+            self.assertEqual(cursor.remove(), wiredtiger.WT_NOTFOUND)
+        else:
+            self.assertEqual(cursor.remove(), 0)
+
+        cursor.set_key(self.gen_key(95))
+        if (self.upper_bounds):
+            self.assertEqual(cursor.remove(), wiredtiger.WT_NOTFOUND)
+        else:
+            self.assertEqual(cursor.remove(), 0)
+        cursor.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/wtbound.py
+++ b/test/suite/wtbound.py
@@ -109,7 +109,7 @@ class bound_base(wttest.WiredTigerTestCase):
     lower_inclusive = True
     upper_inclusive = True
 
-    def create_session_and_cursor(self):
+    def create_session_and_cursor(self, cursor_config=None):
         uri = self.uri + self.file_name
         create_params = 'value_format={},key_format={}'.format(self.value_format, self.key_format)
         if self.use_colgroup:
@@ -123,7 +123,7 @@ class bound_base(wttest.WiredTigerTestCase):
                 suburi = 'colgroup:{0}:g{1}'.format(self.file_name, i)
                 self.session.create(suburi, create_params)
 
-        cursor = self.session.open_cursor(uri)
+        cursor = self.session.open_cursor(uri, None, cursor_config)
         self.session.begin_transaction()
 
         for i in range(self.start_key, self.end_key + 1):


### PR DESCRIPTION
Added bounds checking to insert, and update operations. If the key is outside of the set range we want to return back WT_NOTFOUND error instead. Remove operation uses cursor_valid after positing the cursor to see if we are able to remove the record. The bounds checking in cursor_valid will cover that case.