### PR TITLE
WT-9760 Fix implicit conversion in workgen.cxx

### DIFF
--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1194,7 +1194,7 @@ ThreadRunner::random_signed()
 {
     uint32_t r = random_value();
     int sign = ((r & 0x1) == 0 ? 1 : -1);
-    return (((float)r * sign) / UINT32_MAX);
+    return (((float)r * sign) / (float)UINT32_MAX);
 }
 
 Throttle::Throttle(ThreadRunner &runner, double throttle, double throttle_burst)

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1194,7 +1194,7 @@ ThreadRunner::random_signed()
 {
     uint32_t r = random_value();
     int sign = ((r & 0x1) == 0 ? 1 : -1);
-    return (((float)r * sign) / (float)UINT32_MAX);
+    return ((r * sign) / (float)UINT32_MAX);
 }
 
 Throttle::Throttle(ThreadRunner &runner, double throttle, double throttle_burst)


### PR DESCRIPTION
Fix the below warning observed when compiling wiredtiger using clang 10. 

```
[366/542]` Building CXX object bench/workgen/CMakeFiles/workgen_cxx.dir/workgen.cxx.o
--
../bench/workgen/workgen.cxx:1197:33: warning: implicit conversion from 'unsigned int' to 'float' changes value from 4294967295 to 4294967296 [-Wimplicit-int-float-conversion]
return (((float)r * sign) / UINT32_MAX);
~ ^~~~~~~~~~
/usr/include/stdint.h:129:23: note: expanded from macro 'UINT32_MAX'
# define UINT32_MAX             (4294967295U)
^~~~~~~~~~~
1 warning generated.
```
