### PR TITLE
WT-9899 Validate that bounded cursor logic doesn't apply to random cursors

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -198,6 +198,7 @@ __wt_cursor_set_notsup(WT_CURSOR *cursor)
      * reset all of the cursors in a session. Reconfigure is left open in case it's possible in the
      * future to change these configurations.
      */
+    cursor->bound = __wt_cursor_config_notsup;
     cursor->compare = __wt_cursor_compare_notsup;
     cursor->insert = __wt_cursor_notsup;
     cursor->modify = __wt_cursor_modify_notsup;

--- a/test/suite/test_cursor_bound01.py
+++ b/test/suite/test_cursor_bound01.py
@@ -116,5 +116,12 @@ class test_cursor_bound01(bound_base):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.largest_key(),
             '/Invalid argument/')
 
+        # Check that setting bounds doesn't work with random cursors. Turn it off with column store as column
+        # store doesn't support the next_random config.
+        if (self.key_format != 'r'):
+            cursor = self.session.open_cursor(uri, None, "next_random=true")
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: self.set_bounds(cursor, 40, "lower"), 
+                '/Operation not supported/')
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_cursor_bound01.py
+++ b/test/suite/test_cursor_bound01.py
@@ -122,6 +122,8 @@ class test_cursor_bound01(bound_base):
             cursor = self.session.open_cursor(uri, None, "next_random=true")
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: self.set_bounds(cursor, 40, "lower"), 
                 '/Operation not supported/')
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: self.set_bounds(cursor, 60, "upper"), 
+                '/Operation not supported/')
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Disable setting bounds with random cursors and add scenario in test_cursor_bound01 to validate this behaviour.