### PR TITLE
WT-10396 Use statistics cursor instead of separate API to retrieve record count

### DIFF
--- a/dist/stat.py
+++ b/dist/stat.py
@@ -7,7 +7,7 @@ from operator import attrgetter
 
 # Read the source files.
 from stat_data import groups, dsrc_stats, conn_stats, conn_dsrc_stats, join_stats, \
-    session_stats
+    page_stats, session_stats
 
 ##########################################
 # Check for duplicate stat descriptions:
@@ -23,6 +23,7 @@ def check_unique_description(sorted_list):
 
 check_unique_description(conn_stats)
 check_unique_description(dsrc_stats)
+check_unique_description(page_stats)
 check_unique_description(session_stats)
 check_unique_description(join_stats)
 check_unique_description(conn_dsrc_stats)
@@ -64,6 +65,7 @@ for line in open('../src/include/stat.h', 'r'):
         print_struct('data sources', 'dsrc', 2000, sorted_dsrc_statistics)
         print_struct('join cursors', 'join', 3000, join_stats)
         print_struct('session', 'session', 4000, session_stats)
+        print_struct('page stat', 'page', 5000, page_stats)
 f.close()
 format_srcfile(tmp_file)
 compare_srcfile(tmp_file, '../src/include/stat.h')
@@ -128,6 +130,15 @@ def print_defines():
  */
 ''')
     print_defines_one('SESSION', 4000, session_stats)
+    f.write('''
+/*!
+* @}
+* @name Statistics for page stat
+* @anchor statistics_page
+* @{
+*/
+''')
+    print_defines_one('PAGE', 5000, page_stats)
     f.write('/*! @} */\n')
 
 # Update the #defines in the wiredtiger.in file.
@@ -282,6 +293,7 @@ print_func('dsrc', 'WT_DATA_HANDLE', sorted_dsrc_statistics)
 print_func('connection', 'WT_CONNECTION_IMPL', sorted_conn_stats)
 print_func('join', None, join_stats)
 print_func('session', None, session_stats)
+print_func('page', None, page_stats)
 f.close()
 format_srcfile(tmp_file)
 compare_srcfile(tmp_file, '../src/support/stat.c')

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -100,6 +100,12 @@ class SessionStat(Stat):
     prefix = 'session'
     def __init__(self, name, desc, flags=''):
         Stat.__init__(self, name, SessionStat.prefix, desc, flags)
+
+class PageStat(Stat):
+    prefix = 'page'
+    def __init__(self, name, desc, flags=''):
+        Stat.__init__(self, name, PageStat.prefix, desc, flags)
+
 class PerfHistStat(Stat):
     prefix = 'perf'
     def __init__(self, name, desc, flags=''):
@@ -1023,3 +1029,13 @@ session_stats = [
 ]
 
 session_stats = sorted(session_stats, key=attrgetter('desc'))
+
+##########################################
+# Page Stat statistics
+##########################################
+page_stats = [
+    PageStat('byte_count', 'byte count of a file'),
+    PageStat('row_count', 'row count of a file'),
+]
+
+page_stats = sorted(page_stats, key=attrgetter('desc'))

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -68,7 +68,7 @@ int
 __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag, const WT_PAGE_HEADER *dsk,
   size_t size, WT_ADDR *addr, uint32_t verify_flags)
 {
-    uint8_t flags;
+    uint8_t flags, stat_flags;
     const uint8_t *p, *end;
 
     /* Initialize the verify information. */
@@ -119,6 +119,7 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag, const WT_PAGE_H
 
     /* Check the page flags. */
     flags = dsk->flags;
+    stat_flags = dsk->stat_flags;
     if (LF_ISSET(WT_PAGE_COMPRESSED))
         LF_CLR(WT_PAGE_COMPRESSED);
     if (dsk->type == WT_PAGE_ROW_LEAF) {
@@ -136,10 +137,10 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag, const WT_PAGE_H
         LF_CLR(WT_PAGE_UNUSED);
     if (LF_ISSET(WT_PAGE_FT_UPDATE))
         LF_CLR(WT_PAGE_FT_UPDATE);
-    if (LF_ISSET(WT_PAGE_STAT_BYTE_COUNT))
-        LF_CLR(WT_PAGE_STAT_BYTE_COUNT);
-    if (LF_ISSET(WT_PAGE_STAT_ROW_COUNT))
-        LF_CLR(WT_PAGE_STAT_ROW_COUNT);
+    if (FLD_ISSET(stat_flags, WT_PAGE_STAT_BYTE_COUNT))
+        FLD_CLR(stat_flags, WT_PAGE_STAT_BYTE_COUNT);
+    if (FLD_ISSET(stat_flags, WT_PAGE_STAT_ROW_COUNT))
+        FLD_CLR(stat_flags, WT_PAGE_STAT_ROW_COUNT);
     if (flags != 0)
         WT_RET_VRFY(session, "page at %s has invalid flags set: 0x%" PRIx8, tag, flags);
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -72,15 +72,17 @@ struct __wt_page_header {
 /*
  * No automatic generation: flag values cannot change, they're written to disk.
  */
-#define WT_PAGE_COMPRESSED 0x01u      /* Page is compressed on disk */
-#define WT_PAGE_EMPTY_V_ALL 0x02u     /* Page has all zero-length values */
-#define WT_PAGE_EMPTY_V_NONE 0x04u    /* Page has no zero-length values */
-#define WT_PAGE_ENCRYPTED 0x08u       /* Page is encrypted on disk */
-#define WT_PAGE_UNUSED 0x10u          /* Historic lookaside store page updates, no longer used */
-#define WT_PAGE_FT_UPDATE 0x20u       /* Page contains updated fast-truncate information */
-#define WT_PAGE_STAT_BYTE_COUNT 0x40u /* Page contains byte count information */
-#define WT_PAGE_STAT_ROW_COUNT 0x80u  /* Page contains row count information */
-    uint8_t flags;                    /* 25: flags */
+#define WT_PAGE_COMPRESSED 0x01u   /* Page is compressed on disk */
+#define WT_PAGE_EMPTY_V_ALL 0x02u  /* Page has all zero-length values */
+#define WT_PAGE_EMPTY_V_NONE 0x04u /* Page has no zero-length values */
+#define WT_PAGE_ENCRYPTED 0x08u    /* Page is encrypted on disk */
+#define WT_PAGE_UNUSED 0x10u       /* Historic lookaside store page updates, no longer used */
+#define WT_PAGE_FT_UPDATE 0x20u    /* Page contains updated fast-truncate information */
+    uint8_t flags;                 /* 25: flags */
+
+#define WT_PAGE_STAT_BYTE_COUNT 0x01u /* Page contains byte count information */
+#define WT_PAGE_STAT_ROW_COUNT 0x02u  /* Page contains row count information */
+    uint8_t stat_flags;
 
     /* A byte of padding, positioned to be added to the flags. */
     uint8_t unused; /* 26: unused padding */

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -943,9 +943,9 @@ copy_cell_restart:
     case WT_CELL_ADDR_LEAF_NO:
         /* Unpack the row and/or byte counts if the chunk of data includes it. */
         if (ps != NULL && __wt_process.page_stats_2022) {
-            if (F_ISSET(dsk, WT_PAGE_STAT_BYTE_COUNT))
+            if (FLD_ISSET(dsk->stat_flags, WT_PAGE_STAT_BYTE_COUNT))
                 WT_RET(__wt_vunpack_int(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &ps->byte_count));
-            if (F_ISSET(dsk, WT_PAGE_STAT_ROW_COUNT))
+            if (FLD_ISSET(dsk->stat_flags, WT_PAGE_STAT_ROW_COUNT))
                 WT_RET(__wt_vunpack_int(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &ps->row_count));
         }
         /* FALLTHROUGH */

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -521,6 +521,7 @@ struct __wt_cursor_stat {
         WT_CONNECTION_STATS conn_stats;
         WT_JOIN_STATS_GROUP join_stats_group;
         WT_SESSION_STATS session_stats;
+        WT_PAGE_STATS page_stats;
     } u;
 
     const char **cfg; /* Original cursor configuration */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1502,6 +1502,8 @@ extern int __wt_stat_dsrc_init(WT_SESSION_IMPL *session, WT_DATA_HANDLE *handle)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_stat_join_desc(WT_CURSOR_STAT *cst, int slot, const char **p)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_stat_page_desc(WT_CURSOR_STAT *cst, int slot, const char **p)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_stat_session_desc(WT_CURSOR_STAT *cst, int slot, const char **p)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_statlog_create(WT_SESSION_IMPL *session, const char *cfg[])
@@ -1937,6 +1939,10 @@ extern void __wt_stat_join_aggregate(WT_JOIN_STATS **from, WT_JOIN_STATS *to);
 extern void __wt_stat_join_clear_all(WT_JOIN_STATS **stats);
 extern void __wt_stat_join_clear_single(WT_JOIN_STATS *stats);
 extern void __wt_stat_join_init_single(WT_JOIN_STATS *stats);
+extern void __wt_stat_page_aggregate(WT_PAGE_STATS **from, WT_PAGE_STATS *to);
+extern void __wt_stat_page_clear_all(WT_PAGE_STATS **stats);
+extern void __wt_stat_page_clear_single(WT_PAGE_STATS *stats);
+extern void __wt_stat_page_init_single(WT_PAGE_STATS *stats);
 extern void __wt_stat_session_clear_single(WT_SESSION_STATS *stats);
 extern void __wt_stat_session_init_single(WT_SESSION_STATS *stats);
 extern void __wt_thread_group_start_one(

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1202,4 +1202,13 @@ struct __wt_session_stats {
     int64_t cache_time;
 };
 
+/*
+ * Statistics entries for page stat.
+ */
+#define WT_PAGE_STATS_BASE 5000
+struct __wt_page_stats {
+    int64_t byte_count;
+    int64_t row_count;
+};
+
 /* Statistics section: END */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7443,6 +7443,17 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4006
 /*! session: time waiting for cache (usecs) */
 #define	WT_STAT_SESSION_CACHE_TIME			4007
+
+/*!
+* @}
+* @name Statistics for page stat
+* @anchor statistics_page
+* @{
+*/
+/*! page: byte count of a file */
+#define	WT_STAT_PAGE_BYTE_COUNT				5000
+/*! page: row count of a file */
+#define	WT_STAT_PAGE_ROW_COUNT				5001
 /*! @} */
 /*
  * Statistics section: END

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -299,6 +299,8 @@ struct __wt_page_modify;
 typedef struct __wt_page_modify WT_PAGE_MODIFY;
 struct __wt_page_stat;
 typedef struct __wt_page_stat WT_PAGE_STAT;
+struct __wt_page_stats;
+typedef struct __wt_page_stats WT_PAGE_STATS;
 struct __wt_process;
 typedef struct __wt_process WT_PROCESS;
 struct __wt_rec_chunk;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1890,10 +1890,10 @@ __rec_split_write_header(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK
 
     /* Set the page stat cell information flag. */
     if (__wt_process.page_stats_2022 && WT_PAGE_STAT_HAS_BYTE_COUNT(&chunk->ps))
-        F_SET(dsk, WT_PAGE_STAT_BYTE_COUNT);
+        FLD_SET(dsk->stat_flags, WT_PAGE_STAT_BYTE_COUNT);
 
     if (__wt_process.page_stats_2022 && WT_PAGE_STAT_HAS_ROW_COUNT(&chunk->ps))
-        F_SET(dsk, WT_PAGE_STAT_ROW_COUNT);
+        FLD_SET(dsk->stat_flags, WT_PAGE_STAT_ROW_COUNT);
 
     dsk->unused = 0;
     dsk->version = WT_PAGE_VERSION_TS;

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -3094,3 +3094,45 @@ __wt_stat_session_clear_single(WT_SESSION_STATS *stats)
     stats->lock_schema_wait = 0;
     stats->cache_time = 0;
 }
+
+static const char *const __stats_page_desc[] = {
+  "page: byte count of a file",
+  "page: row count of a file",
+};
+
+int
+__wt_stat_page_desc(WT_CURSOR_STAT *cst, int slot, const char **p)
+{
+    WT_UNUSED(cst);
+    *p = __stats_page_desc[slot];
+    return (0);
+}
+
+void
+__wt_stat_page_init_single(WT_PAGE_STATS *stats)
+{
+    memset(stats, 0, sizeof(*stats));
+}
+
+void
+__wt_stat_page_clear_single(WT_PAGE_STATS *stats)
+{
+    stats->byte_count = 0;
+    stats->row_count = 0;
+}
+
+void
+__wt_stat_page_clear_all(WT_PAGE_STATS **stats)
+{
+    u_int i;
+
+    for (i = 0; i < WT_COUNTER_SLOTS; ++i)
+        __wt_stat_page_clear_single(stats[i]);
+}
+
+void
+__wt_stat_page_aggregate(WT_PAGE_STATS **from, WT_PAGE_STATS *to)
+{
+    to->byte_count += WT_STAT_READ(from, byte_count);
+    to->row_count += WT_STAT_READ(from, row_count);
+}

--- a/test/suite/test_stat11.py
+++ b/test/suite/test_stat11.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_stat11.py
+#    Usage of statistics cursor for retrieving page stats.
+
+import wttest
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+class test_stat11(wttest.WiredTigerTestCase):
+    pfx = 'test_page_stat'
+    conn_config = 'statistics=(all)'
+
+    format = [
+        ('integer-row', dict(key_format='i', value_format='i')),
+        ('string-row', dict(key_format='S', value_format='S')),
+        ('col-var', dict(key_format='r', value_format='i')),
+        ('string-col-var', dict(key_format='r', value_format='S')),
+        ('col-fix', dict(key_format='r', value_format='8t')),
+    ]
+
+    types = [
+        ('file', dict(uri='file:' + pfx, ds=SimpleDataSet)),
+        ('table', dict(uri='table:' + pfx, ds=SimpleDataSet)),
+    ]
+    scenarios = make_scenarios(format, types)
+
+    def create_key(self, i):
+        if self.key_format == 'S':
+            return str(i)
+        return i
+
+    # Test that the row count matches the number of records inserted.
+    def test_page_stat_statistic_cursor(self):
+        create_params = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        self.session.create(self.uri, create_params)
+        c = self.session.open_cursor(self.uri, None, None)
+
+        size='allocation_size=512,internal_page_max=512'
+        ds = self.ds(self, self.uri, 3000, config=size, key_format=self.key_format, value_format=self.value_format)
+
+        # Insert some values and persist them to disk.
+        for i in range (1, 2001):
+            if self.value_format == 'S':
+                value = str(i)
+            elif self.value_format == '8t':
+                value = i % 100
+            else:
+                value = i
+
+            c[self.create_key(i)] = value
+        c.close()
+
+        self.session.checkpoint()
+
+        ps_cursor = self.session.open_cursor('statistics:checkpoint:' + self.uri, None, None)
+        
+        # Use a statistics cursor to get the byte and row counts and verify the values.
+        ps_cursor.next()
+        [desc, pvalue, byte_count] = ps_cursor.get_values()
+        # When the page_stats_2022 feature flag is enabled, this assertion applies.
+        # self.assertGreater(byte_count, 0)
+
+        # Get the row count.
+        ps_cursor.next()
+        [desc, pvalue, row_count] = ps_cursor.get_values()
+        # When the page_stats_2022 feature flag is enabled, this assertion applies.
+        # self.assertEqual(row_count, 2000)
+        ps_cursor.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Trying to get a feel for using the statistics cursor interface. I think the names may be a little confusing, it doesn't feel correct to call the byte and row counts 'checkpoint' statistics since they are not related to checkpoint and they are just stored there, but I'm open to changes as well. 