### PR TITLE
WT-10440 Change out of order checks to remove runtime toggle

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -556,6 +556,7 @@ restart_read_page:
     /* NOTREACHED */
 }
 
+#ifdef HAVE_DIAGNOSTIC
 /*
  * __cursor_key_order_check_col --
  *     Check key ordering for column-store cursor movements.
@@ -582,12 +583,9 @@ __cursor_key_order_check_col(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, boo
         cbt->lastrecno = cbt->recno;
         return (0);
     }
-#ifdef HAVE_DIAGNOSTIC
+
     WT_RET(__wt_msg(session, "dumping the tree"));
     WT_WITH_BTREE(session, btree, ret = __wt_debug_tree_all(session, NULL, NULL, NULL));
-#else
-    WT_UNUSED(btree);
-#endif
     __wt_verbose_error(session, WT_VERB_OUT_OF_ORDER,
       "WT_CURSOR.%s out-of-order returns: returned key %" PRIu64 " then key %" PRIu64,
       next ? "next" : "prev", cbt->lastrecno, cbt->recno);
@@ -630,10 +628,8 @@ __cursor_key_order_check_row(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, boo
       __wt_buf_set_printable_format(
         session, cbt->lastkey->data, cbt->lastkey->size, btree->key_format, false, a),
       __wt_buf_set_printable_format(session, key->data, key->size, btree->key_format, false, b));
-#ifdef HAVE_DIAGNOSTIC
     WT_ERR(__wt_msg(session, "dumping the tree"));
     WT_WITH_BTREE(session, btree, ret = __wt_debug_tree_all(session, NULL, NULL, NULL));
-#endif
     WT_ERR_PANIC(session, EINVAL, "found key out-of-order returns");
 
 err:
@@ -704,6 +700,7 @@ __wt_cursor_key_order_reset(WT_CURSOR_BTREE *cbt)
         cbt->lastkey->size = 0;
     cbt->lastrecno = WT_RECNO_OOB;
 }
+#endif
 
 /*
  * __wt_btcur_iterate_setup --
@@ -733,10 +730,9 @@ __wt_btcur_iterate_setup(WT_CURSOR_BTREE *cbt)
      * the tree, not as a result of a search.
      */
     if (cbt->ref == NULL) {
-        if (EXTRA_DIAGNOSTICS_ENABLED(
-              (WT_SESSION_IMPL *)cbt->iface.session, WT_DIAG_OUT_OF_ORDER)) {
-            __wt_cursor_key_order_reset(cbt);
-        }
+#ifdef HAVE_DIAGNOSTIC
+        __wt_cursor_key_order_reset(cbt);
+#endif
         return;
     }
 
@@ -784,10 +780,12 @@ __wt_btcur_next_prefix(WT_CURSOR_BTREE *cbt, WT_ITEM *prefix, bool truncating)
     WT_SESSION_IMPL *session;
     size_t total_skipped, skipped;
     uint32_t flags;
-    bool inclusive_set;
     bool key_out_of_bounds, newpage, restart, need_walk;
+#ifdef HAVE_DIAGNOSTIC
+    bool inclusive_set;
 
     inclusive_set = false;
+#endif
     cursor = &cbt->iface;
     key_out_of_bounds = false;
     need_walk = false;
@@ -955,38 +953,35 @@ err:
     switch (ret) {
     case 0:
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
+#ifdef HAVE_DIAGNOSTIC
+        /*
+         * Skip key order check, if prev is called after a next returned a prepare conflict error,
+         * i.e cursor has changed direction at a prepared update, hence current key returned could
+         * be same as earlier returned key.
+         *
+         * eg: Initial data set : (1,2,3,...10) insert key 11 in a prepare transaction. loop on next
+         * will return 1,2,3...10 and subsequent call to next will return a prepare conflict. Now if
+         * we call prev key 10 will be returned which will be same as earlier returned key.
+         */
+        if (!F_ISSET(cbt, WT_CBT_ITERATE_RETRY_PREV))
+            ret = __wt_cursor_key_order_check(session, cbt, true);
 
-        if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER)) {
+        if (need_walk) {
             /*
-             * Skip key order check, if prev is called after a next returned a prepare conflict
-             * error, i.e cursor has changed direction at a prepared update, hence current key
-             * returned could be same as earlier returned key.
-             *
-             * eg: Initial data set : (1,2,3,...10) insert key 11 in a prepare transaction. loop on
-             * next will return 1,2,3...10 and subsequent call to next will return a prepare
-             * conflict. Now if we call prev key 10 will be returned which will be same as earlier
-             * returned key.
+             * The bounds positioning code relies on the assumption that if we had to walk then we
+             * can't possibly have walked to the lower bound. We check that assumption here by
+             * comparing the lower bound with our current key or recno. Force inclusive to be false
+             * so we don't consider the bound itself.
              */
-            if (!F_ISSET(cbt, WT_CBT_ITERATE_RETRY_PREV))
-                ret = __wt_cursor_key_order_check(session, cbt, true);
-
-            if (need_walk) {
-                /*
-                 * The bounds positioning code relies on the assumption that if we had to walk then
-                 * we can't possibly have walked to the lower bound. We check that assumption here
-                 * by comparing the lower bound with our current key or recno. Force inclusive to be
-                 * false so we don't consider the bound itself.
-                 */
-                inclusive_set = F_ISSET(cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
-                F_CLR(cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
-                ret = __wt_compare_bounds(
-                  session, cursor, &cbt->iface.key, cbt->recno, false, &key_out_of_bounds);
-                WT_ASSERT_ALWAYS(session, ret == 0 && !key_out_of_bounds,
-                  "Bounded cursor next logic resulted in the cursor being in an illegal state");
-                if (inclusive_set)
-                    F_SET(cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
-            }
+            inclusive_set = F_ISSET(cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
+            F_CLR(cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
+            ret = __wt_compare_bounds(
+              session, cursor, &cbt->iface.key, cbt->recno, false, &key_out_of_bounds);
+            WT_ASSERT(session, ret == 0 && !key_out_of_bounds);
+            if (inclusive_set)
+                F_SET(cursor, WT_CURSTD_BOUND_LOWER_INCLUSIVE);
         }
+#endif
         break;
     case WT_PREPARE_CONFLICT:
         /*

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -717,10 +717,12 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
     WT_SESSION_IMPL *session;
     size_t total_skipped, skipped;
     uint32_t flags;
-    bool inclusive_set;
     bool key_out_of_bounds, newpage, restart, need_walk;
+#ifdef HAVE_DIAGNOSTIC
+    bool inclusive_set;
 
     inclusive_set = false;
+#endif
     cursor = &cbt->iface;
     key_out_of_bounds = false;
     need_walk = false;
@@ -886,38 +888,35 @@ err:
             F_SET(cursor, WT_CURSTD_KEY_INT);
         else
             F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
+#ifdef HAVE_DIAGNOSTIC
+        /*
+         * Skip key order check, if next is called after a prev returned a prepare conflict error,
+         * i.e cursor has changed direction at a prepared update, hence current key returned could
+         * be same as earlier returned key.
+         *
+         * eg: Initial data set : (2,3,...10) insert key 1 in a prepare transaction. loop on prev
+         * will return 10,...3,2 and subsequent call to prev will return a prepare conflict. Now if
+         * we call next key 2 will be returned which will be same as earlier returned key.
+         */
+        if (!F_ISSET(cbt, WT_CBT_ITERATE_RETRY_NEXT))
+            ret = __wt_cursor_key_order_check(session, cbt, false);
 
-        if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER)) {
+        if (need_walk) {
             /*
-             * Skip key order check, if next is called after a prev returned a prepare conflict
-             * error, i.e cursor has changed direction at a prepared update, hence current key
-             * returned could be same as earlier returned key.
-             *
-             * eg: Initial data set : (2,3,...10) insert key 1 in a prepare transaction. loop on
-             * prev will return 10,...3,2 and subsequent call to prev will return a prepare
-             * conflict. Now if we call next key 2 will be returned which will be same as earlier
-             * returned key.
+             * The bounds positioning code relies on the assumption that if we had to walk then we
+             * can't possibly have walked to the upper bound. We check that assumption here by
+             * comparing the upper bound with our current key or recno. Force inclusive to be false
+             * so we don't consider the bound itself.
              */
-            if (!F_ISSET(cbt, WT_CBT_ITERATE_RETRY_NEXT))
-                ret = __wt_cursor_key_order_check(session, cbt, false);
-
-            if (need_walk) {
-                /*
-                 * The bounds positioning code relies on the assumption that if we had to walk then
-                 * we can't possibly have walked to the upper bound. We check that assumption here
-                 * by comparing the upper bound with our current key or recno. Force inclusive to be
-                 * false so we don't consider the bound itself.
-                 */
-                inclusive_set = F_ISSET(cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
-                F_CLR(cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
-                ret = __wt_compare_bounds(
-                  session, cursor, &cbt->iface.key, cbt->recno, true, &key_out_of_bounds);
-                WT_ASSERT_ALWAYS(session, ret == 0 && !key_out_of_bounds,
-                  "Bounded cursor prev logic resulted in the cursor being an illegal state");
-                if (inclusive_set)
-                    F_SET(cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
-            }
+            inclusive_set = F_ISSET(cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
+            F_CLR(cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
+            ret = __wt_compare_bounds(
+              session, cursor, &cbt->iface.key, cbt->recno, true, &key_out_of_bounds);
+            WT_ASSERT(session, ret == 0 && !key_out_of_bounds);
+            if (inclusive_set)
+                F_SET(cursor, WT_CURSTD_BOUND_UPPER_INCLUSIVE);
         }
+#endif
         break;
     case WT_PREPARE_CONFLICT:
         /*

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -527,12 +527,13 @@ __cursor_col_search(WT_CURSOR_BTREE *cbt, WT_REF *leaf, bool *leaf_foundp)
 
     session = CUR2S(cbt);
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER))
-        /*
-         * Turn off cursor-order checks in all cases on search. The search/search-near functions
-         * turn them back on after a successful search.
-         */
-        __wt_cursor_key_order_reset(cbt);
+#ifdef HAVE_DIAGNOSTIC
+    /*
+     * Turn off cursor-order checks in all cases on search. The search/search-near functions turn
+     * them back on after a successful search.
+     */
+    __wt_cursor_key_order_reset(cbt);
+#endif
 
     WT_WITH_PAGE_INDEX(
       session, ret = __wt_col_search(cbt, cbt->iface.recno, leaf, false, leaf_foundp));
@@ -551,12 +552,13 @@ __cursor_row_search(WT_CURSOR_BTREE *cbt, bool insert, WT_REF *leaf, bool *leaf_
 
     session = CUR2S(cbt);
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER))
-        /*
-         * Turn off cursor-order checks in all cases on search. The search/search-near functions
-         * turn them back on after a successful search.
-         */
-        __wt_cursor_key_order_reset(cbt);
+#ifdef HAVE_DIAGNOSTIC
+    /*
+     * Turn off cursor-order checks in all cases on search. The search/search-near functions turn
+     * them back on after a successful search.
+     */
+    __wt_cursor_key_order_reset(cbt);
+#endif
 
     WT_WITH_PAGE_INDEX(
       session, ret = __wt_row_search(cbt, &cbt->iface.key, insert, leaf, false, leaf_foundp));
@@ -847,8 +849,10 @@ __wt_btcur_search(WT_CURSOR_BTREE *cbt)
     if (session->format_private != NULL && (ret == 0 || ret == WT_NOTFOUND))
         session->format_private(ret, session->format_private_arg);
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER) && ret == 0)
+#ifdef HAVE_DIAGNOSTIC
+    if (ret == 0)
         WT_ERR(__wt_cursor_key_order_init(cbt));
+#endif
 
     if (ret == 0)
         WT_ERR(__wt_btcur_evict_reposition(cbt));
@@ -1095,8 +1099,10 @@ err:
     if (ret == 0 && exactp != NULL)
         *exactp = exact;
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER) && ret == 0)
+#ifdef HAVE_DIAGNOSTIC
+    if (ret == 0)
         WT_TRET(__wt_cursor_key_order_init(cbt));
+#endif
 
     if (ret != 0) {
         /*
@@ -2256,10 +2262,10 @@ __wt_btcur_open(WT_CURSOR_BTREE *cbt)
     cbt->upd_value->type = WT_UPDATE_INVALID;
     WT_TIME_WINDOW_INIT(&cbt->upd_value->tw);
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(CUR2S(cbt), WT_DIAG_OUT_OF_ORDER)) {
-        cbt->lastkey = &cbt->_lastkey;
-        cbt->lastrecno = WT_RECNO_OOB;
-    }
+#ifdef HAVE_DIAGNOSTIC
+    cbt->lastkey = &cbt->_lastkey;
+    cbt->lastrecno = WT_RECNO_OOB;
+#endif
 }
 
 /*
@@ -2304,9 +2310,9 @@ __wt_btcur_close(WT_CURSOR_BTREE *cbt, bool lowlevel)
     __wt_buf_free(session, &cbt->_tmp);
     __wt_buf_free(session, &cbt->_modify_update.buf);
     __wt_buf_free(session, &cbt->_upd_value.buf);
-
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER))
-        __wt_buf_free(session, &cbt->_lastkey);
+#ifdef HAVE_DIAGNOSTIC
+    __wt_buf_free(session, &cbt->_lastkey);
+#endif
 
     return (ret);
 }

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -494,14 +494,13 @@ __wt_btcur_next_random(WT_CURSOR_BTREE *cbt)
 
     F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER))
-        /*
-         * Under some conditions we end up using the underlying cursor.next to walk through the
-         * object. Since there are multiple calls, we can hit the cursor-order checks, turn them
-         * off.
-         */
-        __wt_cursor_key_order_reset(cbt);
-
+#ifdef HAVE_DIAGNOSTIC
+    /*
+     * Under some conditions we end up using the underlying cursor.next to walk through the object.
+     * Since there are multiple calls, we can hit the cursor-order checks, turn them off.
+     */
+    __wt_cursor_key_order_reset(cbt);
+#endif
     /*
      * If we don't have a current position in the tree, or if retrieving random values without
      * sampling, pick a roughly random leaf page in the tree and return an entry from it.

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -199,12 +199,13 @@ __curhs_search(WT_CURSOR_BTREE *hs_cbt, bool insert)
     hs_btree = CUR2BT(hs_cbt);
     session = CUR2S(hs_cbt);
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER))
-        /*
-         * Turn off cursor-order checks in all cases on search. The search/search-near functions
-         * turn them back on after a successful search.
-         */
-        __wt_cursor_key_order_reset(hs_cbt);
+#ifdef HAVE_DIAGNOSTIC
+    /*
+     * Turn off cursor-order checks in all cases on search. The search/search-near functions turn
+     * them back on after a successful search.
+     */
+    __wt_cursor_key_order_reset(hs_cbt);
+#endif
 
     WT_ERR(__wt_cursor_localkey(&hs_cbt->iface));
 
@@ -213,8 +214,10 @@ __curhs_search(WT_CURSOR_BTREE *hs_cbt, bool insert)
     WT_WITH_BTREE(session, hs_btree,
       ret = __wt_row_search(hs_cbt, &hs_cbt->iface.key, insert, NULL, false, NULL));
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER) && ret == 0)
+#ifdef HAVE_DIAGNOSTIC
+    if (ret == 0)
         WT_TRET(__wt_cursor_key_order_init(hs_cbt));
+#endif
 
 err:
     if (ret != 0)

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -236,9 +236,11 @@ struct __wt_cursor_btree {
      */
     enum { WT_CBT_RETRY_NOTSET = 0, WT_CBT_RETRY_INSERT, WT_CBT_RETRY_PAGE } iter_retry;
 
+#ifdef HAVE_DIAGNOSTIC
     /* Check that cursor next/prev never returns keys out-of-order. */
     WT_ITEM *lastkey, _lastkey;
     uint64_t lastrecno;
+#endif
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CBT_ACTIVE 0x001u             /* Active in the tree */

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -243,9 +243,9 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
     cursor = &cbt->iface;
     session = CUR2S(cbt);
 
-    if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAG_OUT_OF_ORDER))
-        __wt_cursor_key_order_reset(cbt); /* Clear key-order checks. */
-
+#ifdef HAVE_DIAGNOSTIC
+    __wt_cursor_key_order_reset(cbt); /* Clear key-order checks. */
+#endif
     __cursor_pos_clear(cbt);
 
     /* If the cursor was active, deactivate it. */


### PR DESCRIPTION
Perf tests indicate a ~5% slowdown on some tests which stems from some very frequent calls to `EXTRA_DIAGNOSTICS_ENABLED` in `__wt_btcur_next_prefix` (among others). 
As removing this check touches `__wt_cursor_key_order_check` I've also removed runtime toggling from the full set of coupled functions: `__cursor_key_order_check_col`, `__cursor_key_order_check_row`,  `__wt_cursor_key_order_init`, `__wt_cursor_key_order_reset`, `__wt_btcur_open`,  `__wt_btcur_close`.

The changes were made by checking out the code from prior to WT-10383, so you can treat this a partial revert of the WT-10383 changes. Behaviour is now back to what it was at the start of the project for these specific functions.