### PR TITLE
WT-9860 Debug dumps include page deletion information for fast truncate

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -545,6 +545,7 @@ __debug_cell_int(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_ADDR *unp
 {
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
+    WT_PAGE_DELETED *page_del;
     WT_SESSION_IMPL *session;
     char time_string[WT_TIME_STRING_SIZE];
 
@@ -556,6 +557,18 @@ __debug_cell_int(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_ADDR *unp
     switch (dsk->type) {
     case WT_PAGE_COL_INT:
         WT_RET(ds->f(ds, ", recno: %" PRIu64, unpack->v));
+        break;
+    }
+
+    /* Dump the deleted pages transaction ID, commit timestamp, and durable timestamp. */
+    switch (unpack->raw) {
+    case WT_CELL_ADDR_DEL:
+        if (!F_ISSET(dsk, WT_PAGE_FT_UPDATE))
+            break;
+        page_del = &unpack->page_del;
+        WT_RET(ds->f(ds, ", page_del : %s",
+          __wt_time_point_to_string(
+            page_del->timestamp, page_del->durable_timestamp, page_del->txnid, time_string)));
         break;
     }
 
@@ -1621,6 +1634,7 @@ static int
 __debug_ref(WT_DBG *ds, WT_REF *ref)
 {
     WT_ADDR_COPY addr;
+    WT_PAGE_DELETED *page_del;
     WT_SESSION_IMPL *session;
     char time_string[WT_TIME_STRING_SIZE];
 
@@ -1638,6 +1652,12 @@ __debug_ref(WT_DBG *ds, WT_REF *ref)
     if (__wt_ref_addr_copy(session, ref, &addr) && !WT_TIME_AGGREGATE_IS_EMPTY(&addr.ta))
         WT_RET(ds->f(ds, ", %s, %s", __wt_time_aggregate_to_string(&addr.ta, time_string),
           __wt_addr_string(session, addr.addr, addr.size, ds->t1)));
+    if (ref->state == WT_REF_DELETED && ref->page_del != NULL) {
+        page_del = ref->page_del;
+        WT_RET(ds->f(ds, ", page_del : %s",
+          __wt_time_point_to_string(
+            page_del->timestamp, page_del->durable_timestamp, page_del->txnid, time_string)));
+    }
     return (ds->f(ds, "\n"));
 }
 #endif

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -575,6 +575,13 @@ __debug_cell_int(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_ADDR *unp
     /* Dump timestamps and addresses. */
     switch (unpack->raw) {
     case WT_CELL_ADDR_DEL:
+        if (F_ISSET(dsk, WT_PAGE_FT_UPDATE)) {
+            page_del = &unpack->page_del;
+            WT_RET(ds->f(ds, ", page_del : %s",
+              __wt_time_point_to_string(
+                page_del->timestamp, page_del->durable_timestamp, page_del->txnid, time_string)));
+        }
+    /* FALLTHROUGH */
     case WT_CELL_ADDR_INT:
     case WT_CELL_ADDR_LEAF:
     case WT_CELL_ADDR_LEAF_NO:
@@ -1652,7 +1659,7 @@ __debug_ref(WT_DBG *ds, WT_REF *ref)
     if (__wt_ref_addr_copy(session, ref, &addr) && !WT_TIME_AGGREGATE_IS_EMPTY(&addr.ta))
         WT_RET(ds->f(ds, ", %s, %s", __wt_time_aggregate_to_string(&addr.ta, time_string),
           __wt_addr_string(session, addr.addr, addr.size, ds->t1)));
-    if (ref->state == WT_REF_DELETED && ref->page_del != NULL) {
+    if (ref->page_del != NULL) {
         page_del = ref->page_del;
         WT_RET(ds->f(ds, ", page_del : %s",
           __wt_time_point_to_string(

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -560,21 +560,10 @@ __debug_cell_int(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_ADDR *unp
         break;
     }
 
-    /* Dump the deleted pages transaction ID, commit timestamp, and durable timestamp. */
-    switch (unpack->raw) {
-    case WT_CELL_ADDR_DEL:
-        if (!F_ISSET(dsk, WT_PAGE_FT_UPDATE))
-            break;
-        page_del = &unpack->page_del;
-        WT_RET(ds->f(ds, ", page_del : %s",
-          __wt_time_point_to_string(
-            page_del->timestamp, page_del->durable_timestamp, page_del->txnid, time_string)));
-        break;
-    }
-
     /* Dump timestamps and addresses. */
     switch (unpack->raw) {
     case WT_CELL_ADDR_DEL:
+        /* Dump the deleted pages transaction ID, commit timestamp, and durable timestamp. */
         if (F_ISSET(dsk, WT_PAGE_FT_UPDATE)) {
             page_del = &unpack->page_del;
             WT_RET(ds->f(ds, ", page_del : %s",


### PR DESCRIPTION
[Patch build](https://spruce.mongodb.com/version/635ef16ad6d80a5ef41434f0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).