### PR TITLE
WT-10017 Remove the unstable historical versions at the end of rollback to stable

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -920,7 +920,7 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
      * specified timestamp must be mixed mode.
      */
     WT_ASSERT_ALWAYS(
-        session, ts == 1 || ts == WT_TS_NONE, "out-of-order timestamp update detected");
+      session, ts == 1 || ts == WT_TS_NONE, "out-of-order timestamp update detected");
     /*
      * Fail the eviction if we detect any timestamp ordering issue and the error flag is set. We
      * cannot modify the history store to fix the update's timestamps as it may make the history

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -918,12 +918,9 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     /*
      * If we find a key with a timestamp larger than or equal to the specified timestamp then the
      * specified timestamp must be mixed mode.
-     *
-     * FIXME-WT-10017: Change this back to WT_ASSERT_ALWAYS once WT-10017 is resolved. WT-10017 will
-     * resolve a known issue where this assert fires for column store configurations.
      */
-    WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
-
+    WT_ASSERT_ALWAYS(
+        session, ts == 1 || ts == WT_TS_NONE, "out-of-order timestamp update detected");
     /*
      * Fail the eviction if we detect any timestamp ordering issue and the error flag is set. We
      * cannot modify the history store to fix the update's timestamps as it may make the history

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -143,7 +143,15 @@ __wt_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_times
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 
-    if (F_ISSET(S2C(session), WT_CONN_RECOVERING))
+    /*
+     * Performing eviction in parallel to a checkpoint can lead to situation where the history store
+     * have more updates than its corresponding data store. Performing history store cleanup at the
+     * end can able to remove any such unstable updates that are written to the history store.
+     *
+     * Do not perform the final pass on the history store in an in-memory configuration as it
+     * doesn't exist.
+     */
+    if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
         WT_ERR(__wt_rts_history_final_pass(session, rollback_timestamp));
 
 err:

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -118,7 +118,8 @@ __rts_btree_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *firs
              * on-disk versions are removed while processing the on-disk entries.
              */
             for (; stable_upd != NULL; stable_upd = stable_upd->next)
-                stable_upd->txnid = WT_TXN_ABORTED;
+                if (!dryrun)
+                    stable_upd->txnid = WT_TXN_ABORTED;
         }
         if (stable_update_found != NULL)
             *stable_update_found = true;

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -107,6 +107,17 @@ __rts_btree_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *firs
                     F_CLR(stable_upd, WT_UPDATE_HS | WT_UPDATE_TO_DELETE_FROM_HS);
                 if (tombstone != NULL)
                     F_CLR(tombstone, WT_UPDATE_HS | WT_UPDATE_TO_DELETE_FROM_HS);
+            } else if (WT_IS_HS(session->dhandle) && stable_upd->type != WT_UPDATE_TOMBSTONE) {
+                /*
+                * History store will have a combination of both tombstone and update/modify types in
+                * the update list to represent time window of an update. When we are aborting the
+                * tombstone, make sure to remove all of the remaining updates also. In most of the
+                * scenarios, there will be only one update present except when the data store is a
+                * prepared commit where it is possible to have more than one update. The existing
+                * on-disk versions are removed while processing the on-disk entries.
+                */
+                for (; stable_upd != NULL; stable_upd = stable_upd->next)
+                    stable_upd->txnid = WT_TXN_ABORTED;
             }
         }
         if (stable_update_found != NULL)
@@ -150,22 +161,6 @@ __rts_btree_abort_insert_list(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT
               session, key, ins->upd, rollback_timestamp, &stable_update_found));
             if (stable_update_found && stable_updates_count != NULL)
                 (*stable_updates_count)++;
-            if (!stable_update_found && page->type == WT_PAGE_ROW_LEAF &&
-              !F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
-                /*
-                 * When a new key is added to a page and the page is then checkpointed, updates for
-                 * that key can be present in the History Store while the key isn't present in the
-                 * disk image. RTS will then only remove these updates when there is a stable update
-                 * on-chain. These updates still need removing when no stable updates are on-chain,
-                 * so do so here explicitly. Pass in rollback_timestamp + 1 as history store cleanup
-                 * removes updates inclusive of the provided timestamp, but we only want to remove
-                 * unstable updates.
-                 *
-                 * FIXME-WT-10017: WT-9846 is an interim fix only for row-store while we investigate
-                 * the impacts of a long term correction in WT-10017. Once completed this change can
-                 * be reverted.
-                 */
-                WT_ERR(__wt_rts_history_delete_hs(session, key, rollback_timestamp + 1));
         }
 
 err:

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -109,13 +109,13 @@ __rts_btree_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *firs
                     F_CLR(tombstone, WT_UPDATE_HS | WT_UPDATE_TO_DELETE_FROM_HS);
             } else if (WT_IS_HS(session->dhandle) && stable_upd->type != WT_UPDATE_TOMBSTONE) {
                 /*
-                * History store will have a combination of both tombstone and update/modify types in
-                * the update list to represent time window of an update. When we are aborting the
-                * tombstone, make sure to remove all of the remaining updates also. In most of the
-                * scenarios, there will be only one update present except when the data store is a
-                * prepared commit where it is possible to have more than one update. The existing
-                * on-disk versions are removed while processing the on-disk entries.
-                */
+                 * History store will have a combination of both tombstone and update/modify types
+                 * in the update list to represent time window of an update. When we are aborting
+                 * the tombstone, make sure to remove all of the remaining updates also. In most of
+                 * the scenarios, there will be only one update present except when the data store
+                 * is a prepared commit where it is possible to have more than one update. The
+                 * existing on-disk versions are removed while processing the on-disk entries.
+                 */
                 for (; stable_upd != NULL; stable_upd = stable_upd->next)
                     stable_upd->txnid = WT_TXN_ABORTED;
             }

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -107,18 +107,18 @@ __rts_btree_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *firs
                     F_CLR(stable_upd, WT_UPDATE_HS | WT_UPDATE_TO_DELETE_FROM_HS);
                 if (tombstone != NULL)
                     F_CLR(tombstone, WT_UPDATE_HS | WT_UPDATE_TO_DELETE_FROM_HS);
-            } else if (WT_IS_HS(session->dhandle) && stable_upd->type != WT_UPDATE_TOMBSTONE) {
-                /*
-                 * History store will have a combination of both tombstone and update/modify types
-                 * in the update list to represent time window of an update. When we are aborting
-                 * the tombstone, make sure to remove all of the remaining updates also. In most of
-                 * the scenarios, there will be only one update present except when the data store
-                 * is a prepared commit where it is possible to have more than one update. The
-                 * existing on-disk versions are removed while processing the on-disk entries.
-                 */
-                for (; stable_upd != NULL; stable_upd = stable_upd->next)
-                    stable_upd->txnid = WT_TXN_ABORTED;
             }
+        } else if (WT_IS_HS(session->dhandle) && stable_upd->type != WT_UPDATE_TOMBSTONE) {
+            /*
+             * History store will have a combination of both tombstone and update/modify types in
+             * the update list to represent time window of an update. When we are aborting the
+             * tombstone, make sure to remove all of the remaining updates also. In most of the
+             * scenarios, there will be only one update present except when the data store is a
+             * prepared commit where it is possible to have more than one update. The existing
+             * on-disk versions are removed while processing the on-disk entries.
+             */
+            for (; stable_upd != NULL; stable_upd = stable_upd->next)
+                stable_upd->txnid = WT_TXN_ABORTED;
         }
         if (stable_update_found != NULL)
             *stable_update_found = true;

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -207,8 +207,7 @@ __wt_rts_btree_walk_btree_apply(
      * 1. Empty table or newly-created table.
      * 2. Table has timestamped updates without a stable timestamp.
      */
-    if ((F_ISSET(S2C(session), WT_CONN_RECOVERING) ||
-          F_ISSET(S2C(session), WT_CONN_CLOSING_CHECKPOINT)) &&
+    if (F_ISSET(S2C(session), WT_CONN_RECOVERING) &&
       (addr_size == 0 || (rollback_timestamp == WT_TS_NONE && max_durable_ts != WT_TS_NONE))) {
         __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
           WT_RTS_VERB_TAG_FILE_SKIP "skipping rollback to stable on file=%s because %s", uri,

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -60,8 +60,12 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         ('dryrun', dict(dryrun=True))
     ]
 
-    scenarios = make_scenarios(format_values, in_memory_values, prepare_values, dryrun_values)
+    evict = [
+        ('no_evict', dict(evict=False)),
+        ('evict', dict(evict=True))
+    ]
 
+    scenarios = make_scenarios(format_values, in_memory_values, prepare_values, dryrun_values, evict)
     def conn_config(self):
         config = 'cache_size=500MB,statistics=(all),verbose=(rts:5)'
         if self.in_memory:
@@ -117,6 +121,11 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         self.large_modifies(uri, 'Q', ds, 0, 1, nrows, self.prepare, 30)
         self.large_modifies(uri, 'R', ds, 1, 1, nrows, self.prepare, 40)
         self.large_modifies(uri, 'S', ds, 2, 1, nrows, self.prepare, 50)
+
+        # Evict the pages to disk
+        if self.evict:
+            self.evict_cursor(uri, nrows, value_modS)
+
         self.large_updates(uri, value_b, ds, nrows, self.prepare, 60)
         self.large_updates(uri, value_c, ds, nrows, self.prepare, 70)
         self.large_modifies(uri, 'T', ds, 3, 1, nrows, self.prepare, 80)

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -106,10 +106,6 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
             self.session.checkpoint()
         self.conn.rollback_to_stable()
 
-        # Evict the pages to disk
-        if self.evict:
-            self.evict_cursor(uri, nrows, value_d)
-
         # Check that all keys are removed.
         # (For FLCS, at least for now, they will read back as 0, meaning deleted, rather
         # than disappear.)

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -53,8 +53,8 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
     ]
 
     evict = [
-        ('evict', dict(evict='True')),
-        ('no_evict', dict(evict='False'))
+        ('no_evict', dict(evict=False)),
+        ('evict', dict(evict=True))
     ]
 
     scenarios = make_scenarios(format_values, in_memory_values, prepare_values, evict)
@@ -152,6 +152,6 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
         # Evict the pages to disk
         if self.evict:
             self.evict_cursor(uri, nrows, value_d)
-            
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
The suggested changes are taken from [here](https://jira.mongodb.org/browse/WT-10017?filter=-1) and modified to fit the current codebase. 

Additional testing changes were added. 