### PR TITLE
WT-10054 Review btree and backup cursor verbosity

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -136,7 +136,8 @@ __sync_delete_obsolete_ref(WT_SESSION_IMPL *session, WT_REF *ref)
 
     /* Ignore root pages as they can never be deleted. */
     if (__wt_ref_is_root(ref)) {
-        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping root page", (void *)ref);
+        __wt_verbose_debug2(
+          session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping root page", (void *)ref);
         return (0);
     }
 
@@ -149,7 +150,8 @@ __sync_delete_obsolete_ref(WT_SESSION_IMPL *session, WT_REF *ref)
 
     /* Fast-check, ignore deleted pages. */
     if (ref->state == WT_REF_DELETED) {
-        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping deleted page", (void *)ref);
+        __wt_verbose_debug2(
+          session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping deleted page", (void *)ref);
         return (0);
     }
 
@@ -387,7 +389,8 @@ __sync_page_skip(
      * timestamp.
      */
     if (addr.type == WT_ADDR_LEAF_NO || addr.ta.newest_stop_durable_ts == WT_TS_NONE) {
-        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: page walk skipped", (void *)ref);
+        __wt_verbose_debug2(
+          session, WT_VERB_CHECKPOINT_CLEANUP, "%p: page walk skipped", (void *)ref);
         WT_STAT_CONN_DATA_INCR(session, cc_pages_walk_skipped);
         *skipp = true;
     }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -136,20 +136,20 @@ __sync_delete_obsolete_ref(WT_SESSION_IMPL *session, WT_REF *ref)
 
     /* Ignore root pages as they can never be deleted. */
     if (__wt_ref_is_root(ref)) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping root page", (void *)ref);
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping root page", (void *)ref);
         return (0);
     }
 
     /* Ignore internal pages, these are taken care of during reconciliation. */
     if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p: skipping internal page with parent: %p", (void *)ref, (void *)ref->home);
         return (0);
     }
 
     /* Fast-check, ignore deleted pages. */
     if (ref->state == WT_REF_DELETED) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping deleted page", (void *)ref);
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping deleted page", (void *)ref);
         return (0);
     }
 
@@ -191,7 +191,7 @@ __sync_delete_obsolete_ref(WT_SESSION_IMPL *session, WT_REF *ref)
         } else
             WT_REF_UNLOCK(ref, previous_state);
 
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p on-disk page obsolete check: %s"
           "obsolete, stop time point %s",
           (void *)ref, obsolete ? "" : "not ",
@@ -206,7 +206,7 @@ __sync_delete_obsolete_ref(WT_SESSION_IMPL *session, WT_REF *ref)
      * they might have split or been deleted while we were locking the WT_REF.
      */
     if (previous_state != WT_REF_MEM) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping page", (void *)ref);
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: skipping page", (void *)ref);
         return (0);
     }
 
@@ -289,7 +289,7 @@ __sync_delete_obsolete_ref(WT_SESSION_IMPL *session, WT_REF *ref)
         WT_STAT_CONN_DATA_INCR(session, cc_pages_evict);
     }
 
-    __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+    __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
       "%p in-memory page obsolete check: %s %s"
       "obsolete, stop time point %s",
       (void *)ref, tag, obsolete ? "" : "not ",
@@ -313,7 +313,7 @@ __sync_ref_int_obsolete_cleanup(WT_SESSION_IMPL *session, WT_REF *parent)
     WT_REF *ref;
     uint32_t slot;
 
-    __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+    __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
       "%p: traversing the internal page %p for obsolete child pages", (void *)parent,
       (void *)parent->page);
 
@@ -387,7 +387,7 @@ __sync_page_skip(
      * timestamp.
      */
     if (addr.type == WT_ADDR_LEAF_NO || addr.ta.newest_stop_durable_ts == WT_TS_NONE) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: page walk skipped", (void *)ref);
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: page walk skipped", (void *)ref);
         WT_STAT_CONN_DATA_INCR(session, cc_pages_walk_skipped);
         *skipp = true;
     }

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -345,7 +345,8 @@ __backup_add_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval)
             __wt_verbose_debug2(session, WT_VERB_BACKUP, "Free blk[%u] entry", i);
             break;
         }
-        __wt_verbose_debug2(session, WT_VERB_BACKUP, "Entry blk[%u] has flags 0x%" PRIx8, i, blk->flags);
+        __wt_verbose_debug2(
+          session, WT_VERB_BACKUP, "Entry blk[%u] has flags 0x%" PRIx8, i, blk->flags);
     }
     /*
      * We didn't find an entry. This should not happen.
@@ -415,7 +416,8 @@ __backup_find_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval, WT_BLKINCR **in
             return (0);
         }
     }
-    __wt_verbose_debug2(session, WT_VERB_BACKUP, "Search %.*s not found", (int)cval->len, cval->str);
+    __wt_verbose_debug2(
+      session, WT_VERB_BACKUP, "Search %.*s not found", (int)cval->len, cval->str);
     return (WT_NOTFOUND);
 }
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -342,10 +342,10 @@ __backup_add_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval)
         blk = &conn->incr_backups[i];
         /* If it isn't already in use, we can use it. */
         if (!F_ISSET(blk, WT_BLKINCR_INUSE)) {
-            __wt_verbose(session, WT_VERB_BACKUP, "Free blk[%u] entry", i);
+            __wt_verbose_debug2(session, WT_VERB_BACKUP, "Free blk[%u] entry", i);
             break;
         }
-        __wt_verbose(session, WT_VERB_BACKUP, "Entry blk[%u] has flags 0x%" PRIx8, i, blk->flags);
+        __wt_verbose_debug2(session, WT_VERB_BACKUP, "Entry blk[%u] has flags 0x%" PRIx8, i, blk->flags);
     }
     /*
      * We didn't find an entry. This should not happen.
@@ -355,7 +355,7 @@ __backup_add_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval)
 
     /* Use the slot. */
     if (blk->id_str != NULL)
-        __wt_verbose(
+        __wt_verbose_debug2(
           session, WT_VERB_BACKUP, "Freeing and reusing backup slot with old id %s", blk->id_str);
     /* Free anything that was there. */
     __wt_free(session, blk->id_str);
@@ -410,12 +410,12 @@ __backup_find_id(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval, WT_BLKINCR **in
                 WT_RET_MSG(session, EINVAL, "Incremental backup structure already in use");
             if (incrp != NULL)
                 *incrp = blk;
-            __wt_verbose(
+            __wt_verbose_debug2(
               session, WT_VERB_BACKUP, "Found src id %s at backup slot %u", blk->id_str, i);
             return (0);
         }
     }
-    __wt_verbose(session, WT_VERB_BACKUP, "Search %.*s not found", (int)cval->len, cval->str);
+    __wt_verbose_debug2(session, WT_VERB_BACKUP, "Search %.*s not found", (int)cval->len, cval->str);
     return (WT_NOTFOUND);
 }
 

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -71,10 +71,10 @@ __curbackup_incr_blkmod(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_CURSOR_BAC
         WT_ERR(__wt_config_subgets(session, &v, "offset", &b));
         cb->offset = (uint64_t)b.val;
 
-        __wt_verbose(session, WT_VERB_BACKUP,
+        __wt_verbose_debug2(session, WT_VERB_BACKUP,
           "Found modified incr block gran %" PRIu64 " nbits %" PRIu64 " offset %" PRIu64,
           cb->granularity, cb->nbits, cb->offset);
-        __wt_verbose(session, WT_VERB_BACKUP, "Modified incr block config: \"%s\"", config);
+        __wt_verbose_debug2(session, WT_VERB_BACKUP, "Modified incr block config: \"%s\"", config);
 
         /*
          * The rename configuration string component was added later. So don't error if we don't
@@ -154,7 +154,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
          * incremental cursor below and return WT_NOTFOUND.
          */
         F_SET(cb, WT_CURBACKUP_INCR_INIT);
-        __wt_verbose(session, WT_VERB_BACKUP, "Set key WT_BACKUP_FILE %s size %" PRIuMAX,
+        __wt_verbose_debug2(session, WT_VERB_BACKUP, "Set key WT_BACKUP_FILE %s size %" PRIuMAX,
           cb->incr_file, (uintmax_t)size);
         __wt_cursor_set_key(cursor, 0, size, WT_BACKUP_FILE);
     } else {
@@ -183,7 +183,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
                 if (F_ISSET(cb, WT_CURBACKUP_RENAME) ||
                   (F_ISSET(cb, WT_CURBACKUP_CKPT_FAKE) && F_ISSET(cb, WT_CURBACKUP_HAS_CB_INFO))) {
                     WT_ERR(__wt_fs_size(session, cb->incr_file, &size));
-                    __wt_verbose(session, WT_VERB_BACKUP,
+                    __wt_verbose_debug2(session, WT_VERB_BACKUP,
                       "Set key WT_BACKUP_FILE %s size %" PRIuMAX, cb->incr_file, (uintmax_t)size);
                     __wt_cursor_set_key(cursor, 0, size, WT_BACKUP_FILE);
                     goto done;
@@ -220,7 +220,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
             WT_ERR(WT_NOTFOUND);
         WT_ASSERT(session, cb->granularity != 0);
         WT_ASSERT(session, total_len != 0);
-        __wt_verbose(session, WT_VERB_BACKUP,
+        __wt_verbose_debug2(session, WT_VERB_BACKUP,
           "Set key WT_BACKUP_RANGE %s offset %" PRIu64 " length %" PRIu64, cb->incr_file,
           cb->offset + cb->granularity * start_bitoff, total_len);
         __wt_cursor_set_key(


### PR DESCRIPTION
Some assumptions for the btree code: I'm assuming that stuff used in bt_vrfy and bt_slvg are reasonably uncommon. I'm also assuming that opening a btree isn't anywhere near the hot path, or frequent enough to justify moving to `DEBUG_2`. The split code does log stuff for every split, but it's a single line so I left it. bt_sync's per-page operations moved to debug2, but I think leaving the per-file stuff as debug1 is ok?

For backup cursors, I suspect adding IDs seems like it'd be common enough to move to `DEBUG_2`, but some confirmation would be good here.

Here's the full list of log lines I checked in case you want to check any of them:
src/btree/bt_curnext.c:589
src/btree/bt_curnext.c:625
src/btree/bt_debug.c:72
src/btree/bt_handle.c:321
src/btree/bt_handle.c:326
src/btree/bt_handle.c:975
src/btree/bt_import.c:134
src/btree/bt_slvg.c:1107
src/btree/bt_slvg.c:1168
src/btree/bt_slvg.c:1302
src/btree/bt_slvg.c:1320
src/btree/bt_slvg.c:1522
src/btree/bt_slvg.c:1697
src/btree/bt_slvg.c:1938
src/btree/bt_slvg.c:1953
src/btree/bt_slvg.c:2220
src/btree/bt_slvg.c:2413
src/btree/bt_slvg.c:2476
src/btree/bt_slvg.c:485
src/btree/bt_slvg.c:499
src/btree/bt_slvg.c:505
src/btree/bt_slvg.c:618
src/btree/bt_slvg.c:645
src/btree/bt_slvg.c:669
src/btree/bt_slvg.c:697
src/btree/bt_slvg.c:701
src/btree/bt_slvg.c:774
src/btree/bt_slvg.c:938
src/btree/bt_split.c:2075
src/btree/bt_split.c:2184
src/btree/bt_split.c:2220
src/btree/bt_split.c:2243
src/btree/bt_split.c:432
src/btree/bt_split.c:841
src/btree/bt_split.c:937
src/btree/bt_sync.c:139
src/btree/bt_sync.c:145
src/btree/bt_sync.c:152
src/btree/bt_sync.c:194
src/btree/bt_sync.c:209
src/btree/bt_sync.c:292
src/btree/bt_sync.c:316
src/btree/bt_sync.c:390
src/btree/bt_sync.c:428
src/btree/bt_sync.c:652
src/btree/bt_vrfy.c:227
src/btree/bt_vrfy.c:410
src/cursor/cur_backup.c:205
src/cursor/cur_backup.c:345
src/cursor/cur_backup.c:348
src/cursor/cur_backup.c:358
src/cursor/cur_backup.c:374
src/cursor/cur_backup.c:379
src/cursor/cur_backup.c:413
src/cursor/cur_backup.c:418
src/cursor/cur_backup.c:486
src/cursor/cur_backup_incr.c:157
src/cursor/cur_backup_incr.c:186
src/cursor/cur_backup_incr.c:223
src/cursor/cur_backup_incr.c:285
src/cursor/cur_backup_incr.c:74
src/cursor/cur_backup_incr.c:77
src/cursor/cur_file.c:538