### PR TITLE
WT-9873 Temporarily disable test_stat08

### DIFF
--- a/test/suite/test_stat08.py
+++ b/test/suite/test_stat08.py
@@ -27,6 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os
+from unittest import skip
 import wiredtiger, wttest
 
 # test_stat08.py
@@ -64,6 +65,7 @@ class test_stat08(wttest.WiredTigerTestCase):
         if k is self.BYTES_READ or k is self.READ_TIME:
             self.assertTrue(value > 0)
 
+    @skip("skipping this test: FIXME-WT-9774")
     def test_session_stats(self):
         self.session = self.conn.open_session()
         self.session.create("table:test_stat08",


### PR DESCRIPTION
In order to avoid consistent failures, we are disabling this test until [WT-9774](https://jira.mongodb.org/browse/WT-9774) is resolved.