### PR TITLE
WT-10111 Disable realloc_malloc config in compatibility testing.

### DIFF
--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -155,6 +155,7 @@ create_configs()
     echo "checkpoints=1"  >> $file_name             # Force periodic writes
     echo "compression=snappy"  >> $file_name        # We only built with snappy, force the choice
     echo "data_source=table" >> $file_name
+    echo "debug.realloc_malloc=0" >> $file_name     # WT-10111 - Not supported by older releases
     echo "huffman_key=0" >> $file_name              # WT-6893 - Not supported by newer releases
     echo "in_memory=0" >> $file_name                # Interested in the on-disk format
     echo "leak_memory=1" >> $file_name              # Faster runs


### PR DESCRIPTION
`realloc_malloc` is a `debug_mode` configuration which we do not want to backport to older release versions, I am disabling this config in compatibility testing. 