### PR TITLE
WT-9236 Support durable_timestamp processing

### DIFF
--- a/test/simulator/timestamp/src/include/connection_simulator.h
+++ b/test/simulator/timestamp/src/include/connection_simulator.h
@@ -41,7 +41,10 @@ class connection_simulator {
     static connection_simulator &get_connection();
     session_simulator *open_session();
     void close_session(session_simulator *);
+    int set_durable_timestamp(uint64_t);
     int set_timestamp(const std::string &);
+    uint64_t get_all_durable_ts() const;
+    uint64_t get_durable_ts() const;
     uint64_t get_oldest_ts() const;
     uint64_t get_stable_ts() const;
     uint64_t get_latest_active_read() const;

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -52,7 +52,7 @@ class session_simulator {
     bool get_ts_round_prepared() const;
     bool has_prepare_timestamp();
     int set_commit_timestamp(uint64_t);
-    void set_durable_timestamp(uint64_t);
+    int set_durable_timestamp(uint64_t);
     void set_prepare_timestamp(uint64_t);
     int set_read_timestamp(uint64_t);
     int query_timestamp(const std::string &, std::string &, bool &);

--- a/test/simulator/timestamp/src/include/timestamp_manager.h
+++ b/test/simulator/timestamp/src/include/timestamp_manager.h
@@ -46,7 +46,7 @@ class timestamp_manager {
     /* Methods for validating timestamps */
     public:
     int validate_oldest_and_stable_ts(uint64_t &, uint64_t &, bool &, bool &);
-    int validate_durable_ts(const uint64_t &, const bool &) const;
+    int validate_durable_timestamp(session_simulator *, const uint64_t) const;
     int validate_read_timestamp(session_simulator *, const uint64_t) const;
     int validate_commit_timestamp(session_simulator *, const uint64_t) const;
 


### PR DESCRIPTION
This PR includes:

- Validating the transaction level durable timestamp in the timestamp manager. This is called when setting the durable timestamp. Which in turn is called by commit_transaction or timestamp_transaction.
- Adding the get_all_durable_ts to the connection class for querying the all_durable timestamp.