### PR TITLE
WT-9761 Remove duplicated ASAN test on PPC

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2880,25 +2880,6 @@ tasks:
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120
 
-  # FIXME-WT-8981 - Ubuntu PPC tests have been replaced by RHEL8 tests as of WT-8688, but the RHEL8 tests are currently disabled
-  # due to platform issues. On completion of WT-8981 this can be deleted.
-  - name: format-stress-sanitizer-ppc-test
-    tags: ["stress-test-ppc-ubuntu"]
-    # Set 2.5 hours timeout (60 * 60 * 2.5)
-    exec_timeout_secs: 9000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          # CC is set to the system default "clang" binary here as a workaround to mongo toolchains not supporting ASAN on Ubuntu PPC.
-          <<: *configure_flags_address_sanitizer_clang_with_builtins
-      - func: "format test script"
-        vars:
-          test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
-            ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-          # Run for 2 hours (2 * 60 = 120 minutes), don't stop at failed tests, use default config
-          format_test_script_args: -t 120
 
   - <<: *format-stress-test
     name: format-stress-test-1


### PR DESCRIPTION
When investigating the task timeout failure in WT-9761, it was found we have 2 Evergreen tasks running ASAN testing on the PPC platform:

- format-stress-sanitizer-test-ppc-ubuntu
- format-stress-ppc-zseries-test

The only differences are the former task uses a different ASAN symbolizer (v4 toolchain vs llvm-6.0) and runs format for a longer period of time (6hrs vs 2 hrs). 

The proposed solution is to remove the latter task which hit timeout failure recently (likely due to a slow host issue).