### PR TITLE
WT-10037 Generalise performance test wrapper to work on all performance tests

### DIFF
--- a/bench/perf_run_py/perf_config.py
+++ b/bench/perf_run_py/perf_config.py
@@ -59,7 +59,7 @@ class PerfConfig:
                  verbose: bool = False,
                  git_root: str = None,
                  json_info=None,
-                 opts_flag=None):
+                 improved_accuracy=None):
         if json_info is None:
             json_info = {}
         self.test_type: TestType = test_type
@@ -73,7 +73,7 @@ class PerfConfig:
         self.verbose: bool = verbose
         self.git_root: str = git_root
         self.json_info: dict = json_info
-        self.opts_flag = opts_flag
+        self.improved_accuracy = improved_accuracy
 
     def to_value_dict(self):
         as_dict = {'exec_path': self.exec_path,
@@ -86,5 +86,5 @@ class PerfConfig:
                    'verbose': self.verbose,
                    'git_root': self.git_root,
                    'json_info': self.json_info,
-                   'opts_flag': self.opts_flag}
+                   'improved_accuracy': self.improved_accuracy}
         return as_dict

--- a/bench/perf_run_py/perf_config.py
+++ b/bench/perf_run_py/perf_config.py
@@ -58,7 +58,8 @@ class PerfConfig:
                  run_max: int = 1,
                  verbose: bool = False,
                  git_root: str = None,
-                 json_info=None):
+                 json_info=None,
+                 opts_flag=None):
         if json_info is None:
             json_info = {}
         self.test_type: TestType = test_type
@@ -72,6 +73,7 @@ class PerfConfig:
         self.verbose: bool = verbose
         self.git_root: str = git_root
         self.json_info: dict = json_info
+        self.opts_flag = opts_flag
 
     def to_value_dict(self):
         as_dict = {'exec_path': self.exec_path,
@@ -83,5 +85,6 @@ class PerfConfig:
                    'run_max': self.run_max,
                    'verbose': self.verbose,
                    'git_root': self.git_root,
-                   'json_info': self.json_info}
+                   'json_info': self.json_info,
+                   'opts_flag': self.opts_flag}
         return as_dict

--- a/bench/perf_run_py/perf_run.py
+++ b/bench/perf_run_py/perf_run.py
@@ -188,6 +188,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('-args', '--arguments', help='Additional arguments to pass into the test')
     parser.add_argument('-ops', '--operations', help='List of operations to report metrics for')
     parser.add_argument('-v', '--verbose', action="store_true", help='be verbose')
+    parser.add_argument('-a', '--opts_flag', action='store_true', help='accuracy runs')
     args = parser.parse_args()
 
     if args.verbose:
@@ -238,7 +239,8 @@ def parse_json_args(args: argparse.Namespace) -> Tuple[List[str], List[str], Per
                         run_max=args.runmax,
                         verbose=args.verbose,
                         git_root=args.git_root,
-                        json_info=json_info)
+                        json_info=json_info,
+                        opts_flag=args.opts_flag)
 
     batch_file_contents = None
     if config.batch_file:
@@ -328,6 +330,8 @@ def main():
     args = parse_args()
     (arguments, operations, config, batch_file_contents) = parse_json_args(args=args)
     validate_operations(config=config, batch_file_contents=batch_file_contents, operations=operations)
+    if (config.opts_flag):
+        arguments = ["-o run_time=60"]
     reported_stats = run_perf_tests(config=config,
                                     batch_file_contents=batch_file_contents,
                                     args=args,
@@ -337,3 +341,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/bench/perf_run_py/perf_run.py
+++ b/bench/perf_run_py/perf_run.py
@@ -124,6 +124,37 @@ def detailed_perf_stats(config: PerfConfig, reported_stats: List[PerfStat]):
 
     return as_dict
 
+def configure_for_extra_accuracy(config: PerfConfig, arguments: List[str]):
+    """
+    When the `extra_accuracy` flag is set we want to run each test multiple times to 
+    ensure a more stable result. However, this can take a lot of time for longer tests 
+    so limit them to only a few minutes.
+    """
+
+    new_run_max = 5
+    new_run_time="run_time=120"
+    print("==================")
+    print(f"Extra accuracy flag set. Overriding runmax to {new_run_max} and setting -o {new_run_time}")
+    print("==================")
+    
+    config.run_max = new_run_max
+
+    if(arguments):
+        for (i, arg) in enumerate(arguments):
+            if arg.startswith("-o "):
+                if "run_time=" in arg:
+                    print("Error: Attempting to set `run_time` but it has already been set via the `-args` flag`")
+                    exit(1)
+                else:
+                    arguments[i] = arg + "," + new_run_time
+                    return
+                    
+    # Arguments is of None type - initialise.
+    if not(arguments):
+        arguments = []
+
+    # Else there is no `-o` argument yet. Add one.
+    arguments += [f"-o {new_run_time}"]
 
 def run_test_wrapper(config: PerfConfig, index: int = 0, arguments: List[str] = None):
     for test_run in range(config.run_max):
@@ -188,7 +219,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('-args', '--arguments', help='Additional arguments to pass into the test')
     parser.add_argument('-ops', '--operations', help='List of operations to report metrics for')
     parser.add_argument('-v', '--verbose', action="store_true", help='be verbose')
-    parser.add_argument('-a', '--opts_flag', action='store_true', help='accuracy runs')
+    parser.add_argument('-a', '--improved_accuracy', action='store_true', help='Enable stable runs and results')
     args = parser.parse_args()
 
     if args.verbose:
@@ -240,7 +271,7 @@ def parse_json_args(args: argparse.Namespace) -> Tuple[List[str], List[str], Per
                         verbose=args.verbose,
                         git_root=args.git_root,
                         json_info=json_info,
-                        opts_flag=args.opts_flag)
+                        improved_accuracy=args.improved_accuracy)
 
     batch_file_contents = None
     if config.batch_file:
@@ -330,8 +361,8 @@ def main():
     args = parse_args()
     (arguments, operations, config, batch_file_contents) = parse_json_args(args=args)
     validate_operations(config=config, batch_file_contents=batch_file_contents, operations=operations)
-    if (config.opts_flag):
-        arguments = ["-o run_time=60"]
+    if (config.improved_accuracy):
+            configure_for_extra_accuracy(config, arguments)
     reported_stats = run_perf_tests(config=config,
                                     batch_file_contents=batch_file_contents,
                                     args=args,

--- a/bench/perf_run_py/perf_run.py
+++ b/bench/perf_run_py/perf_run.py
@@ -149,7 +149,6 @@ def configure_for_extra_accuracy(config: PerfConfig, arguments: List[str]):
                     arguments[i] = arg + "," + new_run_time
                     return
                     
-    # Arguments is of None type - initialise.
     # There is no `-o` argument yet. Add one.
     if not(arguments):
         arguments = []

--- a/bench/perf_run_py/perf_run.py
+++ b/bench/perf_run_py/perf_run.py
@@ -139,7 +139,7 @@ def configure_for_extra_accuracy(config: PerfConfig, arguments: List[str]):
     
     config.run_max = new_run_max
 
-    if(arguments):
+    if arguments:
         for (i, arg) in enumerate(arguments):
             if arg.startswith("-o "):
                 if "run_time=" in arg:
@@ -150,10 +150,9 @@ def configure_for_extra_accuracy(config: PerfConfig, arguments: List[str]):
                     return
                     
     # Arguments is of None type - initialise.
+    # There is no `-o` argument yet. Add one.
     if not(arguments):
         arguments = []
-
-    # Else there is no `-o` argument yet. Add one.
     arguments += [f"-o {new_run_time}"]
 
 def run_test_wrapper(config: PerfConfig, index: int = 0, arguments: List[str] = None):

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2361,7 +2361,7 @@ start_run(WTPERF *wtperf)
         total_ops = wtperf->insert_ops + wtperf->modify_ops + wtperf->read_ops + wtperf->update_ops;
 
         run_time = opts->run_time == 0 ? 1 : opts->run_time;
-
+        printf("Run time set to: %u", run_time);
         lprintf(wtperf, 0, 1,
           "Executed %" PRIu64 " insert operations (%" PRIu64 "%%) %" PRIu64 " ops/sec",
           wtperf->insert_ops, (wtperf->insert_ops * 100) / total_ops,

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2361,6 +2361,7 @@ start_run(WTPERF *wtperf)
         total_ops = wtperf->insert_ops + wtperf->modify_ops + wtperf->read_ops + wtperf->update_ops;
 
         run_time = opts->run_time == 0 ? 1 : opts->run_time;
+
         lprintf(wtperf, 0, 1,
           "Executed %" PRIu64 " insert operations (%" PRIu64 "%%) %" PRIu64 " ops/sec",
           wtperf->insert_ops, (wtperf->insert_ops * 100) / total_ops,

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2361,7 +2361,6 @@ start_run(WTPERF *wtperf)
         total_ops = wtperf->insert_ops + wtperf->modify_ops + wtperf->read_ops + wtperf->update_ops;
 
         run_time = opts->run_time == 0 ? 1 : opts->run_time;
-        printf("Run time set to: %u", run_time);
         lprintf(wtperf, 0, 1,
           "Executed %" PRIu64 " insert operations (%" PRIu64 "%%) %" PRIu64 " ops/sec",
           wtperf->insert_ops, (wtperf->insert_ops * 100) / total_ops,

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3668,8 +3668,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-lsm.wtperf
-          maxruns: 3
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: small-lsm.wtperf
@@ -3683,8 +3683,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-lsm.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-lsm.wtperf
@@ -3698,8 +3698,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-lsm-compact.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-lsm-compact.wtperf
@@ -3713,8 +3713,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-multi-lsm.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read", "update"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read", "update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-multi-lsm.wtperf
@@ -3728,8 +3728,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-lsm.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load"']
+          maxruns: 5
+          wtarg: -ops ['"load"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-lsm.wtperf
@@ -3743,8 +3743,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-lsm.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read", "update", "insert"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read", "update", "insert"'] -args ['"-o run_time=300']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-lsm.wtperf
@@ -3762,11 +3762,9 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-btree.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
-        vars:
-          perf-test-name: small-btree.wtperf
 
   - name: perf-test-small-btree-backup
     tags: ["btree-perf"]
@@ -3777,8 +3775,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-btree-backup.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: small-btree-backup.wtperf
@@ -3792,8 +3790,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree.wtperf
-          maxruns: 3
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-btree.wtperf
@@ -3807,8 +3805,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree-backup.wtperf
-          maxruns: 3
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-btree-backup.wtperf
@@ -3822,8 +3820,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-btree.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load"']
+          maxruns: 5
+          wtarg: -ops ['"load"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-btree.wtperf
@@ -3837,8 +3835,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-only-btree.wtperf
-          maxruns: 3
-          wtarg: -ops ['"update"']
+          maxruns: 5
+          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-only-btree.wtperf
@@ -3852,8 +3850,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-btree.wtperf
-          maxruns: 1
-          wtarg: "-bf ../../../bench/wtperf/runners/update-btree.json"
+          maxruns: 5
+          wtarg: -args ['"-o run_time=300"'] "-bf ../../../bench/wtperf/runners/update-btree.json" 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-btree.wtperf
@@ -3867,8 +3865,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-large-record-btree.wtperf
-          maxruns: 3
-          wtarg: -ops ['"load", "update"']
+          maxruns: 5
+          wtarg: -ops ['"load", "update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-large-record-btree.wtperf
@@ -3882,8 +3880,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-large-record-btree.wtperf
-          maxruns: 3
-          wtarg: -ops ['"load", "modify"']
+          maxruns: 5
+          wtarg: -ops ['"load", "modify"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: modify-large-record-btree.wtperf
@@ -3897,8 +3895,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-force-update-large-record-btree.wtperf
-          maxruns: 3
-          wtarg: -ops ['"load", "modify"']
+          maxruns: 5
+          wtarg: -ops ['"load", "modify"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: modify-force-update-large-record-btree.wtperf
@@ -3916,8 +3914,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-oplog.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "insert", "truncate", "database_size"']
+          maxruns: 5
+          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-oplog.wtperf
@@ -3931,8 +3929,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-small-oplog.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "insert", "truncate", "database_size"']
+          maxruns: 5
+          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-small-oplog.wtperf
@@ -3946,8 +3944,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-large-oplog.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "insert", "truncate", "database_size"']
+          maxruns: 5
+          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-large-oplog.wtperf
@@ -3961,8 +3959,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-secondary-apply.wtperf
-          maxruns: 1
-          wtarg: -ops ['"insert"']
+          maxruns: 5
+          wtarg: -ops ['"insert"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-secondary-apply.wtperf
@@ -3980,8 +3978,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
-          maxruns: 1
-          wtarg: "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
+          maxruns: 5
+          wtarg: -args ['"-o run_time=300"'] "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
@@ -3997,7 +3995,7 @@ tasks:
         vars:
           perf-test-name: update-checkpoint-lsm.wtperf
           maxruns: 1
-          wtarg: "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
+          wtarg: -args ['"-o run_time=300"'] "-bf ../../../bench/wtperf/runners/update-checkpoint.json" 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-lsm.wtperf
@@ -4015,8 +4013,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: overflow-10k.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read", "update"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read", "update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: overflow-10k.wtperf
@@ -4030,8 +4028,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: overflow-130k.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read", "update"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read", "update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: overflow-130k.wtperf
@@ -4045,8 +4043,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-stress.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load"']
+          maxruns: 5
+          wtarg: -ops ['"load"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-stress.wtperf
@@ -4060,8 +4058,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-grow-stress.wtperf
-          maxruns: 1
-          wtarg: -ops ['"update"']
+          maxruns: 5
+          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-grow-stress.wtperf
@@ -4075,8 +4073,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-shrink-stress.wtperf
-          maxruns: 1
-          wtarg: -ops ['"update"']
+          maxruns: 5
+          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-shrink-stress.wtperf
@@ -4090,8 +4088,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix1.wtperf
-          maxruns: 1
-          wtarg: -ops ['"update"']
+          maxruns: 5
+          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix1.wtperf
@@ -4105,8 +4103,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix2.wtperf
-          maxruns: 1
-          wtarg: -ops ['"update"']
+          maxruns: 5
+          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix2.wtperf
@@ -4120,8 +4118,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix3.wtperf
-          maxruns: 1
-          wtarg: -ops ['"update"']
+          maxruns: 5
+          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix3.wtperf
@@ -4135,13 +4133,14 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-populate.wtperf
-          maxruns: 1
+          maxruns: 5
+          wtarg: -args ['"-o run_time=300"']
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-workload.wtperf
-          maxruns: 1
+          maxruns: 5
           no_create: true
-          wtarg: -ops ['"read"']
+          wtarg: -ops ['"read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: multi-btree-zipfian-workload.wtperf
@@ -4155,7 +4154,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: many-table-stress.wtperf
-          maxruns: 1
+          maxruns: 5
+          wtarg: -args ['"-o run_time=300"']
 
   - name: perf-test-many-table-stress-backup
     tags: ["stress-perf"]
@@ -4166,7 +4166,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: many-table-stress-backup.wtperf
-          maxruns: 1
+          maxruns: 5
+          wtarg: -args ['"-o run_time=300"']
 
   - name: perf-test-evict-fairness
     tags: ["stress-perf"]
@@ -4177,8 +4178,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-fairness.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false"'] -ops ['"eviction_page_seen"']
+          maxruns: 5
+          wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false", "-o run_time=300"'] -ops ['"eviction_page_seen"']
       - func: "validate-expected-stats"
         vars:
           stat_file: './test_stats/evergreen_out_evict-fairness.wtperf.json'
@@ -4194,8 +4195,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree-stress-multi.wtperf
-          maxruns: 1
-          wtarg: -ops ['"warnings", "top5_latencies_read_update"']
+          maxruns: 5
+          wtarg: -ops ['"warnings", "top5_latencies_read_update"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree-stress-multi.wtperf
@@ -4213,8 +4214,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"'] 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree.wtperf
@@ -4228,8 +4229,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree-1.wtperf
-          maxruns: 1
-          wtarg: -ops ['"read"']
+          maxruns: 5
+          wtarg: -ops ['"read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree-1.wtperf
@@ -4244,8 +4245,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-lsm.wtperf
-          maxruns: 1
-          wtarg: -ops ['"load", "read"']
+          maxruns: 5
+          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-lsm.wtperf
@@ -4260,8 +4261,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-lsm-1.wtperf
-          maxruns: 1
-          wtarg: -ops ['"read"']
+          maxruns: 5
+          wtarg: -ops ['"read"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-lsm-1.wtperf
@@ -4279,8 +4280,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 1
-          wtarg: -ops ['"update", "min_max_update_throughput"']
+          maxruns: 5
+          wtarg: -ops ['"update", "min_max_update_throughput"'] -args ['"-o run_time=300"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4294,8 +4295,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C log=(enabled,file_max=1M)"'] -ops ['"update"']
+          maxruns: 5
+          wtarg: -args ['"-C log=(enabled,file_max=1M)"', '"-o run_time=300"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4309,8 +4310,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C checkpoint=(wait=0)"'] -ops ['"update"']
+          maxruns: 5
+          wtarg: -args ['"-C checkpoint=(wait=0)"', '"-o run_time=300"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4324,8 +4325,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C log=(enabled,file_max=1M,prealloc=false)"'] -ops ['"update"']
+          maxruns: 5
+          wtarg: -args ['"-C log=(enabled,file_max=1M,prealloc=false)"', '"-o run_time=300"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4339,8 +4340,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C log=(enabled,file_max=1M,zero_fill=true)"'] -ops ['"update"']
+          maxruns: 5
+          wtarg: -args ['"-C log=(enabled,file_max=1M,zero_fill=true)"', '"-o run_time=300"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4354,8 +4355,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))"'] -ops ['"update"']
+          maxruns: 5
+          wtarg: -args ['"-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))", "-o run_time=300"'] -ops ['"update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4377,8 +4378,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-populate.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"load", "warnings", "max_latency_insert"']
+          maxruns: 5
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"load", "warnings", "max_latency_insert"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-populate.wtperf
@@ -4408,9 +4409,9 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u.wtperf
-          maxruns: 1
+          maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-50r50u.wtperf
@@ -4435,9 +4436,9 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u-backup.wtperf
-          maxruns: 1
+          maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-50r50u-backup.wtperf
@@ -4462,9 +4463,9 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-80r20u.wtperf
-          maxruns: 1
+          maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-80r20u.wtperf
@@ -4489,9 +4490,9 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-rdonly.wtperf
-          maxruns: 1
+          maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "warnings", "max_latency_read_update", "min_max_read_throughput"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])","-o run_time=300"'] -ops ['"read", "warnings", "max_latency_read_update", "min_max_read_throughput"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-rdonly.wtperf
@@ -4506,8 +4507,8 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: checkpoint-stress.wtperf
-          maxruns: 1
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"update", "checkpoint"']
+          maxruns: 5
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])","-o run_time=300"'] -ops ['"update", "checkpoint"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: checkpoint-stress.wtperf
@@ -4523,8 +4524,8 @@ tasks:
           exec_path: ${python_binary}
           perf-test-path: ../../../bench/workgen/runner
           perf-test-name: many-dhandle-stress.py
-          maxruns: 1
-          wtarg: -ops ['"max_latency_create", "max_latency_drop", "max_latency_drop_diff", "max_latency_insert_micro_sec", "max_latency_read_micro_sec", "max_latency_update_micro_sec", "warning_idle", "warning_idle_create", "warning_idle_drop", "warning_insert", "warning_operations", "warning_read", "warning_update"']
+          maxruns: 5
+          wtarg: -args ['"-o run_time=300"'] -ops ['"max_latency_create", "max_latency_drop", "max_latency_drop_diff", "max_latency_insert_micro_sec", "max_latency_read_micro_sec", "max_latency_update_micro_sec", "warning_idle", "warning_idle_create", "warning_idle_drop", "warning_insert", "warning_operations", "warning_read", "warning_update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: many-dhandle-stress.py

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4873,7 +4873,6 @@ buildvariants:
     - name: ".oplog-perf"
     - name: many-dhandle-stress
     - name: ".wt2853-perf"
-    - name: cppsuite-bounded-cursor-perf-stress
   display_tasks:
     - name: Wiredtiger-perf-btree-jobs
       execution_tasks:
@@ -4964,10 +4963,7 @@ buildvariants:
     - name: Wiredtiger-perf-oplog-jobs
       execution_tasks:
       - ".oplog-perf"
-    - name: WiredTiger-wt2853-perf
-      execution_tasks:
-      - ".wt2853-perf"
-
+      
 - name: large-scale-tests
   display_name: "Large scale tests"
   batchtime: 480 # 3 times a day

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4873,6 +4873,7 @@ buildvariants:
     - name: ".oplog-perf"
     - name: many-dhandle-stress
     - name: ".wt2853-perf"
+    - name: cppsuite-bounded-cursor-perf-stress
   display_tasks:
     - name: Wiredtiger-perf-btree-jobs
       execution_tasks:
@@ -4936,7 +4937,6 @@ buildvariants:
     - name: ".log-perf"
     - name: ".long-perf"
     - name: ".oplog-perf"
-    - name: cppsuite-bounded-cursor-perf-stress
   display_tasks:
     - name: Wiredtiger-perf-btree-jobs
       execution_tasks:
@@ -4963,7 +4963,7 @@ buildvariants:
     - name: Wiredtiger-perf-oplog-jobs
       execution_tasks:
       - ".oplog-perf"
-      
+
 - name: large-scale-tests
   display_name: "Large scale tests"
   batchtime: 480 # 3 times a day

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3668,7 +3668,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-lsm.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3683,7 +3683,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-lsm.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3698,7 +3698,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-lsm-compact.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3713,7 +3713,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-multi-lsm.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3728,7 +3728,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-lsm.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3743,7 +3743,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-lsm.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read", "update", "insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3762,7 +3762,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3777,7 +3777,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-btree-backup.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3792,7 +3792,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3807,7 +3807,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree-backup.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3822,7 +3822,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3837,7 +3837,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-only-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3852,7 +3852,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-btree.json" 
       - func: "upload-perf-test-stats"
         vars:
@@ -3867,7 +3867,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-large-record-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3882,7 +3882,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-large-record-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3897,7 +3897,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-force-update-large-record-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3916,7 +3916,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-oplog.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3931,7 +3931,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-small-oplog.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3946,7 +3946,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-large-oplog.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3961,7 +3961,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-secondary-apply.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3980,7 +3980,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
       - func: "upload-perf-test-stats"
         vars:
@@ -4015,7 +4015,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: overflow-10k.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4030,7 +4030,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: overflow-130k.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4045,7 +4045,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-stress.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4060,7 +4060,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-grow-stress.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4075,7 +4075,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-shrink-stress.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4090,7 +4090,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix1.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4105,7 +4105,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix2.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4120,7 +4120,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix3.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4135,12 +4135,12 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-populate.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: ${improved_accuracy|}
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-workload.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           no_create: true
           wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4156,7 +4156,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: many-table-stress.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: ${improved_accuracy|}
 
   - name: perf-test-many-table-stress-backup
@@ -4168,7 +4168,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: many-table-stress-backup.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: ${improved_accuracy|}
 
   - name: perf-test-evict-fairness
@@ -4180,7 +4180,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-fairness.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false"'] -ops ['"eviction_page_seen"'] ${improved_accuracy|}
       - func: "validate-expected-stats"
         vars:
@@ -4197,7 +4197,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree-stress-multi.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"warnings", "top5_latencies_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4216,7 +4216,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|} 
       - func: "upload-perf-test-stats"
         vars:
@@ -4231,7 +4231,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree-1.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4247,7 +4247,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-lsm.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4263,7 +4263,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-lsm-1.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4282,7 +4282,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -ops ['"update", "min_max_update_throughput"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4297,7 +4297,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C log=(enabled,file_max=1M)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4312,7 +4312,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C checkpoint=(wait=0)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4327,7 +4327,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C log=(enabled,file_max=1M,prealloc=false)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4342,7 +4342,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C log=(enabled,file_max=1M,zero_fill=true)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4357,7 +4357,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4380,7 +4380,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-populate.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"load", "warnings", "max_latency_insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4411,7 +4411,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4438,7 +4438,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u-backup.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4465,7 +4465,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-80r20u.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4492,7 +4492,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-rdonly.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "warnings", "max_latency_read_update", "min_max_read_throughput"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4509,7 +4509,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: checkpoint-stress.wtperf
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"update", "checkpoint"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4526,7 +4526,7 @@ tasks:
           exec_path: ${python_binary}
           perf-test-path: ../../../bench/workgen/runner
           perf-test-name: many-dhandle-stress.py
-          maxruns: ${max_runs_acc|1}
+          maxruns: 1
           wtarg: ${improved_accuracy|} -ops ['"max_latency_create", "max_latency_drop", "max_latency_drop_diff", "max_latency_insert_micro_sec", "max_latency_read_micro_sec", "max_latency_update_micro_sec", "warning_idle", "warning_idle_create", "warning_idle_drop", "warning_insert", "warning_operations", "warning_read", "warning_update"']
       - func: "upload-perf-test-stats"
         vars:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3744,7 +3744,7 @@ tasks:
         vars:
           perf-test-name: update-lsm.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read", "update", "insert"'] -args ['"-o run_time=300']
+          wtarg: -ops ['"load", "read", "update", "insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-lsm.wtperf
@@ -4181,7 +4181,7 @@ tasks:
         vars:
           perf-test-name: evict-fairness.wtperf
           maxruns: 5
-          wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false", "-o run_time=300"'] -ops ['"eviction_page_seen"']
+          wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false"'] -ops ['"eviction_page_seen"'] ${improved_accuracy|}
       - func: "validate-expected-stats"
         vars:
           stat_file: './test_stats/evergreen_out_evict-fairness.wtperf.json'
@@ -4298,7 +4298,7 @@ tasks:
         vars:
           perf-test-name: log.wtperf
           maxruns: 5
-          wtarg: -args ['"-C log=(enabled,file_max=1M)"', '"-o run_time=300"'] -ops ['"update"']
+          wtarg: -args ['"-C log=(enabled,file_max=1M)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4313,7 +4313,7 @@ tasks:
         vars:
           perf-test-name: log.wtperf
           maxruns: 5
-          wtarg: -args ['"-C checkpoint=(wait=0)"', '"-o run_time=300"'] -ops ['"update"']
+          wtarg: -args ['"-C checkpoint=(wait=0)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4328,7 +4328,7 @@ tasks:
         vars:
           perf-test-name: log.wtperf
           maxruns: 5
-          wtarg: -args ['"-C log=(enabled,file_max=1M,prealloc=false)"', '"-o run_time=300"'] -ops ['"update"']
+          wtarg: -args ['"-C log=(enabled,file_max=1M,prealloc=false)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4343,7 +4343,7 @@ tasks:
         vars:
           perf-test-name: log.wtperf
           maxruns: 5
-          wtarg: -args ['"-C log=(enabled,file_max=1M,zero_fill=true)"', '"-o run_time=300"'] -ops ['"update"']
+          wtarg: -args ['"-C log=(enabled,file_max=1M,zero_fill=true)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4358,7 +4358,7 @@ tasks:
         vars:
           perf-test-name: log.wtperf
           maxruns: 5
-          wtarg: -args ['"-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))", "-o run_time=300"'] -ops ['"update"']
+          wtarg: -args ['"-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4381,7 +4381,7 @@ tasks:
         vars:
           perf-test-name: 500m-btree-populate.wtperf
           maxruns: 5
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"load", "warnings", "max_latency_insert"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"load", "warnings", "max_latency_insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-populate.wtperf
@@ -4413,7 +4413,7 @@ tasks:
           perf-test-name: 500m-btree-50r50u.wtperf
           maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-50r50u.wtperf
@@ -4440,7 +4440,7 @@ tasks:
           perf-test-name: 500m-btree-50r50u-backup.wtperf
           maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-50r50u-backup.wtperf
@@ -4467,7 +4467,7 @@ tasks:
           perf-test-name: 500m-btree-80r20u.wtperf
           maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])", "-o run_time=300"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-80r20u.wtperf
@@ -4494,7 +4494,7 @@ tasks:
           perf-test-name: 500m-btree-rdonly.wtperf
           maxruns: 5
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])","-o run_time=300"'] -ops ['"read", "warnings", "max_latency_read_update", "min_max_read_throughput"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "warnings", "max_latency_read_update", "min_max_read_throughput"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: 500m-btree-rdonly.wtperf
@@ -4510,7 +4510,7 @@ tasks:
         vars:
           perf-test-name: checkpoint-stress.wtperf
           maxruns: 5
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])","-o run_time=300"'] -ops ['"update", "checkpoint"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"update", "checkpoint"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: checkpoint-stress.wtperf

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3668,7 +3668,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-lsm.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3683,7 +3683,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-lsm.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3698,7 +3698,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-lsm-compact.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3713,7 +3713,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-multi-lsm.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3728,7 +3728,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-lsm.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3743,7 +3743,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-lsm.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read", "update", "insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3777,7 +3777,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-btree-backup.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3792,7 +3792,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3807,7 +3807,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree-backup.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3822,7 +3822,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3837,7 +3837,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-only-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3852,7 +3852,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-btree.json" 
       - func: "upload-perf-test-stats"
         vars:
@@ -3867,7 +3867,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-large-record-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3882,7 +3882,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-large-record-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3897,7 +3897,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-force-update-large-record-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3916,7 +3916,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-oplog.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3931,7 +3931,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-small-oplog.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3946,7 +3946,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-large-oplog.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3961,7 +3961,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: mongodb-secondary-apply.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3980,7 +3980,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
       - func: "upload-perf-test-stats"
         vars:
@@ -4015,7 +4015,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: overflow-10k.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4030,7 +4030,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: overflow-130k.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4045,7 +4045,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: parallel-pop-stress.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4060,7 +4060,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-grow-stress.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4075,7 +4075,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-shrink-stress.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4090,7 +4090,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix1.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4105,7 +4105,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix2.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4120,7 +4120,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-delta-mix3.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4135,12 +4135,12 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-populate.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: ${improved_accuracy|}
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-workload.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           no_create: true
           wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4156,7 +4156,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: many-table-stress.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: ${improved_accuracy|}
 
   - name: perf-test-many-table-stress-backup
@@ -4168,7 +4168,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: many-table-stress-backup.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: ${improved_accuracy|}
 
   - name: perf-test-evict-fairness
@@ -4180,7 +4180,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-fairness.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false"'] -ops ['"eviction_page_seen"'] ${improved_accuracy|}
       - func: "validate-expected-stats"
         vars:
@@ -4197,7 +4197,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree-stress-multi.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"warnings", "top5_latencies_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4216,7 +4216,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|} 
       - func: "upload-perf-test-stats"
         vars:
@@ -4231,7 +4231,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-btree-1.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4247,7 +4247,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-lsm.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4263,7 +4263,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: evict-lsm-1.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4282,7 +4282,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -ops ['"update", "min_max_update_throughput"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4297,7 +4297,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C log=(enabled,file_max=1M)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4312,7 +4312,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C checkpoint=(wait=0)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4327,7 +4327,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C log=(enabled,file_max=1M,prealloc=false)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4342,7 +4342,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C log=(enabled,file_max=1M,zero_fill=true)"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4357,7 +4357,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: log.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C log=(enabled,file_max=1M),session_max=256", "-o threads=((count=128,updates=1))"'] -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4380,7 +4380,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-populate.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"load", "warnings", "max_latency_insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4411,7 +4411,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4438,7 +4438,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u-backup.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4465,7 +4465,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-80r20u.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "update", "warnings", "max_latency_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4492,7 +4492,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-rdonly.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"read", "warnings", "max_latency_read_update", "min_max_read_throughput"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
@@ -4509,7 +4509,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: checkpoint-stress.wtperf
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:])"'] -ops ['"update", "checkpoint"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4526,7 +4526,7 @@ tasks:
           exec_path: ${python_binary}
           perf-test-path: ../../../bench/workgen/runner
           perf-test-name: many-dhandle-stress.py
-          maxruns: 5
+          maxruns: ${max_runs_acc|1}
           wtarg: ${improved_accuracy|} -ops ['"max_latency_create", "max_latency_drop", "max_latency_drop_diff", "max_latency_insert_micro_sec", "max_latency_read_micro_sec", "max_latency_update_micro_sec", "warning_idle", "warning_idle_create", "warning_idle_drop", "warning_insert", "warning_operations", "warning_read", "warning_update"']
       - func: "upload-perf-test-stats"
         vars:
@@ -4924,7 +4924,7 @@ buildvariants:
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja
     make_command: ninja
-    improved_accuracy: -args ['"-o run_time=60"']
+    improved_accuracy: '--opts_flag'
     max_runs_acc: 5
   tasks:
     - name: compile

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3669,7 +3669,7 @@ tasks:
         vars:
           perf-test-name: small-lsm.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: small-lsm.wtperf
@@ -3684,7 +3684,7 @@ tasks:
         vars:
           perf-test-name: medium-lsm.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-lsm.wtperf
@@ -3699,7 +3699,7 @@ tasks:
         vars:
           perf-test-name: medium-lsm-compact.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-lsm-compact.wtperf
@@ -3714,7 +3714,7 @@ tasks:
         vars:
           perf-test-name: medium-multi-lsm.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read", "update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-multi-lsm.wtperf
@@ -3729,7 +3729,7 @@ tasks:
         vars:
           perf-test-name: parallel-pop-lsm.wtperf
           maxruns: 5
-          wtarg: -ops ['"load"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-lsm.wtperf
@@ -3762,9 +3762,11 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-btree.wtperf
-          maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          maxruns: ${max_runs_acc|1}
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
+        vars:
+          perf-test-name: small-btree.wtperf
 
   - name: perf-test-small-btree-backup
     tags: ["btree-perf"]
@@ -3776,7 +3778,7 @@ tasks:
         vars:
           perf-test-name: small-btree-backup.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: small-btree-backup.wtperf
@@ -3791,7 +3793,7 @@ tasks:
         vars:
           perf-test-name: medium-btree.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-btree.wtperf
@@ -3806,7 +3808,7 @@ tasks:
         vars:
           perf-test-name: medium-btree-backup.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: medium-btree-backup.wtperf
@@ -3821,7 +3823,7 @@ tasks:
         vars:
           perf-test-name: parallel-pop-btree.wtperf
           maxruns: 5
-          wtarg: -ops ['"load"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-btree.wtperf
@@ -3836,7 +3838,7 @@ tasks:
         vars:
           perf-test-name: update-only-btree.wtperf
           maxruns: 5
-          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-only-btree.wtperf
@@ -3851,7 +3853,7 @@ tasks:
         vars:
           perf-test-name: update-btree.wtperf
           maxruns: 5
-          wtarg: -args ['"-o run_time=300"'] "-bf ../../../bench/wtperf/runners/update-btree.json" 
+          wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-btree.json" 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-btree.wtperf
@@ -3866,7 +3868,7 @@ tasks:
         vars:
           perf-test-name: update-large-record-btree.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-large-record-btree.wtperf
@@ -3881,7 +3883,7 @@ tasks:
         vars:
           perf-test-name: modify-large-record-btree.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "modify"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: modify-large-record-btree.wtperf
@@ -3896,7 +3898,7 @@ tasks:
         vars:
           perf-test-name: modify-force-update-large-record-btree.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "modify"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: modify-force-update-large-record-btree.wtperf
@@ -3915,7 +3917,7 @@ tasks:
         vars:
           perf-test-name: mongodb-oplog.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-oplog.wtperf
@@ -3930,7 +3932,7 @@ tasks:
         vars:
           perf-test-name: mongodb-small-oplog.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-small-oplog.wtperf
@@ -3945,7 +3947,7 @@ tasks:
         vars:
           perf-test-name: mongodb-large-oplog.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "insert", "truncate", "database_size"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-large-oplog.wtperf
@@ -3960,7 +3962,7 @@ tasks:
         vars:
           perf-test-name: mongodb-secondary-apply.wtperf
           maxruns: 5
-          wtarg: -ops ['"insert"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"insert"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: mongodb-secondary-apply.wtperf
@@ -3979,7 +3981,7 @@ tasks:
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
           maxruns: 5
-          wtarg: -args ['"-o run_time=300"'] "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
+          wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
@@ -3995,7 +3997,7 @@ tasks:
         vars:
           perf-test-name: update-checkpoint-lsm.wtperf
           maxruns: 1
-          wtarg: -args ['"-o run_time=300"'] "-bf ../../../bench/wtperf/runners/update-checkpoint.json" 
+          wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-checkpoint.json" 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-lsm.wtperf
@@ -4014,7 +4016,7 @@ tasks:
         vars:
           perf-test-name: overflow-10k.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read", "update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: overflow-10k.wtperf
@@ -4029,7 +4031,7 @@ tasks:
         vars:
           perf-test-name: overflow-130k.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read", "update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: overflow-130k.wtperf
@@ -4044,7 +4046,7 @@ tasks:
         vars:
           perf-test-name: parallel-pop-stress.wtperf
           maxruns: 5
-          wtarg: -ops ['"load"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: parallel-pop-stress.wtperf
@@ -4059,7 +4061,7 @@ tasks:
         vars:
           perf-test-name: update-grow-stress.wtperf
           maxruns: 5
-          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-grow-stress.wtperf
@@ -4074,7 +4076,7 @@ tasks:
         vars:
           perf-test-name: update-shrink-stress.wtperf
           maxruns: 5
-          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-shrink-stress.wtperf
@@ -4089,7 +4091,7 @@ tasks:
         vars:
           perf-test-name: update-delta-mix1.wtperf
           maxruns: 5
-          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix1.wtperf
@@ -4104,7 +4106,7 @@ tasks:
         vars:
           perf-test-name: update-delta-mix2.wtperf
           maxruns: 5
-          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix2.wtperf
@@ -4119,7 +4121,7 @@ tasks:
         vars:
           perf-test-name: update-delta-mix3.wtperf
           maxruns: 5
-          wtarg: -ops ['"update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-delta-mix3.wtperf
@@ -4134,13 +4136,13 @@ tasks:
         vars:
           perf-test-name: multi-btree-zipfian-populate.wtperf
           maxruns: 5
-          wtarg: -args ['"-o run_time=300"']
+          wtarg: ${improved_accuracy|}
       - func: "run-perf-test"
         vars:
           perf-test-name: multi-btree-zipfian-workload.wtperf
           maxruns: 5
           no_create: true
-          wtarg: -ops ['"read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: multi-btree-zipfian-workload.wtperf
@@ -4155,7 +4157,7 @@ tasks:
         vars:
           perf-test-name: many-table-stress.wtperf
           maxruns: 5
-          wtarg: -args ['"-o run_time=300"']
+          wtarg: ${improved_accuracy|}
 
   - name: perf-test-many-table-stress-backup
     tags: ["stress-perf"]
@@ -4167,7 +4169,7 @@ tasks:
         vars:
           perf-test-name: many-table-stress-backup.wtperf
           maxruns: 5
-          wtarg: -args ['"-o run_time=300"']
+          wtarg: ${improved_accuracy|}
 
   - name: perf-test-evict-fairness
     tags: ["stress-perf"]
@@ -4196,7 +4198,7 @@ tasks:
         vars:
           perf-test-name: evict-btree-stress-multi.wtperf
           maxruns: 5
-          wtarg: -ops ['"warnings", "top5_latencies_read_update"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"warnings", "top5_latencies_read_update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree-stress-multi.wtperf
@@ -4215,7 +4217,7 @@ tasks:
         vars:
           perf-test-name: evict-btree.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"'] 
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|} 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree.wtperf
@@ -4230,7 +4232,7 @@ tasks:
         vars:
           perf-test-name: evict-btree-1.wtperf
           maxruns: 5
-          wtarg: -ops ['"read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-btree-1.wtperf
@@ -4246,7 +4248,7 @@ tasks:
         vars:
           perf-test-name: evict-lsm.wtperf
           maxruns: 5
-          wtarg: -ops ['"load", "read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-lsm.wtperf
@@ -4262,7 +4264,7 @@ tasks:
         vars:
           perf-test-name: evict-lsm-1.wtperf
           maxruns: 5
-          wtarg: -ops ['"read"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: evict-lsm-1.wtperf
@@ -4281,7 +4283,7 @@ tasks:
         vars:
           perf-test-name: log.wtperf
           maxruns: 5
-          wtarg: -ops ['"update", "min_max_update_throughput"'] -args ['"-o run_time=300"']
+          wtarg: -ops ['"update", "min_max_update_throughput"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: log.wtperf
@@ -4525,7 +4527,7 @@ tasks:
           perf-test-path: ../../../bench/workgen/runner
           perf-test-name: many-dhandle-stress.py
           maxruns: 5
-          wtarg: -args ['"-o run_time=300"'] -ops ['"max_latency_create", "max_latency_drop", "max_latency_drop_diff", "max_latency_insert_micro_sec", "max_latency_read_micro_sec", "max_latency_update_micro_sec", "warning_idle", "warning_idle_create", "warning_idle_drop", "warning_insert", "warning_operations", "warning_read", "warning_update"']
+          wtarg: ${improved_accuracy|} -ops ['"max_latency_create", "max_latency_drop", "max_latency_drop_diff", "max_latency_insert_micro_sec", "max_latency_read_micro_sec", "max_latency_update_micro_sec", "warning_idle", "warning_idle_create", "warning_idle_drop", "warning_insert", "warning_operations", "warning_read", "warning_update"']
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: many-dhandle-stress.py
@@ -4858,6 +4860,72 @@ buildvariants:
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja
     make_command: ninja
+  tasks:
+    - name: compile
+    - name: ".btree-perf"
+    # Disable LSM perf tests till the support for LSM is restored.
+    # - name: ".lsm-perf"
+    - name: ".stress-perf"
+    - name: ".checkpoint-perf"
+    - name: ".evict-perf"
+    - name: ".log-perf"
+    - name: ".long-perf"
+    - name: ".oplog-perf"
+    - name: many-dhandle-stress
+    - name: ".wt2853-perf"
+    - name: cppsuite-bounded-cursor-perf-stress
+  display_tasks:
+    - name: Wiredtiger-perf-btree-jobs
+      execution_tasks:
+      - ".btree-perf"
+    # Disable LSM perf tests till the support for LSM is restored.
+    # - name: Wiredtiger-perf-lsm-jobs
+    #   execution_tasks:
+    #   - ".lsm-perf"
+    - name: Wiredtiger-perf-stress-jobs
+      execution_tasks:
+      - ".stress-perf"
+    - name: Wiredtiger-perf-checkpoint-jobs
+      execution_tasks:
+      - ".checkpoint-perf"
+    - name: Wiredtiger-perf-evict-jobs
+      execution_tasks:
+      - ".evict-perf"
+    - name: Wiredtiger-perf-log-jobs
+      execution_tasks:
+      - ".log-perf"
+    - name: Wiredtiger-perf-long-jobs
+      execution_tasks:
+      - ".long-perf"
+    - name: Wiredtiger-perf-oplog-jobs
+      execution_tasks:
+      - ".oplog-perf"
+    - name: WiredTiger-wt2853-perf
+      execution_tasks:
+      - ".wt2853-perf"
+
+- name: ubuntu2004-perf-tests-accuracy
+  display_name: Ubuntu 20.04 Performance tests (improved accuracy)
+  batchtime: 1440 # 1 day
+  run_on:
+    - ubuntu2004-medium
+  expansions:
+    test_env_vars:
+      WT_TOPDIR=$(git rev-parse --show-toplevel)
+      WT_BUILDDIR=$WT_TOPDIR/cmake_build
+      LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_BUILDDIR/test/utility/
+    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O3
+    HAVE_DIAGNOSTIC: -DHAVE_DIAGNOSTIC=0
+    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
+    CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL
+    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    pip3_binary: '/opt/mongodbtoolchain/v3/bin/pip3'
+    virtualenv_binary: '/opt/mongodbtoolchain/v3/bin/virtualenv'
+    smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
+    cmake_generator: Ninja
+    make_command: ninja
+    improved_accuracy: -args ['"-o run_time=60"']
+    max_runs_acc: 5
   tasks:
     - name: compile
     - name: ".btree-perf"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3668,7 +3668,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: small-lsm.wtperf
-          maxruns: 1
+          maxruns: 3
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3792,7 +3792,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree.wtperf
-          maxruns: 1
+          maxruns: 3
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3807,7 +3807,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: medium-btree-backup.wtperf
-          maxruns: 1
+          maxruns: 3
           wtarg: -ops ['"load", "read"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3837,7 +3837,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-only-btree.wtperf
-          maxruns: 1
+          maxruns: 3
           wtarg: -ops ['"update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3867,7 +3867,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: update-large-record-btree.wtperf
-          maxruns: 1
+          maxruns: 3
           wtarg: -ops ['"load", "update"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3882,7 +3882,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-large-record-btree.wtperf
-          maxruns: 1
+          maxruns: 3
           wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -3897,7 +3897,7 @@ tasks:
       - func: "run-perf-test"
         vars:
           perf-test-name: modify-force-update-large-record-btree.wtperf
-          maxruns: 1
+          maxruns: 3
           wtarg: -ops ['"load", "modify"'] ${improved_accuracy|}
       - func: "upload-perf-test-stats"
         vars:
@@ -4924,7 +4924,7 @@ buildvariants:
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja
     make_command: ninja
-    improved_accuracy: '--opts_flag'
+    improved_accuracy: '--improved_accuracy'
     max_runs_acc: 5
   tasks:
     - name: compile
@@ -4937,8 +4937,6 @@ buildvariants:
     - name: ".log-perf"
     - name: ".long-perf"
     - name: ".oplog-perf"
-    - name: many-dhandle-stress
-    - name: ".wt2853-perf"
     - name: cppsuite-bounded-cursor-perf-stress
   display_tasks:
     - name: Wiredtiger-perf-btree-jobs


### PR DESCRIPTION
Add a function in `perf_run.py` that supports more stable results through increased runs and a limit on the duration of the test (useful for longer running tests). Added a build variant to support increased-accuracy perf runs. 