### PR TITLE
WT-9527 Rename tiered work units for removing objects

### DIFF
--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -211,12 +211,12 @@ __tier_do_operation(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id, co
             /*
              * After successful flushing, push a work unit to perform whatever post-processing the
              * shared storage wants to do for this object. Note that this work unit is unrelated to
-             * the drop local work unit below. They do not need to be in any order and do not
+             * the remove local work unit below. They do not need to be in any order and do not
              * interfere with each other.
              */
             WT_ERR(__wt_tiered_put_flush_finish(session, tiered, id));
             /*
-             * After successful flushing, push a work unit to drop the local object in the future.
+             * After successful flushing, push a work unit to remove the local object in the future.
              * The object will be removed locally after the local retention period expires.
              */
             WT_ERR(__wt_tiered_put_remove_local(session, tiered, id));

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -48,7 +48,7 @@ __tier_storage_remove_local(WT_SESSION_IMPL *session)
             break;
 
         __wt_seconds(session, &now);
-        __wt_tiered_get_drop_local(session, now, &entry);
+        __wt_tiered_get_remove_local(session, now, &entry);
         if (entry == NULL)
             break;
         WT_ERR(__wt_tiered_name(
@@ -219,7 +219,7 @@ __tier_do_operation(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id, co
              * After successful flushing, push a work unit to drop the local object in the future.
              * The object will be removed locally after the local retention period expires.
              */
-            WT_ERR(__wt_tiered_put_drop_local(session, tiered, id));
+            WT_ERR(__wt_tiered_put_remove_local(session, tiered, id));
         }
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1519,13 +1519,13 @@ extern int __wt_tiered_name_str(WT_SESSION_IMPL *session, const char *name, uint
   uint32_t flags, const char **retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tiered_open(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_tiered_put_drop_local(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_tiered_put_drop_shared(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tiered_put_flush(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tiered_put_flush_finish(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_tiered_put_remove_local(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_tiered_put_remove_shared(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_tiered_set_metadata(WT_SESSION_IMPL *session, WT_TIERED *tiered, WT_ITEM *buf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1891,11 +1891,11 @@ extern void __wt_thread_group_start_one(
   WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, bool is_locked);
 extern void __wt_thread_group_stop_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group);
 extern void __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout);
-extern void __wt_tiered_get_drop_local(
-  WT_SESSION_IMPL *session, uint64_t now, WT_TIERED_WORK_UNIT **entryp);
-extern void __wt_tiered_get_drop_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);
 extern void __wt_tiered_get_flush(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);
 extern void __wt_tiered_get_flush_finish(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);
+extern void __wt_tiered_get_remove_local(
+  WT_SESSION_IMPL *session, uint64_t now, WT_TIERED_WORK_UNIT **entryp);
+extern void __wt_tiered_get_remove_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);
 extern void __wt_tiered_pop_work(
   WT_SESSION_IMPL *session, uint32_t type, uint64_t maxval, WT_TIERED_WORK_UNIT **entryp);
 extern void __wt_tiered_push_work(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry);

--- a/src/include/tiered.h
+++ b/src/include/tiered.h
@@ -36,10 +36,10 @@
  * Different types of work units for tiered trees.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_TIERED_WORK_DROP_LOCAL 0x1u   /* Drop object from local storage. */
-#define WT_TIERED_WORK_DROP_SHARED 0x2u  /* Drop object from tier. */
-#define WT_TIERED_WORK_FLUSH 0x4u        /* Flush object to tier. */
-#define WT_TIERED_WORK_FLUSH_FINISH 0x8u /* Perform flush finish on object. */
+#define WT_TIERED_WORK_FLUSH 0x1u         /* Flush object to tier. */
+#define WT_TIERED_WORK_FLUSH_FINISH 0x2u  /* Perform flush finish on object. */
+#define WT_TIERED_WORK_REMOVE_LOCAL 0x4u  /* Remove object from local storage. */
+#define WT_TIERED_WORK_REMOVE_SHARED 0x8u /* Remove object from tier. */
 /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
 
 /*

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -296,8 +296,8 @@ __tiered_restart_work(WT_SESSION_IMPL *session, WT_TIERED *tiered)
          * flushed in order to stop at the first flushed object in the face of multiple crashes. So
          * check all objects that exist locally.
          *
-         * If the object is flushed but still exists locally, restart the work to remove it after the
-         * local retention period expires.
+         * If the object is flushed but still exists locally, restart the work to remove it after
+         * the local retention period expires.
          */
         if (exist) {
             WT_ERR(__wt_metadata_search(session, obj_uri, (char **)&obj_val));

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -307,7 +307,7 @@ __tiered_restart_work(WT_SESSION_IMPL *session, WT_TIERED *tiered)
             if (cval.val == 0)
                 WT_ERR(__wt_tiered_put_flush(session, tiered, i));
             else
-                WT_ERR(__wt_tiered_put_drop_local(session, tiered, i));
+                WT_ERR(__wt_tiered_put_remove_local(session, tiered, i));
             __wt_free(session, obj_val);
         }
         __wt_free(session, obj_uri);
@@ -785,8 +785,8 @@ __tiered_open(WT_SESSION_IMPL *session, const char *cfg[])
         /* Temp code to keep s_all happy. */
         FLD_SET(unused, WT_TIERED_OBJ_LOCAL | WT_TIERED_TREE_UNUSED);
         FLD_SET(unused, WT_TIERED_WORK_FORCE | WT_TIERED_WORK_FREE);
-        WT_ERR(__wt_tiered_put_drop_shared(session, tiered, tiered->current_id));
-        __wt_tiered_get_drop_shared(session, &entry);
+        WT_ERR(__wt_tiered_put_remove_shared(session, tiered, tiered->current_id));
+        __wt_tiered_get_remove_shared(session, &entry);
     }
 #endif
 

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -296,7 +296,7 @@ __tiered_restart_work(WT_SESSION_IMPL *session, WT_TIERED *tiered)
          * flushed in order to stop at the first flushed object in the face of multiple crashes. So
          * check all objects that exist locally.
          *
-         * If the object is flushed but still exists locally, restart the work to drop it after the
+         * If the object is flushed but still exists locally, restart the work to remove it after the
          * local retention period expires.
          */
         if (exist) {

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -185,23 +185,23 @@ __wt_tiered_get_flush(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp)
 }
 
 /*
- * __wt_tiered_get_drop_local --
- *     Get a drop local work unit if it is less than the time given. The caller is responsible for
+ * __wt_tiered_get_remove_local --
+ *     Get a remove local work unit if it is less than the time given. The caller is responsible for
  *     freeing the work unit.
  */
 void
-__wt_tiered_get_drop_local(WT_SESSION_IMPL *session, uint64_t now, WT_TIERED_WORK_UNIT **entryp)
+__wt_tiered_get_remove_local(WT_SESSION_IMPL *session, uint64_t now, WT_TIERED_WORK_UNIT **entryp)
 {
     __wt_tiered_pop_work(session, WT_TIERED_WORK_REMOVE_LOCAL, now, entryp);
     return;
 }
 
 /*
- * __wt_tiered_get_drop_shared --
- *     Get a drop shared work unit. The caller is responsible for freeing the work unit.
+ * __wt_tiered_get_remove_shared --
+ *     Get a remove shared work unit. The caller is responsible for freeing the work unit.
  */
 void
-__wt_tiered_get_drop_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp)
+__wt_tiered_get_remove_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp)
 {
     __wt_tiered_pop_work(session, WT_TIERED_WORK_REMOVE_SHARED, 0, entryp);
     return;
@@ -225,11 +225,11 @@ __wt_tiered_put_flush_finish(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32
 }
 
 /*
- * __wt_tiered_put_drop_local --
- *     Add a drop local work unit for the given ID to the queue.
+ * __wt_tiered_put_remove_local --
+ *     Add a remove local work unit for the given ID to the queue.
  */
 int
-__wt_tiered_put_drop_local(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
+__wt_tiered_put_remove_local(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
 {
     WT_TIERED_WORK_UNIT *entry;
     uint64_t now;
@@ -247,11 +247,11 @@ __wt_tiered_put_drop_local(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t
 }
 
 /*
- * __wt_tiered_put_drop_shared --
- *     Add a drop shared work unit for the given ID to the queue.
+ * __wt_tiered_put_remove_shared --
+ *     Add a remove shared work unit for the given ID to the queue.
  */
 int
-__wt_tiered_put_drop_shared(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
+__wt_tiered_put_remove_shared(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id)
 {
     WT_TIERED_WORK_UNIT *entry;
 

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -192,7 +192,7 @@ __wt_tiered_get_flush(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp)
 void
 __wt_tiered_get_drop_local(WT_SESSION_IMPL *session, uint64_t now, WT_TIERED_WORK_UNIT **entryp)
 {
-    __wt_tiered_pop_work(session, WT_TIERED_WORK_DROP_LOCAL, now, entryp);
+    __wt_tiered_pop_work(session, WT_TIERED_WORK_REMOVE_LOCAL, now, entryp);
     return;
 }
 
@@ -203,7 +203,7 @@ __wt_tiered_get_drop_local(WT_SESSION_IMPL *session, uint64_t now, WT_TIERED_WOR
 void
 __wt_tiered_get_drop_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp)
 {
-    __wt_tiered_pop_work(session, WT_TIERED_WORK_DROP_SHARED, 0, entryp);
+    __wt_tiered_pop_work(session, WT_TIERED_WORK_REMOVE_SHARED, 0, entryp);
     return;
 }
 
@@ -235,7 +235,7 @@ __wt_tiered_put_drop_local(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t
     uint64_t now;
 
     WT_RET(__wt_calloc_one(session, &entry));
-    entry->type = WT_TIERED_WORK_DROP_LOCAL;
+    entry->type = WT_TIERED_WORK_REMOVE_LOCAL;
     entry->id = id;
     WT_ASSERT(session, tiered->bstorage != NULL);
     __wt_seconds(session, &now);
@@ -256,7 +256,7 @@ __wt_tiered_put_drop_shared(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_
     WT_TIERED_WORK_UNIT *entry;
 
     WT_RET(__wt_calloc_one(session, &entry));
-    entry->type = WT_TIERED_WORK_DROP_SHARED;
+    entry->type = WT_TIERED_WORK_REMOVE_SHARED;
     entry->id = id;
     entry->tiered = tiered;
     __wt_tiered_push_work(session, entry);


### PR DESCRIPTION
Renamed the `WT_TIERED_WORK_DROP_LOCAL` and `WT_TIERED_WORK_DROP_SHARED` work units for tiered storage to reflect its purpose and replaced `DROP` with `REMOVE`. This will remove the ambiguity of the work units as they are not used in session->drop(). 

Functions and descriptions for:

- `__wt_tiered_put_remove_shared`
- `__wt_tiered_get_remove_shared`
- `__wt_tiered_put_remove_local`
- `__wt_tiered_get_remove_local` 

Have been adjusted to reflect the naming changes. 