### PR TITLE
WT-9983 Remove tiered timed out message.

### DIFF
--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -469,7 +469,7 @@ __wt_tiered_storage_destroy(WT_SESSION_IMPL *session, bool final_flush)
         __wt_cond_signal(session, conn->flush_cond);
     if (final_flush && conn->tiered_cond != NULL) {
         __wt_cond_signal(session, conn->tiered_cond);
-        WT_TRET(__wt_tiered_flush_work_wait(session, 30));
+        __wt_tiered_flush_work_wait(session, 30);
     }
     FLD_CLR(conn->server_flags, WT_CONN_SERVER_TIERED);
     if (conn->tiered_tid_set) {

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1513,8 +1513,6 @@ extern int __wt_tiered_conn_config(WT_SESSION_IMPL *session, const char **cfg, b
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tiered_discard(WT_SESSION_IMPL *session, WT_TIERED *tiered, bool final)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tiered_name(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle, uint32_t id,
   uint32_t flags, const char **retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tiered_name_str(WT_SESSION_IMPL *session, const char *name, uint32_t id,
@@ -1896,6 +1894,7 @@ extern void __wt_stat_session_init_single(WT_SESSION_STATS *stats);
 extern void __wt_thread_group_start_one(
   WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, bool is_locked);
 extern void __wt_thread_group_stop_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group);
+extern void __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout);
 extern void __wt_tiered_get_drop_local(
   WT_SESSION_IMPL *session, uint64_t now, WT_TIERED_WORK_UNIT **entryp);
 extern void __wt_tiered_get_drop_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -156,7 +156,7 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
             __wt_epoch(session, &now);
         }
         /* We are done if we don't find any work units or exceed the timeout. */
-        done = !found || WT_TIMEDIFF_SEC(now, start) > timeout;
+        done = !found || (WT_TIMEDIFF_SEC(now, start) > timeout);
     }
     return (0);
 }

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -128,7 +128,7 @@ __wt_tiered_pop_work(
  * __wt_tiered_flush_work_wait --
  *     Wait for all flush work units in the work queue to be processed.
  */
-int
+void
 __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
 {
     struct timespec now, start;
@@ -158,7 +158,6 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
         /* We are done if we don't find any work units or exceed the timeout. */
         done = !found || (WT_TIMEDIFF_SEC(now, start) > timeout);
     }
-    return (0);
 }
 
 /*

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -134,12 +134,12 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
     struct timespec now, start;
     WT_CONNECTION_IMPL *conn;
     WT_TIERED_WORK_UNIT *entry;
-    bool done, found, timed_out;
+    bool done, found;
 
     conn = S2C(session);
     __wt_epoch(session, &start);
     now = start;
-    done = found = timed_out = false;
+    done = found = false;
 
     while (!done) {
         found = false;
@@ -156,14 +156,7 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
             __wt_epoch(session, &now);
         }
         /* We are done if we don't find any work units or exceed the timeout. */
-        if (WT_TIMEDIFF_SEC(now, start) > timeout)
-            timed_out = true;
-        done = !found || timed_out;
-    }
-    if (timed_out) {
-        WT_ASSERT(session, !found);
-        WT_RET(__wt_msg(
-          session, "tiered_flush_work_wait: timed out after %" PRIu32 " seconds", timeout));
+        done = !found || WT_TIMEDIFF_SEC(now, start) > timeout;
     }
     return (0);
 }


### PR DESCRIPTION
This came from Sid who was seeing this when running a wtperf job by hand. I'm not sure why we haven't seen it running other tests but it gets printed out on most/all wtperf configurations.