### PR TITLE
WT-9759 Bring down longest-running Pull Request task duration to below 25mins

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2238,7 +2238,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 0/11
+          unit_test_args: -v 2 -b 0/12
 
   - name: unit-test-bucket01
     tags: ["pull_request", "python", "unit_test"]
@@ -2248,7 +2248,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 1/11
+          unit_test_args: -v 2 -b 1/12
 
   - name: unit-test-bucket02
     tags: ["pull_request", "python", "unit_test"]
@@ -2258,7 +2258,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 2/11
+          unit_test_args: -v 2 -b 2/12
 
   - name: unit-test-bucket03
     tags: ["pull_request", "python", "unit_test"]
@@ -2268,7 +2268,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 3/11
+          unit_test_args: -v 2 -b 3/12
 
   - name: unit-test-bucket04
     tags: ["pull_request", "python", "unit_test"]
@@ -2278,7 +2278,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 4/11
+          unit_test_args: -v 2 -b 4/12
 
   - name: unit-test-bucket05
     tags: ["pull_request", "python", "unit_test"]
@@ -2288,7 +2288,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 5/11
+          unit_test_args: -v 2 -b 5/12
 
   - name: unit-test-bucket06
     tags: ["pull_request", "python", "unit_test"]
@@ -2298,7 +2298,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 6/11
+          unit_test_args: -v 2 -b 6/12
 
   - name: unit-test-bucket07
     tags: ["pull_request", "python", "unit_test"]
@@ -2308,7 +2308,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 7/11
+          unit_test_args: -v 2 -b 7/12
 
   - name: unit-test-bucket08
     tags: ["pull_request", "python", "unit_test"]
@@ -2318,7 +2318,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 8/11
+          unit_test_args: -v 2 -b 8/12
 
   - name: unit-test-bucket09
     tags: ["pull_request", "python", "unit_test"]
@@ -2328,7 +2328,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 9/11
+          unit_test_args: -v 2 -b 9/12
 
   - name: unit-test-bucket10
     tags: ["pull_request", "python", "unit_test"]
@@ -2338,7 +2338,17 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 -b 10/11
+          unit_test_args: -v 2 -b 10/12
+
+  - name: unit-test-bucket11
+    tags: ["pull_request", "python", "unit_test"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 11/12
 
   - name: unit-test-long-bucket00
     tags: ["python", "unit_test_long"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2359,7 +2359,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 0/11
+          unit_test_args: -v 2 --long -b 0/12
 
   - name: unit-test-long-bucket01
     tags: ["python", "unit_test_long"]
@@ -2370,7 +2370,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 1/11
+          unit_test_args: -v 2 --long -b 1/12
 
   - name: unit-test-long-bucket02
     tags: ["python", "unit_test_long"]
@@ -2381,7 +2381,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 2/11
+          unit_test_args: -v 2 --long -b 2/12
 
   - name: unit-test-long-bucket03
     tags: ["python", "unit_test_long"]
@@ -2392,7 +2392,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 3/11
+          unit_test_args: -v 2 --long -b 3/12
 
   - name: unit-test-long-bucket04
     tags: ["python", "unit_test_long"]
@@ -2404,7 +2404,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 4/11
+          unit_test_args: -v 2 --long -b 4/12
 
   - name: unit-test-long-bucket05
     tags: ["python", "unit_test_long"]
@@ -2415,7 +2415,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 5/11
+          unit_test_args: -v 2 --long -b 5/12
 
   - name: unit-test-long-bucket06
     tags: ["python", "unit_test_long"]
@@ -2426,7 +2426,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 6/11
+          unit_test_args: -v 2 --long -b 6/12
 
   - name: unit-test-long-bucket07
     tags: ["python", "unit_test_long"]
@@ -2437,7 +2437,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 7/11
+          unit_test_args: -v 2 --long -b 7/12
 
   - name: unit-test-long-bucket08
     tags: ["python", "unit_test_long"]
@@ -2448,7 +2448,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 8/11
+          unit_test_args: -v 2 --long -b 8/12
 
   - name: unit-test-long-bucket09
     tags: ["python", "unit_test_long"]
@@ -2459,7 +2459,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 9/11
+          unit_test_args: -v 2 --long -b 9/12
 
   - name: unit-test-long-bucket10
     tags: ["python", "unit_test_long"]
@@ -2470,7 +2470,19 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
-          unit_test_args: -v 2 --long -b 10/11
+          unit_test_args: -v 2 --long -b 10/12
+
+  - name: unit-test-long-bucket11
+    tags: ["python", "unit_test_long"]
+    patch_only: true
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 --long -b 11/12
+
   # End of Python unit test tasks
 
   - name: s-all

--- a/test/suite/test_truncate20.py
+++ b/test/suite/test_truncate20.py
@@ -74,6 +74,7 @@ class test_truncate20(wttest.WiredTigerTestCase):
         evict_cursor.close()
         self.session.rollback_transaction()
 
+    @wttest.longtest('large number of rows to truncate and checkpoint')
     def test_truncate(self):
         uri = 'table:oplog'
         nrows = 1000000


### PR DESCRIPTION
Changes include:

- add a new bucket to the existing unit-test-bucket tasks to offload some tests.
- add a new bucket to the existing unit-test-long-bucket tasks to match the above change.
- set `test_truncate20.py` to a long test (runs over 10mins), so that it's not triggered in PR builds. 

With the above changes, the longest-running task in a PR patch build (unit-test-bucket02) was below 25 mins. 