### PR TITLE
WT-10762 Remove redundant unit-test task from a few Evergreen builders

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5004,7 +5004,6 @@ buildvariants:
     - name: compile
     - name: doc-compile
     - name: make-check-test
-    - name: unit-test
     - name: configure-combinations
     - name: syscall-linux
     - name: checkpoint-filetypes-test
@@ -5329,7 +5328,6 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-    - name: unit-test
     - name: fops
     - name: time-shift-sensitivity-test
     - name: linux-directio


### PR DESCRIPTION
Remove the `unit-test` task from 2 x Evergreen builders:

- `! Ubuntu 20.04` - covered by `unit-test-bucketxx` tasks
- `RHEL 8.0` - covered by `unit-test-long` task