### PR TITLE
WT-9829 Verify logging is enabled before using printlog

### DIFF
--- a/test/evergreen/verify_wt_datafiles.sh
+++ b/test/evergreen/verify_wt_datafiles.sh
@@ -56,10 +56,12 @@ for d in ${dirs_include_datafile}
 do
 	echo "${d}"
 
-	${wt_binary} -h ${d} printlog > /dev/null
-	if [ "$?" -ne "0" ]; then
-		echo "Failed to dump '${d}' log files, exiting ..."
-		exit 1
+	# Make sure logging is enabled before running the printlog command.
+	if grep -q -E "logging=(1|on)" ${d}/CONFIG; then
+		if ! ${wt_binary} -h ${d} printlog > /dev/null; then
+			echo "Failed to dump '${d}' log files, exiting ..."
+			exit 1
+		fi
 	fi
 
 	tables=$(${wt_binary} -h "${d}" list)

--- a/test/evergreen/verify_wt_datafiles.sh
+++ b/test/evergreen/verify_wt_datafiles.sh
@@ -64,8 +64,7 @@ do
 		fi
 	fi
 
-	tables=$(${wt_binary} -h "${d}" list)
-	if [ "$?" -ne "0" ]; then 
+	if ! tables=$(${wt_binary} -h "${d}" list); then
 		echo "Failed to list '${d}' directory, exiting ..."
 		exit 1
 	fi

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -1179,8 +1179,10 @@ config_transaction(void)
         config_off(NULL, "transaction.timestamps");
         config_off(NULL, "ops.prepare");
     }
-    if (GV(LOGGING) && config_explicit(NULL, "logging"))
+    if (GV(LOGGING) && config_explicit(NULL, "logging")) {
+        config_off(NULL, "transaction.timestamps");
         config_off(NULL, "ops.prepare");
+    }
     if (GV(OPS_SALVAGE) && config_explicit(NULL, "ops.salvage")) { /* FIXME WT-6431 */
         config_off(NULL, "transaction.timestamps");
         config_off(NULL, "ops.prepare");


### PR DESCRIPTION
The changes include:

- Make sure `logging` is enabled before using `printlog`. If `logging` is not enabled, `printlog` won't be able to find any log files to work on.
- Also disabled the `transaction.timestamp` parameter if `logging` is enabled as they are incompatible.