### PR TITLE
WT-10056 Check schema layer tiered storage verbosity

### DIFF
--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -209,7 +209,7 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
      */
     tier = tiered->tiers[WT_TIERED_INDEX_LOCAL].tier;
     if (tier != NULL) {
-        __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: drop local object %s", tier->name);
+        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: drop local object %s", tier->name);
         WT_WITHOUT_DHANDLE(session,
           WT_WITH_HANDLE_LIST_WRITE_LOCK(
             session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
@@ -226,7 +226,7 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
     /* Close any dhandle and remove any tier: entry from metadata. */
     tier = tiered->tiers[WT_TIERED_INDEX_SHARED].tier;
     if (tier != NULL) {
-        __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: drop shared object %s", tier->name);
+        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: drop shared object %s", tier->name);
         WT_WITHOUT_DHANDLE(session,
           WT_WITH_HANDLE_LIST_WRITE_LOCK(
             session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
@@ -241,11 +241,11 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
      */
     for (i = tiered->oldest_id; i < tiered->current_id; ++i) {
         WT_ERR(__wt_tiered_name(session, &tiered->iface, i, WT_TIERED_NAME_LOCAL, &name));
-        __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
+        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
         WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
         __wt_free(session, name);
         WT_ERR(__wt_tiered_name(session, &tiered->iface, i, WT_TIERED_NAME_OBJECT, &name));
-        __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
+        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
         WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
         if (remove_files && tier != NULL) {
             filename = name;

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -209,7 +209,8 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
      */
     tier = tiered->tiers[WT_TIERED_INDEX_LOCAL].tier;
     if (tier != NULL) {
-        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: drop local object %s", tier->name);
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: drop local object %s", tier->name);
         WT_WITHOUT_DHANDLE(session,
           WT_WITH_HANDLE_LIST_WRITE_LOCK(
             session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
@@ -226,7 +227,8 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
     /* Close any dhandle and remove any tier: entry from metadata. */
     tier = tiered->tiers[WT_TIERED_INDEX_SHARED].tier;
     if (tier != NULL) {
-        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: drop shared object %s", tier->name);
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: drop shared object %s", tier->name);
         WT_WITHOUT_DHANDLE(session,
           WT_WITH_HANDLE_LIST_WRITE_LOCK(
             session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
@@ -241,11 +243,13 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
      */
     for (i = tiered->oldest_id; i < tiered->current_id; ++i) {
         WT_ERR(__wt_tiered_name(session, &tiered->iface, i, WT_TIERED_NAME_LOCAL, &name));
-        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
         WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
         __wt_free(session, name);
         WT_ERR(__wt_tiered_name(session, &tiered->iface, i, WT_TIERED_NAME_OBJECT, &name));
-        __wt_verbose_debug2(session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
         WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
         if (remove_files && tier != NULL) {
             filename = name;

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -342,7 +342,7 @@ __tiered_create_object(WT_SESSION_IMPL *session, WT_TIERED *tiered)
     cfg[2] = "flush_time=0,flush_timestamp=0";
     WT_ASSERT(session, tiered->obj_config != NULL);
     WT_ERR(__wt_config_merge(session, cfg, NULL, (const char **)&config));
-    __wt_verbose(
+    __wt_verbose_debug2(
       session, WT_VERB_TIERED, "TIER_CREATE_OBJECT: schema create %s : %s", name, config);
     /* Create the new shared object. */
     WT_ERR(__wt_schema_create(session, name, config));
@@ -455,7 +455,7 @@ __tiered_update_dhandles(WT_SESSION_IMPL *session, WT_TIERED *tiered)
         }
         if (tiered->tiers[i].name == NULL)
             continue;
-        __wt_verbose(
+        __wt_verbose_debug2(
           session, WT_VERB_TIERED, "UPDATE_DH: Get dhandle for %s", tiered->tiers[i].name);
         WT_ERR(__tiered_dhandle_setup(session, tiered, i, tiered->tiers[i].name));
     }


### PR DESCRIPTION
Schema layer: I've assumed there would normally be many more objects than tables.

Tiered storage: I suspect object creation/removal is much more common than adding/removing schemas or tiers.

Here's the full list of lines I reviewed, in case you're *really* bored and want to check:
src/schema/schema_drop.c:212
src/schema/schema_drop.c:229
src/schema/schema_drop.c:244
src/schema/schema_drop.c:248
src/schema/schema_drop.c:289
src/tiered/tiered_config.c:170
src/tiered/tiered_config.c:171
src/tiered/tiered_handle.c:161
src/tiered/tiered_handle.c:209
src/tiered/tiered_handle.c:212
src/tiered/tiered_handle.c:239
src/tiered/tiered_handle.c:305
src/tiered/tiered_handle.c:33
src/tiered/tiered_handle.c:345
src/tiered/tiered_handle.c:36
src/tiered/tiered_handle.c:388
src/tiered/tiered_handle.c:458
src/tiered/tiered_handle.c:463
src/tiered/tiered_handle.c:487
src/tiered/tiered_handle.c:490
src/tiered/tiered_handle.c:521
src/tiered/tiered_handle.c:545
src/tiered/tiered_handle.c:54
src/tiered/tiered_handle.c:599
src/tiered/tiered_handle.c:659
src/tiered/tiered_handle.c:67
src/tiered/tiered_handle.c:734
src/tiered/tiered_handle.c:753
src/tiered/tiered_handle.c:776
src/tiered/tiered_handle.c:798
src/tiered/tiered_handle.c:844
src/tiered/tiered_handle.c:857
src/tiered/tiered_handle.c:878
src/tiered/tiered_handle.c:894
src/tiered/tiered_handle.c:912
