### PR TITLE
WT-9814 Generate dSYM bundles for macOS core dumps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,17 @@ if(ENABLE_SHARED)
     )
     # Set the SOVERSION property of the wiredtiger library, so we can export the appropriately versioned symlinks.
     set_target_properties(wiredtiger_shared PROPERTIES SOVERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+
+    # For MacOS builds we need to generate a dSYM bundle that contains the debug symbols for each 
+    # the WiredTiger library.
+    if (WT_DARWIN AND HAVE_DIAGNOSTIC)
+        add_custom_command(
+            TARGET wiredtiger_shared POST_BUILD
+            COMMAND dsymutil libwiredtiger.${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.dylib
+            COMMENT "Running dsymutil on libwiredtiger.${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.dylib"
+            VERBATIM
+        )
+    endif()
 endif()
 
 # Define an alias target for the WiredTiger library. This being a general target other

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,9 +211,9 @@ if(ENABLE_SHARED)
     # Set the SOVERSION property of the wiredtiger library, so we can export the appropriately versioned symlinks.
     set_target_properties(wiredtiger_shared PROPERTIES SOVERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
-    # For MacOS builds we need to generate a dSYM bundle that contains the debug symbols for each 
-    # the WiredTiger library.
-    if (WT_DARWIN AND HAVE_DIAGNOSTIC)
+    # For MacOS builds we need to generate a dSYM bundle that contains the debug symbols for the 
+    # WiredTiger library.
+    if (WT_DARWIN)
         add_custom_command(
             TARGET wiredtiger_shared POST_BUILD
             COMMAND dsymutil libwiredtiger.${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.dylib

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -37,6 +37,29 @@ function(create_test_executable target)
 
     # Define our test executable.
     add_executable(${target} ${CREATE_TEST_SOURCES})
+
+    # For MacOS builds we need to generate a dSYM bundle that contains the debug symbols for each 
+    # executable.
+    if (WT_DARWIN AND HAVE_DIAGNOSTIC)
+        if ("${CREATE_TEST_EXECUTABLE_NAME}" STREQUAL "")
+            add_custom_command(
+                TARGET ${target} POST_BUILD
+                COMMAND dsymutil ${target}
+                WORKING_DIRECTORY ${test_binary_dir}
+                COMMENT "Running dsymutil on ${target}"
+                VERBATIM
+            )
+        else()
+            add_custom_command(
+                TARGET ${target} POST_BUILD
+                COMMAND dsymutil ${CREATE_TEST_EXECUTABLE_NAME}
+                WORKING_DIRECTORY ${test_binary_dir}
+                COMMENT "Running dsymutil on ${CREATE_TEST_EXECUTABLE_NAME}"
+                VERBATIM
+            )
+        endif()
+    endif()
+
     # If we want the output binary to be a different name than the target.
     if (NOT "${CREATE_TEST_EXECUTABLE_NAME}" STREQUAL "")
         set_target_properties(${target}

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -39,25 +39,22 @@ function(create_test_executable target)
     add_executable(${target} ${CREATE_TEST_SOURCES})
 
     # For MacOS builds we need to generate a dSYM bundle that contains the debug symbols for each 
-    # executable.
-    if (WT_DARWIN AND HAVE_DIAGNOSTIC)
-        if ("${CREATE_TEST_EXECUTABLE_NAME}" STREQUAL "")
-            add_custom_command(
-                TARGET ${target} POST_BUILD
-                COMMAND dsymutil ${target}
-                WORKING_DIRECTORY ${test_binary_dir}
-                COMMENT "Running dsymutil on ${target}"
-                VERBATIM
-            )
+    # executable. The name of the binary will either be the name of the target or some other name
+    # passed to this function. We need to use the correct one for the dsymutil.
+    if (WT_DARWIN)
+        if("${CREATE_TEST_EXECUTABLE_NAME}" STREQUAL "")
+            set(test_name "${target}")
         else()
-            add_custom_command(
-                TARGET ${target} POST_BUILD
-                COMMAND dsymutil ${CREATE_TEST_EXECUTABLE_NAME}
-                WORKING_DIRECTORY ${test_binary_dir}
-                COMMENT "Running dsymutil on ${CREATE_TEST_EXECUTABLE_NAME}"
-                VERBATIM
-            )
+            set(test_name "${CREATE_TEST_EXECUTABLE_NAME}")
         endif()
+
+        add_custom_command(
+            TARGET ${target} POST_BUILD
+            COMMAND dsymutil ${test_name}
+            WORKING_DIRECTORY ${test_binary_dir}
+            COMMENT "Running dsymutil on ${test_name}"
+            VERBATIM
+        )
     endif()
 
     # If we want the output binary to be a different name than the target.


### PR DESCRIPTION
I've added cmake custom commands to the target test executables and wiredtiger shared library in order to generate dSYM bundles using the dsymutil on macOS. This provides a way to load the symbols previously missing in macOS core dumps from evergreen. 