### PR TITLE
WT-10116 Return 0 timestamp for all_durable upon first open transaction

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -162,7 +162,15 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
     WT_STAT_CONN_INCR(session, txn_query_ts);
     WT_RET(__wt_config_gets(session, cfg, "get", &cval));
     if (WT_STRING_MATCH("all_durable", cval.str, cval.len)) {
-        ts = txn_global->has_durable_timestamp ? txn_global->durable_timestamp : 0;
+        /* 
+         * If there is durable timestamp set, there is nothing to return. No need to walk the 
+         * concurrent transactions.
+         */
+        if (!txn_global->has_durable_timestamp) {
+            *tsp = 0;
+            return (0);
+        }
+        ts = txn_global->durable_timestamp;
 
         __wt_readlock(session, &txn_global->rwlock);
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -162,8 +162,8 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
     WT_STAT_CONN_INCR(session, txn_query_ts);
     WT_RET(__wt_config_gets(session, cfg, "get", &cval));
     if (WT_STRING_MATCH("all_durable", cval.str, cval.len)) {
-        /* 
-         * If there is durable timestamp set, there is nothing to return. No need to walk the 
+        /*
+         * If there is durable timestamp set, there is nothing to return. No need to walk the
          * concurrent transactions.
          */
         if (!txn_global->has_durable_timestamp) {

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -167,12 +167,13 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
          * concurrent transactions.
          */
         if (!txn_global->has_durable_timestamp) {
-            *tsp = 0;
+            *tsp = WT_TS_NONE;
             return (0);
         }
-        ts = txn_global->durable_timestamp;
 
         __wt_readlock(session, &txn_global->rwlock);
+
+        ts = txn_global->durable_timestamp;
 
         /* Walk the array of concurrent transactions. */
         WT_ORDERED_READ(session_cnt, conn->session_cnt);

--- a/test/suite/test_timestamp08.py
+++ b/test/suite/test_timestamp08.py
@@ -169,6 +169,11 @@ class test_timestamp08(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.begin_transaction()
         cur1[1] = 1
         self.session.timestamp_transaction_uint(wiredtiger.WT_TS_TXN_TYPE_COMMIT, 3)
+
+        # The all_durable timestamp should return 0 if there a no transactions that have committed 
+        # yet.
+        self.assertTimestampsEqual(
+            self.conn.query_timestamp('get=all_durable'), '0')
         self.session.commit_transaction()
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=all_durable'), '3')
@@ -246,6 +251,22 @@ class test_timestamp08(wttest.WiredTigerTestCase, suite_subprocess):
         self.session.commit_transaction()
         self.assertTimestampsEqual(
             self.conn.query_timestamp('get=all_durable'), '8')
+
+        # After a checkpoint all_durable should return the checkpoint timestamp.
+        self.conn.set_timestamp('oldest_timestamp=9,stable_timestamp=9')
+        self.session.checkpoint()
+        self.reopen_conn()
+
+        self.session.begin_transaction()
+        self.session.timestamp_transaction_uint(wiredtiger.WT_TS_TXN_TYPE_COMMIT, 11)
+        
+        # Before any running transactions have committed all_durable should return the checkpoint
+        # timestamp.
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=all_durable'), self.timestamp_str(9))
+        self.session.commit_transaction()
+
+        # Now the all_durable reflect the last committed transaction.
+        self.assertTimestampsEqual(self.conn.query_timestamp('get=all_durable'), self.timestamp_str(11))
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Querying the all_durable timestamp during the first transaction of a new instance of WT would incorrectly return the commit_timestamp of that transaction. This fixes that scenario and instead returns a 0 timestamp indicating that there is no all_durable timestamp before any transaction has been committed.