### PR TITLE
WT-10378 Allow creating active and shared column groups

### DIFF
--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -73,10 +73,12 @@ __schema_create_collapse(WT_SESSION_IMPL *session, WT_CURSOR_METADATA *mdc, cons
     WT_CURSOR *c;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
-    const char *_cfg[5] = {NULL, NULL, NULL, value, NULL};
+    const char *_cfg[7] = {NULL, NULL, NULL, NULL, NULL, value, NULL};
     const char **cfg, **firstcfg, **lastcfg, *v;
+    bool active, tiered_shared;
 
-    lastcfg = cfg = &_cfg[3]; /* position on value */
+    lastcfg = cfg = &_cfg[5]; /* position on value */
+    active = tiered_shared = false;
     c = NULL;
     if (key != NULL && WT_PREFIX_SKIP(key, "table:")) {
         /*
@@ -93,12 +95,25 @@ __schema_create_collapse(WT_SESSION_IMPL *session, WT_CURSOR_METADATA *mdc, cons
         }
         WT_RET_NOTFOUND_OK(ret);
 
+        if (((ret = __wt_config_getones(session, value, "shared", &cval)) == 0) && cval.val)
+            tiered_shared = true;
+        WT_RET_NOTFOUND_OK(ret);
+
         c = mdc->create_cursor;
         WT_ERR(__wt_scr_alloc(session, 0, &buf));
-        /*
-         * When a table is created without column groups, we create one without a name.
-         */
-        WT_ERR(__wt_buf_fmt(session, buf, "colgroup:%s", key));
+        if (tiered_shared) {
+            active = true;
+tiered_shared:
+            /* When a tiered storage shared table is created, we create two column groups. */
+            if (active)
+                WT_ERR(__wt_buf_fmt(session, buf, "colgroup:%s.%s", key, "active"));
+            else
+                WT_ERR(__wt_buf_fmt(session, buf, "colgroup:%s.%s", key, "shared"));
+        } else {
+            /* When a table is created without column groups, we create one without a name. */
+            WT_ERR(__wt_buf_fmt(session, buf, "colgroup:%s", key));
+        }
+
         c->set_key(c, buf->data);
         if ((ret = c->search(c)) != 0)
             WT_ERR_MSG(session, ret,
@@ -107,6 +122,10 @@ __schema_create_collapse(WT_SESSION_IMPL *session, WT_CURSOR_METADATA *mdc, cons
         WT_ERR(c->get_value(c, &v));
         WT_ERR(__wt_strdup(session, v, --cfg));
         WT_ERR(__schema_source_config(session, c, v, --cfg));
+        if (active) {
+            active = false;
+            goto tiered_shared;
+        }
     } else if (key != NULL && (WT_PREFIX_SKIP(key, "colgroup:") || WT_PREFIX_SKIP(key, "index:"))) {
         if (strchr(key, ':') != NULL) {
             c = mdc->create_cursor;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1422,7 +1422,7 @@ extern int __wt_schema_rename(WT_SESSION_IMPL *session, const char *uri, const c
   const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_session_release(WT_SESSION_IMPL *session, WT_SESSION_IMPL *int_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_schema_tiered_shared_colgroup_name(WT_SESSION_IMPL *session, WT_TABLE *table,
+extern int __wt_schema_tiered_shared_colgroup_name(WT_SESSION_IMPL *session, const char *tablename,
   bool active, WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_tiered_worker(WT_SESSION_IMPL *session, const char *uri,
   int (*file_func)(WT_SESSION_IMPL *, const char *[]),

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1422,6 +1422,8 @@ extern int __wt_schema_rename(WT_SESSION_IMPL *session, const char *uri, const c
   const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_session_release(WT_SESSION_IMPL *session, WT_SESSION_IMPL *int_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_schema_tiered_shared_colgroup_name(WT_SESSION_IMPL *session, WT_TABLE *table,
+  bool active, WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_tiered_worker(WT_SESSION_IMPL *session, const char *uri,
   int (*file_func)(WT_SESSION_IMPL *, const char *[]),
   int (*name_func)(WT_SESSION_IMPL *, const char *, bool *), const char *cfg[], uint32_t open_flags)

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -101,7 +101,7 @@ struct __wt_import_list {
  * columns except tiered shared table as it contains two column groups to represent active and
  * shared tables.
  */
-#define WT_COLGROUPS(t) WT_MAX((t)->ncolgroups, ((t)->is_tiered_shared ? 2 : 1))
+#define WT_COLGROUPS(t) WT_MAX((t)->ncolgroups, (u_int)((t)->is_tiered_shared ? 2 : 1))
 
 /* Helpers for the locked state of the handle list and table locks. */
 #define WT_SESSION_LOCKED_HANDLE_LIST \

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -98,9 +98,10 @@ struct __wt_import_list {
 
 /*
  * Tables without explicit column groups have a single default column group containing all of the
- * columns.
+ * columns except tiered shared table as it contains two column groups to represent active and
+ * shared tables.
  */
-#define WT_COLGROUPS(t) WT_MAX((t)->ncolgroups, 1)
+#define WT_COLGROUPS(t) WT_MAX((t)->ncolgroups, ((t)->is_tiered_shared ? 2 : 1))
 
 /* Helpers for the locked state of the handle list and table locks. */
 #define WT_SESSION_LOCKED_HANDLE_LIST \

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -444,18 +444,18 @@ __schema_is_tiered_storage_shared(WT_SESSION_IMPL *session, const char *config)
     WT_CONFIG_ITEM cval;
 
     /*
-     * The tiered storage shared table needs to have two column groups that are
-     * pointed to the underlying active and shared files. The following checks are
-     * carried out to determine the table can be created as a tiered storage shared
-     * or not based on the table creation configuration where they control the
-     * underlying the source.
+     * The tiered storage shared table needs to have two column groups that point to the
+     * underlying active and shared files. The following checks are carried out to determine
+     * whether the table can be created as a tiered storage shared table or not based on
+     * the table creation configuration.
      *
-     * 1. The table configuration should not specify underlying source.
-     * 2. The table configuration should not specify underlying type of the storage.
-     * 3. The connection is not configured for tiered storage or the table configured
-     *    for non tiered storage.
+     * A table is not a shared if any of the following are true:
+     * 1. The table configuration does not specify an underlying source.
+     * 2. The table configuration does not specify an underlying type of the storage.
+     * 3. The connection is not configured for tiered storage or the table is not
+     *    configured for tiered storage.
      * 4. The connection is not configured for tiered storage shared or the table is
-     *    configured for non tiered storage shared.
+     *    not configured for tiered storage shared.
      */
     if (__wt_config_getones(session, config, "source", &cval) == 0 && cval.len != 0)
         return (false);
@@ -475,7 +475,9 @@ __schema_is_tiered_storage_shared(WT_SESSION_IMPL *session, const char *config)
 
 /*
  * __schema_tiered_shared_colgroup_source --
- *     Get the tiered storage shared URI of the data source for a column group.
+ *     Get the tiered storage shared URI of the data source for a column group. For a shared tiered
+ *     table named table:name the active table is always file:name.wt and the shared table is
+ *     tiered:name which points to the shared components.
  */
 static int
 __schema_tiered_shared_colgroup_source(

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -447,7 +447,8 @@ __schema_is_tiered_storage_shared(WT_SESSION_IMPL *session, const char *config)
      * The tiered storage shared table needs to have two column groups that are
      * pointed to the underlying active and shared files. The following checks are
      * carried out to determine the table can be created as a tiered storage shared
-     * or not based on the table creation configuration.
+     * or not based on the table creation configuration where they control the
+     * underlying the source.
      *
      * 1. The table configuration should not specify underlying source.
      * 2. The table configuration should not specify underlying type of the storage.

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -435,28 +435,41 @@ __wt_find_import_metadata(WT_SESSION_IMPL *session, const char *uri, const char 
 
 /*
  * __schema_is_tiered_storage_shared --
- *     Check whether the table is configured for a tiered storage shared.
+ *     Check whether the table is configured for tiered storage, and if so, whether the tiered table
+ *     is shared.
  */
-static void
-__schema_is_tiered_storage_shared(
-  WT_SESSION_IMPL *session, const char *config, bool *is_tiered_storage_shared)
+static bool
+__schema_is_tiered_storage_shared(WT_SESSION_IMPL *session, const char *config)
 {
     WT_CONFIG_ITEM cval;
 
-    *is_tiered_storage_shared = true;
-
+    /*
+     * The tiered storage shared table needs to have two column groups that are
+     * pointed to the underlying active and shared files. The following checks are
+     * carried out to determine the table can be created as a tiered storage shared
+     * or not based on the table creation configuration.
+     *
+     * 1. The table configuration should not specify underlying source.
+     * 2. The table configuration should not specify underlying type of the storage.
+     * 3. The connection is not configured for tiered storage or the table configured
+     *    for non tiered storage.
+     * 4. The connection is not configured for tiered storage shared or the table is
+     *    configured for non tiered storage shared.
+     */
     if (__wt_config_getones(session, config, "source", &cval) == 0 && cval.len != 0)
-        *is_tiered_storage_shared = false;
+        return (false);
     else if (__wt_config_getones(session, config, "type", &cval) == 0 &&
       !WT_STRING_MATCH("file", cval.str, cval.len))
-        *is_tiered_storage_shared = false;
+        return (false);
     else if ((S2C(session)->bstorage == NULL) ||
       (__wt_config_getones(session, config, "tiered_storage.name", &cval) == 0 && cval.len != 0 &&
         WT_STRING_MATCH("none", cval.str, cval.len)))
-        *is_tiered_storage_shared = false;
+        return (false);
     else if (!S2C(session)->bstorage->tiered_shared ||
       ((__wt_config_getones(session, config, "tiered_storage.shared", &cval) == 0) && !cval.val))
-        *is_tiered_storage_shared = false;
+        return (false);
+
+    return (true);
 }
 
 /*
@@ -473,14 +486,13 @@ __schema_tiered_shared_colgroup_source(
     tablename = table->iface.name + strlen("table:");
     if (active) {
         prefix = "file";
-        len = strlen(prefix);
         suffix = ".wt";
     } else {
         prefix = "tiered";
-        len = strlen(prefix);
         suffix = "";
     }
 
+    len = strlen(prefix);
     return (__wt_buf_fmt(session, buf, "%.*s:%s%s", (int)len, prefix, tablename, suffix));
 }
 
@@ -497,19 +509,19 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
     WT_ITEM confbuf, fmt, namebuf;
     WT_TABLE *table;
     size_t tlen;
+    int i, ncolgroups;
     char *cgconf, *origconf;
     const char **cfgp, *cfg[4] = {WT_CONFIG_BASE(session, colgroup_meta), config, NULL, NULL};
     const char *cgname, *source, *sourceconf, *tablename;
     const char *sourcecfg[] = {config, NULL, NULL};
-    bool active, exists, tiered_storage, tracked;
+    bool exists, tracked;
 
     sourceconf = NULL;
     cgconf = origconf = NULL;
     WT_CLEAR(fmt);
     WT_CLEAR(confbuf);
     WT_CLEAR(namebuf);
-    exists = tiered_storage = tracked = false;
-    active = true;
+    exists = tracked = false;
 
     if (session->import_list != NULL)
         WT_RET(__wt_find_import_metadata(session, name, &cfg[1]));
@@ -542,73 +554,79 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
         WT_ERR_MSG(session, ret == WT_NOTFOUND ? EINVAL : ret,
           "Column group '%s' not found in table '%.*s'", cgname, (int)tlen, tablename);
 
-    if (table->is_tiered_shared) {
-        WT_ERR(__wt_scr_alloc(session, 0, &buf));
-tiered_shared:
-        WT_ERR(__wt_schema_tiered_shared_colgroup_name(session, table, active, buf));
-        name = buf->data;
-    }
-
-    /* Check if the column group already exists. */
-    if ((ret = __wt_metadata_search(session, name, &origconf)) == 0) {
-        if (exclusive)
-            WT_ERR(EEXIST);
-        exists = true;
-    }
-    WT_ERR_NOTFOUND_OK(ret, false);
-
-    /* Find the first NULL entry in the cfg stack. */
-    for (cfgp = &cfg[1]; *cfgp; cfgp++)
-        ;
-
-    /* Add the source to the colgroup config before collapsing. */
-    if (__wt_config_getones(session, config, "source", &cval) == 0 && cval.len != 0) {
-        WT_ERR(__wt_buf_fmt(session, &namebuf, "%.*s", (int)cval.len, cval.str));
-        source = namebuf.data;
-    } else if (table->is_tiered_shared) {
-        WT_ERR(__schema_tiered_shared_colgroup_source(session, table, active, &namebuf));
-        source = namebuf.data;
-        WT_ERR(__wt_buf_fmt(session, &confbuf, "source=\"%s\"", source));
-        *cfgp++ = confbuf.data;
-    } else {
-        WT_ERR(__wt_schema_colgroup_source(session, table, cgname, config, &namebuf));
-        source = namebuf.data;
-        WT_ERR(__wt_buf_fmt(session, &confbuf, "source=\"%s\"", source));
-        *cfgp++ = confbuf.data;
-    }
-
-    if (session->import_list != NULL)
-        /* Use the import configuration, it should have key and value format configurations. */
-        WT_ERR(__wt_find_import_metadata(session, source, &sourcecfg[0]));
-    else {
-        /* Calculate the key/value formats: these go into the source config. */
-        WT_ERR(__wt_buf_fmt(session, &fmt, "key_format=%s", table->key_format));
-        if (cgname == NULL)
-            WT_ERR(__wt_buf_catfmt(session, &fmt, ",value_format=%s", table->value_format));
-        else {
-            if (__wt_config_getones(session, config, "columns", &cval) != 0)
-                WT_ERR_MSG(session, EINVAL, "No 'columns' configuration for '%s'", name);
-            WT_ERR(__wt_buf_catfmt(session, &fmt, ",value_format="));
-            WT_ERR(__wt_struct_reformat(session, table, cval.str, cval.len, NULL, true, &fmt));
+    WT_ERR(__wt_scr_alloc(session, 0, &buf));
+    /*
+     * A simple table have default one column group except the tiered storage shared table that will
+     * have default 2 column groups.
+     */
+    ncolgroups = table->is_tiered_shared ? 2 : 1;
+    for (i = 0; i < ncolgroups; i++) {
+        /* Get the column group name. */
+        if (table->is_tiered_shared) {
+            WT_ERR(__wt_schema_tiered_shared_colgroup_name(
+              session, tablename, i == 0 ? true : false, buf));
+            name = buf->data;
         }
 
-        sourcecfg[1] = fmt.data;
-    }
+        /* Check if the column group already exists. */
+        if ((ret = __wt_metadata_search(session, name, &origconf)) == 0) {
+            if (exclusive)
+                WT_ERR(EEXIST);
+            exists = true;
+        }
+        WT_ERR_NOTFOUND_OK(ret, false);
 
-    WT_ERR(__wt_config_merge(session, sourcecfg, NULL, &sourceconf));
-    WT_ERR(__wt_schema_create(session, source, sourceconf));
+        /* Find the first NULL entry in the cfg stack. */
+        for (cfgp = &cfg[1]; *cfgp; cfgp++)
+            ;
 
-    WT_ERR(__wt_config_collapse(session, cfg, &cgconf));
+        /* Add the source to the colgroup config before collapsing. */
+        if (__wt_config_getones(session, config, "source", &cval) == 0 && cval.len != 0) {
+            WT_ERR(__wt_buf_fmt(session, &namebuf, "%.*s", (int)cval.len, cval.str));
+            source = namebuf.data;
+        } else if (table->is_tiered_shared) {
+            WT_ERR(__schema_tiered_shared_colgroup_source(
+              session, table, i == 0 ? true : false, &namebuf));
+            source = namebuf.data;
+            WT_ERR(__wt_buf_fmt(session, &confbuf, "source=\"%s\"", source));
+            *cfgp++ = confbuf.data;
+        } else {
+            WT_ERR(__wt_schema_colgroup_source(session, table, cgname, config, &namebuf));
+            source = namebuf.data;
+            WT_ERR(__wt_buf_fmt(session, &confbuf, "source=\"%s\"", source));
+            *cfgp++ = confbuf.data;
+        }
 
-    if (!exists) {
-        WT_ERR(__wt_metadata_insert(session, name, cgconf));
-        WT_ERR(__wt_schema_open_colgroups(session, table));
-    }
+        if (session->import_list != NULL)
+            /* Use the import configuration, it should have key and value format configurations. */
+            WT_ERR(__wt_find_import_metadata(session, source, &sourcecfg[0]));
+        else {
+            /* Calculate the key/value formats: these go into the source config. */
+            WT_ERR(__wt_buf_fmt(session, &fmt, "key_format=%s", table->key_format));
+            if (cgname == NULL)
+                WT_ERR(__wt_buf_catfmt(session, &fmt, ",value_format=%s", table->value_format));
+            else {
+                if (__wt_config_getones(session, config, "columns", &cval) != 0)
+                    WT_ERR_MSG(session, EINVAL, "No 'columns' configuration for '%s'", name);
+                WT_ERR(__wt_buf_catfmt(session, &fmt, ",value_format="));
+                WT_ERR(__wt_struct_reformat(session, table, cval.str, cval.len, NULL, true, &fmt));
+            }
 
-    if (table->is_tiered_shared && active) {
+            sourcecfg[1] = fmt.data;
+        }
+
+        WT_ERR(__wt_config_merge(session, sourcecfg, NULL, &sourceconf));
+        WT_ERR(__wt_schema_create(session, source, sourceconf));
+
+        WT_ERR(__wt_config_collapse(session, cfg, &cgconf));
+
+        if (!exists) {
+            WT_ERR(__wt_metadata_insert(session, name, cgconf));
+            WT_ERR(__wt_schema_open_colgroups(session, table));
+        }
+
+        /* Reset the last filled configuration for the next column group. */
         *--cfgp = NULL;
-        active = false;
-        goto tiered_shared;
     }
 
 err:
@@ -902,10 +920,10 @@ __create_table(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const 
     char *cgcfg, *cgname, *filecfg, *filename, *importcfg, *tablecfg;
     const char *cfg[4] = {WT_CONFIG_BASE(session, table_meta), config, NULL, NULL};
     const char *tablename;
-    bool import, import_repair, is_tiered_shared;
+    bool import, import_repair;
 
     import = F_ISSET(session, WT_SESSION_IMPORT);
-    import_repair = is_tiered_shared = false;
+    import_repair = false;
 
     cgcfg = filecfg = importcfg = tablecfg = NULL;
     cgname = filename = NULL;
@@ -964,8 +982,7 @@ __create_table(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const 
 
     WT_ERR(__wt_config_collapse(session, cfg, &tablecfg));
 
-    __schema_is_tiered_storage_shared(session, config, &is_tiered_shared);
-    if (is_tiered_shared) {
+    if (__schema_is_tiered_storage_shared(session, config)) {
         WT_ASSERT(session, import == false);
         WT_ERR(__wt_scr_alloc(session, 0, &tmp));
 

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -33,13 +33,9 @@ __wt_schema_colgroup_name(
  */
 int
 __wt_schema_tiered_shared_colgroup_name(
-  WT_SESSION_IMPL *session, WT_TABLE *table, bool active, WT_ITEM *buf)
+  WT_SESSION_IMPL *session, const char *tablename, bool active, WT_ITEM *buf)
 {
-    const char *tablename;
-
-    tablename = table->iface.name;
-    WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
-
+    WT_PREFIX_SKIP(tablename, "table:");
     return (__wt_buf_fmt(session, buf, "colgroup:%s.%s", tablename, active ? "active" : "shared"));
 }
 
@@ -85,8 +81,8 @@ __wt_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table)
 
         WT_ERR(__wt_buf_init(session, buf, 0));
         if (table->is_tiered_shared)
-            WT_ERR(
-              __wt_schema_tiered_shared_colgroup_name(session, table, i == 0 ? true : false, buf));
+            WT_ERR(__wt_schema_tiered_shared_colgroup_name(
+              session, table->iface.name, i == 0 ? true : false, buf));
         else
             WT_ERR(__wt_schema_colgroup_name(session, table, ckey.str, ckey.len, buf));
         if ((ret = __wt_metadata_search(session, buf->data, &cgconfig)) != 0) {

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -28,6 +28,22 @@ __wt_schema_colgroup_name(
 }
 
 /*
+ * __wt_schema_tiered_shared_colgroup_name --
+ *     Get the URI for a tiered storage shared column group. This is used for metadata lookups.
+ */
+int
+__wt_schema_tiered_shared_colgroup_name(
+  WT_SESSION_IMPL *session, WT_TABLE *table, bool active, WT_ITEM *buf)
+{
+    const char *tablename;
+
+    tablename = table->iface.name;
+    WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
+
+    return (__wt_buf_fmt(session, buf, "colgroup:%s.%s", tablename, active ? "active" : "shared"));
+}
+
+/*
  * __wt_schema_open_colgroups --
  *     Open the column groups for a table.
  */
@@ -68,7 +84,11 @@ __wt_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table)
         __wt_schema_destroy_colgroup(session, &table->cgroups[i]);
 
         WT_ERR(__wt_buf_init(session, buf, 0));
-        WT_ERR(__wt_schema_colgroup_name(session, table, ckey.str, ckey.len, buf));
+        if (table->is_tiered_shared)
+            WT_ERR(
+              __wt_schema_tiered_shared_colgroup_name(session, table, i == 0 ? true : false, buf));
+        else
+            WT_ERR(__wt_schema_colgroup_name(session, table, ckey.str, ckey.len, buf));
         if ((ret = __wt_metadata_search(session, buf->data, &cgconfig)) != 0) {
             /* It is okay if the table is incomplete. */
             if (ret == WT_NOTFOUND)
@@ -442,6 +462,10 @@ __schema_open_table(WT_SESSION_IMPL *session)
 
     if (table->ncolgroups > 0 && table->is_simple)
         WT_RET_MSG(session, EINVAL, "%s requires a table with named columns", tablename);
+
+    if ((ret = __wt_config_gets(session, table_cfg, "shared", &cval)) == 0)
+        table->is_tiered_shared = true;
+    WT_RET_NOTFOUND_OK(ret);
 
     WT_RET(__wt_calloc_def(session, WT_COLGROUPS(table), &table->cgroups));
     WT_RET(__wt_schema_open_colgroups(session, table));

--- a/test/suite/test_tiered18.py
+++ b/test/suite/test_tiered18.py
@@ -39,7 +39,7 @@ class test_tiered18(wttest.WiredTigerTestCase, TieredConfigMixin):
     storage_sources = gen_tiered_storage_sources(wttest.getss_random_prefix(), 'test_tiered18', tiered_only=True, tiered_shared=True)
     scenarios = make_scenarios(storage_sources)
 
-    uri_non_shared = "table:test_tiered18_non_shared"
+    uri_non_shared = "table:test_tiered18_shared_default"
     uri_shared = "table:test_tiered18_shared"
     uri_local = "table:test_tiered18_local"
     uri_fail = "table:test_tiered18_fail"
@@ -67,22 +67,22 @@ class test_tiered18(wttest.WiredTigerTestCase, TieredConfigMixin):
 
     # Test calling the create API with shared enabled.
     def test_tiered_shared(self):
-        self.pr("create tiered")
+        self.pr("create tiered shared with default")
         base_create = 'key_format=S,value_format=S'
         self.session.create(self.uri_non_shared, base_create)
         self.check_metadata(self.uri_non_shared, 'key_format=S')
-        #self.session.drop(self.uri_non_shared)
+        self.session.drop(self.uri_non_shared)
 
         self.pr("create non tiered/local")
         conf = ',tiered_storage=(name=none)'
         self.session.create(self.uri_local, base_create + conf)
         self.check_metadata(self.uri_local, 'name=none')
-        #self.session.drop(self.uri_local)
+        self.session.drop(self.uri_local)
 
         self.pr("create tiered shared")
         conf = ',tiered_storage=(shared=true)'
         self.session.create(self.uri_shared, base_create + conf)
-        #self.session.drop(self.uri_shared)
+        self.session.drop(self.uri_shared)
 
         self.reopen_conn(config = self.saved_conn + ',tiered_storage=(shared=false)')
 

--- a/test/suite/test_tiered18.py
+++ b/test/suite/test_tiered18.py
@@ -71,6 +71,8 @@ class test_tiered18(wttest.WiredTigerTestCase, TieredConfigMixin):
         base_create = 'key_format=S,value_format=S'
         self.session.create(self.uri_non_shared, base_create)
         self.check_metadata(self.uri_non_shared, 'key_format=S')
+        self.check_metadata("colgroup:test_tiered18_shared_default.active", 'file:test_tiered18_shared_default.wt')
+        self.check_metadata("colgroup:test_tiered18_shared_default.shared", 'tiered:test_tiered18_shared_default')
         self.session.drop(self.uri_non_shared)
 
         self.pr("create non tiered/local")
@@ -82,6 +84,9 @@ class test_tiered18(wttest.WiredTigerTestCase, TieredConfigMixin):
         self.pr("create tiered shared")
         conf = ',tiered_storage=(shared=true)'
         self.session.create(self.uri_shared, base_create + conf)
+        self.check_metadata(self.uri_shared, 'key_format=S')
+        self.check_metadata("colgroup:test_tiered18_shared.active", 'file:test_tiered18_shared.wt')
+        self.check_metadata("colgroup:test_tiered18_shared.shared", 'tiered:test_tiered18_shared')
         self.session.drop(self.uri_shared)
 
         self.reopen_conn(config = self.saved_conn + ',tiered_storage=(shared=false)')


### PR DESCRIPTION
To support tiered storage shared, we need to split the current tiered storage table into two internal tables to track the active and shared data across the cluster.

These two internal URIs that are created are referenced using two column groups with extensions of active and shared from a single tablename.