### PR TITLE
WT-10058 Check OS-specific and filesystem verbosity

### DIFF
--- a/src/include/os_fhandle_inline.h
+++ b/src/include/os_fhandle_inline.h
@@ -106,8 +106,8 @@ __wt_read(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, void
     WT_DECL_RET;
     uint64_t time_start, time_stop;
 
-    __wt_verbose(session, WT_VERB_HANDLEOPS, "%s: handle-read: %" WT_SIZET_FMT " at %" PRIuMAX,
-      fh->handle->name, len, (uintmax_t)offset);
+    __wt_verbose_debug2(session, WT_VERB_HANDLEOPS,
+      "%s: handle-read: %" WT_SIZET_FMT " at %" PRIuMAX, fh->handle->name, len, (uintmax_t)offset);
 
     WT_STAT_CONN_INCR_ATOMIC(session, thread_read_active);
     WT_STAT_CONN_INCR(session, read_io);
@@ -185,8 +185,8 @@ __wt_write(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len, con
       !F_ISSET(S2C(session), WT_CONN_READONLY) ||
         WT_STRING_MATCH(fh->name, WT_SINGLETHREAD, strlen(WT_SINGLETHREAD)));
 
-    __wt_verbose(session, WT_VERB_HANDLEOPS, "%s: handle-write: %" WT_SIZET_FMT " at %" PRIuMAX,
-      fh->handle->name, len, (uintmax_t)offset);
+    __wt_verbose_debug2(session, WT_VERB_HANDLEOPS,
+      "%s: handle-write: %" WT_SIZET_FMT " at %" PRIuMAX, fh->handle->name, len, (uintmax_t)offset);
 
     /*
      * Do a final panic check before I/O, so we stop writing as quickly as possible if there's an

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -411,7 +411,7 @@ __posix_file_read(
     session = (WT_SESSION_IMPL *)wt_session;
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-    __wt_verbose(session, WT_VERB_READ, "read: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT,
+    __wt_verbose_debug2(session, WT_VERB_READ, "read: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT,
       file_handle->name, pfh->fd, offset, len);
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
@@ -456,7 +456,7 @@ __posix_file_read_mmap(
     if (!pfh->mmap_file_mappable || pfh->mmap_resizing)
         return (__posix_file_read(file_handle, wt_session, offset, len, buf));
 
-    __wt_verbose(session, WT_VERB_READ,
+    __wt_verbose_debug2(session, WT_VERB_READ,
       "read-mmap: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT
       ", mapped buffer: %p, mapped size = %" PRId64,
       file_handle->name, pfh->fd, offset, len, (void *)pfh->mmap_buf, pfh->mmap_size);
@@ -564,7 +564,7 @@ __posix_file_truncate(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_of
     session = (WT_SESSION_IMPL *)wt_session;
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-    __wt_verbose(session, WT_VERB_FILEOPS,
+    __wt_verbose_debug2(session, WT_VERB_FILEOPS,
       "%s, file-truncate: size=%" PRId64 ", mapped size=%" PRId64, file_handle->name, len,
       pfh->mmap_size);
 
@@ -602,7 +602,7 @@ __posix_file_write(
     session = (WT_SESSION_IMPL *)wt_session;
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-    __wt_verbose(session, WT_VERB_WRITE, "write: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT,
+    __wt_verbose_debug2(session, WT_VERB_WRITE, "write: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT,
       file_handle->name, pfh->fd, offset, len);
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
@@ -640,7 +640,7 @@ __posix_file_write_mmap(
     session = (WT_SESSION_IMPL *)wt_session;
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-    __wt_verbose(session, WT_VERB_WRITE,
+    __wt_verbose_debug2(session, WT_VERB_WRITE,
       "write-mmap: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT
       ", mapped buffer: %p, mapped size = %" PRId64,
       file_handle->name, pfh->fd, offset, len, (void *)pfh->mmap_buf, pfh->mmap_size);

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -411,8 +411,9 @@ __posix_file_read(
     session = (WT_SESSION_IMPL *)wt_session;
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-    __wt_verbose_debug2(session, WT_VERB_READ, "read: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT,
-      file_handle->name, pfh->fd, offset, len);
+    __wt_verbose_debug2(session, WT_VERB_READ,
+      "read: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT, file_handle->name, pfh->fd, offset,
+      len);
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
     WT_ASSERT(session,
@@ -602,8 +603,9 @@ __posix_file_write(
     session = (WT_SESSION_IMPL *)wt_session;
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
-    __wt_verbose_debug2(session, WT_VERB_WRITE, "write: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT,
-      file_handle->name, pfh->fd, offset, len);
+    __wt_verbose_debug2(session, WT_VERB_WRITE,
+      "write: %s, fd=%d, offset=%" PRId64 ", len=%" WT_SIZET_FMT, file_handle->name, pfh->fd,
+      offset, len);
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
     WT_ASSERT(session,

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -72,7 +72,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
         return;
     }
 
-    __wt_verbose(session, WT_VERB_MUTEX, "wait %s", cond->name);
+    __wt_verbose_debug2(session, WT_VERB_MUTEX, "wait %s", cond->name);
     WT_STAT_CONN_INCR(session, cond_wait);
 
     WT_ERR(pthread_mutex_lock(&cond->mtx));
@@ -152,7 +152,7 @@ __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond)
 {
     WT_DECL_RET;
 
-    __wt_verbose(session, WT_VERB_MUTEX, "signal %s", cond->name);
+    __wt_verbose_debug2(session, WT_VERB_MUTEX, "signal %s", cond->name);
 
     /*
      * Our callers often set flags to cause a thread to exit. Add a barrier to ensure exit flags are

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -52,7 +52,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
     if (__wt_atomic_addi32(&cond->waiters, 1) == 0)
         return;
 
-    __wt_verbose(session, WT_VERB_MUTEX, "wait %s", cond->name);
+    __wt_verbose_debug2(session, WT_VERB_MUTEX, "wait %s", cond->name);
     WT_STAT_CONN_INCR(session, cond_wait);
 
     EnterCriticalSection(&cond->mtx);
@@ -129,7 +129,7 @@ __wt_cond_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond)
 {
     WT_DECL_RET;
 
-    __wt_verbose(session, WT_VERB_MUTEX, "signal %s", cond->name);
+    __wt_verbose_debug2(session, WT_VERB_MUTEX, "signal %s", cond->name);
 
     /*
      * Our callers often set flags to cause a thread to exit. Add a barrier to ensure exit flags are


### PR DESCRIPTION
The only assumption I've made here is that reads and writes are more common than open/close/mmap/etc. The full list of lines I reviewed is:
src/include/os_fhandle_inline.h:109
src/include/os_fhandle_inline.h:135
src/include/os_fhandle_inline.h:154
src/include/os_fhandle_inline.h:188
src/include/os_fhandle_inline.h:27
src/include/os_fhandle_inline.h:61
src/include/os_fhandle_inline.h:92
src/include/os_fs_inline.h:111
src/include/os_fs_inline.h:137
src/include/os_fs_inline.h:172
src/include/os_fs_inline.h:212
src/include/os_fs_inline.h:35
src/include/os_fs_inline.h:64
rc/os_common/os_fhandle.c:164
src/os_common/os_fhandle.c:188
src/os_common/os_fhandle.c:327
src/os_posix/os_fs.c:1029
src/os_posix/os_fs.c:1066
src/os_posix/os_fs.c:1121
src/os_posix/os_fs.c:1148
src/os_posix/os_fs.c:346
src/os_posix/os_fs.c:414
src/os_posix/os_fs.c:459
src/os_posix/os_fs.c:567
src/os_posix/os_fs.c:605
src/os_posix/os_fs.c:643
src/os_posix/os_map.c:158
src/os_posix/os_map.c:44
src/os_posix/os_mtx_cond.c:155
src/os_posix/os_mtx_cond.c:75
src/os_win/os_map.c:37
src/os_win/os_map.c:83
src/os_win/os_mtx_cond.c:132
src/os_win/os_mtx_cond.c:55
