### PR TITLE
WT-10192 Fix bug in cursor_prev_skip statistics

### DIFF
--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -875,9 +875,9 @@ done:
 err:
     if (total_skipped != 0) {
         if (total_skipped < 100)
-            WT_STAT_CONN_DATA_INCR(session, cursor_next_skip_lt_100);
+            WT_STAT_CONN_DATA_INCR(session, cursor_prev_skip_lt_100);
         else
-            WT_STAT_CONN_DATA_INCR(session, cursor_next_skip_ge_100);
+            WT_STAT_CONN_DATA_INCR(session, cursor_prev_skip_ge_100);
     }
 
     WT_STAT_CONN_DATA_INCRV(session, cursor_prev_skip_total, total_skipped);


### PR DESCRIPTION
Fixing a cut-and-paste error in `wt_btcur_prev()` that updated the `cursor_next_skip_*` statistics instead of the `cursor_prev_skip_*` statistics.