### PR TITLE
WT-9831 Add tests to new variant Amazon Linux 2

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5368,6 +5368,9 @@ buildvariants:
     - name: wtperf-test
     - name: ftruncate-test
     - name: long-test
-    - name: configure-combinations
-    - name: format-smoke-test
-    - name: tiered-storage-extensions-test
+    # FIXME-WT-10212
+    # - name: configure-combinations
+    # FIXME-WT-10214
+    # - name: format-smoke-test
+    # FIXME-WT-10213
+    # - name: tiered-storage-extensions-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5346,12 +5346,14 @@ buildvariants:
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
-      LD_LIBRARY_PATH=$WT_BUILDDIR
+      LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib
+      LD_PRELOAD=$WT_TOPDIR/TCMALLOC_LIB/lib/libtcmalloc.so
     CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: "Unix Makefiles"
     make_command: make
+    CMAKE_PREFIX_PATH: -DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"
   tasks:
     - name: compile
     - name: make-check-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5361,8 +5361,7 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: unit-test-zstd
     - name: unit-test-long
-      run_on:
-      - amazon2-arm64-large
+      distros: amazon2-arm64-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
     - name: wtperf-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5374,3 +5374,8 @@ buildvariants:
     # - name: format-smoke-test
     # FIXME-WT-10213
     # - name: tiered-storage-extensions-test
+    - name: compile-nonstandalone
+    - name: make-check-nonstandalone
+    - name: unit-test-nonstandalone
+    - name: unit-test-long-nonstandalone
+      distros: amazon2-arm64-large

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5334,3 +5334,40 @@ buildvariants:
     - name: unit-test-nonstandalone
     - name: unit-test-long-nonstandalone
       distros: ubuntu2004-arm64-large
+
+- name: amazon2-arm64
+  display_name: "~ Amazon Linux 2 ARM64"
+  run_on:
+  - amazon2-arm64-small
+  batchtime: 1440 # 24 hours
+  expansions:
+    configure_env_vars:
+      PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+    test_env_vars:
+      WT_TOPDIR=$(git rev-parse --show-toplevel)
+      WT_BUILDDIR=$WT_TOPDIR/cmake_build
+      LD_LIBRARY_PATH=$WT_BUILDDIR
+    CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL
+    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
+    cmake_generator: "Unix Makefiles"
+    make_command: make
+  tasks:
+    - name: compile
+    - name: make-check-test
+    - name: unit-test
+    - name: fops
+    - name: linux-directio
+    - name: checkpoint-filetypes-test
+    - name: unit-test-zstd
+    - name: unit-test-long
+      run_on:
+      - amazon2-arm64-large
+    - name: spinlock-gcc-test
+    - name: spinlock-pthread-adaptive-test
+    - name: wtperf-test
+    - name: ftruncate-test
+    - name: long-test
+    - name: configure-combinations
+    - name: format-smoke-test
+    - name: tiered-storage-extensions-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5336,7 +5336,7 @@ buildvariants:
       distros: ubuntu2004-arm64-large
 
 - name: amazon2-arm64
-  display_name: "~ Amazon Linux 2 ARM64"
+  display_name: "Amazon Linux 2 ARM64"
   run_on:
   - amazon2-arm64-small
   batchtime: 1440 # 24 hours

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -12,7 +12,7 @@ CMAKE_VERSION=$CMAKE_MAJOR_VER.$CMAKE_MINOR_VER.$CMAKE_PATCH_VER
 #   https://github.com/mongodb/mongo-c-driver/blob/master/.evergreen/find-cmake.sh
 find_cmake ()
 {
-    if [ ! -z "$CMAKE" ]; then
+    if [ -n "$CMAKE" ]; then
         return 0
     elif [ -f "/Applications/CMake.app/Contents/bin/cmake" ]; then
         CMAKE="/Applications/CMake.app/Contents/bin/cmake"

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -20,6 +20,10 @@ find_cmake ()
     elif [ -f "/opt/cmake/bin/cmake" ]; then
         CMAKE="/opt/cmake/bin/cmake"
         CTEST="/opt/cmake/bin/ctest"
+    # Newer package system can be kept separate from the older "cmake".
+    elif [ -f "/usr/bin/cmake3" ]; then
+        CMAKE=/usr/bin/cmake3
+        CTEST=/usr/bin/ctest3
     elif command -v cmake 2>/dev/null; then
         CMAKE=cmake
         CTEST=ctest


### PR DESCRIPTION
Added a new variant `amazon2-arm64`
The new variant contains the same tests as `ubuntu2004-arm64`.
There are failing tests, tickets have been created to address them. Until then, they are disabled.