### PR TITLE
WT-10447 Upgrade instance for cppsuite tests

### DIFF
--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -35,7 +35,7 @@ runtime_monitor=
     stat_cache_size=
     (
         max=110,
-        runtime=true,
+        runtime=false,
     ),
     # The data files compress to around 25MB per table at the end of a run so 250MB total.
     # +1.4GB for the history store. With an additional 150MB margin.

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -34,14 +34,13 @@ runtime_monitor=
     ),
     stat_cache_size=
     (
-        max=110,
+        max=200,
         runtime=false,
     ),
     # The data files compress to around 25MB per table at the end of a run so 250MB total.
     # +1.4GB for the history store. With an additional 150MB margin.
     stat_db_size=
     (
-        max=1900000000,
         save=true,
     ),
 ),

--- a/test/cppsuite/configs/operations_test_stress.txt
+++ b/test/cppsuite/configs/operations_test_stress.txt
@@ -11,11 +11,6 @@ runtime_monitor=
 (
     stat_db_size=
     (
-        #At the end of the run the data files are approximately 2.3MB each. Which is a total of:
-        #1.15GB, the history store isn't significant. Give the workload an extra 200MB of margin.
-        max=1350000000,
-        # FIXME-WT-8886 - This check has been disabled to remove noisy failures in evergreen and
-        # will be properly corrected in WT-8886.
         runtime=false,
         save=true,
     )

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4026,7 +4026,7 @@ buildvariants:
   display_name: "Cppsuite Stress Tests"
   batchtime: 480 # 3 times a day
   run_on:
-  - ubuntu2004-test
+  - ubuntu2004-medium
   expansions:
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
This upsizes the vm instance for testing, as the small instance runs out of disk space.