### PR TITLE
WT-10733 Print out full key in test format ops traces

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1823,10 +1823,7 @@ row_truncate(TINFO *tinfo)
     /* The code assumes we're never truncating the entire object, assert that fact. */
     testutil_assert(tinfo->keyno != 0 || tinfo->last != 0);
 
-    trace_op(tinfo, "truncate %" PRIu64 " {%.*s} to %" PRIu64 " {%.*s}", tinfo->keyno,
-      (int)tinfo->key->size, (char *)tinfo->key->data, tinfo->last, (int)tinfo->lastkey->size,
-      (char *)tinfo->lastkey->data);
-
+    trace_op(tinfo, "truncate %" PRIu64 "-%" PRIu64 " start", tinfo->keyno, tinfo->last);
     if (tinfo->keyno == 0) {
         key_gen(tinfo->table, tinfo->key, tinfo->last);
         cursor->set_key(cursor, tinfo->key);
@@ -1849,9 +1846,7 @@ row_truncate(TINFO *tinfo)
     }
 
 err:
-    trace_op(tinfo, "truncate %" PRIu64 " {%.*s} to %" PRIu64 " {%.*s} ret = %d", tinfo->keyno,
-      (int)tinfo->key->size, (char *)tinfo->key->data, tinfo->last, (int)tinfo->lastkey->size,
-      (char *)tinfo->lastkey->data, ret);
+    trace_op(tinfo, "truncate %" PRIu64 "-%" PRIu64 " stop ret %d", tinfo->keyno, tinfo->last, ret);
 
     return (ret);
 }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1443,6 +1443,13 @@ read_row_worker(TINFO *tinfo, TABLE *table, WT_CURSOR *cursor, uint64_t keyno, W
 
         break;
     case ROW:
+        if (tinfo == NULL)
+            trace_msg(cursor->session, "read %" PRIu64 " {%.*s}, {%.*s}", keyno, (int)key->size,
+              (char *)key->data, (int)value->size, (char *)value->data);
+        else
+            trace_op(tinfo, "read %" PRIu64 " {%.*s}, {%.*s}", keyno, (int)key->size,
+              (char *)key->data, (int)value->size, (char *)value->data);
+        break;
     case VAR:
         if (tinfo == NULL)
             trace_msg(cursor->session, "read %" PRIu64 " {%.*s}", keyno, (int)value->size,
@@ -1816,7 +1823,10 @@ row_truncate(TINFO *tinfo)
     /* The code assumes we're never truncating the entire object, assert that fact. */
     testutil_assert(tinfo->keyno != 0 || tinfo->last != 0);
 
-    trace_op(tinfo, "truncate %" PRIu64 "-%" PRIu64 " start", tinfo->keyno, tinfo->last);
+    trace_op(tinfo, "truncate %" PRIu64 " {%.*s} to %" PRIu64 " {%.*s}", tinfo->keyno,
+      (int)tinfo->key->size, (char *)tinfo->key->data, tinfo->last, (int)tinfo->lastkey->size,
+      (char *)tinfo->lastkey->data);
+
     if (tinfo->keyno == 0) {
         key_gen(tinfo->table, tinfo->key, tinfo->last);
         cursor->set_key(cursor, tinfo->key);
@@ -1839,7 +1849,9 @@ row_truncate(TINFO *tinfo)
     }
 
 err:
-    trace_op(tinfo, "truncate %" PRIu64 "-%" PRIu64 " stop ret %d", tinfo->keyno, tinfo->last, ret);
+    trace_op(tinfo, "truncate %" PRIu64 " {%.*s} to %" PRIu64 " {%.*s} ret = %d", tinfo->keyno,
+      (int)tinfo->key->size, (char *)tinfo->key->data, tinfo->last, (int)tinfo->lastkey->size,
+      (char *)tinfo->lastkey->data, ret);
 
     return (ret);
 }
@@ -2125,7 +2137,8 @@ row_remove(TINFO *tinfo, bool positioned)
     if (ret != 0 && ret != WT_NOTFOUND)
         return (ret);
 
-    trace_op(tinfo, "remove %" PRIu64, tinfo->keyno);
+    trace_op(tinfo, "remove %" PRIu64 " {%.*s}", tinfo->keyno, (int)tinfo->key->size,
+      (char *)tinfo->key->data);
 
     return (ret);
 }


### PR DESCRIPTION
Make sure `trace_op`s calls print `tinfo->key` data as well as `tinfo->keyno` in test/format.