### PR TITLE
WT-9227 Support read_timestamp processing

### DIFF
--- a/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.cpp
@@ -94,15 +94,13 @@ void
 call_log_manager::call_log_begin_transaction(const json &call_log_entry)
 {
     const std::string session_id = call_log_entry["session_id"].get<std::string>();
-
-    /* If there is a failure in begin_transaction, there is no work to do. */
-    int ret = call_log_entry["return"]["return_val"].get<int>();
-    if (ret != 0)
-        throw "Cannot begin the transaction for session_id (" + session_id +
-          ") as return value in the call log is: " + std::to_string(ret);
-
     session_simulator *session = get_session(session_id);
-    session->begin_transaction();
+    const std::string config = call_log_entry["input"]["config"].get<std::string>();
+    int ret = session->begin_transaction(config);
+
+    int ret_expected = call_log_entry["return"]["return_val"].get<int>();
+    /* The ret value should be equal to the expected ret value. */
+    assert(ret == ret_expected);
 }
 
 void

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -43,10 +43,10 @@ class session_simulator {
       std::map<std::string, std::string> &, uint64_t &, uint64_t &, uint64_t &, uint64_t &);
     int timestamp_transaction(const std::string &);
     int timestamp_transaction_uint(const std::string &, uint64_t);
-    uint64_t get_commit_timestamp();
-    uint64_t get_durable_timestamp();
-    uint64_t get_prepare_timestamp();
-    uint64_t get_read_timestamp();
+    uint64_t get_commit_timestamp() const;
+    uint64_t get_durable_timestamp() const;
+    uint64_t get_prepare_timestamp() const;
+    uint64_t get_read_timestamp() const;
     bool get_ts_round_read();
     void set_commit_timestamp(uint64_t);
     void set_durable_timestamp(uint64_t);

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -36,7 +36,7 @@ class session_simulator {
     public:
     session_simulator();
     ~session_simulator() = default;
-    void begin_transaction();
+    int begin_transaction(const std::string &);
     void rollback_transaction();
     void commit_transaction();
     int decode_timestamp_config_map(

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -39,10 +39,15 @@ class session_simulator {
     void rollback_transaction();
     void commit_transaction();
     int timestamp_transaction_uint(const std::string &, uint64_t);
+    uint64_t get_commit_timestamp();
+    uint64_t get_durable_timestamp();
+    uint64_t get_prepare_timestamp();
+    uint64_t get_read_timestamp();
+    bool get_ts_round_read();
     void set_commit_timestamp(uint64_t);
     void set_durable_timestamp(uint64_t);
     void set_prepare_timestamp(uint64_t);
-    void set_read_timestamp(uint64_t);
+    int set_read_timestamp(uint64_t);
     int query_timestamp(const std::string &, std::string &, bool &);
 
     public:
@@ -53,6 +58,7 @@ class session_simulator {
     /* Member variables */
     private:
     bool _has_commit_ts;
+    bool _ts_round_read;
     bool _txn_running;
     uint64_t _commit_ts;
     uint64_t _durable_ts;

--- a/test/simulator/timestamp/src/include/timestamp_manager.h
+++ b/test/simulator/timestamp/src/include/timestamp_manager.h
@@ -31,6 +31,8 @@
 #include <map>
 #include <string>
 
+#include "session_simulator.h"
+
 /* Timestamp is a global singleton class responsible for validating the timestamps. */
 class timestamp_manager {
     /* Methods */
@@ -44,6 +46,7 @@ class timestamp_manager {
     public:
     int validate_oldest_and_stable_ts(uint64_t &, uint64_t &, bool &, bool &);
     int validate_durable_ts(const uint64_t &, const bool &) const;
+    int validate_read_timestamp(session_simulator *, const uint64_t) const;
 
     private:
     std::string trim(std::string);

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -37,8 +37,8 @@
 #include "timestamp_manager.h"
 
 session_simulator::session_simulator()
-    : _commit_ts(0), _durable_ts(0), _first_commit_ts(0), _prepare_ts(0), _read_ts(0),
-      _has_commit_ts(false), _ts_round_read(false), _txn_running(false)
+    : _has_commit_ts(false), _ts_round_read(false), _txn_running(false), _commit_ts(0),
+      _durable_ts(0), _first_commit_ts(0), _prepare_ts(0), _read_ts(0)
 {
 }
 
@@ -47,7 +47,6 @@ session_simulator::begin_transaction(const std::string &config)
 {
     /* Make sure that the transaction from this session isn't running. */
     assert(!_txn_running);
-    _ts_round_read = false;
 
     timestamp_manager *ts_manager = &timestamp_manager::get_timestamp_manager();
     std::map<std::string, std::string> config_map;
@@ -56,6 +55,7 @@ session_simulator::begin_transaction(const std::string &config)
 
     /* Check if the read timestamp should be rounded up. */
     auto pos = config_map.find("roundup_timestamps");
+    _ts_round_read = false;
     if (pos != config_map.end() && pos->second.find("read=true")) {
         _ts_round_read = true;
         config_map.erase(pos);
@@ -95,25 +95,25 @@ session_simulator::commit_transaction()
 }
 
 uint64_t
-session_simulator::get_commit_timestamp()
+session_simulator::get_commit_timestamp() const
 {
     return _commit_ts;
 }
 
 uint64_t
-session_simulator::get_durable_timestamp()
+session_simulator::get_durable_timestamp() const
 {
     return _durable_ts;
 }
 
 uint64_t
-session_simulator::get_prepare_timestamp()
+session_simulator::get_prepare_timestamp() const
 {
     return _prepare_ts;
 }
 
 uint64_t
-session_simulator::get_read_timestamp()
+session_simulator::get_read_timestamp() const
 {
     return _read_ts;
 }

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -31,10 +31,15 @@
 #include <cassert>
 #include <iostream>
 
+#include "connection_simulator.h"
 #include "error_simulator.h"
 #include "timestamp_manager.h"
 
-session_simulator::session_simulator() : _has_commit_ts(false), _txn_running(false) {}
+session_simulator::session_simulator()
+    : _commit_ts(0), _durable_ts(0), _first_commit_ts(0), _prepare_ts(0), _read_ts(0),
+      _has_commit_ts(false), _txn_running(false)
+{
+}
 
 void
 session_simulator::begin_transaction()
@@ -63,6 +68,36 @@ session_simulator::commit_transaction()
     _txn_running = false;
 }
 
+uint64_t
+session_simulator::get_commit_timestamp()
+{
+    return _commit_ts;
+}
+
+uint64_t
+session_simulator::get_durable_timestamp()
+{
+    return _durable_ts;
+}
+
+uint64_t
+session_simulator::get_prepare_timestamp()
+{
+    return _prepare_ts;
+}
+
+uint64_t
+session_simulator::get_read_timestamp()
+{
+    return _read_ts;
+}
+
+bool
+session_simulator::get_ts_round_read()
+{
+    return _ts_round_read;
+}
+
 void
 session_simulator::set_commit_timestamp(uint64_t ts)
 {
@@ -86,10 +121,24 @@ session_simulator::set_prepare_timestamp(uint64_t ts)
     _prepare_ts = ts;
 }
 
-void
-session_simulator::set_read_timestamp(uint64_t ts)
+int
+session_simulator::set_read_timestamp(uint64_t read_ts)
 {
-    _read_ts = ts;
+    timestamp_manager *ts_manager = &timestamp_manager::get_timestamp_manager();
+    WT_SIM_RET(ts_manager->validate_read_timestamp(this, read_ts));
+
+    /*
+     * If the given timestamp is earlier than the oldest timestamp then round the read timestamp to
+     * oldest timestamp.
+     */
+    connection_simulator *conn = &connection_simulator::get_connection();
+    uint64_t oldest_ts = conn->get_oldest_ts();
+    if (_ts_round_read && read_ts < oldest_ts) {
+        _read_ts = oldest_ts;
+    } else
+        _read_ts = read_ts;
+
+    return (0);
 }
 
 int
@@ -107,7 +156,7 @@ session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64
     } else if (ts_type == "prepare") {
         set_prepare_timestamp(ts);
     } else if (ts_type == "read") {
-        set_read_timestamp(ts);
+        WT_SIM_RET(set_read_timestamp(ts));
     } else {
         WT_SIM_RET_MSG(
           EINVAL, "Invalid timestamp type (" + ts_type + ") passed to timestamp transaction uint.");

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -159,9 +159,9 @@ session_simulator::set_read_timestamp(uint64_t read_ts)
      */
     connection_simulator *conn = &connection_simulator::get_connection();
     uint64_t oldest_ts = conn->get_oldest_ts();
-    if (_ts_round_read && read_ts < oldest_ts) {
+    if (_ts_round_read && read_ts < oldest_ts)
         _read_ts = oldest_ts;
-    } else
+    else if (read_ts >= oldest_ts)
         _read_ts = read_ts;
 
     return (0);

--- a/test/simulator/timestamp/src/timestamp_manager.cpp
+++ b/test/simulator/timestamp/src/timestamp_manager.cpp
@@ -189,6 +189,13 @@ timestamp_manager::validate_durable_ts(
     return (0);
 }
 
+/*
+ * Validate the read timestamp. The constraints on the read timestamp are:
+ * 1) The read timestamp can only be set before a transaction is prepared
+ * 2) Read timestamps can only be set once.
+ * 3) The read timestamp must be greater than or equal to the oldest timestamp unless rounding
+ * the read timestamp is enabled.
+ */
 int
 timestamp_manager::validate_read_timestamp(session_simulator *session, const uint64_t read_ts) const
 {

--- a/test/simulator/timestamp/src/timestamp_manager.cpp
+++ b/test/simulator/timestamp/src/timestamp_manager.cpp
@@ -202,7 +202,7 @@ timestamp_manager::validate_read_timestamp(session_simulator *session, const uin
         WT_SIM_RET_MSG(EINVAL, "A read_timestamp may only be set once per transaction.");
     }
 
-    /* 
+    /*
      * We cannot set the read timestamp to be earlier than the oldest timestamp if we're not
      * rounding to the oldest.
      */

--- a/test/simulator/timestamp/src/timestamp_manager.cpp
+++ b/test/simulator/timestamp/src/timestamp_manager.cpp
@@ -206,7 +206,7 @@ timestamp_manager::validate_read_timestamp(session_simulator *session, const uin
 
     /* Read timestamps can't change once set. */
     if (session->get_read_timestamp() != 0) {
-        WT_SIM_RET_MSG(EINVAL, "A read_timestamp may only be set once per transaction.");
+        WT_SIM_RET_MSG(EINVAL, "A read_timestamp can only be set once per transaction.");
     }
 
     /*


### PR DESCRIPTION
The focus of this PR is to add the validate_read_timestamp to the timestamp manager which is used to check whether or not a read timestamp is valid before setting it in the transaction. 
Read timestamps can also now be set in begin transaction along with the round_read configuration option.
I've also added getters for the session transaction timestamps so they can be compared against.
