### PR TITLE
WT-10532 Add signal handler to Workgen

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -206,7 +206,7 @@ volatile std::sig_atomic_t signal_raised = 0;
 
 void signal_handler(int signum) {
 
-    std::cerr << "Received signal " << signum << ": " strsignal(signum) << std::endl;
+    std::cerr << "Received signal " << signum << ": " << strsignal(signum) << std::endl;
     signal_raised = signum;
 }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -206,8 +206,8 @@ volatile std::sig_atomic_t signal_raised = 0;
 
 void signal_handler(int signum) {
 
-    std::cerr << "Workgen received signal SIG" << sigabbrev_np(signum) << ": "
-              << strsignal(signum) << "." << std::endl;
+    std::cerr << "Workgen received signal " << signum << ": " << strsignal(signum)
+              << "." << std::endl;
     signal_raised = signum;
 }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -206,7 +206,8 @@ volatile std::sig_atomic_t signal_raised = 0;
 
 void signal_handler(int signum) {
 
-    std::cerr << "Received signal " << signum << ": " << strsignal(signum) << std::endl;
+    std::cerr << "Workgen received signal SIG" << sigabbrev_np(signum) << ": "
+              << strsignal(signum) << "." << std::endl;
     signal_raised = signum;
 }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include <algorithm>
+#include <csignal>
 #include <iomanip>
 #include <iostream>
 #include <filesystem>
@@ -196,6 +197,17 @@ thread_tables_drop_workload(void *arg)
     }
 
     return (nullptr);
+}
+
+// The signal handler allows us to gracefully terminate workgen and the user to close the
+// connection in the runner script, thus ensuring a clean shutdown of wiredtiger. The exact
+// signals handled are registered in the WorkloadRunner::run_all function.
+volatile std::sig_atomic_t signal_raised = 0;
+
+void signal_handler(int signum) {
+
+    std::cerr << "Received signal " << signum << ": " strsignal(signum) << std::endl;
+    signal_raised = signum;
 }
 
 int
@@ -2915,6 +2927,10 @@ WorkloadRunner::run_all(WT_CONNECTION *conn)
 {
     WT_DECL_RET;
 
+    // Register signal handlers for SIGINT (Ctrl-C) and SIGTERM.
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
     Stats counts(false);
     for (size_t i = 0; i < _trunners.size(); i++)
         _trunners[i].get_static_counts(counts);
@@ -3080,10 +3096,11 @@ WorkloadRunner::run_all(WT_CONNECTION *conn)
         timespec end = _start + options->run_time;
         timespec next_report = _start + options->report_interval;
 
-        // Let the test run, reporting as needed.
+        // Let the test run, reporting as needed. Exit when we exceed the run time or
+        // when a registered signal is received.
         Stats curstats(false);
         now = _start;
-        while (now < end) {
+        while (now < end && !signal_raised) {
             timespec sleep_amt;
 
             sleep_amt = end - now;

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -204,10 +204,12 @@ thread_tables_drop_workload(void *arg)
 // signals handled are registered in the WorkloadRunner::run_all function.
 volatile std::sig_atomic_t signal_raised = 0;
 
-void signal_handler(int signum) {
+void
+signal_handler(int signum)
+{
 
-    std::cerr << "Workgen received signal " << signum << ": " << strsignal(signum)
-              << "." << std::endl;
+    std::cerr << "Workgen received signal " << signum << ": " << strsignal(signum) << "."
+              << std::endl;
     signal_raised = signum;
 }
 


### PR DESCRIPTION
This change adds signal handler functionality to `workgen`. This allows us to gracefully terminate `workgen` and the user to close the connection in the python runner script, thus ensuring a clean shutdown of `wiredtiger`, when performing a `Ctrl-C` from the keyboard or when running `workgen` under a `systemd` service. The registered signals to be handled by the signal handler are `SIGINT` and `SIGTERM`, as specified in the `WorkloadRunner::run_all` function.