### PR TITLE
WT-10239 Implement dynamic table deletion in Workgen

### DIFF
--- a/bench/workgen/runner/example_dynamic_tables.py
+++ b/bench/workgen/runner/example_dynamic_tables.py
@@ -149,6 +149,14 @@ while workload_thread.is_alive():
 
 assert workload_thread.join() == 0
 
+# It is possible that Python and Workgen are not matching at this point in terms of tables. Since
+# Workgen cannot remove a table that is still being used, it may have kept reference to it.
+# Now the workload is finished, call the garbage collector on Workgen, nothing should be blocking
+# the deletion of tables that are supposed to be removed.
+# Note that we are not checking what's on disk, we don't need to use what garbage_collection
+# returns.
+workload.garbage_collection()
+
 # Check tables match between Python and Workgen.
 workgen_tables = workload.get_tables()
 

--- a/bench/workgen/runner/example_dynamic_tables.py
+++ b/bench/workgen/runner/example_dynamic_tables.py
@@ -65,7 +65,7 @@ def create(session, workload, table_config):
     try:
         session.create(table_name, table_config)
         # This indicates Workgen a new table exists.
-        workload.create_table(table_name)
+        workload.add_table(table_name)
         tables.append(table_name)
     # Collision may occur.
     except RuntimeError as e:
@@ -76,7 +76,7 @@ def drop(workload, table_name):
 
     try:
         # Mark the table for deletion in Workgen.
-        workload.drop_table(table_name)
+        workload.remove_table(table_name)
         # Delete local data.
         tables.remove(table_name)
     except RuntimeError as e:

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -416,8 +416,8 @@ Context::operator=(const Context &other)
 
 ContextInternal::ContextInternal()
     : _tint(), _table_names(), _table_runtime(nullptr), _runtime_alloced(0), _tint_last(0),
-      _dyn_tint(), _dyn_table_names(), _dyn_table_runtime(), _dyn_tint_last(0), _context_count(0),
-      _dyn_mutex(new std::mutex())
+      _dyn_tint(), _dyn_table_names(), _dyn_table_runtime(), _dyn_tint_last(0), _dyn_table_in_use(),
+      _dyn_tables_delete(), _context_count(0), _dyn_mutex(new std::mutex())
 {
     uint32_t count = workgen_atomic_add32(&context_count, 1);
     if (count != 1)

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -1005,6 +1005,7 @@ ThreadRunner::op_run(Operation *op)
         if (!marked_deleted) {
             ++_icontext->_dyn_table_in_use[uri];
             table_uri = uri;
+            tint = _icontext->_dyn_tint[uri];
         } else {
             goto err;
         }

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -2425,14 +2425,12 @@ Workload::garbage_collection()
         }
 
         // Delete all local data related to the table.
-        // Note that the vector _dyn_table_runtime does not need to be updated. If we were to remove
-        // one entry from it, it would shift all the data. It is important to keep the data in order
-        // as each index corresponds to a tint allocated when the corresponds new table was created.
         icontext->_dyn_table_in_use.erase(uri);
         icontext->_dyn_tables_delete.erase(icontext->_dyn_tables_delete.begin() + i);
         tint_t tint = icontext->_dyn_tint.at(uri);
         icontext->_dyn_tint.erase(uri);
         icontext->_dyn_table_names.erase(tint);
+        icontext->_dyn_table_runtime.erase(tint);
         uris.push_back(uri);
     }
     return uris;
@@ -2453,8 +2451,8 @@ WorkloadRunner::add_table(const std::string &uri)
     icontext->_dyn_tint[uri] = tint;
     icontext->_dyn_table_names[tint] = uri;
 
-    ASSERT(tint == icontext->_dyn_table_runtime.size());
-    icontext->_dyn_table_runtime.push_back(TableRuntime());
+    ASSERT(icontext->_dyn_table_runtime.count(tint) == 0);
+    icontext->_dyn_table_runtime[tint] = TableRuntime();
 
     ++icontext->_dyn_tint_last;
 }

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -2370,17 +2370,17 @@ Workload::run(WT_CONNECTION *conn)
 }
 
 void
-Workload::create_table(const std::string &uri)
+Workload::add_table(const std::string &uri)
 {
     WorkloadRunner runner(this);
-    runner.create_table(uri);
+    runner.add_table(uri);
 }
 
 void
-Workload::drop_table(const std::string &uri)
+Workload::remove_table(const std::string &uri)
 {
     WorkloadRunner runner(this);
-    runner.drop_table(uri);
+    runner.remove_table(uri);
 }
 
 WorkloadRunner::WorkloadRunner(Workload *workload)
@@ -2436,7 +2436,7 @@ Workload::garbage_collection()
 }
 
 void
-WorkloadRunner::create_table(const std::string &uri)
+WorkloadRunner::add_table(const std::string &uri)
 {
     ContextInternal *icontext = _workload->_context->_internal;
     const std::lock_guard<std::mutex> lock(*icontext->_dyn_mutex);
@@ -2457,7 +2457,7 @@ WorkloadRunner::create_table(const std::string &uri)
 }
 
 void
-WorkloadRunner::drop_table(const std::string &uri)
+WorkloadRunner::remove_table(const std::string &uri)
 {
     ContextInternal *icontext = _workload->_context->_internal;
 

--- a/bench/workgen/workgen.cxx
+++ b/bench/workgen/workgen.cxx
@@ -2424,12 +2424,14 @@ Workload::garbage_collection()
         }
 
         // Delete all local data related to the table.
+        // Note that the vector _dyn_table_runtime does not need to be updated. If we were to remove
+        // one entry from it, it would shift all the data. It is important to keep the data in order
+        // as each index corresponds to a tint allocated when the corresponds new table was created.
         icontext->_dyn_table_in_use.erase(uri);
         icontext->_dyn_tables_delete.erase(icontext->_dyn_tables_delete.begin() + i);
         tint_t tint = icontext->_dyn_tint.at(uri);
         icontext->_dyn_tint.erase(uri);
         icontext->_dyn_table_names.erase(tint);
-        // TODO - _dyn_table_runtime
         uris.push_back(uri);
     }
     return uris;

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -493,8 +493,8 @@ struct Workload {
 	}
 	os << "]";
     }
-    void create_table(const std::string& uri);
-    void drop_table(const std::string& uri);
+    void add_table(const std::string& uri);
+    void remove_table(const std::string& uri);
     const std::vector<std::string> get_tables();
     const std::vector<std::string> garbage_collection();
     int run(WT_CONNECTION *conn);

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -494,6 +494,7 @@ struct Workload {
 	os << "]";
     }
     void create_table(const std::string& uri);
+    void drop_table(const std::string& uri);
     const std::vector<std::string> get_tables();
     int run(WT_CONNECTION *conn);
 };

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -496,6 +496,7 @@ struct Workload {
     void create_table(const std::string& uri);
     void drop_table(const std::string& uri);
     const std::vector<std::string> get_tables();
+    const std::vector<std::string> garbage_collection();
     int run(WT_CONNECTION *conn);
 };
 

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -212,6 +212,10 @@ struct ContextInternal {
     std::map<tint_t, std::string> _dyn_table_names;
     std::vector<TableRuntime> _dyn_table_runtime;
     tint_t _dyn_tint_last;
+    // Reference counter on each table.
+    std::map<std::string, size_t> _dyn_table_in_use;
+    // Tables required to be deleted. They should not be selected by any thread.
+    std::vector<std::string> _dyn_tables_delete;
     // This mutex should be used to protect the access to the dynamic tables data.
     std::mutex* _dyn_mutex;
 

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -210,7 +210,7 @@ struct ContextInternal {
     // Dedicated to tables that can be created or removed during the workload.
     std::map<std::string, tint_t> _dyn_tint;
     std::map<tint_t, std::string> _dyn_table_names;
-    std::vector<TableRuntime> _dyn_table_runtime;
+    std::map<tint_t, TableRuntime> _dyn_table_runtime;
     tint_t _dyn_tint_last;
     // Reference counter on each table.
     std::map<std::string, size_t> _dyn_table_in_use;

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -301,8 +301,8 @@ struct WorkloadRunner {
 
     WorkloadRunner(Workload *);
     ~WorkloadRunner() = default;
-    void create_table(const std::string& uri);
-    void drop_table(const std::string& uri);
+    void add_table(const std::string& uri);
+    void remove_table(const std::string& uri);
     int run(WT_CONNECTION *conn);
     int increment_timestamp(WT_CONNECTION *conn);
     int start_table_idle_cycle(WT_CONNECTION *conn);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -302,6 +302,7 @@ struct WorkloadRunner {
     WorkloadRunner(Workload *);
     ~WorkloadRunner() = default;
     void create_table(const std::string& uri);
+    void drop_table(const std::string& uri);
     int run(WT_CONNECTION *conn);
     int increment_timestamp(WT_CONNECTION *conn);
     int start_table_idle_cycle(WT_CONNECTION *conn);


### PR DESCRIPTION
This is reusing the work done in WT-10238 (https://github.com/wiredtiger/wiredtiger/pull/8573).

We are now:

- Using a reference counter when a table in Workgen is used
- Able to ask Workgen to prepare a table for deletion using the new Workgen API `remove_table`
  - When this is the case, the table cannot be used by any other thread. However, the threads currently using the table can finish their job.
  - A new API garbage_collection has been created so Workgen can delete the data associated with those tables when it is safe to do so. **This API only deletes the data in Workgen, the table will still be on disk and the WiredTiger API session:drop should be called on the table**

**Note: reviewing one commit at a time makes the review much easier.**