### PR TITLE
WT-10193 Include optional from thread_worker.h

### DIFF
--- a/test/cppsuite/src/main/thread_worker.h
+++ b/test/cppsuite/src/main/thread_worker.h
@@ -29,6 +29,7 @@
 #ifndef THREAD_WORKER_H
 #define THREAD_WORKER_H
 
+#include <optional>
 #include <string>
 
 #include "database.h"


### PR DESCRIPTION
This fixes the build with newer LLVM versions, where the compilation order seems to be different.