### PR TITLE
WT-10090 Rename wt_verbose_debug -> wt_verbose_debug1

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -86,7 +86,7 @@ __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block, u_int *ms
     time_diff = WT_TIMEDIFF_SEC(cur_time, session->compact->begin);
     if (time_diff / WT_PROGRESS_MSG_PERIOD > *msg_countp) {
         ++*msg_countp;
-        __wt_verbose_debug(session, WT_VERB_COMPACT_PROGRESS,
+        __wt_verbose_debug1(session, WT_VERB_COMPACT_PROGRESS,
           " compacting %s for %" PRIu64 " seconds; reviewed %" PRIu64 " pages, rewritten %" PRIu64
           " pages",
           block->name, time_diff, block->compact_pages_reviewed, block->compact_pages_rewritten);
@@ -155,16 +155,16 @@ __wt_block_compact_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, bool *skipp)
         block->compact_pct_tenths = 1;
     }
 
-    __wt_verbose_debug(session, WT_VERB_COMPACT,
+    __wt_verbose_debug1(session, WT_VERB_COMPACT,
       "%s: total reviewed %" PRIu64 " pages, total rewritten %" PRIu64 " pages", block->name,
       block->compact_pages_reviewed, block->compact_pages_rewritten);
-    __wt_verbose_debug(session, WT_VERB_COMPACT,
+    __wt_verbose_debug1(session, WT_VERB_COMPACT,
       "%s: %" PRIuMAX "MB (%" PRIuMAX ") available space in the first 80%% of the file",
       block->name, (uintmax_t)avail_eighty / WT_MEGABYTE, (uintmax_t)avail_eighty);
-    __wt_verbose_debug(session, WT_VERB_COMPACT,
+    __wt_verbose_debug1(session, WT_VERB_COMPACT,
       "%s: %" PRIuMAX "MB (%" PRIuMAX ") available space in the first 90%% of the file",
       block->name, (uintmax_t)avail_ninety / WT_MEGABYTE, (uintmax_t)avail_ninety);
-    __wt_verbose_debug(session, WT_VERB_COMPACT,
+    __wt_verbose_debug1(session, WT_VERB_COMPACT,
       "%s: require 10%% or %" PRIuMAX "MB (%" PRIuMAX
       ") in the first 90%% of the file to perform compaction, compaction %s",
       block->name, (uintmax_t)(block->size / 10) / WT_MEGABYTE, (uintmax_t)block->size / 10,
@@ -356,19 +356,19 @@ __block_dump_file_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, bool start)
     el = &block->live.avail;
     size = block->size;
 
-    __wt_verbose_debug(session, WT_VERB_COMPACT, "============ %s",
+    __wt_verbose_debug1(session, WT_VERB_COMPACT, "============ %s",
       start ? "testing for compaction" : "ending compaction pass");
 
     if (!start) {
-        __wt_verbose_debug(
+        __wt_verbose_debug1(
           session, WT_VERB_COMPACT, "pages reviewed: %" PRIu64, block->compact_pages_reviewed);
-        __wt_verbose_debug(
+        __wt_verbose_debug1(
           session, WT_VERB_COMPACT, "pages skipped: %" PRIu64, block->compact_pages_skipped);
-        __wt_verbose_debug(
+        __wt_verbose_debug1(
           session, WT_VERB_COMPACT, "pages rewritten : %" PRIu64, block->compact_pages_rewritten);
     }
 
-    __wt_verbose_debug(session, WT_VERB_COMPACT,
+    __wt_verbose_debug1(session, WT_VERB_COMPACT,
       "file size %" PRIuMAX "MB (%" PRIuMAX ") with %" PRIuMAX "%% space available %" PRIuMAX
       "MB (%" PRIuMAX ")",
       (uintmax_t)size / WT_MEGABYTE, (uintmax_t)size,

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2406,7 +2406,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
             if (ret == WT_ROLLBACK) {
                 --cache->evict_aggressive_score;
                 WT_STAT_CONN_INCR(session, txn_fail_cache);
-                __wt_verbose_debug(
+                __wt_verbose_debug1(
                   session, WT_VERB_TRANSACTION, "%s", session->txn->rollback_reason);
             }
             WT_ERR(ret);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1430,7 +1430,7 @@ __wt_txn_modify_block(
     F_CLR(txn, WT_TXN_IGNORE_PREPARE);
     for (; upd != NULL && !__wt_txn_upd_visible(session, upd); upd = upd->next) {
         if (upd->txnid != WT_TXN_ABORTED) {
-            __wt_verbose_debug(session, WT_VERB_TRANSACTION,
+            __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
               "Conflict with update with txn id %" PRIu64 " at timestamp: %s", upd->txnid,
               __wt_timestamp_to_string(upd->start_ts, ts_string));
             rollback = true;
@@ -1456,13 +1456,13 @@ __wt_txn_modify_block(
             if (WT_TIME_WINDOW_HAS_STOP(&tw)) {
                 rollback = !__wt_txn_tw_stop_visible(session, &tw);
                 if (rollback)
-                    __wt_verbose_debug(session, WT_VERB_TRANSACTION,
+                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
                       "Conflict with update %" PRIu64 " at stop timestamp: %s", tw.stop_txn,
                       __wt_timestamp_to_string(tw.stop_ts, ts_string));
             } else {
                 rollback = !__wt_txn_tw_start_visible(session, &tw);
                 if (rollback)
-                    __wt_verbose_debug(session, WT_VERB_TRANSACTION,
+                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
                       "Conflict with update %" PRIu64 " at start timestamp: %s", tw.start_txn,
                       __wt_timestamp_to_string(tw.start_ts, ts_string));
             }
@@ -1483,7 +1483,7 @@ __wt_txn_modify_block(
                       __wt_buf_catfmt(session, buf, "%" PRIu64 ",", txn->snapshot[snap_count]));
                 WT_ERR(__wt_buf_catfmt(session, buf, "%" PRIu64 "]", txn->snapshot[snap_count]));
             }
-            __wt_verbose_debug(session, WT_VERB_TRANSACTION, "%s", (const char *)buf->data);
+            __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "%s", (const char *)buf->data);
         }
 
         WT_STAT_CONN_DATA_INCR(session, txn_update_conflict);

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -171,7 +171,7 @@ struct __wt_verbose_multi_category {
 
 /*
  * __wt_verbose_debug1 --
- *     Wrapper to __wt_verbose_level using the default verbosity level.
+ *     Wrapper to __wt_verbose_level using the default (DEBUG_1) verbosity level.
  */
 #define __wt_verbose_debug1(session, category, fmt, ...) \
     __wt_verbose_level(session, category, WT_VERBOSE_DEBUG_1, fmt, __VA_ARGS__)

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -170,10 +170,10 @@ struct __wt_verbose_multi_category {
     __wt_verbose_level(session, category, WT_VERBOSE_INFO, fmt, __VA_ARGS__)
 
 /*
- * __wt_verbose_debug --
+ * __wt_verbose_debug1 --
  *     Wrapper to __wt_verbose_level using the default verbosity level.
  */
-#define __wt_verbose_debug(session, category, fmt, ...) \
+#define __wt_verbose_debug1(session, category, fmt, ...) \
     __wt_verbose_level(session, category, WT_VERBOSE_DEBUG_1, fmt, __VA_ARGS__)
 
 /*


### PR DESCRIPTION
It became inconsistent with the other functions after we got debug2 and debug3.