### PR TITLE
WT-10674 Fix the location of the "bucket" directory in schema_abort and timestamp_abort

### DIFF
--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -1121,7 +1121,7 @@ main(int argc, char *argv[])
             testutil_lazyfs_setup(&lazyfs, home);
 
         if (opts->tiered_storage) {
-            testutil_check(__wt_snprintf(buf, sizeof(buf), "%s/bucket", home));
+            testutil_check(__wt_snprintf(buf, sizeof(buf), "%s/%s/bucket", home, WT_HOME_DIR));
             testutil_make_work_dir(buf);
         }
 

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -923,7 +923,8 @@ main(int argc, char *argv[])
             testutil_lazyfs_setup(&lazyfs, home);
 
         if (opts->tiered_storage) {
-            testutil_check(__wt_snprintf(bucket, sizeof(bucket), "%s/bucket", home));
+            testutil_check(
+              __wt_snprintf(bucket, sizeof(bucket), "%s/%s/bucket", home, WT_HOME_DIR));
             testutil_make_work_dir(bucket);
         }
 


### PR DESCRIPTION
The fix ensures that the `bucket` directory gets created in the right place, so that the `dir_store` plugin then finds it in the right place. The original ticket was for `schema_abort`, but as `timestamp_abort` has the same issue, this PR fixes it for it as well.

Here is the output from running the tests manually after the fix (some lines are omitted for brevity):
```
wt-10674-schema-abort-bucket-dir$ build/test/csuite/schema_abort/test_schema_abort -PT -T 5 -t 10 -h WT_TEST0
[4/4] cd /home/peter.macko/Projects/wt-10674-schema...4-schema-abort-bucket-dir/test/ctest_dir_sync.cmake
Running test command: build/test/csuite/schema_abort/test_schema_abort -PT -T 5 -t 10 -h WT_TEST0 
Parent: compatibility: false, in-mem log sync: false, timestamp in use: true, tiered in use: true
Parent: Create 5 threads; sleep 10 seconds
CONFIG: test_schema_abort -PT -h WT_TEST0 -T 5 -t 10 -PSD7885690,E10582099
Create checkpoint thread
Create timestamp thread
Create 5 writer threads
Thread 1 starts at 1000000000
Thread 0 starts at 0
Thread 3 starts at 3000000000
Thread 4 starts at 4000000000
Thread 2 starts at 2000000000
SET STABLE: 6e 110
Checkpoint 1 complete: Flush: NO. Minimum ts 524
Checkpoint 2 complete: Flush: NO. Minimum ts 1834
Checkpoint 3 complete: Flush: NO. Minimum ts 2464
Checkpoint 4 complete: Flush: NO. Minimum ts 3199
Checkpoint 5 complete: Flush: YES. Minimum ts 3199
Finished a flush_tier
Kill child
Open database, run recovery and verify content
Got stable_val 3244
619212 records verified
wt-10674-schema-abort-bucket-dir$ build/test/csuite/timestamp_abort/test_timestamp_abort -PT -T 5 -t 10 -h WT_TEST0
[4/4] cd /home/peter.macko/Projects/wt-10674-schema...4-schema-abort-bucket-dir/test/ctest_dir_sync.cmake
Running test command: build/test/csuite/timestamp_abort/test_timestamp_abort -PT -T 5 -t 10 -h WT_TEST0 
Parent: compatibility: false, in-mem log sync: false, add timing stress: false, timestamp in use: true
Parent: Create 5 threads; sleep 10 seconds
CONFIG: test_timestamp_abort -PT -h WT_TEST0 -T 5 -t 10 -PSD1834117,E15080444
Create checkpoint thread
Create timestamp thread
Create 5 writer threads
Thread 2 starts at 2000000000
Thread 4 starts at 4000000000
Thread 3 starts at 3000000000
Thread 1 starts at 1000000000
Thread 0 starts at 0
Checkpoint 1 complete: Flush: NO, at stable 0.
Checkpoint 2 complete: Flush: NO, at stable 498706.
Checkpoint 3 complete: Flush: YES, at stable 613186.
Finished a flush_tier
Checkpoint 4 complete: Flush: NO, at stable 721861.
Checkpoint 5 complete: Flush: YES, at stable 782251.
Finished a flush_tier
Checkpoint 6 complete: Flush: NO, at stable 1045531.
Checkpoint 7 complete: Flush: NO, at stable 1863886.
Kill child
Open database and run recovery
transaction: rollback to stable pages visited: 0
transaction: rollback to stable pages visited: 3
...
transaction: rollback to stable pages visited: 6720
transaction: rollback to stable pages visited: 6726
Connection open and recovery complete. Verify content
Got stable_val 1995721
transaction: rollback to stable pages visited: 6726
846974 records verified
```