### PR TITLE
WT-9939 Enter split generation on eviction to prevent split parent free to early

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -105,15 +105,12 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     WT_DECL_RET;
     WT_PAGE *page;
     uint64_t eviction_time, eviction_time_seconds;
-    bool clean_page, closing, force_evict_hs, inmem_split, local_gen_evict, local_gen_split,
-      tree_dead;
+    bool clean_page, closing, force_evict_hs, inmem_split, tree_dead;
 
     conn = S2C(session);
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
     force_evict_hs = false;
-    local_gen_evict = false;
-    local_gen_split = false;
     eviction_time = eviction_time_seconds = 0;
 
     __wt_verbose(
@@ -128,8 +125,8 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
      * generation (eviction or split) generation (which must be as low as the current generation),
      * untouched.
      */
-    WT_ENTER_GENERATION(session, WT_GEN_EVICT, local_gen_evict);
-    WT_ENTER_GENERATION(session, WT_GEN_SPLIT, local_gen_split);
+    WT_ENTER_GENERATION(session, WT_GEN_EVICT);
+    WT_ENTER_GENERATION(session, WT_GEN_SPLIT);
 
     WT_CLEAR(session->reconcile_timeline);
     WT_CLEAR(session->evict_timeline);
@@ -284,8 +281,8 @@ done:
           WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
             session->reconcile_timeline.hs_wrapup_start));
     /* Leave any local eviction generation. */
-    WT_LEAVE_GENERATION(session, WT_GEN_EVICT, local_gen_evict);
-    WT_LEAVE_GENERATION(session, WT_GEN_SPLIT, local_gen_split);
+    WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);
+    WT_LEAVE_GENERATION(session, WT_GEN_EVICT);
 
     return (ret);
 }

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -105,13 +105,15 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     WT_DECL_RET;
     WT_PAGE *page;
     uint64_t eviction_time, eviction_time_seconds;
-    bool clean_page, closing, force_evict_hs, inmem_split, local_gen, tree_dead;
+    bool clean_page, closing, force_evict_hs, inmem_split, local_gen_evict, local_gen_split,
+      tree_dead;
 
     conn = S2C(session);
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
     force_evict_hs = false;
-    local_gen = false;
+    local_gen_evict = false;
+    local_gen_split = false;
     eviction_time = eviction_time_seconds = 0;
 
     __wt_verbose(
@@ -122,13 +124,12 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         LF_SET(WT_EVICT_CALL_NO_SPLIT);
 
     /*
-     * Enter the eviction generation. If we re-enter eviction, leave the previous eviction
-     * generation (which must be as low as the current generation), untouched.
+     * Enter the eviction and split generation. If we re-enter eviction, leave the previous
+     * generation (eviction or split) generation (which must be as low as the current generation),
+     * untouched.
      */
-    if (__wt_session_gen(session, WT_GEN_EVICT) == 0) {
-        local_gen = true;
-        __wt_session_gen_enter(session, WT_GEN_EVICT);
-    }
+    WT_ENTER_GENERATION(session, WT_GEN_EVICT, local_gen_evict);
+    WT_ENTER_GENERATION(session, WT_GEN_SPLIT, local_gen_split);
 
     WT_CLEAR(session->reconcile_timeline);
     WT_CLEAR(session->evict_timeline);
@@ -283,8 +284,8 @@ done:
           WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
             session->reconcile_timeline.hs_wrapup_start));
     /* Leave any local eviction generation. */
-    if (local_gen)
-        __wt_session_gen_leave(session, WT_GEN_EVICT);
+    WT_LEAVE_GENERATION(session, WT_GEN_EVICT, local_gen_evict);
+    WT_LEAVE_GENERATION(session, WT_GEN_SPLIT, local_gen_split);
 
     return (ret);
 }

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1600,22 +1600,34 @@ struct __wt_col_fix_auxiliary_header {
  * examining an index, we don't want the oldest split generation to move forward and potentially
  * free it.
  */
-#define WT_ENTER_PAGE_INDEX(session)                                         \
-    do {                                                                     \
-        uint64_t __prev_split_gen = __wt_session_gen(session, WT_GEN_SPLIT); \
-        if (__prev_split_gen == 0)                                           \
-            __wt_session_gen_enter(session, WT_GEN_SPLIT);
+#define WT_ENTER_PAGE_INDEX(session)      \
+    do {                                  \
+        bool __entered_split_gen = false; \
+        WT_ENTER_GENERATION((session), WT_GEN_SPLIT, __entered_split_gen);
 
-#define WT_LEAVE_PAGE_INDEX(session)                   \
-    if (__prev_split_gen == 0)                         \
-        __wt_session_gen_leave(session, WT_GEN_SPLIT); \
-    }                                                  \
+#define WT_LEAVE_PAGE_INDEX(session)                                   \
+    WT_LEAVE_GENERATION((session), WT_GEN_SPLIT, __entered_split_gen); \
+    }                                                                  \
     while (0)
 
 #define WT_WITH_PAGE_INDEX(session, e) \
     WT_ENTER_PAGE_INDEX(session);      \
     (e);                               \
     WT_LEAVE_PAGE_INDEX(session)
+
+/*
+ * Manage the given generation number with support for re-entry. Re-entry is allowed as the previous
+ * generation as it must be as low as the current generation.
+ */
+#define WT_ENTER_GENERATION(session, generation, entered) \
+    if (__wt_session_gen((session), (generation)) == 0) { \
+        __wt_session_gen_enter((session), (generation));  \
+        (entered) = true;                                 \
+    }
+
+#define WT_LEAVE_GENERATION(session, generation, entered) \
+    if ((entered))                                        \
+        __wt_session_gen_leave((session), (generation));
 
 /*
  * WT_VERIFY_INFO -- A structure to hold all the information related to a verify operation.


### PR DESCRIPTION
WT-9939 Added entering split generation on eviction to prevent parent from being freed after split.