### PR TITLE
WT-9238 Process the call log for timestamp_transaction()

### DIFF
--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -243,11 +243,13 @@ call_log_manager::call_log_set_timestamp(const json &call_log_entry)
 
 void
 call_log_manager::call_log_timestamp_transaction(const json &call_log_entry){
+    /* Convert the config char * to a string object. */
     const std::string config = call_log_entry["input"]["config"].get<std::string>();
     const std::string session_id = call_log_entry["session_id"].get<std::string>();
     session_simulator *session = get_session(session_id);
 
     int ret = session->timestamp_transaction(config);
+    
     int ret_expected = call_log_entry["return"]["return_val"].get<int>();
     /* The ret value should be equal to the expected ret value. */
     assert(ret == ret_expected);

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -71,6 +71,7 @@ call_log_manager::api_map_setup()
     _api_map["query_timestamp"] = api_method::query_timestamp;
     _api_map["rollback_transaction"] = api_method::rollback_transaction;
     _api_map["set_timestamp"] = api_method::set_timestamp;
+    _api_map["timestamp_transaction"] = api_method::timestamp_transaction;
     _api_map["timestamp_transaction_uint"] = api_method::timestamp_transaction_uint;
 }
 
@@ -241,6 +242,22 @@ call_log_manager::call_log_set_timestamp(const json &call_log_entry)
 }
 
 void
+call_log_manager::call_log_timestamp_transaction(const json &call_log_entry){
+    const std::string config = call_log_entry["input"]["config"].get<std::string>();
+    const std::string session_id = call_log_entry["session_id"].get<std::string>();
+    session_simulator *session = get_session(session_id);
+
+    int ret = session->timestamp_transaction(config);
+    int ret_expected = call_log_entry["return"]["return_val"].get<int>();
+    /* The ret value should be equal to the expected ret value. */
+    assert(ret == ret_expected);
+
+    if (ret != 0)
+        throw "'timestamp_transaction_uint' failed with ret value: '" + std::to_string(ret) +
+          "', and config: '" + config + "'";
+}
+
+void
 call_log_manager::call_log_timestamp_transaction_uint(const json &call_log_entry)
 {
     /* Convert the transaction type char * to a string object. */
@@ -299,6 +316,9 @@ call_log_manager::process_call_log_entry(const json &call_log_entry)
             break;
         case api_method::set_timestamp:
             call_log_set_timestamp(call_log_entry);
+            break;
+        case api_method::timestamp_transaction:
+            call_log_timestamp_transaction(call_log_entry);
             break;
         case api_method::timestamp_transaction_uint:
             call_log_timestamp_transaction_uint(call_log_entry);

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -242,14 +242,15 @@ call_log_manager::call_log_set_timestamp(const json &call_log_entry)
 }
 
 void
-call_log_manager::call_log_timestamp_transaction(const json &call_log_entry){
+call_log_manager::call_log_timestamp_transaction(const json &call_log_entry)
+{
     /* Convert the config char * to a string object. */
     const std::string config = call_log_entry["input"]["config"].get<std::string>();
     const std::string session_id = call_log_entry["session_id"].get<std::string>();
     session_simulator *session = get_session(session_id);
 
     int ret = session->timestamp_transaction(config);
-    
+
     int ret_expected = call_log_entry["return"]["return_val"].get<int>();
     /* The ret value should be equal to the expected ret value. */
     assert(ret == ret_expected);

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.h
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.h
@@ -41,6 +41,7 @@ enum class api_method {
     query_timestamp,
     rollback_transaction,
     set_timestamp,
+    timestamp_transaction,
     timestamp_transaction_uint
 };
 
@@ -63,6 +64,7 @@ class call_log_manager {
     void call_log_query_timestamp(const json &);
     void call_log_rollback_transaction(const json &);
     void call_log_set_timestamp(const json &);
+    void call_log_timestamp_transaction(const json &);
     void call_log_timestamp_transaction_uint(const json &);
 
     /* Member variables */

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <string>
+#include <map>
 
 class session_simulator {
     /* Methods */
@@ -38,6 +39,9 @@ class session_simulator {
     void begin_transaction();
     void rollback_transaction();
     void commit_transaction();
+    int decode_timestamp_config_map(
+      std::map<std::string, std::string> &, uint64_t &, uint64_t &, uint64_t &, uint64_t &);
+    int timestamp_transaction(const std::string &);
     int timestamp_transaction_uint(const std::string &, uint64_t);
     void set_commit_timestamp(uint64_t);
     void set_durable_timestamp(uint64_t);

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -143,6 +143,9 @@ session_simulator::decode_timestamp_config_map(std::map<std::string, std::string
 int
 session_simulator::timestamp_transaction(const std::string &config)
 {
+    /* Make sure that the transaction from this session is running. */
+    assert(_txn_running);
+
     /* If not timestamp was supplied, there's nothing to do. */
     // PM-2564-TODO check this in wiredtiger.
     if (config.empty())
@@ -184,6 +187,9 @@ session_simulator::timestamp_transaction(const std::string &config)
 int
 session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64_t ts)
 {
+    /* Make sure that the transaction from this session is running. */
+    assert(_txn_running);
+
     /* Zero timestamp is not permitted. */
     if (ts == 0) {
         WT_SIM_RET_MSG(EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -101,7 +101,7 @@ session_simulator::decode_timestamp_config_map(std::map<std::string, std::string
     auto pos = config_map.find("commit_timestamp");
     if (pos != config_map.end()) {
         commit_ts = ts_manager->hex_to_decimal(pos->second);
-        if (commit_ts == 0) 
+        if (commit_ts == 0)
             WT_SIM_RET_MSG(EINVAL, "Illegal commit timestamp: zero not permitted.");
         config_map.erase(pos);
     }
@@ -109,7 +109,7 @@ session_simulator::decode_timestamp_config_map(std::map<std::string, std::string
     pos = config_map.find("durable_timestamp");
     if (pos != config_map.end()) {
         durable_ts = ts_manager->hex_to_decimal(pos->second);
-        if (durable_ts == 0) 
+        if (durable_ts == 0)
             WT_SIM_RET_MSG(EINVAL, "Illegal durable timestamp: zero not permitted.");
         config_map.erase(pos);
     }
@@ -117,7 +117,7 @@ session_simulator::decode_timestamp_config_map(std::map<std::string, std::string
     pos = config_map.find("prepare_timestamp");
     if (pos != config_map.end()) {
         prepare_ts = ts_manager->hex_to_decimal(pos->second);
-        if (prepare_ts == 0) 
+        if (prepare_ts == 0)
             WT_SIM_RET_MSG(EINVAL, "Illegal prepare timestamp: zero not permitted.");
         config_map.erase(pos);
     }
@@ -125,7 +125,7 @@ session_simulator::decode_timestamp_config_map(std::map<std::string, std::string
     pos = config_map.find("read_timestamp");
     if (pos != config_map.end()) {
         read_ts = ts_manager->hex_to_decimal(pos->second);
-        if (read_ts == 0) 
+        if (read_ts == 0)
             WT_SIM_RET_MSG(EINVAL, "Illegal read timestamp: zero not permitted.");
         config_map.erase(pos);
     }
@@ -156,21 +156,17 @@ session_simulator::timestamp_transaction(const std::string &config)
       "Incorrect config passed to 'timestamp_transaction': '" + config + "'");
 
     /* Check if the timestamps were included in the configuration string and set them. */
-    if (commit_ts != 0) {
+    if (commit_ts != 0)
         set_commit_timestamp(commit_ts);
-    }
 
-    if (durable_ts != 0) {
+    if (durable_ts != 0)
         set_durable_timestamp(durable_ts);
-    }
 
-    if (prepare_ts != 0) {
+    if (prepare_ts != 0)
         set_prepare_timestamp(prepare_ts);
-    }
 
-    if (read_ts != 0) {
+    if (read_ts != 0)
         set_read_timestamp(read_ts);
-    }
 
     return (0);
 }
@@ -186,15 +182,15 @@ session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64
         WT_SIM_RET_MSG(EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");
     }
 
-    if (ts_type == "commit") {
+    if (ts_type == "commit")
         set_commit_timestamp(ts);
-    } else if (ts_type == "durable") {
+    else if (ts_type == "durable")
         set_durable_timestamp(ts);
-    } else if (ts_type == "prepare") {
+    else if (ts_type == "prepare")
         set_prepare_timestamp(ts);
-    } else if (ts_type == "read") {
+    else if (ts_type == "read")
         set_read_timestamp(ts);
-    } else {
+    else {
         WT_SIM_RET_MSG(
           EINVAL, "Invalid timestamp type (" + ts_type + ") passed to timestamp transaction uint.");
     }
@@ -224,15 +220,15 @@ session_simulator::query_timestamp(
 
     ts_supported = true;
     uint64_t ts;
-    if (query_timestamp == "commit") {
+    if (query_timestamp == "commit")
         ts = _commit_ts;
-    } else if (query_timestamp == "first_commit") {
+    else if (query_timestamp == "first_commit")
         ts = _first_commit_ts;
-    } else if (query_timestamp == "prepare") {
+    else if (query_timestamp == "prepare")
         ts = _prepare_ts;
-    } else if (query_timestamp == "read") {
+    else if (query_timestamp == "read")
         ts = _read_ts;
-    } else {
+    else {
         ts_supported = false;
         WT_SIM_RET_MSG(EINVAL, "Incorrect config (" + config + ") passed in query timestamp");
     }

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -130,13 +130,6 @@ session_simulator::decode_timestamp_config_map(std::map<std::string, std::string
         config_map.erase(pos);
     }
 
-    // std::cout << "commit_ts: " << commit_ts << std::endl;
-    // std::cout << "durable_ts: " << durable_ts << std::endl;
-    // std::cout << "read_ts: " << read_ts << std::endl;
-    // std::cout << "prepare_ts: " << prepare_ts << std::endl;
-
-    // std::cout << "config_map.empty(): " << config_map.empty() << std::endl;
-
     return (config_map.empty() ? 0 : EINVAL);
 }
 
@@ -146,8 +139,7 @@ session_simulator::timestamp_transaction(const std::string &config)
     /* Make sure that the transaction from this session is running. */
     assert(_txn_running);
 
-    /* If not timestamp was supplied, there's nothing to do. */
-    // PM-2564-TODO check this in wiredtiger.
+    /* If no timestamp was supplied, there's nothing to do. */
     if (config.empty())
         return (0);
 
@@ -158,13 +150,12 @@ session_simulator::timestamp_transaction(const std::string &config)
 
     uint64_t commit_ts = 0, durable_ts = 0, prepare_ts = 0, read_ts = 0;
 
-    std::cout << "timestmap_transaction.config: " << config << std::endl;
-
-    // PM-2564-TODO config can have multiple timestamps to set.
+    /* Decode a configuration string that may contain multiple timestamps and store them here. */
     WT_SIM_RET_MSG(
       decode_timestamp_config_map(config_map, commit_ts, durable_ts, prepare_ts, read_ts),
       "Incorrect config passed to 'timestamp_transaction': '" + config + "'");
 
+    /* Check if the timestamps were included in the configuration string and set them. */
     if (commit_ts != 0) {
         set_commit_timestamp(commit_ts);
     }


### PR DESCRIPTION
This PR adds the timestamp_transaction method to the simulator session class and the corresponding processing for the call log manager. Note that multiple timestamps can be set in a single call of timestamp_transaciton.