### PR TITLE
WT-9735 Mirroring enabled too often

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -988,7 +988,7 @@ config_mirrors(void)
      * tables.
      */
     explicit_mirror = config_explicit(NULL, "runs.mirror");
-    if (!explicit_mirror && mmrand(NULL, 1, 10) < 3)
+    if (!explicit_mirror && mmrand(NULL, 1, 10) < 9)
         return;
     config_off_all("runs.mirror");
 


### PR DESCRIPTION
I verified this by changing `format.sh` to add the `-S` option to the format command, which runs the syntax-only mode, running that in a loop, and counting how often it was enabled.