### PR TITLE
WT-10036 Touch-ups to wtperf_run.sh 

### DIFF
--- a/bench/wtperf/runners/wtperf_run.sh
+++ b/bench/wtperf/runners/wtperf_run.sh
@@ -110,16 +110,6 @@ while test "$run" -le "$runmax"; do
 	backup_dir=${home}_$(basename "$wttest")_${run}_$(date +"%s")
 	rsync -r -m --include="*Stat*" --include="CONFIG.wtperf" --include="*monitor" --include="latency*" --include="test.stat" --exclude="*" $home/ "$backup_dir"
 
-	# Load is always using floating point, so handle separately
-	l=$(grep "^Load time:" ./WT_TEST/test.stat)
-	if test "$?" -eq "0"; then
-		load=$(echo "$l" | cut -d ' ' -f 3)
-		echo -e "\tload:\t${load}"
-	else
-		load=0
-	fi
-	cur[$loadindex]=$load
-	sum[$loadindex]=$(echo "${sum[$loadindex]} + $load" | bc)
 	for i in ${!ops[*]}; do
 		l=$(grep "Executed.*${ops[$i]} operations" ./WT_TEST/test.stat)
 		if test "$?" -eq "0"; then
@@ -135,6 +125,18 @@ while test "$run" -le "$runmax"; do
 
 		sum[$i]=$((n + sum[i]))
 	done
+
+	# Load is always using floating point, so handle separately
+	l=$(grep "^Load time:" ./WT_TEST/test.stat)
+	if test "$?" -eq "0"; then
+		load=$(echo "$l" | cut -d ' ' -f 3)
+		echo -e "\tload:\t${load}"
+	else
+		load=0
+	fi
+	cur[$loadindex]=$load
+	sum[$loadindex]=$(echo "${sum[$loadindex]} + $load" | bc)
+
 	#
 	# Keep running track of min and max for each operation type.
 	#

--- a/bench/wtperf/runners/wtperf_run.sh
+++ b/bench/wtperf/runners/wtperf_run.sh
@@ -34,9 +34,11 @@ while [[ $# -gt 0 ]] ; do
 done
 
 home=./WT_TEST
-outfile=./wtperf.out
-rm -f $outfile
-echo "Parsed $# args: test: $wttest runmax: $runmax args: $wtarg" >> $outfile
+logfile=./log_wtperf_run.txt
+resultsfile=./results_$(basename "$wttest").txt
+rm -f "$resultsfile"
+rm -f $logfile
+echo "Parsed $# args: test: $wttest runmax: $runmax args: $wtarg" >> $logfile
 
 # Each of these has an entry for each op in ops below.
 avg=(0 0 0 0 0)
@@ -62,7 +64,7 @@ getval()
 	val="$2"
 	cur="$3"
 	ret=$cur
-	echo "getval: get_max $get_max val $val cur $cur" >> $outfile
+	echo "getval: get_max $get_max val $val cur $cur" >> $logfile
 	if test "$get_max" -eq "1"; then
 		if test "$val" -gt "$cur"; then
 			ret=$val
@@ -112,7 +114,7 @@ while test "$run" -le "$runmax"; do
 	fi
 	cur[$loadindex]=$load
 	sum[$loadindex]=$(echo "${sum[$loadindex]} + $load" | bc)
-	echo "cur ${cur[$loadindex]} sum ${sum[$loadindex]}" >> $outfile
+	echo "cur ${cur[$loadindex]} sum ${sum[$loadindex]}" >> $logfile
 	for i in ${!ops[*]}; do
 		l=$(grep "Executed.*${ops[$i]} operations" ./WT_TEST/test.stat)
 		if test "$?" -eq "0"; then
@@ -202,6 +204,9 @@ for i in ${!min[*]}; do
 	fi
 done
 for i in ${!outp[*]}; do
-	echo "${outp[$i]} ${avg[$i]}" >> $outfile
+	echo "${outp[$i]} ${avg[$i]}" >> $logfile
+	if [[ $i -lt $loadindex && "${avg[$i]}" -ne "0" ]]; then
+		echo "${outp[$i]} ${avg[$i]}" >> "$resultsfile"
+	fi
 done
 exit 0

--- a/bench/wtperf/runners/wtperf_run.sh
+++ b/bench/wtperf/runners/wtperf_run.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 
-# wtperf_run.sh - run wtperf regression tests on the Jenkins platform.
+# wtperf_run.sh - Reduce variance in wtperf measurements.
 #
-# The Jenkins machines show variability so we run this script to run
-# each wtperf test several times.  We throw away the min and max
-# number and average the remaining values.  That is the number we
-# give to Jenkins for plotting.  We write these values to a
-# test.average file in the current directory (which is 
-# build_posix/bench/wtperf).
+# Performance tests have a large variability from run to run, so we use this 
+# script to run each wtperf test several times. The script runs a user-defined 
+# number of times, drops the min and max values from each run, and reports the 
+# average of the remaining values to a results_$TESTNAME.txt file in the current 
+# directory. 
+# This script should be run from the same directory containing the wtperf binary.
 #
-# This script should be invoked with the pathname of the wtperf test
-# config to run and the number of runs.
+# Usage:
+# 	wtperf_run.sh test_conf numruns [wtperf_args]
+# 		test_conf:   The path the the wtperf configuration
+# 		rumruns:     How many times to run the test
+# 		wtperf_args: Additional arguments to pass to wtperf. 
+# 					 If NOCREATE is provided the test uses the same DB for 
+# 					 all test runs. If provided it must be the first argument.
+# Example:
+# 	../../../bench/wtperf/runners/wtperf_run.sh ../../../bench/wtperf/runners/checkpoint-stress.wtperf 1
 #
 if test "$#" -lt "2"; then
 	echo "Must specify wtperf test to run and number of runs"
@@ -20,8 +27,7 @@ wttest=$1
 shift # Consume this arg
 runmax=$1
 shift # Consume this arg
-# Jenkins removes the quotes from the passed in arg so deal with an arbitrary
-# number of arguments
+
 wtarg=""
 create=1
 while [[ $# -gt 0 ]] ; do
@@ -150,7 +156,7 @@ while test "$run" -le "$runmax"; do
 	fi
 	#
 	# After 3 runs see if this is a very stable test.  If so, we
-	# can skip the last 2 runs and just use these values.  We
+	# can skip the remaining tests and just use these values.  We
 	# define "very stable" to be that the min and max are within
 	# 3% of each other.
 	if test "$run" -eq "3"; then

--- a/bench/wtperf/runners/wtperf_run.sh
+++ b/bench/wtperf/runners/wtperf_run.sh
@@ -41,18 +41,18 @@ rm -f $logfile
 echo "Parsed $# args: test: $wttest runmax: $runmax args: $wtarg" >> $logfile
 
 # Each of these has an entry for each op in ops below.
-avg=(0 0 0 0 0)
-max=(0 0 0 0 0)
-min=(0 0 0 0 0)
-sum=(0 0 0 0 0)
+avg=(0 0 0 0 0 0)
+max=(0 0 0 0 0 0)
+min=(0 0 0 0 0 0)
+sum=(0 0 0 0 0 0)
 # Load needs floating point and bc, handle separately.
-loadindex=6
+loadindex=7
 avg[$loadindex]=0
 max[$loadindex]=0
 min[$loadindex]=0
 sum[$loadindex]=0
-ops=(insert modify read truncate update)
-outp=("Insert count:" "Modify count:" "Read count:" "Truncate count:" "Update count:"  )
+ops=(insert modify read truncate update checkpoint)
+outp=("Insert count:" "Modify count:" "Read count:" "Truncate count:" "Update count:" "Checkpoint count:" )
 outp[$loadindex]="Load time:"
 
 # getval min/max val cur

--- a/bench/wtperf/runners/wtperf_run.sh
+++ b/bench/wtperf/runners/wtperf_run.sh
@@ -11,7 +11,7 @@
 #
 # Usage:
 # 	wtperf_run.sh wttest numruns [wtarg]
-# 		wttest:  The path the the wtperf test configuration
+# 		wttest:  The path the wtperf test configuration
 # 		numruns: How many times to run the test
 # 		wtarg:   Additional arguments to pass to wtperf. 
 # 				 If NOCREATE is provided the test uses the same DB for 

--- a/bench/wtperf/runners/wtperf_run.sh
+++ b/bench/wtperf/runners/wtperf_run.sh
@@ -10,12 +10,12 @@
 # This script should be run from the same directory containing the wtperf binary.
 #
 # Usage:
-# 	wtperf_run.sh test_conf numruns [wtperf_args]
-# 		test_conf:   The path the the wtperf configuration
-# 		rumruns:     How many times to run the test
-# 		wtperf_args: Additional arguments to pass to wtperf. 
-# 					 If NOCREATE is provided the test uses the same DB for 
-# 					 all test runs. If provided it must be the first argument.
+# 	wtperf_run.sh wttest numruns [wtarg]
+# 		wttest:  The path the the wtperf test configuration
+# 		numruns: How many times to run the test
+# 		wtarg:   Additional arguments to pass to wtperf. 
+# 				 If NOCREATE is provided the test uses the same DB for 
+# 				 all test runs. If provided it must be the first argument.
 # Example:
 # 	../../../bench/wtperf/runners/wtperf_run.sh ../../../bench/wtperf/runners/checkpoint-stress.wtperf 1
 #


### PR DESCRIPTION
Originally this ticket was to create a new script to get the average results of multiple wtperf test runs, but `wtperf_run.sh` achieves this goal already so I've made a few small tweaks to this script instead. Namely:
- Ran shellcheck on the script and applied recommended changes
- Update traces and save final results to file
- Add code to report the number of checkpoints in wtperf tests, as this is a metric we are tracking in some of our `evergreen.yml` perf tests.

@sueloverso I assume this script is no longer used as of the migration from Jenkins to Evergreen, but just in case please let me know changing the name of `wtperf.out` breaks any existing workflows.