### PR TITLE
WT-10637 Prevent the use of reserved checkpoint names for checkpoint cursors

### DIFF
--- a/src/docs/durability-checkpoint.dox
+++ b/src/docs/durability-checkpoint.dox
@@ -72,7 +72,8 @@ Cursors are normally opened in the live version of a data source.
 However, it is also possible to open a read-only, static view of the
 data source as of a checkpoint.
 This is done by passing the \c checkpoint configuration string to
-WT_SESSION::open_cursor.
+WT_SESSION::open_cursor. Checkpoint cursors can only be opened on application
+named checkpoints or on the latest checkpoint using "WiredTigerCheckpoint".
 This provides a limited form of time-travel, as the static
 view is not changed by subsequent checkpoints and will persist until
 the checkpoint cursor is closed.

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -490,11 +490,10 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
     /*
      * The internal checkpoint name is special, applications aren't allowed to use it. Be aggressive
      * and disallow any matching prefix. However, internally we may want to open the history store
-     * with a specific version, this is allowed.
-     * Applications can use the internal reserved name "WiredTigerCheckpoint" to open the latest
-     * checkpoint, but they are not allowed to directly open specific checkpoint versions, such as
-     * "WiredTigerCheckpoint.6". However, internally it is allowed to open the history store with a
-     * specific version.
+     * with a specific version, this is allowed. Applications can use the internal reserved name
+     * "WiredTigerCheckpoint" to open the latest checkpoint, but they are not allowed to directly
+     * open specific checkpoint versions, such as "WiredTigerCheckpoint.6". However, internally it
+     * is allowed to open the history store with a specific version.
      */
     is_reserved_name = cval.len > strlen(WT_CHECKPOINT) && WT_PREFIX_MATCH(cval.str, WT_CHECKPOINT);
     if (is_reserved_name && (!is_hs || session->hs_checkpoint == NULL))

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -488,12 +488,10 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
         hs_dhandlep = NULL;
 
     /*
-     * The internal checkpoint name is special, applications aren't allowed to use it. Be aggressive
-     * and disallow any matching prefix. However, internally we may want to open the history store
-     * with a specific version, this is allowed. Applications can use the internal reserved name
-     * "WiredTigerCheckpoint" to open the latest checkpoint, but they are not allowed to directly
-     * open specific checkpoint versions, such as "WiredTigerCheckpoint.6". However, internally it
-     * is allowed to open the history store with a specific version.
+     * Applications can use the internal reserved name "WiredTigerCheckpoint" to open the latest
+     * checkpoint, but they are not allowed to directly open specific checkpoint versions, such as
+     * "WiredTigerCheckpoint.6". However, internally it is allowed to open the history store with a
+     * specific version.
      */
     is_reserved_name = cval.len > strlen(WT_CHECKPOINT) && WT_PREFIX_MATCH(cval.str, WT_CHECKPOINT);
     if (is_reserved_name && (!is_hs || session->hs_checkpoint == NULL))

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -491,6 +491,10 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
      * The internal checkpoint name is special, applications aren't allowed to use it. Be aggressive
      * and disallow any matching prefix. However, internally we may want to open the history store
      * with a specific version, this is allowed.
+     * Applications can use the internal reserved name "WiredTigerCheckpoint" to open the latest
+     * checkpoint, but they are not allowed to directly open specific checkpoint versions, such as
+     * "WiredTigerCheckpoint.6". However, internally it is allowed to open the history store with a
+     * specific version.
      */
     is_reserved_name = cval.len > strlen(WT_CHECKPOINT) && WT_PREFIX_MATCH(cval.str, WT_CHECKPOINT);
     if (is_reserved_name && (!is_hs || session->hs_checkpoint == NULL))

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -344,6 +344,8 @@ class test_checkpoint_illegal_name(wttest.WiredTigerTestCase):
             'checkpoint=WiredTigerCheckpointX'):
                 self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                     lambda: self.session.open_cursor(uri, None, conf), msg)
+                self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                    lambda: self.session.open_cursor("file:WiredTigerHS.wt", None, conf), msg)
 
 # Check we can't name checkpoints that include LSM tables.
 class test_checkpoint_lsm_name(wttest.WiredTigerTestCase):

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -312,10 +312,12 @@ class test_checkpoint_last(wttest.WiredTigerTestCase):
             # Don't close the checkpoint cursor, we want it to remain open until
             # the test completes.
 
-# Check we can't use the reserved name as an application checkpoint name.
+# Check we can't use the reserved name as an application checkpoint name or open a checkpoint cursor
+# with it.
 class test_checkpoint_illegal_name(wttest.WiredTigerTestCase):
     def test_checkpoint_illegal_name(self):
-        ds = SimpleDataSet(self, "file:checkpoint", 100, key_format='S')
+        uri = "file:checkpoint"
+        ds = SimpleDataSet(self, uri, 100, key_format='S')
         ds.populate()
         msg = '/the checkpoint name.*is reserved/'
         for conf in (
@@ -336,6 +338,12 @@ class test_checkpoint_illegal_name(wttest.WiredTigerTestCase):
             'name=check\\point'):
                 self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                     lambda: self.session.checkpoint(conf), msg)
+        msg = '/the prefix.*is reserved/'
+        for conf in (
+            'checkpoint=WiredTigerCheckpoint.',
+            'checkpoint=WiredTigerCheckpointX'):
+                self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                    lambda: self.session.open_cursor(uri, None, conf), msg)
 
 # Check we can't name checkpoints that include LSM tables.
 class test_checkpoint_lsm_name(wttest.WiredTigerTestCase):


### PR DESCRIPTION
We are disallowing the use of reserved checkpoint names when opening a checkpoint cursor.

A checkpoint cursor can be opened using a named checkpoint or `WiredTigerCheckpoint`. However, any name that has "WiredTigerCheckpoint" as a prefix is not allowed.

The same behaviour already exists when naming a checkpoint through the `session.checkpoint()` API, there is existing testing to check this in `test_checkpoint01.py`. This test was extended to cover invalid scenarios when opening a checkpoint cursor.