### PR TITLE
WT-9577 Implement bounded cursor API for the Datastore cursor

### DIFF
--- a/examples/c/ex_data_source.c
+++ b/examples/c/ex_data_source.c
@@ -234,6 +234,13 @@ my_cursor_remove(WT_CURSOR *wtcursor)
     return (0);
 }
 static int
+my_cursor_bound(WT_CURSOR *wtcursor, const char* config)
+{
+    (void)wtcursor;
+    (void)config;
+    return (0);
+}
+static int
 my_cursor_close(WT_CURSOR *wtcursor)
 {
     (void)wtcursor;
@@ -271,7 +278,7 @@ my_open_cursor(WT_DATA_SOURCE *dsrc, WT_SESSION *session, const char *uri, WT_CO
     cursor->wtcursor.update = my_cursor_update;
     cursor->wtcursor.remove = my_cursor_remove;
     cursor->wtcursor.close = my_cursor_close;
-
+    cursor->wtcursor.bound = my_cursor_bound;
     /*
      * Configure local cursor information.
      */

--- a/examples/c/ex_data_source.c
+++ b/examples/c/ex_data_source.c
@@ -234,7 +234,7 @@ my_cursor_remove(WT_CURSOR *wtcursor)
     return (0);
 }
 static int
-my_cursor_bound(WT_CURSOR *wtcursor, const char* config)
+my_cursor_bound(WT_CURSOR *wtcursor, const char *config)
 {
     (void)wtcursor;
     (void)config;

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -107,9 +107,8 @@ __curds_bound(WT_CURSOR *cursor, const char *config)
 
     source = ((WT_CURSOR_DATA_SOURCE *)cursor)->source;
 
-    CURSOR_API_CALL_CONF(cursor, session, bound, config, cfg, NULL);
+    CURSOR_API_CALL(cursor, session, bound, NULL);
 
-    WT_UNUSED(cfg);
     WT_ERR(__curds_key_set(cursor));
     ret = __curds_cursor_resolve(cursor, source->bound(source, config));
 
@@ -464,7 +463,6 @@ __wt_curds_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, con
 
     metaconf = NULL;
 
-    WT_ASSERT(session, false);
     WT_RET(__wt_calloc_one(session, &data_source));
     cursor = (WT_CURSOR *)data_source;
     *cursor = iface;

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -96,7 +96,7 @@ __curds_cursor_resolve(WT_CURSOR *cursor, int ret)
 
 /*
  * __curds_bound --
- *     WT_CURSOR.search method for the data-source cursor type.
+ *     WT_CURSOR.bound method for the data-source cursor type.
  */
 static int
 __curds_bound(WT_CURSOR *cursor, const char *config)

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -95,6 +95,29 @@ __curds_cursor_resolve(WT_CURSOR *cursor, int ret)
 }
 
 /*
+ * __curds_bound --
+ *     WT_CURSOR.search method for the data-source cursor type.
+ */
+static int
+__curds_bound(WT_CURSOR *cursor, const char *config)
+{
+    WT_CURSOR *source;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+
+    source = ((WT_CURSOR_DATA_SOURCE *)cursor)->source;
+
+    CURSOR_API_CALL_CONF(cursor, session, bound, config, cfg, NULL);
+
+    WT_UNUSED(cfg);
+    WT_ERR(__curds_key_set(cursor));
+    ret = __curds_cursor_resolve(cursor, source->bound(source, config));
+
+err:
+    API_END_RET(session, ret);
+}
+
+/*
  * __curds_compare --
  *     WT_CURSOR.compare method for the data-source cursor type.
  */
@@ -426,7 +449,7 @@ __wt_curds_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, con
       __curds_reserve,                                /* reserve */
       __wt_cursor_config_notsup,                      /* reconfigure */
       __wt_cursor_notsup,                             /* largest_key */
-      __wt_cursor_config_notsup,                      /* bound */
+      __curds_bound,                                  /* bound */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
@@ -441,6 +464,7 @@ __wt_curds_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, con
 
     metaconf = NULL;
 
+    WT_ASSERT(session, false);
     WT_RET(__wt_calloc_one(session, &data_source));
     cursor = (WT_CURSOR *)data_source;
     *cursor = iface;


### PR DESCRIPTION
This change means that any custom data source cursors requires bounds function to be initialised. 