### PR TITLE
WT-8981 Enable evergreen testing for RHEL8 on PPC (#8308) (BACKPORT)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -411,6 +411,7 @@ STEC
 STL
 STR
 STRUCT
+SYSCALL
 Scalability
 Scalable
 Sedgewick

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -660,6 +660,12 @@ functions:
           set -o verbose
           ./test/evergreen/verify_wt_datafiles.sh 2>&1
 
+#######################################
+#               Variables             #
+#######################################
+
+variables:
+
 #########################################################################################
 # The following stress tests are configured to run for six hours via the "-t 360"
 # argument to format.sh: format-stress-test, format-stress-sanitizer-test, and
@@ -696,9 +702,7 @@ functions:
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_address_sanitizer_mongodb_v4_clang_with_builtins
+      - func: "compile wiredtiger address sanitizer"
       - func: "format test script"
         vars:
           format_test_script_args: -t 360

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -97,11 +97,35 @@ functions:
       working_dir: "wiredtiger"
       shell: bash
       script: |
-        # Fetch the gperftools library.
-        if [[ "${posix_configure_flags|}" =~ (tcmalloc|TCMALLOC) ]]; then
-          is_cmake_build=true
-          git clone git@github.com:wiredtiger/automation-scripts.git
-          . automation-scripts/evergreen/find_gperftools.sh ${s3_access_key} ${s3_secret_key} ${build_variant} $is_cmake_build
+        set -o errexit
+        # Not setting verbose mode as we have sensitive keys that could be logged.
+
+        # Define common config flags for the tasks to make it cleaner when configuring the tasks.
+        # Note that the config flags are resolved prior to changing to cmake_build directory.
+        DEFINED_EVERGREEN_CONFIG_FLAGS="${CMAKE_BUILD_TYPE|} \
+          ${CMAKE_INSTALL_PREFIX|} \
+          ${CMAKE_PREFIX_PATH|} \
+          ${CMAKE_TOOLCHAIN_FILE|} \
+          ${ENABLE_SHARED|} \
+          ${ENABLE_STATIC|} \
+          ${HAVE_BUILTIN_EXTENSION_LZ4|} \
+          ${HAVE_BUILTIN_EXTENSION_SNAPPY|} \
+          ${HAVE_BUILTIN_EXTENSION_ZLIB|} \
+          ${HAVE_BUILTIN_EXTENSION_ZSTD|} \
+          ${HAVE_FTRUNCATE|} \
+          ${HAVE_UNITTEST} \
+          ${NON_BARRIER_DIAGNOSTIC_YIELDS|} \
+          ${HAVE_DIAGNOSTIC|} \
+          ${GNU_C_VERSION|} \
+          ${GNU_CXX_VERSION|} \
+          ${ENABLE_S3|} \
+          ${IMPORT_S3_SDK|} \
+          ${SPINLOCK_TYPE|} \
+          ${CC_OPTIMIZE_LEVEL|}"
+
+        # The RHEL PPC platform does not have ZSTD. Strip it out.
+        if [ "${build_variant|}" = "rhel8-ppc" ] && [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_ZSTD=1) ]]; then
+          DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
         fi
         
         set -o errexit
@@ -665,6 +689,34 @@ functions:
 #######################################
 
 variables:
+  # Configure flags for builtins.
+  - &configure_flags_with_builtins
+    HAVE_BUILTIN_EXTENSION_LZ4: -DHAVE_BUILTIN_EXTENSION_LZ4=1
+    HAVE_BUILTIN_EXTENSION_SNAPPY: -DHAVE_BUILTIN_EXTENSION_SNAPPY=1
+    HAVE_BUILTIN_EXTENSION_ZLIB: -DHAVE_BUILTIN_EXTENSION_ZLIB=1
+    HAVE_BUILTIN_EXTENSION_ZSTD: -DHAVE_BUILTIN_EXTENSION_ZSTD=1
+
+  # Configure flags static library (default in cmake is dynamic).
+  - &configure_flags_static_lib
+    ENABLE_SHARED: -DENABLE_SHARED=0
+    ENABLE_STATIC: -DENABLE_STATIC=1
+
+  # Configure flags static library (default in cmake is dynamic) with builtins.
+  - &configure_flags_static_lib_with_builtins
+    <<: *configure_flags_with_builtins
+    ENABLE_SHARED: -DENABLE_SHARED=0
+    ENABLE_STATIC: -DENABLE_STATIC=1
+
+  # Configure flags for tiered storage S3 extension.
+  - &configure_flags_tiered_storage_s3
+    ENABLE_S3: -DENABLE_S3=1
+    IMPORT_S3_SDK: -DIMPORT_S3_SDK=external
+
+  # Configure flags for address sanitizer for mongodb toolchain v4 clang (include builtins).
+  - &configure_flags_address_sanitizer_mongodb_v4_clang_with_builtins
+    <<: *configure_flags_with_builtins
+    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_clang.cmake
+    CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=ASan
 
 #########################################################################################
 # The following stress tests are configured to run for six hours via the "-t 360"
@@ -682,11 +734,29 @@ variables:
         vars:
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 360
 
+  - &format-stress-sanitizer-ppc-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_address_sanitizer_mongodb_v4_clang_with_builtins
+      - func: "format test script"
+        vars:
+          # Always disable mmap for PPC due to issues on variant setup.
+          # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
+          format_test_script_args: -t 360 -- -C "mmap=false,mmap_all=false"
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
+
   - &format-stress-sanitizer-test
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
-      - func: "compile wiredtiger address sanitizer"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_address_sanitizer_mongodb_v4_clang_with_builtins
       - func: "format test script"
         vars:
           format_test_script_args: -t 360
@@ -2644,9 +2714,8 @@ tasks:
             set -o verbose
             for i in {1..10}; do ${test_env_vars|} ${python_binary|python3} split_stress.py; done
 
-  # The task name is ppc-zseries because this task will be used in both buildVariants
-  - name: format-stress-ppc-zseries-test
-    tags: ["stress-test-ppc-1", "stress-test-zseries-1"]
+  - name: format-stress-zseries-test
+    tags: ["stress-test-zseries-1"]
     # Set 2.5 hours timeout (60 * 60 * 2.5)
     exec_timeout_secs: 9000
     commands:
@@ -2656,6 +2725,23 @@ tasks:
         vars:
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120
+
+  - name: format-stress-ppc-test
+    tags: ["stress-test-ppc-1"]
+    # Set 2.5 hours timeout (60 * 60 * 2.5)
+    exec_timeout_secs: 9000
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+          CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
+      - func: "format test script"
+        vars:
+          #run for 2 hours ( 2 * 60 = 120 minutes), use default config
+          # Always disable mmap for PPC due to issues on variant setup.
+          # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120 -- -C "mmap=false,mmap_all=false"
 
   - <<: *format-stress-test
     name: format-stress-test-1
@@ -2669,12 +2755,18 @@ tasks:
   - <<: *format-stress-test
     name: format-stress-test-4
     tags: ["stress-test-4"]
+  - <<: *format-stress-sanitizer-ppc-test
+    name: format-stress-sanitizer-ppc-test-1
+    tags: ["stress-test-ppc-1"]
+  - <<: *format-stress-sanitizer-ppc-test
+    name: format-stress-sanitizer-ppc-test-2
+    tags: ["stress-test-ppc-2"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-1
-    tags: ["stress-test-1", "stress-test-ppc-1"]
+    tags: ["stress-test-sanitizer-1"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-2
-    tags: ["stress-test-2", "stress-test-ppc-2"]
+    tags: ["stress-test-sanitizer-2"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-3
     tags: ["stress-test-3"]
@@ -4162,8 +4254,6 @@ buildvariants:
 
 - name: rhel8-ppc
   display_name: "~ RHEL8 PPC"
-  # FIXME-WT-8981
-  activate: false
   run_on:
   - rhel81-power8-small
   batchtime: 120 # 2 hours
@@ -4182,8 +4272,8 @@ buildvariants:
       -DENABLE_STRICT=1
       -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
     python_binary: '/opt/mongodbtoolchain/v4/bin/python3'
-    # Use half number of vCPU to avoid OOM kill failure
-    smp_command: -j $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
+    # Use quarter of the vCPUs to avoid OOM kill failure and disk issues on this variant.
+    smp_command: -j $(echo $(grep -c ^processor /proc/cpuinfo) / 4 | bc)
     cmake_generator: Ninja
     make_command: ninja
   tasks:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -660,40 +660,6 @@ functions:
           set -o verbose
           ./test/evergreen/verify_wt_datafiles.sh 2>&1
 
-#######################################
-#               Variables             #
-#######################################
-
-variables:
-  # Configure flags for builtins.
-  - &configure_flags_with_builtins
-    HAVE_BUILTIN_EXTENSION_LZ4: -DHAVE_BUILTIN_EXTENSION_LZ4=1
-    HAVE_BUILTIN_EXTENSION_SNAPPY: -DHAVE_BUILTIN_EXTENSION_SNAPPY=1
-    HAVE_BUILTIN_EXTENSION_ZLIB: -DHAVE_BUILTIN_EXTENSION_ZLIB=1
-    HAVE_BUILTIN_EXTENSION_ZSTD: -DHAVE_BUILTIN_EXTENSION_ZSTD=1
-
-  # Configure flags static library (default in cmake is dynamic).
-  - &configure_flags_static_lib
-    ENABLE_SHARED: -DENABLE_SHARED=0
-    ENABLE_STATIC: -DENABLE_STATIC=1
-
-  # Configure flags static library (default in cmake is dynamic) with builtins.
-  - &configure_flags_static_lib_with_builtins
-    <<: *configure_flags_with_builtins
-    ENABLE_SHARED: -DENABLE_SHARED=0
-    ENABLE_STATIC: -DENABLE_STATIC=1
-
-  # Configure flags for tiered storage S3 extension.
-  - &configure_flags_tiered_storage_s3
-    ENABLE_S3: -DENABLE_S3=1
-    IMPORT_S3_SDK: -DIMPORT_S3_SDK=external
-
-  # Configure flags for address sanitizer for mongodb toolchain v4 clang (include builtins).
-  - &configure_flags_address_sanitizer_mongodb_v4_clang_with_builtins
-    <<: *configure_flags_with_builtins
-    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_clang.cmake
-    CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=ASan
-
 #########################################################################################
 # The following stress tests are configured to run for six hours via the "-t 360"
 # argument to format.sh: format-stress-test, format-stress-sanitizer-test, and
@@ -716,7 +682,7 @@ variables:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          <<: *configure_flags_address_sanitizer_mongodb_v4_clang_with_builtins
+          posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_clang.cmake -DCMAKE_BUILD_TYPE=ASan -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DHAVE_BUILTIN_EXTENSION_SNAPPY=1 -DHAVE_BUILTIN_EXTENSION_ZLIB=1
       - func: "format test script"
         vars:
           # Always disable mmap for PPC due to issues on variant setup.
@@ -2710,7 +2676,7 @@ tasks:
       - func: "get project"
       - func: "compile wiredtiger"
         vars: 
-          posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_clang.cmake  -DCMAKE_BUILD_TYPE=ASan -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DHAVE_BUILTIN_EXTENSION_SNAPPY=1 -DHAVE_BUILTIN_EXTENSION_ZLIB=1
+          posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DHAVE_BUILTIN_EXTENSION_SNAPPY=1 -DHAVE_BUILTIN_EXTENSION_ZLIB=1
       - func: "format test script"
         vars:
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
@@ -2718,7 +2684,7 @@ tasks:
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120 -- -C "mmap=false,mmap_all=false"
 
-  - <<: *format-stress-tests
+  - <<: *format-stress-test
     name: format-stress-test-1
     tags: ["stress-test-1"]
   - <<: *format-stress-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -97,35 +97,11 @@ functions:
       working_dir: "wiredtiger"
       shell: bash
       script: |
-        set -o errexit
-        # Not setting verbose mode as we have sensitive keys that could be logged.
-
-        # Define common config flags for the tasks to make it cleaner when configuring the tasks.
-        # Note that the config flags are resolved prior to changing to cmake_build directory.
-        DEFINED_EVERGREEN_CONFIG_FLAGS="${CMAKE_BUILD_TYPE|} \
-          ${CMAKE_INSTALL_PREFIX|} \
-          ${CMAKE_PREFIX_PATH|} \
-          ${CMAKE_TOOLCHAIN_FILE|} \
-          ${ENABLE_SHARED|} \
-          ${ENABLE_STATIC|} \
-          ${HAVE_BUILTIN_EXTENSION_LZ4|} \
-          ${HAVE_BUILTIN_EXTENSION_SNAPPY|} \
-          ${HAVE_BUILTIN_EXTENSION_ZLIB|} \
-          ${HAVE_BUILTIN_EXTENSION_ZSTD|} \
-          ${HAVE_FTRUNCATE|} \
-          ${HAVE_UNITTEST} \
-          ${NON_BARRIER_DIAGNOSTIC_YIELDS|} \
-          ${HAVE_DIAGNOSTIC|} \
-          ${GNU_C_VERSION|} \
-          ${GNU_CXX_VERSION|} \
-          ${ENABLE_S3|} \
-          ${IMPORT_S3_SDK|} \
-          ${SPINLOCK_TYPE|} \
-          ${CC_OPTIMIZE_LEVEL|}"
-
-        # The RHEL PPC platform does not have ZSTD. Strip it out.
-        if [ "${build_variant|}" = "rhel8-ppc" ] && [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_ZSTD=1) ]]; then
-          DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
+        # Fetch the gperftools library.
+        if [[ "${posix_configure_flags|}" =~ (tcmalloc|TCMALLOC) ]]; then
+          is_cmake_build=true
+          git clone git@github.com:wiredtiger/automation-scripts.git
+          . automation-scripts/evergreen/find_gperftools.sh ${s3_access_key} ${s3_secret_key} ${build_variant} $is_cmake_build
         fi
         
         set -o errexit
@@ -2733,9 +2709,8 @@ tasks:
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-          CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
+        vars: 
+          posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_clang.cmake  -DCMAKE_BUILD_TYPE=ASan -DHAVE_BUILTIN_EXTENSION_LZ4=1 -DHAVE_BUILTIN_EXTENSION_SNAPPY=1 -DHAVE_BUILTIN_EXTENSION_ZLIB=1
       - func: "format test script"
         vars:
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
@@ -2743,7 +2718,7 @@ tasks:
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120 -- -C "mmap=false,mmap_all=false"
 
-  - <<: *format-stress-test
+  - <<: *format-stress-tests
     name: format-stress-test-1
     tags: ["stress-test-1"]
   - <<: *format-stress-test


### PR DESCRIPTION
Updated evergreen yaml to use RHEL8 instead of Ubuntu 18.04 on PPC.  Reducing the concurrency for RHEL8 PPC tests to a quarter of vCPUs. Added retry (WT_SYSCALL_RETRY) for pread which helps on RHEL8 PPC.

(cherry picked from commit b3719943c9d9790b26bbdcf4aabe95801c1de804)