### PR TITLE
WT-10040 - Implement unit test that can call __wt_abort without crashing

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -116,6 +116,12 @@ config_bool(
 )
 
 config_bool(
+    HAVE_UNITTEST_ASSERTS
+    "Enable C++ Catch2 based WiredTiger unit tests. Special configuration for testing assertions"
+    DEFAULT OFF
+)
+
+config_bool(
     HAVE_ATTACH
     "Enable to pause for debugger attach on failure"
     DEFAULT OFF
@@ -356,6 +362,10 @@ endif()
 
 if (NON_BARRIER_DIAGNOSTIC_YIELDS AND NOT HAVE_DIAGNOSTIC)
     message(FATAL_ERROR "`NON_BARRIER_DIAGNOSTIC_YIELDS` can only be enabled when `HAVE_DIAGNOSTIC` is enabled.")
+endif()
+
+if (HAVE_UNITTEST_ASSERTS AND NOT HAVE_UNITTEST)
+    message(FATAL_ERROR "`HAVE_UNITTEST_ASSERTS` can only be enabled when `HAVE_UNITTEST` is enabled.")
 endif()
 
 if(WT_WIN)

--- a/cmake/configs/wiredtiger_config.h.in
+++ b/cmake/configs/wiredtiger_config.h.in
@@ -42,6 +42,12 @@
 /* Define to 1 for unit tests. */
 #cmakedefine HAVE_UNITTEST 0
 
+/* 
+ * Define to 1 for unit testing assertions. 
+ * This overrides normal abort logic and should be used *only* when unit testing assertions.
+ */
+#cmakedefine HAVE_UNITTEST_ASSERTS 0
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #cmakedefine HAVE_DLFCN_H 1
 

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -180,7 +180,20 @@
 /*
  * WT_ASSERT_ALWAYS
  *  Assert an expression, abort in both diagnostic and release mode if it fails.
+ *
+ * When unit testing assertions we don't want to call __wt_abort, but we do want to track that we
+ * should have done so.
  */
+#ifdef HAVE_UNITTEST_ASSERTS
+#define WT_ASSERT_ALWAYS(session, exp, failure_reason)                                          \
+    do {                                                                                        \
+        if (!(exp)) {                                                                           \
+            WT_IGNORE_RET(__wt_snprintf((session)->unittest_assert_msg,                         \
+              WT_SESSION_UNITTEST_BUF_LEN, "Assertion '%s' failed: %s", #exp, failure_reason)); \
+            (session)->unittest_assert_hit = true;                                              \
+        }                                                                                       \
+    } while (0)
+#else
 #define WT_ASSERT_ALWAYS(session, exp, failure_reason)                             \
     do {                                                                           \
         if (!(exp)) {                                                              \
@@ -188,3 +201,4 @@
             __wt_abort(session);                                                   \
         }                                                                          \
     } while (0)
+#endif

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -186,6 +186,16 @@ struct __wt_session_impl {
     uint8_t dump_raw; /* Configure debugging page dump */
 #endif
 
+#ifdef HAVE_UNITTEST_ASSERTS
+/*
+ * Unit testing assertions requires overriding abort logic and instead capturing this information to
+ * be checked by the unit test.
+ */
+#define WT_SESSION_UNITTEST_BUF_LEN 100
+    bool unittest_assert_hit;
+    char unittest_assert_msg[WT_SESSION_UNITTEST_BUF_LEN];
+#endif
+
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_SESSION_LOCKED_CHECKPOINT 0x0001u
 #define WT_SESSION_LOCKED_HANDLE_LIST_READ 0x0002u

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2389,6 +2389,11 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     session_ret->name = NULL;
     session_ret->id = i;
 
+#ifdef HAVE_UNITTEST_ASSERTS
+    session_ret->unittest_assert_hit = false;
+    memset(session->unittest_assert_msg, 0, WT_SESSION_UNITTEST_BUF_LEN);
+#endif
+
     /*
      * Initialize the pseudo random number generator. We're not seeding it, so all of the sessions
      * initialize to the same value and proceed in lock step for the session's life. That's not a

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1176,6 +1176,21 @@ tasks:
             set -o errexit
             set -o verbose
             ${test_env_vars|} test/unittest/unittests
+
+  - name: unittest-assertions
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          HAVE_UNITTEST: -DHAVE_UNITTEST=1 -DHAVE_UNITTEST_ASSERTS=1
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build"
+          script: |
+            set -o errexit
+            set -o verbose
+            ${test_env_vars|} test/unittest/unittests
+
   # End of normal make check test tasks
 
   # Start of cppsuite test tasks.
@@ -4691,6 +4706,7 @@ buildvariants:
     - name: unit-test-long-nonstandalone
       distros: ubuntu2004-large
     - name: ".data-validation-stress-test-nonstandalone"
+    - name: unittest-assertions
 
 - name: ubuntu2004-asan
   display_name: "! Ubuntu 20.04 ASAN"

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -1,22 +1,32 @@
 project(unittest CXX)
 
+# Assertion unit tests require overriding wt_abort such that WiredTiger no longer crashes. 
+# This change will break assertions for all other testing so these tests must be run on their own.
+if(HAVE_UNITTEST_ASSERTS)
+    set(unittests tests/test_assertions.cpp)
+else()
+    set(unittests
+        tests/test_bounds_restore.cpp
+        tests/test_crc32.cpp
+        tests/test_extent_list.cpp
+        tests/test_fnv.cpp
+        tests/test_pow.cpp
+        tests/test_reconciliation_tracking.cpp
+        tests/test_tailq.cpp
+        tests/block/test_bitstring.cpp
+        tests/block/test_block_ckpt.cpp
+        tests/packing/test_intpack.cpp
+    )
+endif()
+
 set(unittest_sources
     tests/main.cpp
-    tests/test_bounds_restore.cpp
-    tests/test_crc32.cpp
-    tests/test_extent_list.cpp
-    tests/test_fnv.cpp
-    tests/test_pow.cpp
-    tests/test_reconciliation_tracking.cpp
-    tests/test_tailq.cpp
     tests/utils.cpp
-    tests/block/test_bitstring.cpp
-    tests/block/test_block_ckpt.cpp
-    tests/packing/test_intpack.cpp
     tests/wrappers/block_mods.cpp
     tests/wrappers/connection_wrapper.cpp
     tests/wrappers/mock_connection.cpp
     tests/wrappers/mock_session.cpp
+    ${unittests}
 )
 
 # Disable 4200 warning on windows, its related to struct definitions with zero sized arrays.

--- a/test/unittest/tests/test_assertions.cpp
+++ b/test/unittest/tests/test_assertions.cpp
@@ -13,7 +13,7 @@
 #include "wrappers/connection_wrapper.h"
 #include "wt_internal.h"
 
-/* Assert that a WT assertion has fired with the expected message, then clear the flag and message. */
+/* Assert that a WT assertion fired with the expected message, then clear the flag and message. */
 void
 expect_assertion(WT_SESSION_IMPL *session, std::string expected_message)
 {
@@ -36,6 +36,9 @@ TEST_CASE("Simple implementation of unit testing WT_ASSERT_ALWAYS", "[assertions
 {
     ConnectionWrapper conn(DB_HOME);
     WT_SESSION_IMPL *session = conn.createSession();
+
+    // Check that the new session has set up our test fields correctly.
+    expect_no_assertion(session);
 
     SECTION("Basic WT_ASSERT_ALWAYS tests")
     {

--- a/test/unittest/tests/test_assertions.cpp
+++ b/test/unittest/tests/test_assertions.cpp
@@ -1,0 +1,48 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "utils.h"
+#include "wiredtiger.h"
+#include "wrappers/connection_wrapper.h"
+#include "wt_internal.h"
+
+/* Assert that a WT assertion has fired with the expected message, then clear the flag and message. */
+void
+expect_assertion(WT_SESSION_IMPL *session, std::string expected_message)
+{
+    REQUIRE(session->unittest_assert_hit);
+    REQUIRE(std::string(session->unittest_assert_msg) == expected_message);
+
+    // Clear the assertion flag and message for the next test step
+    session->unittest_assert_hit = false;
+    memset(session->unittest_assert_msg, 0, WT_SESSION_UNITTEST_BUF_LEN);
+}
+
+void
+expect_no_assertion(WT_SESSION_IMPL *session)
+{
+    REQUIRE_FALSE(session->unittest_assert_hit);
+    REQUIRE(std::string(session->unittest_assert_msg).empty());
+}
+
+TEST_CASE("Simple implementation of unit testing WT_ASSERT_ALWAYS", "[assertions]")
+{
+    ConnectionWrapper conn(DB_HOME);
+    WT_SESSION_IMPL *session = conn.createSession();
+
+    SECTION("Basic WT_ASSERT_ALWAYS tests")
+    {
+        WT_ASSERT_ALWAYS(session, 1 == 2, "Values are not equal!");
+        expect_assertion(session, "Assertion '1 == 2' failed: Values are not equal!");
+
+        WT_ASSERT_ALWAYS(session, 1 == 1, "Values are not equal!");
+        expect_no_assertion(session);
+    }
+}


### PR DESCRIPTION
This is a simple unit test framework for testing that `WT_ASSERT_ALWAYS` has fired without crashing the program under test. I've only made this change for `WT_ASSERT_ALWAYS` as the other `WT_ASSERT`s are still dependent on `HAVE_DIAGNOSTIC` and we plan to remove them as part of this project.

With this change when `HAVE_UNITTEST_ASSERTS` is true we'll remove the call to `__wt_abort` and instead track that the assert has fired and the message that would be printed. We can then check these fields in the unit test.