### PR TITLE
WT-10434 Skip log retention setting during backward compatibility runs.

### DIFF
--- a/test/format/config.sh
+++ b/test/format/config.sh
@@ -137,11 +137,11 @@ CONFIG configuration_list[] = {
 
 {"checkpoint.wait", "seconds to wait if wiredtiger checkpoints configured", 0x0, 5, 100, 3600}
 
-{"debug.checkpoint_retention", "adjust log removal to retain the log records", 0x0, 0, 128, 1024}
+{"debug.checkpoint_retention", "adjust log removal to retain the log records", 0x0, 0, 10, 1024}
 
 {"debug.eviction", "modify internal algorithms to force history store eviction to happen more aggressively", C_BOOL, 2, 0, 0}
 
-{"debug.log_retention", "adjust log removal to retain at least this number of log files", 0x0, 0, 128, 1024}
+{"debug.log_retention", "adjust log removal to retain at least this number of log files", 0x0, 0, 10, 1024}
 
 {"debug.realloc_exact", "reallocation of memory will only provide the exact amount requested", C_BOOL, 0, 0, 0}
 

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -209,7 +209,12 @@ configure_debug_mode(char **p, size_t max)
         CONFIG_APPEND(*p, ",checkpoint_retention=%" PRIu32, GV(DEBUG_CHECKPOINT_RETENTION));
     if (GV(DEBUG_EVICTION))
         CONFIG_APPEND(*p, ",eviction=true");
-    if (GV(DEBUG_LOG_RETENTION) != 0)
+    /*
+     * Don't configure log retention debug mode during backward compatibility mode. Compatibility
+     * requires removing log files on reconfigure. When the version is changed for compatibility,
+     * reconfigure requires removing earlier log files and log retention can make that seem to hang.
+     */
+    if (GV(DEBUG_LOG_RETENTION) != 0 && !g.backward_compatible)
         CONFIG_APPEND(*p, ",log_retention=%" PRIu32, GV(DEBUG_LOG_RETENTION));
     if (GV(DEBUG_REALLOC_EXACT))
         CONFIG_APPEND(*p, ",realloc_exact=true");


### PR DESCRIPTION
This was a hang in test/format. I've turned off setting the debug mode of log retention if backward compatibility is in use. I also reduced the maximum values for those retention settings in test format from 128 way down. The runs that hung were short, generating 4 log files. So retaining over 100 seemed extreme and doesn't really test more than saving a few that we don't specifically need.

The compatibility reconfigure code is the only caller of the `logmgr_force_remove` function. And test/format only sets that for compatibility on connection close. So no more log records are getting written from operations.