### PR TITLE
WT-10682 Update the WT util dump to work on a range of keys

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -835,7 +835,7 @@ isrc
 isspace
 iter
 jjj
-jknprx
+jklnprux
 jprx
 js
 json

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -227,6 +227,9 @@ timestamp.
 @par \c -u
 The upper bound of the key range to dump.
 
+@par \c -w
+Dump n records before and after the record sought.
+
 @par \c -x
 Dump all characters in a hexadecimal encoding (the default is to leave
 printable characters unencoded). The \c -x flag can be combined with \c -p. In this case, the dump

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -202,6 +202,9 @@ the \c -f option re-directs the output to the specified file.
 Dump in JSON (<a href="http://www.json.org">JavaScript Object Notation</a>)
 format.
 
+@par \c -l
+The lower bound of the key range to dump.
+
 @par \c -p
 Dump in human-readable format (pretty-print). The \c -p flag is incompatible
 with the \c load command. The \c -p flag can be combined with \c -x. In this case, raw data elements
@@ -214,6 +217,9 @@ Dump in reverse order, from largest key to smallest.
 By default, the \c dump command opens the most recent version of the data
 source; the \c -t option changes the \c dump command to dump as of the specified
 timestamp.
+
+@par \c -u
+The upper bound of the key range to dump.
 
 @par \c -x
 Dump all characters in a hexadecimal encoding (the default is to leave

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -37,12 +37,12 @@ usage(void)
     static const char *options[] = {"-c checkpoint",
       "dump as of the named checkpoint (the default is the most recent version of the data)",
       "-f output", "dump to the specified file (the default is stdout)", "-j",
-      "dump in JSON format", "-p",
+      "dump in JSON format", "-l", "lower bound of the key range to dump", "-p",
       "dump in human readable format (pretty-print). The -p flag can be combined with -x. In this "
       "case, raw data elements will be formatted like -x with hexadecimal encoding.",
       "-r", "dump in reverse order", "-t timestamp",
       "dump as of the specified timestamp (the default is the most recent version of the data)",
-      "-x",
+      "-u", "upper bound of the key range to dump", "-x",
       "dump all characters in a hexadecimal encoding (by default printable characters are not "
       "encoded). The -x flag can be combined with -p. In this case, the dump will be formatted "
       "similar to -p except for raw data elements, which will look like -x with hexadecimal "
@@ -50,7 +50,7 @@ usage(void)
       "-?", "show this message", NULL, NULL};
 
     util_usage(
-      "dump [-jprx] [-c checkpoint] [-f output-file] [-t timestamp] uri", "options:", options);
+      "dump [-jlprux] [-c checkpoint] [-f output-file] [-t timestamp] uri", "options:", options);
     return (1);
 }
 

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -46,8 +46,8 @@ usage(void)
       "case, raw data elements will be formatted like -x with hexadecimal encoding.",
       "-r", "dump in reverse order", "-t timestamp",
       "dump as of the specified timestamp (the default is the most recent version of the data)",
-      "-u", "upper bound of the key range to dump", "-x",
-      "-w n", "dump n records before and after the record sought", "-x",
+      "-u", "upper bound of the key range to dump", "-x", "-w n",
+      "dump n records before and after the record sought", "-x",
       "dump all characters in a hexadecimal encoding (by default printable characters are not "
       "encoded). The -x flag can be combined with -p. In this case, the dump will be formatted "
       "similar to -p except for raw data elements, which will look like -x with hexadecimal "
@@ -221,7 +221,7 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
         if (dump_config(session, simpleuri, cursor, pretty, hex, json) != 0)
             goto err;
 
-        if(key == NULL) {
+        if (key == NULL) {
             if (start_key != NULL) {
                 cursor->set_key(cursor, start_key);
                 if (cursor->bound(cursor, "action=set,bound=lower") != 0)
@@ -238,7 +238,7 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
               cursor->bound(cursor, "action=clear") != 0)
                 goto err;
         } else if (dump_record(cursor, key, reverse, search_near, json, window) != 0)
-                goto err;
+            goto err;
 
         if (json && dump_json_table_end(session) != 0)
             goto err;

--- a/test/suite/test_dump02.py
+++ b/test/suite/test_dump02.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# wt_util
+# [END_TAGS]
+
+import wttest
+from suite_subprocess import suite_subprocess
+
+# test_dump02.py
+# Test the dump utility to find different keys.
+class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
+    table_format = 'key_format=u,value_format=u'
+    uri = 'table:test_dump'
+    output = 'dump.out'
+    data_header = 'Data\n'
+
+    n_rows = 100
+
+    def gen_key(self, i):
+        return 'key' + str(i)
+
+    def gen_value(self, i):
+        return 'value' + str(i)
+
+    def get_num_data_lines_from_dump(self, file):
+        """
+        Get the number of lines corresponding to data from a dump file.
+        """
+        lines = open(file).readlines()
+        data_started = False
+        num_lines = 0
+        for line in lines:
+            if data_started:
+                num_lines += 1
+
+            if line == self.data_header:
+                assert not data_started
+                data_started = True
+        return num_lines
+
+    def populate_table(self, uri, n_rows):
+        cursor = self.session.open_cursor(uri, None, None)
+        for i in range(1, n_rows):
+            cursor[self.gen_key(i)] = self.gen_value(i)
+        cursor.close()
+
+    def test_dump_bounds(self):
+        self.session.create(self.uri, self.table_format)
+        self.populate_table(self.uri, self.n_rows)
+
+        # Expect half of the keys: 50 to 99, as well as the keys 6, 7, 8 and 9.
+        self.runWt(['dump', '-l', 'key50', self.uri], outfilename=self.output)
+        num_lines = self.get_num_data_lines_from_dump(self.output)
+        assert num_lines == (self.n_rows / 2) * 2 + (4 * 2), num_lines
+
+        # Expect 3 keys.
+        self.runWt(['dump', '-u', 'key11', self.uri], outfilename=self.output)
+        num_lines = self.get_num_data_lines_from_dump(self.output)
+        assert num_lines == 3 * 2, num_lines
+
+        # Expect 10 keys.
+        self.runWt(['dump', '-l', 'key50', '-u', 'key59', self.uri], outfilename=self.output)
+        num_lines = self.get_num_data_lines_from_dump(self.output)
+        assert num_lines == 10 * 2, num_lines
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_dump02.py
+++ b/test/suite/test_dump02.py
@@ -40,7 +40,8 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
     uri = 'table:test_dump'
     output = 'dump.out'
     data_header = 'Data\n'
-
+    # First line is the key, second line is the value.
+    lines_per_record = 2
     n_rows = 100
 
     def gen_key(self, i):
@@ -69,7 +70,7 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
         self.populate_table(self.uri, self.n_rows)
 
         self.runWt(['dump', self.uri], outfilename=self.output)
-        assert self.get_num_data_lines_from_dump(self.output) == (self.n_rows - 1) * 2
+        assert self.get_num_data_lines_from_dump(self.output) == (self.n_rows - 1) * self.lines_per_record
 
     def test_dump_single_key(self):
         self.session.create(self.uri, self.table_format)
@@ -83,12 +84,12 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
         # The nearest key should be found.
         self.runWt(['dump', '-k', 'key0', '-n', self.uri], outfilename=self.output)
         num_lines = self.get_num_data_lines_from_dump(self.output)
-        assert num_lines == 2, num_lines
+        assert num_lines == self.lines_per_record, num_lines
 
         # Existing key.
         self.runWt(['dump', '-k', 'key1', self.uri], outfilename=self.output)
         num_lines = self.get_num_data_lines_from_dump(self.output)
-        assert num_lines == 2, num_lines
+        assert num_lines == self.lines_per_record, num_lines
 
     def test_dump_bounds(self):
         self.session.create(self.uri, self.table_format)
@@ -97,17 +98,17 @@ class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
         # Expect half of the keys: 50 to 99, as well as the keys 6, 7, 8 and 9.
         self.runWt(['dump', '-l', 'key50', self.uri], outfilename=self.output)
         num_lines = self.get_num_data_lines_from_dump(self.output)
-        assert num_lines == (self.n_rows / 2) * 2 + (4 * 2), num_lines
+        assert num_lines == (self.n_rows / 2) * self.lines_per_record + (4 * self.lines_per_record), num_lines
 
         # Expect 3 keys.
         self.runWt(['dump', '-u', 'key11', self.uri], outfilename=self.output)
         num_lines = self.get_num_data_lines_from_dump(self.output)
-        assert num_lines == 3 * 2, num_lines
+        assert num_lines == 3 * self.lines_per_record, num_lines
 
         # Expect 10 keys.
         self.runWt(['dump', '-l', 'key50', '-u', 'key59', self.uri], outfilename=self.output)
         num_lines = self.get_num_data_lines_from_dump(self.output)
-        assert num_lines == 10 * 2, num_lines
+        assert num_lines == 10 * self.lines_per_record, num_lines
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -50,4 +50,4 @@
 |Truncate||[test_truncate01.py](../test/suite/test_truncate01.py)
 |Truncate|Prepare|[test_prepare13.py](../test/suite/test_prepare13.py)
 |Verify|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py), [test_timestamp18.py](../test/suite/test_timestamp18.py)
-|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_util11.py](../test/suite/test_util11.py)
+|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_dump02.py](../test/suite/test_dump02.py), [test_util11.py](../test/suite/test_util11.py)


### PR DESCRIPTION
The changes introduce two new options for the dump command:

```
# Set a lower bound for the key range (-l option)
./wt dump -l "key0" <wt_file>

# Set an upper bound for the key range (-u option)
./wt dump -u "key0" <wt_file>
```