### PR TITLE
WT-10410 Update mongodb compile to use v4 toolchain in evergreen.yml

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -86,6 +86,7 @@ functions:
       script: |
         set -o errexit
         set -o verbose
+        export "PATH=/opt/mongodbtoolchain/v4/bin:$PATH"
         virtualenv -p python3 venv
         source venv/bin/activate
         pip3 install requirements_parser


### PR DESCRIPTION
Mongodb revision [d824f5a6e46](https://github.com/mongodb/mongo/commit/d824f5a6e46ac74967e38e015bc46858c235a788) in triggered a toolchain test failure in the wiredtiger `many-collection-test`. The test was not using the mongodb toolchain when compiling mongodb, and in particular using a python version (3.8) with a known issue having the same symptoms as the test failure. This change updates `evergreen.yml` to use the current mongodb toolchain (v4) when compiling mongodb.