### PR TITLE
WT-10661 Specify IMPORTED_IMPLIB for builtin compressors on Windows 

### DIFF
--- a/cmake/third_party/lz4.cmake
+++ b/cmake/third_party/lz4.cmake
@@ -14,6 +14,7 @@ endif()
 add_library(wt::lz4 SHARED IMPORTED GLOBAL)
 set_target_properties(wt::lz4 PROPERTIES
     IMPORTED_LOCATION ${HAVE_LIBLZ4}
+    IMPORTED_IMPLIB ${HAVE_LIBLZ4}
 )
 if (HAVE_LIBLZ4_INCLUDES)
     set_target_properties(wt::lz4 PROPERTIES

--- a/cmake/third_party/snappy.cmake
+++ b/cmake/third_party/snappy.cmake
@@ -14,6 +14,7 @@ endif()
 add_library(wt::snappy SHARED IMPORTED GLOBAL)
 set_target_properties(wt::snappy PROPERTIES
     IMPORTED_LOCATION ${HAVE_LIBSNAPPY}
+    IMPORTED_IMPLIB ${HAVE_LIBSNAPPY}
 )
 if (HAVE_LIBSNAPPY_INCLUDES)
     set_target_properties(wt::snappy PROPERTIES

--- a/cmake/third_party/zlib.cmake
+++ b/cmake/third_party/zlib.cmake
@@ -14,6 +14,7 @@ endif()
 add_library(wt::zlib SHARED IMPORTED GLOBAL)
 set_target_properties(wt::zlib PROPERTIES
     IMPORTED_LOCATION ${HAVE_LIBZ}
+    IMPORTED_IMPLIB ${HAVE_LIBZ}
 )
 if (HAVE_LIBZ_INCLUDES)
     set_target_properties(wt::zlib PROPERTIES

--- a/cmake/third_party/zstd.cmake
+++ b/cmake/third_party/zstd.cmake
@@ -14,6 +14,7 @@ endif()
 add_library(wt::zstd SHARED IMPORTED GLOBAL)
 set_target_properties(wt::zstd PROPERTIES
     IMPORTED_LOCATION ${HAVE_LIBZSTD}
+    IMPORTED_IMPLIB ${HAVE_LIBZSTD}
 )
 if (HAVE_LIBZSTD_INCLUDES)
     set_target_properties(wt::zstd PROPERTIES


### PR DESCRIPTION
Add `IMPORTED_IMPLIB` property for imported `SHARED` wt::\<compressor\> libraries.
On Windows, `find_library()` always finds a .lib(or .dll.a) file. The `IMPORTED_IMPLIB` should be set to the .lib part of a DLL.
Since `IMPORTED_LOCATION` is needed on non-Windows and is optional on Windows, and `IMPORTED_IMPLIB` is optional on non-Windows and is needed on Windows, simply setting both of them to `${HAVE_LIB<compressor>}` will work.

Also, I notice that other third-party libraries(like sodium and memkind) are also imported SHARED but only specify `IMPORTED_LOCATION`. I'm not sure if I need to modify them by the way, since I don't use them and this ticket is related to builtin compressors.