### PR TITLE
WT-10080 Add a log after validating a collection in the cpp suite

### DIFF
--- a/test/cppsuite/src/main/validator.cpp
+++ b/test/cppsuite/src/main/validator.cpp
@@ -136,6 +136,9 @@ validator::validate(
              */
             verify_collection(session, current_collection_id, current_collection_records);
 
+            logger::log_msg(
+              LOG_INFO, "Verified collection {" + std::to_string(current_collection_id) + "}.");
+
             /* Begin processing the next collection. */
             current_collection_id = tracked_collection_id;
             current_collection_records.clear();


### PR DESCRIPTION
Some of the cppsuite stress tests were timing out as a result of the logs not being properly flushed and validation taking a long time. Adding this extra log message once a collection is validated should help stop evergreen from timing out during the validation stage. If further timeouts persist we may need to consider increasing the timeout in evergreen.