### PR TITLE
WT-10517 Clean up command-line argument parsing for the wt utility

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -276,7 +276,6 @@ LeafGreen
 LevelDB
 Levyx
 LibFuzzer
-LmRrSVv
 LoadLoad
 LockFile
 LogSystemInterface

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -91,7 +91,6 @@ LLVM
 LLVMFuzzerTestOneInput
 LOGREC
 LRU
-LRrVv
 LSB
 LSM
 LSNs
@@ -125,7 +124,6 @@ RepMgr
 Riak
 RocksDB
 Roelofs
-RrVv
 Rrx
 SDK
 SDK's
@@ -568,7 +566,6 @@ px
 py
 qnx
 qqq
-rVv
 rankdir
 rdbms
 rdlock

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -100,6 +100,12 @@
 #define WT_ENCRYPT_LEN_SIZE sizeof(uint32_t)
 
 /*
+ * WT-specific return codes for __wt_getopt(); use __wt_optwt to enable.
+ */
+#define WT_GETOPT_BAD_ARGUMENT 1
+#define WT_GETOPT_BAD_OPTION 2
+
+/*
  * __wt_calloc_def, __wt_calloc_one --
  *     Most calloc calls don't need separate count or sizeof arguments.
  */

--- a/src/os_common/os_getopt.c
+++ b/src/os_common/os_getopt.c
@@ -59,10 +59,6 @@
 
 #include "wt_internal.h"
 
-/* WT-specific return codes for __wt_getopt(); use __wt_optwt to enable */
-#define WT_GETOPT_BAD_OPTION 1
-#define WT_GETOPT_BAD_ARGUMENT 2
-
 extern int __wt_opterr WT_ATTRIBUTE_LIBRARY_VISIBLE;
 extern int __wt_optind WT_ATTRIBUTE_LIBRARY_VISIBLE;
 extern int __wt_optopt WT_ATTRIBUTE_LIBRARY_VISIBLE;

--- a/src/utilities/util.h
+++ b/src/utilities/util.h
@@ -20,10 +20,6 @@ extern bool verbose;             /* Verbose flag */
 
 extern WT_EVENT_HANDLER *verbose_handler;
 
-/* WT-specific return codes for __wt_getopt(); use __wt_optwt to enable */
-#define WT_GETOPT_BAD_OPTION 1
-#define WT_GETOPT_BAD_ARGUMENT 2
-
 extern int __wt_opterr;   /* if error message should be printed */
 extern int __wt_optind;   /* index into parent argv vector */
 extern int __wt_optopt;   /* character checked for validity */

--- a/src/utilities/util_backup.c
+++ b/src/utilities/util_backup.c
@@ -65,7 +65,7 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
 
     if (argc != 1) {
         (void)usage();
-        ret = 1;
+        ret = EXIT_FAILURE;
         goto err;
     }
     directory = *argv;
@@ -94,8 +94,8 @@ util_backup(WT_SESSION *session, int argc, char *argv[])
         goto err;
     }
 
-err:
 done:
+err:
     __wt_scr_free(session_impl, &tmp);
     return (ret);
 }


### PR DESCRIPTION
The PR cleans up a few issues that were raised after #8721 was merged.

The PR does not yet add `-?` to all of the examples in the documentation or in `usage()`, as for example, calling `wt -r -? backup` doesn't make sense. If we'd like, we can still add it to the synopsis of `wt` when it is called by itself, which would be easy to do in the documentation, but it would require a special case `usage()` which I was hoping to avoid. @sueloverso, please let me know if you would like me to do that.