### PR TITLE
WT-9241 Process the call log for timestamp_transaction_uint()

### DIFF
--- a/src/call_log/call_log.c
+++ b/src/call_log/call_log.c
@@ -380,7 +380,7 @@ __wt_call_log_timestamp_transaction_uint(
      * WT_TS_TXN_TYPE and the timestamp itself as input.
      */
     WT_RET(__wt_snprintf(ts_type_buf, sizeof(ts_type_buf), "\"wt_ts_txp_type\": \"%s\"", name));
-    WT_RET(__wt_snprintf(ts_buf, sizeof(ts_buf), "\"timestamp\": \"%" PRIu64 "\"", ts));
+    WT_RET(__wt_snprintf(ts_buf, sizeof(ts_buf), "\"timestamp\": %" PRIu64, ts));
     WT_RET(__call_log_print_input(session, 2, ts_type_buf, ts_buf));
 
     /* timestamp_transaction_uint has no output arguments. */

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -233,9 +233,7 @@ call_log_manager::call_log_timestamp_transaction_uint(const json &call_log_entry
     /* Convert the transaction type char * to a string object. */
     const std::string wt_ts_txn_type = call_log_entry["input"]["wt_ts_txp_type"].get<std::string>();
 
-    /*
-     * There are no timestamps to be set if the timestamp type is not specified.
-     */
+    /* There are no timestamps to be set if the timestamp type is not specified. */
     if (wt_ts_txn_type == "unknown")
         return;
 

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -232,13 +232,13 @@ call_log_manager::call_log_timestamp_transaction_uint(const json &call_log_entry
 {
     /* Convert the transaction type char * to a string object. */
     const std::string wt_ts_txn_type = call_log_entry["input"]["wt_ts_txp_type"].get<std::string>();
+    const std::string session_id = call_log_entry["session_id"].get<std::string>();
 
     /* There are no timestamps to be set if the timestamp type is not specified. */
     if (wt_ts_txn_type == "unknown")
-        return;
+        throw "Cannot set a transaction timestamp for session_id (" + session_id + ") without a valid timestamp type.";
 
     const uint64_t ts = call_log_entry["input"]["timestamp"].get<uint64_t>();
-    const std::string session_id = call_log_entry["session_id"].get<std::string>();
     session_simulator *session = get_session(session_id);
 
     int ret = session->timestamp_transaction_uint(wt_ts_txn_type, ts);

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -236,7 +236,7 @@ call_log_manager::call_log_timestamp_transaction_uint(const json &call_log_entry
     /*
      * There are no timestamps to be set if the timestamp type is not specified.
      */
-    if (wt_ts_txn_type == "unkown")
+    if (wt_ts_txn_type == "unknown")
         return;
 
     const uint64_t ts = call_log_entry["input"]["timestamp"].get<uint64_t>();

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -71,6 +71,7 @@ call_log_manager::api_map_setup()
     _api_map["query_timestamp"] = api_method::query_timestamp;
     _api_map["rollback_transaction"] = api_method::rollback_transaction;
     _api_map["set_timestamp"] = api_method::set_timestamp;
+    _api_map["timestamp_transaction_uint"] = api_method::timestamp_transaction_uint;
 }
 
 session_simulator *
@@ -227,6 +228,32 @@ call_log_manager::call_log_set_timestamp(const json &call_log_entry)
 }
 
 void
+call_log_manager::call_log_timestamp_transaction_uint(const json &call_log_entry)
+{
+    /* Convert the config char * to a string object. */
+    const std::string wt_ts_txn_type = call_log_entry["input"]["wt_ts_txp_type"].get<std::string>();
+
+    /* 
+     * There are no timestamps to be set if the timestamp type is not specified.
+     */
+    if (wt_ts_txn_type == "unkown")
+        return;
+
+    const uint64_t ts = call_log_entry["input"]["timestamp"].get<uint64_t>();
+    const std::string session_id = call_log_entry["session_id"].get<std::string>();
+    session_simulator *session = get_session(session_id);
+
+    int ret = session->timestamp_transaction_uint(wt_ts_txn_type, ts);
+    int ret_expected = call_log_entry["return"]["return_val"].get<int>();
+    /* The ret value should be equal to the expected ret value. */
+    assert(ret == ret_expected);
+
+    if (ret != 0)
+        throw "'timestamp_transaction_uint' failed with ret value: '" + std::to_string(ret) +
+          "', and timestamp type: '" + wt_ts_txn_type + "'";
+}
+
+void
 call_log_manager::process_call_log()
 {
     for (const auto &call_log_entry : _call_log)
@@ -260,6 +287,9 @@ call_log_manager::process_call_log_entry(const json &call_log_entry)
             break;
         case api_method::set_timestamp:
             call_log_set_timestamp(call_log_entry);
+            break;
+        case api_method::timestamp_transaction_uint:
+            call_log_timestamp_transaction_uint(call_log_entry);
             break;
         }
     } catch (std::string &exception_str) {

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -230,10 +230,10 @@ call_log_manager::call_log_set_timestamp(const json &call_log_entry)
 void
 call_log_manager::call_log_timestamp_transaction_uint(const json &call_log_entry)
 {
-    /* Convert the config char * to a string object. */
+    /* Convert the transaction type char * to a string object. */
     const std::string wt_ts_txn_type = call_log_entry["input"]["wt_ts_txp_type"].get<std::string>();
 
-    /* 
+    /*
      * There are no timestamps to be set if the timestamp type is not specified.
      */
     if (wt_ts_txn_type == "unkown")

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.h
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.h
@@ -41,6 +41,7 @@ enum class api_method {
     query_timestamp,
     rollback_transaction,
     set_timestamp,
+    timestamp_transaction_uint
 };
 
 class call_log_manager {
@@ -62,6 +63,7 @@ class call_log_manager {
     void call_log_query_timestamp(const json &);
     void call_log_rollback_transaction(const json &);
     void call_log_set_timestamp(const json &);
+    void call_log_timestamp_transaction_uint(const json &);
 
     /* Member variables */
     private:

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -39,10 +39,10 @@ class session_simulator {
     void rollback_transaction();
     void commit_transaction();
     int timestamp_transaction_uint(const std::string &, const uint64_t &);
-    void set_commit_timestamp(const uint64_t &);
-    void set_durable_timestamp(const uint64_t &);
-    void set_prepare_timestamp(const uint64_t &);
-    void set_read_timestamp(const uint64_t &);
+    void set_commit_timestamp(uint64_t);
+    void set_durable_timestamp(uint64_t);
+    void set_prepare_timestamp(uint64_t);
+    void set_read_timestamp(uint64_t);
 
     public:
     /* Deleted functions should generally be public as it results in better error messages. */
@@ -52,8 +52,8 @@ class session_simulator {
     /* Member variables */
     private:
     bool _txn_running;
-    uint64_t _read_ts;
-    uint64_t _prepare_ts;
     uint64_t _commit_ts;
     uint64_t _durable_ts;
+    uint64_t _prepare_ts;
+    uint64_t _read_ts;
 };

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#include <string>
+
 class session_simulator {
     /* Methods */
     public:
@@ -36,6 +38,11 @@ class session_simulator {
     void begin_transaction();
     void rollback_transaction();
     void commit_transaction();
+    int timestamp_transaction_uint(const std::string &, const uint64_t &);
+    void set_commit_timestamp(const uint64_t &);
+    void set_durable_timestamp(const uint64_t &);
+    void set_prepare_timestamp(const uint64_t &);
+    void set_read_timestamp(const uint64_t &);
 
     public:
     /* Deleted functions should generally be public as it results in better error messages. */
@@ -45,4 +52,8 @@ class session_simulator {
     /* Member variables */
     private:
     bool _txn_running;
+    uint64_t _read_ts;
+    uint64_t _prepare_ts;
+    uint64_t _commit_ts;
+    uint64_t _durable_ts;
 };

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -38,7 +38,7 @@ class session_simulator {
     void begin_transaction();
     void rollback_transaction();
     void commit_transaction();
-    int timestamp_transaction_uint(const std::string &, const uint64_t &);
+    int timestamp_transaction_uint(const std::string &, uint64_t);
     void set_commit_timestamp(uint64_t);
     void set_durable_timestamp(uint64_t);
     void set_prepare_timestamp(uint64_t);

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -62,25 +62,25 @@ session_simulator::commit_transaction()
 }
 
 void
-session_simulator::set_commit_timestamp(const uint64_t &ts)
+session_simulator::set_commit_timestamp(uint64_t ts)
 {
     _commit_ts = ts;
 }
 
 void
-session_simulator::set_durable_timestamp(const uint64_t &ts)
+session_simulator::set_durable_timestamp(uint64_t ts)
 {
     _durable_ts = ts;
 }
 
 void
-session_simulator::set_prepare_timestamp(const uint64_t &ts)
+session_simulator::set_prepare_timestamp(uint64_t ts)
 {
     _prepare_ts = ts;
 }
 
 void
-session_simulator::set_read_timestamp(const uint64_t &ts)
+session_simulator::set_read_timestamp(uint64_t ts)
 {
     _read_ts = ts;
 }

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "session_simulator.h"
+#include "error_simulator.h"
 
 #include <cassert>
 #include <iostream>
@@ -58,4 +59,45 @@ session_simulator::commit_transaction()
     assert(_txn_running);
 
     _txn_running = false;
+}
+
+void
+session_simulator::set_commit_timestamp(const uint64_t &ts){
+    _commit_ts = ts;
+}
+
+void
+session_simulator::set_durable_timestamp(const uint64_t &ts){
+    _durable_ts = ts;
+}
+
+void
+session_simulator::set_prepare_timestamp(const uint64_t &ts){
+    _prepare_ts = ts;
+}
+
+void
+session_simulator::set_read_timestamp(const uint64_t &ts){
+    _read_ts = ts;
+}
+
+int
+session_simulator::timestamp_transaction_uint(const std::string &ts_type, const uint64_t &ts)
+{
+    /* Zero timestamp is not permitted. */
+    if (ts == 0){
+        WT_SIM_RET_MSG(EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");
+    }
+
+    if (ts_type == "commit"){
+        set_commit_timestamp(ts);
+    } else if (ts_type == "durable"){
+        set_durable_timestamp(ts);
+    } else if (ts_type == "prepare"){
+        set_prepare_timestamp(ts);
+    } else if (ts_type == "read"){
+        set_read_timestamp(ts);
+    }
+
+    return (0);
 }

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -86,7 +86,7 @@ session_simulator::set_read_timestamp(uint64_t ts)
 }
 
 int
-session_simulator::timestamp_transaction_uint(const std::string &ts_type, const uint64_t &ts)
+session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64_t ts)
 {
     /* Zero timestamp is not permitted. */
     if (ts == 0) {

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -62,22 +62,26 @@ session_simulator::commit_transaction()
 }
 
 void
-session_simulator::set_commit_timestamp(const uint64_t &ts){
+session_simulator::set_commit_timestamp(const uint64_t &ts)
+{
     _commit_ts = ts;
 }
 
 void
-session_simulator::set_durable_timestamp(const uint64_t &ts){
+session_simulator::set_durable_timestamp(const uint64_t &ts)
+{
     _durable_ts = ts;
 }
 
 void
-session_simulator::set_prepare_timestamp(const uint64_t &ts){
+session_simulator::set_prepare_timestamp(const uint64_t &ts)
+{
     _prepare_ts = ts;
 }
 
 void
-session_simulator::set_read_timestamp(const uint64_t &ts){
+session_simulator::set_read_timestamp(const uint64_t &ts)
+{
     _read_ts = ts;
 }
 
@@ -85,17 +89,17 @@ int
 session_simulator::timestamp_transaction_uint(const std::string &ts_type, const uint64_t &ts)
 {
     /* Zero timestamp is not permitted. */
-    if (ts == 0){
+    if (ts == 0) {
         WT_SIM_RET_MSG(EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");
     }
 
-    if (ts_type == "commit"){
+    if (ts_type == "commit") {
         set_commit_timestamp(ts);
-    } else if (ts_type == "durable"){
+    } else if (ts_type == "durable") {
         set_durable_timestamp(ts);
-    } else if (ts_type == "prepare"){
+    } else if (ts_type == "prepare") {
         set_prepare_timestamp(ts);
-    } else if (ts_type == "read"){
+    } else if (ts_type == "read") {
         set_read_timestamp(ts);
     }
 

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -101,6 +101,9 @@ session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64
         set_prepare_timestamp(ts);
     } else if (ts_type == "read") {
         set_read_timestamp(ts);
+    } else {
+        WT_SIM_RET_MSG(
+          EINVAL, "Invalid timestamp type (" + ts_type + ") passed to timestamp transaction uint.");
     }
 
     return (0);


### PR DESCRIPTION
I've added the processing logic in the call log manager to invoke the timestamp_transaction_uint() API in the session. At the moment the set methods for the timestamps are placeholders and the validation logic for the timestamps will be handled in future tickets. 

I've also removed the quotes in the generate call log for timestamp_transaction_uint() for the timestamp input argument so that it can be interpreted as a uint64_t instead of a string.