### PR TITLE
WT-10825 Allow shared operations to use different tables in Workgen

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1380,7 +1380,7 @@ ThreadRunner::op_create_all(Operation *op, size_t &keysize, size_t &valuesize)
         } else {
             // Set size of vector storing thread-to-table mappings for the operation.
             if (op->_tables.size() != _wrunner->_trunners.size()) {
-                op->_tables.resize(_wrunner->_trunners.size());
+                op->_tables.assign(_wrunner->_trunners.size(), std::string());
             }
         }
     }
@@ -1486,7 +1486,7 @@ bool
 ThreadRunner::op_has_table(Operation *op) const
 {
     if (op->_random_table) {
-        return (op->_tables[_number] != std::string());
+        return (!op->_tables[_number].empty());
     } else {
         return (!op->_table._uri.empty());
     }

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -42,7 +42,6 @@
 #include <iostream>
 #include <filesystem>
 #include <fstream>
-#include <mutex>
 #include <sstream>
 #include "wiredtiger.h"
 #include "workgen.h"

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1475,14 +1475,16 @@ ThreadRunner::op_get_table(Operation *op) const
     return {std::string(), 0};
 }
 
-// Check if the specified operation has an assigned table. For static tables, this
-// information is saved in the Operation structure. For dynamic tables, the
-// operation maintains a table assignment for each thread running the operation.
+/*
+ * Check if the specified operation has an assigned table. For static tables, this information is
+ * saved in the Operation structure. For dynamic tables, the operation maintains a table assignment
+ * for each thread running the operation.
+ */
 bool
 ThreadRunner::op_has_table(Operation *op) const
 {
-    if (_random_table) {
-        return (op->_tables.find(_thread->options.name) != _tables.end());
+    if (op->_random_table) {
+        return (op->_tables.find(_thread->options.name) != op->_tables.end());
     } else {
         return (!op->_table._uri.empty());
     }

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -302,6 +302,8 @@ struct Operation {
     double _timed;
     // Indicates whether a table is selected randomly to be worked on.
     bool _random_table;
+    // Maintain the random table being used by each thread running the operation.
+    std::map<std::string, std::string> _tables;
 
     Operation();
     Operation(OpType optype, Table table, Key key, Value value);
@@ -323,7 +325,6 @@ struct Operation {
     void init_internal(OperationInternal *other);
     void create_all();
     void get_static_counts(Stats &stats, int multiplier);
-    bool has_table() const;
     bool is_table_op() const;
     void kv_compute_max(bool iskey, bool has_random);
     void kv_gen(ThreadRunner *runner, bool iskey, uint64_t compressibility,

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -303,7 +303,7 @@ struct Operation {
     // Indicates whether a table is selected randomly to be worked on.
     bool _random_table;
     // Maintain the random table being used by each thread running the operation.
-    std::map<std::string, std::string> _tables;
+    std::vector<std::string> _tables;
 
     Operation();
     Operation(OpType optype, Table table, Key key, Value value);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -236,6 +236,8 @@ struct ContextInternal {
     tint_t _dyn_tint_last;
     // This mutex should be used to protect the access to the dynamic tables set.
     std::shared_mutex* _dyn_mutex;
+    // This mutex protects access to an operation's thread<->table map.
+    std::shared_mutex* _op_table_mutex;
     // unique id per context, to work with multiple contexts, starts at 1.
     uint32_t _context_count;
 

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -163,7 +163,7 @@ struct ThreadRunner {
     uint64_t op_get_key_recno(Operation *, uint64_t range, tint_t tint);
     void op_get_static_counts(Operation *, Stats &, int);
     std::tuple<std::string, tint_t> op_get_table(Operation *op) const;
-    void op_has_table(Operation *op) const;
+    bool op_has_table(Operation *op) const;
     void op_kv_gen(Operation *op, const tint_t tint);
     int op_run(Operation *);
     int op_run_setup(Operation *);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -236,8 +236,6 @@ struct ContextInternal {
     tint_t _dyn_tint_last;
     // This mutex should be used to protect the access to the dynamic tables set.
     std::shared_mutex* _dyn_mutex;
-    // This mutex protects access to an operation's thread<->table map.
-    std::shared_mutex* _op_table_mutex;
     // unique id per context, to work with multiple contexts, starts at 1.
     uint32_t _context_count;
 

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -162,10 +162,12 @@ struct ThreadRunner {
     void op_create_all(Operation *, size_t &keysize, size_t &valuesize);
     uint64_t op_get_key_recno(Operation *, uint64_t range, tint_t tint);
     void op_get_static_counts(Operation *, Stats &, int);
+    std::tuple<std::string, tint_t> op_get_table(Operation *op) const;
+    void op_has_table(Operation *op) const;
     void op_kv_gen(Operation *op, const tint_t tint);
     int op_run(Operation *);
     int op_run_setup(Operation *);
-    void op_set_table(Operation *op, const std::string &uri, const tint_t tint);
+    void op_set_table(Operation *op, const std::string &uri);
     float random_signed();
     uint32_t random_value();
 


### PR DESCRIPTION
This PR adds functionality to workgen so that different tables can be assigned to a single operation that is shared among threads.