### PR TITLE
WT-9673 Get rid of long running txns in test_truncate15 and test_stat08

### DIFF
--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -142,14 +142,10 @@ class test_truncate15(wttest.WiredTigerTestCase):
 
         # Write a bunch of data at time 10.
         cursor = self.session.open_cursor(ds.uri)
-        self.session.begin_transaction()
         for i in range(1, nrows + 1):
+            self.session.begin_transaction()
             cursor[ds.key(i)] = value_a
-            # Commit every 101 rows to avoid overflowing the cache.
-            if i % 101 == 0:
-                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
-                self.session.begin_transaction()
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Mark it stable.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))


### PR DESCRIPTION
test_truncate15 and test_stat08 fail quite frequently on develop. 
Getting rid of the long-running transactions from test_truncate15 and test_stat08 should get rid of the rollback error. Also, doing so should not affect the intention of the test.

I will be creating a separate ticket for addressing the cache stuck problem.
