### PR TITLE
WT-9946 Make s_clang-format more robust

### DIFF
--- a/dist/s_clang-format
+++ b/dist/s_clang-format
@@ -18,8 +18,16 @@ download_clang_format() {
 	fi
 }
 
-# Find the top-level WiredTiger directory and move to there.
-cd `git rev-parse --show-toplevel` || exit 1
+# Find the top-level WiredTiger directory.
+dest_dir=$(git rev-parse --show-toplevel)
+
+# If this is a MongoDB source tree, move to the WiredTiger subtree.
+git_repo_str=$(git config remote.origin.url)
+is_mongo_repo=$(echo "$git_repo_str" | grep "mongodb/mongo")
+if [ -n "$is_mongo_repo" ] ; then
+       dest_dir="$dest_dir/src/third_party/wiredtiger"
+fi
+cd "$dest_dir" || exit 1
 
 # Override existing Clang Format versions in the PATH.
 export PATH="${PWD}/dist":$PATH


### PR DESCRIPTION
After checking out the Mongo Git repo and trying to run `s_clang-format` from `mongo/src/third_party/wiredtiger/dist`, the script fails due to an invalid path as the script expects to be executed from a WiredTiger Git repo.
These changes fix this issue.

@agorrod, I reused your suggestion from WT-9946 (thanks!) and tweaked it a bit.