### PR TITLE
WT-10172 Tag RHEL PPC Evergreen builder on mongodb-6.1

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4500,6 +4500,7 @@ buildvariants:
   display_name: "~ Ubuntu 18.04 PPC"
   run_on:
   - ubuntu1804-power8-test
+  tags: 
   batchtime: 120 # 2 hours
   expansions:
     format_test_setting: ulimit -c unlimited
@@ -4525,6 +4526,7 @@ buildvariants:
   display_name: "~ RHEL8 PPC"
   # FIXME-WT-8981
   activate: false
+  tags: ["disabled"] # needed by periodic builds to get this builder disabled
   run_on:
   - rhel81-power8-small
   batchtime: 120 # 2 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4525,7 +4525,9 @@ buildvariants:
   display_name: "~ RHEL8 PPC"
   # FIXME-WT-8981
   activate: false
-  tags: ["disabled"] # needed by periodic builds to get this builder disabled
+  # The tasks in this buildvariant are disabled, but periodic builds don't respect the `activate: false` flag set above.
+  # Instead, configure the periodic builds to ignore buildvariants with the `disabled` tag.
+  tags: ["disabled"]
   run_on:
   - rhel81-power8-small
   batchtime: 120 # 2 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4500,7 +4500,6 @@ buildvariants:
   display_name: "~ Ubuntu 18.04 PPC"
   run_on:
   - ubuntu1804-power8-test
-  tags: 
   batchtime: 120 # 2 hours
   expansions:
     format_test_setting: ulimit -c unlimited


### PR DESCRIPTION
Tag the builder so that we can leverage the tag to disable the builder in periodic builds. 

Please note the "activate: false" setting has already been applied onto the builder, but that setting is not respected by periodic builds.