### PR TITLE
WT-10187 Skip core analysis when execfn field is missing

### DIFF
--- a/test/evergreen/print_stack_trace.py
+++ b/test/evergreen/print_stack_trace.py
@@ -141,6 +141,9 @@ def main():
 
         # The field of interest is execfn: '/usr/bin/python3' from the example above.
         start = output.find('execfn: ')
+        if start < 0:
+            print("The 'execfn' is missing, skipping core...")
+            continue
         # Fetch the value of execfn. This is the executable path!
         executable_path = re.search(r'\'.*?\'', output[start:]).group(0)
         executable_path = executable_path.replace("'", "")


### PR DESCRIPTION
When the `execfn` is missing, it is most likely that the core has been analyzed already.