### PR TITLE
WT-10676 Retain program names when rebuilding s_string.ok

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -131,7 +131,8 @@ for f in `find . -name ${t_pfx}\*`; do
         # s_evergree_validate, $FAILED_CMD can be parsed incorrectly and result in a failing
         # script being ignored. Use `[^\w]` to ensure we match on the full command name and
         # not just a substring
-        FAILED_CMD=$(echo "$COMMANDS" | grep "${LOCAL_NAME}[^\w]")
+        CMD_NAME=${LOCAL_NAME#"$t_pfx"}
+        FAILED_CMD=$(echo "$COMMANDS" | grep "${CMD_NAME}[^\w]")
         TRIMMED_CMD=$(echo "$FAILED_CMD" | sed -e 's/ >.*//' -e 's/2>&1 //')
         errchk "$TRIMMED_CMD" "$f"
     fi

--- a/dist/s_all
+++ b/dist/s_all
@@ -131,8 +131,7 @@ for f in `find . -name ${t_pfx}\*`; do
         # s_evergree_validate, $FAILED_CMD can be parsed incorrectly and result in a failing
         # script being ignored. Use `[^\w]` to ensure we match on the full command name and
         # not just a substring
-        CMD_NAME=${LOCAL_NAME#"$t_pfx"}
-        FAILED_CMD=$(echo "$COMMANDS" | grep "${CMD_NAME}[^\w]")
+        FAILED_CMD=$(echo "$COMMANDS" | grep "${LOCAL_NAME}[^\w]")
         TRIMMED_CMD=$(echo "$FAILED_CMD" | sed -e 's/ >.*//' -e 's/2>&1 //')
         errchk "$TRIMMED_CMD" "$f"
     fi

--- a/dist/s_string
+++ b/dist/s_string
@@ -64,6 +64,18 @@ while :
         for f in $l; do
             replace $f
         done | sort -u > $t
+
+        # Between aspell versions 0.60.7-20110707 and 0.60.8 the following program names have been
+        # added to the dictionary and are no longer considered spelling errors. This means
+        # that building a replacement list of words with the newer version of aspell will omit them
+        # from s_string.ok, and subsequently running s_string with older aspell version will
+        # report spelling errors. Manually whitelist these names to address this.
+        prog_names="AWS AWS's MongoDB MONGODB PostgreSQL sanitizer sanitizers"
+        for name in $prog_names; do
+            echo $name >> $t
+        done
+        sort -u -o $t $t
+
 	if ! diff $t s_string.ok >/dev/null 2>&1; then
             echo "The string.ok list will be updated."
             cp $t s_string.ok

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -15,6 +15,8 @@ ARGS
 ASAN
 ASM
 AUS
+AWS
+AWS's
 Addr
 Alakuijala
 Alexandrescu's
@@ -214,6 +216,7 @@ MEM
 MEMALIGN
 MEMORDER
 MERCHANTABILITY
+MONGODB
 MOVEFILE
 MRXB
 MRXBOPC
@@ -226,6 +229,7 @@ Marsaglia's
 Mellor
 Mewhort
 Mitzenmacher
+MongoDB
 MoveFileExW
 MultiByteToWideChar
 Multithreaded
@@ -274,6 +278,7 @@ Phong
 PlatformSDK
 Podir
 Posix
+PostgreSQL
 Pre
 Preload
 Prepend
@@ -1107,6 +1112,8 @@ rw
 rwlock
 sH
 sHQ
+sanitizer
+sanitizers
 scr
 sd
 sdk


### PR DESCRIPTION
A lot of program names have been added to the aspell dictionary between versions `0.60.7-20110707` and `0.60.8`, resulting in words such as `MongoDB` that are considered typos in older versions and ok in new versions.
If we rebuild the `s_string.ok` whitelist using a newer version of aspell words such as `MongoDB` are removed from the whitelist - no longer being considered typos to ignore - but then older of versions of aspell report these as errors due to absence from the whitelist.

This change ensures that the relevant words are retained in the whitelist even when rebuilding with newer versions of aspell.