### PR TITLE
WT-9795 - In test/format, use commit timestamps which are after the stable timestamp

### DIFF
--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -39,7 +39,7 @@ bulk_begin_transaction(WT_SESSION *session)
 
     /* Writes require snapshot isolation. */
     wt_wrap_begin_transaction(session, NULL);
-    ts = __wt_atomic_fetch_addv64(&g.timestamp, 1);
+    ts = __wt_atomic_addv64(&g.timestamp, 1);
     testutil_check(session->timestamp_transaction_uint(session, WT_TS_TXN_TYPE_READ, ts));
 }
 
@@ -52,7 +52,7 @@ bulk_commit_transaction(WT_SESSION *session)
 {
     uint64_t ts;
 
-    ts = __wt_atomic_fetch_addv64(&g.timestamp, 1);
+    ts = __wt_atomic_addv64(&g.timestamp, 1);
     testutil_check(session->timestamp_transaction_uint(session, WT_TS_TXN_TYPE_COMMIT, ts));
     testutil_check(session->commit_transaction(session, NULL));
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -503,7 +503,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
         if (prepared)
             lock_readlock(session, &g.prepare_commit_lock);
 
-        ts = __wt_atomic_fetch_addv64(&g.timestamp, 1);
+        ts = __wt_atomic_addv64(&g.timestamp, 1);
         testutil_check(session->timestamp_transaction_uint(session, WT_TS_TXN_TYPE_COMMIT, ts));
 
         if (prepared)


### PR DESCRIPTION
Switched from __wt_atomic_fetch_addv64() to __wt_atomic_addv64 to return the incremented value, rather than the pre-incremented value.

This means that the returned, new timestamp that is used for the commit is after the stable timestamp, not the same as the stable timestamp