### PR TITLE
WT-9685 Don't exit loop early in __wt_tiered_flush_work_wait

### DIFF
--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -145,9 +145,10 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
         found = false;
         __wt_spin_lock(session, &conn->tiered_lock);
         TAILQ_FOREACH (entry, &conn->tieredqh, q) {
-            if (FLD_ISSET(entry->type, WT_TIERED_WORK_FLUSH))
+            if (FLD_ISSET(entry->type, WT_TIERED_WORK_FLUSH)) {
                 found = true;
-            break;
+                break;
+            }
         }
         __wt_spin_unlock(session, &conn->tiered_lock);
         if (found) {

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -144,12 +144,12 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
     while (!done) {
         found = false;
         __wt_spin_lock(session, &conn->tiered_lock);
-        TAILQ_FOREACH (entry, &conn->tieredqh, q) {
+        TAILQ_FOREACH (entry, &conn->tieredqh, q)
             if (FLD_ISSET(entry->type, WT_TIERED_WORK_FLUSH)) {
                 found = true;
                 break;
             }
-        }
+
         __wt_spin_unlock(session, &conn->tiered_lock);
         if (found) {
             __wt_cond_signal(session, conn->tiered_cond);


### PR DESCRIPTION
Move break statement inside of if branch so we only break from our search when pending flush work is found.

I think this was caused by having the original code 
```c
if (FLD_ISSET(entry->type, WT_TIERED_WORK_FLUSH))
    found = true;
    break;
```
and `s_all` silently re-indenting without providing giving us a `misleading-indentation` warning. I'll create a separate ticket to have `s_all` detect this in future.