### PR TITLE
WT-10730 Fix the overwrite/append options for the util write command

### DIFF
--- a/src/utilities/util_write.c
+++ b/src/utilities/util_write.c
@@ -71,8 +71,8 @@ util_write(WT_SESSION *session, int argc, char *argv[])
     /*
      * Open the object; free allocated memory immediately to simplify future error handling.
      */
-    if ((ret = __wt_snprintf(config, sizeof(config), "%s,%s", append ? "append=true" : "",
-           overwrite ? "overwrite=true" : "")) != 0) {
+    if ((ret = __wt_snprintf(config, sizeof(config), "append=%s,overwrite=%s",
+           append ? "true" : "false", overwrite ? "true" : "false")) != 0) {
         free(uri);
         return (util_err(session, ret, NULL));
     }

--- a/test/suite/test_util12.py
+++ b/test/suite/test_util12.py
@@ -63,7 +63,7 @@ class test_util12(wttest.WiredTigerTestCase, suite_subprocess):
     def test_write_overwrite(self):
         self.session.create('table:' + self.tablename, self.session_params)
         cursor = self.session.open_cursor('table:' + self.tablename, None, None)
-        cursor ['def'] = '789'
+        cursor['def'] = '789'
         cursor.close()
         errfile = 'writeerr.txt'
         self.runWt(['write', 'table:' + self.tablename,

--- a/test/suite/test_util12.py
+++ b/test/suite/test_util12.py
@@ -63,10 +63,13 @@ class test_util12(wttest.WiredTigerTestCase, suite_subprocess):
     def test_write_overwrite(self):
         self.session.create('table:' + self.tablename, self.session_params)
         cursor = self.session.open_cursor('table:' + self.tablename, None, None)
-        cursor.set_key('def')
-        cursor.set_value('789')
+        cursor ['def'] = '789'
         cursor.close()
+        errfile = 'writeerr.txt'
         self.runWt(['write', 'table:' + self.tablename,
+                    'def', '456', 'abc', '123'], errfilename=errfile, failure=True)
+        self.check_file_contains(errfile, 'attempt to insert an existing key')
+        self.runWt(['write', '-o', 'table:' + self.tablename,
                     'def', '456', 'abc', '123'])
         cursor = self.session.open_cursor('table:' + self.tablename, None, None)
         self.assertEqual(cursor.next(), 0)


### PR DESCRIPTION
Now we explicitly set the `overwrite` cursor option to `false` when `-o` is not given to the `write` command. The same change was done for the `append` cursor option.

The relevant test was updated.