### PR TITLE
WT-9900 Create unit test to validate cursor bounds save/restore flag logic

### DIFF
--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -2,6 +2,7 @@ project(unittest CXX)
 
 set(unittest_sources
     tests/main.cpp
+    tests/test_bounds_restore.cpp
     tests/test_crc32.cpp
     tests/test_extent_list.cpp
     tests/test_fnv.cpp

--- a/test/unittest/tests/test_bounds_restore.cpp
+++ b/test/unittest/tests/test_bounds_restore.cpp
@@ -12,7 +12,6 @@
 #include "wiredtiger.h"
 #include "wrappers/connection_wrapper.h"
 #include "wt_internal.h"
-#include <iostream>
 
 int
 validate_cursor_bounds_restore(WT_CURSOR *cursor, uint64_t original_cursor_flags)

--- a/test/unittest/tests/test_bounds_restore.cpp
+++ b/test/unittest/tests/test_bounds_restore.cpp
@@ -8,30 +8,14 @@
 
 #include <catch2/catch.hpp>
 
+#include "utils.h"
 #include "wiredtiger.h"
+#include "wrappers/connection_wrapper.h"
 #include "wt_internal.h"
-
-struct MockCursor {
-    uint64_t flags;
-};
+#include <iostream>
 
 int
-mock_cursor_bounds_save(MockCursor *cursor, WT_CURSOR_BOUNDS_STATE *state)
-{
-    state->bound_flags = F_MASK(cursor, WT_CURSTD_BOUND_ALL);
-    return (0);
-}
-
-int
-mock_cursor_bounds_restore(MockCursor *cursor, WT_CURSOR_BOUNDS_STATE *state)
-{
-    F_CLR(cursor, WT_CURSTD_BOUND_ALL);
-    F_SET(cursor, state->bound_flags);
-    return (0);
-}
-
-int
-validate_mock_cursor_bounds_restore(MockCursor *cursor, uint64_t original_cursor_flags)
+validate_cursor_bounds_restore(WT_CURSOR *cursor, uint64_t original_cursor_flags)
 {
     assert(cursor->flags == original_cursor_flags);
     return (0);
@@ -40,29 +24,41 @@ validate_mock_cursor_bounds_restore(MockCursor *cursor, uint64_t original_cursor
 TEST_CASE("Bounds save and restore flag logic", "[bounds_restore]")
 {
     uint64_t original_cursor_flags;
-    MockCursor *mock_cursor;
+    WT_CURSOR mock_cursor;
     WT_CURSOR_BOUNDS_STATE mock_state;
+
+    ConnectionWrapper conn(DB_HOME);
+    WT_SESSION_IMPL *session = conn.createSession();
+
+    mock_state.lower_bound = NULL;
+    mock_state.upper_bound = NULL;
+
+    mock_cursor.lower_bound.size = 0;
+    mock_cursor.lower_bound.data = NULL;
+    mock_cursor.upper_bound.size = 0;
+    mock_cursor.upper_bound.data = NULL;
 
     // Save bounds flags and ensure that the restore logic correctly restores the desired flags.
     SECTION("Save non-empty non-inclusive bounds flags and restore")
     {
-        mock_cursor = (MockCursor *)calloc(1, sizeof(MockCursor));
-        F_SET(mock_cursor, WT_CURSTD_BOUND_UPPER);
-        F_SET(mock_cursor, WT_CURSTD_BOUND_LOWER);
-        original_cursor_flags = mock_cursor->flags;
-        REQUIRE(mock_cursor_bounds_save(mock_cursor, &mock_state) == 0);
-        REQUIRE(mock_cursor_bounds_restore(mock_cursor, &mock_state) == 0);
-        REQUIRE(validate_mock_cursor_bounds_restore(mock_cursor, original_cursor_flags) == 0);
+        F_SET(&mock_cursor, WT_CURSTD_BOUND_UPPER);
+        F_SET(&mock_cursor, WT_CURSTD_BOUND_LOWER);
+        original_cursor_flags = mock_cursor.flags;
+        REQUIRE(__wt_cursor_bounds_save(session, &mock_cursor, &mock_state) == 0);
+        REQUIRE(__wt_cursor_bounds_restore(session, &mock_cursor, &mock_state) == 0);
+        REQUIRE(validate_cursor_bounds_restore(&mock_cursor, original_cursor_flags) == 0);
+        __wt_scr_free(session, &mock_state.lower_bound);
+        __wt_scr_free(session, &mock_state.upper_bound);
     }
 
+    mock_cursor.flags = 0;
     SECTION("Save non-empty inclusive bounds flags and restore")
     {
-        mock_cursor = (MockCursor *)calloc(1, sizeof(MockCursor));
-        F_SET(mock_cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
-        F_SET(mock_cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
-        original_cursor_flags = mock_cursor->flags;
-        REQUIRE(mock_cursor_bounds_save(mock_cursor, &mock_state) == 0);
-        REQUIRE(mock_cursor_bounds_restore(mock_cursor, &mock_state) == 0);
-        REQUIRE(validate_mock_cursor_bounds_restore(mock_cursor, original_cursor_flags) == 0);
+        F_SET(&mock_cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
+        F_SET(&mock_cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
+        original_cursor_flags = mock_cursor.flags;
+        REQUIRE(__wt_cursor_bounds_save(session, &mock_cursor, &mock_state) == 0);
+        REQUIRE(__wt_cursor_bounds_restore(session, &mock_cursor, &mock_state) == 0);
+        REQUIRE(validate_cursor_bounds_restore(&mock_cursor, original_cursor_flags) == 0);
     }
 }

--- a/test/unittest/tests/test_bounds_restore.cpp
+++ b/test/unittest/tests/test_bounds_restore.cpp
@@ -13,16 +13,14 @@
 #include "wrappers/connection_wrapper.h"
 #include "wt_internal.h"
 
-int
+bool
 validate_cursor_bounds_restore(WT_CURSOR *cursor, uint64_t original_cursor_flags)
 {
-    assert(cursor->flags == original_cursor_flags);
-    return (0);
+    return cursor->flags == original_cursor_flags;
 }
 
 TEST_CASE("Bounds save and restore flag logic", "[bounds_restore]")
 {
-    uint64_t original_cursor_flags;
     WT_CURSOR mock_cursor;
     WT_CURSOR_BOUNDS_STATE mock_state;
 
@@ -32,6 +30,7 @@ TEST_CASE("Bounds save and restore flag logic", "[bounds_restore]")
     mock_state.lower_bound = NULL;
     mock_state.upper_bound = NULL;
 
+    mock_cursor.flags = 0;
     mock_cursor.lower_bound.size = 0;
     mock_cursor.lower_bound.data = NULL;
     mock_cursor.upper_bound.size = 0;
@@ -42,22 +41,21 @@ TEST_CASE("Bounds save and restore flag logic", "[bounds_restore]")
     {
         F_SET(&mock_cursor, WT_CURSTD_BOUND_UPPER);
         F_SET(&mock_cursor, WT_CURSTD_BOUND_LOWER);
-        original_cursor_flags = mock_cursor.flags;
+        uint64_t original_cursor_flags = mock_cursor.flags;
         REQUIRE(__wt_cursor_bounds_save(session, &mock_cursor, &mock_state) == 0);
         REQUIRE(__wt_cursor_bounds_restore(session, &mock_cursor, &mock_state) == 0);
-        REQUIRE(validate_cursor_bounds_restore(&mock_cursor, original_cursor_flags) == 0);
+        REQUIRE(validate_cursor_bounds_restore(&mock_cursor, original_cursor_flags));
         __wt_scr_free(session, &mock_state.lower_bound);
         __wt_scr_free(session, &mock_state.upper_bound);
     }
 
-    mock_cursor.flags = 0;
     SECTION("Save non-empty inclusive bounds flags and restore")
     {
         F_SET(&mock_cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
         F_SET(&mock_cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
-        original_cursor_flags = mock_cursor.flags;
+        uint64_t original_cursor_flags = mock_cursor.flags;
         REQUIRE(__wt_cursor_bounds_save(session, &mock_cursor, &mock_state) == 0);
         REQUIRE(__wt_cursor_bounds_restore(session, &mock_cursor, &mock_state) == 0);
-        REQUIRE(validate_cursor_bounds_restore(&mock_cursor, original_cursor_flags) == 0);
+        REQUIRE(validate_cursor_bounds_restore(&mock_cursor, original_cursor_flags));
     }
 }

--- a/test/unittest/tests/test_bounds_restore.cpp
+++ b/test/unittest/tests/test_bounds_restore.cpp
@@ -1,0 +1,68 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wiredtiger.h"
+#include "wt_internal.h"
+
+struct MockCursor {
+    uint64_t flags;
+};
+
+int
+mock_cursor_bounds_save(MockCursor *cursor, WT_CURSOR_BOUNDS_STATE *state)
+{
+    state->bound_flags = F_MASK(cursor, WT_CURSTD_BOUND_ALL);
+    return (0);
+}
+
+int
+mock_cursor_bounds_restore(MockCursor *cursor, WT_CURSOR_BOUNDS_STATE *state)
+{
+    F_CLR(cursor, WT_CURSTD_BOUND_ALL);
+    F_SET(cursor, state->bound_flags);
+    return (0);
+}
+
+int
+validate_mock_cursor_bounds_restore(MockCursor *cursor, uint64_t original_cursor_flags)
+{
+    assert(cursor->flags == original_cursor_flags);
+    return (0);
+}
+
+TEST_CASE("Bounds save and restore flag logic", "[bounds_restore]")
+{
+    uint64_t original_cursor_flags;
+    MockCursor *mock_cursor;
+    WT_CURSOR_BOUNDS_STATE mock_state;
+
+    // Save bounds flags and ensure that the restore logic correctly restores the desired flags.
+    SECTION("Save non-empty non-inclusive bounds flags and restore")
+    {
+        mock_cursor = (MockCursor *)calloc(1, sizeof(MockCursor));
+        F_SET(mock_cursor, WT_CURSTD_BOUND_UPPER);
+        F_SET(mock_cursor, WT_CURSTD_BOUND_LOWER);
+        original_cursor_flags = mock_cursor->flags;
+        REQUIRE(mock_cursor_bounds_save(mock_cursor, &mock_state) == 0);
+        REQUIRE(mock_cursor_bounds_restore(mock_cursor, &mock_state) == 0);
+        REQUIRE(validate_mock_cursor_bounds_restore(mock_cursor, original_cursor_flags) == 0);
+    }
+
+    SECTION("Save non-empty inclusive bounds flags and restore")
+    {
+        mock_cursor = (MockCursor *)calloc(1, sizeof(MockCursor));
+        F_SET(mock_cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
+        F_SET(mock_cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
+        original_cursor_flags = mock_cursor->flags;
+        REQUIRE(mock_cursor_bounds_save(mock_cursor, &mock_state) == 0);
+        REQUIRE(mock_cursor_bounds_restore(mock_cursor, &mock_state) == 0);
+        REQUIRE(validate_mock_cursor_bounds_restore(mock_cursor, original_cursor_flags) == 0);
+    }
+}


### PR DESCRIPTION
Created a unit test to check the logic behind flag saving and restoration for bounds. 