### PR TITLE
WT-9926 Remove backup file after recovery checkpoint. (#8316) (#8428) (v5.0 Backport)

### DIFF
--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -324,8 +324,11 @@ __wt_turtle_init(WT_SESSION_IMPL *session)
         WT_RET(ret);
     }
 
-    /* Remove the backup files, we'll never read them again. */
-    return (__wt_backup_file_remove(session));
+    /*
+     * We used to remove the backup file here. But we cannot do that until the metadata is fully
+     * synced to disk after recovery.
+     */
+    return (ret);
 }
 
 /*

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1086,6 +1086,9 @@ done:
          */
         WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
 
+    /* Remove any backup file now that metadata has been synced. */
+    WT_ERR(__wt_backup_file_remove(session));
+
     /*
      * Update the open dhandles write generations and base write generation with the connection's
      * base write generation because the recovery checkpoint writes the pages to disk with new write


### PR DESCRIPTION
Cherry-picked from the 6.0 branch (c01e34c7a23abf8b0da9a7ef1ee2a7c5cfc1b7ae)

* WT-9926 Remove backup file after recovery checkpoint.

* Don't delete checkpoints during recovery from backup.

(cherry picked from commit ebdf18ec2ef5e700a56f36822d1afa19dd7f73f7)

Co-authored-by: sueloverso <sue@mongodb.com>
(cherry picked from commit c01e34c7a23abf8b0da9a7ef1ee2a7c5cfc1b7ae)