### PR TITLE
WT-10649 Run s_string -r locally.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1236,7 +1236,6 @@ unescaped
 unhandled
 uninstantiated
 unistd
-unittest
 unlink
 unmap
 unmapping


### PR DESCRIPTION
I should have rerun `s_string -r` locally on the other branch after pulling to current develop. One minor change when the new evergreen script ran.