### PR TITLE
WT-9590 Fixing linking to TCMALLOC for S3 extension

### DIFF
--- a/ext/storage_sources/s3_store/CMakeLists.txt
+++ b/ext/storage_sources/s3_store/CMakeLists.txt
@@ -46,6 +46,10 @@ target_link_libraries(
         aws-sdk::core
 )
 
+if(ENABLE_TCMALLOC)
+    target_link_libraries(wiredtiger_s3_store PRIVATE wt::tcmalloc)
+endif()
+
 # Add the unit tests, need Catch2 which is resolved with HAVE_UNITTEST.
 if(HAVE_UNITTEST)
     add_subdirectory(test)

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -780,7 +780,6 @@ variables:
   - &configure_flags_tiered_storage_s3
     ENABLE_S3: -DENABLE_S3=1
     IMPORT_S3_SDK: -DIMPORT_S3_SDK=external
-    CMAKE_PREFIX_PATH: # FIXME-WT-9590 - the S3 extension tests core with TCMALLOC.
 
   # Configure flags for address sanitizer for mongodb toolchain v4 clang (include builtins).
   - &configure_flags_address_sanitizer_mongodb_v4_clang_with_builtins


### PR DESCRIPTION
Previously TCMALLOC wasn't enabled for the S3 extension as it cored. Turns out it was a linking issue.