### PR TITLE
WT-10380 Fix expected warning output in test_cursor_random

### DIFF
--- a/test/suite/test_cursor_random.py
+++ b/test/suite/test_cursor_random.py
@@ -42,6 +42,7 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         ('not-sample', dict(config='next_random=true'))
     ]
     scenarios = make_scenarios(types, config)
+    expected_warning_msg = 'Eviction took more than 1 minute'
 
     # Check that opening a random cursor on a row-store returns not-supported
     # for methods other than next, reconfigure and reset, and next returns
@@ -114,7 +115,7 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
         if (sys.platform.startswith('darwin')):
-            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
+            self.ignoreStdoutPatternIfExists(self.expected_warning_msg)
 
     def test_cursor_random_multiple_insert_records_small(self):
         self.cursor_random_multiple_insert_records(2000)
@@ -147,7 +148,7 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
         if (sys.platform.startswith('darwin')):
-            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
+            self.ignoreStdoutPatternIfExists(self.expected_warning_msg)
 
     def test_cursor_random_multiple_page_records_reopen_small(self):
         self.cursor_random_multiple_page_records(2000, True)
@@ -185,7 +186,7 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
         if (sys.platform.startswith('darwin')):
-            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
+            self.ignoreStdoutPatternIfExists(self.expected_warning_msg)
 
     # Check that next_random fails in the presence of a set of values, all of
     # which are deleted.
@@ -208,7 +209,7 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
         if (sys.platform.startswith('darwin')):
-            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
+            self.ignoreStdoutPatternIfExists(self.expected_warning_msg)
 
 # Check that opening a random cursor on column-store returns not-supported.
 class test_cursor_random_column(wttest.WiredTigerTestCase):

--- a/test/suite/test_cursor_random.py
+++ b/test/suite/test_cursor_random.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger, wttest
+import wiredtiger, wttest, sys
 from wtdataset import SimpleDataSet, ComplexDataSet, simple_key, simple_value
 from wtscenario import make_scenarios
 
@@ -113,7 +113,8 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # Ignore the eviction generation drain warning as it is possible for eviction to
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
-        self.ignoreStdoutPatternIfExists('evict generation drain waited')
+        if (sys.platform.startswith('darwin')):
+            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
 
     def test_cursor_random_multiple_insert_records_small(self):
         self.cursor_random_multiple_insert_records(2000)
@@ -145,7 +146,8 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # Ignore the eviction generation drain warning as it is possible for eviction to
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
-        self.ignoreStdoutPatternIfExists('evict generation drain waited')
+        if (sys.platform.startswith('darwin')):
+            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
 
     def test_cursor_random_multiple_page_records_reopen_small(self):
         self.cursor_random_multiple_page_records(2000, True)
@@ -182,7 +184,8 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # Ignore the eviction generation drain warning as it is possible for eviction to
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
-        self.ignoreStdoutPatternIfExists('evict generation drain waited')
+        if (sys.platform.startswith('darwin')):
+            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
 
     # Check that next_random fails in the presence of a set of values, all of
     # which are deleted.
@@ -204,7 +207,8 @@ class test_cursor_random(wttest.WiredTigerTestCase):
         # Ignore the eviction generation drain warning as it is possible for eviction to
         # take longer to evict pages due to overflow items on the page.
         self.conn.close()
-        self.ignoreStdoutPatternIfExists('evict generation drain waited')
+        if (sys.platform.startswith('darwin')):
+            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
 
 # Check that opening a random cursor on column-store returns not-supported.
 class test_cursor_random_column(wttest.WiredTigerTestCase):


### PR DESCRIPTION
test_cursor_random started failing again on the macOS host after WT-10197 changed the warning message for eviction taking more than 1 minute. Not all the BFGs are linked to the ticket, there are others that appear in the logs of the other macOS failures. The test was initially failing on macOS due to stress on the host from running many tests concurrently. The original fix in WT-7492 was to ignore the warning as the expected output however that message is now outdated. I've fixed the test to reflect the new warning message.

In the WT-7492 it was discussed whether we should check for the masOS platform when ignoring the output. I've included it here but I'm not sure whether to keep that check.

