### PR TITLE
WT-9863 - Downgrade assertion in __hs_delete_reinsert_from_pos

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -900,7 +900,11 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     WT_UNUSED(key);
 #endif
 
-    /* This function should only accept mixed mode timestamped updates. */
+    /*
+     * This function should only accept mixed mode timestamped updates.
+     *
+     * FIXME-WT-9846: Change this back to WT_ASSERT_ALWAYS once WT-9846 is resolved
+     */
     WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
 
     /*

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -900,6 +900,9 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     WT_UNUSED(key);
 #endif
 
+    /* This function should only accept mixed mode timestamped updates. */
+    WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
+
     /*
      * If we delete all the updates of the key from the history store, we should not reinsert any
      * update except when a tombstone without a timestamp is not globally visible yet.
@@ -976,9 +979,6 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     if (ret == WT_NOTFOUND)
         return (0);
     WT_ERR(ret);
-
-    WT_ASSERT_ALWAYS(
-      session, ts == 1 || ts == WT_TS_NONE, "out-of-order timestamp update detected");
 
     /*
      * Fail the eviction if we detect any timestamp ordering issue and the error flag is set. We

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -901,13 +901,6 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
 #endif
 
     /*
-     * This function should only accept mixed mode timestamped updates.
-     *
-     * FIXME-WT-9846: Change this back to WT_ASSERT_ALWAYS once WT-9846 is resolved
-     */
-    WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
-
-    /*
      * If we delete all the updates of the key from the history store, we should not reinsert any
      * update except when a tombstone without a timestamp is not globally visible yet.
      */
@@ -983,6 +976,14 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     if (ret == WT_NOTFOUND)
         return (0);
     WT_ERR(ret);
+
+    /*
+     * If we find a key with a timestamp larger than or equal to the specified timestamp then the
+     * specified timestamp must be mixed mode.
+     *
+     * FIXME-WT-9846: Change this back to WT_ASSERT_ALWAYS once WT-9846 is resolved
+     */
+    WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
 
     /*
      * Fail the eviction if we detect any timestamp ordering issue and the error flag is set. We


### PR DESCRIPTION
This assertion was triggering in mongo tests and causing a crash and core dump. However, the impact of this assertion not firing would be to add an invisible update to the history store which would be quickly cleaned up, has no impact on data integrity, and is preferable to a crash in release mode.

As such, downgrade this assertion to only fire in diagnostic mode. Investigation into the root cause will continue in WT-9846