### PR TITLE
WT-9846 Use oldest unstable timestamp to clean history store when no stable updates are on chain

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -910,9 +910,11 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     /*
      * If we find a key with a timestamp larger than or equal to the specified timestamp then the
      * specified timestamp must be mixed mode.
+     *
+     * FIXME-WT-10017: Change this back to WT_ASSERT_ALWAYS once WT-10017 is resolved. WT-10017 will
+     * resolve a known issue where this assert fires for column store configurations.
      */
-    WT_ASSERT_ALWAYS(
-      session, ts == 1 || ts == WT_TS_NONE, "out-of-order timestamp update detected");
+    WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
 
     /*
      * Fail the eviction if we detect any timestamp ordering issue and the error flag is set. We

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -910,10 +910,9 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     /*
      * If we find a key with a timestamp larger than or equal to the specified timestamp then the
      * specified timestamp must be mixed mode.
-     *
-     * FIXME-WT-9846: Change this back to WT_ASSERT_ALWAYS once WT-9846 is resolved
      */
-    WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
+    WT_ASSERT_ALWAYS(
+      session, ts == 1 || ts == WT_TS_NONE, "out-of-order timestamp update detected");
 
     /*
      * Fail the eviction if we detect any timestamp ordering issue and the error flag is set. We

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -181,6 +181,9 @@ __rollback_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *first
        * When stable update cleanup isn't performed make sure any unstable updates in the history
        * store are removed. An unstable update in the data store will be removed when the page is
        * next reconciled.
+       *
+       * FIXME-WT-10017: WT-9846 is an interim fix while we investigate the impacts of a longer term
+       * correction in WT-10017. Once completed this change can be reverted.
        */
       if (oldest_unstable_hs_upd != NULL)
         WT_RET(__rollback_delete_hs(session, key, oldest_unstable_hs_upd->start_ts));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -178,9 +178,11 @@ __rollback_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *first
             *stable_update_found = true;
     } else
       /*
-       * When stable update cleanup isn't performed make sure any unstable updates in the history
-       * store are removed. An unstable update in the data store will be removed when the page is
-       * next reconciled.
+       * When stable update cleanup isn't performed make sure unstable updates that were flushed to
+       * the history store are removed - unstable updates in the data store are removed when the
+       * page is next reconciled. We only remove up to the earliest on-chain update, rather than all
+       * unstable updates in this history store, as we don't know if there are scenarios such as a
+       * reverse modify on-disk we may break.
        *
        * FIXME-WT-10017: WT-9846 is an interim fix while we investigate the impacts of a longer term
        * correction in WT-10017. Once completed this change can be reverted.

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -212,7 +212,8 @@ __rollback_abort_insert_list(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT_
               session, key, ins->upd, rollback_timestamp, &stable_update_found));
             if (stable_update_found && stable_updates_count != NULL)
                 (*stable_updates_count)++;
-            if (!stable_update_found && page->type == WT_PAGE_ROW_LEAF)
+            if (!stable_update_found && page->type == WT_PAGE_ROW_LEAF &&
+              !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
                 /*
                  * When a new key is added to a page and the page is then checkpointed, updates for
                  * that key can be present in the History Store while the key isn't present in the

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -129,7 +129,11 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
         else:
             self.assertGreaterEqual(upd_aborted + hs_removed + keys_removed, nrows * 4)
 
-        if not self.in_memory:
+        if not self.in_memory and self.key_format == 'i':
+            # FIXME-WT-10017: WT-9846 is a temporary fix only for row store and a 
+            # more complete fix including column store will be made in WT-10017.
+            # Once delivered the key_format == 'i' check is no longer needed.
+            # 
             # Reinsert the same updates with the same timestamps and flush to disk.
             # If the updates have not been correctly removed by RTS WiredTiger will 
             # see the key already exists in the history store and abort. 

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -129,5 +129,16 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
         else:
             self.assertGreaterEqual(upd_aborted + hs_removed + keys_removed, nrows * 4)
 
+        if not self.in_memory:
+            # Reinsert the same updates with the same timestamps and flush to disk.
+            # If the updates have not been correctly removed by RTS WiredTiger will 
+            # see the key already exists in the history store and abort. 
+            self.large_updates(uri, value_a, ds, nrows, self.prepare, 20)
+            self.large_updates(uri, value_b, ds, nrows, self.prepare, 30)
+            self.large_updates(uri, value_c, ds, nrows, self.prepare, 40)
+            self.large_updates(uri, value_d, ds, nrows, self.prepare, 50)
+
+            self.session.checkpoint()
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
In the case where we had an update chain inside an insert list that:
- contained only unstable updates, and
- was on a page that had been reconciled but not evicted since the new update chain was created
RTS would leave unstable updates in the history store as it didn't find any stable updates on the chain, and the key being rolled back was not present in the pages disk image.

This change tracks the oldest timestamp of an unstable update in the chain that is also in the history store. When no stable updates are found on-chain RTS will instead clean the history store using this unstable timestamp.

There is a preferred change in which `__rollback_to_stable_hs_final_pass` is now called for user triggered RTS and shutdown RTS, but issues were found when implementing this so additional work has been split out into WT-10017 to fully understand these impacts before delivering. When WT-10017 is merged these changes can be reverted.

@kommiharibabu this is a reduced implementation of your suggestion which I believe is identical. Please let me know if there's anything I've missed.