### PR TITLE
WT-9673 Avoid long running txn in test_truncate15

### DIFF
--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -140,14 +140,10 @@ class test_truncate15(wttest.WiredTigerTestCase):
 
         # Write a bunch of data at time 10.
         cursor = self.session.open_cursor(ds.uri)
-        self.session.begin_transaction()
         for i in range(1, nrows + 1):
+            self.session.begin_transaction()
             cursor[ds.key(i)] = value_a
-            # Commit every 101 rows to avoid overflowing the cache.
-            if i % 101 == 0:
-                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
-                self.session.begin_transaction()
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
         # Mark it stable.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -131,10 +131,8 @@ class test_truncate15(wttest.WiredTigerTestCase):
 
         if self.value_format == '8t':
             value_a = 97
-            value_b = 98
         else:
             value_a = "aaaaa" * 500
-            value_b = "bbbbb" * 500
 
         # Pin oldest and stable timestamps to 1.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +


### PR DESCRIPTION
The changes include:
- Avoid long running transaction as it does not change the intent of the test but can cause undesired cache pressure
- Remove unused variables