### PR TITLE
WT-9902 Fix python test test_checkpoint01.test_checkpoint_target with timestamps

### DIFF
--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -218,9 +218,8 @@ class test_checkpoint_target(wttest.WiredTigerTestCase):
         self.assertEquals(cursor[ds.key(10)], value)
         cursor.close()
 
-    # FIXME-WT-9902
-    @wttest.skip_for_hook("tiered", "strange interaction with tiered and named checkpoints using target")
-    @wttest.skip_for_hook("timestamp", "strange interaction with timestamps and named checkpoints using target")
+    # FIXME-WT-10836
+    # @wttest.skip_for_hook("tiered", "strange interaction with tiered and named checkpoints using target")
     def test_checkpoint_target(self):
         # Create 3 objects, change one record to an easily recognizable string.
         uri = self.uri + '1'


### PR DESCRIPTION
- The original symptom of this ticket has since gone away, so the scope of this ticket was reduced to removing the skip hook annotation.
- A new FIXME ticket has been created to fix the skip tiered hook that is still resulting in an error. 