### PR TITLE
WT-9612 Add the -? option to the wt commands and fix the documentation.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -43,6 +43,7 @@ BDB's
 BDmpvXx
 BIGENDIAN
 BLKCACHE
+BLmRrSVv
 BOOL
 BSR
 BTREE
@@ -568,6 +569,7 @@ addr
 addrs
 addtw
 agc
+ajn
 alfred
 alloc
 allocator
@@ -745,6 +747,7 @@ cryptobad
 cryptographic
 cryptographically
 cstring
+cstu
 csuite
 csv
 ctime
@@ -1283,6 +1286,7 @@ oplist
 oplog
 optimizations
 optrack
+optwt
 optype
 ori
 origstartrecno

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -28,18 +28,23 @@ Verify the WiredTiger metadata as part of opening the database.
 Run recovery if the underlying database is configured to do so.
 @par \c -r
 Access the database via a readonly connection
+@par \c -S
+Run salvage recovery if the underlying database is configured to do so.
 @par \c -V
 Display WiredTiger version and exit.
 @par \c -v
 Set verbose output.
+@par \c -?
+Print the help message and exit.
 
 Unless otherwise described by a \c wt command, the \c wt tool exits zero
 on success and non-zero on error.
 
-The \c wt tool supports several commands.  If configured in the underlying
-database, some commands will run recovery when opening the database.  If
-the user wants to force recovery on any command, use the \c -R option.
-In general, commands that modify the database or tables will run recovery
+The \c wt tool supports several commands.  You can use the \c -? option
+with any of these commands to print the help message.  If configured in the
+underlying database, some commands will run recovery when opening the database.
+If the user wants to force recovery on any command, use the \c -R or the \c -S
+option. In general, commands that modify the database or tables will run recovery
 by default and commands that only read data will not run recovery. It is
 recommended when attempting to diagnose a corrupt database, that the -r
 flag be used. This flag will open the connection read-only and prevent
@@ -51,7 +56,7 @@ any of the existing database objects.
 Alter a table.
 
 @subsection util_alter_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] alter uri configuration ...`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] alter uri configuration ...`
 
 The \c uri and \c configuration pairs may be specified to the
 \c alter command.  These configuration pairs can be used to modify the
@@ -89,7 +94,7 @@ opened as a WiredTiger database.  See @ref backup for more information,
 and @ref file_permissions for specifics on the copied file permissions.
 
 @subsection util_backup_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] backup [-t uri] directory`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] backup [-t uri] directory`
 
 @subsection util_backup_options Options
 The following are command-specific options for the \c backup command:
@@ -107,10 +112,22 @@ The \c compact command attempts to rewrite the specified table to
 consume less disk space.
 
 @subsection util_compact_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] compact uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] compact uri`
 
 @subsection util_compact_options Options
 The \c compact command has no command-specific options.
+
+<hr>
+@section util_copyright wt copyright
+Print the copyright information.
+
+The \c copyright command just prints the copyright information and exits.
+
+@subsection util_copyright_synopsis Synopsis
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] copyright`
+
+@subsection util_copyright_options Options
+The \c copyright command has no command-specific options.
 
 <hr>
 @section util_create wt create
@@ -121,7 +138,7 @@ configuration.  It is equivalent to a call to WT_SESSION::create with
 the specified string arguments.
 
 @subsection util_create_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] create [-c config] uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] create [-c config] uri`
 
 @subsection util_create_options Options
 The following are command-specific options for the \c create command:
@@ -136,7 +153,7 @@ Downgrade a database.
 The \c downgrade command downgrades the database to the specified compatibility version.
 
 @subsection util_downgrade_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] downgrade -V version`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] downgrade -V version`
 
 @subsection util_downgrade_options Options
 The following are command-specific options for the \c downgrade command:
@@ -152,7 +169,7 @@ The \c drop command drops the specified \c uri.  It is equivalent to a
 call to WT_SESSION::drop with the "force" configuration argument.
 
 @subsection util_drop_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] drop uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] drop uri`
 
 @subsection util_drop_options Options
 The \c drop command has no command-specific options.
@@ -167,7 +184,7 @@ which can be re-loaded into a new table using the \c load command.
 See @subpage dump_formats for details of the dump file formats.
 
 @subsection util_dump_synopsis Synopsis
-`wt [-RrVv] [-C config] [-E secretkey ] [-h directory] dump [-jprx] [-c checkpoint] [-f output] [-t timestamp] uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] dump [-jprx] [-c checkpoint] [-f output] [-t timestamp] uri`
 
 @subsection util_dump_options Options
 The following are command-specific options for the \c dump command:
@@ -214,7 +231,7 @@ database.  If a URI is specified as an argument, only information about
 that data source is printed.
 
 @subsection util_list_synopsis Synopsis
-`wt [-RrVv] [-C config] [-E secretkey ] [-h directory] list [-cv] [uri]`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] list [-cv] [uri]`
 
 @subsection util_list_options Options
 The following are command-specific options for the \c list command:
@@ -242,7 +259,7 @@ to make an attempt to overwrite existing data return an error).  Existing
 keys will not be removed.
 
 @subsection util_load_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] load [-ajn] [-f input] [-r name] [uri configuration ...]`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] load [-ajn] [-f input] [-r name] [uri configuration ...]`
 
 @subsection util_load_options Options
 The following are command-specific options for the \c load command:
@@ -317,7 +334,7 @@ with matching keys.  For either column-store or row-store tables, existing
 keys will not be removed.
 
 @subsection util_loadtext_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] loadtext [-f input] uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] loadtext [-f input] uri`
 
 @subsection util_loadtext_options Options
 The following are command-specific options for the \c loadtext command:
@@ -334,7 +351,7 @@ data are redacted.
 The \c printlog command outputs the database log.
 
 @subsection util_printlog_synopsis Synopsis
-\c wt [-RrVv] [-C config] [-E secretkey ] [-h directory] printlog [-mux] [-f output]
+\c wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] printlog [-mux] [-f output] [-l start-file,start-offset]|[-l start-file,start-offset,end-file,end-offset]
 
 @subsection util_printlog_options Options
 The following are command-specific options for the \c printlog command:
@@ -342,6 +359,10 @@ The following are command-specific options for the \c printlog command:
 @par \c -f
 By default, the \c printlog command output is written to the standard
 output; the \c -f option re-directs the output to the specified file.
+
+@par \c -l
+Specify the start LSN from which the log will be printed, and optionally
+also the end LSN.
 
 @par \c -m
 Print only message-type log records.
@@ -364,7 +385,7 @@ with string or record number keys and string values.
 The \c read command exits non-zero if a specified record is not found.
 
 @subsection util_read_synopsis Synopsis
-`wt [-RrVv] [-C config] [-E secretkey ] [-h directory] read uri key ...`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] read uri key ...`
 
 @subsection util_read_options Options
 The \c read command has no command-specific options.
@@ -376,7 +397,7 @@ Rename a table.
 The \c rename command renames the specified table.
 
 @subsection util_rename_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] rename uri name`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] rename uri new-uri`
 
 @subsection util_rename_options Options
 The \c rename command has no command-specific options.
@@ -390,7 +411,7 @@ data that cannot be recovered.  Underlying files are re-written in place,
 overwriting the original file contents.
 
 @subsection util_salvage_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] salvage [-F] uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] salvage [-F] uri`
 
 @subsection util_salvage_options Options
 The following are command-specific options for the \c salvage command:
@@ -408,7 +429,7 @@ The \c stat command outputs run-time statistics for the WiredTiger
 engine, or, if specified, for the URI on the command-line.
 
 @subsection util_stat_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] stat [-f] [uri]`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] stat [-f] [uri]`
 
 @subsection util_stat_options Options
 The following are command-specific options for the \c stat command:
@@ -425,7 +446,7 @@ The \c truncate command truncates the specified \c uri.  It is equivalent to a
 call to WT_SESSION::truncate with no start or stop specified.
 
 @subsection util_truncate_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] truncate uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] truncate uri`
 
 @subsection util_truncate_options Options
 The \c truncate command has no command-specific options.
@@ -439,7 +460,7 @@ the data source is up-to-date, and failure if the data source cannot be
 upgraded.
 
 @subsection util_upgrade_synopsis Synopsis
-`wt [-RVv] [-C config] [-E secretkey ] [-h directory] upgrade uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] upgrade uri`
 
 @subsection util_upgrade_options Options
 The \c upgrade command has no command-specific options.
@@ -452,10 +473,13 @@ The \c verify command verifies the specified table, exiting success if
 the data source is correct, and failure if the data source is corrupted.
 
 @subsection util_verify_synopsis Synopsis
-`wt [-RrVv] [-C config] [-E secretkey ] [-h directory] verify [-s] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | dump_pages ] [uri]`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] verify [-cstu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | dump_pages ] [uri]`
 
 @subsection util_verify_options Options
 The following are command-specific options for the \c verify command:
+
+\c -c
+Continue to the next page after encountering error during verification.
 
 \c -d [config]
 This option allows you to specify values which you want to be displayed
@@ -464,6 +488,13 @@ when verification is run. See the WT_SESSION::verify configuration options.
 \c -s
 This option allows you to verify against the stable timestamp, valid only after a
 rollback-to-stable operation. See the WT_SESSION::verify configuration options.
+
+\c -t
+Do not clear transaction IDs during verification.
+
+\c -u
+Display the application data when dumping with configuration \c dump_blocks
+or \c dump_page.
 
 <hr>
 @section util_write wt write
@@ -482,9 +513,10 @@ Attempting to overwrite an already existing record will fail.
 
 @subsection util_write_synopsis Synopsis
 \c
-wt [-RVv] [-C config] [-E secretkey ] [-h directory] write -a uri value ...
+wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] write -a uri value ...
 <br>
-wt [-RVv] [-C config] [-E secretkey ] [-h directory] write [-o] uri key value ...
+\c
+wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] write [-o] uri key value ...
 
 @subsection util_write_options Options
 The following are command-specific options for the \c write command:

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -42,8 +42,8 @@ on success and non-zero on error.
 
 The \c wt tool supports several commands.  You can use the \c -? option
 with any of these commands to print the help message.  If configured in the
-underlying database, some commands will run recovery when opening the database.
-If the user wants to force recovery on any command, use the \c -R or the \c -S
+underlying database, some commands will run recovery when opening the
+database. If the user wants to force recovery on any command, use the \c -R
 option. In general, commands that modify the database or tables will run recovery
 by default and commands that only read data will not run recovery. It is
 recommended when attempting to diagnose a corrupt database, that the -r

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -11,6 +11,7 @@ Adler's
 Atomicity
 BLOBs
 BLRrVv
+BLmRrSVv
 CAS
 CFLAGS
 CMake
@@ -247,6 +248,7 @@ crashless
 crc
 cryptographic
 cryptographically
+cstu
 csuite
 ctest
 curfile

--- a/src/os_common/os_getopt.c
+++ b/src/os_common/os_getopt.c
@@ -59,15 +59,21 @@
 
 #include "wt_internal.h"
 
+/* WT-specific return codes for __wt_getopt(); use __wt_optwt to enable */
+#define WT_GETOPT_BAD_OPTION 1
+#define WT_GETOPT_BAD_ARGUMENT 2
+
 extern int __wt_opterr WT_ATTRIBUTE_LIBRARY_VISIBLE;
 extern int __wt_optind WT_ATTRIBUTE_LIBRARY_VISIBLE;
 extern int __wt_optopt WT_ATTRIBUTE_LIBRARY_VISIBLE;
 extern int __wt_optreset WT_ATTRIBUTE_LIBRARY_VISIBLE;
+extern int __wt_optwt WT_ATTRIBUTE_LIBRARY_VISIBLE;
 
 int __wt_opterr = 1, /* if error message should be printed */
   __wt_optind = 1,   /* index into parent argv vector */
   __wt_optopt,       /* character checked for validity */
-  __wt_optreset;     /* reset getopt */
+  __wt_optreset,     /* reset getopt */
+  __wt_optwt = 0;    /* enable WT-specific behavior, e.g., using WT_* return codes */
 
 extern char *__wt_optarg WT_ATTRIBUTE_LIBRARY_VISIBLE;
 char *__wt_optarg; /* argument associated with option */
@@ -119,7 +125,7 @@ __wt_getopt(const char *progname, int nargc, char *const *nargv, const char *ost
             ++__wt_optind;
         if (__wt_opterr && *ostr != ':')
             (void)fprintf(stderr, "%s: illegal option -- %c\n", progname, __wt_optopt);
-        return (BADCH);
+        return (__wt_optwt ? WT_GETOPT_BAD_OPTION : BADCH);
     }
 
     /* Does this option need an argument? */
@@ -139,11 +145,11 @@ __wt_getopt(const char *progname, int nargc, char *const *nargv, const char *ost
             /* option-argument absent */
             place = EMSG;
             if (*ostr == ':')
-                return (BADARG);
+                return (__wt_optwt ? WT_GETOPT_BAD_ARGUMENT : BADARG);
             if (__wt_opterr)
                 (void)fprintf(
                   stderr, "%s: option requires an argument -- %c\n", progname, __wt_optopt);
-            return (BADCH);
+            return (__wt_optwt ? WT_GETOPT_BAD_OPTION : BADCH);
         }
         place = EMSG;
         ++__wt_optind;

--- a/src/utilities/util.h
+++ b/src/utilities/util.h
@@ -20,10 +20,15 @@ extern bool verbose;             /* Verbose flag */
 
 extern WT_EVENT_HANDLER *verbose_handler;
 
+/* WT-specific return codes for __wt_getopt(); use __wt_optwt to enable */
+#define WT_GETOPT_BAD_OPTION 1
+#define WT_GETOPT_BAD_ARGUMENT 2
+
 extern int __wt_opterr;   /* if error message should be printed */
 extern int __wt_optind;   /* index into parent argv vector */
 extern int __wt_optopt;   /* character checked for validity */
 extern int __wt_optreset; /* reset getopt */
+extern int __wt_optwt;    /* enable WT-specific behavior, e.g., using WT_* return codes */
 extern char *__wt_optarg; /* argument associated with option */
 
 int util_alter(WT_SESSION *, int, char *[]);

--- a/src/utilities/util_alter.c
+++ b/src/utilities/util_alter.c
@@ -15,7 +15,9 @@
 static int
 usage(void)
 {
-    util_usage("alter uri configuration ...", NULL, NULL);
+    static const char *options[] = {"-?", "show this message", NULL, NULL};
+
+    util_usage("alter uri configuration ...", "options:", options);
     return (1);
 }
 
@@ -30,9 +32,11 @@ util_alter(WT_SESSION *session, int argc, char *argv[])
     int ch;
     char **configp;
 
-    while ((ch = __wt_getopt(progname, argc, argv, "")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
         switch (ch) {
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }
@@ -41,7 +45,7 @@ util_alter(WT_SESSION *session, int argc, char *argv[])
     argv += __wt_optind;
 
     /* The remaining arguments are uri/string pairs. */
-    if (argc % 2 != 0)
+    if (argc == 0 || argc % 2 != 0)
         return (usage());
 
     for (configp = argv; *configp != NULL; configp += 2)

--- a/src/utilities/util_backup.c
+++ b/src/utilities/util_backup.c
@@ -18,7 +18,8 @@ static int
 usage(void)
 {
     static const char *options[] = {"-t uri",
-      "backup the named data sources (by default the entire database is backed up)", NULL, NULL};
+      "backup the named data sources (by default the entire database is backed up)", "-?",
+      "show this message", NULL, NULL};
 
     util_usage("backup [-t uri] directory", "options:", options);
     return (1);
@@ -42,7 +43,7 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
     session_impl = (WT_SESSION_IMPL *)session;
 
     target = false;
-    while ((ch = __wt_getopt(progname, argc, argv, "t:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "t:?")) != EOF)
         switch (ch) {
         case 't':
             if (!target) {
@@ -53,6 +54,9 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
             target = true;
             break;
         case '?':
+            usage();
+            ret = 0;
+            goto done;
         default:
             WT_ERR(usage());
         }
@@ -61,6 +65,7 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
 
     if (argc != 1) {
         (void)usage();
+        ret = 1;
         goto err;
     }
     directory = *argv;
@@ -90,6 +95,7 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
     }
 
 err:
+done:
     __wt_scr_free(session_impl, &tmp);
     return (ret);
 }

--- a/src/utilities/util_compact.c
+++ b/src/utilities/util_compact.c
@@ -15,7 +15,9 @@
 static int
 usage(void)
 {
-    util_usage("compact uri", NULL, NULL);
+    static const char *options[] = {"-?", "show this message", NULL, NULL};
+
+    util_usage("compact uri", "options:", options);
     return (1);
 }
 
@@ -31,9 +33,11 @@ util_compact(WT_SESSION *session, int argc, char *argv[])
     char *uri;
 
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
         switch (ch) {
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_create.c
+++ b/src/utilities/util_create.c
@@ -15,8 +15,9 @@
 static int
 usage(void)
 {
-    static const char *options[] = {
-      "-c config", "a configuration string to be passed to WT_SESSION.create", NULL, NULL};
+    static const char *options[] = {"-c config",
+      "a configuration string to be passed to WT_SESSION.create", "-?", "show this message", NULL,
+      NULL};
 
     util_usage("create [-c configuration] uri", "options:", options);
     return (1);
@@ -34,12 +35,14 @@ util_create(WT_SESSION *session, int argc, char *argv[])
     char *config, *uri;
 
     config = uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "c:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "c:?")) != EOF)
         switch (ch) {
         case 'c': /* command-line configuration */
             config = __wt_optarg;
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_downgrade.c
+++ b/src/utilities/util_downgrade.c
@@ -15,8 +15,9 @@
 static int
 usage(void)
 {
-    static const char *options[] = {
-      "-V", "a required option, the version to which the database is downgraded", NULL, NULL};
+    static const char *options[] = {"-V",
+      "a required option, the version to which the database is downgraded", "-?",
+      "show this message", NULL, NULL};
 
     util_usage("downgrade -V release", "options:", options);
     return (1);
@@ -35,12 +36,14 @@ util_downgrade(WT_SESSION *session, int argc, char *argv[])
     char config_str[128], *release;
 
     release = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "V:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "V:?")) != EOF)
         switch (ch) {
         case 'V':
             release = __wt_optarg;
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_drop.c
+++ b/src/utilities/util_drop.c
@@ -15,7 +15,9 @@
 static int
 usage(void)
 {
-    util_usage("drop uri", NULL, NULL);
+    static const char *options[] = {"-?", "show this message", NULL, NULL};
+
+    util_usage("drop uri", "options:", options);
     return (1);
 }
 
@@ -31,9 +33,11 @@ util_drop(WT_SESSION *session, int argc, char *argv[])
     char *uri;
 
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
         switch (ch) {
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -47,7 +47,7 @@ usage(void)
       "encoded). The -x flag can be combined with -p. In this case, the dump will be formatted "
       "similar to -p except for raw data elements, which will look like -x with hexadecimal "
       "encoding.",
-      NULL, NULL};
+      "-?", "show this message", NULL, NULL};
 
     util_usage(
       "dump [-jprx] [-c checkpoint] [-f output-file] [-t timestamp] uri", "options:", options);
@@ -78,7 +78,7 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
     hs_dump_cursor = NULL;
     checkpoint = ofile = simpleuri = uri = timestamp = NULL;
     hex = json = pretty = reverse = false;
-    while ((ch = __wt_getopt(progname, argc, argv, "c:f:t:jprx")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "c:f:t:jprx?")) != EOF)
         switch (ch) {
         case 'c':
             checkpoint = __wt_optarg;
@@ -102,6 +102,8 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
             hex = true;
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -21,8 +21,8 @@ usage(void)
 {
     static const char *options[] = {"-c",
       "display checkpoints in human-readable format (by default checkpoints are not displayed)",
-      "-v", "display the complete schema table (by default only a subset is displayed)", NULL,
-      NULL};
+      "-v", "display the complete schema table (by default only a subset is displayed)", "-?",
+      "show this message", NULL, NULL};
 
     util_usage("list [-cv] [uri]", "options:", options);
     return (1);
@@ -42,7 +42,7 @@ util_list(WT_SESSION *session, int argc, char *argv[])
 
     cflag = vflag = false;
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "cv")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "cv?")) != EOF)
         switch (ch) {
         case 'c':
             cflag = true;
@@ -51,6 +51,8 @@ util_list(WT_SESSION *session, int argc, char *argv[])
             vflag = true;
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -32,10 +32,11 @@ usage(void)
       "ignore record number keys in the input and assign new record number keys", "-f input",
       "read from the specified file (by default records are read from stdin)", "-j",
       "read in JSON format", "-n", "fail at any attempt to overwrite existing data", "-r name",
-      "use the argument as the table name, ignoring any name in the source", NULL, NULL};
+      "use the argument as the table name, ignoring any name in the source", "-?",
+      "show this message", NULL, NULL};
 
     util_usage(
-      "load [-as] [-f input-file] [-r name] [object configuration ...]", "options:", options);
+      "load [-ajn] [-f input-file] [-r name] [object configuration ...]", "options:", options);
     return (1);
 }
 
@@ -53,7 +54,7 @@ util_load(WT_SESSION *session, int argc, char *argv[])
     flags = 0;
 
     filename = "<stdin>";
-    while ((ch = __wt_getopt(progname, argc, argv, "af:jnr:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "af:jnr:?")) != EOF)
         switch (ch) {
         case 'a': /* append (ignore record number keys) */
             append = true;
@@ -74,6 +75,8 @@ util_load(WT_SESSION *session, int argc, char *argv[])
             cmdname = __wt_optarg;
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_loadtext.c
+++ b/src/utilities/util_loadtext.c
@@ -18,8 +18,9 @@ static int text(WT_SESSION *, const char *);
 static int
 usage(void)
 {
-    static const char *options[] = {
-      "-f", "read from the specified file (by default rows are read from stdin)", NULL, NULL};
+    static const char *options[] = {"-f",
+      "read from the specified file (by default rows are read from stdin)", "-?",
+      "show this message", NULL, NULL};
 
     util_usage("loadtext [-f input-file] uri", "options:", options);
     return (1);
@@ -37,13 +38,15 @@ util_loadtext(WT_SESSION *session, int argc, char *argv[])
     char *uri;
 
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "f:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "f:?")) != EOF)
         switch (ch) {
         case 'f': /* input file */
             if (freopen(__wt_optarg, "r", stdin) == NULL)
                 return (util_err(session, errno, "%s: reopen", __wt_optarg));
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -11,7 +11,7 @@
 const char *home = "."; /* Home directory */
 const char *progname;   /* Program name */
                         /* Global arguments */
-const char *usage_prefix = "[-LmRrSVv] [-C config] [-E secretkey] [-h home]";
+const char *usage_prefix = "[-BLmRrSVv] [-C config] [-E secretkey] [-h home]";
 bool verbose = false; /* Verbose flag */
 
 static const char *command; /* Command name */
@@ -50,7 +50,7 @@ usage(void)
       "-R", "run recovery (if recovery configured)", "-r",
       "access the database via a readonly connection", "-S",
       "run salvage recovery (if recovery configured)", "-V", "display library version and exit",
-      "-v", "verbose", NULL, NULL};
+      "-v", "verbose", "-?", "show this message", NULL, NULL};
     static const char *commands[] = {"alter", "alter an object", "backup", "database backup",
       "compact", "compact an object", "copyright", "display copyright information", "create",
       "create an object", "downgrade", "downgrade a database", "drop", "drop an object", "dump",
@@ -112,7 +112,8 @@ main(int argc, char *argv[])
     rec_config = REC_ERROR;
     backward_compatible = logoff = meta_verify = readonly = recover = salvage = false;
     /* Check for standard options. */
-    while ((ch = __wt_getopt(progname, argc, argv, "BC:E:h:LmRrSVv")) != EOF)
+    __wt_optwt = 1; /* enable WT-specific behavior */
+    while ((ch = __wt_getopt(progname, argc, argv, "BC:E:h:LmRrSVv?")) != EOF)
         switch (ch) {
         case 'B': /* backward compatibility */
             backward_compatible = true;
@@ -160,6 +161,8 @@ main(int argc, char *argv[])
             verbose = true;
             break;
         case '?':
+            usage();
+            goto done;
         default:
             usage();
             goto err;

--- a/src/utilities/util_printlog.c
+++ b/src/utilities/util_printlog.c
@@ -15,11 +15,11 @@
 static int
 usage(void)
 {
-    static const char *options[] = {"-f", "output to the specified file", "-x",
-      "display key and value items in hexadecimal format", "-l",
+    static const char *options[] = {"-f", "output to the specified file", "-l",
       "the start LSN from which the log will be printed, optionally the end LSN can also be "
       "specified",
-      "-m", "output log message records only", "-u", "print user data, don't redact", NULL, NULL};
+      "-m", "output log message records only", "-u", "print user data, don't redact", "-x",
+      "display key and value items in hexadecimal format", "-?", "show this message", NULL, NULL};
 
     util_usage(
       "printlog [-mux] [-f output-file] [-l start-file,start-offset]|[-l "
@@ -52,7 +52,7 @@ util_printlog(WT_SESSION *session, int argc, char *argv[])
      * it is redacted unless they make the effort to keep it in. It lessens the risk of doing the
      * wrong command.
      */
-    while ((ch = __wt_getopt(progname, argc, argv, "f:l:mux")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "f:l:mux?")) != EOF)
         switch (ch) {
         case 'f': /* output file */
             ofile = __wt_optarg;
@@ -81,6 +81,8 @@ util_printlog(WT_SESSION *session, int argc, char *argv[])
             LF_SET(WT_TXN_PRINTLOG_HEX);
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_read.c
+++ b/src/utilities/util_read.c
@@ -15,7 +15,9 @@
 static int
 usage(void)
 {
-    util_usage("read uri key ...", NULL, NULL);
+    static const char *options[] = {"-?", "show this message", NULL, NULL};
+
+    util_usage("read uri key ...", "options:", options);
     return (1);
 }
 
@@ -34,9 +36,11 @@ util_read(WT_SESSION *session, int argc, char *argv[])
     bool rkey, rval;
 
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
         switch (ch) {
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_rename.c
+++ b/src/utilities/util_rename.c
@@ -15,7 +15,9 @@
 static int
 usage(void)
 {
-    util_usage("rename uri newuri", NULL, NULL);
+    static const char *options[] = {"-?", "show this message", NULL, NULL};
+
+    util_usage("rename uri newuri", "options:", options);
     return (1);
 }
 
@@ -31,9 +33,11 @@ util_rename(WT_SESSION *session, int argc, char *argv[])
     char *uri, *newuri;
 
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
         switch (ch) {
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_salvage.c
+++ b/src/utilities/util_salvage.c
@@ -17,7 +17,7 @@ usage(void)
 {
     static const char *options[] = {"-F",
       "force salvage (by default salvage will refuse to salvage tables that fail basic tests)",
-      NULL, NULL};
+      "-?", "show this message", NULL, NULL};
 
     util_usage("salvage [-F] uri", "options:", options);
     return (1);
@@ -37,12 +37,14 @@ util_salvage(WT_SESSION *session, int argc, char *argv[])
 
     force = NULL;
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "F")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "F?")) != EOF)
         switch (ch) {
         case 'F':
             force = "force";
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_stat.c
+++ b/src/utilities/util_stat.c
@@ -15,8 +15,8 @@
 static int
 usage(void)
 {
-    static const char *options[] = {
-      "-f", "include only \"fast\" statistics in the output", NULL, NULL};
+    static const char *options[] = {"-f", "include only \"fast\" statistics in the output", "-?",
+      "show this message", NULL, NULL};
 
     util_usage("stat [-f] [uri]", "options:", options);
     return (1);
@@ -40,7 +40,7 @@ util_stat(WT_SESSION *session, int argc, char *argv[])
     objname_free = false;
     objname = uri = NULL;
     config = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "af")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "af?")) != EOF)
         switch (ch) {
         case 'a':
             /*
@@ -54,6 +54,8 @@ util_stat(WT_SESSION *session, int argc, char *argv[])
             config = "statistics=(fast)";
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_truncate.c
+++ b/src/utilities/util_truncate.c
@@ -15,7 +15,9 @@
 static int
 usage(void)
 {
-    util_usage("truncate uri", NULL, NULL);
+    static const char *options[] = {"-?", "show this message", NULL, NULL};
+
+    util_usage("truncate uri", "options:", options);
     return (1);
 }
 
@@ -31,9 +33,11 @@ util_truncate(WT_SESSION *session, int argc, char *argv[])
     char *uri;
 
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
         switch (ch) {
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_upgrade.c
+++ b/src/utilities/util_upgrade.c
@@ -15,7 +15,9 @@
 static int
 usage(void)
 {
-    util_usage("upgrade uri", NULL, NULL);
+    static const char *options[] = {"-?", "show this message", NULL, NULL};
+
+    util_usage("upgrade uri", "options:", options);
     return (1);
 }
 
@@ -31,9 +33,11 @@ util_upgrade(WT_SESSION *session, int argc, char *argv[])
     char *uri;
 
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
         switch (ch) {
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -15,16 +15,16 @@
 static int
 usage(void)
 {
-    static const char *options[] = {"-d config",
-      "display underlying information during verification", "-c",
-      "continue to the next page after encountering error during verification", "-s",
+    static const char *options[] = {"-c",
+      "continue to the next page after encountering error during verification", "-d config",
+      "display underlying information during verification", "-s",
       "verify against the specified timestamp", "-t", "do not clear txn ids during verification",
       "-u",
       "display the application data when dumping with configuration dump_blocks or dump_pages",
-      NULL, NULL};
+      "-?", "show this message", NULL, NULL};
 
     util_usage(
-      "verify [-s] [-t] [-c] [-u] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# "
+      "verify [-cstu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# "
       "| dump_pages] [uri]",
       "options:", options);
 
@@ -48,7 +48,7 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
     do_not_clear_txn_id = dump_address = dump_app_data = dump_blocks = dump_layout = dump_pages =
       read_corrupt = stable_timestamp = false;
     config = dump_offsets = uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "cd:stu")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "cd:stu?")) != EOF)
         switch (ch) {
         case 'c':
             read_corrupt = true;
@@ -82,6 +82,8 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
             do_not_clear_txn_id = true;
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/src/utilities/util_write.c
+++ b/src/utilities/util_write.c
@@ -16,9 +16,10 @@ static int
 usage(void)
 {
     static const char *options[] = {"-a", "append each value as a new record in the data source",
-      "-o", "allow overwrite of previously existing records", NULL, NULL};
+      "-o", "allow overwrite of previously existing records", "-?", "show this message", NULL,
+      NULL};
 
-    util_usage("write [-ao] uri key ...", "options:", options);
+    util_usage("write [-ao] uri key value ...", "options:", options);
     return (1);
 }
 
@@ -38,7 +39,7 @@ util_write(WT_SESSION *session, int argc, char *argv[])
 
     append = overwrite = false;
     uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "ao")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "ao?")) != EOF)
         switch (ch) {
         case 'a':
             append = true;
@@ -47,6 +48,8 @@ util_write(WT_SESSION *session, int argc, char *argv[])
             overwrite = true;
             break;
         case '?':
+            usage();
+            return (0);
         default:
             return (usage());
         }

--- a/test/suite/test_util22.py
+++ b/test/suite/test_util22.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from suite_subprocess import suite_subprocess
+from helper import compare_files
+
+
+# test_util22.py
+# Check that wt correctly processes the help option and that it handles invalid options correctly.
+class test_util21(wttest.WiredTigerTestCase, suite_subprocess):
+    conn_config = ''
+
+    # Skip 'copyright', which does not process options
+    commands = ['alter', 'backup', 'compact', 'create', 'downgrade', 'drop', 'dump', 'list', 'load',
+                'loadtext', 'printlog', 'read', 'rename', 'salvage', 'stat', 'truncate', 'upgrade',
+                'verify', 'write']
+
+    def test_help_option(self):
+        errfilename = "errfile.txt"
+        self.runWt(['-?'], errfilename=errfilename)
+        self.check_file_contains(errfilename, 'global_options:')
+
+        for cmd in self.commands:
+            self.runWt([cmd, '-?'], errfilename=errfilename)
+            self.check_file_contains(errfilename, 'options:')
+
+    def test_no_argument(self):
+        errfilename = "errfile.txt"
+        self.runWt(['-h'], errfilename=errfilename, failure=True)
+        self.check_file_contains(errfilename, 'wt: option requires an argument -- h')
+        self.check_file_contains(errfilename, 'global_options:')
+
+    def test_unsupported_command(self):
+        errfilename = "errfile.txt"
+        self.runWt(['unsupported'], errfilename=errfilename, failure=True)
+        self.check_file_contains(errfilename, 'global_options:')
+
+    def test_unsupported_option(self):
+        errfilename = "errfile.txt"
+        self.runWt(['-^'], errfilename=errfilename, failure=True)
+        self.check_file_contains(errfilename, 'wt: illegal option -- ^')
+        self.check_file_contains(errfilename, 'global_options:')
+
+        for cmd in self.commands:
+            self.runWt([cmd, '-^'], errfilename=errfilename, failure=True)
+            self.check_file_contains(errfilename, 'wt: illegal option -- ^')
+            self.check_file_contains(errfilename, 'options:')
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
The PR adds the `-?` option to the `wt` commands. When executed with the `-?` option, the command exits with exit code 0, because this is not an error, but if there is an invalid argument, it still exits with an error code.

To that extent, I had to modify `__wt_getopt` to use a different exit code than `'?'` on error, because it would be otherwise impossible to distinguish between an invalid option and the `-?` command-line argument. As this is a non-standard behavior, the caller has to enable it through a global variable. I was inspired to do it this way, as we already added the ability to reset option parsing using a global variable.

I also used this as an opportunity to correct the documentation. Please check especially that the `-S` option is used correctly in the paragraph below the list of supported global options for `wt`.