### PR TITLE
WT-9841 Fix tracking of live_open variable, so it works both in diagnostic and non-diagnostic mode.

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -159,9 +159,7 @@ __wt_block_checkpoint_unload(WT_SESSION_IMPL *session, WT_BLOCK *block, bool che
 
         __wt_spin_lock(session, &block->live_lock);
         __wt_block_ckpt_destroy(session, &block->live);
-#ifdef HAVE_DIAGNOSTIC
         block->live_open = false;
-#endif
         __wt_spin_unlock(session, &block->live_lock);
     }
 


### PR DESCRIPTION
Without this fix, an assertion occurs in non-diagnostic mode.