### PR TITLE
WT-9323 Fix a race tracking whether a tree has updates after a checkpoint (#8194) (#8228) (#8356) (v4.4 Backport)

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -679,6 +679,13 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
 
         S2BT(session)->modified = true;
         WT_FULL_BARRIER();
+
+        /*
+         * There is a potential race where checkpoint walks the tree and marks it as clean before a
+         * page is subsequently marked as dirty, leaving us with a dirty page on a clean tree. Yield
+         * here to encourage this scenario and ensure we're handling it correctly.
+         */
+        WT_DIAGNOSTIC_YIELD;
     }
 
     /*
@@ -738,6 +745,18 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     __wt_tree_modify_set(session);
 
     __wt_page_only_modify_set(session, page);
+
+    /*
+     * We need to make sure a checkpoint doesn't come through and mark the tree clean before we have
+     * a chance to mark the page dirty. Otherwise, the checkpoint may also visit the page before it
+     * is marked dirty and skip it without also marking the tree clean. Worst case scenario with
+     * this approach is that a future checkpoint reviews the tree again unnecessarily - however, it
+     * is likely this is necessary since the update triggering this modify set would not be included
+     * in the checkpoint. If hypothetically a checkpoint came through after the page was modified
+     * and before the tree is marked dirty again, that is fine. The transaction installing this
+     * update wasn't visible to the checkpoint, so it's reasonable for the tree to remain dirty.
+     */
+    __wt_tree_modify_set(session);
 }
 
 /*


### PR DESCRIPTION
Cherry-picked from the 5.0 backport (d9340610d5c44fc315912673d15203b25ce5a80b)

Co-authored-by: Ruby Chen <ruby.chen@mongodb.com>
Co-authored-by: Andrew Morton <andrew.morton@mongodb.com>
(cherry picked from commit 68d75efac2541f9bbba05d03f7510f50cfa2a83d)

Co-authored-by: Alex Gorrod <alexander.gorrod@mongodb.com>
(cherry picked from commit 3ecab025d4c0a337fe80b6fe55538896c43c159e) (cherry picked from commit d9340610d5c44fc315912673d15203b25ce5a80b)