### PR TITLE
WT-10524 Match on full script name in s_all

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -124,11 +124,15 @@ echo "$COMMANDS" | xargs $xp -I{} /bin/sh -c {}
 
 for f in `find . -name ${t_pfx}\*`; do
     if `test -s $f`; then
-        LOCAL_NAME=`basename $f`
+        LOCAL_NAME=$(basename "$f")
         # Find original command and trim redirect garbage
-        FAILED_CMD=`echo "$COMMANDS" | grep $LOCAL_NAME | \
-            sed -e 's/ >.*//' -e 's/2>&1 //'`
-        errchk "$FAILED_CMD" $f
+        # If one command in $COMMANDS is a substring of another like s_evergreen and
+        # s_evergree_validate, $FAILED_CMD can be parsed incorrectly and result in a failing
+        # script being ignored. Use `[^\w]` to ensure we match on the full command name and
+        # not just a substring
+        FAILED_CMD=$(echo "$COMMANDS" | grep "${LOCAL_NAME}[^\w]")
+        TRIMMED_CMD=$(echo "$FAILED_CMD" | sed -e 's/ >.*//' -e 's/2>&1 //')
+        errchk "$TRIMMED_CMD" "$f"
     fi
 done
 

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -26,6 +26,8 @@ make_check_subdir_skips = [
     "test/cppsuite",
     "test/fuzz",
     "test/syscall",
+    "ext/storage_sources/azure_store/test",
+    "ext/storage_sources/gcp_store/test",
     "ext/storage_sources/s3_store/test"
 ]
 


### PR DESCRIPTION
A small cleanup to `s_all` that fixes an issue where we would ignore the failure of our `s_evergreen` script.

When checking the result of our scripts that run in parallel we get the name of a failing script by grepping the name of the output file it produced (`$LOCAL_NAME`) against the list of parallel scripts in `$COMMANDS`.
The problem occurs when `s_evergreen` reports a problem, but the resulting grep of `LOCAL_NAME` matches against both the `s_evergreen` command as well as the `s_evergreen_validate` command. This results in an incorrect `$FAILED_CMD` value being passed into `errchk` which breaks the `# If the test was skipped, ignore the failure.` and suppresses the error.

To fix this we now match against the full name of the command (`[^\w]` ensures there are no further characters following `${LOCAL_NAME}`). This means `s_evergreen` will now only match against `s_evergreen` and not against `s_evergreen_validate`.