### PR TITLE
WT-9945 Remove doc-compile task from ASAN build variant

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2307,8 +2307,6 @@ tasks:
             env CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:/opt/java/jdk11/bin:$PATH sh s_release `date +%Y%m%d`
 
   - name: doc-compile
-    run_on:
-    - ubuntu2004-test
     commands:
       - func: "get project"
       - func: "compile wiredtiger docs"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2307,7 +2307,6 @@ tasks:
             env CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:/opt/java/jdk11/bin:$PATH sh s_release `date +%Y%m%d`
 
   - name: doc-compile
-    tags: ["pull_request"]
     run_on:
     - ubuntu2004-test
     commands:
@@ -3980,6 +3979,7 @@ buildvariants:
   tasks:
     - name: ".pull_request !.pull_request_compilers"
     - name: compile
+    - name: doc-compile
     - name: make-check-test
     - name: unit-test
     - name: configure-combinations

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2306,6 +2306,8 @@ tasks:
             set -o verbose
             env CC=/opt/mongodbtoolchain/v3/bin/gcc CXX=/opt/mongodbtoolchain/v3/bin/g++ PATH=/opt/mongodbtoolchain/v3/bin:/opt/java/jdk11/bin:$PATH sh s_release `date +%Y%m%d`
 
+  # Note that the project settings use this task name to compile the documentation during PR
+  # testing, keep this in mind if you decide to change it.
   - name: doc-compile
     commands:
       - func: "get project"


### PR DESCRIPTION
Before these changes, the `doc-compile` task is executed by the two variants `! Ubuntu 20.04` and `! Ubuntu 20.04 ASAN`. It is fine to execute that task only on `! Ubuntu 20.04`.