### PR TITLE
WT-10471 Adding diagnostics for page_state updates when reconciling

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -76,8 +76,8 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
         __wt_page_modify_clear(session, page);
 
     WT_ASSERT_ALWAYS(session, !__wt_page_is_modified(page), "Attempting to discard dirty page");
-    WT_ASSERT_ALWAYS(session, !F_ISSET(page->modify, WT_PAGE_MODIFY_RECONCILING),
-      "Attempting to discard page being reconciled");
+    WT_ASSERT_ALWAYS(
+      session, !__wt_page_is_reconciling(page), "Attempting to discard page being reconciled");
     WT_ASSERT_ALWAYS(session, !F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU),
       "Attempting to discard page queued for eviction");
 
@@ -278,10 +278,6 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
     if (ref == NULL)
         return;
 
-    WT_ASSERT_ALWAYS(session,
-      !__wt_page_is_modified(ref->page) || !F_ISSET(ref->page->modify, WT_PAGE_MODIFY_RECONCILING),
-      "Attempting to discard ref to a page being reconciled");
-
     /*
      * We create WT_REFs in many places, assert a WT_REF has been configured as either an internal
      * page or a leaf page, to catch any we've missed.
@@ -295,6 +291,8 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
      * clean explicitly.)
      */
     if (free_pages && ref->page != NULL) {
+        WT_ASSERT_ALWAYS(session, !__wt_page_is_reconciling(ref->page),
+          "Attempting to discard ref to a page being reconciled");
         __wt_page_modify_clear(session, ref->page);
         __wt_page_out(session, &ref->page);
     }
@@ -352,8 +350,7 @@ __wt_free_ref_index(WT_SESSION_IMPL *session, WT_PAGE *page, WT_PAGE_INDEX *pind
     if (pindex == NULL)
         return;
 
-    WT_ASSERT_ALWAYS(session,
-      !__wt_page_is_modified(page) || !F_ISSET(page->modify, WT_PAGE_MODIFY_RECONCILING),
+    WT_ASSERT_ALWAYS(session, !__wt_page_is_reconciling(page),
       "Attempting to discard ref to a page being reconciled");
 
     for (i = 0; i < pindex->entries; ++i) {

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -77,7 +77,7 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
 
     WT_ASSERT_ALWAYS(session, !__wt_page_is_modified(page), "Attempting to discard dirty page");
     WT_ASSERT_ALWAYS(session, !F_ISSET(page->modify, WT_PAGE_MODIFY_RECONCILING),
-      "Attempting to disable page being reconciled");
+      "Attempting to discard page being reconciled");
     WT_ASSERT_ALWAYS(session, !F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU),
       "Attempting to discard page queued for eviction");
 
@@ -280,7 +280,7 @@ __wt_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pa
 
     WT_ASSERT_ALWAYS(session,
       !__wt_page_is_modified(ref->page) || !F_ISSET(ref->page->modify, WT_PAGE_MODIFY_RECONCILING),
-      "Attempting to free ref when page is being reconciled");
+      "Attempting to discard ref to a page being reconciled");
 
     /*
      * We create WT_REFs in many places, assert a WT_REF has been configured as either an internal
@@ -354,7 +354,7 @@ __wt_free_ref_index(WT_SESSION_IMPL *session, WT_PAGE *page, WT_PAGE_INDEX *pind
 
     WT_ASSERT_ALWAYS(session,
       !__wt_page_is_modified(page) || !F_ISSET(page->modify, WT_PAGE_MODIFY_RECONCILING),
-      "Attempting to free ref index when page it is being reconciled");
+      "Attempting to discard ref to a page being reconciled");
 
     for (i = 0; i < pindex->entries; ++i) {
         ref = pindex->index[i];

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -499,14 +499,12 @@ struct __wt_page_modify {
 #define WT_PAGE_RS_RESTORED 0x1
     uint8_t restore_state; /* Created by restoring updates */
 
-/* Additional diagnostics fields to catch invalid updates to page_state. */
-#ifdef HAVE_DIAGNOSTIC
+/* Additional diagnostics fields to catch invalid updates to page_state, even in release builds. */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_PAGE_MODIFY_EXCLUSIVE 0x1u
 #define WT_PAGE_MODIFY_RECONCILING 0x2u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
-#endif
 };
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -498,6 +498,15 @@ struct __wt_page_modify {
 
 #define WT_PAGE_RS_RESTORED 0x1
     uint8_t restore_state; /* Created by restoring updates */
+
+/* Additional diagnostics fields to catch invalid updates to page_state. */
+#ifdef HAVE_DIAGNOSTIC
+/* AUTOMATIC FLAG VALUE GENERATION START 0 */
+#define WT_PAGE_MODIFY_EXCLUSIVE 0x1u
+#define WT_PAGE_MODIFY_RECONCILING 0x2u
+    /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
+    uint8_t flags;
+#endif
 };
 
 /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -798,8 +798,6 @@ __wt_page_modify_clear(WT_SESSION_IMPL *session, WT_PAGE *page)
      * page is owned by a single thread.
      *
      * Allow the call to be made on clean pages.
-     *
-     * Assert the page is not being reconciled.
      */
     if (__wt_page_is_modified(page)) {
         WT_ASSERT_ALWAYS(session,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2053,6 +2053,8 @@ static inline bool __wt_page_is_empty(WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_page_is_modified(WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_page_is_reconciling(WT_PAGE *page)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_rec_need_split(WT_RECONCILE *r, size_t len)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -577,8 +577,8 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     r->orig_txn_checkpoint_gen = __wt_gen(session, WT_GEN_CHECKPOINT);
 
 #ifdef HAVE_DIAGNOSTIC
-    /* Track that the page is being reconciled and if it is expected to be occur exclusively. */
     WT_ASSERT(session, page->modify->flags == 0);
+    /* Track that the page is being reconciled and if it is exclusive (e.g. eviction). */
     F_SET(page->modify, WT_PAGE_MODIFY_RECONCILING);
     if (LF_ISSET(WT_REC_EVICT))
         F_SET(page->modify, WT_PAGE_MODIFY_EXCLUSIVE);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -178,9 +178,7 @@ __reconcile_post_wrapup(
 
     btree = S2BT(session);
 
-#ifdef HAVE_DIAGNOSTIC
     page->modify->flags = 0;
-#endif
 
     /* Release the reconciliation lock. */
     *page_lockedp = false;
@@ -576,13 +574,13 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     r->orig_btree_checkpoint_gen = btree->checkpoint_gen;
     r->orig_txn_checkpoint_gen = __wt_gen(session, WT_GEN_CHECKPOINT);
 
-#ifdef HAVE_DIAGNOSTIC
-    WT_ASSERT(session, page->modify->flags == 0);
+    WT_ASSERT_ALWAYS(
+      session, page->modify->flags == 0, "Illegal page state when initializing reconcile");
+
     /* Track that the page is being reconciled and if it is exclusive (e.g. eviction). */
     F_SET(page->modify, WT_PAGE_MODIFY_RECONCILING);
     if (LF_ISSET(WT_REC_EVICT))
         F_SET(page->modify, WT_PAGE_MODIFY_EXCLUSIVE);
-#endif
 
     /*
      * Update the page state to indicate that all currently installed updates will be included in
@@ -2347,9 +2345,7 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     __wt_page_modify_set(session, parent);
 
 err:
-#ifdef HAVE_DIAGNOSTIC
     r->ref->page->modify->flags = 0;
-#endif
     WT_TRET(__rec_cleanup(session, r));
     WT_TRET(__rec_destroy(session, &cbulk->reconcile));
 


### PR DESCRIPTION
WT-10471. Adding flags for page modify to catch paths trying to make unsupported changes while reconciling.