### PR TITLE
WT-10709 Update the WT util dump to perform a search on a key

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -835,6 +835,7 @@ isrc
 isspace
 iter
 jjj
+jknprx
 jprx
 js
 json

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -206,7 +206,7 @@ format.
 The specific key to look for in the format of the data packed into key items.
 
 @par \c -n
-Use \c search_near instead of \c search when a key is given through the \c -k option.
+If the requested key (see the \c -k option) cannot be found, return the key retrieved by \c search_near.
 
 @par \c -p
 Dump in human-readable format (pretty-print). The \c -p flag is incompatible

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -203,7 +203,7 @@ Dump in JSON (<a href="http://www.json.org">JavaScript Object Notation</a>)
 format.
 
 @par \c -k
-The specific key to look for.
+The specific key to look for in the format of the data packed into key items.
 
 @par \c -n
 Use \c search_near instead of \c search when a key is given through the \c -k option.

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -184,7 +184,7 @@ which can be re-loaded into a new table using the \c load command.
 See @subpage dump_formats for details of the dump file formats.
 
 @subsection util_dump_synopsis Synopsis
-`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] dump [-jprx] [-c checkpoint] [-f output] [-t timestamp] uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] dump [-jknprx] [-c checkpoint] [-f output] [-t timestamp] uri`
 
 @subsection util_dump_options Options
 The following are command-specific options for the \c dump command:
@@ -201,6 +201,12 @@ the \c -f option re-directs the output to the specified file.
 @par \c -j
 Dump in JSON (<a href="http://www.json.org">JavaScript Object Notation</a>)
 format.
+
+@par \c -k
+The specific key to look for.
+
+@par \c -n
+Use \c search_near instead of \c search when a key is given through the \c -k option.
 
 @par \c -p
 Dump in human-readable format (pretty-print). The \c -p flag is incompatible

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -673,15 +673,19 @@ dump_record(WT_CURSOR *cursor, const char *key, bool reverse, bool search_near, 
             ret = cursor->search_near(cursor, &exact);
 
             if (ret != 0 && ret != WT_NOTFOUND)
-                return (util_cerr(cursor, search_near ? "search_near" : "search", ret));
+                return (util_cerr(cursor, "search_near", ret));
 
-            /* If search near is disabled and there is not an exact match, the key is missing. */
-            if(!search_near && exact != 0)
+            /*
+             * If a key has been found but search near is disabled and there is no exact match, the
+             * requested key is missing.
+             */
+            if (ret == 0 && !search_near && exact != 0)
                 ret = WT_NOTFOUND;
 
+            /* A key has been found. */
             if (ret == 0) {
                 if (search_near && exact != 0) {
-                    /* Retrieve the nearest key. */
+                    /* Retrieve the key found by search_near. */
                     if ((ret = cursor->get_key(cursor, &current_key)) != 0)
                         return (util_cerr(cursor, "get_key", ret));
                 }
@@ -697,7 +701,7 @@ dump_record(WT_CURSOR *cursor, const char *key, bool reverse, bool search_near, 
                     return (util_cerr(cursor, "get_key", ret));
                 if ((ret = cursor->get_value(cursor, &value)) != 0)
                     return (util_cerr(cursor, "get_value", ret));
-            } else if(ret != WT_NOTFOUND)
+            } else if (ret != WT_NOTFOUND)
                 return (util_cerr(cursor, (reverse ? "prev" : "next"), ret));
         }
 
@@ -717,7 +721,7 @@ dump_record(WT_CURSOR *cursor, const char *key, bool reverse, bool search_near, 
         return (util_err(session, EIO, NULL));
 
     /* When a key is not specified, WT_NOTFOUND means we have reached the end of the file. */
-    if(key == NULL && ret == WT_NOTFOUND)
+    if (key == NULL && ret == WT_NOTFOUND)
         ret = 0;
     return (ret);
 }

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -19,7 +19,7 @@ static int dump_json_separator(WT_SESSION *);
 static int dump_json_table_end(WT_SESSION *);
 static const char *get_dump_type(bool, bool, bool);
 static int dump_prefix(WT_SESSION *, bool, bool, bool);
-static int dump_record(WT_CURSOR *, bool, bool);
+static int dump_record(WT_CURSOR *, const char *, bool, bool, bool);
 static int dump_suffix(WT_SESSION *, bool);
 static int dump_table_config(WT_SESSION *, WT_CURSOR *, WT_CURSOR *, const char *, bool);
 static int dump_table_parts_config(WT_SESSION *, WT_CURSOR *, const char *, const char *, bool);
@@ -70,15 +70,17 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
     WT_SESSION_IMPL *session_impl;
     int ch, format_specifiers, i;
     char *checkpoint, *ofile, *p, *simpleuri, *timestamp, *uri;
-    bool hex, json, pretty, reverse;
+    const char *key;
+    bool hex, json, pretty, reverse, search_near;
 
     session_impl = (WT_SESSION_IMPL *)session;
-
     cursor = NULL;
     hs_dump_cursor = NULL;
+    key = NULL;
     checkpoint = ofile = simpleuri = uri = timestamp = NULL;
-    hex = json = pretty = reverse = false;
-    while ((ch = __wt_getopt(progname, argc, argv, "c:f:t:jprx?")) != EOF)
+    hex = json = pretty = reverse = search_near = false;
+
+    while ((ch = __wt_getopt(progname, argc, argv, "c:f:k:t:jnprx?")) != EOF)
         switch (ch) {
         case 'c':
             checkpoint = __wt_optarg;
@@ -88,6 +90,12 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
             break;
         case 'j':
             json = true;
+            break;
+        case 'k':
+            key = __wt_optarg;
+            break;
+        case 'n':
+            search_near = true;
             break;
         case 'p':
             pretty = true;
@@ -190,10 +198,10 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
             /* Set the "ignore tombstone" flag on the underlying cursor. */
             F_SET(hs_dump_cursor->child, WT_CURSTD_IGNORE_TOMBSTONE);
         }
+
         if (dump_config(session, simpleuri, cursor, pretty, hex, json) != 0)
             goto err;
-
-        if (dump_record(cursor, reverse, json) != 0)
+        if (dump_record(cursor, key, reverse, search_near, json) != 0)
             goto err;
         if (json && dump_json_table_end(session) != 0)
             goto err;
@@ -633,16 +641,17 @@ dump_prefix(WT_SESSION *session, bool pretty, bool hex, bool json)
  *     Dump a single record, advance cursor to next/prev, along with JSON formatting if needed.
  */
 static int
-dump_record(WT_CURSOR *cursor, bool reverse, bool json)
+dump_record(WT_CURSOR *cursor, const char *key, bool reverse, bool search_near, bool json)
 {
     WT_DECL_RET;
     WT_SESSION *session;
-    const char *infix, *key, *prefix, *suffix, *value;
+    int exact;
+    const char *current_key, *infix, *prefix, *suffix, *value;
     bool once;
 
     session = cursor->session;
-
     once = false;
+
     if (json) {
         prefix = "\n{\n";
         infix = ",\n";
@@ -652,18 +661,53 @@ dump_record(WT_CURSOR *cursor, bool reverse, bool json)
         infix = "\n";
         suffix = "\n";
     }
-    while ((ret = (reverse ? cursor->prev(cursor) : cursor->next(cursor))) == 0) {
-        if ((ret = cursor->get_key(cursor, &key)) != 0)
-            return (util_cerr(cursor, "get_key", ret));
-        if ((ret = cursor->get_value(cursor, &value)) != 0)
-            return (util_cerr(cursor, "get_value", ret));
-        if (fprintf(
-              fp, "%s%s%s%s%s%s", json && once ? "," : "", prefix, key, infix, value, suffix) < 0)
-            return (util_err(session, EIO, NULL));
-        once = true;
+
+    /* A specific is requested. */
+    if (key != NULL) {
+        current_key = key;
+        cursor->set_key(cursor, current_key);
+        if (search_near)
+            ret = cursor->search_near(cursor, &exact);
+        else
+            ret = cursor->search(cursor);
+
+        if (ret != 0 && ret != WT_NOTFOUND)
+            return (util_cerr(cursor, search_near ? "search_near" : "search", ret));
+
+        if (ret == 0) {
+            if (search_near && exact != 0) {
+                /* Retrieve the nearest key. */
+                if ((ret = cursor->get_key(cursor, &current_key)) != 0)
+                    return (util_cerr(cursor, "get_key", ret));
+            }
+            if ((ret = cursor->get_value(cursor, &value)) != 0)
+                return (util_cerr(cursor, "get_value", ret));
+
+            if (fprintf(fp, "%s%s%s%s%s%s", json && once ? "," : "", prefix, current_key, infix,
+                  value, suffix) < 0)
+                return (util_err(session, EIO, NULL));
+            once = true;
+        }
+
+    } else {
+        /* Parse the whole file. */
+        while ((ret = (reverse ? cursor->prev(cursor) : cursor->next(cursor))) == 0) {
+            if ((ret = cursor->get_key(cursor, &current_key)) != 0)
+                return (util_cerr(cursor, "get_key", ret));
+            if ((ret = cursor->get_value(cursor, &value)) != 0)
+                return (util_cerr(cursor, "get_value", ret));
+            if (fprintf(fp, "%s%s%s%s%s%s", json && once ? "," : "", prefix, current_key, infix,
+                  value, suffix) < 0)
+                return (util_err(session, EIO, NULL));
+            once = true;
+        }
     }
+
     if (json && once && fprintf(fp, "\n") < 0)
         return (util_err(session, EIO, NULL));
+
+    if (key != NULL)
+        return (ret);
     return (ret == WT_NOTFOUND ? 0 : util_cerr(cursor, (reverse ? "prev" : "next"), ret));
 }
 

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -37,7 +37,8 @@ usage(void)
     static const char *options[] = {"-c checkpoint",
       "dump as of the named checkpoint (the default is the most recent version of the data)",
       "-f output", "dump to the specified file (the default is stdout)", "-j",
-      "dump in JSON format", "-p",
+      "dump in JSON format", "-k", "specify a key too look for", "-n",
+      "if the specified key to look for cannot be found, return the result from search_near", "-p",
       "dump in human readable format (pretty-print). The -p flag can be combined with -x. In this "
       "case, raw data elements will be formatted like -x with hexadecimal encoding.",
       "-r", "dump in reverse order", "-t timestamp",
@@ -50,7 +51,7 @@ usage(void)
       "-?", "show this message", NULL, NULL};
 
     util_usage(
-      "dump [-jprx] [-c checkpoint] [-f output-file] [-t timestamp] uri", "options:", options);
+      "dump [-jknprx] [-c checkpoint] [-f output-file] [-t timestamp] uri", "options:", options);
     return (1);
 }
 

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -669,13 +669,14 @@ dump_record(WT_CURSOR *cursor, const char *key, bool reverse, bool search_near, 
             current_key = key;
             cursor->set_key(cursor, current_key);
 
-            if (search_near)
-                ret = cursor->search_near(cursor, &exact);
-            else
-                ret = cursor->search(cursor);
+            ret = cursor->search_near(cursor, &exact);
 
             if (ret != 0 && ret != WT_NOTFOUND)
                 return (util_cerr(cursor, search_near ? "search_near" : "search", ret));
+
+            /* If search near is disabled and there is not an exact match, the key is missing. */
+            if(!search_near && exact != 0)
+                ret = WT_NOTFOUND;
 
             if (ret == 0) {
                 if (search_near && exact != 0) {

--- a/test/suite/test_dump01.py
+++ b/test/suite/test_dump01.py
@@ -71,7 +71,7 @@ class test_pretty_hex_dump(wttest.WiredTigerTestCase, suite_subprocess):
     def test_dump(self):
         """
         Generates test table with byte array values. After that dumps the table in hex, pretty and
-        pretty hex formats. And then valudates pretty hex dump.
+        pretty hex formats. And then validates pretty hex dump.
         """
         # Create three dumps: hex, pretty and pretty_hex
         self.session.create(self.uri, self.table_format)
@@ -88,9 +88,9 @@ class test_pretty_hex_dump(wttest.WiredTigerTestCase, suite_subprocess):
 
         # First validate number of lines the dumps
         self.assertEqual(True, len(pretty) == len(pretty_hex),
-            'Pretty and pretty_hex output must have the same numbler of lines.')
+            'Pretty and pretty_hex output must have the same number of lines.')
         self.assertEqual(True, len(hex) == len(pretty_hex),
-            'Hex and pretty_hex output must have the same numbler of lines.')
+            'Hex and pretty_hex output must have the same number of lines.')
 
         # Next analyse the pretty hex dump line by line
         data_started = False
@@ -118,7 +118,7 @@ class test_pretty_hex_dump(wttest.WiredTigerTestCase, suite_subprocess):
                     self.assertEqual(True, p == px,
                         'Dump lines differ!\n' + 'Pretty: ' + p + ', Pretty_hex: ' + px)
 
-            # Test if data sectio has started
+            # Test if data section has started
             if not data_started and p == self.data_header:
                 self.assertEqual(True, p == px,
                     'Data section starts at different lines.\n' + 'Pretty: ' + p + 'Pretty_hex: ' + px)

--- a/test/suite/test_dump02.py
+++ b/test/suite/test_dump02.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# wt_util
+# [END_TAGS]
+
+import wttest
+from suite_subprocess import suite_subprocess
+
+# test_dump02.py
+# Test the dump utility to find different keys.
+class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
+    table_format = 'key_format=u,value_format=u'
+    uri = 'table:test_dump'
+    output = 'dump.out'
+    data_header = 'Data\n'
+
+    n_rows = 100
+
+    def gen_key(self, i):
+        return 'key' + str(i)
+
+    def gen_value(self, i):
+        return 'value' + str(i)
+    
+    def get_num_data_lines_from_dump(self, file):
+        """
+        Get the number of lines corresponding to data from a dump file.
+        """
+        lines = open(file).readlines()
+        data_started = False
+        num_lines = 0
+        for line in lines:
+            if data_started:
+                num_lines += 1
+
+            if line == self.data_header:
+                assert not data_started
+                data_started = True
+        return num_lines
+
+    def populate_table(self, uri, n_rows):
+        cursor = self.session.open_cursor(uri, None, None)
+        for i in range(1, n_rows):
+            cursor[self.gen_key(i)] = self.gen_value(i)
+        cursor.close()
+
+    def test_dump(self):
+        self.session.create(self.uri, self.table_format)
+        self.populate_table(self.uri, self.n_rows)
+
+        self.runWt(['dump', self.uri], outfilename=self.output)
+        assert self.get_num_data_lines_from_dump(self.output) == (self.n_rows - 1) * 2
+
+
+    def test_dump_single_key(self):
+        self.session.create(self.uri, self.table_format)
+        self.populate_table(self.uri, self.n_rows)
+
+        # The key does not exist.
+        self.runWt(['dump', '-k', 'key0', self.uri], outfilename=self.output)
+        num_lines = self.get_num_data_lines_from_dump(self.output)
+        assert num_lines == 0, num_lines
+
+        # The nearest key should be found.
+        self.runWt(['dump', '-k', 'key0', '-n', self.uri], outfilename=self.output)
+        num_lines = self.get_num_data_lines_from_dump(self.output)
+        assert num_lines == 2, num_lines
+
+        # Existing key.
+        self.runWt(['dump', '-k', 'key1', self.uri], outfilename=self.output)
+        num_lines = self.get_num_data_lines_from_dump(self.output)
+        assert num_lines == 2, num_lines
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_dump02.py
+++ b/test/suite/test_dump02.py
@@ -54,16 +54,9 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
         Get the number of lines corresponding to data from a dump file.
         """
         lines = open(file).readlines()
-        data_started = False
-        num_lines = 0
-        for line in lines:
-            if data_started:
-                num_lines += 1
-
-            if line == self.data_header:
-                assert not data_started
-                data_started = True
-        return num_lines
+        data_start = lines.index(self.data_header)
+        assert self.data_header not in lines[data_start + 1:]
+        return len(lines) - data_start - 1
 
     def populate_table(self, uri, n_rows):
         cursor = self.session.open_cursor(uri, None, None)

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -50,4 +50,4 @@
 |Truncate||[test_truncate01.py](../test/suite/test_truncate01.py)
 |Truncate|Prepare|[test_prepare13.py](../test/suite/test_prepare13.py)
 |Verify|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py), [test_timestamp18.py](../test/suite/test_timestamp18.py)
-|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_util11.py](../test/suite/test_util11.py)
+|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_dump02.py](../test/suite/test_dump02.py), [test_util11.py](../test/suite/test_util11.py)


### PR DESCRIPTION
The changes introduce two new options for the `dump` command:

```
# Look for a single key (-k option)
./wt dump -k "key0" <wt_file>

# Look for a single key using search_near (-n option)
./wt dump -k "key0" -n <wt_file>
```
