### PR TITLE
WT-10432 Fix expected warning output for test_hs20 on macos

### DIFF
--- a/test/suite/test_hs20.py
+++ b/test/suite/test_hs20.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger, wttest
+import wiredtiger, wttest, sys
 from wtscenario import make_scenarios
 
 # test_hs20.py
@@ -101,3 +101,9 @@ class test_hs20(wttest.WiredTigerTestCase):
         for i in range(0, 10):
             with self.transaction(read_timestamp = 3, rollback = True):
                 self.assertEqual(cursor[self.make_key(i)], value1 + "B")
+
+        self.conn.close()
+        if (sys.platform.startswith('darwin')):
+            # Ignore the eviction generation drain warning as it is possible for eviction to take 
+            # longer to evict pages due to overflow items on the page.
+            self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')

--- a/test/suite/test_hs20.py
+++ b/test/suite/test_hs20.py
@@ -102,7 +102,6 @@ class test_hs20(wttest.WiredTigerTestCase):
             with self.transaction(read_timestamp = 3, rollback = True):
                 self.assertEqual(cursor[self.make_key(i)], value1 + "B")
 
-        self.conn.close()
         if (sys.platform.startswith('darwin')):
             # Ignore the eviction generation drain warning as it is possible for eviction to take 
             # longer to evict pages due to overflow items on the page.


### PR DESCRIPTION
Applying the same fix as WT-10380 for test_hs20. This warning only occurs when there are many tests running in parallel putting a large amount of stress on the system. See the WT-10380 PR (#8850) or the tickets for more information.