### PR TITLE
WT-10727 Make the util dump command interactive

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -662,7 +662,7 @@ dup
 dv
 eee
 eg
-ejklnpruwx
+ejklnprux
 el
 emp
 encodings

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -901,6 +901,7 @@ lsn
 lt
 lte
 lu
+luc
 lwsync
 lz
 madvise

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -465,6 +465,7 @@ basecfg
 bbb
 bbuilddir
 bcr
+bd
 beginthreadex
 bigram
 binutils
@@ -486,6 +487,7 @@ booleans
 boption
 br
 breakpoint
+bs
 bstorage
 bswap
 btcur
@@ -660,6 +662,7 @@ dup
 dv
 eee
 eg
+ejknprx
 el
 emp
 encodings
@@ -835,8 +838,6 @@ isrc
 isspace
 iter
 jjj
-jknprx
-jprx
 js
 json
 kB
@@ -1073,6 +1074,7 @@ rN
 rS
 rbrace
 rbracket
+rc
 rdlock
 rdtsc
 rduppo
@@ -1101,6 +1103,7 @@ retp
 revint
 rf
 risc
+rl
 rle
 rmw
 rng
@@ -1139,6 +1142,7 @@ skiplist
 skiplists
 skipp
 slvg
+sn
 snaplen
 snapsort
 snprintf

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -184,7 +184,7 @@ which can be re-loaded into a new table using the \c load command.
 See @subpage dump_formats for details of the dump file formats.
 
 @subsection util_dump_synopsis Synopsis
-`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] dump [-jknprx] [-c checkpoint] [-f output] [-t timestamp] uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] dump [-ejknprx] [-c checkpoint] [-f output] [-t timestamp] uri`
 
 @subsection util_dump_options Options
 The following are command-specific options for the \c dump command:
@@ -193,6 +193,9 @@ The following are command-specific options for the \c dump command:
 By default, the \c dump command opens the most recent version of the data
 source; the \c -c option changes the \c dump command to dump as of the named
 checkpoint.
+
+@par \c -e
+Start the explore mode to dump the file interactively.
 
 @par \c -f
 By default, the \c dump command output is written to the standard output;

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -184,7 +184,7 @@ which can be re-loaded into a new table using the \c load command.
 See @subpage dump_formats for details of the dump file formats.
 
 @subsection util_dump_synopsis Synopsis
-`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] dump [-ejknprx] [-c checkpoint] [-f output] [-t timestamp] uri`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] dump [-ejknprx] [-c checkpoint] [-f output] [-t timestamp] [-w n] uri`
 
 @subsection util_dump_options Options
 The following are command-specific options for the \c dump command:

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -39,7 +39,8 @@ usage(void)
 {
     static const char *options[] = {"-c checkpoint",
       "dump as of the named checkpoint (the default is the most recent version of the data)", "-e",
-      "explore a file in an interactive fashion, everything is to stdout, hence incompatible with "
+      "explore a file in an interactive fashion, everything is redirected to stdout, hence "
+      "incompatible with "
       "the -f option",
       "-f output", "dump to the specified file (the default is stdout)", "-j",
       "dump in JSON format", "-k", "specify a key too look for", "-n",

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -57,7 +57,7 @@ usage(void)
       "case, raw data elements will be formatted like -x with hexadecimal encoding.",
       "-r", "dump in reverse order", "-t timestamp",
       "dump as of the specified timestamp (the default is the most recent version of the data)",
-      "-u", "upper bound of the key range to dump", "-x", "-w n",
+      "-u", "upper bound of the key range to dump", "-w n",
       "dump n records before and after the record sought", "-x",
       "dump all characters in a hexadecimal encoding (by default printable characters are not "
       "encoded). The -x flag can be combined with -p. In this case, the dump will be formatted "

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -168,7 +168,7 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
     if (ofile == NULL)
         fp = stdout;
     else if (explore) {
-        fprintf(stderr, "%s: the options are -e and -f are incompatible\n", progname);
+        fprintf(stderr, "%s: the options -e and -f are incompatible\n", progname);
         return (usage());
     } else if ((fp = fopen(ofile, "w")) == NULL)
         return (util_err(session, errno, "%s: open", ofile));

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -776,7 +776,7 @@ dump_record(
         return (WT_NOTFOUND);
 
     if (window == 0)
-        ret = print_record(cursor, json);
+        WT_RET(print_record(cursor, json));
     else {
         fwd = (reverse) ? cursor->prev : cursor->next;
         bck = (reverse) ? cursor->next : cursor->prev;
@@ -804,7 +804,7 @@ dump_record(
                 if (fputc(',', fp) == EOF)
                     return (util_err(session, EIO, NULL));
             }
-            print_record(cursor, json);
+            WT_RET(print_record(cursor, json));
             if ((ret = fwd(cursor)) != 0) {
                 if (ret == WT_NOTFOUND)
                     break;
@@ -838,7 +838,7 @@ dump_all_records(WT_CURSOR *cursor, bool reverse, bool json)
             if (fputc(',', fp) == EOF)
                 return (util_err(session, EIO, NULL));
         }
-        print_record(cursor, json);
+        WT_RET(print_record(cursor, json));
         once = true;
     }
 
@@ -1064,7 +1064,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
                 printf("Error: %d\n", ret);
                 ret = 0;
             } else
-                ret = print_record(cursor, json);
+                WT_RET(print_record(cursor, json));
             break;
         /* Range cursor. */
         case 'r':

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -71,12 +71,13 @@ static void
 explore_usage(void)
 {
     static const char *options[] = {"a", "show the current cursor's position", "b",
-      "list bookmarks", "b bookmark", "jump to bookmark", "bd bookmark", "delete bookmark", "bs [key]",
-      "save cursor's position to bookmarks or the given key", "c", "reset the cursor", "d key",
-      "delete the given key", "h", "show this message", "i key value", "insert the key/value pair",
-      "m", "dump the config", "n", "call cursor next", "p", "call cursor prev", "q", "exit", "rl",
-      "set the lower bound", "ru", "set the upper bound", "s key", "search for a key", "sn key",
-      "search for a key using search_near", "u key value", "update the key/value pair", NULL, NULL};
+      "list bookmarks", "b bookmark", "jump to bookmark", "bd bookmark", "delete bookmark",
+      "bs [key]", "save cursor's position to bookmarks or the given key", "c", "reset the cursor",
+      "d key", "delete the given key", "h", "show this message", "i key value",
+      "insert the key/value pair", "m", "dump the config", "n", "call cursor next", "p",
+      "call cursor prev", "q", "exit", "rl", "set the lower bound", "ru", "set the upper bound",
+      "s key", "search for a key", "sn key", "search for a key using search_near", "u key value",
+      "update the key/value pair", NULL, NULL};
     util_usage(NULL, NULL, options);
 }
 
@@ -1042,8 +1043,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
                         break;
                     }
                 }
-            }
-            else {
+            } else {
                 printf("Error: the key '%s' does not exist.\n", key);
                 ret = 0;
             }

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -842,6 +842,9 @@ dump_all_records(WT_CURSOR *cursor, bool reverse, bool json)
         once = true;
     }
 
+    if (ret != WT_NOTFOUND)
+        return (util_err(session, ret, reverse ? "WT_CURSOR.prev" : "WT_CURSOR.next"));
+
     if (json && once && fprintf(fp, "\n") < 0)
         return (util_err(session, EIO, NULL));
     return (0);

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -1074,7 +1074,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
             break;
         /* Range cursor. */
         case 'r':
-            if (first_arg[1] != 'l' && first_arg[1] != 'u' && first_arg[1] != 'c') {
+            if (strchr("luc", first_arg[1]) == NULL) {
                 printf(
                   "Error: use 'rl' for lower range, 'ru' for upper range and 'rc' to clear "
                   "range.\n");

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -1063,14 +1063,8 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
             if (ret == WT_NOTFOUND) {
                 printf("Error: %d\n", ret);
                 ret = 0;
-            } else {
-                if ((ret = cursor->get_key(cursor, &key)) != 0)
-                    return (util_cerr(cursor, "get_key", ret));
-                if ((ret = cursor->get_value(cursor, &value)) != 0)
-                    return (util_cerr(cursor, "get_value", ret));
-                if (fprintf(fp, "%s%s%s%s%s", prefix, key, infix, value, suffix) < 0)
-                    return (util_err(session, EIO, NULL));
-            }
+            } else
+                ret = print_record(cursor, json);
             break;
         /* Range cursor. */
         case 'r':

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -866,7 +866,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
     uint64_t bookmark_index, window;
     int i, exact, num_args;
     char *args[MAX_ARGS], *bookmarks[MAX_BOOKMARKS];
-    char *first_arg, user_input[MAX_ARGS], *current_arg;
+    char *first_arg, user_input[ARG_BUF_SIZE], *current_arg;
     const char *key, *value;
     bool once, search_near;
 

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -71,8 +71,8 @@ static void
 explore_usage(void)
 {
     static const char *options[] = {"a", "show the current cursor's position", "b",
-      "list bookmarks", "b bookmark", "jump to bookmark", "bd bookmark", "delete bookmark", "bs",
-      "save cursor's position to bookmarks", "c", "reset the cursor", "d key",
+      "list bookmarks", "b bookmark", "jump to bookmark", "bd bookmark", "delete bookmark", "bs [key]",
+      "save cursor's position to bookmarks or the given key", "c", "reset the cursor", "d key",
       "delete the given key", "h", "show this message", "i key value", "insert the key/value pair",
       "m", "dump the config", "n", "call cursor next", "p", "call cursor prev", "q", "exit", "rl",
       "set the lower bound", "ru", "set the upper bound", "s key", "search for a key", "sn key",
@@ -986,6 +986,13 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
             }
             /* Save. */
             else if (strcmp(first_arg, "bs") == 0) {
+                if (num_args >= 2) {
+                    key = args[1];
+                    cursor->set_key(cursor, key);
+                    ret = cursor->search(cursor);
+                    if (ret != 0)
+                        return (util_cerr(cursor, "search", ret));
+                }
                 ret = cursor->get_key(cursor, &key);
                 if (ret != 0 && ret != EINVAL)
                     return (util_cerr(cursor, "get_key", ret));

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -1064,7 +1064,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
             if (ret != 0 && ret != WT_NOTFOUND)
                 return (util_cerr(cursor, (reverse ? "prev" : "next"), ret));
             if (ret == WT_NOTFOUND) {
-                printf("Error: %d\n", ret);
+                printf("Start/End of file reached.\n");
                 ret = 0;
             } else
                 WT_RET(print_record(cursor, json));

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -825,7 +825,7 @@ dump_all_records(WT_CURSOR *cursor, bool reverse, bool json)
 
 /*
  * dump_explore --
- *     Dump content in an interactive fashion.
+ *     Dump data in an interactive fashion.
  */
 static int
 dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool hex, bool json)

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -1024,8 +1024,18 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
             ret = cursor->remove(cursor);
             if (ret != 0 && ret != WT_NOTFOUND)
                 return (util_cerr(cursor, "remove", ret));
-            if (ret == 0)
+            if (ret == 0) {
                 printf("Removed key '%s'.\n", key);
+                /* Remove the bookmark associated with the key, if any. */
+                for (i = 0; i < MAX_LIMIT; ++i) {
+                    if (bookmarks[i] != NULL && strcmp(bookmarks[i], key) == 0) {
+                        free(bookmarks[i]);
+                        bookmarks[i] = NULL;
+                        printf("Bookmark %d deleted.\n", i);
+                        break;
+                    }
+                }
+            }
             else {
                 printf("Error: the key '%s' does not exist.\n", key);
                 ret = 0;

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -927,7 +927,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
 
             printf("Current position:\n");
             printf("key:%s\n", key);
-            printf("key:%s\n", value);
+            printf("value:%s\n", value);
             break;
         /* Bookmarks. */
         case 'b':

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -58,7 +58,7 @@ usage(void)
       "encoding.",
       "-?", "show this message", NULL, NULL};
 
-    util_usage("dump [-ejklnpruwx] [-c checkpoint] [-f output-file] [-t timestamp] uri",
+    util_usage("dump [-ejklnprux] [-c checkpoint] [-f output-file] [-t timestamp] [-w n] uri",
       "options:", options);
     return (1);
 }

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -1127,7 +1127,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
             if (ret != 0 && ret != WT_NOTFOUND)
                 return (util_cerr(cursor, "search_near", ret));
             if (ret == WT_NOTFOUND || (!search_near && exact != 0)) {
-                printf("Error: %d\n", ret);
+                printf("Error: %d\n", ret == 0 ? WT_NOTFOUND : ret);
                 ret = 0;
             } else {
                 if (search_near && exact != 0) {


### PR DESCRIPTION
When the -e option is given to the dump command, it is possible to go through the file in an interactive fashion:
```
$ ./wt dump -e file:test_dump.wt

**************************
Explore mode for file:test_dump.wt.
**************************
Enter 'h' for help, 'q' to exit.
```