### PR TITLE
WT-10171 Fix perf_run's new improved_accuracy flag when used with batch files

### DIFF
--- a/bench/perf_run_py/perf_run.py
+++ b/bench/perf_run_py/perf_run.py
@@ -124,7 +124,7 @@ def detailed_perf_stats(config: PerfConfig, reported_stats: List[PerfStat]):
 
     return as_dict
 
-def configure_for_extra_accuracy(config: PerfConfig, arguments: List[str]):
+def configure_for_extra_accuracy(config: PerfConfig, arguments: List[str]) -> List[str]:
     """
     When the `extra_accuracy` flag is set we want to run each test multiple times to 
     ensure a more stable result. However, this can take a lot of time for longer tests 
@@ -153,6 +153,7 @@ def configure_for_extra_accuracy(config: PerfConfig, arguments: List[str]):
     if not(arguments):
         arguments = []
     arguments += [f"-o {new_run_time}"]
+    return arguments
 
 def run_test_wrapper(config: PerfConfig, index: int = 0, arguments: List[str] = None):
     for test_run in range(config.run_max):
@@ -320,13 +321,17 @@ def run_perf_tests(config: PerfConfig,
             if args.verbose:
                 print("Batch test {}: Arguments: {}, Operations: {}".
                       format(index,  content["arguments"], content["operations"]))
-                perf_stats = PerfStatCollection(content["operations"])
-                if not args.reuse:
-                    run_test_wrapper(config=config, index=index, arguments=content["arguments"])
-                reported_stats += process_results(config, perf_stats, index=index)
+            perf_stats = PerfStatCollection(content["operations"])
+            if (config.improved_accuracy):
+                arguments = configure_for_extra_accuracy(config, content["arguments"])
+            if not args.reuse:
+                run_test_wrapper(config=config, index=index, arguments=content["arguments"])
+            reported_stats += process_results(config, perf_stats, index=index)
     else:
         perf_stats = PerfStatCollection(operations)
         if not args.reuse:
+            if (config.improved_accuracy):
+                arguments = configure_for_extra_accuracy(config, arguments)
             run_test_wrapper(config=config, index=0, arguments=arguments)
         reported_stats = process_results(config, perf_stats)
 
@@ -359,8 +364,6 @@ def main():
     args = parse_args()
     (arguments, operations, config, batch_file_contents) = parse_json_args(args=args)
     validate_operations(config=config, batch_file_contents=batch_file_contents, operations=operations)
-    if (config.improved_accuracy):
-            configure_for_extra_accuracy(config, arguments)
     reported_stats = run_perf_tests(config=config,
                                     batch_file_contents=batch_file_contents,
                                     args=args,

--- a/bench/perf_run_py/perf_run.py
+++ b/bench/perf_run_py/perf_run.py
@@ -322,9 +322,9 @@ def run_perf_tests(config: PerfConfig,
                 print("Batch test {}: Arguments: {}, Operations: {}".
                       format(index,  content["arguments"], content["operations"]))
             perf_stats = PerfStatCollection(content["operations"])
-            if (config.improved_accuracy):
-                arguments = configure_for_extra_accuracy(config, content["arguments"])
             if not args.reuse:
+                if (config.improved_accuracy):
+                    arguments = configure_for_extra_accuracy(config, content["arguments"])
                 run_test_wrapper(config=config, index=index, arguments=content["arguments"])
             reported_stats += process_results(config, perf_stats, index=index)
     else:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4766,9 +4766,6 @@ tasks:
           test_name: "update-delta-mix3"
       - func: "fetch perf stats" 
         vars:
-          test_name: "multi-btree-zipfian-workload" 
-      - func: "fetch perf stats" 
-        vars:
           test_name: "evict-btree-stress-multi"
       - func: "fetch perf stats" 
         vars:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4789,9 +4789,6 @@ tasks:
       - func: "fetch perf stats" 
         vars:
           test_name: "log"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "many-dhandle-stress"
       - func: "aggregate-perf-stats" 
 
 #######################################

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4687,7 +4687,7 @@ tasks:
       - name: ".btree-perf"
       - name: ".oplog-perf !perf-test-mongodb-large-oplog"
       - name: perf-test-update-checkpoint-btree
-      - name: ".stress-perf !perf-test-many-table-stress !perf-test-many-table-stress-backup !perf-test-evict-fairness" 
+      - name: ".stress-perf !perf-test-many-table-stress !perf-test-many-table-stress-backup !perf-test-evict-fairness !perf-test-multi-btree-zipfian" 
       - name: ".evict-perf"
       - name: ".log-perf"
       - name: perf-test-long-checkpoint-stress

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -46,7 +46,10 @@ functions:
     params:
       aws_key: ${aws_key}
       aws_secret: ${aws_secret}
-      remote_file: "wiredtiger/${build_variant}/${revision}/perf-test-${test_name}-${build_id}-${execution}/evergreen_out_${test_name}.wtperf.json"
+      # Note that this path doesn't include ${execution}. This file is identical to the one 
+      # displayed on the Files page of the task, but located in a separate folder so `fetch perf stats` 
+      # can handle when a task fails and has to be restarted.
+      remote_file: "wiredtiger/${build_variant}/${revision}/perf-test-${test_name}-${build_id}/evergreen_out_${test_name}.wtperf.json"
       bucket: build_external
       local_file: "perf_stats/evergreen_out_${test_name}.wtperf.json"
   "fetch endian format artifacts" :
@@ -740,6 +743,17 @@ functions:
         permissions: public-read
         content_type: text/html
         remote_file: wiredtiger/${build_variant}/${revision}/${task_name}-${build_id}-${execution}/
+    # Also save the evergreen results to a second folder that ignores ${execution}.
+    # This allows `fetch perf stats` to work even if this task needs to be restarted.
+    - command: s3.put
+      params:
+        aws_secret: ${aws_secret}
+        aws_key: ${aws_key}
+        local_files_include_filter: wiredtiger/cmake_build/bench/wtperf/test_stats/evergreen_out_${perf-test-name}.json
+        bucket: build_external
+        permissions: public-read
+        content_type: text/html
+        remote_file: wiredtiger/${build_variant}/${revision}/${task_name}-${build_id}/
 
   "aggregate-perf-stats":
     - command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4684,9 +4684,8 @@ tasks:
 
   - name: aggregate-perf-stats
     depends_on:
-      - name: ".lsm-perf"
       - name: ".btree-perf"
-      - name: ".oplog-perf"
+      - name: ".oplog-perf !perf-test-mongodb-large-oplog"
       - name: perf-test-update-checkpoint-btree
       - name: ".stress-perf !perf-test-many-table-stress !perf-test-many-table-stress-backup !perf-test-evict-fairness" 
       - name: ".evict-perf"
@@ -4699,24 +4698,6 @@ tasks:
           shell: bash
           script: |
             mkdir perf_stats
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "small-lsm"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "medium-lsm"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "medium-lsm-compact"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "medium-multi-lsm"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "parallel-pop-lsm"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "update-lsm"
       - func: "fetch perf stats" 
         vars:
           test_name: "small-btree"
@@ -4753,9 +4734,6 @@ tasks:
       - func: "fetch perf stats" 
         vars:
           test_name: "mongodb-small-oplog"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "mongodb-large-oplog"
       - func: "fetch perf stats" 
         vars:
           test_name: "mongodb-secondary-apply"
@@ -5105,7 +5083,7 @@ buildvariants:
     - name: Wiredtiger-perf-btree-jobs
       execution_tasks:
       - ".btree-perf"
-    # Disable LSM perf tests till the support for LSM is restored.
+    # FIXME-WT-8867: Disable LSM perf tests till the support for LSM is restored.
     # - name: Wiredtiger-perf-lsm-jobs
     #   execution_tasks:
     #   - ".lsm-perf"
@@ -5155,7 +5133,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: ".btree-perf"
-    # Disable LSM perf tests till the support for LSM is restored.
+    # FIXME-WT-8867: Disable LSM perf tests till the support for LSM is restored.
     # - name: ".lsm-perf"
     - name: ".stress-perf"
     - name: ".checkpoint-perf"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4704,7 +4704,6 @@ tasks:
       - name: ".stress-perf !perf-test-many-table-stress !perf-test-many-table-stress-backup !perf-test-evict-fairness !perf-test-multi-btree-zipfian" 
       - name: ".evict-perf"
       - name: ".log-perf"
-      - name: perf-test-long-checkpoint-stress
     commands:
       - func: "get project"
       - command: shell.exec
@@ -4790,9 +4789,6 @@ tasks:
       - func: "fetch perf stats" 
         vars:
           test_name: "log"
-      - func: "fetch perf stats" 
-        vars:
-          test_name: "checkpoint-stress"
       - func: "fetch perf stats" 
         vars:
           test_name: "many-dhandle-stress"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3968,7 +3968,7 @@ tasks:
         vars:
           perf-test-name: update-btree.wtperf
           maxruns: 1
-          wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-btree.json" 
+          wtarg: "-bf ../../../bench/wtperf/runners/update-btree.json ${improved_accuracy|} " 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-btree.wtperf
@@ -4096,7 +4096,7 @@ tasks:
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
           maxruns: 1
-          wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-checkpoint.json"
+          wtarg: "-bf ../../../bench/wtperf/runners/update-checkpoint.json ${improved_accuracy|}"
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-btree.wtperf
@@ -4112,7 +4112,7 @@ tasks:
         vars:
           perf-test-name: update-checkpoint-lsm.wtperf
           maxruns: 1
-          wtarg: ${improved_accuracy|} "-bf ../../../bench/wtperf/runners/update-checkpoint.json" 
+          wtarg: "-bf ../../../bench/wtperf/runners/update-checkpoint.json ${improved_accuracy|}" 
       - func: "upload-perf-test-stats"
         vars:
           perf-test-name: update-checkpoint-lsm.wtperf


### PR DESCRIPTION
A couple of tweaks to fix the failures we're seeing in our project patch builds:
- Have `configure_for_extra_accuracy` return `arguments` rather than modify it so we're sure that the changes are sticking
- Move `configure_for_extra_accuracy` from `main` into `run_perf_tests`. When we're running tests with a batch file (via the `-bf` flag) this would overwrite the `run_time` value we set with `--improved_accuracy`
- Update the `wtarg` field in evergreen to fix a string parsing issue
- Remove some perf tests from the aggregate task. They were either disabled for the buildvariant (lsm) or unreliable (mongodb-large-oplog) 