### PR TITLE
WT-10155 Move unit-test-long-bucket04 onto a larger Evergreen distro

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2352,6 +2352,7 @@ tasks:
     patch_only: true
     depends_on:
     - name: compile
+    run_on: ubuntu2004-medium
     commands:
       - func: "fetch artifacts"
       - func: "unit test"


### PR DESCRIPTION
In [WT-10148](https://jira.mongodb.org/browse/WT-10148) we ran into a Python test failure (connection lost). As the affected test is part of our pre-merge testing (i.e. commit-queue patch builds), we'd mitigate the test failures for now by moving the "unit-test-long-bucket04" Evergreen task onto a larger instance type (proved to be effective by a patch build).