### PR TITLE
WT-10389 Setup a tiered shared server background worker

### DIFF
--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -482,8 +482,8 @@ __wt_tiered_storage_create(WT_SESSION_IMPL *session)
     WT_ERR(__wt_thread_create(session, &conn->tiered_tid, __tiered_server, session));
     conn->tiered_tid_set = true;
 
-    /* Start the shared thread. */
-    if (conn->bstorage->tiered_shared) {
+    /* Start the shared storage thread. */
+    if (conn->bstorage != NULL && conn->bstorage->tiered_shared) {
         WT_ERR(
           __wt_thread_create(session, &conn->tiered_shared_tid, __tiered_shared_server, session));
         conn->tiered_shared_tid_set = true;

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -458,9 +458,12 @@ struct __wt_connection_impl {
 
     WT_SESSION_IMPL *tiered_session; /* Tiered thread session */
     wt_thread_t tiered_tid;          /* Tiered thread */
+    wt_thread_t tiered_shared_tid;   /* Tiered shared thread */
     bool tiered_tid_set;             /* Tiered thread set */
+    bool tiered_shared_tid_set;      /* Tiered shared thread set */
     WT_CONDVAR *flush_cond;          /* Flush wait mutex */
     WT_CONDVAR *tiered_cond;         /* Tiered wait mutex */
+    WT_CONDVAR *tiered_shared_cond;  /* Tiered shared wait mutex */
     uint64_t tiered_interval;        /* Tiered work interval */
     bool tiered_server_running;      /* Internal tiered server operating */
     bool flush_ckpt_complete;        /* Checkpoint after flush completed */


### PR DESCRIPTION
When the connection level tiered storage is configured for sharing, this background workers gets started during the startup and does the job of moving the data from the active table to the shared table.