### PR TITLE
WT-10586 Disable compile-clang task in Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -977,7 +977,9 @@ tasks:
       - func: "cleanup"
 
   - name: compile-gcc
-    tags: ["pull_request", "pull_request_compilers"]
+    # The task is disabled as a package is missed on the ubuntu2004-wt-large distro.
+    # We can re-enable the task once the missing package is added. WT-10595.
+    # tags: ["pull_request", "pull_request_compilers"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1000,8 +1000,9 @@ tasks:
           DGNU_CXX_VERSION: -DDGNU_CXX_VERSION=9
 
   - name: compile-clang
+    # FIXME: WT-10595
     # The task is disabled as a package is missed on the ubuntu2004-wt-large distro.
-    # We can re-enable the task once the missing package is added. WT-10595.
+    # We can re-enable the task once the missing package is added.
     # tags: ["pull_request", "pull_request_compilers"]
     commands:
       - func: "get project"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -977,9 +977,7 @@ tasks:
       - func: "cleanup"
 
   - name: compile-gcc
-    # The task is disabled as a package is missed on the ubuntu2004-wt-large distro.
-    # We can re-enable the task once the missing package is added. WT-10595.
-    # tags: ["pull_request", "pull_request_compilers"]
+    tags: ["pull_request", "pull_request_compilers"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -1002,7 +1000,9 @@ tasks:
           DGNU_CXX_VERSION: -DDGNU_CXX_VERSION=9
 
   - name: compile-clang
-    tags: ["pull_request", "pull_request_compilers"]
+    # The task is disabled as a package is missed on the ubuntu2004-wt-large distro.
+    # We can re-enable the task once the missing package is added. WT-10595.
+    # tags: ["pull_request", "pull_request_compilers"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"


### PR DESCRIPTION
Disable the `compile-clang` task in Evergreen for now, as it kept failing and affected PR testing. 
We'll re-enable the task once the package missing issue on the Evergreen distro is addressed, using WT-10595.