### PR TITLE
WT-10026 Verify the timestamp simulator with the timestamp python tests

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -91,7 +91,6 @@ Checkpointing
 Checksum
 Checksums
 CityHash
-ClassName
 CloseHandle
 Cmvz
 Collet
@@ -298,7 +297,6 @@ Marsaglia's
 Mellor
 Memrata
 Metadata
-MethodName
 Mewhort
 Mitzenmacher
 Mmap
@@ -399,7 +397,6 @@ RedHat
 Redistributions
 Refactor
 Resize
-ReturnVal
 RocksDB
 Rogerio
 Runtime
@@ -859,7 +856,6 @@ eof
 epi
 eq
 equalp
-errMsg
 errhandler
 errno
 errx
@@ -1249,7 +1245,6 @@ num
 numSymbols
 numbare
 nvram
-objectId
 objs
 offpage
 ofh

--- a/src/call_log/call_log.c
+++ b/src/call_log/call_log.c
@@ -276,10 +276,15 @@ __wt_call_log_query_timestamp(
     WT_RET(__wt_snprintf(config_buf, sizeof(config_buf), "\"config\": \"%s\"", config));
     WT_RET(__call_log_print_input(session, 1, config_buf));
 
-    /* The timestamp queried is the output from the original query timestamp API call. */
-    WT_RET(__wt_snprintf(
-      hex_ts_buf, sizeof(hex_ts_buf), "\"timestamp_queried\": \"%s\"", hex_timestamp));
-    WT_RET(__call_log_print_output(session, 1, hex_ts_buf));
+    /* 
+     * The timestamp queried is the output from the original query timestamp API call. Don't output
+     * the timestamp to the call log if the query has failed as it will be a garbage value.
+     */
+    if (ret_val == 0){
+        WT_RET(__wt_snprintf(
+        hex_ts_buf, sizeof(hex_ts_buf), "\"timestamp_queried\": \"%s\"", hex_timestamp));
+        WT_RET(__call_log_print_output(session, 1, hex_ts_buf));
+    }
 
     WT_RET(__wt_call_log_print_return(conn, session, ret_val, ""));
 

--- a/src/call_log/call_log.c
+++ b/src/call_log/call_log.c
@@ -276,13 +276,13 @@ __wt_call_log_query_timestamp(
     WT_RET(__wt_snprintf(config_buf, sizeof(config_buf), "\"config\": \"%s\"", config));
     WT_RET(__call_log_print_input(session, 1, config_buf));
 
-    /* 
+    /*
      * The timestamp queried is the output from the original query timestamp API call. Don't output
      * the timestamp to the call log if the query has failed as it will be a garbage value.
      */
-    if (ret_val == 0){
+    if (ret_val == 0) {
         WT_RET(__wt_snprintf(
-        hex_ts_buf, sizeof(hex_ts_buf), "\"timestamp_queried\": \"%s\"", hex_timestamp));
+          hex_ts_buf, sizeof(hex_ts_buf), "\"timestamp_queried\": \"%s\"", hex_timestamp));
         WT_RET(__call_log_print_output(session, 1, hex_ts_buf));
     }
 

--- a/test/simulator/timestamp/src/connection_simulator.cpp
+++ b/test/simulator/timestamp/src/connection_simulator.cpp
@@ -237,8 +237,8 @@ connection_simulator::set_timestamp(const std::string &config)
     uint64_t new_stable_ts = 0, new_oldest_ts = 0, new_durable_ts = 0;
     bool has_stable = false, has_oldest = false, has_durable = false, force = false;
 
-    decode_timestamp_config_map(config_map, new_oldest_ts, new_stable_ts, new_durable_ts,
-      has_oldest, has_stable, has_durable, force);
+    WT_SIM_RET(decode_timestamp_config_map(config_map, new_oldest_ts, new_stable_ts, new_durable_ts,
+      has_oldest, has_stable, has_durable, force));
 
     if (!force) {
         /* Validate the new durable timestamp. */

--- a/test/simulator/timestamp/src/include/error_simulator.h
+++ b/test/simulator/timestamp/src/include/error_simulator.h
@@ -44,23 +44,23 @@
             return (__ret);     \
     } while (0)
 
-#define WT_TXN_SIM_RET(_txn_error, a) \
-    do {                              \
-        int __ret;                    \
-        if ((__ret = (a)) != 0) {     \
-            _txn_error = true;        \
-            return (__ret);           \
-        }                             \
+#define WT_TXN_SIM_RET(a)         \
+    do {                          \
+        int __ret;                \
+        if ((__ret = (a)) != 0) { \
+            _txn_error = true;    \
+            return (__ret);       \
+        }                         \
     } while (0)
 
-#define WT_TXN_SIM_RET_MSG(_txn_error, a, msg) \
-    do {                                       \
-        int __ret;                             \
-        if ((__ret = (a)) != 0) {              \
-            _txn_error = true;                 \
-            std::cerr << msg << std::endl;     \
-            return (__ret);                    \
-        }                                      \
+#define WT_TXN_SIM_RET_MSG(a, msg)         \
+    do {                                   \
+        int __ret;                         \
+        if ((__ret = (a)) != 0) {          \
+            _txn_error = true;             \
+            std::cerr << msg << std::endl; \
+            return (__ret);                \
+        }                                  \
     } while (0)
 
 /* Error list */

--- a/test/simulator/timestamp/src/include/error_simulator.h
+++ b/test/simulator/timestamp/src/include/error_simulator.h
@@ -44,5 +44,24 @@
             return (__ret);     \
     } while (0)
 
+#define WT_TXN_SIM_RET(_txn_error, a)      \
+    do {                                    \
+        int __ret;                          \
+        if ((__ret = (a)) != 0){            \
+            _txn_error = true;              \
+            return (__ret);                 \
+        }                                   \
+    } while (0)
+
+#define WT_TXN_SIM_RET_MSG(_txn_error, a, msg)  \
+    do {                                        \
+        int __ret;                              \
+        if ((__ret = (a)) != 0) {               \
+            _txn_error = true;                  \
+            std::cerr << msg << std::endl;      \
+            return (__ret);                     \
+        }                                       \
+    } while (0)
+
 /* Error list */
 #define EINVAL 22 /* Invalid argument */

--- a/test/simulator/timestamp/src/include/error_simulator.h
+++ b/test/simulator/timestamp/src/include/error_simulator.h
@@ -44,23 +44,23 @@
             return (__ret);     \
     } while (0)
 
-#define WT_TXN_SIM_RET(_txn_error, a)      \
-    do {                                    \
-        int __ret;                          \
-        if ((__ret = (a)) != 0){            \
-            _txn_error = true;              \
-            return (__ret);                 \
-        }                                   \
+#define WT_TXN_SIM_RET(_txn_error, a) \
+    do {                              \
+        int __ret;                    \
+        if ((__ret = (a)) != 0) {     \
+            _txn_error = true;        \
+            return (__ret);           \
+        }                             \
     } while (0)
 
-#define WT_TXN_SIM_RET_MSG(_txn_error, a, msg)  \
-    do {                                        \
-        int __ret;                              \
-        if ((__ret = (a)) != 0) {               \
-            _txn_error = true;                  \
-            std::cerr << msg << std::endl;      \
-            return (__ret);                     \
-        }                                       \
+#define WT_TXN_SIM_RET_MSG(_txn_error, a, msg) \
+    do {                                       \
+        int __ret;                             \
+        if ((__ret = (a)) != 0) {              \
+            _txn_error = true;                 \
+            std::cerr << msg << std::endl;     \
+            return (__ret);                    \
+        }                                      \
     } while (0)
 
 /* Error list */

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -63,6 +63,7 @@ class session_simulator {
     bool is_round_read_ts_set() const;
     bool is_txn_prepared() const;
     bool is_txn_running() const;
+    bool is_txn_error() const;
 
     private:
     int decode_timestamp_config_map(
@@ -86,6 +87,7 @@ class session_simulator {
     bool _txn_running;
     bool _prepared_txn;
     bool _durable_ts_set;
+    bool _txn_error;
     uint64_t _commit_ts;
     uint64_t _durable_ts;
     uint64_t _first_commit_ts;

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -63,7 +63,6 @@ class session_simulator {
     bool is_round_read_ts_set() const;
     bool is_txn_prepared() const;
     bool is_txn_running() const;
-    bool is_txn_error() const;
 
     private:
     int decode_timestamp_config_map(

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -121,7 +121,7 @@ session_simulator::prepare_transaction(const std::string &config)
 
     /* Make sure that the transaction from this session is running. */
     if (!_txn_running)
-        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL, "'prepare_transaction' only permitted in a running transaction");
+        WT_SIM_RET_MSG(EINVAL, "'prepare_transaction' only permitted in a running transaction");
 
     timestamp_manager *ts_manager = &timestamp_manager::get_timestamp_manager();
     std::map<std::string, std::string> config_map;
@@ -129,19 +129,22 @@ session_simulator::prepare_transaction(const std::string &config)
     const std::vector<std::string> supported_ops = {"prepare_timestamp"};
     const std::vector<std::string> unsupported_ops;
 
-    WT_TXN_SIM_RET_MSG(_txn_error, ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
+    WT_TXN_SIM_RET_MSG(_txn_error,
+      ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
       "Incorrect config (" + config + ") passed in prepare_transaction");
 
     auto pos = config_map.find("prepare_timestamp");
     if (pos != config_map.end()) {
-        WT_TXN_SIM_RET(_txn_error, ts_manager->validate_hex_value(pos->second, "prepare timestamp"));
+        WT_TXN_SIM_RET(
+          _txn_error, ts_manager->validate_hex_value(pos->second, "prepare timestamp"));
         uint64_t prepare_ts = ts_manager->hex_to_decimal(pos->second);
         WT_TXN_SIM_RET(_txn_error, set_prepare_timestamp(prepare_ts));
     }
 
     /* A prepared timestamp should have been set at this point. */
     if (!has_prepare_timestamp())
-        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL, "'prepare_transaction' - prepare timestamp is not set");
+        WT_TXN_SIM_RET_MSG(
+          _txn_error, EINVAL, "'prepare_transaction' - prepare timestamp is not set");
 
     /* Commit timestamp must not be set before transaction is prepared. */
     if (_has_commit_ts)

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -129,26 +129,23 @@ session_simulator::prepare_transaction(const std::string &config)
     const std::vector<std::string> supported_ops = {"prepare_timestamp"};
     const std::vector<std::string> unsupported_ops;
 
-    WT_TXN_SIM_RET_MSG(_txn_error,
-      ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
+    WT_TXN_SIM_RET_MSG(ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
       "Incorrect config (" + config + ") passed in prepare_transaction");
 
     auto pos = config_map.find("prepare_timestamp");
     if (pos != config_map.end()) {
-        WT_TXN_SIM_RET(
-          _txn_error, ts_manager->validate_hex_value(pos->second, "prepare timestamp"));
+        WT_TXN_SIM_RET(ts_manager->validate_hex_value(pos->second, "prepare timestamp"));
         uint64_t prepare_ts = ts_manager->hex_to_decimal(pos->second);
-        WT_TXN_SIM_RET(_txn_error, set_prepare_timestamp(prepare_ts));
+        WT_TXN_SIM_RET(set_prepare_timestamp(prepare_ts));
     }
 
     /* A prepared timestamp should have been set at this point. */
     if (!has_prepare_timestamp())
-        WT_TXN_SIM_RET_MSG(
-          _txn_error, EINVAL, "'prepare_transaction' - prepare timestamp is not set");
+        WT_TXN_SIM_RET_MSG(EINVAL, "'prepare_transaction' - prepare timestamp is not set");
 
     /* Commit timestamp must not be set before transaction is prepared. */
     if (_has_commit_ts)
-        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL,
+        WT_TXN_SIM_RET_MSG(EINVAL,
           "'prepare_transaction' - commit timestamp must not be set before transaction is "
           "prepared");
 
@@ -281,28 +278,27 @@ session_simulator::timestamp_transaction(const std::string &config)
       "commit_timestamp", "durable_timestamp", "prepare_timestamp", "read_timestamp"};
     const std::vector<std::string> unsupported_ops;
 
-    WT_TXN_SIM_RET_MSG(_txn_error,
-      ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
+    WT_TXN_SIM_RET_MSG(ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
       "Incorrect config (" + config + ") passed in timestamp_transaction");
 
     uint64_t commit_ts = 0, durable_ts = 0, prepare_ts = 0, read_ts = 0;
 
     /* Decode a configuration string that may contain multiple timestamps and store them here. */
-    WT_TXN_SIM_RET(_txn_error,
+    WT_TXN_SIM_RET(
       decode_timestamp_config_map(config_map, commit_ts, durable_ts, prepare_ts, read_ts));
 
     /* Check if the timestamps were included in the configuration string and set them. */
     if (commit_ts != 0)
-        WT_TXN_SIM_RET(_txn_error, set_commit_timestamp(commit_ts));
+        WT_TXN_SIM_RET(set_commit_timestamp(commit_ts));
 
     if (durable_ts != 0)
-        WT_TXN_SIM_RET(_txn_error, set_durable_timestamp(durable_ts));
+        WT_TXN_SIM_RET(set_durable_timestamp(durable_ts));
 
     if (prepare_ts != 0)
-        WT_TXN_SIM_RET(_txn_error, set_prepare_timestamp(prepare_ts));
+        WT_TXN_SIM_RET(set_prepare_timestamp(prepare_ts));
 
     if (read_ts != 0)
-        WT_TXN_SIM_RET(_txn_error, set_read_timestamp(read_ts));
+        WT_TXN_SIM_RET(set_read_timestamp(read_ts));
 
     return (0);
 }
@@ -318,19 +314,19 @@ session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64
     /* Zero timestamp is not permitted. */
     if (ts == 0)
         WT_TXN_SIM_RET_MSG(
-          _txn_error, EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");
+          EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");
 
     if (ts_type == "commit")
-        WT_TXN_SIM_RET(_txn_error, set_commit_timestamp(ts));
+        WT_TXN_SIM_RET(set_commit_timestamp(ts));
     else if (ts_type == "durable")
-        WT_TXN_SIM_RET(_txn_error, set_durable_timestamp(ts));
+        WT_TXN_SIM_RET(set_durable_timestamp(ts));
     else if (ts_type == "prepare")
-        WT_TXN_SIM_RET(_txn_error, set_prepare_timestamp(ts));
+        WT_TXN_SIM_RET(set_prepare_timestamp(ts));
     else if (ts_type == "read")
-        WT_TXN_SIM_RET(_txn_error, set_read_timestamp(ts));
+        WT_TXN_SIM_RET(set_read_timestamp(ts));
     else {
-        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL,
-          "Invalid timestamp type (" + ts_type + ") passed to timestamp transaction uint.");
+        WT_TXN_SIM_RET_MSG(
+          EINVAL, "Invalid timestamp type (" + ts_type + ") passed to timestamp transaction uint.");
     }
 
     return (0);

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -121,7 +121,7 @@ session_simulator::prepare_transaction(const std::string &config)
 
     /* Make sure that the transaction from this session is running. */
     if (!_txn_running)
-        WT_SIM_RET_MSG(EINVAL, "'prepare_transaction' only permitted in a running transaction");
+        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL, "'prepare_transaction' only permitted in a running transaction");
 
     timestamp_manager *ts_manager = &timestamp_manager::get_timestamp_manager();
     std::map<std::string, std::string> config_map;
@@ -129,23 +129,23 @@ session_simulator::prepare_transaction(const std::string &config)
     const std::vector<std::string> supported_ops = {"prepare_timestamp"};
     const std::vector<std::string> unsupported_ops;
 
-    WT_SIM_RET_MSG(ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
+    WT_TXN_SIM_RET_MSG(_txn_error, ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
       "Incorrect config (" + config + ") passed in prepare_transaction");
 
     auto pos = config_map.find("prepare_timestamp");
     if (pos != config_map.end()) {
-        WT_SIM_RET(ts_manager->validate_hex_value(pos->second, "prepare timestamp"));
+        WT_TXN_SIM_RET(_txn_error, ts_manager->validate_hex_value(pos->second, "prepare timestamp"));
         uint64_t prepare_ts = ts_manager->hex_to_decimal(pos->second);
-        WT_SIM_RET(set_prepare_timestamp(prepare_ts));
+        WT_TXN_SIM_RET(_txn_error, set_prepare_timestamp(prepare_ts));
     }
 
     /* A prepared timestamp should have been set at this point. */
     if (!has_prepare_timestamp())
-        WT_SIM_RET_MSG(EINVAL, "'prepare_transaction' - prepare timestamp is not set");
+        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL, "'prepare_transaction' - prepare timestamp is not set");
 
     /* Commit timestamp must not be set before transaction is prepared. */
     if (_has_commit_ts)
-        WT_SIM_RET_MSG(EINVAL,
+        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL,
           "'prepare_transaction' - commit timestamp must not be set before transaction is "
           "prepared");
 

--- a/test/simulator/timestamp/src/session_simulator.cpp
+++ b/test/simulator/timestamp/src/session_simulator.cpp
@@ -221,28 +221,28 @@ session_simulator::commit_transaction(const std::string &config)
     }
 
     /* We need to rollback a transaction if it failed earlier. */
-    if (_txn_error){
+    if (_txn_error) {
         rollback_transaction();
         WT_SIM_RET(EINVAL);
     }
 
     if (_prepared_txn) {
-        if (!_has_commit_ts){
+        if (!_has_commit_ts) {
             rollback_transaction();
             WT_SIM_RET_MSG(EINVAL, "commit timestamp is required for a prepared transaction");
         }
 
-        if (!is_durable_ts_set()){
+        if (!is_durable_ts_set()) {
             rollback_transaction();
             WT_SIM_RET_MSG(EINVAL, "durable timestamp is required for a prepared transaction");
         }
     } else {
-        if (has_prepare_timestamp()){
+        if (has_prepare_timestamp()) {
             rollback_transaction();
             WT_SIM_RET_MSG(EINVAL, "prepare timestamp is set for non-prepared transaction");
         }
 
-        if (is_durable_ts_set()){
+        if (is_durable_ts_set()) {
             rollback_transaction();
             WT_SIM_RET_MSG(
               EINVAL, "durable timestamp should not be specified for non-prepared transaction");
@@ -278,13 +278,15 @@ session_simulator::timestamp_transaction(const std::string &config)
       "commit_timestamp", "durable_timestamp", "prepare_timestamp", "read_timestamp"};
     const std::vector<std::string> unsupported_ops;
 
-    WT_TXN_SIM_RET_MSG(_txn_error, ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
+    WT_TXN_SIM_RET_MSG(_txn_error,
+      ts_manager->parse_config(config, supported_ops, unsupported_ops, config_map),
       "Incorrect config (" + config + ") passed in timestamp_transaction");
 
     uint64_t commit_ts = 0, durable_ts = 0, prepare_ts = 0, read_ts = 0;
 
     /* Decode a configuration string that may contain multiple timestamps and store them here. */
-    WT_TXN_SIM_RET(_txn_error, decode_timestamp_config_map(config_map, commit_ts, durable_ts, prepare_ts, read_ts));
+    WT_TXN_SIM_RET(_txn_error,
+      decode_timestamp_config_map(config_map, commit_ts, durable_ts, prepare_ts, read_ts));
 
     /* Check if the timestamps were included in the configuration string and set them. */
     if (commit_ts != 0)
@@ -312,7 +314,8 @@ session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64
 
     /* Zero timestamp is not permitted. */
     if (ts == 0)
-        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");
+        WT_TXN_SIM_RET_MSG(
+          _txn_error, EINVAL, "Illegal " + std::to_string(ts) + " timestamp: zero not permitted.");
 
     if (ts_type == "commit")
         WT_TXN_SIM_RET(_txn_error, set_commit_timestamp(ts));
@@ -323,8 +326,8 @@ session_simulator::timestamp_transaction_uint(const std::string &ts_type, uint64
     else if (ts_type == "read")
         WT_TXN_SIM_RET(_txn_error, set_read_timestamp(ts));
     else {
-        WT_TXN_SIM_RET_MSG(_txn_error, 
-          EINVAL, "Invalid timestamp type (" + ts_type + ") passed to timestamp transaction uint.");
+        WT_TXN_SIM_RET_MSG(_txn_error, EINVAL,
+          "Invalid timestamp type (" + ts_type + ") passed to timestamp transaction uint.");
     }
 
     return (0);

--- a/test/simulator/timestamp/src/timestamp_manager.cpp
+++ b/test/simulator/timestamp/src/timestamp_manager.cpp
@@ -113,10 +113,12 @@ timestamp_manager::parse_config(const std::string &config,
      */
     while (std::getline(conf, token, ',')) {
         int pos = token.find('=');
-        if (pos == -1)
-            config_map.insert({trim(token), ""});
-        else
-            config_map.insert({trim(token.substr(0, pos)), trim(token.substr(pos + 1))});
+        if (token != ""){
+            if (pos == -1)
+                config_map.insert({trim(token), ""});
+            else
+                config_map.insert({trim(token.substr(0, pos)), trim(token.substr(pos + 1))});
+        }
     }
 
     /* Get rid of the unsupported ops. */

--- a/test/simulator/timestamp/src/timestamp_manager.cpp
+++ b/test/simulator/timestamp/src/timestamp_manager.cpp
@@ -113,6 +113,7 @@ timestamp_manager::parse_config(const std::string &config,
      */
     while (std::getline(conf, token, ',')) {
         int pos = token.find('=');
+        /* Ignore the string if it's empty. This will occur if extra commas are included. */
         if (token != "") {
             if (pos == -1)
                 config_map.insert({trim(token), ""});

--- a/test/simulator/timestamp/src/timestamp_manager.cpp
+++ b/test/simulator/timestamp/src/timestamp_manager.cpp
@@ -113,7 +113,7 @@ timestamp_manager::parse_config(const std::string &config,
      */
     while (std::getline(conf, token, ',')) {
         int pos = token.find('=');
-        if (token != ""){
+        if (token != "") {
             if (pos == -1)
                 config_map.insert({trim(token), ""});
             else


### PR DESCRIPTION
This PR includes a few fixes to the timestamp simulator after testing it against the call logs generated from the python timestamp tests. 

- test_timestamp13.py failed as a result of outputting a garbage timestamp value into the call log when query_timestamp fails. I've added a check in __wt_call_log_query_timestamp to not print the queried timestamp in the case of an error.
- test_timestamp22.py failed due to commit_transaction not rolling back if an earlier API call failed on that transaction. Adding a txn_error boolean to the session simulator class fixes this. This boolean is set if any part of the transaction fails and the transaction needs to be rollback during commit transaction. 
- There is also a small fix for parsing timestamp configurations.