### PR TITLE
WT-8981 Enable evergreen testing for RHEL8 on PPC (v4.4 backport) 

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -377,6 +377,7 @@ STAILQ
 STEC
 STR
 STRUCT
+SYSCALL
 Scalability
 Scalable
 Sedgewick

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -649,6 +649,22 @@ variables:
         vars:
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 360
 
+  - &format-stress-sanitizer-ppc-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          posix_configure_flags: --enable-lz4 --enable-snappy --enable-zlib
+      - func: "format test script"
+        vars:
+          # Always disable mmap for PPC due to issues on variant setup.
+          # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
+          format_test_script_args: -t 360 -- -C "mmap=false,mmap_all=false"
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
+
   - &format-stress-sanitizer-test
     exec_timeout_secs: 25200
     commands:
@@ -2696,9 +2712,8 @@ tasks:
             set -o verbose
             for i in {1..10}; do ${test_env_vars|} ${python_binary|python3} split_stress.py; done
 
-  # The task name is ppc-zseries because this task will be used in both buildVariants
-  - name: format-stress-ppc-zseries-test
-    tags: ["stress-test-ppc-1", "stress-test-zseries-1"]
+  - name: format-stress-zseries-test
+    tags: ["stress-test-zseries-1"]
     # Set 2.5 hours timeout (60 * 60 * 2.5)
     exec_timeout_secs: 9000
     commands:
@@ -2733,8 +2748,10 @@ tasks:
           test_env_vars:
             ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
             ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-          # Run for 2 hours (2 * 60 = 120 minutes), don't stop at failed tests, use default config
-          format_test_script_args: -t 120
+          # Run for 2 hours ( 2 * 60 = 120 minutes), use default config
+          # Always disable mmap for PPC due to issues on variant setup.
+          # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
+          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120 -- -C "mmap=false,mmap_all=false"
 
   # Replace this test with format-stress-sanitizer-smoke-test after BUILD-10248 fix.
   - name: format-stress-sanitizer-smoke-ppc-test
@@ -2777,12 +2794,18 @@ tasks:
   - <<: *format-stress-test
     name: format-stress-test-4
     tags: ["stress-test-4"]
+  - <<: *format-stress-sanitizer-ppc-test
+    name: format-stress-sanitizer-ppc-test-1
+    tags: ["stress-test-ppc-1"]
+  - <<: *format-stress-sanitizer-ppc-test
+    name: format-stress-sanitizer-ppc-test-2
+    tags: ["stress-test-ppc-2"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-1
-    tags: ["stress-test-1"]
+    tags: ["stress-test-sanitizer-1"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-2
-    tags: ["stress-test-2"]
+    tags: ["stress-test-sanitizer-2"]
   - <<: *format-stress-sanitizer-test
     name: format-stress-sanitizer-test-3
     tags: ["stress-test-3"]
@@ -3622,14 +3645,15 @@ buildvariants:
   - name: verify-datafile-big-endian
   - name: verify-datafile-from-little-endian
 
-- name: ubuntu1804-ppc
-  display_name: "~ Ubuntu 18.04 PPC"
+- name: rhel8-ppc
+  display_name: "~ RHEL8 PPC"
   run_on:
-  - ubuntu1804-power8-test
+  - rhel81-power8-small
   batchtime: 120 # 2 hours
   expansions:
     format_test_setting: ulimit -c unlimited
-    smp_command: -j $(grep -c ^processor /proc/cpuinfo)
+    # Use quarter of the vCPUs to avoid OOM kill failure and disk issues on this variant.
+    smp_command: -j $(echo $(grep -c ^processor /proc/cpuinfo) / 4 | bc)
     make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH make
     test_env_vars:
       PATH=/opt/mongodbtoolchain/v3/bin:$PATH
@@ -3652,34 +3676,6 @@ buildvariants:
   - name: format-wtperf-test
   - name: ".stress-test-ppc-1"
   - name: ".stress-test-ppc-2"
-
-- name: ubuntu1804-ppc-cmake
-  display_name: "* Ubuntu 18.04 PPC CMake"
-  run_on:
-  - ubuntu1804-power8-test
-  batchtime: 10080 # 7 days
-  expansions:
-    test_env_vars:
-      WT_BUILDDIR=$(git rev-parse --show-toplevel)/cmake_build
-      LD_LIBRARY_PATH=$WT_BUILDDIR
-    posix_configure_flags:
-      -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v3_gcc.cmake
-      -DCMAKE_C_FLAGS="-ggdb"
-      -DHAVE_DIAGNOSTIC=1
-      -DENABLE_PYTHON=1
-      -DENABLE_ZLIB=1
-      -DENABLE_SNAPPY=1
-      -DENABLE_STRICT=1
-      -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
-    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
-    smp_command: -j $(grep -c ^processor /proc/cpuinfo)
-    cmake_generator: Ninja
-    make_command: ninja
-    is_cmake_build: true
-  tasks:
-    - name: compile
-    - name: make-check-test
-    - name: unit-test
 
 - name: ubuntu1804-zseries
   display_name: "~ Ubuntu 18.04 zSeries"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2745,13 +2745,12 @@ tasks:
           posix_configure_flags: --enable-diagnostic --with-builtins=lz4,snappy,zlib
       - func: "format test script"
         vars:
-          test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0"
-            ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
-          # Run for 2 hours ( 2 * 60 = 120 minutes), use default config
           # Always disable mmap for PPC due to issues on variant setup.
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 120 -- -C "mmap=false,mmap_all=false"
+          format_test_script_args: -t 360 -- -C "mmap=false,mmap_all=false"
+          test_env_vars:
+            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
 
   # Replace this test with format-stress-sanitizer-smoke-test after BUILD-10248 fix.
   - name: format-stress-sanitizer-smoke-ppc-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2747,7 +2747,7 @@ tasks:
         vars:
           # Always disable mmap for PPC due to issues on variant setup.
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
-          format_test_script_args: -t 360 -- -C "mmap=false,mmap_all=false"
+          format_test_script_args: -t 120 -- -C "mmap=false,mmap_all=false"
           test_env_vars:
             ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer


### PR DESCRIPTION

(cherry picked from commit de2888df11ef8cdfa9b4c2e8ec76f1b4a64a346b)

* WT-8981 Enable evergreen testing for RHEL8 on PPC (#8308) (BACKPORT) (#8626)

* WT-8981 Enable evergreen testing for RHEL8 on PPC (#8308)

Updated evergreen yaml to use RHEL8 instead of Ubuntu 18.04 on PPC.  Reducing the concurrency for RHEL8 PPC tests to a quarter of vCPUs. Added retry (WT_SYSCALL_RETRY) for pread which helps on RHEL8 PPC.

(cherry picked from commit b3719943c9d9790b26bbdcf4aabe95801c1de804)

Co-authored-by: Mick Graham <99703363+mickgraham-mongodb@users.noreply.github.com>
(cherry picked from commit 4dff67dd815aeaecb3f2987afa9bb63766b8c888)

---------

(cherry picked from commit ad583b158e9ccb035d29c1efaa7bce4c6907851b)