### PR TITLE
WT-10055 Check metadata and reconciliation verbosity

### DIFF
--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -184,6 +184,13 @@ struct __wt_verbose_multi_category {
     __wt_verbose_level(session, category, WT_VERBOSE_DEBUG_2, fmt, __VA_ARGS__)
 
 /*
+ * __wt_verbose_debug3 --
+ *     Wrapper to __wt_verbose_level using the DEBUG_3 level.
+ */
+#define __wt_verbose_debug3(session, category, fmt, ...) \
+    __wt_verbose_level(session, category, WT_VERBOSE_DEBUG_3, fmt, __VA_ARGS__)
+
+/*
  * __wt_verbose --
  *     Display a verbose message using the default verbosity level. Not an inlined function because
  *     you can't inline functions taking variadic arguments and we don't want to make a function

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -183,7 +183,7 @@ __wt_metadata_insert(WT_SESSION_IMPL *session, const char *key, const char *valu
     WT_CURSOR *cursor;
     WT_DECL_RET;
 
-    __wt_verbose(session, WT_VERB_METADATA,
+    __wt_verbose_debug3(session, WT_VERB_METADATA,
       "Insert: key: %s, value: %s, tracking: %s, %s"
       "turtle",
       key, value, WT_META_TRACKING(session) ? "true" : "false",
@@ -213,7 +213,7 @@ __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *valu
     WT_CURSOR *cursor;
     WT_DECL_RET;
 
-    __wt_verbose(session, WT_VERB_METADATA,
+    __wt_verbose_debug3(session, WT_VERB_METADATA,
       "Update: key: %s, value: %s, tracking: %s, %s"
       "turtle",
       key, value, WT_META_TRACKING(session) ? "true" : "false",
@@ -249,7 +249,7 @@ __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key)
     WT_CURSOR *cursor;
     WT_DECL_RET;
 
-    __wt_verbose(session, WT_VERB_METADATA,
+    __wt_verbose_debug3(session, WT_VERB_METADATA,
       "Remove: key: %s, tracking: %s, %s"
       "turtle",
       key, WT_META_TRACKING(session) ? "true" : "false", __metadata_turtle(key) ? "" : "not ");
@@ -293,7 +293,7 @@ __wt_metadata_search(WT_SESSION_IMPL *session, const char *key, char **valuep)
 
     *valuep = NULL;
 
-    __wt_verbose(session, WT_VERB_METADATA,
+    __wt_verbose_debug3(session, WT_VERB_METADATA,
       "Search: key: %s, tracking: %s, %s"
       "turtle",
       key, WT_META_TRACKING(session) ? "true" : "false", __metadata_turtle(key) ? "" : "not ");

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -43,7 +43,7 @@ __ovfl_discard_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell, c
     unpack = &_unpack;
     __wt_cell_unpack_kv(session, page->dsk, cell, unpack);
 
-    __wt_verbose(session, WT_VERB_OVERFLOW, "discard: %s%s%p %s", tag == NULL ? "" : tag,
+    __wt_verbose_debug2(session, WT_VERB_OVERFLOW, "discard: %s%s%p %s", tag == NULL ? "" : tag,
       tag == NULL ? "" : ": ", (void *)page,
       __wt_addr_string(session, unpack->data, unpack->size, tmp));
 
@@ -86,7 +86,7 @@ __ovfl_discard_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     track = page->modify->ovfl_track;
     for (i = 0, cellp = track->discard; i < track->discard_entries; ++i, ++cellp) {
-        if (WT_VERBOSE_ISSET(session, WT_VERB_OVERFLOW))
+        if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_discard_verbose(session, page, *cellp, "free"));
 
         /* Discard each cell's overflow item. */
@@ -131,7 +131,7 @@ __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
       session, &track->discard_allocated, track->discard_entries + 1, &track->discard));
     track->discard[track->discard_entries++] = cell;
 
-    if (WT_VERBOSE_ISSET(session, WT_VERB_OVERFLOW))
+    if (WT_VERBOSE_LEVEL_ISSETISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
         WT_RET(__ovfl_discard_verbose(session, page, cell, "add"));
 
     return (0);
@@ -166,7 +166,7 @@ __ovfl_reuse_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_OVFL_REUSE *reu
 
     WT_RET(__wt_scr_alloc(session, 64, &tmp));
 
-    __wt_verbose(session, WT_VERB_OVERFLOW, "reuse: %s%s%p %s (%s%s%s) {%.*s}",
+    __wt_verbose_debug2(session, WT_VERB_OVERFLOW, "reuse: %s%s%p %s (%s%s%s) {%.*s}",
       tag == NULL ? "" : tag, tag == NULL ? "" : ": ", (void *)page,
       __wt_addr_string(session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size, tmp),
       F_ISSET(reuse, WT_OVFL_REUSE_INUSE) ? "inuse" : "",
@@ -339,7 +339,7 @@ __ovfl_reuse_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
         WT_ASSERT_ALWAYS(session, !F_ISSET(reuse, WT_OVFL_REUSE_JUST_ADDED),
           "Attempting to reuse dirty overflow record");
 
-        if (WT_VERBOSE_ISSET(session, WT_VERB_OVERFLOW))
+        if (WT_VERBOSE_LEVEL_ISSETISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
         WT_RET(bm->free(bm, session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
@@ -394,7 +394,7 @@ __ovfl_reuse_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
         }
         *e = reuse->next[0];
 
-        if (WT_VERBOSE_ISSET(session, WT_VERB_OVERFLOW))
+        if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
         WT_TRET(bm->free(bm, session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
@@ -436,7 +436,7 @@ __wt_ovfl_reuse_search(WT_SESSION_IMPL *session, WT_PAGE *page, uint8_t **addrp,
     *addr_sizep = reuse->addr_size;
     F_SET(reuse, WT_OVFL_REUSE_INUSE);
 
-    if (WT_VERBOSE_ISSET(session, WT_VERB_OVERFLOW))
+    if (WT_VERBOSE_LEVEL_ISSETISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
         WT_RET(__ovfl_reuse_verbose(session, page, reuse, "reclaim"));
     return (0);
 }
@@ -491,7 +491,7 @@ __wt_ovfl_reuse_add(WT_SESSION_IMPL *session, WT_PAGE *page, const uint8_t *addr
         *stack[i] = reuse;
     }
 
-    if (WT_VERBOSE_ISSET(session, WT_VERB_OVERFLOW))
+    if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
         WT_RET(__ovfl_reuse_verbose(session, page, reuse, "add"));
 
     return (0);

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -131,7 +131,7 @@ __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
       session, &track->discard_allocated, track->discard_entries + 1, &track->discard));
     track->discard[track->discard_entries++] = cell;
 
-    if (WT_VERBOSE_LEVEL_ISSETISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
+    if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
         WT_RET(__ovfl_discard_verbose(session, page, cell, "add"));
 
     return (0);
@@ -339,7 +339,7 @@ __ovfl_reuse_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
         WT_ASSERT_ALWAYS(session, !F_ISSET(reuse, WT_OVFL_REUSE_JUST_ADDED),
           "Attempting to reuse dirty overflow record");
 
-        if (WT_VERBOSE_LEVEL_ISSETISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
+        if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
         WT_RET(bm->free(bm, session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
@@ -436,7 +436,7 @@ __wt_ovfl_reuse_search(WT_SESSION_IMPL *session, WT_PAGE *page, uint8_t **addrp,
     *addr_sizep = reuse->addr_size;
     F_SET(reuse, WT_OVFL_REUSE_INUSE);
 
-    if (WT_VERBOSE_LEVEL_ISSETISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
+    if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
         WT_RET(__ovfl_reuse_verbose(session, page, reuse, "reclaim"));
     return (0);
 }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2372,18 +2372,18 @@ __rec_split_dump_keys(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     btree = S2BT(session);
 
-    __wt_verbose(session, WT_VERB_SPLIT, "split: %" PRIu32 " pages", r->multi_next);
+    __wt_verbose_debug2(session, WT_VERB_SPLIT, "split: %" PRIu32 " pages", r->multi_next);
 
     if (btree->type == BTREE_ROW) {
         WT_RET(__wt_scr_alloc(session, 0, &tkey));
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
-            __wt_verbose(session, WT_VERB_SPLIT, "starting key %s",
+            __wt_verbose_debug2(session, WT_VERB_SPLIT, "starting key %s",
               __wt_buf_set_printable(
                 session, WT_IKEY_DATA(multi->key.ikey), multi->key.ikey->size, false, tkey));
         __wt_scr_free(session, &tkey);
     } else
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
-            __wt_verbose(session, WT_VERB_SPLIT, "starting recno %" PRIu64, multi->key.recno);
+            __wt_verbose_debug2(session, WT_VERB_SPLIT, "starting recno %" PRIu64, multi->key.recno);
     return (0);
 }
 
@@ -2544,7 +2544,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
             WT_STAT_DATA_INCR(session, rec_multiblock_leaf);
 
         /* Optionally display the actual split keys in verbose mode. */
-        if (WT_VERBOSE_ISSET(session, WT_VERB_SPLIT))
+        if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_SPLIT, WT_VERBOSE_DEBUG_2))
             WT_RET(__rec_split_dump_keys(session, r));
 
         /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2383,7 +2383,8 @@ __rec_split_dump_keys(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         __wt_scr_free(session, &tkey);
     } else
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
-            __wt_verbose_debug2(session, WT_VERB_SPLIT, "starting recno %" PRIu64, multi->key.recno);
+            __wt_verbose_debug2(
+              session, WT_VERB_SPLIT, "starting recno %" PRIu64, multi->key.recno);
     return (0);
 }
 


### PR DESCRIPTION
Some notes: for the metadata code, some stuff logs with the "checkpoint progress" module, I left this alone since it's different to the "checkpoint" module and can be left at INFO separately.

For the reconciliation code, I'm assuming that overflow records are reasonably frequently modified/used. In rec_write, I'm assuming dumping keys is appropriate at a higher debug level than seeing which pages were reconciled.

Here's the full list of everything that was reviewed in this PR:
src/meta/meta_ckpt.c:1530
src/meta/meta_ckpt.c:1727
src/meta/meta_table.c:186
src/meta/meta_table.c:216
src/meta/meta_table.c:252
src/meta/meta_table.c:296
src/meta/meta_turtle.c:389
src/meta/meta_turtle.c:549
src/reconcile/rec_track.c:134
src/reconcile/rec_track.c:169
src/reconcile/rec_track.c:342
src/reconcile/rec_track.c:397
src/reconcile/rec_track.c:439
src/reconcile/rec_track.c:46
src/reconcile/rec_track.c:494
src/reconcile/rec_track.c:89
src/reconcile/rec_visibility.c:310
src/reconcile/rec_write.c:2375
src/reconcile/rec_write.c:2380
src/reconcile/rec_write.c:2386
src/reconcile/rec_write.c:2479
src/reconcile/rec_write.c:2547
src/reconcile/rec_write.c:43
src/reconcile/rec_write.c:450