### PR TITLE
WT-10023 Remove duplicate call to verify in test/format

### DIFF
--- a/test/format/t.c
+++ b/test/format/t.c
@@ -383,9 +383,11 @@ skip_operations:
 
     /*
      * Verify the objects. Verify closes the underlying handle and discards the statistics, read
-     * them first.
+     * them first. However, for verify_only we've already completed the verification above. Skip
+     * this one.
      */
-    TIMED_MAJOR_OP(wts_verify(g.wts_conn, true));
+    if (!verify_only)
+        TIMED_MAJOR_OP(wts_verify(g.wts_conn, true));
 
     track("shutting down", 0ULL);
     wts_close(&g.wts_conn);

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -381,6 +381,12 @@ main(int argc, char *argv[])
 skip_operations:
     locks_destroy(g.wts_conn);
 
+    /*
+     * Verify the objects. Verify closes the underlying handle and discards the statistics, read
+     * them first.
+     */
+    TIMED_MAJOR_OP(wts_verify(g.wts_conn, true));
+
     track("shutting down", 0ULL);
     wts_close(&g.wts_conn);
 

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -381,12 +381,6 @@ main(int argc, char *argv[])
 skip_operations:
     locks_destroy(g.wts_conn);
 
-    /*
-     * Verify the objects. Verify closes the underlying handle and discards the statistics, read
-     * them first.
-     */
-    TIMED_MAJOR_OP(wts_verify(g.wts_conn, true));
-
     track("shutting down", 0ULL);
     wts_close(&g.wts_conn);
 


### PR DESCRIPTION
There is already a call to `wts_verify` before we get to the `skip_operations` label.