### PR TITLE
WT-8839 Hide AWS creds when running tests in evergreen

### DIFF
--- a/ext/storage_sources/s3_store/test/test_s3_connection.cpp
+++ b/ext/storage_sources/s3_store/test/test_s3_connection.cpp
@@ -98,8 +98,11 @@ TEST_CASE("Testing class S3Connection", "s3-connection")
     awsConfig.throughputTargetGbps = TestDefaults::throughputTargetGbps;
     awsConfig.partSize = TestDefaults::partSize;
 
+    Aws::Auth::AWSCredentials credentials(
+      std::getenv("aws_sdk_s3_ext_access_key"), std::getenv("aws_sdk_s3_ext_secret_key"));
+
     // Initialize the API.
-    S3Connection conn(awsConfig, TestDefaults::bucketName, TestDefaults::objPrefix);
+    S3Connection conn(credentials, awsConfig, TestDefaults::bucketName, TestDefaults::objPrefix);
     bool exists = false;
     size_t objectSize;
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -221,14 +221,11 @@ functions:
       params:
         working_dir: "wiredtiger/cmake_build"
         shell: bash
-        silent: true
+        include_expansions_in_env:
+          - aws_sdk_s3_ext_access_key
+          - aws_sdk_s3_ext_secret_key
         script: |
           set -o errexit
-          export AWS_ACCESS_KEY_ID=${aws_sdk_s3_ext_access_key}
-          export AWS_SECRET_ACCESS_KEY=${aws_sdk_s3_ext_secret_key}
-
-          # Only set verbose after having put the AWS access credentials into the environment.
-          set -o verbose
 
           virtualenv -p python3 venv
           source venv/bin/activate
@@ -2879,13 +2876,11 @@ tasks:
         params:
           working_dir: "wiredtiger/cmake_build"
           shell: bash
-          silent: true
+          include_expansions_in_env:
+            - aws_sdk_s3_ext_access_key
+            - aws_sdk_s3_ext_secret_key
           script: |
             set -o errexit
-            export AWS_ACCESS_KEY_ID=${aws_sdk_s3_ext_access_key}
-            export AWS_SECRET_ACCESS_KEY=${aws_sdk_s3_ext_secret_key}
-
-            # Only set verbose after having put the AWS access credentials into the environment.
             set -o verbose
 
             # Run S3 extension unit testing.

--- a/test/suite/helper_tiered.py
+++ b/test/suite/helper_tiered.py
@@ -41,8 +41,8 @@ def get_auth_token(storage_source):
     if storage_source == 's3_store':
         # Auth token is the AWS access key ID and the AWS secret key as semi-colon separated values.
         # We expect the values to have been provided through the environment variables.
-        access_key = os.getenv('AWS_ACCESS_KEY_ID')
-        secret_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+        access_key = os.getenv('aws_sdk_s3_ext_access_key')
+        secret_key = os.getenv('aws_sdk_s3_ext_secret_key')
         if access_key and secret_key:
             auth_token = access_key + ";" + secret_key
     return auth_token


### PR DESCRIPTION
Use the evergreen feature include_expansions_in_env to include the access/secret key in the env and then update our code to use these env vars.