### PR TITLE
Revert "WT-10692 Strip away prefix when listing objects for both providers"

### DIFF
--- a/ext/storage_sources/azure_store/azure_connection.cpp
+++ b/ext/storage_sources/azure_store/azure_connection.cpp
@@ -71,9 +71,9 @@ azure_connection::list_objects(
 
     auto list_blobs_response = _azure_client.ListBlobs(blob_parameters);
 
-    for (const auto blob_item : list_blobs_response.Blobs)
-        objects.push_back(blob_item.Name.substr(_bucket_prefix.length()));
-
+    for (const auto blob_item : list_blobs_response.Blobs) {
+        objects.push_back(blob_item.Name);
+    }
     return 0;
 }
 

--- a/ext/storage_sources/azure_store/test/test_azure_connection.cpp
+++ b/ext/storage_sources/azure_store/test/test_azure_connection.cpp
@@ -137,6 +137,7 @@ TEST_CASE("Testing Azure Connection Class", "azure-connection")
         // List single. Object size should be 1.
         REQUIRE(conn.list_objects(object_name, objects, true) == 0);
         REQUIRE(objects.size() == 1);
+
         objects.clear();
     }
 

--- a/ext/storage_sources/gcp_store/gcp_connection.cpp
+++ b/ext/storage_sources/gcp_store/gcp_connection.cpp
@@ -64,7 +64,7 @@ gcp_connection::list_objects(
                 "' failed: " + object_metadata.status().message());
         }
 
-        objects.push_back(object_metadata->name().substr(_bucket_prefix.length()));
+        objects.push_back(object_metadata->name());
 
         if (list_single)
             break;

--- a/test/suite/test_tiered19.py
+++ b/test/suite/test_tiered19.py
@@ -160,7 +160,7 @@ class test_tiered19(wttest.WiredTigerTestCase, TieredConfigMixin):
 
 
         # Test directory list is able to find the file.
-        self.assertEquals(fs.fs_directory_list(session, '', ''), [local_file_name])
+        self.assertEquals(fs.fs_directory_list(session, '', ''), [prefix + local_file_name])
 
         # File handle lock call not used in GCP implementation.
         self.assertEqual(fh_1.fh_lock(session, True), 0)
@@ -290,7 +290,7 @@ class test_tiered19(wttest.WiredTigerTestCase, TieredConfigMixin):
         self.assertEqual(ss.ss_flush_finish(session, azure_fs, 'foobar', 'foobar', None), 0)
 
         # The object exists now.
-        self.assertEquals(azure_fs.fs_directory_list(session, None, None), ['foobar'])
+        self.assertEquals(azure_fs.fs_directory_list(session, None, None), [prefix_1 + 'foobar'])
         try:
             exists = azure_fs.fs_exist(session, 'foobar')
         except:
@@ -348,18 +348,18 @@ class test_tiered19(wttest.WiredTigerTestCase, TieredConfigMixin):
         self.ignoreStderrPatternIfExists('does not exist in Azure')
 
         # Test that the no new objects exist after failed flush.
-        self.assertEquals(azure_fs.fs_directory_list(session, None, None), ['foobar'])
+        self.assertEquals(azure_fs.fs_directory_list(session, None, None), [prefix_1 + 'foobar'])
 
         err_msg = '/Exception: Operation not supported/'
 
         # Test that POSIX Remove and Rename are not supported.
         self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
             lambda: azure_fs.fs_remove(session, 'foobar', 0), err_msg)
-        self.assertEquals(azure_fs.fs_directory_list(session, None, None), ['foobar'])
+        self.assertEquals(azure_fs.fs_directory_list(session, None, None), [prefix_1 + 'foobar'])
 
         self.assertRaisesHavingMessage(wiredtiger.WiredTigerError,
             lambda: azure_fs.fs_rename(session, 'foobar', 'foobar2', 0), err_msg)
-        self.assertEquals(azure_fs.fs_directory_list(session, None, None), ['foobar'])
+        self.assertEquals(azure_fs.fs_directory_list(session, None, None), [prefix_1 + 'foobar'])
 
         # Flush second valid file into Azure.
         self.assertEqual(ss.ss_flush(session, azure_fs, 'foobar', 'foobar2', None), 0)
@@ -368,10 +368,10 @@ class test_tiered19(wttest.WiredTigerTestCase, TieredConfigMixin):
         self.assertEqual(ss.ss_flush_finish(session, azure_fs, 'foobar', 'foobar2', None), 0)
 
         # Directory list should show 2 objects in Azure.
-        self.assertEquals(azure_fs.fs_directory_list(session, None, None), ['foobar', 'foobar2'])
+        self.assertEquals(azure_fs.fs_directory_list(session, None, None), [prefix_1 + 'foobar', prefix_1 + 'foobar2'])
 
         # Directory list single should show 1 object.
-        self.assertEquals(azure_fs.fs_directory_list_single(session, None, None), ['foobar'])
+        self.assertEquals(azure_fs.fs_directory_list_single(session, None, None), [prefix_1 + 'foobar'])
 
         # Verify that file system size returns the size in bytes of the 'foobar' object.
         self.assertEquals(azure_fs.fs_size(session, 'foobar'), len(outbytes))


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#8878