### PR TITLE
WT-10710 Emit macro debug information in diagnostic builds

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -375,14 +375,15 @@ if(ENABLE_DEBUG_INFO)
         # Ensure a PDB file can be generated for debugging symbols.
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG")
     else()
+        # Higher debug levels `-g3`/`-ggdb3` emit additional debug information, including 
+        # macro definitions that allow us to evaluate macros such as `p S2C(session)` inside of gdb.
+        # This needs to be in DWARF version 2 format or later - and should be by default - but 
+        # we'll specify version 4 here to be safe.
         add_compile_options(-g3)
-        add_compile_options(-ggdb)
-        add_compile_options(-gdwarf)
+        add_compile_options(-ggdb3)
+        add_compile_options(-gdwarf-4)
         if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-            # Emit macro debug information which allows us to use macros in gdb, for example: 
-            # `p S2C(session)`.
-            # We only need the `debug-macro` flag for Clang. For gcc the flags `-g3` and `-gdwarf` 
-            # above are enough to output macro debug info. 
+            # Clang requires one additional flag to output macro debug information.
             add_compile_options(-fdebug-macro)
         endif()
     endif()

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -375,8 +375,16 @@ if(ENABLE_DEBUG_INFO)
         # Ensure a PDB file can be generated for debugging symbols.
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG")
     else()
-        add_compile_options(-g)
+        add_compile_options(-g3)
         add_compile_options(-ggdb)
+        add_compile_options(-gdwarf)
+        if("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+            # Emit macro debug information which allows us to use macros in gdb, for example: 
+            # `p S2C(session)`.
+            # We only need the `debug-macro` flag for Clang. For gcc the flags `-g3` and `-gdwarf` 
+            # above are enough to output macro debug info. 
+            add_compile_options(-fdebug-macro)
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Have clang and gcc emit debug info for macros when we compile with `HAVE_DIAGNOSTIC=1`. This allows us to use macros inside gdb:
```
(gdb) p S2C(session)
$1 = (WT_CONNECTION_IMPL *) 0x4a9280
```
