### PR TITLE
WT-10062 Fix checkpoint cleanup not to skip internal pages

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -382,11 +382,8 @@ __sync_page_skip(
     if (!__wt_ref_addr_copy(session, ref, &addr))
         return (0);
 
-    /*
-     * Skip reading the pages that are normal leaf pages or don't have an aggregated durable stop
-     * timestamp.
-     */
-    if (addr.type == WT_ADDR_LEAF_NO || addr.ta.newest_stop_durable_ts == WT_TS_NONE) {
+    /* Skip reading normal leaf pages. */
+    if (addr.type == WT_ADDR_LEAF_NO) {
         __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP, "%p: page walk skipped", (void *)ref);
         WT_STAT_CONN_DATA_INCR(session, cc_pages_walk_skipped);
         *skipp = true;


### PR DESCRIPTION
Earlier checkpoint cleanup skips the internal pages that don't have aggregated stop durable timestamp, but this logic can go wrong when an obsolete page is created by a non timestamped transaction and this page was never freed from disk.

Reading all the internal pages into the cache frees the obsolete pages and reclaims the disk space.