### PR TITLE
WT-10847 Add the checkpoint name to the error

### DIFF
--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1732,7 +1732,7 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
                 F_CLR(ckpt, WT_CKPT_DELETE);
                 continue;
             }
-            WT_RET_MSG(session, ret, "checkpoints cannot be dropped when in-use");
+            WT_RET_MSG(session, ret, "checkpoint %s cannot be dropped when in-use", ckpt->name);
         }
     /*
      * There are special trees: those being bulk-loaded, salvaged, upgraded or verified during the

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -182,7 +182,7 @@ class test_checkpoint_cursor(wttest.WiredTigerTestCase):
         # Check creating an identically named checkpoint fails. */
         # Check dropping the specific checkpoint fails.
         # Check dropping all checkpoints fails.
-        msg = '/checkpoints cannot be dropped/'
+        msg = '/checkpoint.*cannot be dropped/'
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.checkpoint("force,name=checkpoint-2"), msg)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -179,14 +179,14 @@ class test_checkpoint_cursor(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(
             self.uri, None, "checkpoint=checkpoint-2")
 
-        # Check creating an identically named checkpoint fails. */
-        # Check dropping the specific checkpoint fails.
-        # Check dropping all checkpoints fails.
         msg = '/checkpoint.*cannot be dropped/'
+        # Check creating an identically named checkpoint fails. */
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.checkpoint("force,name=checkpoint-2"), msg)
+        # Check dropping the specific checkpoint fails.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.checkpoint("drop=(checkpoint-2)"), msg)
+        # Check dropping all checkpoints fails.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.checkpoint("drop=(from=all)"), msg)
 


### PR DESCRIPTION
When a checkpoint is marked for deletion while still in use, we should add the name of the checkpoint to the error for a better debugging experience.