### PR TITLE
WT-10021 Remove directory exclusions for release packages

### DIFF
--- a/dist/s_release
+++ b/dist/s_release
@@ -16,16 +16,12 @@ PKG="wiredtiger-$pkgver"
 DEST="$RELEASE_DIR/$PKG"
 
 rm -rf $DEST ; mkdir -p $DEST
-EXCLUSIONS=`sed -e '/^#/d' -e 's/^/--exclude /' < s_release.list`
 
-if [ -d ../.hg ] ; then
-	echo "Running 'hg archive' to copy the tree"
-	(cd .. && hg archive $EXCLUSIONS $DEST)
-elif [ -d ../.git ] ; then
+if [ -d ../.git ] ; then
 	echo "Running 'git archive' to copy the tree"
-	(cd .. && git archive HEAD) | (cd $DEST && tar xf - $EXCLUSIONS)
+	(cd .. && git archive HEAD) | (cd $DEST && tar xf -)
 else
-	echo "$0 must be run in a Git or Mercurial tree"
+	echo "$0 must be run in a Git tree"
 	exit 1
 fi
 

--- a/dist/s_release.list
+++ b/dist/s_release.list
@@ -1,9 +1,0 @@
-# Exclusions from release packages.
-# Each non-comment line is excluded from the release.
-lang/python/src
-src/server
-test/format
-test/packing
-test/salvage
-test/snapshot
-test/thread

--- a/src/docs/top/main.dox
+++ b/src/docs/top/main.dox
@@ -7,7 +7,7 @@ WiredTiger is an high performance, scalable, production quality, NoSQL,
 
 <table>
 @row{<b>WiredTiger 11.0.0</b> (current),
-	<a href="releases/wiredtiger-11.0.0.tar.bz2"><b>[Release package]</b></a>,
+	<a href="https://github.com/wiredtiger/wiredtiger/releases/tag/11.0.0"><b>[Source code]</b></a>,
 	<a href="11.0.0/index.html"><b>[Documentation]</b></a>}
 @row{<b>WiredTiger 10.0.0</b> (previous),
 	<a href="releases/wiredtiger-10.0.0.tar.bz2"><b>[Release package]</b></a>,


### PR DESCRIPTION
Two changes are made in this PR:
- Remove the contents and logic of skipping given directories for release packages
- Update the WT doc homepage to replace the "release package" link with a "source code" link for the 11.0.0 release