### PR TITLE
WT-9787 Add printing of update structure flags.

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1584,7 +1584,7 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
         if (prepare_state != NULL)
             WT_RET(ds->f(ds, ", prepare %s", prepare_state));
 
-        WT_RET(ds->f(ds, "\n"));
+        WT_RET(ds->f(ds, ", flags 0x%" PRIx8 "\n", upd->flags));
     }
     return (0);
 }


### PR DESCRIPTION
@quchenhao here's what I added to my debugging today. Is this what you had in mind? I am just printing out the value in hex. I could be more sophisticated and translate the values to strings. But this felt initially okay to me (and then we don't have to worry about someone adding a flag and forgetting to add it here too).