### PR TITLE
WT-9117 Revert

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -263,13 +263,8 @@ config_table(TABLE *table, void *arg)
      * direct I/O can be so slow the additional I/O for overflow items causes eviction to stall).
      */
     if (GV(RUNS_IN_MEMORY) || GV(DISK_DIRECT_IO)) {
-        if (TV(RUNS_ROWS) > 1000000) {
-            if (GV(RUNS_IN_MEMORY) && !config_explicit(table, "runs.in_memory")) {
-                WARN("%s", "correcting runs.rows value to 1000000 as runs.in_memory=1");
-                config_single(table, "runs.rows=1000000", false);
-            } else if (!config_explicit(table, "runs.rows"))
-                config_single(table, "runs.rows=1000000", false);
-        }
+        if (!config_explicit(table, "runs.rows") && TV(RUNS_ROWS) > 1000000)
+            config_single(table, "runs.rows=1000000", false);
         if (!config_explicit(table, "btree.key_max"))
             config_single(table, "btree.key_max=32", false);
         if (!config_explicit(table, "btree.key_min"))


### PR DESCRIPTION
Revert WT-9117: Restrict in memory rows count to 1 million if in memory was not explicit (#8531)

This reverts commit 6fddc2ea2b9c07b3a0e7dbdb51f46d601ee32ca0.