### PR TITLE
WT-9733 Clean up the __wt_timing_stress interface

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -502,7 +502,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
     WT_ERR(__split_ref_prepare(session, alloc_index, &locked, false));
 
     /* Encourage a race */
-    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_1);
+    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_1, NULL);
 
     /*
      * Confirm the root page's index hasn't moved, then update it, which makes the split visible to
@@ -513,7 +513,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
     alloc_index = NULL;
 
     /* Encourage a race */
-    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_2);
+    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_2, NULL);
 
     /*
      * Mark the root page with the split generation.
@@ -761,7 +761,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     WT_NOT_READ(complete, WT_ERR_PANIC);
 
     /* Encourage a race */
-    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_3);
+    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_3, NULL);
 
     /*
      * Confirm the parent page's index hasn't moved then update it, which makes the split visible to
@@ -772,7 +772,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     alloc_index = NULL;
 
     /* Encourage a race */
-    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_4);
+    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_4, NULL);
 
     /*
      * Get a generation for this split, mark the page. This must be after the new index is swapped
@@ -1028,7 +1028,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
     WT_ERR(__split_ref_prepare(session, alloc_index, &locked, true));
 
     /* Encourage a race */
-    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_5);
+    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_5, NULL);
 
     /* Split into the parent. */
     WT_ERR(__split_parent(
@@ -1042,7 +1042,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
     WT_INTL_INDEX_SET(page, replace_index);
 
     /* Encourage a race */
-    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_6);
+    __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_6, NULL);
 
     /*
      * Get a generation for this split, mark the parent page. This must be after the new index is
@@ -1182,7 +1182,7 @@ __split_internal_lock(WT_SESSION_IMPL *session, WT_REF *ref, bool trylock, WT_PA
         parent = ref->home;
 
         /* Encourage races. */
-        __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_7);
+        __wt_timing_stress(session, WT_TIMING_STRESS_SPLIT_7, NULL);
 
         /* Page locks live in the modify structure. */
         WT_RET(__wt_page_modify_init(session, parent));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2402,7 +2402,7 @@ static inline void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_struct_size_adjust(WT_SESSION_IMPL *session, size_t *sizep);
-static inline void __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag);
+static inline void __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag, struct timespec *tsp);
 static inline void __wt_tree_modify_set(WT_SESSION_IMPL *session);
 static inline void __wt_txn_cursor_op(WT_SESSION_IMPL *session);
 static inline void __wt_txn_err_set(WT_SESSION_IMPL *session, int ret);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2403,6 +2403,7 @@ static inline void __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t
 static inline void __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_struct_size_adjust(WT_SESSION_IMPL *session, size_t *sizep);
 static inline void __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag, struct timespec *tsp);
+static inline void __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session);
 static inline void __wt_tree_modify_set(WT_SESSION_IMPL *session);
 static inline void __wt_txn_cursor_op(WT_SESSION_IMPL *session);
 static inline void __wt_txn_err_set(WT_SESSION_IMPL *session, int ret);

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -175,9 +175,6 @@ __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs)
     __wt_sleep(0, (*sleep_usecs));
 }
 
-/* Maximum stress delay is 1/10 of a second. */
-#define WT_TIMING_STRESS_MAX_DELAY (100000)
-
 /*
  * __wt_timing_stress --
  *     Optionally add delay to stress code paths.
@@ -185,18 +182,29 @@ __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs)
 static inline void
 __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag, struct timespec *tsp)
 {
-    double pct;
-    uint64_t i, max;
-
     /* Optionally only sleep when a specified configuration flag is set. */
     if (flag != 0 && !FLD_ISSET(S2C(session)->timing_stress_flags, flag))
         return;
 
-    /* If a delay is provided then use that delay and return. */
-    if (tsp != NULL) {
+    /* If a delay is provided then use that delay otherwise sleep for a random time. */
+    if (tsp != NULL)
         __wt_sleep((uint64_t)tsp->tv_sec, (uint64_t)tsp->tv_nsec / WT_THOUSAND);
-        return;
-    }
+    else
+        __wt_timing_stress_sleep_random(session);
+}
+
+/* Maximum stress delay is 1/10 of a second. */
+#define WT_TIMING_STRESS_MAX_DELAY (100000)
+
+/*
+ * __wt_timing_stress_sleep_random --
+ *     Sleep for a random time, with a bias towards shorter sleeps.
+ */
+static inline void
+__wt_timing_stress_sleep_random(WT_SESSION_IMPL *session)
+{
+    double pct;
+    uint64_t i, max;
 
     /*
      * If there is a lot of cache pressure, don't let the sleep time get too large. If the cache is

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -183,7 +183,7 @@ __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs)
  *     Optionally add delay to stress code paths.
  */
 static inline void
-__wt_timing_stress(WT_SESSION_IMPL *session, u_int flag)
+__wt_timing_stress(WT_SESSION_IMPL *session, u_int flag, struct timespec *tsp)
 {
     double pct;
     uint64_t i, max;
@@ -191,6 +191,12 @@ __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag)
     /* Optionally only sleep when a specified configuration flag is set. */
     if (flag != 0 && !FLD_ISSET(S2C(session)->timing_stress_flags, flag))
         return;
+
+    /* If a delay is provided then use that delay and return. */
+    if (tsp != NULL) {
+        __wt_sleep((uint64_t)tsp->tv_sec, (uint64_t)tsp->tv_nsec / WT_THOUSAND);
+        return;
+    }
 
     /*
      * If there is a lot of cache pressure, don't let the sleep time get too large. If the cache is

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1126,7 +1126,7 @@ retry:
 
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
     if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
-        __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH);
+        __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
         WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,
           cbt->upd_value, &cbt->upd_value->buf));
     }

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -257,7 +257,7 @@ __compact_worker(WT_SESSION_IMPL *session)
             if (session->op_handle[i]->compact_skip)
                 continue;
 
-            __wt_timing_stress(session, WT_TIMING_STRESS_COMPACT_SLOW);
+            __wt_timing_stress(session, WT_TIMING_STRESS_COMPACT_SLOW, NULL);
 
             session->compact_state = WT_COMPACT_RUNNING;
             WT_WITH_DHANDLE(session, session->op_handle[i], ret = __wt_compact(session));


### PR DESCRIPTION
The `__wt_timing_stress` function currently does not allow for a specific sleep time, and generates a random sleep time by default when called. 

- We have made changes so the function will take an explicit sleep time if given. 
- Refactored the function so it looks cleaner. 

