### PR TITLE
WT-9752 Change WT_ASSERT to WT_ASSERT_ALWAYS in __wt_hs_insert_updates

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -517,7 +517,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
 
             /* Detect any update without a timestamp. */
             if (prev_upd != NULL && prev_upd->start_ts < upd->start_ts) {
-                WT_ASSERT(session, prev_upd->start_ts == WT_TS_NONE);
+                WT_ASSERT_ALWAYS(session, prev_upd->start_ts == WT_TS_NONE, "out-of-order updated detected");
                 /*
                  * Fail the eviction if we detect any timestamp ordering issue and the error flag is
                  * set. We cannot modify the history store to fix the updates' timestamps as it may

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -609,8 +609,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
          * all the updates of the key in the history store with timestamps.
          */
         if (oldest_upd->type == WT_UPDATE_TOMBSTONE && oldest_upd->start_ts == WT_TS_NONE) {
-            WT_ERR(__wt_hs_delete_key_from_ts(
-              session, hs_cursor, btree->id, key, false, error_on_ts_ordering));
+            WT_ERR(
+              __wt_hs_delete_key(session, hs_cursor, btree->id, key, false, error_on_ts_ordering));
 
             /* Reset the update without a timestamp if it is the last update in the chain. */
             if (oldest_upd == no_ts_upd)
@@ -822,12 +822,11 @@ err:
 }
 
 /*
- * __wt_hs_delete_key_from_ts --
- *     Delete history store content of a given key from a timestamp and optionally reinsert them
- *     with ts-1 timestamp.
+ * __wt_hs_delete_key --
+ *     Delete history store content of a given key and optionally reinsert them with ts-1 timestamp.
  */
 int
-__wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btree_id,
+__wt_hs_delete_key(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btree_id,
   const WT_ITEM *key, bool reinsert, bool error_on_ts_ordering)
 {
     WT_DECL_RET;

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -517,7 +517,7 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
 
             /* Detect any update without a timestamp. */
             if (prev_upd != NULL && prev_upd->start_ts < upd->start_ts) {
-                WT_ASSERT_ALWAYS(session, prev_upd->start_ts == WT_TS_NONE, "out-of-order updated detected");
+                WT_ASSERT_ALWAYS(session, prev_upd->start_ts == WT_TS_NONE, "out-of-order timestamp update detected");
                 /*
                  * Fail the eviction if we detect any timestamp ordering issue and the error flag is
                  * set. We cannot modify the history store to fix the updates' timestamps as it may

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -517,7 +517,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
 
             /* Detect any update without a timestamp. */
             if (prev_upd != NULL && prev_upd->start_ts < upd->start_ts) {
-                WT_ASSERT_ALWAYS(session, prev_upd->start_ts == WT_TS_NONE, "out-of-order timestamp update detected");
+                WT_ASSERT_ALWAYS(session, prev_upd->start_ts == WT_TS_NONE,
+                  "out-of-order timestamp update detected");
                 /*
                  * Fail the eviction if we detect any timestamp ordering issue and the error flag is
                  * set. We cannot modify the history store to fix the updates' timestamps as it may
@@ -931,6 +932,9 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     if (ret == WT_NOTFOUND)
         return (0);
     WT_ERR(ret);
+
+    WT_ASSERT_ALWAYS(
+      session, ts == 1 || ts == WT_TS_NONE, "out-of-order timestamp update detected");
 
     /*
      * Fail the eviction if we detect any timestamp ordering issue and the error flag is set. We

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -823,7 +823,7 @@ err:
 
 /*
  * __wt_hs_delete_key --
- *     Delete history store content of a given key and optionally reinsert them with ts-1 timestamp.
+ *     Delete history store content of a given key and optionally reinsert them with 0 timestamp.
  */
 int
 __wt_hs_delete_key(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btree_id,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -792,8 +792,8 @@ extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
-  uint32_t btree_id, const WT_ITEM *key, bool reinsert, bool error_on_ts_ordering)
+extern int __wt_hs_delete_key(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btree_id,
+  const WT_ITEM *key, bool reinsert, bool error_on_ts_ordering)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
   const char *value_format, uint64_t recno, WT_UPDATE_VALUE *upd_value, WT_ITEM *base_value_buf)

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2761,7 +2761,7 @@ __wt_rec_hs_clear_on_tombstone(
      * checkpoint itself and lead to history store inconsistency. (Note: WT_REC_CHECKPOINT_RUNNING
      * is set only during evictions, and never in the checkpoint thread itself.)
      */
-    WT_RET(__wt_hs_delete_key_from_ts(
+    WT_RET(__wt_hs_delete_key(
       session, r->hs_cursor, btree->id, key, reinsert, F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)));
 
     /* Fail 0.01% of the time. */


### PR DESCRIPTION
A data corruption bug in [WT-9705](https://jira.mongodb.org/browse/WT-9705) is rarely reproducible (more info in the ticket itself). In diagnostic mode, the following assert is hit.

`WT_ASSERT(session, prev_upd->start_ts == WT_TS_NONE); `

However, in release mode, EBUSY is returned. It would be helpful to have a core file when/if this issue happens in MongoDB to extract more information about the bug.
The scope of this ticket is to convert the WT_ASSERT to WT_ASSERT_ALWAYS.