### PR TITLE
WT-10644 Fix undefined behavior in workgen signal handler

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -212,8 +212,6 @@ volatile std::sig_atomic_t signal_raised = 0;
 void
 signal_handler(int signum)
 {
-    std::cerr << "Workgen received signal " << signum << ": " << strsignal(signum) << "."
-              << std::endl;
     signal_raised = signum;
 }
 


### PR DESCRIPTION
Removed output code from the `signal_handler` function.