### PR TITLE
WT-10085 Updating code complexity batch time to run every commit.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4558,7 +4558,6 @@ buildvariants:
 
 - name: code-statistics
   display_name: "Code statistics"
-  batchtime: 10080 # 7 days
   run_on:
   - ubuntu2004-test
   expansions:
@@ -4574,6 +4573,7 @@ buildvariants:
     CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL
   tasks:
     - name: coverage-report
+      batchtime: 10080 # 7 days
     - name: cyclomatic-complexity
 
 - name: compatibility-tests-less-frequent


### PR DESCRIPTION
…hat the complexity task runs per commit and the coverage report task occurs once every 7 days.