### PR TITLE
WT-10672 No special handling for predictable replay needed when read timestamps become invalid in test/format

### DIFF
--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -122,8 +122,8 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
          * For predictable replay, we need the oldest timestamp to lag when the process exits. That
          * allows two runs that finish with stable timestamps in the same ballpark to be compared.
          */
-        if (stable_timestamp > 1 * WT_THOUSAND)
-            oldest_timestamp = stable_timestamp - 1 * WT_THOUSAND;
+        if (stable_timestamp > 10 * WT_THOUSAND)
+            oldest_timestamp = stable_timestamp - 10 * WT_THOUSAND;
         else
             oldest_timestamp = stable_timestamp / 2;
     } else if (!final) {

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -111,21 +111,21 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
 
     if (GV(RUNS_PREDICTABLE_REPLAY)) {
         /*
-         * For predictable replay, we need the oldest timestamp to lag when the process exits. That
-         * allows two runs that finish with stable timestamps in the same ballpark to be compared.
-         */
-        if (stable_timestamp > 10 * WT_THOUSAND)
-            oldest_timestamp = stable_timestamp - 10 * WT_THOUSAND;
-        else
-            oldest_timestamp = stable_timestamp / 2;
-
-        /*
          * For predictable replay, our end state is to have the stable timestamp represent a precise
          * number of operations.
          */
         WT_ORDERED_READ(stop_timestamp, g.stop_timestamp);
         if (stable_timestamp > stop_timestamp && stop_timestamp != 0)
             stable_timestamp = stop_timestamp;
+
+        /*
+         * For predictable replay, we need the oldest timestamp to lag when the process exits. That
+         * allows two runs that finish with stable timestamps in the same ballpark to be compared.
+         */
+        if (stable_timestamp > 1 * WT_THOUSAND)
+            oldest_timestamp = stable_timestamp - 1 * WT_THOUSAND;
+        else
+            oldest_timestamp = stable_timestamp / 2;
     } else if (!final) {
         /*
          * If lag is permitted, update the oldest timestamp halfway to the largest timestamp that's

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -496,7 +496,6 @@ begin_transaction_ts(TINFO *tinfo)
 
     session = tinfo->session;
 
-retry:
     /* Pick a read timestamp. */
     if (GV(RUNS_PREDICTABLE_REPLAY))
         ts = replay_read_ts(tinfo);
@@ -525,13 +524,6 @@ retry:
 
         testutil_assert(ret == EINVAL);
         testutil_check(session->rollback_transaction(session, NULL));
-
-        /*
-         * For predictable retry, we'll get another read timestamp. For regular runs, we'll continue
-         * without an explicit read timestamp.
-         */
-        if (GV(RUNS_PREDICTABLE_REPLAY))
-            goto retry;
     }
 
     wt_wrap_begin_transaction(session, NULL);


### PR DESCRIPTION
Also, fix timestamp thread so that oldest ts is always less than stable ts.