### PR TITLE
WT-10240 Implement mirrored dynamic tables in workgen

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1307,7 +1307,7 @@ ThreadRunner::run()
         _throttle = new Throttle(*this, options->throttle, options->throttle_burst);
     }
     for (int cnt = 0; !_stop && (_repeat || cnt < 1) && ret == 0; cnt++) {
-        WT_ERR(op_run_prepare(&_thread->_op));
+        WT_ERR(op_run_setup(&_thread->_op));
     }
 
 err :
@@ -1510,7 +1510,7 @@ ThreadRunner::op_kv_gen(Operation *op, const tint_t tint)
 }
 
 int
-ThreadRunner::op_run_prepare(Operation *op)
+ThreadRunner::op_run_setup(Operation *op)
 {
     WT_DECL_RET;
 
@@ -1665,7 +1665,7 @@ ThreadRunner::op_run(Operation *op)
         track->begin();
 
     // Set the cursor for the key and value first, outside the transaction which may
-    // be retried. The key and value are generated in op_run_prepare.
+    // be retried. The key and value are generated in op_run_setup.
     if (op->is_table_op()) {
 
         const std::string key_format(cursor->key_format);
@@ -1781,7 +1781,7 @@ ThreadRunner::op_run(Operation *op)
             for (int count = 0; (!_stop || _in_transaction) && count < op->_repeatgroup; count++) {
                 for (std::vector<Operation>::iterator i = op->_group->begin();
                      i != op->_group->end(); i++) {
-                    WT_ERR(op_run_prepare(&*i));
+                    WT_ERR(op_run_setup(&*i));
                 }
             }
             workgen_clock(&now);

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1834,7 +1834,6 @@ err:
     }
 
     if (op->_random_table) {
-
         const std::shared_lock lock(*_icontext->_dyn_mutex);
         // For operations on random tables, if a table has been selected, decrement the
         // reference counter.
@@ -1842,13 +1841,8 @@ err:
         // Use atomic here as we can race with another thread that acquires the shared lock.
         (void)workgen_atomic_sub32(&_icontext->_dyn_table_runtime[tint]._in_use, 1);
         op_clear_table(op);
-/*
-        if (_in_transaction && _icontext->_dyn_table_runtime[tint]._in_use == 0) {
-            std::cerr << "table '" << table_uri << "' is NOT in use! thread = " << this 
-                << " _in_transaction = " << _in_transaction << std::endl;
-        }
-*/
     }
+
     return (ret);
 }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include <algorithm>
+#include <csignal>
 #include <iomanip>
 #include <iostream>
 #include <filesystem>
@@ -62,7 +63,8 @@ extern "C" {
 #define LATENCY_MS_BUCKETS 1000
 #define LATENCY_SEC_BUCKETS 100
 
-#define THROTTLE_PER_SEC 20 // times per sec we will throttle
+#define TABLE_MAX_RETRIES 10 // times we will retry an operation on a table
+#define THROTTLE_PER_SEC 20  // times per sec we will throttle
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 #define MAX(a, b) ((a) < (b) ? (b) : (a))
@@ -105,7 +107,9 @@ extern "C" {
 #define OP_HAS_VALUE(op) \
     ((op)->_optype == Operation::OP_INSERT || (op)->_optype == Operation::OP_UPDATE)
 
-#define DYN_TABLE_APP_METADATA "app_metadata=\"workgen_dynamic_table\""
+const std::string DYN_TABLE_APP_METADATA = "workgen_dynamic_table=true";
+const std::string MIRROR_TABLE_APP_METADATA = "workgen_table_mirror=";
+const std::string BASE_TABLE_APP_METADATA = "workgen_base_table=";
 
 namespace workgen {
 
@@ -196,6 +200,19 @@ thread_tables_drop_workload(void *arg)
     }
 
     return (nullptr);
+}
+
+// The signal handler allows us to gracefully terminate workgen and the user to close the
+// connection in the runner script, thus ensuring a clean shutdown of wiredtiger. The exact
+// signals handled are registered in the WorkloadRunner::run_all function.
+volatile std::sig_atomic_t signal_raised = 0;
+
+void
+signal_handler(int signum)
+{
+    std::cerr << "Workgen received signal " << signum << ": " << strsignal(signum) << "."
+              << std::endl;
+    signal_raised = signum;
 }
 
 int
@@ -327,6 +344,47 @@ gen_random_table_name(char *name, workgen_random_state volatile *rand_state)
     }
     name[DYNAMIC_TABLE_LEN - 1] = '\0';
 }
+
+// Create a dynamic table with the specified name and config. If mirroring tables, add the
+// mirror table uri to the table runtime. Return an error status if the uri already exists
+// or the create fails.
+int
+WorkloadRunner::create_table(
+  WT_SESSION *session, const std::string &config, const std::string &uri, const std::string &mirror_uri, const bool is_base)
+{
+    // Check if a table with this name already exists. Return if it does. Use a shared lock to
+    // read the dynamic table structure.
+    ContextInternal *icontext = _workload->_context->_internal;
+    {
+        const std::shared_lock lock(*icontext->_dyn_mutex);
+        if (icontext->_tint.count(uri) > 0 || icontext->_dyn_tint.count(uri) > 0)
+            return EEXIST;
+    }
+
+    // Create the table.
+    WT_DECL_RET;
+    if ((ret = session->create(session, uri.c_str(), config.c_str())) != 0) {
+        if (ret != EBUSY)
+            THROW("Failed to create table '" << uri << "'.");
+        return ret;
+    }
+
+    // The data structures for the dynamic table set are protected by a mutex.
+    {
+        const std::lock_guard<std::shared_mutex> lock(*icontext->_dyn_mutex);
+
+        // Add the table into the list of dynamic set.
+        tint_t tint = icontext->_dyn_tint_last;
+        icontext->_dyn_tint[uri] = tint;
+        icontext->_dyn_table_names[tint] = uri;
+        icontext->_dyn_table_runtime[tint] = TableRuntime(is_base, mirror_uri);
+        ++icontext->_dyn_tint_last;
+        VERBOSE(*_workload, "Created table and added to the dynamic set: " << uri);
+    }
+
+    return 0;
+}
+
 /*
  * This function creates one or more tables at regular intervals, where the interval length and
  * number of tables are specified in the workload options. It also monitors the database size and
@@ -352,6 +410,24 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
         // Initially we start creating tables if the database size is less than the create target.
         creating = db_size < _workload->options.create_target;
     }
+
+    std::string uri;
+    std::string mirror_uri = std::string();
+    int creates, retries, status;
+    char rand_chars[DYNAMIC_TABLE_LEN];
+    
+    // Add app_metadata to the config to indicate the table was created dynamically (can be
+    // selected for random deletion), the name of the table's mirror if mirroring is enabled,
+    // and if this table is a base table or a mirror. We want these settings to persist over
+    // restarts.
+    std::string base_config = "key_format=S,value_format=S,app_metadata=\"" + DYN_TABLE_APP_METADATA;
+    if (_workload->options.mirror_tables) {
+        base_config += "," + MIRROR_TABLE_APP_METADATA;
+    } else {
+        base_config += "," + BASE_TABLE_APP_METADATA + "true\"";
+    }
+    std::string config = base_config;
+
     while (!stopping) {
         /*
          * When managing the database size: If we are creating tables, continue until we reach the
@@ -383,54 +459,89 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
             continue;
         }
 
-        int creates = 0;
+        retries = 0;
+        creates = 0;
         while (creates < _workload->options.create_count) {
-            char rand_chars[DYNAMIC_TABLE_LEN];
-            gen_random_table_name(rand_chars, _rand_state);
 
-            std::string uri("table:");
-            // Add the user specified prefix and a random alphanumeric sequence.
+            // Generate a table name from the user specified prefix and a random alphanumeric
+            // sequence.
+            gen_random_table_name(rand_chars, _rand_state);
+            uri = "table:";
             uri += _workload->options.create_prefix;
             uri += rand_chars;
 
-            // Check if a table with this name already exists. Skip if it does.
-            // Use a shared lock to read the dynamic tables structures.
-            {
-                const std::shared_lock lock(*icontext->_dyn_mutex);
-                if (icontext->_tint.count(uri) > 0 || icontext->_dyn_tint.count(uri) > 0)
-                    continue;
+            if (_workload->options.mirror_tables) {
+                // The mirror table name is the table name with the user specified suffix.
+                mirror_uri = uri + _workload->options.mirror_suffix;
+                config = base_config + mirror_uri + "," + BASE_TABLE_APP_METADATA + "true\"";
             }
 
-            /*
-             * Create the table. Mark the table as part of the dynamic set by storing extra
-             * information in the app_metadata.
-             */
-            WT_DECL_RET;
-            if ((ret = session->create(session, uri.c_str(),
-                   "key_format=S,value_format=S," DYN_TABLE_APP_METADATA)) != 0) {
-                if (ret == EBUSY)
-                    continue;
-                THROW("Table create failed in start_tables_create.");
+            // Create the table. Simply continue on failure.
+            if (create_table(session, config, uri, mirror_uri, true) == 0) {
+                VERBOSE(*_workload, "Created base table '" << uri << "'");
+                if (_workload->options.mirror_tables) {
+                    // Create the mirror. Retry on failure and throw an exception after
+                    // making too many retry attempts.
+                    config = base_config + uri + "," + BASE_TABLE_APP_METADATA + "false\"";
+                    do
+                        status = create_table(session, config, mirror_uri, uri, false);
+                    while (status == EBUSY && ++retries < TABLE_MAX_RETRIES);
+                    if (status != 0)
+                        THROW_ERRNO(status,
+                          "Failed to create mirror table '" << mirror_uri << "'.");
+                    VERBOSE(*_workload, "Created mirror table '" << mirror_uri << "'");
+                }
+                ++creates;
             }
-
-            // The data structures for the dynamic table set are protected by a mutex.
-            {
-                const std::lock_guard<std::shared_mutex> lock(*icontext->_dyn_mutex);
-
-                // Add the table into the list of dynamic set.
-                tint_t tint = icontext->_dyn_tint_last;
-                icontext->_dyn_tint[uri] = tint;
-                icontext->_dyn_table_names[tint] = uri;
-                icontext->_dyn_table_runtime[tint] = TableRuntime();
-                ++icontext->_dyn_tint_last;
-                VERBOSE(*_workload, "Created table and added to the dynamic set: " << uri);
-            }
-            ++creates;
         }
-
         sleep(_workload->options.create_interval);
     }
 
+    return 0;
+}
+
+// Randomly select a dynamic table to drop. The selected table is flagged for deletion and
+// added to a pending delete list. If the table has a mirror, the mirror is also flagged for
+// deletion and added to the pending delete list. The function returns an EEXIST error status
+// if the selected table is already scheduled for deletion.
+int
+WorkloadRunner::select_table_for_drop(std::vector<std::string> &pending_delete)
+{
+    // Select a random table to drop. Skip tables already flagged for deletion.
+    ContextInternal *icontext = _workload->_context->_internal;
+    auto table_itr = icontext->_dyn_tint.begin();
+    std::advance(table_itr, workgen_random(_rand_state) % icontext->_dyn_tint.size());
+    if (icontext->_dyn_table_runtime[table_itr->second]._pending_delete) {
+        return EEXIST;
+    }
+
+    // The data structures for the dynamic table set are protected by a mutex.
+    {
+        const std::lock_guard<std::shared_mutex> lock(*icontext->_dyn_mutex);
+
+        // Flag table for deletion.
+        VERBOSE(*_workload, "Flagging pending delete for: " << table_itr->first);
+        icontext->_dyn_table_runtime[table_itr->second]._pending_delete = true;
+    
+        // Add table to the pending delete list.
+        ASSERT(std::find(pending_delete.begin(), pending_delete.end(), table_itr->first) ==
+        pending_delete.end());
+        pending_delete.push_back(table_itr->first);
+
+        // If the table has a mirror, prepare the mirror table for deletion too.
+        if (icontext->_dyn_table_runtime[table_itr->second].has_mirror()) {
+            auto mirror_itr =
+            icontext->_dyn_tint.find(icontext->_dyn_table_runtime[table_itr->second]._mirror);
+            ASSERT(mirror_itr != icontext->_dyn_tint.end());
+
+            VERBOSE(*_workload, "Flagging pending delete for: " << mirror_itr->first);
+            icontext->_dyn_table_runtime[mirror_itr->second]._pending_delete = true;
+
+            ASSERT(std::find(pending_delete.begin(), pending_delete.end(), mirror_itr->first) ==
+            pending_delete.end());
+            pending_delete.push_back(mirror_itr->first);
+        }
+    }
     return 0;
 }
 
@@ -504,21 +615,9 @@ WorkloadRunner::start_tables_drop(WT_CONNECTION *conn)
             int drop_count = std::min(tables_remaining, _workload->options.drop_count);
             int drops = 0;
             while (drops < drop_count) {
-                /*
-                 * Walk the map and select random tables to delete. Skip tables already marked for
-                 * deletion.
-                 */
-                auto it = icontext->_dyn_tint.begin();
-                std::advance(it, workgen_random(_rand_state) % icontext->_dyn_tint.size());
-                if (icontext->_dyn_table_runtime[it->second]._pending_delete) {
+                if (select_table_for_drop(pending_delete) != 0) {
                     continue;
                 }
-
-                VERBOSE(*_workload, "Marking pending removal for: " << it->first);
-                icontext->_dyn_table_runtime[it->second]._pending_delete = true;
-                ASSERT(std::find(pending_delete.begin(), pending_delete.end(), it->first) ==
-                  pending_delete.end());
-                pending_delete.push_back(it->first);
                 ++drops;
             }
 
@@ -557,9 +656,10 @@ WorkloadRunner::start_tables_drop(WT_CONNECTION *conn)
                 VERBOSE(*_workload, "Drop returned EBUSY for table: " << uri);
             }
             if (ret != 0)
-                THROW("Table drop failed in start_tables_drop.");
+                THROW("Table drop failed for '" << uri << "' in start_tables_drop.");
 
             VERBOSE(*_workload, "Dropped table: " << uri);
+            std::cerr << "Dropped '" << uri << "'." << std::endl;
         }
 
         sleep(_workload->options.drop_interval);
@@ -779,24 +879,50 @@ ContextInternal::create_all(WT_CONNECTION *conn)
 
     /* Walk the entries in the metadata and extract the dynamic set. */
     while ((ret = cursor->next(cursor)) == 0) {
-        const char *key, *value;
+        const char *key, *v;
         if ((ret = cursor->get_key(cursor, &key)) != 0) {
             THROW(
               "Error getting the key for a metadata entry while extracting dynamic set of tables.");
         }
-        if ((ret = cursor->get_value(cursor, &value)) != 0) {
+        if ((ret = cursor->get_value(cursor, &v)) != 0) {
             THROW(
               "Error getting the value for a metadata entry while extracting dynamic set of "
               "tables.");
         }
 
-        if (std::string(value).find(DYN_TABLE_APP_METADATA) != std::string::npos &&
-          WT_PREFIX_MATCH(key, "table:")) {
+        std::string value = std::string(v);
+        size_t pos = value.find(DYN_TABLE_APP_METADATA);
+        if (pos != std::string::npos && WT_PREFIX_MATCH(key, "table:")) {
             // Add the table into the list of dynamic set. We are single threaded here and hence
             // do not yet need to protect the dynamic table structures with a lock.
             _dyn_tint[key] = _dyn_tint_last;
             _dyn_table_names[_dyn_tint_last] = key;
             _dyn_table_runtime[_dyn_tint_last] = TableRuntime();
+
+            size_t start, end;
+            pos = value.find(MIRROR_TABLE_APP_METADATA);
+            // If the table has a mirror, add the mirror name to the runtime data.
+            if (pos != std::string::npos) {
+                start = value.find_first_of('=', pos);
+                end = value.find_first_of(",\"", start);
+                if (start == std::string::npos || end == std::string::npos) {
+                    THROW("Unable to retrieve mirror name from metadata.");
+                }
+                _dyn_table_runtime[_dyn_tint_last]._mirror = value.substr(start+1, end-start-1);
+            }
+
+            pos = value.find(BASE_TABLE_APP_METADATA);
+            // Is this a base table or a mirror?
+            if (pos != std::string::npos) {
+                start = value.find_first_of('=', pos);
+                end = value.find_first_of(",\"", start);
+                if (start == std::string::npos || end == std::string::npos) {
+                    THROW("Unable to retrieve base table status from metadata.");
+                }
+                _dyn_table_runtime[_dyn_tint_last]._is_base =
+                  (value.substr(start+1, end-start-1) == "true");
+            }
+
             ++_dyn_tint_last;
         }
     }
@@ -1179,8 +1305,9 @@ ThreadRunner::run()
     if (options->throttle != 0) {
         _throttle = new Throttle(*this, options->throttle, options->throttle_burst);
     }
-    for (int cnt = 0; !_stop && (_repeat || cnt < 1) && ret == 0; cnt++)
-        WT_ERR(op_run(&_thread->_op));
+    for (int cnt = 0; !_stop && (_repeat || cnt < 1) && ret == 0; cnt++) {
+        WT_ERR(op_run_prepare(&_thread->_op));
+    }
 
 err :
 #ifdef _DEBUG
@@ -1208,9 +1335,10 @@ ThreadRunner::op_create_all(Operation *op, size_t &keysize, size_t &valuesize)
     op->create_all();
     if (op->is_table_op()) {
         op->kv_compute_max(true, false);
-        if (OP_HAS_VALUE(op))
-            op->kv_compute_max(false, op->_table.options.random_value);
-
+        if (OP_HAS_VALUE(op)) {
+            op->kv_compute_max(false,
+              (op->_table.options.random_value || _workload->options.random_table_values));
+        }
         if (op->_key._keytype == Key::KEYGEN_PARETO && op->_key._pareto.param == 0)
             THROW("Key._pareto value must be set if KEYGEN_PARETO specified");
         op->kv_size_buffer(true, keysize);
@@ -1314,37 +1442,87 @@ ThreadRunner::op_get_key_recno(Operation *op, uint64_t range, tint_t tint)
     return (rval % recno_count + 1); // recnos are one-based.
 }
 
-int
-ThreadRunner::op_run(Operation *op)
+// Clear the table uri and tint value for a dynamic table operation.
+void
+ThreadRunner::op_clear_table(Operation *op)
 {
-    Track *track;
-    tint_t tint;
-    WT_CURSOR *cursor;
-    WT_ITEM item;
-    WT_DECL_RET;
-    uint64_t recno;
-    uint64_t range;
-    bool measure_latency, own_cursor, retry_op;
-    timespec start_time;
-    uint64_t time_us;
-    char buf[BUF_SIZE];
-    std::string table_uri;
+    if (op->_random_table && op->is_table_op()) {
+        op->_table._uri = std::string();
+        op->_table._internal->_tint = 0;
+    }
+}
 
-    WT_CLEAR(item);
-    track = nullptr;
-    cursor = nullptr;
-    recno = 0;
-    own_cursor = false;
-    retry_op = true;
-    range = op->_table.options.range;
+// Generate and set a key and value for the operation managed by this thread.
+// Set the table uri and tint value for a dynamic table operation.
+void
+ThreadRunner::op_set_table(Operation *op, const std::string& uri, const tint_t tint)
+{
+    if (op->_random_table && op->is_table_op()) {
+        op->_table._uri = uri;
+        op->_table._internal->_tint = tint;
+    }
+}
+
+void
+ThreadRunner::op_kv_gen(Operation *op, const tint_t tint)
+{
+    if (!op->is_table_op()) {
+        return;
+    }
+
+    // A potential race: thread1 is inserting, and increments Context->_recno[] for fileX.wt.
+    // thread2 is doing one of remove/search/update and grabs the new value of Context->_recno[]
+    // for fileX.wt. thread2 randomly chooses the highest recno (which has not yet been inserted
+    // by thread1), and when it accesses the record will get WT_NOTFOUND. It should be somewhat 
+    // rare (and most likely when the threads are first beginning). Any WT_NOTFOUND returns are
+    // allowed and get their own statistic bumped.
+    uint64_t recno = 0;
+    uint64_t range = op->_table.options.range;
+    switch (op->_optype) {
+    case Operation::OP_INSERT:
+        if (op->_key._keytype == Key::KEYGEN_APPEND || op->_key._keytype == Key::KEYGEN_AUTO) {
+            if (op->_random_table) {
+                const std::shared_lock lock(*_icontext->_dyn_mutex);
+                recno = workgen_atomic_add64(&_icontext->_dyn_table_runtime.at(tint)._max_recno, 1);
+            } else {
+                recno = workgen_atomic_add64(&_icontext->_table_runtime[tint]._max_recno, 1);
+            }
+        } else {
+            recno = op_get_key_recno(op, range, tint);
+        }
+        break;
+    case Operation::OP_REMOVE:
+    case Operation::OP_SEARCH:
+    case Operation::OP_UPDATE:
+        recno = op_get_key_recno(op, range, tint);
+        break;
+    }
+
+    VERBOSE(*this, "OP " << op->_optype << " " << _icontext->_dyn_table_names[tint].c_str()
+      << ", recno=" << recno);
+
+    // Generate the key and value for the operation.
+    op->kv_gen(this, true, 100, recno, _keybuf);
+    if (OP_HAS_VALUE(op)) {
+        uint64_t compressibility =
+          (op->_table.options.random_value || _workload->options.random_table_values) ?
+            0 : op->_table.options.value_compressibility;
+        op->kv_gen(this, false, compressibility, recno, _valuebuf);
+    }
+}
+
+int
+ThreadRunner::op_run_prepare(Operation *op)
+{
+    WT_DECL_RET;
+
     if (_throttle != nullptr) {
         while (_throttle_ops >= _throttle_limit && !_in_transaction && !_stop) {
-            /*
-             * Calling throttle causes a sleep until the next time division, and we are given a new
-             * batch of operations to do before calling throttle again. If the number of operations
-             * in the batch is zero, we'll need to go around and throttle again.
-             */
-            WT_ERR(_throttle->throttle(_throttle_ops, &_throttle_limit));
+            // Calling throttle causes a sleep until the next time division, and we are given a
+            // new batch of operations to do before calling throttle again. If the number of
+            // operations in the batch is zero, we'll need to go around and throttle again.
+            if ((ret = _throttle->throttle(_throttle_ops, &_throttle_limit)) != 0)
+                return ret;
             _throttle_ops = 0;
             if (_throttle_limit != 0)
                 break;
@@ -1353,90 +1531,132 @@ ThreadRunner::op_run(Operation *op)
             ++_throttle_ops;
     }
 
-    // Find a table to operate on.
-    if (op->_random_table) {
-        const std::shared_lock lock(*_icontext->_dyn_mutex);
-        size_t num_tables = _icontext->_dyn_table_names.size();
-
-        if (num_tables == 0)
-            goto err;
-
-        // Select a random table.
-        auto it = _icontext->_dyn_tint.begin();
-        std::advance(it, random_value() % _icontext->_dyn_tint.size());
-        const std::string uri(it->first);
-
-        // Make sure the table is not marked for deletion.
-        bool marked_deleted = _icontext->_dyn_table_runtime[_icontext->_tint[uri]]._pending_delete;
-        if (!marked_deleted) {
-            table_uri = uri;
-            tint = _icontext->_dyn_tint[uri];
-            // Use atomic here as we can race with another thread that acquires the shared lock.
-            (void)workgen_atomic_add32(&_icontext->_dyn_table_runtime[tint]._in_use, 1);
-        } else {
-            goto err;
-        }
-    } else {
-        tint = op->_table._internal->_tint;
-        table_uri = op->_table._uri;
+    // If this is not a table operation, or if it is and has a table assigned, we have
+    // nothing more to do here.
+    if (!op->is_table_op() || op->has_table()) {
+        return op_run(op);
     }
 
-    /*
-     * A potential race: thread1 is inserting, and increments Context->_recno[] for fileX.wt.
-     * thread2 is doing one of remove/search/update and grabs the new value of Context->_recno[] for
-     * fileX.wt. thread2 randomly chooses the highest recno (which has not yet been inserted by
-     * thread1), and when it accesses the record will get WT_NOTFOUND. It should be somewhat rare
-     * (and most likely when the threads are first beginning). Any WT_NOTFOUND returns are allowed
-     * and get their own statistic bumped.
-     */
+    // Find a random table to operate on.
+    ASSERT(op->_random_table);
+    Operation base_op, mirror_op;
+
+    {
+        const std::shared_lock lock(*_icontext->_dyn_mutex);
+
+        // Select a random base table that is not flagged for deletion.
+        std::map<std::string, tint_t>::iterator itr;
+        uint32_t retries = 0;
+        size_t num_tables;
+
+        while ( (num_tables = _icontext->_dyn_table_names.size()) > 0 &&
+            ++retries < TABLE_MAX_RETRIES) {
+            itr = _icontext->_dyn_tint.begin();
+            std::advance(itr, random_value() % num_tables);
+
+            if (_icontext->_dyn_table_runtime[itr->second]._is_base &&
+                !_icontext->_dyn_table_runtime[itr->second]._pending_delete) {
+                break;
+            }
+        }
+        if (num_tables == 0 || retries >= TABLE_MAX_RETRIES) { // Try again next time.
+            return 0;
+        }
+
+        std::string op_uri = itr->first; // Get the table name.
+        tint_t op_tint = itr->second;    // Get the tint.
+        op_kv_gen(op, op_tint);          // Set the key and value for the operation.
+
+        // Use atomic here as we can race with another thread that acquires the shared lock.
+        (void)workgen_atomic_add32(&_icontext->_dyn_table_runtime[op_tint]._in_use, 1);
+
+        // Do we need to mirror operations? If not, we are done here.
+        if (!_icontext->_dyn_table_runtime[op_tint].has_mirror()) {
+            op_set_table(op, op_uri, op_tint);
+            return op_run(op);
+        }
+
+        // Copy this operation to two new operations on the base table and the mirror.
+        base_op = *op;
+        op_set_table(&base_op, op_uri, op_tint);
+
+        mirror_op = *op;
+        std::string mirror_op_uri = _icontext->_dyn_table_runtime[op_tint]._mirror;
+        tint_t mirror_op_tint = _icontext->_dyn_tint[mirror_op_uri];
+        op_set_table(&mirror_op, mirror_op_uri, mirror_op_tint);
+        (void)workgen_atomic_add32(&_icontext->_dyn_table_runtime[mirror_op_tint]._in_use, 1);
+        ASSERT(!_icontext->_dyn_table_runtime[mirror_op_tint]._pending_delete);
+    }
+
+    // Create a new operation with the base and mirror table ops. Group them in a transaction
+    // unless we are already in a transaction.
+    Operation new_op;
+    std::vector<Operation> new_group = {base_op, mirror_op};
+    new_op._group = &new_group;
+    new_op._repeatgroup = 1;
+
+    if (!_in_transaction) {
+        Transaction txn;
+        new_op.transaction = &txn;
+    }
+
+    return op_run(&new_op);
+}
+
+int
+ThreadRunner::op_run(Operation *op)
+{
+    Track *track;
+    WT_CURSOR *cursor;
+    WT_ITEM item;
+    WT_DECL_RET;
+    bool measure_latency, own_cursor, retry_op;
+    timespec start_time;
+    uint64_t time_us;
+    char buf[BUF_SIZE];
+    std::string table_uri = op->_table._uri;
+    tint_t tint = op->_table._internal->_tint;
+
+    WT_CLEAR(item);
+    track = nullptr;
+    cursor = nullptr;
+    own_cursor = false;
+    retry_op = true;
+
     switch (op->_optype) {
     case Operation::OP_CHECKPOINT:
-        recno = 0;
         track = &_stats.checkpoint;
         break;
     case Operation::OP_INSERT:
         track = &_stats.insert;
-        if (op->_key._keytype == Key::KEYGEN_APPEND || op->_key._keytype == Key::KEYGEN_AUTO) {
-            if (op->_random_table) {
-                const std::shared_lock lock(*_icontext->_dyn_mutex);
-                recno = workgen_atomic_add64(&_icontext->_dyn_table_runtime.at(tint)._max_recno, 1);
-            } else {
-                recno = workgen_atomic_add64(&_icontext->_table_runtime[tint]._max_recno, 1);
-            }
-        } else
-            recno = op_get_key_recno(op, range, tint);
         break;
     case Operation::OP_LOG_FLUSH:
     case Operation::OP_NONE:
     case Operation::OP_NOOP:
-        recno = 0;
         break;
     case Operation::OP_REMOVE:
         track = &_stats.remove;
-        recno = op_get_key_recno(op, range, tint);
         break;
     case Operation::OP_SEARCH:
         track = &_stats.read;
-        recno = op_get_key_recno(op, range, tint);
         break;
     case Operation::OP_UPDATE:
         track = &_stats.update;
-        recno = op_get_key_recno(op, range, tint);
         break;
     case Operation::OP_SLEEP:
-        recno = 0;
         break;
     }
+
     if (op->_random_table || ((op->_internal->_flags & WORKGEN_OP_REOPEN) != 0)) {
         WT_ERR(_session->open_cursor(_session, table_uri.c_str(), nullptr, nullptr, &cursor));
         own_cursor = true;
-    } else
+    } else {
         cursor = _cursors[tint];
+    }
 
     measure_latency = track != nullptr && track->ops != 0 && track->track_latency() &&
       (track->ops % _workload->options.sample_rate == 0);
 
-    VERBOSE(*this, "OP " << op->_optype << " " << table_uri.c_str() << ", recno=" << recno);
     uint64_t start;
     if (measure_latency)
         workgen_clock(&start);
@@ -1446,10 +1666,10 @@ ThreadRunner::op_run(Operation *op)
     if (track != nullptr)
         track->begin();
 
-    // Set up the key and value first, outside the transaction which may
-    // be retried.
+    // Set the cursor for the key and value first, outside the transaction which may
+    // be retried. The key and value are generated in op_run_prepare.
     if (op->is_table_op()) {
-        op->kv_gen(this, true, 100, recno, _keybuf);
+
         const std::string key_format(cursor->key_format);
         if (key_format == "S") {
             cursor->set_key(cursor, _keybuf);
@@ -1461,9 +1681,7 @@ ThreadRunner::op_run(Operation *op)
             THROW("The key format ('" << key_format << "') must be 'u' or 'S'.");
         }
         if (OP_HAS_VALUE(op)) {
-            uint64_t compressibility =
-              op->_table.options.random_value ? 0 : op->_table.options.value_compressibility;
-            op->kv_gen(this, false, compressibility, recno, _valuebuf);
+
             const std::string value_format(cursor->value_format);
             if (value_format == "S") {
                 cursor->set_value(cursor, _valuebuf);
@@ -1560,13 +1778,15 @@ ThreadRunner::op_run(Operation *op)
           *this, "GROUP operation " << op->_timed << " secs, " << op->_repeatgroup << "times");
 
         do {
-            for (int count = 0; !_stop && count < op->_repeatgroup; count++) {
+            // Wait for transactions to complete before stopping.
+            for (int count = 0; (!_stop || _in_transaction) && count < op->_repeatgroup; count++) {
                 for (std::vector<Operation>::iterator i = op->_group->begin();
-                     i != op->_group->end(); i++)
-                    WT_ERR(op_run(&*i));
+                     i != op->_group->end(); i++) {
+                    WT_ERR(op_run_prepare(&*i));
+                }
             }
             workgen_clock(&now);
-        } while (!_stop && ns_to_us(now) < endtime);
+        } while ((!_stop || _in_transaction)  && ns_to_us(now) < endtime);
 
         if (op->_timed != 0.0)
             _op_time_us = endtime;
@@ -1598,15 +1818,16 @@ err:
         _in_transaction = false;
     }
 
-    // For operations on random tables, if a table has been selected, decrement the reference
-    // counter.
-    if (op->_random_table && !table_uri.empty()) {
+    if (op->_random_table) {
+
+        op_clear_table(op);
         const std::shared_lock lock(*_icontext->_dyn_mutex);
+        // For operations on random tables, if a table has been selected, decrement the
+        // reference counter.
         ASSERT(_icontext->_dyn_table_runtime[tint]._in_use > 0);
         // Use atomic here as we can race with another thread that acquires the shared lock.
         (void)workgen_atomic_sub32(&_icontext->_dyn_table_runtime[tint]._in_use, 1);
     }
-
     return (ret);
 }
 
@@ -1985,6 +2206,12 @@ Operation::get_static_counts(Stats &stats, int multiplier)
     if (_group != nullptr)
         for (std::vector<Operation>::iterator i = _group->begin(); i != _group->end(); i++)
             i->get_static_counts(stats, multiplier * _repeatgroup);
+}
+
+bool
+Operation::has_table() const
+{
+    return (!_table._uri.empty());
 }
 
 bool
@@ -2662,7 +2889,8 @@ WorkloadOptions::WorkloadOptions()
       sample_rate(1), warmup(0), oldest_timestamp_lag(0.0), stable_timestamp_lag(0.0),
       timestamp_advance(0.0), max_idle_table_cycle_fatal(false), create_count(0),
       create_interval(0), create_prefix(""), create_target(0), create_trigger(0), drop_count(0),
-      drop_interval(0), drop_target(0), drop_trigger(0), _options()
+      drop_interval(0), drop_target(0), drop_trigger(0), random_table_values(false),
+      mirror_tables(false), mirror_suffix("_mirror"), _options()
 {
     _options.add_int("max_latency", max_latency,
       "prints warning if any latency measured exceeds this number of "
@@ -2718,6 +2946,11 @@ WorkloadOptions::WorkloadOptions()
       "if specified, start dropping tables when the database exceeds this size in MB");
     _options.add_int("drop_target", drop_target,
       "if specified, stop dropping tables when the database drops below this size in MB");
+    _options.add_bool("random_table_values", random_table_values,
+      "generate random content for the table value");
+    _options.add_bool("mirror_tables", mirror_tables, "mirror database operations");
+    _options.add_string(
+      "mirror_suffix", mirror_suffix, "the suffix to append to mirrored table names");
 }
 
 WorkloadOptions::WorkloadOptions(const WorkloadOptions &other)
@@ -2915,6 +3148,10 @@ WorkloadRunner::run_all(WT_CONNECTION *conn)
 {
     WT_DECL_RET;
 
+    // Register signal handlers for SIGINT (Ctrl-C) and SIGTERM.
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
     Stats counts(false);
     for (size_t i = 0; i < _trunners.size(); i++)
         _trunners[i].get_static_counts(counts);
@@ -3080,10 +3317,11 @@ WorkloadRunner::run_all(WT_CONNECTION *conn)
         timespec end = _start + options->run_time;
         timespec next_report = _start + options->report_interval;
 
-        // Let the test run, reporting as needed.
+        // Let the test run, reporting as needed. Exit when we exceed the run time or
+        // when a registered signal is received.
         Stats curstats(false);
         now = _start;
-        while (now < end) {
+        while (now < end && !signal_raised) {
             timespec sleep_amt;
 
             sleep_amt = end - now;

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -289,7 +289,7 @@ WorkloadRunner::start_table_idle_cycle(WT_CONNECTION *conn)
          * Drop the table. Keep retrying on EBUSY failure - it is an expected return when
          * checkpoints are happening.
          */
-        while ((ret = session->drop(session, uri, "force,checkpoint_wait=false")) == EBUSY)
+        while ((ret = session->drop(session, uri, "checkpoint_wait=false")) == EBUSY)
             sleep(1);
 
         if (ret != 0) {
@@ -650,10 +650,11 @@ WorkloadRunner::start_tables_drop(WT_CONNECTION *conn)
          */
         for (auto uri : drop_files) {
             WT_DECL_RET;
-            // Spin on EBUSY, we do not expect to get stuck
+            // Spin on EBUSY. We do not expect to get stuck.
             while (
-              (ret = session->drop(session, uri.c_str(), "force,checkpoint_wait=false")) == EBUSY) {
+              (ret = session->drop(session, uri.c_str(), "checkpoint_wait=false")) == EBUSY) {
                 VERBOSE(*_workload, "Drop returned EBUSY for table: " << uri);
+                sleep(1);
             }
             if (ret != 0)
                 THROW("Table drop failed for '" << uri << "' in start_tables_drop.");

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1593,8 +1593,8 @@ ThreadRunner::op_run_prepare(Operation *op)
     new_op._group = &new_group;
     new_op._repeatgroup = 1;
 
+    Transaction txn;
     if (!_in_transaction) {
-        Transaction txn;
         new_op.transaction = &txn;
     }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -380,7 +380,6 @@ WorkloadRunner::create_table(WT_SESSION *session, const std::string &config, con
         icontext->_dyn_table_runtime[tint] = TableRuntime(is_base, mirror_uri);
         ++icontext->_dyn_tint_last;
         VERBOSE(*_workload, "Created table and added to the dynamic set: " << uri);
-        std::cerr << "Created table: " << uri << std::endl;
     }
 
     return 0;
@@ -535,7 +534,6 @@ WorkloadRunner::schedule_table_for_drop(
     ContextInternal *icontext = _workload->_context->_internal;
     ASSERT(itr != icontext->_dyn_tint.end());
     VERBOSE(*_workload, "Flagging pending delete for: " << itr->first);
-    std::cerr << "Flagging pending delete for: " << itr->first << std::endl;
     icontext->_dyn_table_runtime[itr->second]._pending_delete = true;
 
     ASSERT(
@@ -658,7 +656,6 @@ WorkloadRunner::start_tables_drop(WT_CONNECTION *conn)
                 THROW("Table drop failed for '" << uri << "' in start_tables_drop.");
 
             VERBOSE(*_workload, "Dropped table: " << uri);
-            std::cerr << "Dropped '" << uri << "'." << std::endl;
         }
 
         sleep(_workload->options.drop_interval);

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1453,7 +1453,6 @@ ThreadRunner::op_clear_table(Operation *op)
     }
 }
 
-// Generate and set a key and value for the operation managed by this thread.
 // Set the table uri and tint value for a dynamic table operation.
 void
 ThreadRunner::op_set_table(Operation *op, const std::string &uri, const tint_t tint)
@@ -1464,6 +1463,7 @@ ThreadRunner::op_set_table(Operation *op, const std::string &uri, const tint_t t
     }
 }
 
+// Generate and set a key and value for the operation managed by this thread.
 void
 ThreadRunner::op_kv_gen(Operation *op, const tint_t tint)
 {

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -323,6 +323,7 @@ struct Operation {
     void init_internal(OperationInternal *other);
     void create_all();
     void get_static_counts(Stats &stats, int multiplier);
+    bool has_table() const;
     bool is_table_op() const;
     void kv_compute_max(bool iskey, bool has_random);
     void kv_gen(ThreadRunner *runner, bool iskey, uint64_t compressibility,
@@ -457,6 +458,9 @@ struct WorkloadOptions {
     int drop_interval;
     int drop_target;
     int drop_trigger;
+    bool random_table_values;
+    bool mirror_tables;
+    std::string mirror_suffix;
 
     WorkloadOptions();
     WorkloadOptions(const WorkloadOptions &other);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -158,10 +158,14 @@ struct ThreadRunner {
     int open_all();
     int run();
 
+    void op_clear_table(Operation *op);
     void op_create_all(Operation *, size_t &keysize, size_t &valuesize);
     uint64_t op_get_key_recno(Operation *, uint64_t range, tint_t tint);
     void op_get_static_counts(Operation *, Stats &, int);
+    void op_kv_gen(Operation *op, const tint_t tint);
     int op_run(Operation *);
+    int op_run_prepare(Operation *);
+    void op_set_table(Operation *op, const std::string &uri, const tint_t tint);
     float random_signed();
     uint32_t random_value();
 
@@ -199,14 +203,21 @@ private:
 };
 
 struct TableRuntime {
-    uint64_t _max_recno;                           // highest recno allocated
-    bool _disjoint;                                // does key space have holes?
+    uint64_t _max_recno;              // highest recno allocated
+    bool _disjoint;                   // does key space have holes?
 
-    /* Only used for the dynamic table set. */
-    uint32_t _in_use;                              // How many operations are using this table
-    bool _pending_delete;                          // Delete this table once not in use
+    // Only used for the dynamic table set.
+    bool _is_base;                    // true if this is the base table, false if the mirror
+    std::string _mirror;              // table uri of mirror, if mirrored
+    uint32_t _in_use;                 // How many operations are using this table
+    bool _pending_delete;             // Delete this table once not in use
 
-    TableRuntime() : _max_recno(0), _disjoint(0), _in_use(0), _pending_delete(false) {}
+    TableRuntime() : _max_recno(0), _disjoint(0), _is_base(true), _mirror(std::string()),
+        _in_use(0), _pending_delete(false) {}
+    TableRuntime(const bool is_base, const std::string &mirror) : _max_recno(0), _disjoint(0),
+        _is_base(is_base), _mirror(mirror), _in_use(0), _pending_delete(false) {}
+    bool is_base_table() { return _is_base == true; }
+    bool has_mirror() { return !_mirror.empty(); }
 };
 
 struct ContextInternal {
@@ -223,7 +234,6 @@ struct ContextInternal {
     tint_t _dyn_tint_last;
     // This mutex should be used to protect the access to the dynamic tables set.
     std::shared_mutex* _dyn_mutex;
-
     // unique id per context, to work with multiple contexts, starts at 1.
     uint32_t _context_count;
 
@@ -266,7 +276,7 @@ struct TableOperationInternal : OperationInternal {
     uint_t _valuemax;
 
     TableOperationInternal() : OperationInternal(), _keysize(0), _valuesize(0),
-			       _keymax(0),_valuemax(0) {}
+			       _keymax(0), _valuemax(0) {}
     TableOperationInternal(const TableOperationInternal &other) :
 	OperationInternal(other),
 	_keysize(other._keysize), _valuesize(other._valuesize),
@@ -317,12 +327,15 @@ struct WorkloadRunner {
 private:
     int close_all();
     int create_all(WT_CONNECTION *conn, Context *context);
+    int create_table(WT_SESSION *session, const std::string &config, const std::string &uri,
+      const std::string &mirror_uri, const bool is_base);
     void final_report(timespec &);
     void get_stats(Stats *stats);
     int open_all();
     void open_report_file(std::ofstream &, const std::string&, const std::string&);
     void report(time_t, time_t, Stats *stats);
     int run_all(WT_CONNECTION *conn);
+    int select_table_for_drop(std::vector<std::string> &pending_delete);
 
     WorkloadRunner(const WorkloadRunner &);                 // disallowed
     WorkloadRunner& operator=(const WorkloadRunner &other); // disallowed

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -332,6 +332,8 @@ private:
     int create_table(WT_SESSION *session, const std::string &config, const std::string &uri,
       const std::string &mirror_uri, const bool is_base);
     void final_report(timespec &);
+    void schedule_table_for_drop(const std::map<std::string, tint_t>::iterator &itr,
+      std::vector<std::string> &pending_delete);
     void get_stats(Stats *stats);
     int open_all();
     void open_report_file(std::ofstream &, const std::string&, const std::string&);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -164,7 +164,7 @@ struct ThreadRunner {
     void op_get_static_counts(Operation *, Stats &, int);
     void op_kv_gen(Operation *op, const tint_t tint);
     int op_run(Operation *);
-    int op_run_prepare(Operation *);
+    int op_run_setup(Operation *);
     void op_set_table(Operation *op, const std::string &uri, const tint_t tint);
     float random_signed();
     uint32_t random_value();


### PR DESCRIPTION
This PR adds mirror table functionality to workgen for dynamic tables. Tables created by the `Table()` class are not affected. I used the `tools/wt_cmp_uri` script to validate mirrored content (thanks @ddanderson!!)

Changes include:
* Added new members to the `TableRuntime` to indicate if a table is a base table or a mirror.
* Added a boolean to the `app_metadata` indicating if the table is a base or mirror.
* Added the mirror table name to the `app_metadata` if the table is mirrored.
* Updated the dynamic table create and drop to operate on mirror table pairs.
* Moved random table selection out of `op_run` and into a new `op_run_prepare` function so that (non-transaction) mirrored table operations could be wrapped in a transaction.
* Removed the `force` config setting from the `session->drop` calls (see WT-10576) 
* Added a workload option to enable mirroring.
* Added a workload option to specify the suffix for table mirrors.