### PR TITLE
WT-10175 Update Workgen to work with the 'u' format

### DIFF
--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -958,6 +958,7 @@ ThreadRunner::op_run(Operation *op)
     uint64_t time_us;
     char buf[BUF_SIZE];
 
+    WT_CLEAR(item);
     track = NULL;
     cursor = NULL;
     recno = 0;

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1043,7 +1043,7 @@ ThreadRunner::op_run(Operation *op)
     // be retried.
     if (op->is_table_op()) {
         op->kv_gen(this, true, 100, recno, _keybuf);
-        if(std::string(cursor->key_format) == "u") {
+        if (std::string(cursor->key_format) == "u") {
             item.data = _keybuf;
             item.size = strlen(_keybuf);
             cursor->set_key(cursor, &item);
@@ -1054,7 +1054,7 @@ ThreadRunner::op_run(Operation *op)
             uint64_t compressibility =
               op->_table.options.random_value ? 0 : op->_table.options.value_compressibility;
             op->kv_gen(this, false, compressibility, recno, _valuebuf);
-            if(std::string(cursor->value_format) == "u") {
+            if (std::string(cursor->value_format) == "u") {
                 item.data = _valuebuf;
                 item.size = strlen(_valuebuf);
                 cursor->set_value(cursor, &item);

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1044,7 +1044,9 @@ ThreadRunner::op_run(Operation *op)
     // be retried.
     if (op->is_table_op()) {
         op->kv_gen(this, true, 100, recno, _keybuf);
-        if (std::string(cursor->key_format) == "u") {
+        const std::string key_format(cursor->key_format);
+        ASSERT(key_format == "u" || key_format == "S");
+        if (key_format == "u") {
             item.data = _keybuf;
             item.size = strlen(_keybuf);
             cursor->set_key(cursor, &item);
@@ -1055,7 +1057,9 @@ ThreadRunner::op_run(Operation *op)
             uint64_t compressibility =
               op->_table.options.random_value ? 0 : op->_table.options.value_compressibility;
             op->kv_gen(this, false, compressibility, recno, _valuebuf);
-            if (std::string(cursor->value_format) == "u") {
+            const std::string value_format(cursor->value_format);
+            ASSERT(value_format == "u" || value_format == "S");
+            if (value_format == "u") {
                 item.data = _valuebuf;
                 item.size = strlen(_valuebuf);
                 cursor->set_value(cursor, &item);

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1045,26 +1045,28 @@ ThreadRunner::op_run(Operation *op)
     if (op->is_table_op()) {
         op->kv_gen(this, true, 100, recno, _keybuf);
         const std::string key_format(cursor->key_format);
-        ASSERT(key_format == "u" || key_format == "S");
-        if (key_format == "u") {
+        if (key_format == "S") {
+            cursor->set_key(cursor, _keybuf);
+        } else if (key_format == "u") {
             item.data = _keybuf;
             item.size = strlen(_keybuf);
             cursor->set_key(cursor, &item);
         } else {
-            cursor->set_key(cursor, _keybuf);
+            THROW("The key format ('" << key_format << "') must be 'u' or 'S'.");
         }
         if (OP_HAS_VALUE(op)) {
             uint64_t compressibility =
               op->_table.options.random_value ? 0 : op->_table.options.value_compressibility;
             op->kv_gen(this, false, compressibility, recno, _valuebuf);
             const std::string value_format(cursor->value_format);
-            ASSERT(value_format == "u" || value_format == "S");
-            if (value_format == "u") {
+            if (value_format == "S") {
+                cursor->set_value(cursor, _valuebuf);
+            } else if (value_format == "u") {
                 item.data = _valuebuf;
                 item.size = strlen(_valuebuf);
                 cursor->set_value(cursor, &item);
             } else {
-                cursor->set_value(cursor, _valuebuf);
+                THROW("The value format ('" << value_format << "') must be 'u' or 'S'.");
             }
         }
     }


### PR DESCRIPTION
I tested the changes by replacing the key/value format to `u` in some of our existing files.
I also tested against https://github.com/wiredtiger/testy/pull/6 and it worked.