### PR TITLE
WT-7492 Ignore the evict drain wait msg in stdout.txt for test_cursor_random

### DIFF
--- a/test/suite/test_cursor_random.py
+++ b/test/suite/test_cursor_random.py
@@ -110,6 +110,11 @@ class test_cursor_random(wttest.WiredTigerTestCase):
             list.append(cursor.get_key())
         self.assertGreater(len(set(list)), 80)
 
+        # Ignore the eviction generation drain warning as it is possible for eviction to
+        # take longer to evict pages due to overflow items on the page.
+        self.conn.close()
+        self.ignoreStdoutPatternIfExists('evict generation drain waited')
+
     def test_cursor_random_multiple_insert_records_small(self):
         self.cursor_random_multiple_insert_records(2000)
     def test_cursor_random_multiple_insert_records_large(self):
@@ -136,6 +141,11 @@ class test_cursor_random(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.next(), 0)
             list.append(cursor.get_key())
         self.assertGreater(len(set(list)), 80)
+
+        # Ignore the eviction generation drain warning as it is possible for eviction to
+        # take longer to evict pages due to overflow items on the page.
+        self.conn.close()
+        self.ignoreStdoutPatternIfExists('evict generation drain waited')
 
     def test_cursor_random_multiple_page_records_reopen_small(self):
         self.cursor_random_multiple_page_records(2000, True)
@@ -169,6 +179,11 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         for i in range(1,10):
             self.assertEqual(cursor.next(), 0)
 
+        # Ignore the eviction generation drain warning as it is possible for eviction to
+        # take longer to evict pages due to overflow items on the page.
+        self.conn.close()
+        self.ignoreStdoutPatternIfExists('evict generation drain waited')
+
     # Check that next_random fails in the presence of a set of values, all of
     # which are deleted.
     def test_cursor_random_deleted_all(self):
@@ -185,6 +200,11 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         cursor = ds.open_cursor(uri, None, self.config)
         for i in range(1,10):
             self.assertTrue(cursor.next(), wiredtiger.WT_NOTFOUND)
+
+        # Ignore the eviction generation drain warning as it is possible for eviction to
+        # take longer to evict pages due to overflow items on the page.
+        self.conn.close()
+        self.ignoreStdoutPatternIfExists('evict generation drain waited')
 
 # Check that opening a random cursor on column-store returns not-supported.
 class test_cursor_random_column(wttest.WiredTigerTestCase):


### PR DESCRIPTION
test_cursor_random.py fails as there is the following output in stdout.txt
`[WT_VERB_GENERATION][NOTICE]: evict generation drain waited 1 minutes `

After looking at the core and the FTDC (more explanation on the ticket), it is clear that eviction is struggling with evicting the overflow items. This is because the system is running multiple tests in parallel and is under a lot of stress. Also, as mentioned in [WT-7187](https://jira.mongodb.org/browse/WT-7187) overflow items make eviction very slow, especially on macOS platforms.

That said, the easy solution is to simply ignore the output in the stdout file that matches the following pattern:
`evict generation drain waited `