### PR TITLE
WT-10252 Define a Workgen Operation that works on random collections

### DIFF
--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1360,14 +1360,14 @@ Thread::describe(std::ostream &os) const
 
 Operation::Operation()
     : _optype(OP_NONE), _internal(nullptr), _table(), _key(), _value(), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
     init_internal(nullptr);
 }
 
 Operation::Operation(OpType optype, Table table, Key key, Value value)
     : _optype(optype), _internal(nullptr), _table(table), _key(key), _value(value), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
     init_internal(nullptr);
     size_check();
@@ -1375,7 +1375,7 @@ Operation::Operation(OpType optype, Table table, Key key, Value value)
 
 Operation::Operation(OpType optype, Table table, Key key)
     : _optype(optype), _internal(nullptr), _table(table), _key(key), _value(), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
     init_internal(nullptr);
     size_check();
@@ -1383,7 +1383,7 @@ Operation::Operation(OpType optype, Table table, Key key)
 
 Operation::Operation(OpType optype, Table table)
     : _optype(optype), _internal(nullptr), _table(table), _key(), _value(), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
     init_internal(nullptr);
     size_check();
@@ -1392,7 +1392,8 @@ Operation::Operation(OpType optype, Table table)
 Operation::Operation(const Operation &other)
     : _optype(other._optype), _internal(nullptr), _table(other._table), _key(other._key),
       _value(other._value), _config(other._config), transaction(other.transaction),
-      _group(other._group), _repeatgroup(other._repeatgroup), _timed(other._timed)
+      _group(other._group), _repeatgroup(other._repeatgroup), _timed(other._timed),
+      _random_table(other._random_table)
 {
     // Creation and destruction of _group and transaction is managed
     // by Python.
@@ -1401,7 +1402,7 @@ Operation::Operation(const Operation &other)
 
 Operation::Operation(OpType optype, const std::string &config)
     : _optype(optype), _internal(nullptr), _table(), _key(), _value(), _config(config),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
     init_internal(nullptr);
 }
@@ -1423,6 +1424,7 @@ Operation::operator=(const Operation &other)
     _group = other._group;
     _repeatgroup = other._repeatgroup;
     _timed = other._timed;
+    _random_table = other._random_table;
     delete _internal;
     _internal = nullptr;
     init_internal(other._internal);

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -930,12 +930,17 @@ ThreadRunner::op_get_key_recno(Operation *op, uint64_t range, tint_t tint)
         recno_count = range;
     else
         recno_count = _icontext->_table_runtime[tint]._max_recno;
+
     if (recno_count == 0)
         // The file has no entries, returning 0 forces a WT_NOTFOUND return.
         return (0);
-    uint32_t rval = random_value();
+
+    uint32_t rval;
     if (op->_key._keytype == Key::KEYGEN_PARETO)
         rval = pareto_calculation(rval, recno_count, op->_key._pareto);
+    else
+        rval = random_value();
+
     return (rval % recno_count + 1); // recnos are one-based.
 }
 

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1369,6 +1369,7 @@ Operation::Operation(OpType optype, Table table, Key key, Value value)
     : _optype(optype), _internal(nullptr), _table(table), _key(key), _value(value), _config(),
       transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
+    ASSERT(is_table_op());
     init_internal(nullptr);
     size_check();
 }
@@ -1377,6 +1378,7 @@ Operation::Operation(OpType optype, Table table, Key key)
     : _optype(optype), _internal(nullptr), _table(table), _key(key), _value(), _config(),
       transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
+    ASSERT(is_table_op());
     init_internal(nullptr);
     size_check();
 }
@@ -1385,6 +1387,7 @@ Operation::Operation(OpType optype, Table table)
     : _optype(optype), _internal(nullptr), _table(table), _key(), _value(), _config(),
       transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
+    ASSERT(is_table_op());
     init_internal(nullptr);
     size_check();
 }
@@ -1393,6 +1396,7 @@ Operation::Operation(OpType optype, Key key, Value value)
     : _optype(optype), _internal(nullptr), _table(), _key(key), _value(value), _config(),
       transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(true)
 {
+    ASSERT(is_table_op());
     init_internal(nullptr);
 }
 
@@ -1411,6 +1415,7 @@ Operation::Operation(OpType optype, const std::string &config)
     : _optype(optype), _internal(nullptr), _table(), _key(), _value(), _config(config),
       transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
 {
+    ASSERT(!is_table_op());
     init_internal(nullptr);
 }
 

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1722,9 +1722,10 @@ void
 Operation::size_check() const
 {
     if (is_table_op() && !_random_kv) {
-        if (_key._size == 0 && _table.options.key_size == 0)
+        if (_key._size == 0 && !_random_table && _table.options.key_size == 0)
             THROW("operation requires a key size");
-        if (OP_HAS_VALUE(this) && _value._size == 0 && _table.options.value_size == 0)
+        if (OP_HAS_VALUE(this) && _value._size == 0 && !_random_table &&
+          _table.options.value_size == 0)
             THROW("operation requires a value size");
     }
 }

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1437,6 +1437,11 @@ Operation::Operation(OpType optype)
 {
     ASSERT(is_table_op());
     init_internal(nullptr);
+    // TODO - Do I need to set this here for now?
+    // _key._keytype = Key::KEYGEN_PARETO;
+    // _key._pareto.range_low = 0;
+    // _key._pareto.range_high = 1;
+    // _key._pareto.param = 20;
 }
 
 Operation::Operation(const Operation &other)

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -926,7 +926,6 @@ ThreadRunner::op_get_key_recno(Operation *op, uint64_t range, tint_t tint)
 {
     uint64_t recno_count;
 
-    (void)op;
     if (range > 0)
         recno_count = range;
     else
@@ -1743,7 +1742,6 @@ SleepOperationInternal::parse_config(const std::string &config)
 int
 SleepOperationInternal::run(ThreadRunner *runner, WT_SESSION *session)
 {
-    (void)runner;  /* not used */
     (void)session; /* not used */
 
     uint64_t now;

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1389,6 +1389,13 @@ Operation::Operation(OpType optype, Table table)
     size_check();
 }
 
+Operation::Operation(OpType optype, Key key, Value value)
+    : _optype(optype), _internal(nullptr), _table(), _key(key), _value(value), _config(),
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(true)
+{
+    init_internal(nullptr);
+}
+
 Operation::Operation(const Operation &other)
     : _optype(other._optype), _internal(nullptr), _table(other._table), _key(other._key),
       _value(other._value), _config(other._config), transaction(other.transaction),

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1429,6 +1429,14 @@ Operation::Operation(OpType optype, Key key, Value value)
     init_internal(nullptr);
 }
 
+Operation::Operation(OpType optype)
+    : _optype(optype), _internal(nullptr), _table(), _key(), _value(), _config(),
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(true), _random_kv(true)
+{
+    ASSERT(is_table_op());
+    init_internal(nullptr);
+}
+
 Operation::Operation(const Operation &other)
     : _optype(other._optype), _internal(nullptr), _table(other._table), _key(other._key),
       _value(other._value), _config(other._config), transaction(other.transaction),

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1384,14 +1384,16 @@ Thread::describe(std::ostream &os) const
 
 Operation::Operation()
     : _optype(OP_NONE), _internal(nullptr), _table(), _key(), _value(), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false),
+      _random_kv(false)
 {
     init_internal(nullptr);
 }
 
 Operation::Operation(OpType optype, Table table, Key key, Value value)
     : _optype(optype), _internal(nullptr), _table(table), _key(key), _value(value), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false),
+      _random_kv(false)
 {
     ASSERT(is_table_op());
     init_internal(nullptr);
@@ -1400,7 +1402,8 @@ Operation::Operation(OpType optype, Table table, Key key, Value value)
 
 Operation::Operation(OpType optype, Table table, Key key)
     : _optype(optype), _internal(nullptr), _table(table), _key(key), _value(), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false),
+      _random_kv(false)
 {
     ASSERT(is_table_op());
     init_internal(nullptr);
@@ -1409,7 +1412,8 @@ Operation::Operation(OpType optype, Table table, Key key)
 
 Operation::Operation(OpType optype, Table table)
     : _optype(optype), _internal(nullptr), _table(table), _key(), _value(), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false),
+      _random_kv(false)
 {
     ASSERT(is_table_op());
     init_internal(nullptr);
@@ -1418,7 +1422,8 @@ Operation::Operation(OpType optype, Table table)
 
 Operation::Operation(OpType optype, Key key, Value value)
     : _optype(optype), _internal(nullptr), _table(), _key(key), _value(value), _config(),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(true)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(true),
+      _random_kv(false)
 {
     ASSERT(is_table_op());
     init_internal(nullptr);
@@ -1428,7 +1433,7 @@ Operation::Operation(const Operation &other)
     : _optype(other._optype), _internal(nullptr), _table(other._table), _key(other._key),
       _value(other._value), _config(other._config), transaction(other.transaction),
       _group(other._group), _repeatgroup(other._repeatgroup), _timed(other._timed),
-      _random_table(other._random_table)
+      _random_table(other._random_table), _random_kv(other._random_kv)
 {
     // Creation and destruction of _group and transaction is managed
     // by Python.
@@ -1437,7 +1442,8 @@ Operation::Operation(const Operation &other)
 
 Operation::Operation(OpType optype, const std::string &config)
     : _optype(optype), _internal(nullptr), _table(), _key(), _value(), _config(config),
-      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false)
+      transaction(nullptr), _group(nullptr), _repeatgroup(0), _timed(0.0), _random_table(false),
+      _random_kv(false)
 {
     ASSERT(!is_table_op());
     init_internal(nullptr);
@@ -1461,6 +1467,7 @@ Operation::operator=(const Operation &other)
     _repeatgroup = other._repeatgroup;
     _timed = other._timed;
     _random_table = other._random_table;
+    _random_kv = other._random_kv;
     delete _internal;
     _internal = nullptr;
     init_internal(other._internal);

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1033,7 +1033,7 @@ ThreadRunner::op_run(Operation *op)
         recno = 0;
         break;
     }
-    if ((op->_internal->_flags & WORKGEN_OP_REOPEN) != 0) {
+    if (op->_random_table || ((op->_internal->_flags & WORKGEN_OP_REOPEN) != 0)) {
         WT_ERR(_session->open_cursor(_session, table_uri.c_str(), nullptr, nullptr, &cursor));
         own_cursor = true;
     } else

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -310,6 +310,7 @@ struct Operation {
     Operation(OpType optype, Table table);
     // Constructor with no table implies the use of random tables.
     Operation(OpType optype, Key key, Value value);
+    Operation(OpType optype);
     // Constructor with string applies to NOOP, SLEEP, CHECKPOINT
     Operation(OpType optype, const std::string& config);
     Operation(const Operation &other);

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -301,6 +301,7 @@ struct Operation {
     std::vector<Operation> *_group;
     int _repeatgroup;
     double _timed;
+    bool _random_table;
 
     Operation();
     Operation(OpType optype, Table table, Key key, Value value);

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -326,7 +326,7 @@ struct Operation {
     void create_all();
     void get_static_counts(Stats &stats, int multiplier);
     bool is_table_op() const;
-    void kv_compute_max(bool iskey, bool has_random);
+    void kv_compute_max(ThreadRunner *runner, bool iskey, bool has_random);
     void kv_gen(ThreadRunner *runner, bool iskey, uint64_t compressibility,
        uint64_t n, char *result) const;
     void kv_size_buffer(bool iskey, size_t &size) const;

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -302,6 +302,7 @@ struct Operation {
     int _repeatgroup;
     double _timed;
     bool _random_table;
+    bool _random_kv;
 
     Operation();
     Operation(OpType optype, Table table, Key key, Value value);

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -307,6 +307,8 @@ struct Operation {
     Operation(OpType optype, Table table, Key key, Value value);
     Operation(OpType optype, Table table, Key key);
     Operation(OpType optype, Table table);
+    // Constructor with no table implies the use of random tables.
+    Operation(OpType optype, Key key, Value value);
     // Constructor with string applies to NOOP, SLEEP, CHECKPOINT
     Operation(OpType optype, const std::string& config);
     Operation(const Operation &other);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -152,7 +152,6 @@ struct ThreadRunner {
 
     void op_create_all(Operation *, size_t &keysize, size_t &valuesize);
     uint64_t op_get_key_recno(Operation *, uint64_t range, tint_t tint);
-    void op_get_static_counts(Operation *, Stats &, int);
     int op_run(Operation *);
     float random_signed();
     uint32_t random_value();


### PR DESCRIPTION
**Reviewing one commit at a time should make the review easier.**

The intent of these changes is the creation of two new constructors for the `Operation` class where the `Table` argument is missing to force the selection of random tables.
When a random table is selected, there are two cases:

- If the `Key` and `Value` fields are defined through the constructor, we can proceed with the usual flow with them.
- If they are not defined, we need to generate them and this is where it can get tricky and **more work needs to be done in this area**.