### PR TITLE
WT-10755 Modify timestamp_abort to do more work after recovery

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -97,7 +97,7 @@ static const char *const ckpt_file = "checkpoint_done";
 
 static bool backup_verify_quick, backup_verify_throughout;
 static bool columns, stress, use_backups, use_lazyfs, use_ts;
-static uint32_t backup_granularity_kb;
+static uint32_t backup_full_interval, backup_granularity_kb;
 
 static TEST_OPTS *opts, _opts;
 
@@ -146,10 +146,15 @@ extern char *__wt_optarg;
  * sometimes want the durable timestamp ahead of the commit timestamp, so we reserve the last
  * timestamp for that use.
  */
-#define RESERVED_TIMESTAMPS_FOR_ITERATION(td, iter) (((iter)*nth + (td)->threadnum) * 3 + 1)
+#define RESERVED_TIMESTAMPS_FOR_ITERATION(td, iter) \
+    ((uint64_t)WT_BILLION * (td)->workload_iteration + ((iter)*nth + (td)->threadnum) * 3 + 1)
 
 /* The index of a backup. */
-#define BACKUP_INDEX(td, sequence_number) (sequence_number)
+#define BACKUP_INDEX(td, sequence_number) \
+    ((td)->workload_iteration * WT_THOUSAND + (sequence_number))
+
+/* Get back the sequence number from a backup index. */
+#define BACKUP_INDEX_TO_SEQUENCE(index) ((index) % WT_THOUSAND)
 
 typedef struct {
     uint64_t absent_key; /* Last absent key */
@@ -163,6 +168,7 @@ typedef struct {
     WT_CONNECTION *conn;
     uint64_t start;
     uint32_t threadnum;
+    uint32_t workload_iteration;
     WT_RAND_STATE data_rnd;
     WT_RAND_STATE extra_rnd;
 } THREAD_DATA;
@@ -291,7 +297,10 @@ handle_general(WT_EVENT_HANDLER *handler, WT_CONNECTION *conn, WT_SESSION *sessi
 static void
 usage(void)
 {
-    fprintf(stderr, "usage: %s %s [-T threads] [-t time] [-BCcLlsvz]\n", progname, opts->usage);
+    fprintf(stderr,
+      "usage: %s %s [-F full-backup-interval] [-I iterations] [-T threads] [-t time] "
+      "[-BCcLlsvz]\n",
+      progname, opts->usage);
     exit(EXIT_FAILURE);
 }
 
@@ -392,7 +401,8 @@ backup_create_full(WT_CONNECTION *conn, bool consolidate, uint32_t index)
 
     nfiles = 0;
 
-    printf("Create full backup %" PRIu32 " - start: consolidate=%d\n", index, consolidate);
+    printf("Create full backup %" PRIu32 " - start: consolidate=%d, granularity=%" PRIu32 "KB\n",
+      index, consolidate, backup_granularity_kb);
 
     /* Prepare the directory. */
     testutil_check(__wt_snprintf(backup_home, sizeof(backup_home), BACKUP_BASE "%" PRIu32, index));
@@ -702,15 +712,53 @@ thread_ckpt_run(void *arg)
 static WT_THREAD_RET
 thread_backup_run(void *arg)
 {
+    struct stat sb;
     THREAD_DATA *td;
+    WT_CURSOR *cursor;
     WT_SESSION *session;
-    uint32_t last_backup, last_full, sleep_time, u;
-    int i;
+    uint32_t i, last_backup, last_full, sleep_time, u;
+    int ret;
+    char buf[1024];
+    char *str;
 
     td = (THREAD_DATA *)arg;
     last_backup = last_full = 0;
 
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
+
+    /*
+     * Find the last successful backup.
+     */
+    if (td->workload_iteration > 0) {
+        testutil_check(session->open_cursor(session, "backup:query_id", NULL, NULL, &cursor));
+        while ((ret = cursor->next(cursor)) == 0) {
+            testutil_check(cursor->get_key(cursor, &str));
+            testutil_assert(strncmp(str, "ID", 2) == 0);
+            u = (uint32_t)atoi(str + 2);
+
+            /* Check whether the backup has indeed completed. */
+            testutil_check(__wt_snprintf(buf, sizeof(buf), BACKUP_BASE "%" PRIu32 "/done", u));
+            if (stat(buf, &sb) != 0) {
+                testutil_assert_errno(errno == ENOENT);
+                printf("Found backup %" PRIu32 ", but it is not complete\n", u);
+                continue;
+            }
+
+            printf("Found backup %" PRIu32 "\n", u);
+            if (u > last_backup)
+                last_backup = u;
+
+            /* Is it a full backup? */
+            if (u == 1 ||
+              (backup_full_interval > 0 &&
+                BACKUP_INDEX_TO_SEQUENCE(u) % backup_full_interval == 0)) {
+                if (u > last_full)
+                    last_full = u;
+            }
+        }
+        testutil_assert(ret == WT_NOTFOUND);
+        testutil_check(cursor->close(cursor));
+    }
 
     /*
      * Create backups until we get killed.
@@ -720,8 +768,8 @@ thread_backup_run(void *arg)
         __wt_sleep(sleep_time, 0);
 
         /* Create a backup. */
-        u = BACKUP_INDEX(td, (uint32_t)i);
-        if (last_backup == 0 || i % 4 == 0) {
+        u = BACKUP_INDEX(td, i);
+        if (last_backup == 0 || (backup_full_interval > 0 && i % backup_full_interval == 0)) {
             backup_create_full(td->conn, __wt_random(&td->extra_rnd) % 2, u);
             last_full = u;
         } else
@@ -955,16 +1003,18 @@ rollback:
  *     Initialize the thread data struct.
  */
 static void
-init_thread_data(THREAD_DATA *td, WT_CONNECTION *conn, uint64_t start, uint32_t threadnum)
+init_thread_data(THREAD_DATA *td, WT_CONNECTION *conn, uint64_t start, uint32_t threadnum,
+  uint32_t workload_iteration)
 {
     td->conn = conn;
     td->start = start;
     td->threadnum = threadnum;
+    td->workload_iteration = workload_iteration;
     testutil_random_from_random(&td->data_rnd, &opts->data_rnd);
     testutil_random_from_random(&td->extra_rnd, &opts->extra_rnd);
 }
 
-static void run_workload(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
+static void run_workload(uint32_t) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
 /*
  * run_workload --
@@ -972,7 +1022,7 @@ static void run_workload(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
  *     until it is killed by the parent.
  */
 static void
-run_workload(void)
+run_workload(uint32_t workload_iteration)
 {
     WT_CONNECTION *conn;
     WT_SESSION *session;
@@ -1020,23 +1070,25 @@ run_workload(void)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
     /*
-     * Create all the tables.
+     * Create all the tables on the first iteration.
      */
-    if (columns) {
-        table_config_nolog = "key_format=r,value_format=u,log=(enabled=false)";
-        table_config = "key_format=r,value_format=u";
-    } else {
-        table_config_nolog = "key_format=S,value_format=u,log=(enabled=false)";
-        table_config = "key_format=S,value_format=u";
+    if (workload_iteration == 0) {
+        if (columns) {
+            table_config_nolog = "key_format=r,value_format=u,log=(enabled=false)";
+            table_config = "key_format=r,value_format=u";
+        } else {
+            table_config_nolog = "key_format=S,value_format=u,log=(enabled=false)";
+            table_config = "key_format=S,value_format=u";
+        }
+        testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_collection));
+        testutil_check(session->create(session, uri, table_config_nolog));
+        testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_shadow));
+        testutil_check(session->create(session, uri, table_config_nolog));
+        testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_local));
+        testutil_check(session->create(session, uri, table_config));
+        testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_oplog));
+        testutil_check(session->create(session, uri, table_config));
     }
-    testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_collection));
-    testutil_check(session->create(session, uri, table_config_nolog));
-    testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_shadow));
-    testutil_check(session->create(session, uri, table_config_nolog));
-    testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_local));
-    testutil_check(session->create(session, uri, table_config));
-    testutil_check(__wt_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_oplog));
-    testutil_check(session->create(session, uri, table_config));
 
     /*
      * Don't log the stable timestamp table so that we know what timestamp was stored at the
@@ -1056,27 +1108,42 @@ run_workload(void)
     /* The backup, checkpoint, timestamp, and worker threads are added at the end. */
     backup_id = nth;
     if (use_backups) {
-        init_thread_data(&td[backup_id], conn, 0, nth);
+        init_thread_data(&td[backup_id], conn, 0, nth, workload_iteration);
         printf("Create backup thread\n");
         testutil_check(
           __wt_thread_create(NULL, &thr[backup_id], thread_backup_run, &td[backup_id]));
     }
 
     ckpt_id = nth + 1;
-    init_thread_data(&td[ckpt_id], conn, 0, nth);
+    init_thread_data(&td[ckpt_id], conn, 0, nth, workload_iteration);
     printf("Create checkpoint thread\n");
     testutil_check(__wt_thread_create(NULL, &thr[ckpt_id], thread_ckpt_run, &td[ckpt_id]));
 
     ts_id = nth + 2;
     if (use_ts) {
-        init_thread_data(&td[ts_id], conn, 0, nth);
+        init_thread_data(&td[ts_id], conn, 0, nth, workload_iteration);
         printf("Create timestamp thread\n");
         testutil_check(__wt_thread_create(NULL, &thr[ts_id], thread_ts_run, &td[ts_id]));
     }
 
     printf("Create %" PRIu32 " writer threads\n", nth);
     for (i = 0; i < nth; ++i) {
-        init_thread_data(&td[i], conn, WT_BILLION * (uint64_t)i, i);
+        /*
+         * We use the following key format:
+         *
+         *    12004000000123
+         *     ^  ^        ^
+         *     |  |        |
+         *     |  |        +-- key
+         *     |  +----------- thread ID
+         *     +-------------- iteration ID
+         *
+         * This setup creates a unique key-space for each thread execution. We can accommodate one
+         * billion keys and one thousand threads for each iteration.
+         */
+        init_thread_data(&td[i], conn,
+          (uint64_t)WT_THOUSAND * WT_BILLION * workload_iteration + WT_BILLION * (uint64_t)i, i,
+          workload_iteration);
         testutil_check(__wt_thread_create(NULL, &thr[i], thread_run, &td[i]));
     }
 
@@ -1249,7 +1316,13 @@ recover_and_verify(uint32_t backup_index)
     } else {
         testutil_check(__wt_snprintf(buf, sizeof(buf), BACKUP_BASE "%" PRIu32, backup_index));
         testutil_system("rm -rf check; cp -rf %s check", buf);
-        testutil_wiredtiger_open(opts, "check", NULL, &my_event, &conn, true, false);
+        /*
+         * Open the database connection to the backup. But don't pass our event handlers, so that we
+         * don't create another statistics thread. Not only we don't need it here, but trying to
+         * create it would cause the test to abort as we currently allow only one statistics thread
+         * at a time.
+         */
+        testutil_wiredtiger_open(opts, "check", NULL, NULL, &conn, true, false);
     }
 
     /* Sleep to guarantee the statistics thread has enough time to run. */
@@ -1500,7 +1573,7 @@ main(int argc, char *argv[])
     struct stat sb;
     WT_LAZY_FS lazyfs;
     pid_t pid;
-    uint32_t rand_value, timeout;
+    uint32_t iteration, num_iterations, rand_value, timeout;
     int ch, status, ret;
     char buf[PATH_MAX], bucket[512];
     char cwd_start[PATH_MAX]; /* The working directory when we started */
@@ -1511,11 +1584,13 @@ main(int argc, char *argv[])
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
 
+    backup_full_interval = 4;
     backup_granularity_kb = 16;
-    backup_verify_quick = true;
+    backup_verify_quick = false;
     backup_verify_throughout = false;
     columns = stress = false;
     nth = MIN_TH;
+    num_iterations = 1;
     rand_th = rand_time = true;
     ret = 0;
     timeout = MIN_TIME;
@@ -1526,7 +1601,7 @@ main(int argc, char *argv[])
 
     testutil_parse_begin_opt(argc, argv, SHARED_PARSE_OPTIONS, opts);
 
-    while ((ch = __wt_getopt(progname, argc, argv, "BcLlsT:t:vz" SHARED_PARSE_OPTIONS)) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "BcF:I:LlsT:t:vz" SHARED_PARSE_OPTIONS)) != EOF)
         switch (ch) {
         case 'B':
             use_backups = true;
@@ -1534,6 +1609,14 @@ main(int argc, char *argv[])
         case 'c':
             /* Variable-length columns only (for now) */
             columns = true;
+            break;
+        case 'F':
+            backup_full_interval = (uint32_t)atoi(__wt_optarg);
+            break;
+        case 'I':
+            num_iterations = (uint32_t)atoi(__wt_optarg);
+            if (num_iterations == 0)
+                num_iterations = 1;
             break;
         case 'L':
             table_pfx = "lsm";
@@ -1640,12 +1723,12 @@ main(int argc, char *argv[])
           opts->compat ? "true" : "false", opts->inmem ? "true" : "false",
           stress ? "true" : "false", use_ts ? "true" : "false");
         printf("Parent: Create %" PRIu32 " threads; sleep %" PRIu32 " seconds\n", nth, timeout);
-        printf("CONFIG: %s%s%s%s%s%s%s%s%s -h %s -T %" PRIu32 " -t %" PRIu32
-               " " TESTUTIL_SEED_FORMAT "\n",
+        printf("CONFIG: %s%s%s%s%s%s%s%s%s -F %" PRIu32 " -h %s -I %" PRIu32 " -T %" PRIu32
+               " -t %" PRIu32 " " TESTUTIL_SEED_FORMAT "\n",
           progname, use_backups ? " -B" : "", opts->compat ? " -C" : "", columns ? " -c" : "",
           use_lazyfs ? " -l" : "", opts->inmem ? " -m" : "", opts->tiered_storage ? " -PT" : "",
-          stress ? " -s" : "", !use_ts ? " -z" : "", opts->home, nth, timeout, opts->data_seed,
-          opts->extra_seed);
+          stress ? " -s" : "", !use_ts ? " -z" : "", backup_full_interval, opts->home,
+          num_iterations, nth, timeout, opts->data_seed, opts->extra_seed);
 
         /*
          * Go inside the home directory (typically WT_TEST), but not all the way into the database's
@@ -1655,90 +1738,116 @@ main(int argc, char *argv[])
             testutil_die(errno, "parent chdir: %s", home);
 
         /*
-         * Fork a child to insert as many items. We will then randomly kill the child, run recovery
-         * and make sure all items we wrote exist after recovery runs.
+         * Create the database, run the test, and fail. Do multiple iterations to make sure that we
+         * don't only recover, but that we can also keep going, as sometimes bugs can occur during
+         * database operation following an unclean shutdown.
          */
-        testutil_assert_errno((pid = fork()) >= 0);
-        if (pid == 0) { /* child */
-            run_workload();
-            /* NOTREACHED */
+        for (iteration = 0; iteration < num_iterations; iteration++) {
+
+            if (num_iterations > 1)
+                printf("\n=== Iteration %" PRIu32 "/%" PRIu32 "\n", iteration + 1, num_iterations);
+
+            /*
+             * Fork a child to insert as many items. We will then randomly kill the child, run
+             * recovery and make sure all items we wrote exist after recovery runs.
+             */
+            testutil_assert_errno((pid = fork()) >= 0);
+            if (pid == 0) { /* child */
+                run_workload(iteration);
+                /* NOTREACHED */
+            }
+
+            /* parent */
+
+            /*
+             * Set the child death handler, but only for the parent process. Setting this before the
+             * fork has the unfortunate consequence of the handler getting called on any invocation
+             * of system(). But because we set this up after fork, we need to double-check that the
+             * child process is still running, i.e., that it did not fail already.
+             */
+            memset(&sa, 0, sizeof(sa));
+            sa.sa_handler = handler;
+            testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+
+            /* Check on the child; positive return value indicates that it has already died. */
+            testutil_assertfmt(waitpid(pid, &status, WNOHANG) == 0,
+              "Child process %" PRIu64 " already exited with status %d", pid, status);
+
+            /*
+             * Sleep for the configured amount of time before killing the child. Start the timeout
+             * from the time we notice that the file has been created. That allows the test to run
+             * correctly on really slow machines.
+             */
+            while (stat(ckpt_file, &sb) != 0)
+                testutil_sleep_wait(1, pid);
+            sleep(timeout);
+            sa.sa_handler = SIG_DFL;
+            testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+
+            /*
+             * !!! It should be plenty long enough to make sure more than
+             * one log file exists.  If wanted, that check would be added
+             * here.
+             */
+            printf("Kill child\n");
+            testutil_assert_errno(kill(pid, SIGKILL) == 0);
+            testutil_assert_errno(waitpid(pid, &status, 0) != -1);
+
+            /* We don't need the file that checks whether the checkpoint was created. */
+            testutil_assert_errno(unlink(ckpt_file) == 0);
+
+            /*
+             * !!! If we wanted to take a copy of the directory before recovery,
+             * this is the place to do it. Don't do it all the time because
+             * it can use a lot of disk space, which can cause test machine
+             * issues.
+             */
+
+            /* Copy the data to a separate folder for debugging purpose. */
+            testutil_copy_data(home);
+
+            /*
+             * Clear the cache, if we are using LazyFS. Do this after we save the data for debugging
+             * purposes, so that we can see what we might have lost. If we are using LazyFS, the
+             * underlying directory shows the state that we'd get after we clear the cache.
+             */
+            if (!verify_only && use_lazyfs)
+                testutil_lazyfs_clear_cache(&lazyfs);
+
+            /*
+             * Clean up any previous backup file. The file would be present if we happen to crash
+             * during a backup, in which case, when we recover in the next step, WiredTiger would
+             * think that we are recovering from the backup instead of from the main database
+             * location. It would ignore the turtle file, and as a side effect, we would lose the
+             * information about incremental snapshots.
+             */
+            if (use_backups) {
+                ret = unlink(WT_HOME_DIR DIR_DELIM_STR "WiredTiger.backup");
+                testutil_assert_errno(ret == 0 || errno == ENOENT);
+                if (ret == 0)
+                    printf("Deleted " WT_HOME_DIR DIR_DELIM_STR "WiredTiger.backup\n");
+            }
+
+            /*
+             * Recover and verify the database, and test all backups.
+             */
+            ret = recover_and_verify(0);
+            if (ret != EXIT_SUCCESS)
+                break;
         }
+    } else {
+        /* If we are just verifying, first recover the database and then verify. */
 
-        /* parent */
+        /* Go inside the home directory (typically WT_TEST). */
+        if (chdir(home) != 0)
+            testutil_die(errno, "parent chdir: %s", home);
 
-        /*
-         * Set the child death handler, but only for the parent process. Setting this before the
-         * fork has the unfortunate consequence of the handler getting called on any invocation of
-         * system(). But because we set this up after fork, we need to double-check that the child
-         * process is still running, i.e., that it did not fail already.
-         */
-        memset(&sa, 0, sizeof(sa));
-        sa.sa_handler = handler;
-        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+        /* Copy the data to a separate folder for debugging purpose. */
+        testutil_copy_data(home);
 
-        /* Check on the child; positive return value indicates that it has already died. */
-        testutil_assertfmt(waitpid(pid, &status, WNOHANG) == 0,
-          "Child process %" PRIu64 " already exited with status %d", pid, status);
-
-        /*
-         * Sleep for the configured amount of time before killing the child. Start the timeout from
-         * the time we notice that the file has been created. That allows the test to run correctly
-         * on really slow machines.
-         */
-        while (stat(ckpt_file, &sb) != 0)
-            testutil_sleep_wait(1, pid);
-        sleep(timeout);
-        sa.sa_handler = SIG_DFL;
-        testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
-
-        /*
-         * !!! It should be plenty long enough to make sure more than
-         * one log file exists.  If wanted, that check would be added
-         * here.
-         */
-        printf("Kill child\n");
-        testutil_assert_errno(kill(pid, SIGKILL) == 0);
-        testutil_assert_errno(waitpid(pid, &status, 0) != -1);
-
-        /* We don't need the file that checks whether the checkpoint was created. */
-        testutil_assert_errno(unlink(ckpt_file) == 0);
+        /* Now do the actual recovery and verification. */
+        ret = recover_and_verify(0);
     }
-
-    /*
-     * !!! If we wanted to take a copy of the directory before recovery,
-     * this is the place to do it. Don't do it all the time because
-     * it can use a lot of disk space, which can cause test machine
-     * issues.
-     */
-
-    /* Copy the data to a separate folder for debugging purpose. */
-    testutil_copy_data(home);
-
-    /*
-     * Clear the cache, if we are using LazyFS. Do this after we save the data for debugging
-     * purposes, so that we can see what we might have lost. If we are using LazyFS, the underlying
-     * directory shows the state that we'd get after we clear the cache.
-     */
-    if (!verify_only && use_lazyfs)
-        testutil_lazyfs_clear_cache(&lazyfs);
-
-    /*
-     * Clean up any previous backup file. The file would be present if we happen to crash during a
-     * backup, in which case, when we recover in the next step, WiredTiger would think that we are
-     * recovering from the backup instead of from the main database location. It would ignore the
-     * turtle file, and as a side effect, we would lose the information about incremental snapshots.
-     */
-    if (use_backups) {
-        ret = unlink(WT_HOME_DIR DIR_DELIM_STR "WiredTiger.backup");
-        testutil_assert_errno(ret == 0 || errno == ENOENT);
-        if (ret == 0)
-            printf("Deleted " WT_HOME_DIR DIR_DELIM_STR "WiredTiger.backup\n");
-    }
-
-    /*
-     * Recover and verify the database, and test all backups.
-     */
-    ret = recover_and_verify(0);
 
     /*
      * Clean up.


### PR DESCRIPTION
The ticket also changes the default backup verification method from quick to full.