### PR TITLE
WT-9872 Perform input validation for create_test.sh

### DIFF
--- a/test/cppsuite/create_test.sh
+++ b/test/cppsuite/create_test.sh
@@ -8,10 +8,10 @@ if [ $# -eq 0 ]
 fi
 
 # Check the test name
-if [[ $1 =~ ^[a-zA-Z]+(_[0-9a-zA-Z]+)$ ]]; then
+if [[ $1 =~ ^[a-z][_a-z0-9]+$ ]]; then
     echo "Generating test: $1..."
 else
-    echo "Invalid test name. Test name must match the regex '[a-zA-Z]+(_[0-9a-zA-Z]+)$'"
+    echo "Invalid test name. Test name must match the regex '[a-z][_a-z0-9]+$'"
     exit 128
 fi
 

--- a/test/cppsuite/create_test.sh
+++ b/test/cppsuite/create_test.sh
@@ -8,12 +8,13 @@ if [ $# -eq 0 ]
 fi
 
 # Check the test name
-if [[ $1 =~ ^[0-9a-zA-Z_-]+$ ]];then
+if [[ $1 =~ ^[a-zA-Z]+(_[0-9a-zA-Z]+)$ ]]; then
     echo "Generating test: $1..."
 else
-    echo "Invalid test name. Only alphanumeric characters are allowed. \"_\" and \"-\" can be used too."
+    echo "Invalid test name. Test name must match the regex '[a-zA-Z]+(_[0-9a-zA-Z]+)$'"
     exit 128
 fi
+
 # Check if the test already exists.
 FILE=tests/$1.cpp
 if test -f "$FILE"; then

--- a/test/cppsuite/create_test.sh
+++ b/test/cppsuite/create_test.sh
@@ -8,10 +8,10 @@ if [ $# -eq 0 ]
 fi
 
 # Check the test name
-if [[ $1 =~ ^[0-9a-zA-Z_-]+$ ]];then
+if [[ $1 =~ ^[0-9a-zA-Z_-]+$ ]] && ! [[ ${1::1} =~ ^[0-9] ]] && ! [[ $1 = *" "* ]];then
     echo "Generating test: $1..."
 else
-    echo "Invalid test name. Only alphanumeric characters are allowed. \"_\" and \"-\" can be used too."
+    echo "Invalid test name. Must not start with a number or contain spaces. Only alphanumeric characters are allowed. \"_\" and \"-\" can be used too."
     exit 128
 fi
 

--- a/test/cppsuite/create_test.sh
+++ b/test/cppsuite/create_test.sh
@@ -8,13 +8,12 @@ if [ $# -eq 0 ]
 fi
 
 # Check the test name
-if [[ $1 =~ ^[0-9a-zA-Z_-]+$ ]] && ! [[ ${1::1} =~ ^[0-9] ]] && ! [[ $1 = *" "* ]];then
+if [[ $1 =~ ^[0-9a-zA-Z_-]+$ ]];then
     echo "Generating test: $1..."
 else
-    echo "Invalid test name. Must not start with a number or contain spaces. Only alphanumeric characters are allowed. \"_\" and \"-\" can be used too."
+    echo "Invalid test name. Only alphanumeric characters are allowed. \"_\" and \"-\" can be used too."
     exit 128
 fi
-
 # Check if the test already exists.
 FILE=tests/$1.cpp
 if test -f "$FILE"; then

--- a/test/wt_hang_analyzer/wt_hang_analyzer.py
+++ b/test/wt_hang_analyzer/wt_hang_analyzer.py
@@ -377,7 +377,7 @@ class GDBDumper(object):
     @staticmethod
     def __find_debugger(debugger):
         """Find the installed debugger."""
-        return find_program(debugger, ['/opt/mongodbtoolchain/v3/bin/gdb', '/usr/bin'])
+        return find_program(debugger, ['/opt/mongodbtoolchain/v4/bin/gdb', '/usr/bin'])
 
     def dump_info(self, root_logger, logger, pid, process_name, take_dump):
         """Dump info."""


### PR DESCRIPTION
Changed input validation to regex string match C++ Style 

Updated error message to 
`Invalid test name. Test name must match the regex '[a-zA-Z]+(_[0-9a-zA-Z]+)$'`