### PR TITLE
WT-10070 Don't mirror when tables turn off mirroring

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -1012,7 +1012,7 @@ config_mirrors(void)
 
     /*
      * We also can't mirror if we don't have enough tables that have allowed mirroring. It's
-     * possible for a table to explicitly set runs.mirrors=0, so check how many tables have done
+     * possible for a table to explicitly set runs.mirror=0, so check how many tables have done
      * that and remove them from the count of tables we can use for mirroring.
      */
     available_tables = ntables;

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -975,6 +975,13 @@ config_mirrors(void)
     if (already_set) {
         if (g.base_mirror == NULL)
             testutil_die(EINVAL, "no table configured that can act as the base mirror");
+        /*
+         * Assume that mirroring is already configured if one of the tables has explicitly
+         * configured it on. This isn't optimal since there could still be other tables that haven't
+         * set it at all (and might be usable as extra mirrors), but that's an uncommon scenario and
+         * it lets us avoid a bunch of extra logic around figuring out whether we have an acceptable
+         * minimum number of tables.
+         */
         return;
     }
 
@@ -989,29 +996,32 @@ config_mirrors(void)
     explicit_mirror = config_explicit(NULL, "runs.mirror");
     if (!explicit_mirror && mmrand(NULL, 1, 10) < 9)
         return;
-    config_off_all("runs.mirror");
 
     /*
      * We can't mirror if we don't have enough tables. A FLCS table can be a mirror, but it can't be
      * the source of the bulk-load mirror records. Find the first table we can use as a base.
      */
     for (i = 1; i <= ntables; ++i)
-        if (tables[i]->type != FIX)
+        if (tables[i]->type != FIX && !NT_EXPLICIT_OFF(tables[i], RUNS_MIRROR))
             break;
+
+    if (i > ntables && explicit_mirror) {
+        WARN("%s", "table selection didn't support mirroring, turning off mirroring");
+        return;
+    }
 
     /*
      * We also can't mirror if we don't have enough tables that have allowed mirroring. It's
-     * possible for a table to explicitly set config.mirrors=0, check how many tables have done that
-     * and remove them from the count of tables we can use for mirroring.
+     * possible for a table to explicitly set config.mirrors=0, so check how many tables have done
+     * that and remove them from the count of tables we can use for mirroring.
      */
     available_tables = ntables;
     for (i = 1; i <= ntables; ++i)
         if (NT_EXPLICIT_OFF(tables[i], RUNS_MIRROR))
             --available_tables;
 
-    if (available_tables < 2 || i > ntables) {
-        if (explicit_mirror)
-            WARN("%s", "table selection didn't support mirroring, turning off mirroring");
+    if (available_tables < 2 && explicit_mirror) {
+        WARN("%s", "not enough tables left mirroring enabled, turning off mirroring");
         return;
     }
 
@@ -1024,22 +1034,28 @@ config_mirrors(void)
         }
     config_off_all("btree.reverse");
 
-    /* Good to go: pick the first non-FLCS table as our base and turn on mirroring. */
+    /* Good to go: pick the first non-FLCS table that allows mirroring as our base. */
     for (i = 1; i <= ntables; ++i)
-        if (tables[i]->type != FIX)
+        if (tables[i]->type != FIX && !NT_EXPLICIT_OFF(tables[i], RUNS_MIRROR))
             break;
     tables[i]->mirror = true;
     config_single(tables[i], "runs.mirror=1", false);
     g.base_mirror = tables[i];
 
-    /* Pick some number of tables to mirror, then turn on mirroring the next (n-1) tables. */
-    for (mirrors = mmrand(NULL, 2, ntables) - 1, i = 1; i <= ntables; ++i)
+    /*
+     * Pick some number of tables to mirror, then turn on mirroring the next (n-1) tables, where
+     * allowed.
+     */
+    for (mirrors = mmrand(NULL, 2, ntables) - 1, i = 1; i <= ntables; ++i) {
+        if (NT_EXPLICIT_OFF(tables[i], RUNS_MIRROR))
+            continue;
         if (tables[i] != g.base_mirror) {
             tables[i]->mirror = true;
             config_single(tables[i], "runs.mirror=1", false);
             if (--mirrors == 0)
                 break;
         }
+    }
 
     /*
      * Give each mirror the same number of rows (it's not necessary, we could treat end-of-table on

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -961,7 +961,7 @@ config_lsm_reset(TABLE *table)
 static void
 config_mirrors(void)
 {
-    u_int i, mirrors;
+    u_int available_tables, i, mirrors;
     char buf[100];
     bool already_set, explicit_mirror;
 
@@ -998,7 +998,13 @@ config_mirrors(void)
     for (i = 1; i <= ntables; ++i)
         if (tables[i]->type != FIX)
             break;
-    if (ntables < 2 || i > ntables) {
+
+    available_tables = ntables;
+    for (i = 1; i <= ntables; ++i)
+        if (tables[i]->v[V_TABLE_RUNS_MIRROR].set && tables[i]->v[V_TABLE_RUNS_MIRROR].v == 0)
+            --available_tables;
+
+    if (available_tables < 2 || i > ntables) {
         if (explicit_mirror)
             WARN("%s", "table selection didn't support mirroring, turning off mirroring");
         return;

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -1012,7 +1012,7 @@ config_mirrors(void)
 
     /*
      * We also can't mirror if we don't have enough tables that have allowed mirroring. It's
-     * possible for a table to explicitly set config.mirrors=0, so check how many tables have done
+     * possible for a table to explicitly set runs.mirrors=0, so check how many tables have done
      * that and remove them from the count of tables we can use for mirroring.
      */
     available_tables = ntables;

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -1001,7 +1001,7 @@ config_mirrors(void)
 
     available_tables = ntables;
     for (i = 1; i <= ntables; ++i)
-        if (tables[i]->v[V_TABLE_RUNS_MIRROR].set && tables[i]->v[V_TABLE_RUNS_MIRROR].v == 0)
+        if (NT_EXPLICIT_OFF(tables[i], RUNS_MIRROR))
             --available_tables;
 
     if (available_tables < 2 || i > ntables) {

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -999,6 +999,11 @@ config_mirrors(void)
         if (tables[i]->type != FIX)
             break;
 
+    /*
+     * We also can't mirror if we don't have enough tables that have allowed mirroring. It's
+     * possible for a table to explicitly set config.mirrors=0, check how many tables have done that
+     * and remove them from the count of tables we can use for mirroring.
+     */
     available_tables = ntables;
     for (i = 1; i <= ntables; ++i)
         if (NT_EXPLICIT_OFF(tables[i], RUNS_MIRROR))

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -174,6 +174,8 @@ extern u_int ntables;
     ((table)->v[V_TABLE_##off].vstr == NULL ? "off" : (table)->v[V_TABLE_##off].vstr)
 #define TV(off) NTV(table, off)
 #define TVS(off) NTVS(table, off)
+#define NT_EXPLICIT_SET(table, off) ((table)->v[V_TABLE_##off].set)
+#define NT_EXPLICIT_OFF(table, off) (NT_EXPLICIT_SET(table, off) && !NTV(table, off))
 
 #define DATASOURCE(table, ds) (strcmp((table)->v[V_TABLE_RUNS_SOURCE].vstr, ds) == 0)
 


### PR DESCRIPTION
There's really three values a table can have for mirroring - explicit on, explicit off, and unspecified. If a table has it as explicitly on, `config_mirrors` works fine - we'll set `already_set` to true, hopefully pick a base mirror, and return. If a table leaves it unspecified, the code also works fine - `already_set` will be false, we'll fall out of the loop, see that `set_explicit` is false, and do the probability thing. 

If a table explicitly sets it to zero, however, the code is wrong - we won't ever hit the `if (NTV(tables[i], RUNS_MIRROR))` condition, so we fall out of the loop. But then `set_explicit` is true, and we'll skip the probability thing and turn it on. The core of the issue here seems to be a misunderstanding of `config_explicit`, which simply returns whether a config item is present in the config file at all, regardless of the value.

The fix isn't as simple as "a table set it explicit off, so return" since one table could have it as explicitly off, while other tables may have it explicitly on (or unspecified).