### PR TITLE
WT-10526 Fix CMake build errors and docs on Window system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(cmake/define_libwiredtiger.cmake)
 if(NOT WT_ARCH)
     # Defer to our hosts architecture as our target architecture.
     # PROCESSOR_ARCHITECTURE env variable could be unset on certain Windows systems,
-    # in that case mapping the architecture to x86.
+    # in that case map the architecture to x86.
     if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(x86_64|i686|i386|AMD64|)$")
         set(WT_ARCH "x86")
     elseif ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(arm64|aarch64)$")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ include(cmake/define_libwiredtiger.cmake)
 # being defined (in base.cmake) since it will prevent it having a default value.
 if(NOT WT_ARCH)
     # Defer to our hosts architecture as our target architecture.
-    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(x86_64|i686|i386|AMD64)$")
+    # PROCESSOR_ARCHITECTURE env variable could be unset on certain Windows systems,
+    # in that case mapping the architecture to x86.
+    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(x86_64|i686|i386|AMD64|)$")
         set(WT_ARCH "x86")
     elseif ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(arm64|aarch64)$")
         set(WT_ARCH "aarch64")

--- a/src/docs/build-windows.dox
+++ b/src/docs/build-windows.dox
@@ -8,7 +8,7 @@ and proceed with @ref windows_building
 First, clone the repository:
 
 @code
-git clone git://github.com/wiredtiger/wiredtiger.git
+git clone https://github.com/wiredtiger/wiredtiger.git
 @endcode
 
 Now proceed with @ref windows_building
@@ -17,7 +17,7 @@ Now proceed with @ref windows_building
 
 Building WiredTiger on Windows requires
 <a href="https://cmake.org/">CMake</a> as well as the Microsoft Visual
-C++ compiler in Microsoft Visual Studio 2017.
+C++ compiler in Microsoft Visual Studio 2017 (or newer).
 
 You can build WiredTiger from source using command-line tools.
 When compiling via command-line tools, we recommend a prompt/shell that has been appropriately
@@ -35,10 +35,10 @@ cd build
 @endcode
 
 Change into your newly created build directory and using CMake run the build configuration
-step to generate your build.
+step to generate your build. "-A x64" is needed if it's a 64-bit architecture build system.
 
 @code
-cmake ..\.
+cmake ..\. -A x64
 @endcode
 
 In the absence of an explicit generator, CMake will generate Visual Studio project files


### PR DESCRIPTION
Changes in this PR include:

- Fix to make Windows CMake builds compatible with systems that have unset `PROCESSOR_ARCHITECTURE` env variable
- Fix docs to git clone with https, and use "-A x64" to make builds work on 64-bit Windows systems. 

Changes has been verified on a Windows spawn host (distro `windows-64-vs2017-small`) with a successful CMake compilation and installation. 