### PR TITLE
WT-10195 Disallow doxygen v1.9.5

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -211,9 +211,9 @@ EOF
 v=$(doxygen --version)
 case "$v" in
     1.8.17) doxyfile="Doxyfile";;
-    1.9.*) doxyfile="Doxyfile.9";;
+    1.9.4) doxyfile="Doxyfile.9";;
     *)
-        echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17 or 1.9.XX"
+        echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17 or 1.9.4"
         exit 0
 esac
 

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -211,9 +211,9 @@ EOF
 v=$(doxygen --version)
 case "$v" in
     1.8.17) doxyfile="Doxyfile";;
-    1.9.4) doxyfile="Doxyfile.9";;
+    1.9.3) doxyfile="Doxyfile.9";;
     *)
-        echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17 or 1.9.4"
+        echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17 or 1.9.3"
         exit 0
 esac
 


### PR DESCRIPTION
It's currently buggy: https://github.com/doxygen/doxygen/issues/9552

This version results in the error message
```
s_all run of: "./s_docs" resulted in:
    /home/ubuntu/dev/pm-3094/wt-clean/src/include/wiredtiger.in:4018: error: WT_COLLATOR::compare has @param documentation sections but no arguments (warning treated as error, aborting now)
```

I could probably allow anything from v1.9 except 1.9.5, but we have a whitelist mechanism already so it was simpler to use that. Let me know if you disagree with this call. I believe our CI is currently running v1.8.17, so that should be fine.