### PR TITLE
WT-10780 Change .clang-format so that C++ access modifies are not indented

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language:        Cpp
 # BasedOnStyle:  LLVM
-AccessModifierOffset: 0
+AccessModifierOffset: -4
 AlignAfterOpenBracket: DontAlign
 AlignConsecutiveMacros: false
 AlignConsecutiveAssignments: false

--- a/ext/storage_sources/azure_store/azure_connection.h
+++ b/ext/storage_sources/azure_store/azure_connection.h
@@ -53,7 +53,7 @@ static const std::map<Azure::Core::Http::HttpStatusCode, int32_t> to_errno = {
  * unique container.
  */
 class azure_connection {
-    public:
+public:
     azure_connection(const std::string &bucket_name, const std::string &bucket_prefix = "");
     int list_objects(
       const std::string &search_prefix, std::vector<std::string> &objects, bool list_single) const;
@@ -62,7 +62,7 @@ class azure_connection {
     int read_object(const std::string &object_key, int64_t offset, size_t len, void *buf) const;
     int object_exists(const std::string &object_key, bool &exists, size_t &object_size) const;
 
-    private:
+private:
     const std::string _bucket_name;
     const std::string _bucket_prefix;
     const Azure::Storage::Blobs::BlobContainerClient _azure_client;

--- a/ext/storage_sources/azure_store/azure_log_system.h
+++ b/ext/storage_sources/azure_store/azure_log_system.h
@@ -51,7 +51,7 @@ const std::map<int32_t, Azure::Core::Diagnostics::Logger::Level> wt_to_azure_ver
  * logged through the use of the WT_EXTENSION_API.
  */
 class azure_log_system {
-    public:
+public:
     explicit azure_log_system(WT_EXTENSION_API *wt_api, int32_t wt_verbosity_level);
     const Azure::Core::Diagnostics::Logger::Level wt_to_azure_verbosity_level(
       int32_t wt_verbosity_level);
@@ -60,7 +60,7 @@ class azure_log_system {
     void log_debug_message(const std::string &message) const;
     void azure_log_listener(Azure::Core::Diagnostics::Logger::Level lvl, std::string msg);
 
-    private:
+private:
     void log_verbose_message(int32_t verbosity_level, const std::string &message) const;
     WT_EXTENSION_API *_wt_api;
     int32_t _wt_verbosity_level;

--- a/ext/storage_sources/gcp_store/gcp_connection.h
+++ b/ext/storage_sources/gcp_store/gcp_connection.h
@@ -42,7 +42,7 @@ static const std::map<google::cloud::StatusCode, int32_t> toErrno = {
   {google::cloud::StatusCode::kAlreadyExists, EBUSY},
   {google::cloud::StatusCode::kPermissionDenied, EACCES}};
 class gcp_connection {
-    public:
+public:
     gcp_connection(const std::string &bucket_name, const std::string &prefix);
     int list_objects(
       std::string search_prefix, std::vector<std::string> &objects, bool list_single);
@@ -54,7 +54,7 @@ class gcp_connection {
 
     ~gcp_connection() = default;
 
-    private:
+private:
     google::cloud::storage::Client _gcp_client;
     const std::string _bucket_name;
     const std::string _bucket_prefix;

--- a/ext/storage_sources/gcp_store/gcp_log_system.h
+++ b/ext/storage_sources/gcp_store/gcp_log_system.h
@@ -53,7 +53,7 @@ static const std::map<int32_t, google::cloud::Severity> verbosity_mapping = {
  * GCP's LogSink is used to initialize the log system to the SDK.
  */
 class gcp_log_system : public google::cloud::LogBackend {
-    public:
+public:
     explicit gcp_log_system(WT_EXTENSION_API *wt_api, int32_t wt_verbosity_level);
 
     void Process(const google::cloud::LogRecord &log_record) override;
@@ -87,7 +87,7 @@ class gcp_log_system : public google::cloud::LogBackend {
     // to this.
     void set_wt_verbosity_level(int32_t wtVerbosityLevel);
 
-    private:
+private:
     void log_verbose_message(int32_t verbosity_level, const std::string &message) const;
     google::cloud::Severity _gcp_log_level;
     WT_EXTENSION_API *_wt_api;

--- a/ext/storage_sources/s3_store/s3_aws_manager.h
+++ b/ext/storage_sources/s3_store/s3_aws_manager.h
@@ -40,7 +40,7 @@
  * reaches 0 at which point SDK shutdown will be called.
  */
 class AwsManager {
-    public:
+public:
     static AwsManager &
     Get()
     {
@@ -62,7 +62,7 @@ class AwsManager {
         return Get().TerminateInternal();
     }
 
-    private:
+private:
     AwsManager()
     {
         refCount = 0;

--- a/ext/storage_sources/s3_store/s3_connection.h
+++ b/ext/storage_sources/s3_store/s3_connection.h
@@ -55,7 +55,7 @@ static const std::map<Aws::Http::HttpResponseCode, int32_t> toErrno = {
  * the S3 client.
  */
 class S3Connection {
-    public:
+public:
     /*
      * We have two constructors for the two different ways to start a S3 connection. First
      * constructor uses provided credentials, the following uses credentials stored in a local file.
@@ -74,7 +74,7 @@ class S3Connection {
 
     ~S3Connection() = default;
 
-    private:
+private:
     const Aws::S3Crt::S3CrtClient _s3CrtClient;
     const std::string _bucketName;
     const std::string _objectPrefix;

--- a/ext/storage_sources/s3_store/s3_log_system.h
+++ b/ext/storage_sources/s3_store/s3_log_system.h
@@ -56,7 +56,7 @@ static const std::map<int32_t, Aws::Utils::Logging::LogLevel> verbosityMapping =
  * with WiredTiger's logging system.
  */
 class S3LogSystem : public Aws::Utils::Logging::LogSystemInterface {
-    public:
+public:
     S3LogSystem(WT_EXTENSION_API *wtApi, uint32_t wtVerbosityLevel);
     Aws::Utils::Logging::LogLevel
     GetLogLevel(void) const override
@@ -92,7 +92,7 @@ class S3LogSystem : public Aws::Utils::Logging::LogSystemInterface {
     {
     }
 
-    private:
+private:
     void LogAwsMessage(const char *tag, const std::string &message) const;
     void LogVerboseMessage(int32_t verbosityLevel, const std::string &message) const;
     std::atomic<Aws::Utils::Logging::LogLevel> _awsLogLevel;

--- a/ext/storage_sources/s3_store/test/s3_cleanup.h
+++ b/ext/storage_sources/s3_store/test/s3_cleanup.h
@@ -34,7 +34,7 @@
 #include <string>
 
 class S3Cleanup {
-    public:
+public:
     S3Cleanup(S3Connection &conn, const std::string &prefix, const std::string &fileName)
         : _conn(conn), _prefix(prefix), _fileName(fileName), _totalObjects(0)
     {
@@ -54,7 +54,7 @@ class S3Cleanup {
         std::remove(_fileName.c_str());
     }
 
-    private:
+private:
     S3Connection &_conn;
     const std::string &_prefix;
     const std::string &_fileName;

--- a/test/cppsuite/src/bound/bound.h
+++ b/test/cppsuite/src/bound/bound.h
@@ -32,7 +32,7 @@
 
 namespace test_harness {
 class bound {
-    public:
+public:
     bound();
     bound(const std::string &key, bool lower_bound, bool inclusive);
     bound(uint64_t key_size_max, bool lower_bound);
@@ -46,7 +46,7 @@ class bound {
     void clear();
     void apply(scoped_cursor &cursor) const;
 
-    private:
+private:
     std::string _key;
     bool _inclusive;
     bool _lower_bound;

--- a/test/cppsuite/src/bound/bound_set.h
+++ b/test/cppsuite/src/bound/bound_set.h
@@ -37,7 +37,7 @@ namespace test_harness {
  * convenient way of creating prefix bounds.
  */
 class bound_set {
-    public:
+public:
     /* No default constructor is allowed. */
     bound_set() = delete;
     /* Construct a bound set given two bounds. */
@@ -52,7 +52,7 @@ class bound_set {
     const bound &get_lower() const;
     const bound &get_upper() const;
 
-    private:
+private:
     bound _lower;
     bound _upper;
 };

--- a/test/cppsuite/src/common/logger.h
+++ b/test/cppsuite/src/common/logger.h
@@ -55,14 +55,14 @@ namespace test_harness {
 void get_time(char *time_buf, size_t buf_size);
 
 class logger {
-    public:
+public:
     /* Current log level. Default is LOG_WARN. */
     static int64_t trace_level;
 
     /* Include date in the logs if enabled. Default is true. */
     static bool include_date;
 
-    public:
+public:
     /* Used to print out traces for debugging purpose. */
     static void log_msg(int64_t trace_type, const std::string &str);
 

--- a/test/cppsuite/src/common/random_generator.h
+++ b/test/cppsuite/src/common/random_generator.h
@@ -46,7 +46,7 @@ namespace test_harness {
 enum class characters_type { PSEUDO_ALPHANUMERIC, ALPHABET };
 
 class random_generator {
-    public:
+public:
     static random_generator &instance();
 
     /* No copies of the singleton allowed. */
@@ -78,7 +78,7 @@ class random_generator {
         return dis(_generator);
     }
 
-    private:
+private:
     random_generator();
     std::uniform_int_distribution<> &get_distribution(characters_type type);
     const std::string &get_characters(characters_type type);

--- a/test/cppsuite/src/common/thread_manager.h
+++ b/test/cppsuite/src/common/thread_manager.h
@@ -35,7 +35,7 @@
 namespace test_harness {
 /* Class that handles threads, from their initialization to their deletion. */
 class thread_manager {
-    public:
+public:
     ~thread_manager();
 
     /*
@@ -54,7 +54,7 @@ class thread_manager {
      */
     void join();
 
-    private:
+private:
     std::vector<std::thread *> _workers;
 };
 } // namespace test_harness

--- a/test/cppsuite/src/component/component.h
+++ b/test/cppsuite/src/component/component.h
@@ -39,7 +39,7 @@ namespace test_harness {
  * the following order: load, run, end_run, finish.
  */
 class component {
-    public:
+public:
     component(const std::string &name, configuration *config);
     virtual ~component();
 
@@ -81,13 +81,13 @@ class component {
      */
     virtual void finish();
 
-    protected:
+protected:
     bool _enabled = false;
     volatile bool _running = false;
     uint64_t _sleep_time_ms = 1000;
     configuration *_config;
 
-    private:
+private:
     std::string _name;
 };
 } // namespace test_harness

--- a/test/cppsuite/src/component/metrics_monitor.h
+++ b/test/cppsuite/src/component/metrics_monitor.h
@@ -46,10 +46,10 @@ namespace test_harness {
  * relevant to the given workload.
  */
 class metrics_monitor : public component {
-    public:
+public:
     static void get_stat(scoped_cursor &, int, int64_t *);
 
-    public:
+public:
     metrics_monitor(const std::string &test_name, configuration *config, database &database);
     virtual ~metrics_monitor() = default;
 
@@ -61,7 +61,7 @@ class metrics_monitor : public component {
     void do_work() override final;
     void finish() override final;
 
-    private:
+private:
     scoped_session _session;
     scoped_cursor _cursor;
     const std::string _test_name;

--- a/test/cppsuite/src/component/metrics_writer.h
+++ b/test/cppsuite/src/component/metrics_writer.h
@@ -37,10 +37,10 @@
 namespace test_harness {
 /* Singleton class that can write statistics to a file. */
 class metrics_writer {
-    public:
+public:
     static metrics_writer &instance();
 
-    public:
+public:
     /* No copies of the singleton allowed. */
     metrics_writer(metrics_writer const &) = delete;
     metrics_writer &operator=(metrics_writer const &) = delete;
@@ -48,7 +48,7 @@ class metrics_writer {
     void add_stat(const std::string &stat_string);
     void output_perf_file(const std::string &test_name);
 
-    private:
+private:
     metrics_writer();
     std::vector<std::string> _stats;
     std::mutex _stat_mutex;

--- a/test/cppsuite/src/component/operation_tracker.h
+++ b/test/cppsuite/src/component/operation_tracker.h
@@ -57,7 +57,7 @@ enum class tracking_operation { CREATE_COLLECTION, CUSTOM, DELETE_COLLECTION, DE
 
 /* Class used to track operations performed on collections */
 class operation_tracker : public component {
-    public:
+public:
     operation_tracker(configuration *_config, const bool use_compression, timestamp_manager &tsm);
     virtual ~operation_tracker() = default;
 
@@ -83,7 +83,7 @@ class operation_tracker : public component {
       const uint64_t &collection_id, const std::string &key, const std::string &value,
       wt_timestamp_t ts, scoped_cursor &op_track_cursor);
 
-    private:
+private:
     scoped_session _session;
     scoped_session _sweep_session;
     scoped_cursor _schema_track_cursor;

--- a/test/cppsuite/src/component/statistics/cache_limit.h
+++ b/test/cppsuite/src/component/statistics/cache_limit.h
@@ -38,14 +38,14 @@
 namespace test_harness {
 
 class cache_limit : public statistics {
-    public:
+public:
     cache_limit(configuration &config, const std::string &name);
     virtual ~cache_limit() = default;
 
     void check(scoped_cursor &cursor) override final;
     std::string get_value_str(scoped_cursor &cursor) override final;
 
-    private:
+private:
     double get_cache_value(scoped_cursor &cursor);
 };
 } // namespace test_harness

--- a/test/cppsuite/src/component/statistics/database_size.h
+++ b/test/cppsuite/src/component/statistics/database_size.h
@@ -38,7 +38,7 @@
 namespace test_harness {
 
 class database_size : public statistics {
-    public:
+public:
     database_size(configuration &config, const std::string &name, database &database);
     virtual ~database_size() = default;
 
@@ -46,11 +46,11 @@ class database_size : public statistics {
     void check(scoped_cursor &) override final;
     std::string get_value_str(scoped_cursor &) override final;
 
-    private:
+private:
     size_t get_db_size() const;
     const std::vector<std::string> get_file_names() const;
 
-    private:
+private:
     database &_database;
 };
 } // namespace test_harness

--- a/test/cppsuite/src/component/statistics/statistics.h
+++ b/test/cppsuite/src/component/statistics/statistics.h
@@ -37,7 +37,7 @@
 namespace test_harness {
 
 class statistics {
-    public:
+public:
     statistics() = default;
     statistics(configuration &config, const std::string &stat_name, int stat_field);
     virtual ~statistics() = default;
@@ -57,7 +57,7 @@ class statistics {
     bool get_runtime() const;
     bool get_save() const;
 
-    protected:
+protected:
     int field;
     int64_t max;
     int64_t min;

--- a/test/cppsuite/src/component/timestamp_manager.h
+++ b/test/cppsuite/src/component/timestamp_manager.h
@@ -46,10 +46,10 @@ namespace test_harness {
  * The last 32 bits represent an increment for uniqueness.
  */
 class timestamp_manager : public component {
-    public:
+public:
     static const std::string decimal_to_hex(uint64_t value);
 
-    public:
+public:
     explicit timestamp_manager(configuration *config);
     virtual ~timestamp_manager() = default;
 
@@ -74,11 +74,11 @@ class timestamp_manager : public component {
      */
     wt_timestamp_t get_valid_read_ts() const;
 
-    private:
+private:
     /* Get the current time in seconds, bit shifted to the expected location. */
     uint64_t get_time_now_s() const;
 
-    private:
+private:
     std::atomic<wt_timestamp_t> _increment_ts{0};
     /* The tracking table sweep needs to read the oldest timestamp. */
     std::atomic<wt_timestamp_t> _oldest_ts{0U};

--- a/test/cppsuite/src/component/workload_manager.h
+++ b/test/cppsuite/src/component/workload_manager.h
@@ -41,7 +41,7 @@ namespace test_harness {
  * Class that can execute operations based on a given configuration.
  */
 class workload_manager : public component {
-    public:
+public:
     workload_manager(configuration *configuration, database_operation *db_operation,
       timestamp_manager *timestamp_manager, database &database);
 
@@ -61,7 +61,7 @@ class workload_manager : public component {
     /* Set the tracking component. */
     void set_operation_tracker(operation_tracker *op_tracker);
 
-    private:
+private:
     database &_database;
     database_operation *_database_operation = nullptr;
     thread_manager _thread_manager;

--- a/test/cppsuite/src/main/collection.h
+++ b/test/cppsuite/src/main/collection.h
@@ -36,7 +36,7 @@ namespace test_harness {
 
 /* A collection is made of mapped key value objects. */
 class collection {
-    public:
+public:
     collection(const uint64_t id, const uint64_t key_count, const std::string &name);
 
     /* Copies aren't allowed. */
@@ -60,11 +60,11 @@ class collection {
      */
     void increase_key_count(uint64_t increment);
 
-    public:
+public:
     const std::string name;
     const uint64_t id;
 
-    private:
+private:
     std::atomic<uint64_t> _key_count{0};
 };
 } // namespace test_harness

--- a/test/cppsuite/src/main/configuration.h
+++ b/test/cppsuite/src/main/configuration.h
@@ -57,7 +57,7 @@ split_string(const std::string &str, const char delim)
 }
 
 class configuration {
-    public:
+public:
     configuration(const std::string &test_config_name, const std::string &config);
     explicit configuration(const WT_CONFIG_ITEM &nested);
 
@@ -85,7 +85,7 @@ class configuration {
     /* Get the sleep time from the configuration in ms. */
     uint64_t get_throttle_ms();
 
-    private:
+private:
     enum class types { BOOL, INT, LIST, STRING, STRUCT };
 
     template <typename T>
@@ -106,7 +106,7 @@ class configuration {
     static bool comparator(
       std::pair<std::string, std::string> a, std::pair<std::string, std::string> b);
 
-    private:
+private:
     std::string _config;
     WT_CONFIG_PARSER *_config_parser = nullptr;
 };

--- a/test/cppsuite/src/main/database.h
+++ b/test/cppsuite/src/main/database.h
@@ -42,10 +42,10 @@ typedef std::string key_value_t;
 
 /* Representation of the collections in memory. */
 class database {
-    public:
+public:
     static std::string build_collection_name(const uint64_t id);
 
-    public:
+public:
     /*
      * Add a new collection, this will create the underlying collection in the database.
      */
@@ -71,7 +71,7 @@ class database {
     void set_operation_tracker(operation_tracker *op_tracker);
     void set_create_config(bool use_compression, bool use_reverse_collator);
 
-    private:
+private:
     std::string _collection_create_config = "";
     scoped_session _session;
     timestamp_manager *_tsm = nullptr;

--- a/test/cppsuite/src/main/database_operation.h
+++ b/test/cppsuite/src/main/database_operation.h
@@ -34,7 +34,7 @@
 
 namespace test_harness {
 class database_operation {
-    public:
+public:
     /*
      * Function that performs the following steps using the configuration that is defined by the
      * test:

--- a/test/cppsuite/src/main/operation_configuration.h
+++ b/test/cppsuite/src/main/operation_configuration.h
@@ -40,13 +40,13 @@ namespace test_harness {
  * Helper class to enable scalable operation types in the database_operation.
  */
 class operation_configuration {
-    public:
+public:
     operation_configuration(configuration *config, thread_type type);
 
     /* Returns a function pointer to the member function of the supplied database operation. */
     std::function<void(thread_worker *)> get_func(database_operation *dbo);
 
-    public:
+public:
     configuration *config;
     const thread_type type;
     const int64_t thread_count;

--- a/test/cppsuite/src/main/test.h
+++ b/test/cppsuite/src/main/test.h
@@ -48,7 +48,7 @@ struct test_args {
  * The base class for a test, the standard usage pattern is to just call run().
  */
 class test : public database_operation {
-    public:
+public:
     explicit test(const test_args &args);
     virtual ~test();
 
@@ -64,13 +64,13 @@ class test : public database_operation {
      */
     virtual void run();
 
-    protected:
+protected:
     const test_args &_args;
     configuration *_config;
     timestamp_manager *_timestamp_manager = nullptr;
     operation_tracker *_operation_tracker = nullptr;
 
-    private:
+private:
     std::vector<component *> _components;
     metrics_monitor *_metrics_monitor = nullptr;
     thread_manager *_thread_manager = nullptr;

--- a/test/cppsuite/src/main/thread_worker.h
+++ b/test/cppsuite/src/main/thread_worker.h
@@ -49,7 +49,7 @@ const std::string type_string(thread_type type);
 
 /* Container class for a thread and any data types it may need to interact with the database. */
 class thread_worker {
-    public:
+public:
     thread_worker(uint64_t id, thread_type type, configuration *config,
       scoped_session &&created_session, timestamp_manager *timestamp_manager,
       operation_tracker *op_tracker, database &dbase);
@@ -103,7 +103,7 @@ class thread_worker {
     bool running() const;
     void sync();
 
-    public:
+public:
     const int64_t collection_count;
     const int64_t key_count;
     const int64_t key_size;
@@ -119,7 +119,7 @@ class thread_worker {
     transaction txn;
     operation_tracker *op_tracker;
 
-    private:
+private:
     std::shared_ptr<barrier> _barrier = nullptr;
     bool _running = true;
     uint64_t _sleep_time_ms = 1000;

--- a/test/cppsuite/src/main/transaction.h
+++ b/test/cppsuite/src/main/transaction.h
@@ -41,7 +41,7 @@ extern "C" {
 namespace test_harness {
 
 class transaction {
-    public:
+public:
     transaction(configuration *config, timestamp_manager *timestamp_manager, WT_SESSION *session);
 
     bool active() const;
@@ -69,7 +69,7 @@ class transaction {
     /* Get the number of operations this transaction needs before it can commit */
     int64_t get_target_op_count() const;
 
-    private:
+private:
     bool _in_txn = false;
     bool _needs_rollback = false;
 

--- a/test/cppsuite/src/main/validator.h
+++ b/test/cppsuite/src/main/validator.h
@@ -45,7 +45,7 @@ struct key_state {
 typedef std::map<key_value_t, key_state> validation_collection;
 /* Class that defines a basic validation algorithm. */
 class validator {
-    public:
+public:
     /*
      * Validate the on disk data against what has been tracked during the test. This is done by
      * replaying the tracked operations so a representation in memory of the collections is created.
@@ -57,7 +57,7 @@ class validator {
     void validate(
       const std::string &operation_table_name, const std::string &schema_table_name, database &db);
 
-    private:
+private:
     /*
      * Read the tracking table to retrieve the created and deleted collections during the test.
      * collection_name: collection that contains the operations on the different collections during

--- a/test/cppsuite/src/storage/connection_manager.h
+++ b/test/cppsuite/src/storage/connection_manager.h
@@ -47,10 +47,10 @@ namespace test_harness {
  * required connection API calls.
  */
 class connection_manager {
-    public:
+public:
     static connection_manager &instance();
 
-    public:
+public:
     /* No copies of the singleton allowed. */
     connection_manager(connection_manager const &) = delete;
     connection_manager &operator=(connection_manager const &) = delete;
@@ -67,10 +67,10 @@ class connection_manager {
      */
     void set_timestamp(const std::string &config);
 
-    private:
+private:
     connection_manager();
 
-    private:
+private:
     WT_CONNECTION *_conn = nullptr;
     std::mutex _conn_mutex;
 };

--- a/test/cppsuite/src/storage/scoped_cursor.h
+++ b/test/cppsuite/src/storage/scoped_cursor.h
@@ -45,7 +45,7 @@ extern "C" {
 
 namespace test_harness {
 class scoped_cursor {
-    public:
+public:
     scoped_cursor() = default;
     scoped_cursor(WT_SESSION *session, const std::string &uri, const std::string &cfg);
 
@@ -65,7 +65,7 @@ class scoped_cursor {
 
     WT_CURSOR *get();
 
-    private:
+private:
     WT_CURSOR *_cursor = nullptr;
 };
 } // namespace test_harness

--- a/test/cppsuite/src/storage/scoped_session.h
+++ b/test/cppsuite/src/storage/scoped_session.h
@@ -47,7 +47,7 @@ extern "C" {
 
 namespace test_harness {
 class scoped_session {
-    public:
+public:
     scoped_session() = default;
     explicit scoped_session(WT_CONNECTION *conn);
 
@@ -74,7 +74,7 @@ class scoped_session {
 
     scoped_cursor open_scoped_cursor(const std::string &uri, const std::string &cfg = "");
 
-    private:
+private:
     WT_SESSION *_session = nullptr;
 };
 

--- a/test/cppsuite/src/util/barrier.h
+++ b/test/cppsuite/src/util/barrier.h
@@ -41,14 +41,14 @@ namespace test_harness {
  * called wait() they will exit the wait() and continue.
  */
 class barrier {
-    public:
+public:
     /* Mutexes have a deleted copy constructor so we need to as well. */
     barrier(barrier const &) = delete;
     ~barrier() = default;
     explicit barrier(std::size_t thread_count);
     void wait();
 
-    private:
+private:
     std::mutex _mutex;
     std::condition_variable _cond;
     std::size_t _threshold;

--- a/test/cppsuite/src/util/execution_timer.h
+++ b/test/cppsuite/src/util/execution_timer.h
@@ -38,7 +38,7 @@ namespace test_harness {
  * statistics writer when destroyed.
  */
 class execution_timer {
-    public:
+public:
     execution_timer(const std::string id, const std::string &test_name);
     virtual ~execution_timer();
 
@@ -51,7 +51,7 @@ class execution_timer {
      */
     template <typename T> auto track(T lambda);
 
-    private:
+private:
     std::string _id;
     std::string _test_name;
     int _it_count;

--- a/test/cppsuite/tests/bounded_cursor_perf.cpp
+++ b/test/cppsuite/tests/bounded_cursor_perf.cpp
@@ -37,7 +37,7 @@ using namespace test_harness;
  * taken is added to the perf file. The test traverses all keys in the collection.
  */
 class bounded_cursor_perf : public test {
-    public:
+public:
     bounded_cursor_perf(const test_args &args) : test(args)
     {
         init_operation_tracker();

--- a/test/cppsuite/tests/bounded_cursor_prefix_indices.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_indices.cpp
@@ -47,7 +47,7 @@ class bounded_cursor_prefix_indices : public test {
     std::vector<std::vector<std::string>> prefixes_map;
     const std::string ALPHABET{"abcdefghijklmnopqrstuvwxyz"};
 
-    public:
+public:
     bounded_cursor_prefix_indices(const test_args &args) : test(args)
     {
         init_operation_tracker();

--- a/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
@@ -42,7 +42,7 @@ using namespace test_harness;
  * Each search_near call with bounds enabled is verified using the default search_near.
  */
 class bounded_cursor_prefix_search_near : public test {
-    public:
+public:
     bounded_cursor_prefix_search_near(const test_args &args) : test(args)
     {
         init_operation_tracker();
@@ -220,7 +220,7 @@ class bounded_cursor_prefix_search_near : public test {
         tc->txn.try_rollback();
     }
 
-    private:
+private:
     /* Validate bounded search_near call outputs using a cursor without bounds key enabled. */
     void
     validate_prefix_search_near(int ret_prefix, int exact_prefix, const std::string &key_prefix,

--- a/test/cppsuite/tests/bounded_cursor_prefix_stat.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_stat.cpp
@@ -102,7 +102,7 @@ class bounded_cursor_prefix_stat : public test {
         }
     }
 
-    public:
+public:
     bounded_cursor_prefix_stat(const test_args &args) : test(args)
     {
         init_operation_tracker();

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -49,12 +49,12 @@ using namespace test_harness;
  */
 class bounded_cursor_stress : public test {
     /* Class helper to represent the lower and uppers bounds for the range cursor. */
-    private:
+private:
     bool _reverse_collator_enabled = false;
     const uint64_t MAX_ROLLBACKS = 100;
     enum class bound_action { NO_BOUNDS, LOWER_BOUND_SET, UPPER_BOUND_SET, ALL_BOUNDS_SET };
 
-    public:
+public:
     bounded_cursor_stress(const test_args &args) : test(args)
     {
         /* Track reverse_collator value as it is required for the custom comparator. */

--- a/test/cppsuite/tests/burst_inserts.cpp
+++ b/test/cppsuite/tests/burst_inserts.cpp
@@ -36,7 +36,7 @@ using namespace test_harness;
  * mongod instance loading a large amount of data over a long period of time.
  */
 class burst_inserts : public test {
-    public:
+public:
     burst_inserts(const test_args &args) : test(args)
     {
         _burst_duration = _config->get_int("burst_duration");
@@ -149,6 +149,6 @@ class burst_inserts : public test {
         tc->txn.try_rollback();
     }
 
-    private:
+private:
     int _burst_duration = 0;
 };

--- a/test/cppsuite/tests/cache_resize.cpp
+++ b/test/cppsuite/tests/cache_resize.cpp
@@ -37,7 +37,7 @@ using namespace test_harness;
 /* Defines what data is written to the tracking table for use in custom validation. */
 class operation_tracker_cache_resize : public operation_tracker {
 
-    public:
+public:
     operation_tracker_cache_resize(
       configuration *config, const bool use_compression, timestamp_manager &tsm)
         : operation_tracker(config, use_compression, tsm)
@@ -70,7 +70,7 @@ class operation_tracker_cache_resize : public operation_tracker {
  * be allowed.
  */
 class cache_resize : public test {
-    public:
+public:
     cache_resize(const test_args &args) : test(args)
     {
         init_operation_tracker(

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -41,7 +41,7 @@ using namespace test_harness;
  * This is then tracked using the associated statistic which can be found in the metrics_monitor.
  */
 class hs_cleanup : public test {
-    public:
+public:
     hs_cleanup(const test_args &args) : test(args)
     {
         init_operation_tracker();

--- a/test/cppsuite/tests/operations_test.cpp
+++ b/test/cppsuite/tests/operations_test.cpp
@@ -37,7 +37,7 @@ using namespace test_harness;
  * Can be used to create stress tests in various ways.
  */
 class operations_test : public test {
-    public:
+public:
     operations_test(const test_args &args) : test(args)
     {
         init_operation_tracker();

--- a/test/cppsuite/tests/reverse_split.cpp
+++ b/test/cppsuite/tests/reverse_split.cpp
@@ -37,7 +37,7 @@ namespace test_harness {
  * added at the end of the tree. This means the test frequently executes the reverse split path.
  */
 class reverse_split : public test {
-    public:
+public:
     reverse_split(test_args &args) : test(args)
     {
         /*

--- a/test/cppsuite/tests/test_template.cpp
+++ b/test/cppsuite/tests/test_template.cpp
@@ -34,7 +34,7 @@ namespace test_harness {
 /* Defines what data is written to the tracking table for use in custom validation. */
 class operation_tracker_template : public operation_tracker {
 
-    public:
+public:
     operation_tracker_template(
       configuration *config, const bool use_compression, timestamp_manager &tsm)
         : operation_tracker(config, use_compression, tsm)
@@ -57,7 +57,7 @@ class operation_tracker_template : public operation_tracker {
  * can be overridden and customized.
  */
 class test_template : public test {
-    public:
+public:
     test_template(const test_args &args) : test(args)
     {
         init_operation_tracker(

--- a/test/simulator/timestamp/call_log_manager/call_log_manager.h
+++ b/test/simulator/timestamp/call_log_manager/call_log_manager.h
@@ -48,16 +48,16 @@ enum class api_method {
 
 class call_log_manager {
     /* Methods */
-    public:
+public:
     call_log_manager(const std::string &);
     void process_call_log();
 
-    private:
+private:
     void process_call_log_entry(const json &);
     void api_map_setup();
     session_simulator *get_session(const std::string &);
 
-    private:
+private:
     void call_log_begin_transaction(const json &);
     void call_log_close_session(const json &);
     void call_log_commit_transaction(const json &);
@@ -70,7 +70,7 @@ class call_log_manager {
     void call_log_timestamp_transaction_uint(const json &);
 
     /* Member variables */
-    private:
+private:
     connection_simulator *_conn;
     json _call_log;
     std::map<std::string, api_method> _api_map;

--- a/test/simulator/timestamp/src/include/connection_simulator.h
+++ b/test/simulator/timestamp/src/include/connection_simulator.h
@@ -37,7 +37,7 @@
 /* The connection simulator is a Singleton class. */
 class connection_simulator {
     /* Methods */
-    public:
+public:
     static connection_simulator &get_connection();
     session_simulator *open_session();
     void close_session(session_simulator *);
@@ -52,21 +52,21 @@ class connection_simulator {
     int query_timestamp(const std::string &, std::string &, bool &);
     ~connection_simulator();
 
-    private:
+private:
     int decode_timestamp_config_map(std::map<std::string, std::string> &, uint64_t &, uint64_t &,
       uint64_t &, bool &, bool &, bool &, bool &);
 
     /* No copies of the singleton allowed. */
-    private:
+private:
     connection_simulator();
 
-    public:
+public:
     /* Deleted functions should generally be public as it results in better error messages. */
     connection_simulator(connection_simulator const &) = delete;
     connection_simulator &operator=(connection_simulator const &) = delete;
 
     /* Member variables */
-    private:
+private:
     std::vector<session_simulator *> _session_list;
     uint64_t _oldest_ts;
     uint64_t _stable_ts;

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -33,12 +33,12 @@
 
 class session_simulator {
     /* Methods */
-    public:
+public:
     session_simulator();
     ~session_simulator() = default;
 
     /* API functions */
-    public:
+public:
     int begin_transaction(const std::string & = "");
     int rollback_transaction(const std::string & = "");
     int prepare_transaction(const std::string & = "");
@@ -48,7 +48,7 @@ class session_simulator {
     int query_timestamp(const std::string &, std::string &);
 
     /* Transaction relevant functions. */
-    public:
+public:
     uint64_t get_commit_timestamp() const;
     uint64_t get_durable_timestamp() const;
     uint64_t get_first_commit_timestamp() const;
@@ -64,7 +64,7 @@ class session_simulator {
     bool is_txn_prepared() const;
     bool is_txn_running() const;
 
-    private:
+private:
     int decode_timestamp_config_map(
       std::map<std::string, std::string> &, uint64_t &, uint64_t &, uint64_t &, uint64_t &);
     int set_commit_timestamp(uint64_t);
@@ -73,13 +73,13 @@ class session_simulator {
     int set_read_timestamp(uint64_t);
     void reset_txn_level_var();
 
-    public:
+public:
     /* Deleted functions should generally be public as it results in better error messages. */
     session_simulator(session_simulator const &) = delete;
     session_simulator &operator=(session_simulator const &) = delete;
 
     /* Transaction relevant member variables */
-    private:
+private:
     bool _has_commit_ts;
     bool _ts_round_prepared;
     bool _ts_round_read;

--- a/test/simulator/timestamp/src/include/timestamp_manager.h
+++ b/test/simulator/timestamp/src/include/timestamp_manager.h
@@ -37,7 +37,7 @@
 /* Timestamp is a global singleton class responsible for validating the timestamps. */
 class timestamp_manager {
     /* Methods */
-    public:
+public:
     static timestamp_manager &get_timestamp_manager();
     int parse_config(const std::string &, const std::vector<std::string> &,
       const std::vector<std::string> &, std::map<std::string, std::string> &);
@@ -46,7 +46,7 @@ class timestamp_manager {
     int validate_hex_value(const std::string &, const std::string &);
 
     /* Methods for validating timestamps */
-    public:
+public:
     int validate_oldest_and_stable_timestamp(uint64_t &, uint64_t &, bool &, bool &);
     int validate_conn_durable_timestamp(const uint64_t &, const bool &) const;
     int validate_read_timestamp(session_simulator *, const uint64_t) const;
@@ -54,14 +54,14 @@ class timestamp_manager {
     int validate_prepare_timestamp(session_simulator *, uint64_t) const;
     int validate_session_durable_timestamp(session_simulator *, uint64_t);
 
-    private:
+private:
     std::string trim(std::string);
 
     /* No copies of the singleton allowed. */
-    private:
+private:
     timestamp_manager();
 
-    public:
+public:
     timestamp_manager(timestamp_manager const &) = delete;
     timestamp_manager &operator=(timestamp_manager const &) = delete;
 };

--- a/test/unittest/tests/test_tailq.cpp
+++ b/test/unittest/tests/test_tailq.cpp
@@ -17,7 +17,7 @@ template <class T> struct tailq_entry {
 };
 
 template <class T> class TestTailQWrapper {
-    public:
+public:
     TestTailQWrapper();
     ~TestTailQWrapper();
     void pushBack(T const &value);
@@ -25,7 +25,7 @@ template <class T> class TestTailQWrapper {
     void removeValue(T const &value);
     std::list<T> copyItemsFromTailQ();
 
-    private:
+private:
     TAILQ_HEAD(, tailq_entry<T>) _tailq;
 };
 

--- a/test/unittest/tests/wrappers/block_mods.h
+++ b/test/unittest/tests/wrappers/block_mods.h
@@ -12,7 +12,7 @@
 #include "wt_internal.h"
 
 class BlockMods {
-    public:
+public:
     BlockMods();
     ~BlockMods();
     WT_BLOCK_MODS *
@@ -21,7 +21,7 @@ class BlockMods {
         return &_block_mods;
     };
 
-    private:
+private:
     void initBlockMods();
     WT_BLOCK_MODS _block_mods;
 };

--- a/test/unittest/tests/wrappers/connection_wrapper.h
+++ b/test/unittest/tests/wrappers/connection_wrapper.h
@@ -23,7 +23,7 @@
  * also need to be removed.
  */
 class ConnectionWrapper {
-    public:
+public:
     ConnectionWrapper(const std::string &db_home, const char *cfg_str = "create");
     ~ConnectionWrapper();
 
@@ -37,7 +37,7 @@ class ConnectionWrapper {
     WT_CONNECTION_IMPL *getWtConnectionImpl() const;
     WT_CONNECTION *getWtConnection() const;
 
-    private:
+private:
     WT_CONNECTION_IMPL *_conn_impl;
     WT_CONNECTION *_conn;
     std::string _db_home;

--- a/test/unittest/tests/wrappers/item_wrapper.h
+++ b/test/unittest/tests/wrappers/item_wrapper.h
@@ -11,7 +11,7 @@
 #include <string>
 
 class item_wrapper {
-    public:
+public:
     explicit item_wrapper(const char *string);
     ~item_wrapper();
     WT_ITEM *
@@ -20,7 +20,7 @@ class item_wrapper {
         return &_item;
     };
 
-    private:
+private:
     WT_ITEM _item;
     std::string _string;
 };

--- a/test/unittest/tests/wrappers/mock_connection.h
+++ b/test/unittest/tests/wrappers/mock_connection.h
@@ -18,7 +18,7 @@
  * will write a bunch of files to disk during the test, which also need to be removed.
  */
 class MockConnection {
-    public:
+public:
     ~MockConnection();
     WT_CONNECTION_IMPL *
     getWtConnectionImpl()
@@ -33,7 +33,7 @@ class MockConnection {
 
     static std::shared_ptr<MockConnection> buildTestMockConnection();
 
-    private:
+private:
     explicit MockConnection(WT_CONNECTION_IMPL *connectionImpl);
 
     // This class is implemented such that it owns, and is responsible for freeing,

--- a/test/unittest/tests/wrappers/mock_session.h
+++ b/test/unittest/tests/wrappers/mock_session.h
@@ -14,7 +14,7 @@
 #include "mock_connection.h"
 
 class MockSession {
-    public:
+public:
     ~MockSession();
     WT_SESSION_IMPL *
     getWtSessionImpl()
@@ -24,7 +24,7 @@ class MockSession {
 
     static std::shared_ptr<MockSession> buildTestMockSession();
 
-    private:
+private:
     explicit MockSession(
       WT_SESSION_IMPL *sessionImpl, std::shared_ptr<MockConnection> mockConnection = nullptr);
 

--- a/tools/memory-model-test/README.md
+++ b/tools/memory-model-test/README.md
@@ -46,6 +46,7 @@ There are two options:
 - Use the CMakeLists.txt file with CMake:
   ```
   mkdir build
+  cd build
   cmake -G Ninja ../.
   ninja
   ```

--- a/tools/memory-model-test/memory_model_test.cpp
+++ b/tools/memory-model-test/memory_model_test.cpp
@@ -21,7 +21,7 @@
 
 #ifdef AVOID_CPP20_SEMAPHORE
 #include "basic_semaphore.h"
-using  binary_semaphore = basic_semaphore;
+using binary_semaphore = basic_semaphore;
 const std::string binary_semaphore_version = "basic_semaphore";
 #else
 #include <semaphore>
@@ -57,7 +57,7 @@ thread_function(std::string const &thread_name, binary_semaphore &start_semaphor
 
 template <typename thread_1_code_t, typename thread_2_code_t, typename out_of_order_check_code_t>
 class test_config {
-    public:
+public:
     test_config(std::string test_name, std::string test_description, thread_1_code_t thread_1_code,
       thread_2_code_t thread_2_code, out_of_order_check_code_t out_of_order_check_code,
       bool out_of_order_allowed)
@@ -79,9 +79,9 @@ class test_config {
 template <typename thread_1_code, typename thread_2_code, typename out_of_order_check_code>
 void
 perform_test(test_config<thread_1_code, thread_2_code, out_of_order_check_code> config, int &x,
-  int &y, int &r1, int &r2, binary_semaphore &start_semaphore1,
-  binary_semaphore &start_semaphore2, binary_semaphore &end_semaphore1,
-  binary_semaphore &end_semaphore2, std::ostream &ostream, int loop_count, bool progress)
+  int &y, int &r1, int &r2, binary_semaphore &start_semaphore1, binary_semaphore &start_semaphore2,
+  binary_semaphore &end_semaphore1, binary_semaphore &end_semaphore2, std::ostream &ostream,
+  int loop_count, bool progress)
 {
     ostream << "Test name:        " << config._test_name << std::endl;
     ostream << "Test description: " << config._test_description << std::endl;
@@ -398,8 +398,8 @@ main(int argc, char *argv[])
         }
     }
 
-    std::cout << "C++ language standard: " << __cplusplus << ", with binary_semaphore: " << binary_semaphore_version
-              << std::endl;
+    std::cout << "C++ language standard: " << __cplusplus
+              << ", with binary_semaphore: " << binary_semaphore_version << std::endl;
 
     if (is_arm64)
         std::cout << "Running on ARM64";


### PR DESCRIPTION
I changed .clang-format so that the C++ access modifies are not indented and ran clang-format on all relevant files. Note that this resulted in a few other small changes to `memory-model-test`.

I also modified `memory-model-test`'s README to include a missing command in the build instructions. Please let me know if I need to do it in a separate ticket, as this change was, strictly speaking, outside of the original scope for this ticket.