### PR TITLE
WT-10589 Halve the number of concurrent jobs for macOS unit tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5184,6 +5184,8 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
+    # FIXME: WT-9575
+    # Using a special version of unit test for macOS to reduce the concurrency level.
     - name: unit-test-macos
     - name: fops
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2165,6 +2165,16 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
 
+  - name: unit-test-macos
+    tags: ["python"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+           smp_command: -j $(echo $(sysctl -n hw.logicalcpu) / 2 | bc)
+
   - name: unit-test-nonstandalone
     tags: ["python"]
     depends_on:
@@ -5174,7 +5184,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: unit-test
+    - name: unit-test-macos
     - name: fops
 
 - name: little-endian


### PR DESCRIPTION
Temporarily reduce the concurrency level (and cache pressure) for the macOS unit tests to avoid hitting repeated failures addressed in WT-9575. It's expected this fix gets reverted as part of WT-9575.