### PR TITLE
WT-9442 - Replace enums with enum classes in cppsuite

### DIFF
--- a/test/cppsuite/src/common/random_generator.cpp
+++ b/test/cppsuite/src/common/random_generator.cpp
@@ -86,11 +86,10 @@ random_generator::get_distribution(characters_type type)
     switch (type) {
     case characters_type::ALPHABET:
         return (_alpha_distrib);
-        break;
     case characters_type::PSEUDO_ALPHANUMERIC:
         return (_alphanum_distrib);
-        break;
     }
+    testutil_die(EINVAL, "unexpected characters_type: %d", type);
 }
 
 const std::string &
@@ -99,11 +98,10 @@ random_generator::get_characters(characters_type type)
     switch (type) {
     case characters_type::ALPHABET:
         return (_alphabet);
-        break;
     case characters_type::PSEUDO_ALPHANUMERIC:
         return (_pseudo_alphanum);
-        break;
     }
+    testutil_die(EINVAL, "unexpected characters_type: %d", static_cast<int>(type));
 }
 
 } // namespace test_harness

--- a/test/cppsuite/src/common/random_generator.cpp
+++ b/test/cppsuite/src/common/random_generator.cpp
@@ -90,9 +90,6 @@ random_generator::get_distribution(characters_type type)
     case characters_type::PSEUDO_ALPHANUMERIC:
         return (_alphanum_distrib);
         break;
-    default:
-        testutil_die(type, "Unexpected characters_type");
-        break;
     }
 }
 
@@ -105,9 +102,6 @@ random_generator::get_characters(characters_type type)
         break;
     case characters_type::PSEUDO_ALPHANUMERIC:
         return (_pseudo_alphanum);
-        break;
-    default:
-        testutil_die(type, "Unexpected characters_type");
         break;
     }
 }

--- a/test/cppsuite/src/common/random_generator.h
+++ b/test/cppsuite/src/common/random_generator.h
@@ -43,7 +43,7 @@
 namespace test_harness {
 /* Helper class to generate random values using uniform distributions. */
 
-enum characters_type { PSEUDO_ALPHANUMERIC, ALPHABET };
+enum class characters_type { PSEUDO_ALPHANUMERIC, ALPHABET };
 
 class random_generator {
     public:
@@ -55,14 +55,14 @@ class random_generator {
 
     /* Generate a random string of a given length. */
     std::string generate_random_string(
-      std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
+      std::size_t length, characters_type type = characters_type::PSEUDO_ALPHANUMERIC);
 
     /*
      * Generate a pseudo random string which compresses better. It should not be used to generate
      * keys due to the limited randomness.
      */
     std::string generate_pseudo_random_string(
-      std::size_t length, characters_type type = PSEUDO_ALPHANUMERIC);
+      std::size_t length, characters_type type = characters_type::PSEUDO_ALPHANUMERIC);
 
     /* Generate a random integer between min and max. */
     template <typename T>

--- a/test/cppsuite/src/main/operation_configuration.cpp
+++ b/test/cppsuite/src/main/operation_configuration.cpp
@@ -52,9 +52,6 @@ operation_configuration::get_func(database_operation *dbo)
         return (std::bind(&database_operation::remove_operation, dbo, std::placeholders::_1));
     case thread_type::UPDATE:
         return (std::bind(&database_operation::update_operation, dbo, std::placeholders::_1));
-    default:
-        /* This may cause a separate testutil_die in type_string but that should be okay. */
-        testutil_die(EINVAL, "unexpected thread_type: %s", type_string(type).c_str());
     }
 }
 } // namespace test_harness

--- a/test/cppsuite/src/main/operation_configuration.cpp
+++ b/test/cppsuite/src/main/operation_configuration.cpp
@@ -53,5 +53,6 @@ operation_configuration::get_func(database_operation *dbo)
     case thread_type::UPDATE:
         return (std::bind(&database_operation::update_operation, dbo, std::placeholders::_1));
     }
+    testutil_die(EINVAL, "unexpected thread_type: %d", static_cast<int>(type));
 }
 } // namespace test_harness

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -54,6 +54,7 @@ type_string(thread_type type)
     case thread_type::UPDATE:
         return ("update");
     }
+    testutil_die(EINVAL, "unexpected thread_type: %d", static_cast<int>(type));
 }
 
 thread_worker::thread_worker(uint64_t id, thread_type type, configuration *config,

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -53,8 +53,6 @@ type_string(thread_type type)
         return ("remove");
     case thread_type::UPDATE:
         return ("update");
-    default:
-        testutil_die(EINVAL, "unexpected thread_type: %d", static_cast<int>(type));
     }
 }
 

--- a/test/cppsuite/src/main/thread_worker.h
+++ b/test/cppsuite/src/main/thread_worker.h
@@ -40,7 +40,7 @@
 #include "transaction.h"
 
 namespace test_harness {
-enum thread_type { CHECKPOINT, CUSTOM, INSERT, READ, REMOVE, UPDATE };
+enum class thread_type { CHECKPOINT, CUSTOM, INSERT, READ, REMOVE, UPDATE };
 
 const std::string type_string(thread_type type);
 


### PR DESCRIPTION
Update enums to enum classes in cppsuite. This removes the need for default cases on switches as unhandled cases are now caught at compile time.