### PR TITLE
WT-10022 - Replace sprintf with snprintf in bench and test code

### DIFF
--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -200,7 +200,7 @@ WorkloadRunner::start_table_idle_cycle(WT_CONNECTION *conn)
     }
 
     for (cycle_count = 0; !stopping; ++cycle_count) {
-        sprintf(uri, "table:test_cycle%04d", cycle_count);
+        snprintf(uri, BUF_SIZE, "table:test_cycle%04d", cycle_count);
 
         workgen_clock(&start);
         /* Create a table. */
@@ -258,13 +258,13 @@ WorkloadRunner::increment_timestamp(WT_CONNECTION *conn)
     while (!stopping) {
         if (_workload->options.oldest_timestamp_lag > 0) {
             time_us = WorkgenTimeStamp::get_timestamp_lag(_workload->options.oldest_timestamp_lag);
-            sprintf(buf, "oldest_timestamp=%" PRIu64, time_us);
+            snprintf(buf, BUF_SIZE, "oldest_timestamp=%" PRIu64, time_us);
             conn->set_timestamp(conn, buf);
         }
 
         if (_workload->options.stable_timestamp_lag > 0) {
             time_us = WorkgenTimeStamp::get_timestamp_lag(_workload->options.stable_timestamp_lag);
-            sprintf(buf, "stable_timestamp=%" PRIu64, time_us);
+            snprintf(buf, BUF_SIZE, "stable_timestamp=%" PRIu64, time_us);
             conn->set_timestamp(conn, buf);
         }
 
@@ -1061,9 +1061,10 @@ ThreadRunner::op_run(Operation *op)
             if (op->transaction->read_timestamp_lag > 0) {
                 uint64_t read =
                   WorkgenTimeStamp::get_timestamp_lag(op->transaction->read_timestamp_lag);
-                sprintf(buf, "%s=%" PRIu64, op->transaction->_begin_config.c_str(), read);
+                snprintf(
+                  buf, BUF_SIZE, "%s=%" PRIu64, op->transaction->_begin_config.c_str(), read);
             } else {
-                sprintf(buf, "%s", op->transaction->_begin_config.c_str());
+                snprintf(buf, BUF_SIZE, "%s", op->transaction->_begin_config.c_str());
             }
             WT_ERR(_session->begin_transaction(_session, buf));
 
@@ -1154,14 +1155,14 @@ err:
             // Set prepare, commit and durable timestamp if prepare is set.
             if (op->transaction->use_prepare_timestamp) {
                 time_us = WorkgenTimeStamp::get_timestamp();
-                sprintf(buf, "prepare_timestamp=%" PRIu64, time_us);
+                snprintf(buf, BUF_SIZE, "prepare_timestamp=%" PRIu64, time_us);
                 ret = _session->prepare_transaction(_session, buf);
-                sprintf(
-                  buf, "commit_timestamp=%" PRIu64 ",durable_timestamp=%" PRIu64, time_us, time_us);
+                snprintf(buf, BUF_SIZE, "commit_timestamp=%" PRIu64 ",durable_timestamp=%" PRIu64,
+                  time_us, time_us);
                 ret = _session->commit_transaction(_session, buf);
             } else if (op->transaction->use_commit_timestamp) {
                 uint64_t commit_time_us = WorkgenTimeStamp::get_timestamp();
-                sprintf(buf, "commit_timestamp=%" PRIu64, commit_time_us);
+                snprintf(buf, BUF_SIZE, "commit_timestamp=%" PRIu64, commit_time_us);
                 ret = _session->commit_transaction(_session, buf);
             } else {
                 ret =

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1434,7 +1434,6 @@ snprintf
 sp
 spinlock
 spinlocks
-sprintf
 src
 srch
 ss

--- a/dist/s_style
+++ b/dist/s_style
@@ -155,6 +155,7 @@ else
 	fi
 
 	if ! expr "$f" : 'examples/c/*' > /dev/null &&
+	   ! expr "$f" : 'bench/*' > /dev/null &&
 	   ! expr "$f" : '.*cxx' > /dev/null &&
 	   ! expr "$f" : '.*cpp' > /dev/null &&
 	   ! expr "$f" : 'ext/*' > /dev/null &&

--- a/ext/storage_sources/dir_store/dir_store.c
+++ b/ext/storage_sources/dir_store/dir_store.c
@@ -403,7 +403,7 @@ dir_store_path(WT_FILE_SYSTEM *file_system, const char *dir, const char *name, c
         return (dir_store_err(FS2DS(file_system), NULL, ENOMEM, "dir_store_path"));
     if (snprintf(p, len, "%s/%s", dir, name) >= (int)len) {
         free(p);
-        return (dir_store_err(FS2DS(file_system), NULL, EINVAL, "overflow sprintf"));
+        return (dir_store_err(FS2DS(file_system), NULL, EINVAL, "overflow snprintf"));
     }
     *pathp = p;
     return (ret);

--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -39,6 +39,8 @@
 
 #define NUM_RECORDS 1000000
 #define CHECKPOINT_NUM 3
+#define HOME_BUF_SIZE 512
+#define STAT_BUF_SIZE 128
 
 /* Constants and variables declaration. */
 /*
@@ -124,7 +126,7 @@ static void
 run_test_clean(bool stress_test, bool column_store, bool preserve, const char *home,
   const char *suffix, const char *uri)
 {
-    char home_full[512];
+    char home_full[HOME_BUF_SIZE];
 
     ready_counter = 0;
 
@@ -132,7 +134,7 @@ run_test_clean(bool stress_test, bool column_store, bool preserve, const char *h
     printf("Running %s test with %s store...\n", stress_test ? "stress" : "normal",
       column_store ? "column" : "row");
     testutil_assert(sizeof(home_full) > strlen(home) + strlen(suffix) + 2);
-    sprintf(home_full, "%s.%s", home, suffix);
+    testutil_check(__wt_snprintf(home_full, HOME_BUF_SIZE, "%s.%s", home, suffix));
     run_test(stress_test, column_store, home_full, uri);
 
     /* Cleanup */
@@ -369,9 +371,9 @@ static void
 get_file_stats(WT_SESSION *session, const char *uri, uint64_t *file_sz, uint64_t *avail_bytes)
 {
     WT_CURSOR *cur_stat;
-    char *descr, *str_val, stat_uri[128];
+    char *descr, *str_val, stat_uri[STAT_BUF_SIZE];
 
-    sprintf(stat_uri, "statistics:%s", uri);
+    testutil_check(__wt_snprintf(stat_uri, STAT_BUF_SIZE, "statistics:%s", uri));
     testutil_check(session->open_cursor(session, stat_uri, NULL, "statistics=(all)", &cur_stat));
 
     /* Get file size. */
@@ -412,9 +414,9 @@ get_compact_progress(WT_SESSION *session, const char *uri, uint64_t *pages_revie
 
     WT_CURSOR *cur_stat;
     char *descr, *str_val;
-    char stat_uri[128];
+    char stat_uri[STAT_BUF_SIZE];
 
-    sprintf(stat_uri, "statistics:%s", uri);
+    testutil_check(__wt_snprintf(stat_uri, STAT_BUF_SIZE, "statistics:%s", uri));
     testutil_check(session->open_cursor(session, stat_uri, NULL, "statistics=(all)", &cur_stat));
 
     cur_stat->set_key(cur_stat, WT_STAT_DSRC_BTREE_COMPACT_PAGES_REVIEWED);

--- a/test/fuzz/fuzz_util.c
+++ b/test/fuzz/fuzz_util.c
@@ -32,12 +32,14 @@
 
 FUZZ_GLOBAL_STATE fuzz_state = {.conn = NULL, .session = NULL};
 
+#define HOME_BUF_SIZE 100
+
 /*
  * fuzzutil_generate_home_name --
  *     Create a unique home directory per worker that LibFuzzer creates.
  */
 static void
-fuzzutil_generate_home_name(char *buf)
+fuzzutil_generate_home_name(char *buf, int buf_len)
 {
     pid_t pid;
 
@@ -47,7 +49,7 @@ fuzzutil_generate_home_name(char *buf)
      * the end of the name.
      */
     pid = getpid();
-    sprintf(buf, "WT_TEST_%d", pid);
+    testutil_check(__wt_snprintf(buf, buf_len, "WT_TEST_%d", pid));
 }
 
 /*
@@ -57,7 +59,7 @@ fuzzutil_generate_home_name(char *buf)
 void
 fuzzutil_setup(void)
 {
-    char home[100];
+    char home[HOME_BUF_SIZE];
 
     if (fuzz_state.conn != NULL) {
         testutil_assert(fuzz_state.session != NULL);
@@ -65,7 +67,7 @@ fuzzutil_setup(void)
     }
 
     WT_CLEAR(home);
-    fuzzutil_generate_home_name(home);
+    fuzzutil_generate_home_name(home, HOME_BUF_SIZE);
     testutil_make_work_dir(home);
     testutil_check(wiredtiger_open(home, NULL,
       "create,cache_size=5MB,statistics=(all),statistics_log=(json,on_close,wait=1)",


### PR DESCRIPTION
Compiling locally with Clang 14.0.0 fails with
```
warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  
Due to security concerns inherent in the design of sprintf(3), it is highly recommended 
that you use snprintf(3) instead. [-Wdeprecated-declarations]
```
This is due to `sprintf` writing past the end of the buffer if the input string is long enough, while `sprintf` will truncate the string instead.

This PR replaces `sprintf` with `snprintf`, or `__wt_snprintf` where possible.