### PR TITLE
WT-10245 Check output of Workgen and Wtperf workloads

### DIFF
--- a/bench/workgen/runner/compress_ratio.py
+++ b/bench/workgen/runner/compress_ratio.py
@@ -113,7 +113,8 @@ ins_ops = operations(Operation.OP_INSERT, tables, Key(Key.KEYGEN_APPEND, 20), Va
 thread = Thread(ins_ops * icount)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 ins_ops = operations(Operation.OP_INSERT, tables, Key(Key.KEYGEN_APPEND, 20), Value(500), 0)
 upd_ops = operations(Operation.OP_UPDATE, tables, Key(Key.KEYGEN_UNIFORM, 20), Value(500), 0)
@@ -131,4 +132,5 @@ workload.options.report_interval = 1
 workload.options.sample_interval = 1
 workload.options.sample_rate = 1
 print('Update heavy workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret

--- a/bench/workgen/runner/compress_ratio.py
+++ b/bench/workgen/runner/compress_ratio.py
@@ -101,7 +101,7 @@ conn = context.wiredtiger_open(conn_config)
 s = conn.open_session()
 
 tables = []
-for name_ext, compress_config in compression_opts.iteritems():
+for name_ext, compress_config in compression_opts.items():
     tname = "table:test_" + name_ext
     s.create(tname, 'key_format=S,value_format=S,' + table_config + "," + compress_config)
     table = Table(tname)
@@ -129,7 +129,7 @@ threads = ins_thread * 2 + upd_thread * 10
 workload = Workload(context, threads)
 workload.options.run_time = 60
 workload.options.report_interval = 1
-workload.options.sample_interval = 1
+workload.options.sample_interval_ms = 1000
 workload.options.sample_rate = 1
 print('Update heavy workload:')
 ret = workload.run(conn)

--- a/bench/workgen/runner/evict-btree-hs.py
+++ b/bench/workgen/runner/evict-btree-hs.py
@@ -110,7 +110,8 @@ pop_ops = op_multi_table(pop_ops, tables)
 nops_per_thread = icount // (populate_threads * table_count)
 pop_thread = Thread(pop_ops * nops_per_thread)
 pop_workload = Workload(context, populate_threads * pop_thread)
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 # Log like file, requires that logging be enabled in the connection config.
 log_name = "table:log"
@@ -158,7 +159,8 @@ workload = Workload(context, 400 * thread0 + 100 * thread1 +\
 workload.options.report_interval=5
 workload.options.run_time=500
 workload.options.max_latency=50000
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = homedir + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/evict-btree-hs.py
+++ b/bench/workgen/runner/evict-btree-hs.py
@@ -162,6 +162,6 @@ workload.options.max_latency=50000
 ret = workload.run(conn)
 assert ret == 0, ret
 
-latency_filename = homedir + "/latency.out"
+latency_filename = os.path.join(context.args.home, "latency.out")
 latency.workload_latency(workload, latency_filename)
 conn.close()

--- a/bench/workgen/runner/example_prepare.py
+++ b/bench/workgen/runner/example_prepare.py
@@ -48,7 +48,8 @@ op = Operation(Operation.OP_INSERT, table)
 thread = Thread(op * 5000)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 opread = Operation(Operation.OP_SEARCH, table)
 read_txn = txn(opread * 5, 'read_timestamp')
@@ -82,7 +83,8 @@ workload.options.stable_timestamp_lag=10
 # timestamp_advance is the number of seconds to wait before moving oldest and stable timestamp.
 workload.options.timestamp_advance=1
 print('transactional prepare workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 end_time = time.time()
 run_time = end_time - start_time

--- a/bench/workgen/runner/example_simple.py
+++ b/bench/workgen/runner/example_simple.py
@@ -61,10 +61,12 @@ s.create(tname, 'key_format=S,value_format=S')
 ops = Operation(Operation.OP_INSERT, Table(tname), Key(Key.KEYGEN_APPEND, 10), Value(40))
 thread = Thread(ops)
 workload = Workload(context, thread)
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 show(tname, s, context.args)
 
 thread = Thread(ops * 5)
 workload = Workload(context, thread)
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 show(tname, s, context.args)

--- a/bench/workgen/runner/example_txn.py
+++ b/bench/workgen/runner/example_txn.py
@@ -44,7 +44,8 @@ op = Operation(Operation.OP_INSERT, table)
 thread = Thread(op * 500000)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 opread = Operation(Operation.OP_SEARCH, table)
 opwrite = Operation(Operation.OP_INSERT, table)
@@ -54,4 +55,5 @@ workload = Workload(context, treader * 8 + twriter * 2)
 workload.options.run_time = 10
 workload.options.report_interval = 5
 print('transactional write workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret

--- a/bench/workgen/runner/insert_stress.py
+++ b/bench/workgen/runner/insert_stress.py
@@ -48,7 +48,8 @@ op = Operation(Operation.OP_INSERT, table)
 thread = Thread(op * 500)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 op = Operation(Operation.OP_INSERT, table, Key(Key.KEYGEN_UNIFORM, 10), Value(130 * 1024))
 op2 = Operation(Operation.OP_INSERT, table, Key(Key.KEYGEN_UNIFORM, 10), Value(100))
@@ -63,4 +64,5 @@ workload = Workload(context, t * 8 + read_thread)
 workload.options.run_time = 240
 workload.options.report_interval = 5
 print('workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret

--- a/bench/workgen/runner/insert_test.py
+++ b/bench/workgen/runner/insert_test.py
@@ -66,7 +66,8 @@ ops = Operation(Operation.OP_INSERT, Table(tname0), Key(Key.KEYGEN_APPEND, 10), 
 workload = Workload(context, Thread(ops))
 
 print('RUN1')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 show(tname0)
 
 # The context has memory of how many keys are in all the tables.
@@ -83,7 +84,8 @@ print('multiplying op is: ' + str(o))
 thread0 = Thread(o + op + op)
 workload = Workload(context, thread0)
 print('RUN2')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 show(tname0)
 show(tname1)
 
@@ -97,7 +99,8 @@ op += Operation(Operation.OP_INSERT, Table(tname0), Key(Key.KEYGEN_APPEND, 10), 
 thread0 = Thread(op * 10 + op2 * 20)
 workload = Workload(context, thread0)
 print('RUN3')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 show(tname0)
 show(tname1)
 

--- a/bench/workgen/runner/maintain_low_dirty_cache.py
+++ b/bench/workgen/runner/maintain_low_dirty_cache.py
@@ -98,7 +98,8 @@ ins_ops = operations(Operation.OP_INSERT, tables, Key(Key.KEYGEN_APPEND, 20), Va
 thread = Thread(ins_ops * icount)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 ins_ops = operations(Operation.OP_INSERT, tables, Key(Key.KEYGEN_APPEND, 20), Value(500), 0, logtable)
 upd_ops = operations(Operation.OP_UPDATE, tables, Key(Key.KEYGEN_UNIFORM, 20), Value(500), 0, logtable)
@@ -120,7 +121,8 @@ workload.options.report_interval = 1
 workload.options.sample_interval = 5
 workload.options.sample_rate = 1
 print('heavy stress workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = conn.get_home() + '/latency.out'
 print('for latency output, see: ' + latency_filename)

--- a/bench/workgen/runner/maintain_low_dirty_cache.py
+++ b/bench/workgen/runner/maintain_low_dirty_cache.py
@@ -80,7 +80,6 @@ def operations(optype, tables, key, value = None, ops_per_txn = 0, logtable = No
 context = Context()
 conn_config="create,cache_size=2GB,session_max=1000,eviction=(threads_min=4,threads_max=8),log=(enabled=false),transaction_sync=(enabled=false),checkpoint_sync=true,checkpoint=(wait=8),statistics=(fast),statistics_log=(json,wait=1)"
 table_config="allocation_size=4k,memory_page_max=10MB,prefix_compression=false,split_pct=90,leaf_page_max=32k,internal_page_max=16k,type=file,block_compressor=snappy"
-conn_config += extensions_config(['compressors/snappy'])
 conn = context.wiredtiger_open(conn_config)
 s = conn.open_session()
 
@@ -118,7 +117,7 @@ threads = ins_thread * 4 + upd_thread * 9 + read_thread * 90
 workload = Workload(context, threads)
 workload.options.run_time = 1200
 workload.options.report_interval = 1
-workload.options.sample_interval = 5
+workload.options.sample_interval_ms = 5000
 workload.options.sample_rate = 1
 print('heavy stress workload:')
 ret = workload.run(conn)

--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -94,7 +94,8 @@ pop_ops = Operation(Operation.OP_INSERT, tables[0])
 pop_ops = op_populate_with_range(pop_ops, tables, icount, random_range, populate_threads)
 pop_thread = Thread(pop_ops)
 pop_workload = Workload(context, populate_threads * pop_thread)
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 ops = Operation(Operation.OP_INSERT, tables[0], Key(Key.KEYGEN_PARETO, 0, ParetoOptions(10)))
 # Updated the range_partition to False, because workgen has some issues with range_partition true.
@@ -121,7 +122,8 @@ workload.options.sample_interval_ms = 5000
 # Uncomment to fail instead of generating a warning
 # workload.options.max_idle_table_cycle_fatal = True
 workload.options.max_idle_table_cycle = 2
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/multi_btree_heavy_stress.py
+++ b/bench/workgen/runner/multi_btree_heavy_stress.py
@@ -99,7 +99,8 @@ ins_ops = operations(Operation.OP_INSERT, tables, Key(Key.KEYGEN_APPEND, 20), Va
 thread = Thread(ins_ops * icount)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 ins_ops = operations(Operation.OP_INSERT, tables, Key(Key.KEYGEN_APPEND, 20), Value(500), 0, logtable)
 upd_ops = operations(Operation.OP_UPDATE, tables, Key(Key.KEYGEN_UNIFORM, 20), Value(500), 0, logtable)
@@ -123,7 +124,8 @@ workload.options.report_interval = 1
 workload.options.sample_interval = 5
 workload.options.sample_rate = 1
 print('heavy stress workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = conn.get_home() + '/latency.out'
 print('for latency output, see: ' + latency_filename)

--- a/bench/workgen/runner/multi_btree_heavy_stress.py
+++ b/bench/workgen/runner/multi_btree_heavy_stress.py
@@ -79,7 +79,6 @@ context = Context()
 ## cache_size=20GB
 conn_config="create,cache_size=1GB,session_max=1000,eviction=(threads_min=4,threads_max=8),log=(enabled=false),transaction_sync=(enabled=false),checkpoint_sync=true,checkpoint=(wait=60),statistics=(fast),statistics_log=(json,wait=1)"
 table_config="allocation_size=4k,memory_page_max=10MB,prefix_compression=false,split_pct=90,leaf_page_max=32k,internal_page_max=16k,type=file,block_compressor=snappy"
-conn_config += extensions_config(['compressors/snappy'])
 conn = context.wiredtiger_open(conn_config)
 s = conn.open_session()
 
@@ -121,7 +120,7 @@ workload = Workload(context, threads)
 ##workload.options.run_time = 3600
 workload.options.run_time = 30
 workload.options.report_interval = 1
-workload.options.sample_interval = 5
+workload.options.sample_interval_ms = 5000
 workload.options.sample_rate = 1
 print('heavy stress workload:')
 ret = workload.run(conn)

--- a/bench/workgen/runner/multiversion.py
+++ b/bench/workgen/runner/multiversion.py
@@ -62,10 +62,12 @@ s.create(tname, 'key_format=S,value_format=S')
 ops = Operation(Operation.OP_INSERT, Table(tname), Key(Key.KEYGEN_APPEND, 10), Value(40))
 thread = Thread(ops)
 workload = Workload(context, thread)
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 show(tname, s)
 
 thread = Thread(ops * 5)
 workload = Workload(context, thread)
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 show(tname, s)

--- a/bench/workgen/runner/prepare_stress.py
+++ b/bench/workgen/runner/prepare_stress.py
@@ -115,7 +115,8 @@ nops_per_thread = icount // (populate_threads * table_count)
 pop_thread = Thread(pop_ops * nops_per_thread)
 pop_thread.options.session_config="isolation=snapshot"
 pop_workload = Workload(context, populate_threads * pop_thread)
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 # Log like file, requires that logging be enabled in the connection config.
 log_name = "table:log"
@@ -187,7 +188,8 @@ workload.options.oldest_timestamp_lag=30
 workload.options.stable_timestamp_lag=10
 # timestamp_advance is the number of seconds to wait before moving oldest and stable timestamp.
 workload.options.timestamp_advance=1
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 end_time = time.time()
 run_time = end_time - start_time

--- a/bench/workgen/runner/read_write_storms.py
+++ b/bench/workgen/runner/read_write_storms.py
@@ -65,7 +65,8 @@ pop_ops = op_multi_table(pop_ops, tables)
 nops_per_thread = icount // (populate_threads * table_count)
 pop_thread = Thread(pop_ops * nops_per_thread)
 pop_workload = Workload(context, populate_threads * pop_thread)
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 print('populate complete')
 
 # Log like file, requires that logging be enabled in the connection config.
@@ -138,7 +139,8 @@ workload.options.run_time=900
 workload.options.sample_rate=1
 workload.options.warmup=0
 workload.options.sample_interval_ms = 1000
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/read_write_sync_long.py
+++ b/bench/workgen/runner/read_write_sync_long.py
@@ -66,7 +66,8 @@ pop_ops = op_multi_table(pop_ops, tables)
 nops_per_thread = icount // (populate_threads * table_count)
 pop_thread = Thread(pop_ops * nops_per_thread)
 pop_workload = Workload(context, populate_threads * pop_thread)
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 print('populate complete')
 
 # Log like file, requires that logging be enabled in the connection config.
@@ -130,7 +131,8 @@ workload.options.run_time=1800
 workload.options.sample_rate=1
 workload.options.warmup=0
 workload.options.sample_interval_ms = 1000
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/read_write_sync_short.py
+++ b/bench/workgen/runner/read_write_sync_short.py
@@ -66,7 +66,8 @@ pop_ops = op_multi_table(pop_ops, tables)
 nops_per_thread = icount // (populate_threads * table_count)
 pop_thread = Thread(pop_ops * nops_per_thread)
 pop_workload = Workload(context, populate_threads * pop_thread)
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 print('populate complete')
 
 # Log like file, requires that logging be enabled in the connection config.
@@ -145,7 +146,8 @@ workload.options.run_time=900
 workload.options.sample_rate=1
 workload.options.warmup=0
 workload.options.sample_interval_ms = 1000
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/runner/small_btree.py
+++ b/bench/workgen/runner/small_btree.py
@@ -44,7 +44,8 @@ op = Operation(Operation.OP_INSERT, table)
 thread = Thread(op * 500000)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 op = Operation(Operation.OP_SEARCH, table)
 t = Thread(op)
@@ -52,4 +53,5 @@ workload = Workload(context, t * 8)
 workload.options.run_time = 120
 workload.options.report_interval = 5
 print('read workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret

--- a/bench/workgen/runner/small_btree_reopen.py
+++ b/bench/workgen/runner/small_btree_reopen.py
@@ -44,7 +44,8 @@ op = Operation(Operation.OP_INSERT, table)
 thread = Thread(op * 500000)
 pop_workload = Workload(context, thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 op = Operation(Operation.OP_SEARCH, table)
 op._config = 'reopen'
@@ -53,4 +54,5 @@ workload = Workload(context, t * 8)
 workload.options.run_time = 120
 workload.options.report_interval = 5
 print('read workload:')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret

--- a/bench/workgen/runner/split_stress.py
+++ b/bench/workgen/runner/split_stress.py
@@ -65,7 +65,8 @@ nops_per_thread = icount // (populate_threads * table_count)
 pop_thread = Thread(pop_ops * nops_per_thread)
 pop_workload = Workload(context, populate_threads * pop_thread)
 print('populate:')
-pop_workload.run(conn)
+ret = pop_workload.run(conn)
+assert ret == 0, ret
 
 # Run phase.
 ops = Operation(Operation.OP_INSERT, tables[0])
@@ -76,7 +77,8 @@ workload = Workload(context, 20 * thread0)
 workload.options.report_interval=5
 workload.options.run_time=300
 print('Split stress workload running...')
-workload.run(conn)
+ret = workload.run(conn)
+assert ret == 0, ret
 
 latency_filename = context.args.home + "/latency.out"
 latency.workload_latency(workload, latency_filename)

--- a/bench/workgen/wtperf.py
+++ b/bench/workgen/wtperf.py
@@ -490,7 +490,8 @@ class Translator:
         s += 'pop_workload = Workload(context, populate_threads * pop_thread)\n'
         if self.verbose > 0:
             s += 'print("populate:")\n'
-        s += 'pop_workload.run(conn)\n'
+        s += 'ret = pop_workload.run(conn)\n'
+        s += 'assert ret == 0, ret\n'
 
         return s
 
@@ -609,7 +610,8 @@ class Translator:
 
             if self.verbose > 0:
                 s += 'print("workload:")\n'
-            s += 'workload.run(conn)\n\n'
+            s += 'ret = workload.run(conn)\n'
+            s += 'assert ret == 0, ret\n'
             s += 'latency_filename = context.args.home + "/latency.out"\n'
             s += 'latency.workload_latency(workload, latency_filename)\n'
 


### PR DESCRIPTION
- Added an assertion when the `run` command is expected. We expect it to return `0`.
- Modified a few workloads to align with Python3 and work with the latest version of Workgen.  