### PR TITLE
WT-10620 Reducing default test format ops tracing in evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -496,7 +496,7 @@ functions:
         set -o errexit
         set -o verbose
         for i in $(seq ${times|1}); do
-          ./t -c ${config|../../../test/format/CONFIG.stress} ${trace_args|-T bulk,txn,retain=100} ${extra_args|} || ( [ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG ) 2>&1
+          ./t -c ${config|../../../test/format/CONFIG.stress} ${trace_args|-T bulk,txn,retain=50} ${extra_args|} || ( [ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG ) 2>&1
         done
   "format test predictable":
     command: shell.exec


### PR DESCRIPTION
Discussed in office hours and agreed this is the best approach to reduce disk space usage. 50 ops tracing logs should be enough to cover majority of cases.