### PR TITLE
WT-9963 Create a new option to list all the cpp tests

### DIFF
--- a/test/cppsuite/tests/run.cpp
+++ b/test/cppsuite/tests/run.cpp
@@ -234,6 +234,11 @@ main(int argc, char *argv[])
                 test_harness::logger::trace_level = std::stoi(argv[++i]);
             else
                 error_code = -1;
+        } else if (std::string(argv[i]) == "--list") {
+            std::cout << "The tests are:" << std::endl;
+            for (const auto &test_name : all_tests)
+                std::cout << "\t" << test_name << std::endl;
+            return 0;
         } else
             error_code = -1;
     }

--- a/test/cppsuite/tests/run.cpp
+++ b/test/cppsuite/tests/run.cpp
@@ -191,10 +191,11 @@ main(int argc, char *argv[])
 
     /* See print_help() for all the different options and their description. */
     for (size_t i = 1; (i < argc) && (error_code == 0); ++i) {
-        if (std::string(argv[i]) == "-h" || std::string(argv[i]) == "--help") {
+        const std::string option = std::string(argv[i]);
+        if (option == "-h" || option == "--help") {
             print_help();
             return 0;
-        } else if (std::string(argv[i]) == "-C") {
+        } else if (option == "-C") {
             if ((i + 1) < argc) {
                 wt_open_config = argv[++i];
                 /* Add a comma to the front if the user didn't supply one. */
@@ -202,7 +203,7 @@ main(int argc, char *argv[])
                     wt_open_config.insert(0, 1, ',');
             } else
                 error_code = -1;
-        } else if (std::string(argv[i]) == "-c") {
+        } else if (option == "-c") {
             if (!config_filename.empty()) {
                 test_harness::logger::log_msg(LOG_ERROR, "Option -C cannot be used with -f");
                 error_code = -1;
@@ -210,7 +211,7 @@ main(int argc, char *argv[])
                 cfg = argv[++i];
             else
                 error_code = -1;
-        } else if (std::string(argv[i]) == "-f") {
+        } else if (option == "-f") {
             if (!cfg.empty()) {
                 test_harness::logger::log_msg(LOG_ERROR, "Option -f cannot be used with -C");
                 error_code = -1;
@@ -218,17 +219,17 @@ main(int argc, char *argv[])
                 config_filename = argv[++i];
             else
                 error_code = -1;
-        } else if (std::string(argv[i]) == "-t") {
+        } else if (option == "-t") {
             if ((i + 1) < argc)
                 test_name = argv[++i];
             else
                 error_code = -1;
-        } else if (std::string(argv[i]) == "-l") {
+        } else if (option == "-l") {
             if ((i + 1) < argc)
                 test_harness::logger::trace_level = std::stoi(argv[++i]);
             else
                 error_code = -1;
-        } else if (std::string(argv[i]) == "--list") {
+        } else if (option == "--list") {
             std::cout << "The tests are:" << std::endl;
             for (const auto &test_name : all_tests)
                 std::cout << "\t" << test_name << std::endl;

--- a/test/cppsuite/tests/run.cpp
+++ b/test/cppsuite/tests/run.cpp
@@ -108,13 +108,13 @@ print_help()
     std::cout << std::endl;
     std::cout << "OPTIONS" << std::endl;
     std::cout << "\t-h Output a usage message and exit." << std::endl;
-    std::cout << "\t-C Additional wiredtiger open configuration." << std::endl;
+    std::cout << "\t-C Additional WiredTiger open configuration." << std::endl;
     std::cout << "\t-c Test framework configuration. Cannot be used with -f." << std::endl;
     std::cout << "\t-f File that contains the configuration. Cannot be used with -C." << std::endl;
     std::cout << "\t-l Trace level from 0 to 3. "
                  "1 is the default level, all warnings and errors are logged."
               << std::endl;
-    std::cout << "\t--list List all the tests." << std::endl;
+    std::cout << "\t--list List all the tests that can be executed." << std::endl;
     std::cout << "\t-t Test name to be executed." << std::endl;
 }
 

--- a/test/cppsuite/tests/run.cpp
+++ b/test/cppsuite/tests/run.cpp
@@ -92,6 +92,7 @@ print_help()
     std::cout << "\trun -c [TEST_FRAMEWORK_CONFIGURATION]" << std::endl;
     std::cout << "\trun -f [FILE]" << std::endl;
     std::cout << "\trun -l [TRACE_LEVEL]" << std::endl;
+    std::cout << "\trun --list" << std::endl;
     std::cout << "\trun -t [TEST_NAME]" << std::endl;
     std::cout << std::endl;
     std::cout << "DESCRIPTION" << std::endl;
@@ -113,6 +114,7 @@ print_help()
     std::cout << "\t-l Trace level from 0 to 3. "
                  "1 is the default level, all warnings and errors are logged."
               << std::endl;
+    std::cout << "\t--list List all the tests." << std::endl;
     std::cout << "\t-t Test name to be executed." << std::endl;
 }
 
@@ -187,17 +189,9 @@ main(int argc, char *argv[])
     /* Set the program name for error messages. */
     (void)testutil_set_progname(argv);
 
-    /* Parse args
-     * -C   : Additional wiredtiger_open configuration.
-     * -c   : Test framework configuration. Cannot be used with -f. If no specific test is specified
-     * to be run, the same configuration will be used for all existing tests.
-     * -f   : Filename that contains the configuration. Cannot be used with -C. If no specific test
-     * is specified to be run, the same configuration will be used for all existing tests.
-     * -l   : Trace level.
-     * -t   : Test to run. All tests are run if not specified.
-     */
+    /* See print_help() for all the different options and their description. */
     for (size_t i = 1; (i < argc) && (error_code == 0); ++i) {
-        if (std::string(argv[i]) == "-h") {
+        if (std::string(argv[i]) == "-h" || std::string(argv[i]) == "--help") {
             print_help();
             return 0;
         } else if (std::string(argv[i]) == "-C") {


### PR DESCRIPTION
Use the executable `run` with the `--list` option to list all the cpp tests:
```
./run --list
The tests are:
        bounded_cursor_perf
        bounded_cursor_prefix_indices
        bounded_cursor_prefix_search_near
        bounded_cursor_prefix_stat
        bounded_cursor_stress
        burst_inserts
        cache_resize
        hs_cleanup
        operations_test
        search_near_01
        search_near_02
        search_near_03
        test_template
```