### PR TITLE
WT-10001 Increase variant size for little endian tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4648,7 +4648,7 @@ buildvariants:
 - name: little-endian
   display_name: "~ Little-endian (x86)"
   run_on:
-  - ubuntu1804-test
+  - ubuntu1804-large
   batchtime: 4320 # 3 days
   expansions:
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'


### PR DESCRIPTION
Increase run on variant for little endian tests due to ops tracking in format using more disk space