### PR TITLE
WT-10536 Fix statistic check cache_hs_key_truncate_onpage_removal in test_hs32.py (#8771) (v6.3 backport)

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -548,6 +548,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
             WT_ERR(
               __wt_hs_delete_key(session, hs_cursor, btree->id, key, false, error_on_ts_ordering));
 
+            WT_STAT_CONN_DATA_INCR(session, cache_hs_key_truncate);
+
             /* Reset the update without a timestamp if it is the last update in the chain. */
             if (oldest_upd == no_ts_upd)
                 no_ts_upd = NULL;

--- a/test/suite/test_hs32.py
+++ b/test/suite/test_hs32.py
@@ -33,7 +33,7 @@ from wiredtiger import stat
 # test_hs32.py
 # Ensure that updates without timestamps clear the history store records.
 class test_hs32(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB,statistics=(all)'
+    conn_config = 'cache_size=500MB,statistics=(all)'
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
         ('column-fix', dict(key_format='r', value_format='8t')),
@@ -152,5 +152,5 @@ class test_hs32(wttest.WiredTigerTestCase):
                         self.assertEqual(cursor[self.create_key(i)], value1)
 
         if self.update_type == 'deletion':
-            hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
-            self.assertGreater(hs_truncate, 0)
+            cache_hs_key_truncate = self.get_stat(stat.conn.cache_hs_key_truncate)
+            self.assertGreater(cache_hs_key_truncate, 0)


### PR DESCRIPTION
(cherry picked from commit de4e9ae0b5c52c680ba9a86cb62b621f8f92e7c2)