### PR TITLE
WT-9966 Switch toolchain to v4 for WT hang analyzer

### DIFF
--- a/test/wt_hang_analyzer/wt_hang_analyzer.py
+++ b/test/wt_hang_analyzer/wt_hang_analyzer.py
@@ -377,7 +377,7 @@ class GDBDumper(object):
     @staticmethod
     def __find_debugger(debugger):
         """Find the installed debugger."""
-        return find_program(debugger, ['/opt/mongodbtoolchain/v3/bin/gdb', '/usr/bin'])
+        return find_program(debugger, ['/opt/mongodbtoolchain/v4/bin/gdb', '/usr/bin'])
 
     def dump_info(self, root_logger, logger, pid, process_name, take_dump):
         """Dump info."""


### PR DESCRIPTION
This change was split from SERVER-62995 as it touches a source file in the wiredtiger repository.

The plan is to merge this PR after SERVER-62995 is merged, and then vendor this change to mongo master via the daily WT release task. 