### PR TITLE
WT-10597 Fix tiered storage extensions test

### DIFF
--- a/cmake/third_party/aws_sdk.cmake
+++ b/cmake/third_party/aws_sdk.cmake
@@ -15,7 +15,7 @@ config_choice(
         "package;IMPORT_S3_SDK_PACKAGE;ENABLE_S3"
         "external;IMPORT_S3_SDK_EXTERNAL;ENABLE_S3"
 )
- 
+
 if(IMPORT_S3_SDK_NONE)
     message(FATAL_ERROR "Cannot enable S3 extension without specifying an IMPORT_S3_SDK method (package, external).")
 endif()
@@ -35,15 +35,15 @@ elseif(IMPORT_S3_SDK_EXTERNAL)
     ExternalProject_Add(aws-sdk
         PREFIX aws-sdk-cpp
         GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
-        GIT_TAG 1.9.175
+        GIT_TAG 1.11.17
         CMAKE_ARGS
             -DBUILD_SHARED_LIBS=ON
             -DBUILD_ONLY=s3-crt
             -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
             # ENABLE TESTING decides whether or not to build the AWS CPP SDK with the services integration tests.
-            # Alternatively you can build with testing enabled but set AUTORUN_UNIT_TESTS flag to ON/OFF to decide 
-            # whether or not to run the tests. If testing is not enabled, the AUTORUN_UNIT_TESTS flag gets ignored. 
+            # Alternatively you can build with testing enabled but set AUTORUN_UNIT_TESTS flag to ON/OFF to decide
+            # whether or not to run the tests. If testing is not enabled, the AUTORUN_UNIT_TESTS flag gets ignored.
             -DENABLE_TESTING=OFF
         BUILD_ALWAYS FALSE
         INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/aws-sdk-cpp/install

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -4,7 +4,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 # CMake version we fallback to and download when cmake doesn't exist on the
 # host system.
 CMAKE_MAJOR_VER=3
-CMAKE_MINOR_VER=11
+CMAKE_MINOR_VER=13
 CMAKE_PATCH_VER=0
 CMAKE_VERSION=$CMAKE_MAJOR_VER.$CMAKE_MINOR_VER.$CMAKE_PATCH_VER
 
@@ -14,6 +14,9 @@ find_cmake ()
 {
     if [ -n "$CMAKE" ]; then
         return 0
+    elif [ -f "/opt/mongodbtoolchain/v4/bin/cmake" ]; then
+        CMAKE="/opt/mongodbtoolchain/v4/bin/cmake"
+        CTEST="/opt/mongodbtoolchain/v4/bin/ctest"
     elif [ -f "/Applications/CMake.app/Contents/bin/cmake" ]; then
         CMAKE="/Applications/CMake.app/Contents/bin/cmake"
         CTEST="/Applications/CMake.app/Contents/bin/ctest"


### PR DESCRIPTION
This does a few things:
1. Clean up some minor whitespace issues in the AWS CMake file
2. Updates the AWS SDK version to a version that no longer uses curl in a deprecated way (this was the original cause of the build failure - some systems got a newer libcurl and starting throwing warnings while building)
3. Looks for CMake/CTest in the Mongo toolchain v4 directory, since the new AWS SDK version needs CMake >= 3.13, which is newer than some of the system-wide installations that `find_cmake.sh` was getting.