### PR TITLE
WT-10503 Fix false positives in s_all

### DIFF
--- a/dist/comment_style.py
+++ b/dist/comment_style.py
@@ -135,14 +135,15 @@ if __name__ == '__main__':
 
     result = subprocess.run(command, shell=True, capture_output=True, text=True).stdout.strip('\n')
     count = 0
-    for file_name in result.split('\n'):
-        if file_name in ignore_files:
-            continue
+    if result != "":
+        for file_name in result.split('\n'):
+            if file_name in ignore_files:
+                continue
 
-        if file_is_cpp(file_name):
-            count += check_cpp_comments(file_name)
-        else:
-            count += check_c_comments(file_name)
+            if file_is_cpp(file_name):
+                count += check_cpp_comments(file_name)
+            else:
+                count += check_c_comments(file_name)
 
     if (count != 0):
         print('Detected ' + str(count) +' comment format issues!')

--- a/dist/comment_style.py
+++ b/dist/comment_style.py
@@ -135,7 +135,7 @@ if __name__ == '__main__':
 
     result = subprocess.run(command, shell=True, capture_output=True, text=True).stdout.strip('\n')
     count = 0
-    if result != "":
+    if result:
         for file_name in result.split('\n'):
             if file_name in ignore_files:
                 continue

--- a/dist/s_export
+++ b/dist/s_export
@@ -25,6 +25,9 @@ check()
     (sed -e '/^#/d' s_export.list &&
     eval $NM |
     sed 's/.* //' |
+    # Functions beginning with __ut are intentionally exposed to support unit testing when
+    # Wiredtiger is compiled with HAVE_UNITTEST=1.
+    egrep -v '^__ut' |
     egrep -v '^__wt') |
     sort |
     uniq -u |

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -21,3 +21,11 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
+# These symbols are only exposed when unit testing WiredTiger with HAVE_UNITTEST=1
+__ut_block_first_srch
+__ut_block_off_srch
+__ut_block_off_srch_last
+__ut_block_size_srch
+__ut_ckpt_add_blkmod_entry
+__ut_ovfl_discard_verbose
+__ut_ovfl_discard_wrapup

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -21,11 +21,3 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
-# These symbols are only exposed when unit testing WiredTiger with HAVE_UNITTEST=1
-__ut_block_first_srch
-__ut_block_off_srch
-__ut_block_off_srch_last
-__ut_block_size_srch
-__ut_ckpt_add_blkmod_entry
-__ut_ovfl_discard_verbose
-__ut_ovfl_discard_wrapup

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -133,9 +133,15 @@ def get_make_check_dirs():
     # Make sure we are under the repo top level directory
     os.chdir(run('git rev-parse --show-toplevel'))
 
+    # Find the build folder. It can be identified by the presence of the `CMakeFiles` file.
+    p = subprocess.Popen("find . -name CMakeFiles -maxdepth 2", stdout=subprocess.PIPE, shell=True, 
+        universal_newlines=True)
+    build_folder = os.path.dirname(p.stdout.read().strip())
+
     # Search keyword in CMakeLists.txt to identify directories that involve test configuration.
     # Need to use subprocess 'shell=True' to get the expected shell command output.
-    cmd = "find . -not -path './releases/*' -not -path './build/*' -not -path './cmake_build/*' -name CMakeLists.txt -exec grep -H -e '\(add_test\|define_c_test|define_test_variants\)' {} \; | cut -d: -f1 | cut -c3- | uniq"
+    # `{{}}`` is used here to print `{}` when using python f-strings.
+    cmd = f"find . -not -path './releases/*' -not -path '{build_folder}/*' -name CMakeLists.txt -exec grep -H -e '\(add_test\|define_c_test|define_test_variants\)' {{}} \; | cut -d: -f1 | cut -c3- | uniq"
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     mkfiles_with_tests = p.stdout.readlines()
 

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -135,7 +135,7 @@ def get_make_check_dirs():
 
     # Search keyword in CMakeLists.txt to identify directories that involve test configuration.
     # Need to use subprocess 'shell=True' to get the expected shell command output.
-    cmd = "find . -not -path './releases/*' -name CMakeLists.txt -exec grep -H -e '\(add_test\|define_c_test|define_test_variants\)' {} \; | cut -d: -f1 | cut -c3- | uniq"
+    cmd = "find . -not -path './releases/*' -not -path './build/*' -not -path './cmake_build/*' -name CMakeLists.txt -exec grep -H -e '\(add_test\|define_c_test|define_test_variants\)' {} \; | cut -d: -f1 | cut -c3- | uniq"
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     mkfiles_with_tests = p.stdout.readlines()
 


### PR DESCRIPTION
This fixes a handful of false positives when running s_all:
- When run in fast mode `comment_style.py` only checks files that have been modified since the branch diverged from develop. When no files have changed this list is empty which the script script didn't handle.
- When compiled with `HAVE_UNITTEST=1` unit test functions (prefixed with `__ut`) are exposed so we can perform testing on internal functions. `s_export` reports this as an error so add the unit test functions to the whitelist.
- Finally `evg_cfg.py` was looking in our build directories and reporting an error that the third party dependency `catch2` didn't have any associated evergreen tests. This isn't required so exclude the build directory from checking
