### PR TITLE
WT-10044 Remove HAVE_DIAGNOSTIC ifdefs that break WT_ASSERT

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -572,11 +572,7 @@ __cursor_row_search(WT_CURSOR_BTREE *cbt, bool insert, WT_REF *leaf, bool *leaf_
 static inline int
 __cursor_col_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, u_int modify_type)
 {
-#ifdef HAVE_DIAGNOSTIC
     return (__wt_col_modify(cbt, cbt->iface.recno, value, NULL, modify_type, false, false));
-#else
-    return (__wt_col_modify(cbt, cbt->iface.recno, value, NULL, modify_type, false));
-#endif
 }
 
 /*
@@ -586,11 +582,7 @@ __cursor_col_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, u_int modify_typ
 static inline int
 __cursor_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, u_int modify_type)
 {
-#ifdef HAVE_DIAGNOSTIC
     return (__wt_row_modify(cbt, &cbt->iface.key, value, NULL, modify_type, false, false));
-#else
-    return (__wt_row_modify(cbt, &cbt->iface.key, value, NULL, modify_type, false));
-#endif
 }
 
 /*

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -523,11 +523,7 @@ __instantiate_col_var(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_DELETED *pa
                 WT_ASSERT(session, cbt.slot == WT_COL_SLOT(page, cip));
 
                 /* Attach the tombstone, using the update-restore path. */
-#ifdef HAVE_DIAGNOSTIC
                 WT_ERR(__wt_col_modify(&cbt, recno + j, NULL, upd, WT_UPDATE_INVALID, true, true));
-#else
-                WT_ERR(__wt_col_modify(&cbt, recno + j, NULL, upd, WT_UPDATE_INVALID, true));
-#endif
                 /* Null the pointer so we don't free it twice. */
                 upd = NULL;
             }

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -31,6 +31,7 @@ __wt_ref_out(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     WT_ASSERT(session, S2BT(session)->evict_ref != ref);
 
+#ifdef HAVE_DIAGNOSTIC
     /*
      * Make sure no other thread has a hazard pointer on the page we are about to discard. This is
      * complicated by the fact that readers publish their hazard pointer before re-checking the page
@@ -38,6 +39,7 @@ __wt_ref_out(WT_SESSION_IMPL *session, WT_REF *ref)
      * hazard pointer, wait for it to be cleared.
      */
     WT_ASSERT(session, __wt_hazard_check_assert(session, ref, true));
+#endif
 
     /* Check we are not evicting an accessible internal page with an active split generation. */
     WT_ASSERT(session,
@@ -347,11 +349,13 @@ __wt_free_ref_index(WT_SESSION_IMPL *session, WT_PAGE *page, WT_PAGE_INDEX *pind
     for (i = 0; i < pindex->entries; ++i) {
         ref = pindex->index[i];
 
+#ifdef HAVE_DIAGNOSTIC
         /*
          * Used when unrolling splits and other error paths where there should never have been a
          * hazard pointer taken.
          */
         WT_ASSERT(session, __wt_hazard_check_assert(session, ref, false));
+#endif
 
         __wt_free_ref(session, ref, page->type, free_pages);
     }

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -201,11 +201,7 @@ __page_inmem_prepare_update_col(WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR
 
     /* Search the page and apply the modification. */
     WT_RET(__wt_col_search(cbt, recno, ref, true, NULL));
-#ifdef HAVE_DIAGNOSTIC
     WT_RET(__wt_col_modify(cbt, recno, NULL, *updp, WT_UPDATE_INVALID, true, true));
-#else
-    WT_RET(__wt_col_modify(cbt, recno, NULL, *updp, WT_UPDATE_INVALID, true));
-#endif
     return (0);
 }
 
@@ -311,11 +307,7 @@ __wt_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
 
             /* Search the page and apply the modification. */
             WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
-#ifdef HAVE_DIAGNOSTIC
             WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true, true));
-#else
-            WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
-#endif
             upd = NULL;
         }
     }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1498,11 +1498,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             WT_ERR(__wt_col_search(&cbt, recno, ref, true, NULL));
 
             /* Apply the modification. */
-#ifdef HAVE_DIAGNOSTIC
             WT_ERR(__wt_col_modify(&cbt, recno, NULL, upd, WT_UPDATE_INVALID, true, true));
-#else
-            WT_ERR(__wt_col_modify(&cbt, recno, NULL, upd, WT_UPDATE_INVALID, true));
-#endif
             break;
         case WT_PAGE_ROW_LEAF:
             /* Build a key. */
@@ -1517,11 +1513,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
 
             /* Apply the modification. */
-#ifdef HAVE_DIAGNOSTIC
             WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true, true));
-#else
-            WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
-#endif
             break;
         default:
             WT_ERR(__wt_illegal_value(session, orig->type));

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -16,12 +16,7 @@ static int __col_insert_alloc(WT_SESSION_IMPL *, uint64_t, u_int, WT_INSERT **, 
  */
 int
 __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_UPDATE *upd_arg,
-  u_int modify_type, bool exclusive
-#ifdef HAVE_DIAGNOSTIC
-  ,
-  bool restore
-#endif
-)
+  u_int modify_type, bool exclusive, bool restore)
 {
     WT_BTREE *btree;
     WT_DECL_RET;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -42,12 +42,7 @@ err:
  */
 int
 __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, WT_UPDATE *upd_arg,
-  u_int modify_type, bool exclusive
-#ifdef HAVE_DIAGNOSTIC
-  ,
-  bool restore
-#endif
-)
+  u_int modify_type, bool exclusive, bool restore)
 {
     WT_DECL_RET;
     WT_INSERT *ins;

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -25,14 +25,9 @@ __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
      * We don't have exclusive access to the history store page so we need to pass "false" here to
      * ensure that we're locking when inserting new keys to an insert list.
      */
-#ifdef HAVE_DIAGNOSTIC
     WT_WITH_BTREE(CUR2S(hs_cbt), CUR2BT(hs_cbt),
       ret =
         __wt_row_modify(hs_cbt, &hs_cbt->iface.key, NULL, hs_upd, WT_UPDATE_INVALID, false, false));
-#else
-    WT_WITH_BTREE(CUR2S(hs_cbt), CUR2BT(hs_cbt),
-      ret = __wt_row_modify(hs_cbt, &hs_cbt->iface.key, NULL, hs_upd, WT_UPDATE_INVALID, false));
-#endif
     return (ret);
 }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -394,12 +394,8 @@ extern int __wt_clsm_request_switch(WT_CURSOR_LSM *clsm)
 extern int __wt_col_fix_read_auxheader(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,
   WT_COL_FIX_AUXILIARY_HEADER *auxhdr) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value,
-  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive
-#ifdef HAVE_DIAGNOSTIC
-  ,
-  bool restore
-#endif
-  ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive, bool restore)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_col_search(WT_CURSOR_BTREE *cbt, uint64_t search_recno, WT_REF *leaf,
   bool leaf_safe, bool *leaf_foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_collator_config(WT_SESSION_IMPL *session, const char *uri, WT_CONFIG_ITEM *cname,
@@ -1305,12 +1301,8 @@ extern int __wt_row_leaf_key_copy(WT_SESSION_IMPL *session, WT_PAGE *page, WT_RO
 extern int __wt_row_leaf_key_work(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip_arg,
   WT_ITEM *keyb, bool instantiate) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
-  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive
-#ifdef HAVE_DIAGNOSTIC
-  ,
-  bool restore
-#endif
-  ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive, bool restore)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_search(WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key, bool insert, WT_REF *leaf,
   bool leaf_safe, bool *leaf_foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rts_btree_abort_updates(WT_SESSION_IMPL *session, WT_REF *ref,

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -379,7 +379,6 @@ __wt_col_fix_estimate_auxiliary_space(WT_PAGE *page)
     return (count * 63 + WT_COL_FIX_AUXHEADER_RESERVATION);
 }
 
-#ifdef HAVE_DIAGNOSTIC
 /*
  * __rec_col_fix_get_bitmap_size --
  *     Figure the bitmap size of a new page from the reconciliation info.
@@ -395,7 +394,6 @@ __rec_col_fix_get_bitmap_size(WT_SESSION_IMPL *session, WT_RECONCILE *r)
     /* Subtract off the main page header. */
     return (primary_size - WT_PAGE_HEADER_BYTE_SIZE(S2BT(session)));
 }
-#endif
 
 /*
  * __wt_rec_col_fix_addtw --

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -183,11 +183,7 @@ __rts_btree_col_modify(WT_SESSION_IMPL *session, WT_REF *ref, WT_UPDATE *upd, ui
     WT_ERR(__wt_col_search(&cbt, recno, ref, true, NULL));
 
     /* Apply the modification. */
-#ifdef HAVE_DIAGNOSTIC
     WT_ERR(__wt_col_modify(&cbt, recno, NULL, upd, WT_UPDATE_INVALID, true, false));
-#else
-    WT_ERR(__wt_col_modify(&cbt, recno, NULL, upd, WT_UPDATE_INVALID, true));
-#endif
 
 err:
     /* Free any resources that may have been cached in the cursor. */
@@ -213,11 +209,7 @@ __rts_btree_row_modify(WT_SESSION_IMPL *session, WT_REF *ref, WT_UPDATE *upd, WT
     WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
 
     /* Apply the modification. */
-#ifdef HAVE_DIAGNOSTIC
     WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true, false));
-#else
-    WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true));
-#endif
 
 err:
     /* Free any resources that may have been cached in the cursor. */

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -244,10 +244,8 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
     uint8_t type;
     char ts_string[4][WT_TS_INT_STRING_SIZE];
     char tw_string[WT_TIME_STRING_SIZE];
-    bool valid_update_found;
-#ifdef HAVE_DIAGNOSTIC
     bool first_record;
-#endif
+    bool valid_update_found;
 
     page = ref->page;
 
@@ -256,9 +254,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
     hs_durable_ts = hs_start_ts = hs_stop_durable_ts = WT_TS_NONE;
     hs_btree_id = S2BT(session)->id;
     valid_update_found = false;
-#ifdef HAVE_DIAGNOSTIC
     first_record = true;
-#endif
 
     /* Allocate buffers for the data store and history store key. */
     WT_ERR(__wt_scr_alloc(session, 0, &hs_key));
@@ -444,9 +440,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
          * stop time point as a tombstone when we rollback the history store record.
          */
         newer_hs_durable_ts = hs_durable_ts;
-#ifdef HAVE_DIAGNOSTIC
         first_record = false;
-#endif
 
         WT_ERR(hs_cursor->remove(hs_cursor));
         WT_STAT_CONN_DATA_INCR(session, txn_rts_hs_removed);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -56,8 +56,8 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
 {
     WT_CURSOR *cursor, *cursor_tmp;
     WT_CURSOR_LIST *cached_list;
-    WT_DECL_RET;
     WT_DATA_HANDLE *saved_dhandle;
+    WT_DECL_RET;
     uint64_t now;
     uint32_t position;
     int i, t_ret, nbuckets, nexamined, nclosed;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -57,9 +57,7 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
     WT_CURSOR *cursor, *cursor_tmp;
     WT_CURSOR_LIST *cached_list;
     WT_DECL_RET;
-#ifdef HAVE_DIAGNOSTIC
     WT_DATA_HANDLE *saved_dhandle;
-#endif
     uint64_t now;
     uint32_t position;
     int i, t_ret, nbuckets, nexamined, nclosed;
@@ -79,9 +77,7 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
     position = session->cursor_sweep_position;
     productive = true;
     nbuckets = nexamined = nclosed = 0;
-#ifdef HAVE_DIAGNOSTIC
     saved_dhandle = session->dhandle;
-#endif
 
     /* Turn off caching so that cursor close doesn't try to cache. */
     F_CLR(session, WT_SESSION_CACHE_CURSORS);

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -464,7 +464,6 @@ __wt_writeunlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_DIAGNOSTIC_YIELD;
 }
 
-#ifdef HAVE_DIAGNOSTIC
 /*
  * __wt_rwlock_islocked --
  *     Return if a read/write lock is currently locked for reading or writing.
@@ -479,4 +478,3 @@ __wt_rwlock_islocked(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     old.u.v = l->u.v;
     return (old.u.s.current != old.u.s.next || old.u.s.readers_active != 0);
 }
-#endif

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1071,17 +1071,10 @@ __txn_append_tombstone(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_CURSOR_BTREE 
     btree = S2BT(session);
 
     WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &not_used));
-#ifdef HAVE_DIAGNOSTIC
     WT_WITH_BTREE(session, op->btree,
       ret = btree->type == BTREE_ROW ?
         __wt_row_modify(cbt, &cbt->iface.key, NULL, tombstone, WT_UPDATE_INVALID, false, false) :
         __wt_col_modify(cbt, cbt->recno, NULL, tombstone, WT_UPDATE_INVALID, false, false));
-#else
-    WT_WITH_BTREE(session, op->btree,
-      ret = btree->type == BTREE_ROW ?
-        __wt_row_modify(cbt, &cbt->iface.key, NULL, tombstone, WT_UPDATE_INVALID, false) :
-        __wt_col_modify(cbt, cbt->recno, NULL, tombstone, WT_UPDATE_INVALID, false));
-#endif
     WT_ERR(ret);
     tombstone = NULL;
 


### PR DESCRIPTION
Continuation of WT-10043. Now that WT_ASSERTs can run in release mode there are some variables requires by these asserts that should no longer be hidden behind `#ifdef HAVE_DIAGNOSTIC`. 
The one exception to this is the assertions of `__wt_hazard_check_assert`, these assertions are now hidden behind an `#ifdef` as they are only applicable when `HAVE_DIAGNOSTIC=1`.

This PR is currently targeting the WT-10043 branch so we can see only the WT-10044 diffs. Once WT-10043 is merged into pm-2897 this PR will immediately follow.