### PR TITLE
WT-10107 Fix potential overflow in testutil_tiered_sleep

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -184,7 +184,7 @@ real_checkpointer(void)
     WT_RAND_STATE rnd;
     WT_SESSION *session;
     wt_timestamp_t stable_ts, oldest_ts, verify_ts;
-    uint32_t delay;
+    uint64_t delay;
     int ret;
     char buf[128], flush_tier_config[128], timestamp_buf[64];
     const char *checkpoint_config, *ts_config;

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -542,7 +542,7 @@ thread_ckpt_run(void *arg)
     WT_RAND_STATE rnd;
     WT_SESSION *session;
     uint64_t ts;
-    uint32_t sleep_time;
+    uint64_t sleep_time;
     int i;
     char ckpt_flush_config[128], ckpt_config[128];
     bool first_ckpt, flush_tier;

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -418,7 +418,7 @@ void testutil_wiredtiger_open(
   TEST_OPTS *, const char *, const char *, WT_EVENT_HANDLER *, WT_CONNECTION **, bool, bool);
 void testutil_tiered_begin(TEST_OPTS *);
 void testutil_tiered_flush_complete(TEST_OPTS *, WT_SESSION *, void *);
-void testutil_tiered_sleep(TEST_OPTS *, WT_SESSION *, uint32_t, bool *);
+void testutil_tiered_sleep(TEST_OPTS *, WT_SESSION *, uint64_t, bool *);
 uint64_t testutil_time_us(WT_SESSION *);
 void testutil_work_dir_from_path(char *, size_t, const char *);
 WT_THREAD_RET thread_append(void *);

--- a/test/utility/tiered.c
+++ b/test/utility/tiered.c
@@ -57,7 +57,7 @@ testutil_tiered_begin(TEST_OPTS *opts)
  *     exit.
  */
 void
-testutil_tiered_sleep(TEST_OPTS *opts, WT_SESSION *session, uint32_t seconds, bool *do_flush_tier)
+testutil_tiered_sleep(TEST_OPTS *opts, WT_SESSION *session, uint64_t seconds, bool *do_flush_tier)
 {
     uint64_t now, wake_time;
     bool do_flush;


### PR DESCRIPTION
Coverity warning: Change the type of `seconds` in `testutil_tiered_sleep` from `uint32_t` to `uint64_t` to avoid overflow.

This was pretty harmless - we'd only hit this if we decided to write a test where tiered needs to sleep for over an hour and all current calls to `testutil_tiered_sleep` are capped at a 5 second wait.
All the same, the type has been updated.