### PR TITLE
WT-9947 Tidy up cursor->bound API error messages

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1158,7 +1158,7 @@ __wt_cursor_largest_key(WT_CURSOR *cursor)
     CURSOR_API_CALL(cursor, session, largest_key, CUR2BT(cbt));
 
     if (WT_CURSOR_BOUNDS_SET(cursor))
-        WT_ERR_MSG(session, EINVAL, "cursor largest key is not compatible with bounded cursors");
+        WT_ERR_MSG(session, EINVAL, "setting bounds is not compatible with cursor largest key");
 
     WT_ERR(__wt_scr_alloc(session, 0, &key));
 
@@ -1223,10 +1223,10 @@ __wt_cursor_bound(WT_CURSOR *cursor, const char *config)
     CURSOR_API_CALL(cursor, session, bound, NULL);
 
     if (CUR2BT(cursor)->type == BTREE_COL_FIX)
-        WT_ERR_MSG(session, EINVAL, "setting bounds is not compatible with fixed column store.");
+        WT_ERR_MSG(session, EINVAL, "setting bounds is not compatible with fixed column store");
 
     if (F_ISSET(cursor, WT_CURSTD_PREFIX_SEARCH))
-        WT_ERR_MSG(session, EINVAL, "setting bounds is not compatible with prefix search.");
+        WT_ERR_MSG(session, EINVAL, "setting bounds is not compatible with prefix search");
 
     if (config == NULL || config[0] == '\0')
         WT_ERR_MSG(session, EINVAL, "an empty config is not valid when setting or clearing bounds");

--- a/test/suite/test_cursor_bound01.py
+++ b/test/suite/test_cursor_bound01.py
@@ -134,7 +134,6 @@ class test_cursor_bound01(bound_base):
         cursor.reset()
 
         cursor.set_key(self.gen_key(1))
-        cursor.bound("action=set,bound=lower")
         # Giving an invalid action like "dump" won't work.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.bound("action=dump"),
             '/an action of either "clear" or "set" should be specified when setting bounds/')

--- a/test/suite/test_cursor_bound01.py
+++ b/test/suite/test_cursor_bound01.py
@@ -110,6 +110,40 @@ class test_cursor_bound01(bound_base):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.largest_key(),
             '/Invalid argument/')
 
+        # Check edge cases with bounds config
+        cursor.set_key(self.gen_key(1))
+        # Setting the bound without providing an action works.
+        self.assertEqual(cursor.bound("bound=lower"), 0)
+        cursor.reset()
+
+        cursor.set_key(self.gen_key(1))
+        # Setting an action without a bound won't work.
+        self.assertEqual(cursor.bound("action=set"), 0)
+        cursor.reset()
+
+        cursor.set_key(self.gen_key(1))
+        # Giving a longer config string works, WT_PREFIX_MATCH will accept it.
+        self.assertEqual(cursor.bound("action=setting, bound=lower"), 0)
+        cursor.reset()
+
+        cursor.set_key(self.gen_key(1))
+        cursor.bound("action=set,bound=lower")
+        # Giving a longer config string works, WT_PREFIX_MATCH will accept it.
+        self.assertEqual(cursor.bound("action=clearing"), 0)
+        cursor.reset()
+
+        cursor.set_key(self.gen_key(1))
+        cursor.bound("action=set,bound=lower")
+        # Giving an invalid action like "dump" won't work.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.bound("action=dump"),
+            '/Invalid argument/')
+        cursor.reset()
+
+        cursor.set_key(self.gen_key(1))
+        # Giving a substring of the config string will not work.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.bound("action=cl"),
+            '/Invalid argument/')
+
         # Check that setting bounds doesn't work with random cursors. Turn it off with column store as column
         # store doesn't support the next_random config.
         if (self.key_format != 'r'):

--- a/test/suite/test_cursor_bound01.py
+++ b/test/suite/test_cursor_bound01.py
@@ -108,7 +108,7 @@ class test_cursor_bound01(bound_base):
         cursor.set_key(self.gen_key(1))
         cursor.bound("action=set,bound=lower")
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.largest_key(),
-            '/Invalid argument/')
+            '/setting bounds is not compatible with cursor largest key/')
 
         # Check edge cases with bounds config
         cursor.set_key(self.gen_key(1))
@@ -118,7 +118,8 @@ class test_cursor_bound01(bound_base):
 
         cursor.set_key(self.gen_key(1))
         # Setting an action without a bound won't work.
-        self.assertEqual(cursor.bound("action=set"), 0)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.bound("action=set"),
+            '/a bound must be specified when setting bounds, either "lower" or "upper"/')
         cursor.reset()
 
         cursor.set_key(self.gen_key(1))
@@ -136,13 +137,13 @@ class test_cursor_bound01(bound_base):
         cursor.bound("action=set,bound=lower")
         # Giving an invalid action like "dump" won't work.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.bound("action=dump"),
-            '/Invalid argument/')
+            '/an action of either "clear" or "set" should be specified when setting bounds/')
         cursor.reset()
 
         cursor.set_key(self.gen_key(1))
         # Giving a substring of the config string will not work.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.bound("action=cl"),
-            '/Invalid argument/')
+            '/an action of either "clear" or "set" should be specified when setting bounds/')
 
         # Check that setting bounds doesn't work with random cursors. Turn it off with column store as column
         # store doesn't support the next_random config.


### PR DESCRIPTION
- Make bounded API error messages consistent.
- Update bounded testing to account for new configuration changes.
- Expand cursor_bound01 to include edge cases.