### PR TITLE
WT-9755 Retain database files after a failure in run_format_configs.sh

### DIFF
--- a/test/evergreen/run_format_configs.sh
+++ b/test/evergreen/run_format_configs.sh
@@ -10,7 +10,7 @@ set -e
 # Switch to the Git repo toplevel directory
 cd $(git rev-parse --show-toplevel)
 # Walk into the test/format directory
-cd cmake_build/test/format
+cd build/test/format
 set +e
 
 # Check the existence of 't' binary
@@ -26,11 +26,12 @@ failure=0
 for config in $(find ../../../test/format/failure_configs/ -name "CONFIG.*" | sort)
 do
 	echo -e "\nTesting CONFIG $config ...\n"
-	if (./t -c $config); then
+	if (./t -c $config -h WT_TEST); then
 		let "success++"
 	else
 		let "failure++"
-		[ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG
+		[ -f WT_TEST/CONFIG ] && cat WT_TEST/CONFIG
+		mv WT_TEST WT_TEST_${config##*/}
 	fi
 done
 

--- a/test/evergreen/run_format_configs.sh
+++ b/test/evergreen/run_format_configs.sh
@@ -10,7 +10,7 @@ set -e
 # Switch to the Git repo toplevel directory
 cd $(git rev-parse --show-toplevel)
 # Walk into the test/format directory
-cd build/test/format
+cd cmake_build/test/format
 set +e
 
 # Check the existence of 't' binary

--- a/test/evergreen/run_format_configs.sh
+++ b/test/evergreen/run_format_configs.sh
@@ -31,7 +31,7 @@ do
 	else
 		let "failure++"
 		[ -f WT_TEST/CONFIG ] && cat WT_TEST/CONFIG
-		mv WT_TEST WT_TEST_${config##*/}
+		mv WT_TEST WT_TEST_$(basename $config)
 	fi
 done
 


### PR DESCRIPTION
The RUNDIR (renamed WT_TEST in this PR) gets replaced by each new iteration of format config test runs, even when there is a failure. 

To preserve the database files when there is a failure for debugging purposes; we move the WT_TEST directory to a new directory if there is a failure and prevent it from being overwritten or deleted. 

The directory is named after the failure config in the format WT_TEST_{CONFIG}.

