### PR TITLE
WT-10057 Check log and LSM verbosity

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2752,7 +2752,7 @@ __wt_log_vprintf(WT_SESSION_IMPL *session, const char *fmt, va_list ap)
 
     WT_ERR(__wt_vsnprintf((char *)logrec->data + logrec->size, len, fmt, ap));
 
-    __wt_verbose(session, WT_VERB_LOG, "log_printf: %s", (char *)logrec->data + logrec->size);
+    __wt_verbose_debug3(session, WT_VERB_LOG, "log_printf: %s", (char *)logrec->data + logrec->size);
 
     logrec->size += len;
     WT_ERR(__wt_log_write(session, logrec, NULL, 0));
@@ -2798,7 +2798,7 @@ __wt_log_flush(WT_SESSION_IMPL *session, uint32_t flags)
         WT_RET(__wt_log_flush_lsn(session, &lsn, false));
     }
 
-    __wt_verbose(session, WT_VERB_LOG, "log_flush: flags %#" PRIx32 " LSN %" PRIu32 "/%" PRIu32,
+    __wt_verbose_debug2(session, WT_VERB_LOG, "log_flush: flags %#" PRIx32 " LSN %" PRIu32 "/%" PRIu32,
       flags, lsn.l.file, lsn.l.offset);
     /*
      * If the user wants write-no-sync, there is nothing more to do. If the user wants background

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2752,7 +2752,7 @@ __wt_log_vprintf(WT_SESSION_IMPL *session, const char *fmt, va_list ap)
 
     WT_ERR(__wt_vsnprintf((char *)logrec->data + logrec->size, len, fmt, ap));
 
-    __wt_verbose_debug3(session, WT_VERB_LOG, "log_printf: %s", (char *)logrec->data + logrec->size);
+    __wt_verbose(session, WT_VERB_LOG, "log_printf: %s", (char *)logrec->data + logrec->size);
 
     logrec->size += len;
     WT_ERR(__wt_log_write(session, logrec, NULL, 0));
@@ -2798,7 +2798,7 @@ __wt_log_flush(WT_SESSION_IMPL *session, uint32_t flags)
         WT_RET(__wt_log_flush_lsn(session, &lsn, false));
     }
 
-    __wt_verbose_debug2(session, WT_VERB_LOG, "log_flush: flags %#" PRIx32 " LSN %" PRIu32 "/%" PRIu32,
+    __wt_verbose(session, WT_VERB_LOG, "log_flush: flags %#" PRIx32 " LSN %" PRIu32 "/%" PRIu32,
       flags, lsn.l.file, lsn.l.offset);
     /*
      * If the user wants write-no-sync, there is nothing more to do. If the user wants background

--- a/src/lsm/lsm_merge.c
+++ b/src/lsm/lsm_merge.c
@@ -372,12 +372,12 @@ __wt_lsm_merge(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, u_int id)
      * We only want to do the chunk loop if we're running with verbose, so we wrap these statements
      * in the conditional. Avoid the loop in the normal path.
      */
-    if (WT_VERBOSE_ISSET(session, WT_VERB_LSM)) {
-        __wt_verbose(session, WT_VERB_LSM,
+    if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_LSM, WT_VERBOSE_DEBUG_2)) {
+        __wt_verbose_debug2(session, WT_VERB_LSM,
           "Merging %s chunks %u-%u into %u (%" PRIu64 " records), generation %" PRIu32,
           lsm_tree->name, start_chunk, end_chunk, dest_id, record_count, generation);
         for (verb = start_chunk; verb < end_chunk + 1; verb++)
-            __wt_verbose(session, WT_VERB_LSM,
+            __wt_verbose_debug2(session, WT_VERB_LSM,
               "Merging %s: Chunk[%u] id %" PRIu32 ", gen: %" PRIu32 ", size: %" PRIu64
               ", records: %" PRIu64,
               lsm_tree->name, verb, lsm_tree->chunk[verb]->id, lsm_tree->chunk[verb]->generation,

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -1147,7 +1147,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
     }
 
     if (push_flush) {
-        __wt_verbose(session, WT_VERB_LSM,
+        __wt_verbose_debug2(session, WT_VERB_LSM,
           "Compact force flush %s flags 0x%" PRIx32 " chunk %" PRIu32 " flags 0x%" PRIx32, name,
           lsm_tree->flags, chunk->id, chunk->flags);
         flushing = true;
@@ -1166,7 +1166,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
         compacting = true;
         progress = lsm_tree->merge_progressing;
         F_SET(lsm_tree, WT_LSM_TREE_COMPACTING);
-        __wt_verbose(session, WT_VERB_LSM, "COMPACT: Start compacting %s", lsm_tree->name);
+        __wt_verbose_debug2(session, WT_VERB_LSM, "COMPACT: Start compacting %s", lsm_tree->name);
         locked = false;
         __wt_lsm_tree_writeunlock(session, lsm_tree);
     }
@@ -1180,7 +1180,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
         if (flushing) {
             WT_ASSERT(session, chunk != NULL);
             if (F_ISSET(chunk, WT_LSM_CHUNK_ONDISK)) {
-                __wt_verbose(session, WT_VERB_LSM,
+                __wt_verbose_debug2(session, WT_VERB_LSM,
                   "Compact flush done %s chunk %" PRIu32 ". Start compacting progress %" PRIu64,
                   name, chunk->id, lsm_tree->merge_progressing);
                 (void)__wt_atomic_sub32(&chunk->refcnt, 1);
@@ -1189,7 +1189,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
                 F_SET(lsm_tree, WT_LSM_TREE_COMPACTING);
                 progress = lsm_tree->merge_progressing;
             } else {
-                __wt_verbose(
+                __wt_verbose_debug2(
                   session, WT_VERB_LSM, "Compact flush retry %s chunk %" PRIu32, name, chunk->id);
                 WT_ERR(__wt_lsm_manager_push_entry(
                   session, WT_LSM_WORK_FLUSH, WT_LSM_WORK_FORCE, lsm_tree));

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -114,7 +114,7 @@ __wt_lsm_get_chunk_to_flush(
         chunk = (evict_chunk != NULL) ? evict_chunk : flush_chunk;
 
     if (chunk != NULL) {
-        __wt_verbose(session, WT_VERB_LSM, "Flush%s: return chunk %" PRIu32 " of %" PRIu32 ": %s",
+        __wt_verbose_debug2(session, WT_VERB_LSM, "Flush%s: return chunk %" PRIu32 " of %" PRIu32 ": %s",
           force ? " w/ force" : "", i, lsm_tree->nchunks, chunk->uri);
 
         (void)__wt_atomic_add32(&chunk->refcnt, 1);
@@ -364,7 +364,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LS
             WT_RET_MSG(session, ret, "discard handle");
     }
     if (F_ISSET(chunk, WT_LSM_CHUNK_ONDISK)) {
-        __wt_verbose(session, WT_VERB_LSM, "LSM worker %s already on disk", chunk->uri);
+        __wt_verbose_debug2(session, WT_VERB_LSM, "LSM worker %s already on disk", chunk->uri);
         return (0);
     }
 
@@ -378,7 +378,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LS
         if (__wt_eviction_needed(session, false, false, NULL))
             WT_ERR(__wt_lsm_manager_push_entry(session, WT_LSM_WORK_ENABLE_EVICT, 0, lsm_tree));
 
-        __wt_verbose(
+        __wt_verbose_debug2(
           session, WT_VERB_LSM, "LSM worker %s: running transaction, return", chunk->uri);
         return (0);
     }
@@ -386,7 +386,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LS
         return (0);
     flush_set = true;
 
-    __wt_verbose(session, WT_VERB_LSM, "LSM worker flushing %s", chunk->uri);
+    __wt_verbose_debug2(session, WT_VERB_LSM, "LSM worker flushing %s", chunk->uri);
 
     /*
      * Flush the file before checkpointing: this is the expensive part in
@@ -409,7 +409,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LS
     session->txn->isolation = saved_isolation;
     WT_ERR(ret);
 
-    __wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointing %s", chunk->uri);
+    __wt_verbose_debug2(session, WT_VERB_LSM, "LSM worker checkpointing %s", chunk->uri);
 
     /*
      * Ensure we don't race with a running checkpoint: the checkpoint lock protects against us
@@ -454,7 +454,7 @@ __wt_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_LS
     /* Make sure we aren't pinning a transaction ID. */
     __wt_txn_release_snapshot(session);
 
-    __wt_verbose(session, WT_VERB_LSM, "LSM worker checkpointed %s", chunk->uri);
+    __wt_verbose_debug2(session, WT_VERB_LSM, "LSM worker checkpointed %s", chunk->uri);
 
     /* Schedule a bloom filter create for our newly flushed chunk. */
     if (!FLD_ISSET(lsm_tree->bloom, WT_LSM_BLOOM_OFF))

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -114,8 +114,9 @@ __wt_lsm_get_chunk_to_flush(
         chunk = (evict_chunk != NULL) ? evict_chunk : flush_chunk;
 
     if (chunk != NULL) {
-        __wt_verbose_debug2(session, WT_VERB_LSM, "Flush%s: return chunk %" PRIu32 " of %" PRIu32 ": %s",
-          force ? " w/ force" : "", i, lsm_tree->nchunks, chunk->uri);
+        __wt_verbose_debug2(session, WT_VERB_LSM,
+          "Flush%s: return chunk %" PRIu32 " of %" PRIu32 ": %s", force ? " w/ force" : "", i,
+          lsm_tree->nchunks, chunk->uri);
 
         (void)__wt_atomic_add32(&chunk->refcnt, 1);
     }

--- a/src/lsm/lsm_worker.c
+++ b/src/lsm/lsm_worker.c
@@ -68,7 +68,7 @@ __lsm_worker_general_op(WT_SESSION_IMPL *session, WT_LSM_WORKER_ARGS *cookie, bo
          * If we got a chunk to flush, checkpoint it.
          */
         if (chunk != NULL) {
-            __wt_verbose(session, WT_VERB_LSM, "Flush%s chunk %" PRIu32 " %s",
+            __wt_verbose_debug2(session, WT_VERB_LSM, "Flush%s chunk %" PRIu32 " %s",
               force ? " w/ force" : "", chunk->id, chunk->uri);
             ret = __wt_lsm_checkpoint_chunk(session, entry->lsm_tree, chunk);
             WT_ASSERT(session, chunk->refcnt > 0);


### PR DESCRIPTION
Notes for the log/ verbose calls: opening/renaming/removing a file isn't super frequent, so I've left them.

For LSM, I'm assuming tree switches are uncommon, while flushes and chunk checkpoints are common. I don't know this code at all, unfortunately.

Here's the full list of verbose calls I checked:
src/log/log.c:1001
src/log/log.c:1009
src/log/log.c:1015
src/log/log.c:1062
src/log/log.c:1411
src/log/log.c:1458
src/log/log.c:1462
src/log/log.c:1509
src/log/log.c:1536
src/log/log.c:1597
src/log/log.c:1620
src/log/log.c:1639
src/log/log.c:1704
src/log/log.c:1710
src/log/log.c:1717
src/log/log.c:1956
src/log/log.c:1972
src/log/log.c:2007
src/log/log.c:2138
src/log/log.c:2170
src/log/log.c:2189
src/log/log.c:2210
src/log/log.c:2377
src/log/log.c:2755
src/log/log.c:2801
src/log/log.c:301
src/log/log.c:322
src/log/log.c:822
src/log/log.c:938
src/log/log.c:994
src/log/log_slot.c:27
src/log/log_sys.c:90
src/log/log_sys.c:94
src/lsm/lsm_cursor.c:348
src/lsm/lsm_cursor.c:590
src/lsm/lsm_manager.c:397
src/lsm/lsm_merge.c:115
src/lsm/lsm_merge.c:375
src/lsm/lsm_merge.c:376
src/lsm/lsm_merge.c:380
src/lsm/lsm_merge.c:456
src/lsm/lsm_merge.c:583
src/lsm/lsm_merge.c:585
src/lsm/lsm_tree.c:1150
src/lsm/lsm_tree.c:1169
src/lsm/lsm_tree.c:1183
src/lsm/lsm_tree.c:1192
src/lsm/lsm_tree.c:1245
src/lsm/lsm_tree.c:729
src/lsm/lsm_work_unit.c:117
src/lsm/lsm_work_unit.c:367
src/lsm/lsm_work_unit.c:381
src/lsm/lsm_work_unit.c:389
src/lsm/lsm_work_unit.c:412
src/lsm/lsm_work_unit.c:457
src/lsm/lsm_work_unit.c:574
src/lsm/lsm_work_unit.c:639
src/lsm/lsm_work_unit.c:642
src/lsm/lsm_worker.c:21
src/lsm/lsm_worker.c:71
