### PR TITLE
WT-10059 Check RTS and txn verbosity

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -762,7 +762,7 @@ __txn_prepare_rollback_restore_hs_update(
     F_SET(upd, WT_UPDATE_RESTORED_FROM_HS | WT_UPDATE_TO_DELETE_FROM_HS);
     total_size += size;
 
-    __wt_verbose(session, WT_VERB_TRANSACTION,
+    __wt_verbose_debug2(session, WT_VERB_TRANSACTION,
       "update restored from history store (txnid: %" PRIu64 ", start_ts: %s, durable_ts: %s",
       upd->txnid, __wt_timestamp_to_string(upd->start_ts, ts_string[0]),
       __wt_timestamp_to_string(upd->durable_ts, ts_string[1]));
@@ -782,7 +782,7 @@ __txn_prepare_rollback_restore_hs_update(
         F_SET(tombstone, WT_UPDATE_RESTORED_FROM_HS | WT_UPDATE_TO_DELETE_FROM_HS);
         total_size += size;
 
-        __wt_verbose(session, WT_VERB_TRANSACTION,
+        __wt_verbose_debug2(session, WT_VERB_TRANSACTION,
           "tombstone restored from history store (txnid: %" PRIu64 ", start_ts: %s, durable_ts: %s",
           tombstone->txnid, __wt_timestamp_to_string(tombstone->start_ts, ts_string[0]),
           __wt_timestamp_to_string(tombstone->durable_ts, ts_string[1]));
@@ -1178,14 +1178,14 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
     WT_RET(__txn_search_prepared_op(session, op, cursorp, &upd));
 
     if (commit)
-        __wt_verbose(session, WT_VERB_TRANSACTION,
+        __wt_verbose_debug2(session, WT_VERB_TRANSACTION,
           "commit resolving prepared transaction with txnid: %" PRIu64
           "and timestamp: %s to commit and durable timestamps: %s,%s",
           txn->id, __wt_timestamp_to_string(txn->prepare_timestamp, ts_string[0]),
           __wt_timestamp_to_string(txn->commit_timestamp, ts_string[1]),
           __wt_timestamp_to_string(txn->durable_timestamp, ts_string[2]));
     else
-        __wt_verbose(session, WT_VERB_TRANSACTION,
+        __wt_verbose_debug2(session, WT_VERB_TRANSACTION,
           "rollback resolving prepared transaction with txnid: %" PRIu64 "and timestamp:%s",
           txn->id, __wt_timestamp_to_string(txn->prepare_timestamp, ts_string[0]));
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -106,7 +106,7 @@ __checkpoint_flush_tier(WT_SESSION_IMPL *session, bool force)
         cursor->get_value(cursor, &value);
         /* For now just switch tiers which just does metadata manipulation. */
         if (WT_PREFIX_MATCH(key, "tiered:")) {
-            __wt_verbose(
+            __wt_verbose_debug2(
               session, WT_VERB_TIERED, "CKPT_FLUSH_TIER: %s %s force %d", key, value, force);
             if (!force) {
                 /*

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -106,7 +106,7 @@ __recovery_cursor(
  */
 #define GET_RECOVERY_CURSOR(session, r, lsnp, fileid, cp)                            \
     ret = __recovery_cursor(session, r, lsnp, fileid, false, cp);                    \
-    __wt_verbose(session, WT_VERB_RECOVERY,                                          \
+    __wt_verbose_debug2(session, WT_VERB_RECOVERY,                                   \
       "%s op %" PRIu32 " to file %" PRIu32 " at LSN %" PRIu32 "/%" PRIu32,           \
       ret != 0 ? "Error" : cursor == NULL ? "Skipping" : "Applying", optype, fileid, \
       (lsnp)->l.file, (lsnp)->l.offset);                                             \

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -388,7 +388,8 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
     }
 
     WT_ERR(__wt_scr_alloc(session, 0, &key_string));
-    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2, "rolling back the on-disk key: %s",
+    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2,
+      "rolling back the on-disk key: %s",
       __wt_key_string(session, key->data, key->size, S2BT(session)->key_format, key_string));
 
     WT_ERR(__wt_scr_alloc(session, 0, &full_value));
@@ -640,7 +641,8 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
     } else {
         WT_ERR(__wt_upd_alloc_tombstone(session, &upd, NULL));
         WT_STAT_CONN_DATA_INCR(session, txn_rts_keys_removed);
-        __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3, "%s", "key removed");
+        __wt_verbose_level_multi(
+          session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3, "%s", "key removed");
     }
 
     if (rip != NULL)
@@ -830,8 +832,8 @@ __rollback_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, u
     }
 
     WT_ERR(__wt_scr_alloc(session, 0, &key_string));
-    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2, "removing the key%s: %s",
-      upd->type == WT_UPDATE_TOMBSTONE ? "" : " tombstone",
+    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2,
+      "removing the key%s: %s", upd->type == WT_UPDATE_TOMBSTONE ? "" : " tombstone",
       __wt_key_string(session, key->data, key->size, S2BT(session)->key_format, key_string));
 
     if (rip != NULL)
@@ -1256,8 +1258,8 @@ __rollback_abort_updates(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
     }
 
     WT_STAT_CONN_INCR(session, txn_rts_pages_visited);
-    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2, "%p: roll back %s page", (void *)ref,
-      modified ? "modified" : "clean");
+    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2,
+      "%p: roll back %s page", (void *)ref, modified ? "modified" : "clean");
 
     switch (page->type) {
     case WT_PAGE_COL_FIX:

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -388,7 +388,7 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
     }
 
     WT_ERR(__wt_scr_alloc(session, 0, &key_string));
-    __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session), "rolling back the on-disk key: %s",
+    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2, "rolling back the on-disk key: %s",
       __wt_key_string(session, key->data, key->size, S2BT(session)->key_format, key_string));
 
     WT_ERR(__wt_scr_alloc(session, 0, &full_value));
@@ -476,7 +476,7 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
                 WT_ERR(__wt_buf_set(session, full_value, hs_value->data, hs_value->size));
             }
         } else
-            __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
+            __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2,
               "history store update more recent than on-disk update with time window: %s and type: "
               "%" PRIu8,
               __wt_time_window_to_string(hs_tw, tw_string), type);
@@ -528,7 +528,7 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
          */
         if (__rollback_txn_visible_id(session, hs_tw->start_txn) &&
           hs_tw->durable_start_ts <= rollback_timestamp) {
-            __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
+            __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2,
               "history store update valid with time window: %s, type: %" PRIu8
               " and stable timestamp: %s",
               __wt_time_window_to_string(hs_tw, tw_string), type,
@@ -640,7 +640,7 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
     } else {
         WT_ERR(__wt_upd_alloc_tombstone(session, &upd, NULL));
         WT_STAT_CONN_DATA_INCR(session, txn_rts_keys_removed);
-        __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session), "%s", "key removed");
+        __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3, "%s", "key removed");
     }
 
     if (rip != NULL)
@@ -830,7 +830,7 @@ __rollback_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, u
     }
 
     WT_ERR(__wt_scr_alloc(session, 0, &key_string));
-    __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session), "removing the key%s: %s",
+    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2, "removing the key%s: %s",
       upd->type == WT_UPDATE_TOMBSTONE ? "" : " tombstone",
       __wt_key_string(session, key->data, key->size, S2BT(session)->key_format, key_string));
 
@@ -1250,13 +1250,13 @@ __rollback_abort_updates(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
     page = ref->page;
     modified = __wt_page_is_modified(page);
     if (!modified && !__rollback_page_needs_abort(session, ref, rollback_timestamp)) {
-        __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
+        __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3,
           "%p: unmodified stable page skipped", (void *)ref);
         return (0);
     }
 
     WT_STAT_CONN_INCR(session, txn_rts_pages_visited);
-    __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session), "%p: roll back %s page", (void *)ref,
+    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_2, "%p: roll back %s page", (void *)ref,
       modified ? "modified" : "clean");
 
     switch (page->type) {


### PR DESCRIPTION
For this, I'm assuming stuff that happens once per checkpoint isn't going to be too much logging. I'm also assuming RTS isn't something where we need to be sensitive about extra logging.

Here's the full list of verbose lines I checked as part of this PR:
src/txn/txn.c:1181
src/txn/txn.c:1188
src/txn/txn.c:1792
src/txn/txn.c:2432
src/txn/txn.c:2499
src/txn/txn.c:2503
src/txn/txn.c:2569
src/txn/txn.c:2573
src/txn/txn.c:2640
src/txn/txn.c:491
src/txn/txn.c:493
src/txn/txn.c:765
src/txn/txn.c:785
src/txn/txn_ckpt.c:109
src/txn/txn_ckpt.c:425
src/txn/txn_ckpt.c:560
src/txn/txn_ckpt.c:618
src/txn/txn_ckpt.c:626
src/txn/txn_ckpt.c:783
src/txn/txn_ckpt.c:80
src/txn/txn_recover.c:109
src/txn/txn_recover.c:403
src/txn/txn_recover.c:432
src/txn/txn_recover.c:590
src/txn/txn_recover.c:76
src/txn/txn_recover.c:901
src/txn/txn_recover.c:922
src/txn/txn_recover.c:990
src/txn/txn_rollback_to_stable.c:119
src/txn/txn_rollback_to_stable.c:1217
src/txn/txn_rollback_to_stable.c:1243
src/txn/txn_rollback_to_stable.c:1248
src/txn/txn_rollback_to_stable.c:1316
src/txn/txn_rollback_to_stable.c:1337
src/txn/txn_rollback_to_stable.c:1380
src/txn/txn_rollback_to_stable.c:1457
src/txn/txn_rollback_to_stable.c:1526
src/txn/txn_rollback_to_stable.c:1596
src/txn/txn_rollback_to_stable.c:1601
src/txn/txn_rollback_to_stable.c:1639
src/txn/txn_rollback_to_stable.c:1751
src/txn/txn_rollback_to_stable.c:1784
src/txn/txn_rollback_to_stable.c:1794
src/txn/txn_rollback_to_stable.c:1894
src/txn/txn_rollback_to_stable.c:1955
src/txn/txn_rollback_to_stable.c:1961
src/txn/txn_rollback_to_stable.c:385
src/txn/txn_rollback_to_stable.c:443
src/txn/txn_rollback_to_stable.c:473
src/txn/txn_rollback_to_stable.c:525
src/txn/txn_rollback_to_stable.c:535
src/txn/txn_rollback_to_stable.c:579
src/txn/txn_rollback_to_stable.c:618
src/txn/txn_rollback_to_stable.c:637
src/txn/txn_rollback_to_stable.c:705
src/txn/txn_rollback_to_stable.c:720
src/txn/txn_rollback_to_stable.c:787
src/txn/txn_rollback_to_stable.c:824
src/txn/txn_timestamp.c:300
src/txn/txn_timestamp.c:410
src/txn/txn_timestamp.c:419
src/txn/txn_timestamp.c:428
src/txn/txn_timestamp.c:747
src/txn/txn_timestamp.c:833
src/txn/txn_timestamp.c:850
