### PR TITLE
WT-10321 Introduce WT_ASSERT_OPTIONAL, keep WT_ASSERT behind compile flag

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -31,15 +31,14 @@ __wt_ref_out(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     WT_ASSERT(session, S2BT(session)->evict_ref != ref);
 
-#ifdef HAVE_DIAGNOSTIC
     /*
      * Make sure no other thread has a hazard pointer on the page we are about to discard. This is
      * complicated by the fact that readers publish their hazard pointer before re-checking the page
      * state, so our check can race with readers without indicating a real problem. If we find a
      * hazard pointer, wait for it to be cleared.
      */
-    WT_ASSERT(session, __wt_hazard_check_assert(session, ref, true));
-#endif
+    WT_ASSERT_OPTIONAL(session, __wt_hazard_check_assert(session, ref, true),
+      "Attempting to evict page with hazard pointers");
 
     /* Check we are not evicting an accessible internal page with an active split generation. */
     WT_ASSERT(session,
@@ -349,13 +348,12 @@ __wt_free_ref_index(WT_SESSION_IMPL *session, WT_PAGE *page, WT_PAGE_INDEX *pind
     for (i = 0; i < pindex->entries; ++i) {
         ref = pindex->index[i];
 
-#ifdef HAVE_DIAGNOSTIC
         /*
          * Used when unrolling splits and other error paths where there should never have been a
          * hazard pointer taken.
          */
-        WT_ASSERT(session, __wt_hazard_check_assert(session, ref, false));
-#endif
+        WT_ASSERT_OPTIONAL(session, __wt_hazard_check_assert(session, ref, false),
+          "Attempting to discard ref to a page with hazard pointers");
 
         __wt_free_ref(session, ref, page->type, free_pages);
     }

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -38,7 +38,7 @@ __wt_ref_out(WT_SESSION_IMPL *session, WT_REF *ref)
      * hazard pointer, wait for it to be cleared.
      */
     WT_ASSERT_OPTIONAL(session, __wt_hazard_check_assert(session, ref, true),
-      "Attempting to evict page with hazard pointers");
+      "Attempted to free a page with active hazard pointers");
 
     /* Check we are not evicting an accessible internal page with an active split generation. */
     WT_ASSERT(session,

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1680,7 +1680,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_R
       multi->disk_image == NULL ||
         __wt_verify_dsk_image(session, "[page instantiate]", multi->disk_image, 0, &multi->addr,
           WT_VRFY_DISK_EMPTY_PAGE_OK) == 0,
-      "Disk image verification failed");
+      "Failed to verify a disk image");
 
     /* Allocate an underlying WT_REF. */
     WT_RET(__wt_calloc_one(session, refp));
@@ -1777,8 +1777,8 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
      * reality after the split.
      */
     WT_ASSERT_OPTIONAL(session, __wt_leaf_page_can_split(session, page),
-      "Attempting to split page that does not require splitting");
-    WT_ASSERT_ALWAYS(session, __wt_page_is_modified(page), "Attempting to split clean page");
+      "Attempted to split a page that cannot be split");
+    WT_ASSERT_ALWAYS(session, __wt_page_is_modified(page), "Attempted to split a clean page");
 
     F_SET_ATOMIC_16(page, WT_PAGE_SPLIT_INSERT); /* Only split in-memory once. */
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1676,10 +1676,11 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_R
       session, multi->disk_image != NULL || (multi->supd_entries == 0 && !multi->supd_restore));
 
     /* Verify any disk image we have. */
-    WT_ASSERT(session,
+    WT_ASSERT_OPTIONAL(session,
       multi->disk_image == NULL ||
         __wt_verify_dsk_image(session, "[page instantiate]", multi->disk_image, 0, &multi->addr,
-          WT_VRFY_DISK_EMPTY_PAGE_OK) == 0);
+          WT_VRFY_DISK_EMPTY_PAGE_OK) == 0,
+      "Disk image verification failed");
 
     /* Allocate an underlying WT_REF. */
     WT_RET(__wt_calloc_one(session, refp));
@@ -1775,8 +1776,9 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
      * otherwise the page might be evicted based on its last reconciliation which no longer matches
      * reality after the split.
      */
-    WT_ASSERT(session, __wt_leaf_page_can_split(session, page));
-    WT_ASSERT(session, __wt_page_is_modified(page));
+    WT_ASSERT_OPTIONAL(session, __wt_leaf_page_can_split(session, page),
+      "Attempting to split page that does not require splitting");
+    WT_ASSERT_ALWAYS(session, __wt_page_is_modified(page), "Attempting to split clean page");
 
     F_SET_ATOMIC_16(page, WT_PAGE_SPLIT_INSERT); /* Only split in-memory once. */
 

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -80,7 +80,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     } else {
         /* Since on this path we never set append, make sure we aren't appending. */
         WT_ASSERT_ALWAYS(
-          session, recno != WT_RECNO_OOB, "Out-of-band recno provided for a non-append operation");
+          session, recno != WT_RECNO_OOB, "Out-of-bound recno provided for a non-append operation");
         WT_ASSERT_OPTIONAL(session,
           cbt->compare == 0 ||
             recno <= (btree->type == BTREE_COL_VAR ? __col_var_last_recno(cbt->ref) :

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -85,7 +85,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
           cbt->compare == 0 ||
             recno <= (btree->type == BTREE_COL_VAR ? __col_var_last_recno(cbt->ref) :
                                                      __col_fix_last_recno(cbt->ref)),
-          "Out-of-band recno provided for a non-append operation");
+          "Out-of-bound recno provided for a non-append operation");
     }
 
     /*

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -80,12 +80,12 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     } else {
         /* Since on this path we never set append, make sure we aren't appending. */
         WT_ASSERT_ALWAYS(
-          session, recno != WT_RECNO_OOB, "Attempting to append when recno is in bounds");
+          session, recno != WT_RECNO_OOB, "Out-of-band recno provided for a non-append operation");
         WT_ASSERT_OPTIONAL(session,
           cbt->compare == 0 ||
             recno <= (btree->type == BTREE_COL_VAR ? __col_var_last_recno(cbt->ref) :
                                                      __col_fix_last_recno(cbt->ref)),
-          "Attempting to append when recno is in bounds");
+          "Out-of-band recno provided for a non-append operation");
     }
 
     /*
@@ -150,7 +150,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
              * on the existing update chain.
              */
             WT_ASSERT_ALWAYS(session, !restore || old_upd == NULL,
-              "Update found on the existing update chain during an update restore eviction");
+              "Illegal update on chain during update restore eviction");
 
             /*
              * We can either put multiple new updates or a single update on the update chain.

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -147,7 +147,8 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
              * If we restore an update chain in update restore eviction, there should be no update
              * on the existing update chain.
              */
-            WT_ASSERT(session, !restore || old_upd == NULL);
+            WT_ASSERT_ALWAYS(session, !restore || old_upd == NULL,
+              "Update found on the existing update chain during an update restore eviction");
 
             /*
              * We can either put multiple new updates or a single update on the update chain.

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -79,11 +79,13 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
         }
     } else {
         /* Since on this path we never set append, make sure we aren't appending. */
-        WT_ASSERT(session, recno != WT_RECNO_OOB);
-        WT_ASSERT(session,
+        WT_ASSERT_ALWAYS(
+          session, recno != WT_RECNO_OOB, "Attempting to append when recno is in bounds");
+        WT_ASSERT_OPTIONAL(session,
           cbt->compare == 0 ||
             recno <= (btree->type == BTREE_COL_VAR ? __col_var_last_recno(cbt->ref) :
-                                                     __col_fix_last_recno(cbt->ref)));
+                                                     __col_fix_last_recno(cbt->ref)),
+          "Attempting to append when recno is in bounds");
     }
 
     /*

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -146,7 +146,8 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
              * If we restore an update chain in update restore eviction, there should be no update
              * on the existing update chain.
              */
-            WT_ASSERT(session, !restore || *upd_entry == NULL);
+            WT_ASSERT_ALWAYS(session, !restore || *upd_entry == NULL,
+              "Update found on the existing update chain during an update restore eviction");
 
             /*
              * We can either put multiple new updates or a single update on the update chain.

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -184,16 +184,29 @@
 
 /*
  * WT_ASSERT --
- *  Assert an expression provided that diagnostic asserts are enabled.
- *
- * FIXME-WT-10045 - WT_ASSERT should now always take an error message as an argument.
+ *  Assert an expression and abort if it fails.
+ *  Only enabled when compiled with HAVE_DIAGNOSTIC=1.
  */
-#define WT_ASSERT(session, exp)                                           \
-    do {                                                                  \
-        if (UNLIKELY(DIAGNOSTIC_ASSERTS_ENABLED(session)))                \
-            if (UNLIKELY(!(exp))) {                                       \
-                TRIGGER_ABORT(session, exp, "Expression returned false"); \
-            }                                                             \
+#ifdef HAVE_DIAGNOSTIC
+#define WT_ASSERT(session, exp)                                       \
+    do {                                                              \
+        if (UNLIKELY(!(exp)))                                         \
+            TRIGGER_ABORT(session, exp, "Expression returned false"); \
+    } while (0)
+#else
+#define WT_ASSERT(session, exp) WT_UNUSED(session)
+#endif
+
+/*
+ * WT_ASSERT_OPTIONAL --
+ *  Assert an expression provided that diagnostic asserts are enabled.
+ *  Can be enabled at runtime via runtime flags.
+ */
+#define WT_ASSERT_OPTIONAL(session, exp, ...)              \
+    do {                                                   \
+        if (UNLIKELY(DIAGNOSTIC_ASSERTS_ENABLED(session))) \
+            if (UNLIKELY(!(exp)))                          \
+                TRIGGER_ABORT(session, exp, __VA_ARGS__);  \
     } while (0)
 
 /*

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -214,7 +214,9 @@ __clsm_enter(WT_CURSOR_LSM *clsm, bool reset, bool update)
                     switch_txn = clsm->chunks[i]->switch_txn;
                     if (WT_TXNID_LT(switch_txn, pinned_id))
                         break;
-                    WT_ASSERT(session, !__wt_txn_visible_all(session, switch_txn, WT_TS_NONE));
+                    WT_ASSERT_OPTIONAL(session,
+                      !__wt_txn_visible_all(session, switch_txn, WT_TS_NONE),
+                      "Switch transaction is not globally visible");
                 }
             }
         }

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -407,8 +407,9 @@ __wt_rec_col_fix_addtw(
     size_t add_len, len;
     uint8_t keyspace[WT_INTPACK64_MAXSIZE], *p;
 
-    WT_ASSERT(session,
-      recno_offset <= ((__rec_col_fix_get_bitmap_size(session, r)) * 8) / S2BT(session)->bitcnt);
+    WT_ASSERT_ALWAYS(session,
+      recno_offset <= ((__rec_col_fix_get_bitmap_size(session, r)) * 8) / S2BT(session)->bitcnt,
+      "Attempting to write time window information into bitmap memory");
 
     key = &r->k;
     val = &r->v;

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -392,10 +392,11 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
          * changes before the transaction fixes the history store update to have a proper stop
          * timestamp. It is a rare scenario.
          */
-        WT_ASSERT(session,
+        WT_ASSERT_ALWAYS(session,
           hs_stop_durable_ts <= newer_hs_durable_ts || hs_start_ts == hs_stop_durable_ts ||
             hs_start_ts == newer_hs_durable_ts || newer_hs_durable_ts == hs_durable_ts ||
-            first_record || hs_stop_durable_ts == WT_TS_MAX);
+            first_record || hs_stop_durable_ts == WT_TS_MAX,
+          "Out of order history store updates detected");
 
         if (hs_stop_durable_ts < newer_hs_durable_ts)
             WT_STAT_CONN_DATA_INCR(session, txn_rts_hs_stop_older_than_newer_start);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -115,7 +115,8 @@ __wt_session_cursor_cache_sweep(WT_SESSION_IMPL *session)
     WT_STAT_CONN_INCRV(session, cursor_sweep_examined, nexamined);
     WT_STAT_CONN_INCRV(session, cursor_sweep_closed, nclosed);
 
-    WT_ASSERT(session, session->dhandle == saved_dhandle);
+    WT_ASSERT_ALWAYS(
+      session, session->dhandle == saved_dhandle, "Session dhandle changed during cursor sweep");
     return (ret);
 }
 

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -260,12 +260,8 @@ __wt_gen_active(WT_SESSION_IMPL *session, int which, uint64_t generation)
             return (true);
     }
 
-#ifdef HAVE_DIAGNOSTIC
-    {
-        uint64_t oldest = __gen_oldest(session, which);
-        WT_ASSERT(session, generation < oldest);
-    }
-#endif
+    WT_ASSERT_OPTIONAL(
+      session, generation < __gen_oldest(session, which), "Generation is older than gen_oldest");
     return (false);
 }
 

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -390,6 +390,10 @@ __wt_hazard_check_assert(WT_SESSION_IMPL *session, void *ref, bool waitfor)
         __wt_sleep(0, 10000);
     }
 #ifdef HAVE_DIAGNOSTIC
+    /*
+     * In diagnostic mode we also track the file and line where the hazard pointer is set. If this
+     * is available report it in the error trace.
+     */
     __wt_errx(session,
       "hazard pointer reference to discarded object: (%p: session %p name %s: %s, line %d)",
       (void *)hp->ref, (void *)s, s->name == NULL ? "UNKNOWN" : s->name, hp->func, hp->line);

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -370,7 +370,6 @@ __wt_hazard_count(WT_SESSION_IMPL *session, WT_REF *ref)
     return (count);
 }
 
-#ifdef HAVE_DIAGNOSTIC
 /*
  * __wt_hazard_check_assert --
  *     Assert there's no hazard pointer to the page.
@@ -390,12 +389,18 @@ __wt_hazard_check_assert(WT_SESSION_IMPL *session, void *ref, bool waitfor)
             break;
         __wt_sleep(0, 10000);
     }
+#ifdef HAVE_DIAGNOSTIC
     __wt_errx(session,
       "hazard pointer reference to discarded object: (%p: session %p name %s: %s, line %d)",
       (void *)hp->ref, (void *)s, s->name == NULL ? "UNKNOWN" : s->name, hp->func, hp->line);
+#else
+    __wt_errx(session, "hazard pointer reference to discarded object: (%p: session %p name %s)",
+      (void *)hp->ref, (void *)s, s->name == NULL ? "UNKNOWN" : s->name);
+#endif
     return (false);
 }
 
+#ifdef HAVE_DIAGNOSTIC
 /*
  * __hazard_dump --
  *     Display the list of hazard pointers.

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -124,9 +124,10 @@ __wt_txn_release_snapshot(WT_SESSION_IMPL *session)
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
-    WT_ASSERT(session,
+    WT_ASSERT_OPTIONAL(session,
       txn_shared->pinned_id == WT_TXN_NONE || session->txn->isolation == WT_ISO_READ_UNCOMMITTED ||
-        !__wt_txn_visible_all(session, txn_shared->pinned_id, WT_TS_NONE));
+        !__wt_txn_visible_all(session, txn_shared->pinned_id, WT_TS_NONE),
+      "Releasing snapshot that is not globally visible");
 
     txn_shared->metadata_pinned = txn_shared->pinned_id = WT_TXN_NONE;
     F_CLR(txn, WT_TXN_HAS_SNAPSHOT);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -127,7 +127,7 @@ __wt_txn_release_snapshot(WT_SESSION_IMPL *session)
     WT_ASSERT_OPTIONAL(session,
       txn_shared->pinned_id == WT_TXN_NONE || session->txn->isolation == WT_ISO_READ_UNCOMMITTED ||
         !__wt_txn_visible_all(session, txn_shared->pinned_id, WT_TS_NONE),
-      "Releasing snapshot that is not globally visible");
+      "A transactions pinned id cannot become globally visible before the snapshot is released");
 
     txn_shared->metadata_pinned = txn_shared->pinned_id = WT_TXN_NONE;
     F_CLR(txn, WT_TXN_HAS_SNAPSHOT);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -127,7 +127,7 @@ __wt_txn_release_snapshot(WT_SESSION_IMPL *session)
     WT_ASSERT_OPTIONAL(session,
       txn_shared->pinned_id == WT_TXN_NONE || session->txn->isolation == WT_ISO_READ_UNCOMMITTED ||
         !__wt_txn_visible_all(session, txn_shared->pinned_id, WT_TS_NONE),
-      "A transactions pinned id cannot become globally visible before the snapshot is released");
+      "A transactions pinned id cannot become globally visible before its snapshot is released");
 
     txn_shared->metadata_pinned = txn_shared->pinned_id = WT_TXN_NONE;
     F_CLR(txn, WT_TXN_HAS_SNAPSHOT);


### PR DESCRIPTION
Two changes in this PR:
1. Change `WT_ASSERT` back to its original behaviour where it is enabled via compile flag `HAVE_DIAGNOSTIC` and not by the new runtime flag. Some calls to `WT_ASSERT` have been changed to `WT_ASSERT_ALWAYS` as part of this step to avoid `unused variable` errors. We could wrap these vars in `#ifdef HAVE_DIAGNOSTIC` again, but we'll just end up removing them again in the next ticket.
2. Update some `WT_ASSERT` calls to `WT_ASSERT_OPTIONAL`. These asserts are now runtime enable-able, but we don't want them running all the time (`ALWAYS`) as they call expensive subfunctions. 

The remaining `WT_ASSERT`s will be reviewed in later tickets to see if they should become `WT_ASSERT_ALWAYS`.

I'm also open to any better names for `WT_ASSERT_OPTIONAL`. The current situation is as follows:
`WT_ASSERT` is turned on/off at compile time
`WT_ASSERT_OPTIONAL` can be turned on/off at runtime
`WT_ASSERT_ALWAYS` always runs regardless of settings.
