### PR TITLE
WT-10635 Remove duplicate Python crash code

### DIFF
--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -33,7 +33,7 @@
 # are part of the package. To create the distribution, in this directory, run
 # "python setup_pip.py sdist", this creates a tar.gz file under ./dist .
 from __future__ import print_function
-import os, os.path, re, shutil, site, sys
+import os, os.path, re, shutil, sys
 from setuptools import setup, Distribution, Extension
 import distutils.sysconfig
 import distutils.ccompiler

--- a/test/suite/test_prepare21.py
+++ b/test/suite/test_prepare21.py
@@ -26,8 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import threading, time
-from helper import simulate_crash_restart
+import threading
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet

--- a/test/suite/test_rollback_to_stable32.py
+++ b/test/suite/test_rollback_to_stable32.py
@@ -25,9 +25,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
-from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 

--- a/test/suite/test_rollback_to_stable34.py
+++ b/test/suite/test_rollback_to_stable34.py
@@ -28,7 +28,7 @@
 
 from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
-from wiredtiger import stat, WT_NOTFOUND
+from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 

--- a/test/suite/test_rollback_to_stable35.py
+++ b/test/suite/test_rollback_to_stable35.py
@@ -29,7 +29,6 @@
 import wttest, threading, time
 from wtdataset import SimpleDataSet
 from wtthread import checkpoint_thread
-from helper import simulate_crash_restart
 from wiredtiger import stat
 from helper import copy_wiredtiger_home
 from wtscenario import make_scenarios

--- a/test/suite/test_rollback_to_stable36.py
+++ b/test/suite/test_rollback_to_stable36.py
@@ -28,7 +28,7 @@
 
 import wttest
 from helper import simulate_crash_restart
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_NOTFOUND, WT_ROLLBACK
+from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 

--- a/test/suite/test_rollback_to_stable37.py
+++ b/test/suite/test_rollback_to_stable37.py
@@ -29,7 +29,6 @@
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
-from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 
 # test_rollback_to_stable37.py

--- a/test/suite/test_rollback_to_stable40.py
+++ b/test/suite/test_rollback_to_stable40.py
@@ -26,8 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import fnmatch, os, shutil, time
-from helper import copy_wiredtiger_home, simulate_crash_restart
+from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet

--- a/test/suite/test_truncate09.py
+++ b/test/suite/test_truncate09.py
@@ -30,7 +30,7 @@
 #   Check for fast-truncate rollback-to-stable timestamps.
 
 import wttest
-from helper import copy_wiredtiger_home, simulate_crash_restart
+from helper import simulate_crash_restart
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
 
@@ -100,7 +100,6 @@ class test_truncate09(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Restart, testing RTS on the copy.
-        copy_wiredtiger_home(self, ".", "RESTART")
         simulate_crash_restart(self, ".", "RESTART")
 
         # Search for a key in the truncated range which is stabilised, hence should not find it.

--- a/test/suite/test_truncate13.py
+++ b/test/suite/test_truncate13.py
@@ -27,9 +27,8 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from helper import simulate_crash_restart
 from test_rollback_to_stable01 import test_rollback_to_stable_base
-from wiredtiger import stat, WT_NOTFOUND
+from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 

--- a/test/suite/test_truncate16.py
+++ b/test/suite/test_truncate16.py
@@ -27,8 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from helper import simulate_crash_restart
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_NOTFOUND, WT_ROLLBACK
+from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 

--- a/test/suite/test_truncate17.py
+++ b/test/suite/test_truncate17.py
@@ -27,8 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from helper import simulate_crash_restart
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_NOTFOUND, WT_ROLLBACK
+from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 

--- a/test/suite/test_truncate18.py
+++ b/test/suite/test_truncate18.py
@@ -27,8 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from helper import simulate_crash_restart
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_NOTFOUND, WT_ROLLBACK
+from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 

--- a/test/suite/test_txn13.py
+++ b/test/suite/test_txn13.py
@@ -31,7 +31,6 @@
 # able to write them.  Expect an error over 4Gb.
 #
 
-#import fnmatch, os, shutil, run, time
 from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 import wiredtiger, wttest

--- a/test/suite/test_txn22.py
+++ b/test/suite/test_txn22.py
@@ -29,24 +29,10 @@
 # test_txn22.py
 #   Transactions: test salvage with removed
 
-import os, shutil
+import os
 from wtscenario import make_scenarios
 from suite_subprocess import suite_subprocess
-import wiredtiger, wttest
-
-def copy_for_crash_restart(olddir, newdir):
-    ''' Simulate a crash from olddir and restart in newdir. '''
-    # with the connection still open, copy files to new directory
-    shutil.rmtree(newdir, ignore_errors=True)
-    os.mkdir(newdir)
-    for fname in os.listdir(olddir):
-        fullname = os.path.join(olddir, fname)
-        # Skip lock file on Windows since it is locked
-        if os.path.isfile(fullname) and \
-            "WiredTiger.lock" not in fullname and \
-            "Tmplog" not in fullname and \
-            "Preplog" not in fullname:
-            shutil.copy(fullname, newdir)
+import helper, wiredtiger, wttest
 
 class test_txn22(wttest.WiredTigerTestCase, suite_subprocess):
     base_config = 'cache_size=1GB'
@@ -141,10 +127,10 @@ class test_txn22(wttest.WiredTigerTestCase, suite_subprocess):
         # The second directory will be used to run:
         #    wiredtiger_open with salvage flag first.
 
-        copy_for_crash_restart(self.home, newdir)
+        helper.copy_wiredtiger_home(self, self.home, newdir)
         self.close_conn()
         self.corrupt_meta(newdir)
-        copy_for_crash_restart(newdir, newdir2)
+        helper.copy_wiredtiger_home(self, newdir, newdir2)
 
         for salvagedir in [ newdir, newdir2 ]:
             # Removing the 'WiredTiger.turtle' file has weird behavior:


### PR DESCRIPTION
The changes remove the redefinition of a function to simulate a crash since there is one that already exists as a helper function.