### PR TITLE
WT-9237 Generate call log for timestamp_transaction()

### DIFF
--- a/src/call_log/call_log.c
+++ b/src/call_log/call_log.c
@@ -353,6 +353,35 @@ __wt_call_log_rollback_transaction(WT_SESSION_IMPL *session, int ret_val)
  *     Print the call log entry for the timestamp_transaction_uint API call.
  */
 int
+__wt_call_log_timestamp_transaction(WT_SESSION_IMPL *session, const char *config, int ret_val)
+{
+    WT_CONNECTION_IMPL *conn;
+    char config_buf[128];
+
+    conn = S2C(session);
+
+    WT_RET(__call_log_print_start(session, "session", "timestamp_transaction"));
+    WT_RET(__wt_fprintf(session, conn->call_log_fst, "    \"session_id\": \"%p\",\n", session));
+
+    /*
+     * The timestamp transaction entry includes the timestamp configuration string which is copied 
+     * from the original API call.
+     */
+    WT_RET(__wt_snprintf(config_buf, sizeof(config_buf), "\"config\": \"%s\"", config));
+    WT_RET(__call_log_print_input(session, 1, config_buf));
+
+    /* timestamp_transaction has no output arguments. */
+    WT_RET(__call_log_print_output(session, 0));
+    WT_RET(__wt_call_log_print_return(conn, session, ret_val, ""));
+
+    return (0);
+}
+
+/*
+ * __wt_call_log_timestamp_transaction_uint --
+ *     Print the call log entry for the timestamp_transaction_uint API call.
+ */
+int
 __wt_call_log_timestamp_transaction_uint(
   WT_SESSION_IMPL *session, WT_TS_TXN_TYPE which, uint64_t ts, int ret_val)
 {

--- a/src/call_log/call_log.c
+++ b/src/call_log/call_log.c
@@ -349,8 +349,8 @@ __wt_call_log_rollback_transaction(WT_SESSION_IMPL *session, int ret_val)
 }
 
 /*
- * __wt_call_log_timestamp_transaction_uint --
- *     Print the call log entry for the timestamp_transaction_uint API call.
+ * __wt_call_log_timestamp_transaction --
+ *     Print the call log entry for the timestamp_transaction API call.
  */
 int
 __wt_call_log_timestamp_transaction(WT_SESSION_IMPL *session, const char *config, int ret_val)
@@ -364,7 +364,7 @@ __wt_call_log_timestamp_transaction(WT_SESSION_IMPL *session, const char *config
     WT_RET(__wt_fprintf(session, conn->call_log_fst, "    \"session_id\": \"%p\",\n", session));
 
     /*
-     * The timestamp transaction entry includes the timestamp configuration string which is copied 
+     * The timestamp transaction entry includes the timestamp configuration string which is copied
      * from the original API call.
      */
     WT_RET(__wt_snprintf(config_buf, sizeof(config_buf), "\"config\": \"%s\"", config));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -365,6 +365,8 @@ extern int __wt_call_log_rollback_transaction(WT_SESSION_IMPL *session, int ret_
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_call_log_set_timestamp(WT_SESSION_IMPL *session, const char *config, int ret_val)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_call_log_timestamp_transaction(WT_SESSION_IMPL *session, const char *config,
+  int ret_val) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_call_log_timestamp_transaction_uint(WT_SESSION_IMPL *session, WT_TS_TXN_TYPE which,
   uint64_t ts, int ret_val) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1839,6 +1839,9 @@ __session_timestamp_transaction(WT_SESSION *wt_session, const char *config)
 
     ret = __wt_txn_set_timestamp(session, cfg, false);
 err:
+#ifdef HAVE_CALL_LOG
+    WT_TRET(__wt_call_log_timestamp_transaction(session, config, ret));
+#endif
     API_END_RET(session, ret);
 }
 


### PR DESCRIPTION
This PR adds a method to print the call log entry for session.timestamp_transaction().