### PR TITLE
WT-10507 Enable format-stress-pull-request-test in evergreen.yml 

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3730,9 +3730,10 @@ tasks:
           <<: *configure_flags_with_builtins
           NONSTANDALONE: -DWT_STANDALONE_BUILD=0
           CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_gcc.cmake
-      - func: "format test script"
-        vars:
-          format_test_script_args: -a -t 30
+      # FIXME-WT-9767
+      # - func: "format test script"
+      #   vars:
+      #     format_test_script_args: -a -t 30
 
   - name: many-collection-test
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3112,7 +3112,6 @@ tasks:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          smp_command: -j $(grep -c ^processor /proc/cpuinfo)
           # run for 10 minutes.
           format_test_script_args: -t 10 rows=10000 ops=50000
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3110,12 +3110,11 @@ tasks:
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
-      # FIXME-WT-9770
-      # - func: "format test script"
-      #   vars:
-      #     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
-      #     # run for 10 minutes.
-      #     format_test_script_args: -t 10 rows=10000 ops=50000
+      - func: "format test script"
+        vars:
+          smp_command: -j $(grep -c ^processor /proc/cpuinfo)
+          # run for 10 minutes.
+          format_test_script_args: -t 10 rows=10000 ops=50000
 
   - name: format-smoke-test
     commands:
@@ -3731,10 +3730,9 @@ tasks:
           <<: *configure_flags_with_builtins
           NONSTANDALONE: -DWT_STANDALONE_BUILD=0
           CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_gcc.cmake
-      # FIXME-WT-9767
-      # - func: "format test script"
-      #   vars:
-      #     format_test_script_args: -a -t 30
+      - func: "format test script"
+        vars:
+          format_test_script_args: -a -t 30
 
   - name: many-collection-test
     commands:
@@ -4879,7 +4877,8 @@ buildvariants:
     - name: compile-production-disable-static
     - name: examples-c-production-disable-shared-test
     - name: examples-c-production-disable-static-test
-    - name: format-stress-pull-request-test
+    # FIXME-WT-10386 Enable this test once this failure is resolved.
+    # - name: format-stress-pull-request-test
     - name: make-check-test
     - name: cppsuite-operations-test-default
     - name: cppsuite-hs-cleanup-default


### PR DESCRIPTION
Enabled the `format-stress-pull-request-test` in `evergreen.yml` for all testing except on the UBSan build variant, where there is a known failure (see Jira ticket for details). 

Note that this test wasn't disabled "correctly". It was creating an EC2 instance for every PR over multiple build variants (for the past six months!) only to run a compile and exit. **Please disable tests at the build variant level!**