### PR TITLE
WT-10643 Fix s_all not reporting name of failing checks

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -123,7 +123,7 @@ if test $? -eq 0; then
 fi
 echo "$COMMANDS" | xargs $xp -I{} /bin/sh -c {}
 
-# For each command check if an output file has been generated. If it has report the contents and
+# For each command check if an output file has been generated. If it has, report the contents and
 # the command used to populate it.
 echo "$COMMANDS" | while read -r line; do
     outputfile=$(echo "$line" | sed -e 's/.* > //')

--- a/dist/s_all
+++ b/dist/s_all
@@ -123,17 +123,13 @@ if test $? -eq 0; then
 fi
 echo "$COMMANDS" | xargs $xp -I{} /bin/sh -c {}
 
-for f in `find . -name ${t_pfx}\*`; do
-    if `test -s $f`; then
-        LOCAL_NAME=$(basename "$f")
-        # Find original command and trim redirect garbage
-        # If one command in $COMMANDS is a substring of another like s_evergreen and
-        # s_evergree_validate, $FAILED_CMD can be parsed incorrectly and result in a failing
-        # script being ignored. Use `[^\w]` to ensure we match on the full command name and
-        # not just a substring
-        FAILED_CMD=$(echo "$COMMANDS" | grep "${LOCAL_NAME}[^\w]")
-        TRIMMED_CMD=$(echo "$FAILED_CMD" | sed -e 's/ >.*//' -e 's/2>&1 //')
-        errchk "$TRIMMED_CMD" "$f"
+# For each command check if an output file has been generated. If it has report the contents and
+# the command used to populate it.
+echo "$COMMANDS" | while read -r line; do
+    outputfile=$(echo "$line" | sed -e 's/.* > //')
+    if test -s "$outputfile" ; then
+        check=$(echo "$line" | sed -e 's/ >.*//' -e 's/2>&1 //')
+        errchk "$check" "$outputfile"
     fi
 done
 


### PR DESCRIPTION
When a script called by `s_all` fails it writes output to an appropriately named `__s_all_tmp_*` file in the dist folder. Previously the script was iterating through all created output files, then grepping against the contents of the `COMMANDS` variable to find the which check had produced the output file.

This grep was proving troublesome as it was either overly lenient (matching the file `s_evergreen` against the command populating `s_evergreen_validate`), or too strict and not finding the correct line in `COMMANDS`.

Rather than iterating over created output files and finding the correct check in `COMMANDS` I've flipped the logic to iterate through all checks in `COMMANDS` and finding which ones have produced an output file. This avoids the `evergreen`/`evergreen_validate` issue mentioned above and correctly prints out the name of the failing check as follows:

```
Updating files that include the package version
####################### MESSAGE ############################
s_all run of: "./s_longlines" resulted in:
    dist/type_to_str.py:38
#######################
####################### MESSAGE ############################
s_all run of: "./s_string" resulted in:
    ==== test/csuite/wt4156_metadata_salvage/main.c
    ASAN
#######################
####################### MESSAGE ############################
s_all run of: "python3 function.py" resulted in:
    Updating ../src/txn/txn.c
#######################
dist/s_all run finished
```