### PR TITLE
WT-10061 Changing test/format statistics setting to fast

### DIFF
--- a/test/format/trace.c
+++ b/test/format/trace.c
@@ -99,7 +99,7 @@ trace_init(void)
 
     /* Configure logging with automatic removal, and keep the last N log files. */
     testutil_check(__wt_snprintf(config, sizeof(config),
-      "create,log=(enabled=true,remove=true),debug_mode=(log_retention=%d),statistics=(all),"
+      "create,log=(enabled=true,remove=true),debug_mode=(log_retention=%d),statistics=(fast),"
       "statistics_log=(json,on_close,wait=5)",
       retain));
     testutil_check(__wt_snprintf(tracedir, sizeof(tracedir), "%s/%s", g.home, TRACE_DIR));

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -218,7 +218,7 @@ create_database(const char *home, WT_CONNECTION **connp)
       ",checkpoint_sync=false"
       ",error_prefix=\"%s\""
       ",operation_timeout_ms=2000"
-      ",statistics=(all)"
+      ",statistics=(fast)"
       ",statistics_log=(json,on_close,wait=5)",
       GV(CACHE), progname);
 
@@ -488,7 +488,7 @@ wts_open(const char *home, WT_CONNECTION **connp, bool verify_metadata)
         CONFIG_APPEND(p, ",encryption=(name=%s)", enc);
 
     CONFIG_APPEND(
-      p, ",error_prefix=\"%s\",statistics=(all),statistics_log=(json,on_close,wait=5)", progname);
+      p, ",error_prefix=\"%s\",statistics=(fast),statistics_log=(json,on_close,wait=5)", progname);
 
     /* Optional timing stress. */
     configure_timing_stress(&p, max);


### PR DESCRIPTION
Changing test/format statistics setting to fast from all to reduce the cache stuck issues that are a CI blocker and tracked in WT-8054. 

The cache stuck issue is currently see in btree_walk (which is on when all is used) and we hit the sources setting in format.