### PR TITLE
WT-9117 Restricting runs.rows to 1,000,000 when runs.in_memory is auto enabled

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -887,7 +887,7 @@ config_in_memory(void)
         if (NTV(tables[0], RUNS_ROWS) > 1000000) {
             WARN("%s",
               "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");
-            config_single(NULL, "runs.rows=1000000", false);
+            config_single(NULL, "runs.rows=1000000", true);
         }
     }
 }

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -266,14 +266,14 @@ config_table(TABLE *table, void *arg)
         /*
          * Always limit the row count if its greater that 1,000,000 and in memory wasn't explicitly
          * set. Direct IO is always explicitly set, never limit the row count because the user has
-         * taken control..
+         * taken control.
          */
         if (GV(RUNS_IN_MEMORY) && TV(RUNS_ROWS) > 1000000 &&
           config_explicit(NULL, "runs.in_memory")) {
             WARN("limiting table%" PRIu32
                  ".runs.rows to 1,000,000 as runs.in_memory has been automatically enabled",
               table->id)
-            config_single(table, "runs.rows=1000000", config_explicit(table, "runs.rows"));
+            config_single(table, "runs.rows=1000000", false);
         }
         if (!config_explicit(table, "btree.key_max"))
             config_single(table, "btree.key_max=32", false);
@@ -883,10 +883,11 @@ config_in_memory(void)
 
     if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1) {
         config_single(NULL, "runs.in_memory=1", false);
+        /* Use table[0] to access the global value (RUN_ROWS is a table value). */
         if (NTV(tables[0], RUNS_ROWS) > 1000000) {
             WARN("%s",
               "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");
-            config_single(NULL, "runs.rows=1000000", config_explicit(NULL, "runs.rows"));
+            config_single(NULL, "runs.rows=1000000", false);
         }
     }
 }

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -268,7 +268,7 @@ config_table(TABLE *table, void *arg)
          * set. Direct IO is always explicitly set, never limit the row count because the user has
          * taken control.
          */
-        if (GV(RUNS_IN_MEMORY) && TV(RUNS_ROWS) > 1000000 &&
+        if (GV(RUNS_IN_MEMORY) && TV(RUNS_ROWS) > WT_MILLION &&
           config_explicit(NULL, "runs.in_memory")) {
             WARN("limiting table%" PRIu32
                  ".runs.rows to 1,000,000 as runs.in_memory has been automatically enabled",
@@ -884,7 +884,7 @@ config_in_memory(void)
     if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1) {
         config_single(NULL, "runs.in_memory=1", false);
         /* Use table[0] to access the global value (RUN_ROWS is a table value). */
-        if (NTV(tables[0], RUNS_ROWS) > 1000000) {
+        if (NTV(tables[0], RUNS_ROWS) > WT_MILLION) {
             WARN("%s",
               "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");
             config_single(NULL, "runs.rows=1000000", true);


### PR DESCRIPTION
WT-9117 Restricting runs.rows to 1,000,000 when runs.in_memory is automatically enabled. Removing restriction on runs.rows when direct IO is enabled (as it most likely never used).