### PR TITLE
WT-9926 Remove backup file after recovery checkpoint.

### DIFF
--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -600,8 +600,11 @@ err:
         }
     __wt_free(session, backuphash);
 
-    /* Remove the backup files, we'll never read them again. */
-    return (__wt_backup_file_remove(session));
+    /*
+     * We used to remove the backup file here. But we cannot do that until the metadata is fully
+     * synced to disk after recovery.
+     */
+    return (ret);
 }
 
 /*

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1493,6 +1493,15 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
         is_wt_ckpt = WT_PREFIX_MATCH(ckpt->name, WT_CHECKPOINT);
 
         /*
+         * If we are restarting from a backup and we're in recovery do not delete any checkpoints.
+         * In the event of a crash we may need to restart from the backup and all checkpoints that
+         * were in the backup file must remain.
+         */
+        if (F_ISSET(conn, WT_CONN_RECOVERING) && F_ISSET(conn, WT_CONN_WAS_BACKUP)) {
+            F_CLR(ckpt, WT_CKPT_DELETE);
+            continue;
+        }
+        /*
          * If there is a hot backup, don't delete any WiredTiger checkpoint that could possibly have
          * been created before the backup started. Fail if trying to delete any other named
          * checkpoint.

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1012,6 +1012,9 @@ done:
          */
         WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
 
+    /* Remove any backup file now that metadata has been synced. */
+    WT_ERR(__wt_backup_file_remove(session));
+
     /*
      * Update the open dhandles write generations and base write generation with the connection's
      * base write generation because the recovery checkpoint writes the pages to disk with new write


### PR DESCRIPTION
I have run existing backup tests and will kick off a test format stress test forcing backup and abort both on.