### PR TITLE
WT-10585 Record the location of the last key to help debug key out of order (6.3 backport) (#8793)

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -581,6 +581,9 @@ __cursor_key_order_check_col(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, boo
 
     if (cbt->lastrecno == WT_RECNO_OOB || (next && cmp < 0) || (!next && cmp > 0)) {
         cbt->lastrecno = cbt->recno;
+        cbt->lastref = cbt->ref;
+        cbt->lastslot = cbt->slot;
+        cbt->lastins = cbt->ins;
         return (0);
     }
 
@@ -616,8 +619,12 @@ __cursor_key_order_check_row(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, boo
     if (cbt->lastkey->size != 0)
         WT_RET(__wt_compare(session, btree->collator, cbt->lastkey, key, &cmp));
 
-    if (cbt->lastkey->size == 0 || (next && cmp < 0) || (!next && cmp > 0))
+    if (cbt->lastkey->size == 0 || (next && cmp < 0) || (!next && cmp > 0)) {
+        cbt->lastref = cbt->ref;
+        cbt->lastslot = cbt->slot;
+        cbt->lastins = cbt->ins;
         return (__wt_buf_set(session, cbt->lastkey, cbt->iface.key.data, cbt->iface.key.size));
+    }
 
     WT_ERR(__wt_scr_alloc(session, 512, &a));
     WT_ERR(__wt_scr_alloc(session, 512, &b));
@@ -669,6 +676,10 @@ __wt_cursor_key_order_init(WT_CURSOR_BTREE *cbt)
 
     session = CUR2S(cbt);
 
+    cbt->lastref = cbt->ref;
+    cbt->lastslot = cbt->slot;
+    cbt->lastins = cbt->ins;
+
     /*
      * Cursor searches set the position for cursor movements, set the last-key value for diagnostic
      * checking.
@@ -699,6 +710,10 @@ __wt_cursor_key_order_reset(WT_CURSOR_BTREE *cbt)
     if (cbt->lastkey != NULL)
         cbt->lastkey->size = 0;
     cbt->lastrecno = WT_RECNO_OOB;
+
+    cbt->lastref = NULL;
+    cbt->lastslot = UINT32_MAX;
+    cbt->lastins = NULL;
 }
 #endif
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -2265,6 +2265,9 @@ __wt_btcur_open(WT_CURSOR_BTREE *cbt)
 #ifdef HAVE_DIAGNOSTIC
     cbt->lastkey = &cbt->_lastkey;
     cbt->lastrecno = WT_RECNO_OOB;
+    cbt->lastref = NULL;
+    cbt->lastslot = UINT32_MAX;
+    cbt->lastins = NULL;
 #endif
 }
 

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -240,6 +240,11 @@ struct __wt_cursor_btree {
     /* Check that cursor next/prev never returns keys out-of-order. */
     WT_ITEM *lastkey, _lastkey;
     uint64_t lastrecno;
+
+    /* Record where the last key is when we see it to help debugging out of order issues. */
+    WT_REF *lastref;    /* The page where the last key is */
+    uint32_t lastslot;  /* WT_COL/WT_ROW 0-based slot */
+    WT_INSERT *lastins; /* The last insert list */
 #endif
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */


### PR DESCRIPTION
(cherry picked from commit fa1ea9f917c56947c5ca22185285d29f713e6401)