### PR TITLE
WT-10594 Disable cursor_reposition in test/format for older releases

### DIFF
--- a/test/evergreen/compatibility_test_for_releases.sh
+++ b/test/evergreen/compatibility_test_for_releases.sh
@@ -160,6 +160,7 @@ create_configs()
     echo "checkpoints=1"  >> $file_name             # Force periodic writes
     echo "compression=snappy"  >> $file_name        # We only built with snappy, force the choice
     echo "data_source=table" >> $file_name
+    echo "debug.cursor_reposition=0" >> $file_name  # WT-10594 - Not supported by older releases
     echo "debug.log_retention=0" >> $file_name      # WT-10434 - Not supported by older releases
     echo "debug.realloc_malloc=0" >> $file_name     # WT-10111 - Not supported by older releases
     echo "huffman_key=0" >> $file_name              # WT-6893 - Not supported by newer releases


### PR DESCRIPTION
See the details described in [WT-10594](https://jira.mongodb.org/browse/WT-10594), `cursor_reposition` is not supported in older releases.