### PR TITLE
WT-10595 Re-enable compile-clang task in Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1000,10 +1000,7 @@ tasks:
           DGNU_CXX_VERSION: -DDGNU_CXX_VERSION=9
 
   - name: compile-clang
-    # FIXME: WT-10595
-    # The task is disabled as a package is missed on the ubuntu2004-wt-large distro.
-    # We can re-enable the task once the missing package is added.
-    # tags: ["pull_request", "pull_request_compilers"]
+    tags: ["pull_request", "pull_request_compilers"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"


### PR DESCRIPTION
As the image of the problematic distro has been reverted to a working version, let's re-enable the task in Evergreen.