### PR TITLE
WT-10063 Enable unit-test-long-bucket tasks in patch builds

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2089,7 +2089,8 @@ tasks:
           unit_test_args: -v 2 -b 10/11
 
   - name: unit-test-long-bucket00
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2099,7 +2100,8 @@ tasks:
           unit_test_args: -v 2 --long -b 0/11
 
   - name: unit-test-long-bucket01
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2109,7 +2111,8 @@ tasks:
           unit_test_args: -v 2 --long -b 1/11
 
   - name: unit-test-long-bucket02
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2119,7 +2122,8 @@ tasks:
           unit_test_args: -v 2 --long -b 2/11
 
   - name: unit-test-long-bucket03
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2129,7 +2133,8 @@ tasks:
           unit_test_args: -v 2 --long -b 3/11
 
   - name: unit-test-long-bucket04
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2139,7 +2144,8 @@ tasks:
           unit_test_args: -v 2 --long -b 4/11
 
   - name: unit-test-long-bucket05
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2149,7 +2155,8 @@ tasks:
           unit_test_args: -v 2 --long -b 5/11
 
   - name: unit-test-long-bucket06
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2159,7 +2166,8 @@ tasks:
           unit_test_args: -v 2 --long -b 6/11
 
   - name: unit-test-long-bucket07
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2169,7 +2177,8 @@ tasks:
           unit_test_args: -v 2 --long -b 7/11
 
   - name: unit-test-long-bucket08
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2179,7 +2188,8 @@ tasks:
           unit_test_args: -v 2 --long -b 8/11
 
   - name: unit-test-long-bucket09
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -2189,7 +2199,8 @@ tasks:
           unit_test_args: -v 2 --long -b 9/11
 
   - name: unit-test-long-bucket10
-    tags: ["python"]
+    tags: ["python", "unit_test_long"]
+    patch_only: true
     depends_on:
     - name: compile
     commands:
@@ -4134,6 +4145,7 @@ buildvariants:
     data_validation_stress_test_args: -t r -m -W 3 -D -p -n 100000 -k 100000 -C cache_size=100MB
   tasks:
     - name: ".pull_request !.pull_request_compilers"
+    - name: ".unit_test_long"
     - name: compile
     - name: doc-compile
     - name: make-check-test


### PR DESCRIPTION
Changes made in this PR include:
- apply a new tag to the set of unit-test-long-bucket tasks, and add them to the `ubuntu2004` builder
- apply `patch_only: true` to all unit-test-long-bucket tasks, so that they are not triggered by commit builds

After this PR is merged, it is expected we are able to config commit-queue to pick the set of unit-test-long-bucket tasks.