### PR TITLE
WT-10888 Don't hold block handle arrray lock when opening a handle.

### DIFF
--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -11,11 +11,11 @@
 static void __bm_method_set(WT_BM *, bool);
 
 /*
- * __bm_close_block --
+ * __wt_bm_close_block --
  *     Close a block handle.
  */
-static int
-__bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
+int
+__wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_CONNECTION_IMPL *conn;
 
@@ -264,7 +264,7 @@ __bm_close(WT_BM *bm, WT_SESSION_IMPL *session)
         return (0);
 
     if (!bm->is_multi_handle)
-        ret = __bm_close_block(session, bm->block);
+        ret = __wt_bm_close_block(session, bm->block);
     else {
         /*
          * Higher-level code ensures that we can only have one call to close a block manager. So we
@@ -273,7 +273,7 @@ __bm_close(WT_BM *bm, WT_SESSION_IMPL *session)
          * We don't need to explicitly close the active handle; it is also in the handle array.
          */
         for (i = 0; i < bm->handle_array_next; ++i)
-            WT_TRET(__bm_close_block(session, bm->handle_array[i]));
+            WT_TRET(__wt_bm_close_block(session, bm->handle_array[i]));
 
         __wt_rwlock_destroy(session, &bm->handle_array_lock);
         __wt_free(session, bm->handle_array);

--- a/src/block_cache/block_tier.c
+++ b/src/block_cache/block_tier.c
@@ -96,7 +96,7 @@ err:
 }
 
 /*
- * __blockcache_find_open_handle --
+ * __blkcache_find_open_handle --
  *     If the block manager's handle array already has an entry for the given object, return it.
  */
 static void

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -258,6 +258,8 @@ extern int __wt_bloom_intersection(WT_BLOOM *bloom, WT_BLOOM *other)
 extern int __wt_bloom_open(WT_SESSION_IMPL *session, const char *uri, uint32_t factor, uint32_t k,
   WT_CURSOR *owner, WT_BLOOM **bloomp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bm_corrupt(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_bm_read(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr,


### PR DESCRIPTION
Refactor `__wt_blkcache_get_handle()` so that it doesn't hold the handle array lock while opening a block handle. This makes error handling a bit more complicated, but avoids holding the lock across an operation that is likely to be slow.