### PR TITLE
WT-10633 Add a backup source verify function to the test utilities.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1484,6 +1484,7 @@ spinlocks
 srand
 src
 srch
+srctest
 ss
 ssize
 startup

--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -827,7 +827,8 @@ main(int argc, char *argv[])
     uint32_t file_max, iter, max_value_size, next_checkpoint, rough_size, slot;
     int ch, ncheckpoints, nreopens, status;
     const char *backup_verbose, *working_dir;
-    char conf[1024], home[1024], backup_check[1024], backup_dir[1024], command[4096];
+    char command[4096], conf[1024], home[1024], backup_check[1024], backup_dir[1024],
+      backup_src[1024];
     bool preserve;
 
     preserve = false;
@@ -867,8 +868,9 @@ main(int argc, char *argv[])
         rnd.v = seed;
 
     testutil_work_dir_from_path(home, sizeof(home), working_dir);
-    testutil_check(__wt_snprintf(backup_dir, sizeof(backup_dir), "../%s.BACKUP", home));
-    testutil_check(__wt_snprintf(backup_check, sizeof(backup_check), "../%s.CHECK", home));
+    testutil_check(__wt_snprintf(backup_dir, sizeof(backup_dir), "./%s.BACKUP", home));
+    testutil_check(__wt_snprintf(backup_check, sizeof(backup_check), "./%s.CHECK", home));
+    testutil_check(__wt_snprintf(backup_src, sizeof(backup_src), "./%s.BACKUP.SRC", home));
     printf("Seed: %" PRIu64 "\n", seed);
 
     testutil_check(
@@ -955,11 +957,21 @@ main(int argc, char *argv[])
         }
 
         /* Close and reopen the connection once in a while. */
-        if (__wt_random(&rnd) % 10 == 0) {
+        if (__wt_random(&rnd) % 5 == 0) {
             VERBOSE(2, "Close and reopen the connection %d\n", nreopens);
             testutil_check(conn->close(conn, NULL));
+            /* Check the source bitmap after restart. Copy while closed. */
+            testutil_check(__wt_snprintf(command, sizeof(command),
+              "rm -rf %s; mkdir %s; cp -rp %s/* %s", backup_src, backup_src, home, backup_src));
+            if ((status = system(command)) < 0)
+                testutil_die(status, "system: %s", command);
+
             testutil_check(wiredtiger_open(home, NULL, conf, &conn));
             testutil_check(conn->open_session(conn, NULL, NULL, &session));
+
+            /* Test both against the last backup directory and copied directory. */
+            testutil_verify_src_backup(conn, backup_dir, home);
+            testutil_verify_src_backup(conn, backup_src, home);
             nreopens++;
         }
 

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -461,6 +461,7 @@ void testutil_tiered_begin(TEST_OPTS *);
 void testutil_tiered_flush_complete(TEST_OPTS *, WT_SESSION *, void *);
 void testutil_tiered_sleep(TEST_OPTS *, WT_SESSION *, uint64_t, bool *);
 uint64_t testutil_time_us(WT_SESSION *);
+void testutil_verify_src_backup(WT_CONNECTION *, const char *, const char *);
 void testutil_work_dir_from_path(char *, size_t, const char *);
 WT_THREAD_RET thread_append(void *);
 


### PR DESCRIPTION
I added an example of using it. Right now that appears to have caught a difference that I'm investigating. I didn't expect a clean shutdown to show any differences but I don't think it is a bug in the change but a detection.