### PR TITLE
WT-10706 Updated reverse_split test to reset cursor more often

### DIFF
--- a/test/cppsuite/tests/reverse_split.cpp
+++ b/test/cppsuite/tests/reverse_split.cpp
@@ -98,6 +98,10 @@ public:
                 logger::log_msg(LOG_WARN,
                   "thread {" + std::to_string(tc->id) + "} failed to commit truncation of " +
                     std::to_string(end_key_id - min_key_id) + " records.");
+
+            /* Reset our cursor to avoid pinning content prior to sleep and sync. */
+            testutil_check(write_cursor->reset(write_cursor.get()));
+
             tc->sleep();
             /*
              * Synchronize across our truncate threads so they don't diverge over time. This results


### PR DESCRIPTION
WT-10706 Updated reverse_split test to reset cursor used to locate the start key of truncate prior to blocking to prevent pinning content in the cache.