### PR TITLE
WT-10375 union tables run time process flag configuration

### DIFF
--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -29,6 +29,7 @@ struct __wt_process {
 
     bool fast_truncate_2022; /* fast-truncate fix run-time configuration */
     bool page_stats_2022;    /* Page stats run-time configuration */
+    bool tiered_shared_2023; /* tiered shared run-time configuration */
 
     WT_CACHE_POOL *cache_pool; /* shared cache information */
 

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -66,7 +66,7 @@ struct __wt_table {
     WT_INDEX **indices;
     size_t idx_alloc;
 
-    bool cg_complete, idx_complete, is_simple;
+    bool cg_complete, idx_complete, is_simple, is_tiered_shared;
     u_int ncolgroups, nindices, nkey_columns;
 };
 

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -128,6 +128,7 @@ __global_once(void)
 #ifdef WT_STANDALONE_BUILD
     __wt_process.fast_truncate_2022 = true;
     __wt_process.page_stats_2022 = false;
+    __wt_process.tiered_shared_2023 = true;
 #endif
 }
 


### PR DESCRIPTION
This run time flag is enabled in WiredTiger standalone mode and it is used to protect any metadata changes slipping into the MongoDB release before the feature gets stable.