### PR TITLE
WT-10184 Update SWIG mapping for int64_t*

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -90,6 +90,9 @@ from packing import pack, unpack
 %typemap(in, numinputs=0) wt_off_t * (wt_off_t temp = false) {
 	$1 = &temp;
 }
+%typemap(in, numinputs=0) int64_t * (int64_t temp = 0) {
+	$1 = &temp;
+}
 
 %typemap(in, numinputs=0) WT_EVENT_HANDLER * %{
 	$1 = &pyApiEventHandler;
@@ -322,11 +325,6 @@ from packing import pack, unpack
 %typemap(out) uint64_t {
 	$result = PyLong_FromUnsignedLongLong($1);
 }
-%typemap(out) int64_t {
-	$result = PyLong_FromLongLong($1);
-}
-
-%pointer_class(int64_t, int64_t_ptr);
 
 /* Internal _set_key, _set_value methods take a 'bytes' object as parameter. */
 %pybuffer_binary(unsigned char *data, int);
@@ -668,6 +666,10 @@ OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, search_near, (self))
 		data = PyBytes_FromStringAndSize(*$3, *$4);
 		$result = SWIG_Python_AppendOutput($result, data);
 	}
+}
+
+%typemap(argout) int64_t * {
+	$result = PyLong_FromLongLong(*$1);
 }
 
 /* Handle binary data input from FILE_HANDLE->fh_write. */

--- a/test/suite/test_count01.py
+++ b/test/suite/test_count01.py
@@ -38,11 +38,9 @@ class test_count01(wttest.WiredTigerTestCase):
 
     def test_count_api(self):
         self.session.create(self.uri, 'key_format=i,value_format=i')
-
-        count = wiredtiger.int64_t_ptr()
+       
         self.assertRaisesException(
-             wiredtiger.WiredTigerError, lambda: self.session.count(self.uri, count))
-        self.assertEqual(count.value(), -1)
+            wiredtiger.WiredTigerError, lambda: self.session.count(self.uri))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tested by hand that
```
count = self.session.count(self.uri)
```
works when the API returns `OK`, but because the skeleton API returns `WT_NOTFOUND` right now, it's not easily testable for now.
