### PR TITLE
WT-10276 Improve RTS test coverage

### DIFF
--- a/src/rollback_to_stable/rts_history.c
+++ b/src/rollback_to_stable/rts_history.c
@@ -142,7 +142,7 @@ __wt_rts_history_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
 
     WT_RTS_STAT_CONN_DATA_INCR(session, cache_hs_btree_truncate);
 
-    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+    __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
       "Rollback to stable has truncated records for btree %u from the history store", btree_id);
 
 done:

--- a/test/suite/test_rollback_to_stable42.py
+++ b/test/suite/test_rollback_to_stable42.py
@@ -54,6 +54,8 @@ class test_rollback_to_stable42(test_rollback_to_stable_base):
         uri = 'table:test_rollback_to_stable42'
         nrows = 1000
 
+        self.ignoreTearDownLogs = True
+
         if self.value_format == '8t':
             value_a = 97
             value_b = 98

--- a/test/suite/test_rollback_to_stable42.py
+++ b/test/suite/test_rollback_to_stable42.py
@@ -38,12 +38,15 @@ from test_rollback_to_stable01 import test_rollback_to_stable_base
 # unacceptable or we don't see the needle at all.
 def custom_validator(data):
     acceptable = [
-        "page with reconciled",
-        "performing shutdown rollback",
-        "performing rollback to stable",
-        "tree rolled back",
         "connection logging enabled",
-        "WT_VERB_RTS",
+        "deleted page walk skipped",
+        "page with reconciled",
+        "performing recovery rollback",
+        "performing rollback to stable",
+        "performing shutdown rollback",
+        "recovered checkpoint snapshot",
+        "tree rolled back",
+        "update aborted with txnid",
     ]
     needle = "skipped performing rollback to stable"
 

--- a/test/suite/test_rollback_to_stable42.py
+++ b/test/suite/test_rollback_to_stable42.py
@@ -93,11 +93,9 @@ class test_rollback_to_stable42(test_rollback_to_stable_base):
         nrows = 1000
 
         if self.value_format == '8t':
-            value_a = 97
-            value_b = 98
+            value = 97
         else:
-            value_a = 'a' * 10
-            value_b = 'b' * 10
+            value = 'a' * 10
 
         # Create our table.
         ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
@@ -105,7 +103,7 @@ class test_rollback_to_stable42(test_rollback_to_stable_base):
 
         # Save some unstable updates to disk.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
-        self.large_updates(uri, value_b, ds, nrows, False, 60)
+        self.large_updates(uri, value, ds, nrows, False, 60)
         self.session.checkpoint()
 
         os.remove('test_rollback_to_stable42.wt')

--- a/test/suite/test_rollback_to_stable42.py
+++ b/test/suite/test_rollback_to_stable42.py
@@ -56,7 +56,6 @@ def custom_validator(data):
         if needle in line:
             found = True
         for s in acceptable:
-            print(f"looking for {s} in {line}")
             if s in line:
                 ok = True
                 break
@@ -111,6 +110,10 @@ class test_rollback_to_stable42(test_rollback_to_stable_base):
 
         os.remove('test_rollback_to_stable42.wt')
 
+        # RTS runs at shutdown and startup, and we need WiredTiger to
+        # see that the file was deleted from under it (it might all be
+        # in memory if we call conn.rollback_to_stable()). Kill both
+        # of these birds with one stone.
         with self.customStdoutPattern(custom_validator):
             simulate_crash_restart(self, ".", "RESTART")
 

--- a/test/suite/test_rollback_to_stable42.py
+++ b/test/suite/test_rollback_to_stable42.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+
+from helper import simulate_crash_restart
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+
+def custom_validator(pattern):
+    pass
+
+# test_rollback_to_stable42.py
+# Test that rollback to stable on a missing file complains and bails.
+class test_rollback_to_stable42(test_rollback_to_stable_base):
+    def conn_config(self):
+        return 'verbose=(rts:1)'
+
+    format_values = [
+        # ('column', dict(key_format='r', value_format='S')),
+        # ('column_fix', dict(key_format='r', value_format='8t')),
+        ('row_integer', dict(key_format='i', value_format='S')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def test_reopen_after_delete(self):
+        uri = 'table:test_rollback_to_stable42'
+        nrows = 1000
+
+        if self.value_format == '8t':
+            value_a = 97
+            value_b = 98
+        else:
+            value_a = 'a' * 10
+            value_b = 'b' * 10
+
+        # Create our table.
+        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds.populate()
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
+        self.large_updates(uri, value_b, ds, nrows, False, 60)
+        self.session.checkpoint()
+
+        os.remove('test_rollback_to_stable42.wt')
+
+        with self.customStdoutPattern(custom_validator):
+            simulate_crash_restart(self, ".", "RESTART")
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -190,13 +190,18 @@ class CapturedFd(object):
         """
         if self.file != None:
             self.file.flush()
-        gotstr = self.readFileFrom(self.filename, self.expectpos, 1500)
+
+        # Custom validators probably don't want to see truncated output.
+        # Give them the whole string.
+        new_expectpos = os.path.getsize(self.filename)
+        diff = new_expectpos - self.expectpos
+        gotstr = self.readFileFrom(self.filename, self.expectpos, diff)
         try:
             f(gotstr)
         except Exception as e:
             testcase.fail('in ' + self.desc +
                           ', custom validator failed: ' + str(e))
-        self.expectpos = os.path.getsize(self.filename)
+        self.expectpos = new_expectpos
 
 class TestSuiteConnection(object):
     def __init__(self, conn, connlist):

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -652,6 +652,7 @@ class WiredTigerTestCase(unittest.TestCase):
             namefile.write(str(self) + '\n')
         self.fdSetUp()
         self._threadLocal.currentTestCase = self
+        self.ignoreTearDownLogs = False
         # tearDown needs a conn field, set it here in case the open fails.
         self.conn = None
         try:
@@ -732,7 +733,7 @@ class WiredTigerTestCase(unittest.TestCase):
         self._connections = []
         try:
             self.fdTearDown()
-            if not dueToRetry:
+            if not (dueToRetry or self.ignoreTearDownLogs):
                 self.captureout.check(self)
                 self.captureerr.check(self)
         finally:


### PR DESCRIPTION
Of the four scenarios in the ticket:
1. We don't want a test that runs long enough to trigger this.
2. This was being tested, but not by an RTS test.
3. This was also being tested, but the logging was done under the wrong subsystem, so fix it.
4. This is almost all of the PR. It needed some supporting infra in `wttest.py`, in particular the idea of a custom log validator and `ignoreTeardownLogs`. This latter part seems a little hacky to me, but I'm not sure how to improve it - perhaps a getter/setter? Feedback welcome here.

The other possibly-controversial part is the lack of Windows support - we delete the file while WiredTiger has it open, and this doesn't work nicely with the Windows model of "only one process opens the file".