### PR TITLE
WT-10619 Update Clang-Format to 12.0.1

### DIFF
--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -20,7 +20,7 @@ cd "$dest_dir" || exit 1
 export PATH="${PWD}/dist":$PATH
 
 # Check if Clang-Format is already available with the desired version.
-desired_version="10.0.0"
+desired_version="12.0.1"
 if ! command -v clang-format &> /dev/null || ! clang-format --version | grep -q $desired_version; then
     echo "Failed to find Clang-Format, make sure the binary (version: $desired_version) is in your env PATH."
     exit 1

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -5,29 +5,6 @@ set -o pipefail
 t=__wt.$$
 trap 'rm -rf $t' 0 1 2 3 13 15
 
-download_clang_format() {
-    version=$1
-    # FIXME-WT-10583
-    arch=$(uname -m)
-    if [ ! "$arch" = "x86_64" ]; then
-        echo "$0: unsupported architecture $arch to run clang_format"
-        return 1
-    fi
-
-    archive=dist/clang-format.tar.gz
-    sys_os=$(uname)
-    if [ "$sys_os" = "Linux" ]; then
-        curl https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-llvm-"$version"-x86_64-linux-gnu-ubuntu-20.04.tar-1.gz -o $archive
-        tar --strip=1 -C dist/ -xf $archive clang-format-llvm-"$version"-x86_64-linux-gnu-ubuntu-20.04/clang-format && rm $archive
-    elif [ "$sys_os" = "Darwin" ]; then
-        curl https://s3.amazonaws.com/boxes.10gen.com/build/build/clang-format-llvm-"$version"-x86_64-apple-darwin.tar.gz -o $archive
-        tar --strip=1 -C dist/ -xf $archive clang-format-llvm-"$version"-x86_64-apple-darwin/clang-format && rm $archive
-    else
-        echo "$0: unsupported environment $sys_os"
-        return 1
-    fi
-}
-
 # Find the top-level WiredTiger directory.
 dest_dir=$(git rev-parse --show-toplevel)
 
@@ -44,15 +21,10 @@ export PATH="${PWD}/dist":$PATH
 
 # Check if Clang-Format is already available with the desired version.
 desired_version="10.0.0"
-if ! command -v clang-format &> /dev/null; then
-    download_clang_format $desired_version || exit 1
-elif ! clang-format --version | grep -q $desired_version; then
-    download_clang_format $desired_version || exit 1
+if ! command -v clang-format &> /dev/null || ! clang-format --version | grep -q $desired_version; then
+    echo "Failed to find Clang-Format, make sure the binary (version: $desired_version) is in your env PATH."
+    exit 1
 fi
-
-# Users may need to manually approve binaries.
-# If we're not allowed to run Clang-Format, let's exit (should be obvious from the dialog).
-clang-format --version &> /dev/null || exit 1
 
 exclude=true
 case $# in

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -21,8 +21,12 @@ export PATH="${PWD}/dist":$PATH
 
 # Check if Clang-Format is already available with the desired version.
 desired_version="12.0.1"
-if ! command -v clang-format &> /dev/null || ! clang-format --version | grep -q $desired_version; then
-    echo "Failed to find Clang-Format, make sure the binary (version: $desired_version) is in your env PATH."
+if ! command -v clang-format &> /dev/null; then
+    echo "Failed to find clang-format, make sure the binary (version: $desired_version) is in your env PATH."
+    exit 1
+fi
+if ! clang-format --version | grep -q $desired_version; then
+    echo "The binary $(which clang-format) does not have the expected version: $desired_version."
     exit 1
 fi
 

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -19,7 +19,7 @@ cd "$dest_dir" || exit 1
 # Check if Clang-Format is already available with the desired version.
 desired_version="12.0.1"
 if ! command -v clang-format &> /dev/null; then
-    echo "Failed to find clang-format, make sure the binary (version: $desired_version) is in your env PATH."
+    echo "Failed to find clang-format, make sure the binary (version: $desired_version) is installed and in your env PATH."
     exit 1
 fi
 if ! clang-format --version | grep -q $desired_version; then

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -16,9 +16,6 @@ if [ -n "$is_mongo_repo" ] ; then
 fi
 cd "$dest_dir" || exit 1
 
-# Override existing Clang-Format versions in the PATH.
-export PATH="${PWD}/dist":$PATH
-
 # Check if Clang-Format is already available with the desired version.
 desired_version="12.0.1"
 if ! command -v clang-format &> /dev/null; then

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -604,7 +604,9 @@ __blkcache_init(WT_SESSION_IMPL *session, size_t cache_size, u_int hash_size, u_
 
     __wt_verbose(session, WT_VERB_BLKCACHE,
       "block cache initialized: type=%s, size=%" WT_SIZET_FMT " path=%s",
-      (type == WT_BLKCACHE_NVRAM) ? "nvram" : (type == WT_BLKCACHE_DRAM) ? "dram" : "unconfigured",
+      (type == WT_BLKCACHE_NVRAM)  ? "nvram" :
+        (type == WT_BLKCACHE_DRAM) ? "dram" :
+                                     "unconfigured",
       cache_size, (blkcache->nvram_device_path == NULL) ? "--" : blkcache->nvram_device_path);
 
     return (ret);

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -53,9 +53,9 @@ __search_insert_append(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_INSERT
          * serialized insert function.
          */
         for (i = WT_SKIP_MAXDEPTH - 1; i >= 0; i--) {
-            cbt->ins_stack[i] = (i == 0) ?
-              &ins->next[0] :
-              (ins_head->tail[i] != NULL) ? &ins_head->tail[i]->next[i] : &ins_head->head[i];
+            cbt->ins_stack[i] = (i == 0)  ? &ins->next[0] :
+              (ins_head->tail[i] != NULL) ? &ins_head->tail[i]->next[i] :
+                                            &ins_head->head[i];
             cbt->next_stack[i] = NULL;
         }
         cbt->compare = -cmp;

--- a/src/checksum/arm64/crc32-arm64.c
+++ b/src/checksum/arm64/crc32-arm64.c
@@ -39,16 +39,16 @@
 #endif
 
 #define CRC32CX(crc, value) \
-    __asm__("crc32cx %w[c], %w[c], %x[v]" : [ c ] "+r"(*&crc) : [ v ] "r"(+value))
+    __asm__("crc32cx %w[c], %w[c], %x[v]" : [c] "+r"(*&crc) : [v] "r"(+value))
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-macros"
 #define CRC32CW(crc, value) \
-    __asm__("crc32cw %w[c], %w[c], %w[v]" : [ c ] "+r"(*&crc) : [ v ] "r"(+value))
+    __asm__("crc32cw %w[c], %w[c], %w[v]" : [c] "+r"(*&crc) : [v] "r"(+value))
 #define CRC32CH(crc, value) \
-    __asm__("crc32ch %w[c], %w[c], %w[v]" : [ c ] "+r"(*&crc) : [ v ] "r"(+value))
+    __asm__("crc32ch %w[c], %w[c], %w[v]" : [c] "+r"(*&crc) : [v] "r"(+value))
 #pragma GCC diagnostic pop
 #define CRC32CB(crc, value) \
-    __asm__("crc32cb %w[c], %w[c], %w[v]" : [ c ] "+r"(*&crc) : [ v ] "r"(+value))
+    __asm__("crc32cb %w[c], %w[c], %w[v]" : [c] "+r"(*&crc) : [v] "r"(+value))
 
 /*
  * __wt_checksum_hw --

--- a/src/include/column_inline.h
+++ b/src/include/column_inline.h
@@ -212,9 +212,9 @@ __col_insert_search(
     /* Fast path appends. */
     if (recno >= WT_INSERT_RECNO(ret_ins)) {
         for (i = 0; i < WT_SKIP_MAXDEPTH; i++) {
-            ins_stack[i] = (i == 0) ?
-              &ret_ins->next[0] :
-              (ins_head->tail[i] != NULL) ? &ins_head->tail[i]->next[i] : &ins_head->head[i];
+            ins_stack[i] = (i == 0)       ? &ret_ins->next[0] :
+              (ins_head->tail[i] != NULL) ? &ins_head->tail[i]->next[i] :
+                                            &ins_head->head[i];
             next_stack[i] = NULL;
         }
         return (ret_ins);

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -71,12 +71,12 @@
 #define WT_CLOCKDIFF_MS(end, begin) (WT_CLOCKDIFF_NS(end, begin) / WT_MILLION)
 #define WT_CLOCKDIFF_SEC(end, begin) (WT_CLOCKDIFF_NS(end, begin) / WT_BILLION)
 
-#define WT_TIMECMP(t1, t2)                                                        \
-    ((t1).tv_sec < (t2).tv_sec ?                                                  \
-        -1 :                                                                      \
-        (t1).tv_sec == (t2).tv_sec ?                                              \
-        (t1).tv_nsec < (t2).tv_nsec ? -1 : (t1).tv_nsec == (t2).tv_nsec ? 0 : 1 : \
-        1)
+#define WT_TIMECMP(t1, t2)                                              \
+    ((t1).tv_sec < (t2).tv_sec     ? -1 :                               \
+        (t1).tv_sec == (t2).tv_sec ? (t1).tv_nsec < (t2).tv_nsec ? -1 : \
+          (t1).tv_nsec == (t2).tv_nsec                           ? 0 :  \
+                                                                   1 :                            \
+                                     1)
 
 /*
  * Macros to ensure a file handle is inserted or removed from both the main and the hashed queue,

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -117,13 +117,11 @@ __wt_verbose_dump_log(WT_SESSION_IMPL *session)
     WT_RET(__wt_msg(session, "Logging directory: %s", conn->log_path));
     WT_RET(__wt_msg(session, "Logging maximum file size: %" PRId64, (int64_t)conn->log_file_max));
     WT_RET(__wt_msg(session, "Log sync setting: %s",
-      !FLD_ISSET(conn->txn_logsync, WT_LOG_SYNC_ENABLED) ?
-        "none" :
-        FLD_ISSET(conn->txn_logsync, WT_LOG_DSYNC) ?
-        "dsync" :
-        FLD_ISSET(conn->txn_logsync, WT_LOG_FLUSH) ?
-        "write to OS" :
-        FLD_ISSET(conn->txn_logsync, WT_LOG_FSYNC) ? "fsync to disk" : "unknown sync setting"));
+      !FLD_ISSET(conn->txn_logsync, WT_LOG_SYNC_ENABLED) ? "none" :
+        FLD_ISSET(conn->txn_logsync, WT_LOG_DSYNC)       ? "dsync" :
+        FLD_ISSET(conn->txn_logsync, WT_LOG_FLUSH)       ? "write to OS" :
+        FLD_ISSET(conn->txn_logsync, WT_LOG_FSYNC)       ? "fsync to disk" :
+                                                           "unknown sync setting"));
     WT_RET(__wt_msg(session, "Log record allocation alignment: %" PRIu32, log->allocsize));
     WT_RET(__wt_msg(session, "Current log file number: %" PRIu32, log->fileid));
     WT_RET(__wt_msg(session, "Current log version number: %" PRIu16, log->log_version));

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1210,7 +1210,9 @@ __wt_ckpt_blkmod_to_meta(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_CKPT *ckpt)
           "%s\"%s\"=(id=%" PRIu32 ",granularity=%" PRIu64 ",nbits=%" PRIu64 ",offset=%" PRIu64
           "%s,blocks=%.*s)",
           i == 0 ? "" : ",", blk->id_str, i, blk->granularity, blk->nbits, blk->offset,
-          skip_rename ? "" : F_ISSET(blk, WT_BLOCK_MODS_RENAME) ? ",rename=1" : ",rename=0",
+          skip_rename                          ? "" :
+            F_ISSET(blk, WT_BLOCK_MODS_RENAME) ? ",rename=1" :
+                                                 ",rename=0",
           (int)bitstring.size, (char *)bitstring.data));
         /* The hex string length should match the appropriate number of bits. */
         WT_ASSERT(session, (blk->nbits >> 2) <= bitstring.size);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -555,10 +555,9 @@ __wt_txn_config(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_ERR(__wt_config_gets_def(session, cfg, "isolation", 0, &cval));
     if (cval.len != 0)
-        txn->isolation = WT_STRING_MATCH("snapshot", cval.str, cval.len) ?
-          WT_ISO_SNAPSHOT :
-          WT_STRING_MATCH("read-committed", cval.str, cval.len) ? WT_ISO_READ_COMMITTED :
-                                                                  WT_ISO_READ_UNCOMMITTED;
+        txn->isolation = WT_STRING_MATCH("snapshot", cval.str, cval.len) ? WT_ISO_SNAPSHOT :
+          WT_STRING_MATCH("read-committed", cval.str, cval.len)          ? WT_ISO_READ_COMMITTED :
+                                                                           WT_ISO_READ_UNCOMMITTED;
 
     WT_ERR(__txn_config_operation_timeout(session, cfg, false));
 
@@ -640,7 +639,7 @@ __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)
     ret = __wt_config_getones(session, config, "isolation", &cval);
     if (ret == 0 && cval.len != 0) {
         session->isolation = txn->isolation = WT_STRING_MATCH("snapshot", cval.str, cval.len) ?
-          WT_ISO_SNAPSHOT :
+                                                                    WT_ISO_SNAPSHOT :
           WT_STRING_MATCH("read-uncommitted", cval.str, cval.len) ? WT_ISO_READ_UNCOMMITTED :
                                                                     WT_ISO_READ_COMMITTED;
     }

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -104,14 +104,16 @@ __recovery_cursor(
 /*
  * Helper to a cursor if this operation is to be applied during recovery.
  */
-#define GET_RECOVERY_CURSOR(session, r, lsnp, fileid, cp)                            \
-    ret = __recovery_cursor(session, r, lsnp, fileid, false, cp);                    \
-    __wt_verbose_debug2(session, WT_VERB_RECOVERY,                                   \
-      "%s op %" PRIu32 " to file %" PRIu32 " at LSN %" PRIu32 "/%" PRIu32,           \
-      ret != 0 ? "Error" : cursor == NULL ? "Skipping" : "Applying", optype, fileid, \
-      (lsnp)->l.file, (lsnp)->l.offset);                                             \
-    WT_ERR(ret);                                                                     \
-    if (cursor == NULL)                                                              \
+#define GET_RECOVERY_CURSOR(session, r, lsnp, fileid, cp)                  \
+    ret = __recovery_cursor(session, r, lsnp, fileid, false, cp);          \
+    __wt_verbose_debug2(session, WT_VERB_RECOVERY,                         \
+      "%s op %" PRIu32 " to file %" PRIu32 " at LSN %" PRIu32 "/%" PRIu32, \
+      ret != 0         ? "Error" :                                         \
+        cursor == NULL ? "Skipping" :                                      \
+                         "Applying",                                       \
+      optype, fileid, (lsnp)->l.file, (lsnp)->l.offset);                   \
+    WT_ERR(ret);                                                           \
+    if (cursor == NULL)                                                    \
     break
 
 /*

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -621,7 +621,10 @@ dump_prefix(WT_SESSION *session, bool pretty, bool hex, bool json)
 
     if (!json &&
       (fprintf(fp, "WiredTiger Dump (WiredTiger Version %d.%d.%d)\n", vmajor, vminor, vpatch) < 0 ||
-        fprintf(fp, "Format=%s\n", (pretty && hex) ? "print hex" : hex ? "hex" : "print") < 0 ||
+        fprintf(fp, "Format=%s\n",
+          (pretty && hex) ? "print hex" :
+            hex           ? "hex" :
+                            "print") < 0 ||
         fprintf(fp, "Header\n") < 0))
         return (util_err(session, EIO, NULL));
 

--- a/test/cppsuite/src/common/thread_manager.h
+++ b/test/cppsuite/src/common/thread_manager.h
@@ -43,7 +43,7 @@ class thread_manager {
      */
     template <typename Callable, typename... Args>
     void
-    add_thread(Callable &&fct, Args &&... args)
+    add_thread(Callable &&fct, Args &&...args)
     {
         std::thread *t = new std::thread(fct, std::forward<Args>(args)...);
         _workers.push_back(t);

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2577,7 +2577,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            sh s_all -A -E 2>&1
+            ${test_env_vars|} sh s_all -A -E 2>&1
 
   - name: conf-dump-test
     tags: ["pull_request", "python"]
@@ -4834,6 +4834,7 @@ buildvariants:
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
+      PATH=/opt/mongodbtoolchain/v4/bin:$PATH
       LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib
       LD_PRELOAD=$WT_TOPDIR/TCMALLOC_LIB/lib/libtcmalloc.so
     CMAKE_PREFIX_PATH: -DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2566,7 +2566,6 @@ tasks:
   # End of Python unit test tasks
 
   - name: s-all
-    tags: ["pull_request"]
     depends_on:
     - name: compile
     commands:
@@ -4847,6 +4846,7 @@ buildvariants:
     - name: ".pull_request !.pull_request_compilers"
     - name: ".unit_test_long"
     - name: compile
+    - name: s-all
     - name: doc-compile
     - name: make-check-test
     - name: unit-test

--- a/test/packing/intpack-test3.c
+++ b/test/packing/intpack-test3.c
@@ -72,7 +72,7 @@ test_value(int64_t val)
           ", got %" WT_SIZET_FMT "\n",
           sinput, used_len,
           cp > p ? used_len + (size_t)(cp - p) : /* More than buf used */
-            used_len - (size_t)(p - cp));        /* Less than buf used */
+                   used_len - (size_t)(p - cp));        /* Less than buf used */
         abort();
     }
 


### PR DESCRIPTION
- We do not download clang format as part of s_clang_format.sh anymore
- We rely on what's installed on the system and expect a specific version
- The current expected version is 12.0.1 and after running it, a few files are impacted by some format changes.