### PR TITLE
WT-10777 Set name for internal threads.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1003,6 +1003,7 @@ notfound
 notsup
 novalue
 nowait
+np
 nrecs
 nsec
 nset
@@ -1149,6 +1150,7 @@ sdk
 secretkey
 sessionp
 setkv
+setname
 setstr
 setv
 setvbuf

--- a/src/include/os_windows.h
+++ b/src/include/os_windows.h
@@ -13,6 +13,7 @@ typedef CONDITION_VARIABLE wt_cond_t;
 typedef CRITICAL_SECTION wt_mutex_t;
 typedef struct {
     bool created;
+    uint16_t name_index; /* Not used on Windows */
     HANDLE id;
 } wt_thread_t;
 

--- a/src/include/posix.h
+++ b/src/include/posix.h
@@ -27,6 +27,7 @@ typedef pthread_cond_t wt_cond_t;
 typedef pthread_mutex_t wt_mutex_t;
 typedef struct {
     bool created;
+    uint16_t name_index; /* Used in thread name to distinguish multiple threads of same type. */
     pthread_t id;
 } wt_thread_t;
 

--- a/src/lsm/lsm_manager.c
+++ b/src/lsm/lsm_manager.c
@@ -211,6 +211,7 @@ __wt_lsm_manager_start(WT_SESSION_IMPL *session)
         WT_ERR(__wt_open_internal_session(conn, "lsm-worker", false, 0, 0, &worker_session));
         worker_session->isolation = WT_ISO_READ_UNCOMMITTED;
         manager->lsm_worker_cookies[i].session = worker_session;
+        manager->lsm_worker_cookies[i].tid.name_index = (uint16_t)i;
     }
 
     FLD_SET(conn->server_flags, WT_CONN_SERVER_LSM);

--- a/src/os_posix/os_thread.c
+++ b/src/os_posix/os_thread.c
@@ -31,7 +31,7 @@ __thread_set_name(WT_SESSION_IMPL *session, uint32_t thread_num, pthread_t threa
             WT_RET(__wt_snprintf(thread_name, MAX_NAME_LEN, "%s", session->name));
         else {
             WT_RET(__wt_snprintf(short_name, MAX_NAME_LEN - 3, "%s", session->name));
-            if (thread_num < 99)
+            if (thread_num < 100)
                 WT_RET(
                   __wt_snprintf(thread_name, MAX_NAME_LEN, "%s %" PRIu32, short_name, thread_num));
             else
@@ -65,8 +65,6 @@ __wt_thread_create(WT_SESSION_IMPL *session, wt_thread_t *tidret,
         tidret->created = true;
 #ifdef __linux__
         WT_IGNORE_RET(__thread_set_name(session, tidret->name_index, tidret->id));
-#else
-        WT_NOTUSED(thread_num);
 #endif
         return (0);
     }

--- a/src/os_posix/os_thread.c
+++ b/src/os_posix/os_thread.c
@@ -17,7 +17,9 @@
 
 /*
  * __thread_set_name --
- *     Set the pthread-level thread name using the session name.
+ *     Set the pthread-level thread name. If the session name is set, use that, truncated to fit. If
+ *     the caller provides a non-zero thread number, append that to the session name to distinguish
+ *     between multiple threads of the same type/name.
  */
 static void
 __thread_set_name(WT_SESSION_IMPL *session, uint32_t thread_num, pthread_t thread_id)

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -186,6 +186,7 @@ __thread_group_resize(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
         if (LF_ISSET(WT_THREAD_PANIC_FAIL))
             F_SET(thread, WT_THREAD_PANIC_FAIL);
         thread->id = i;
+        thread->tid.name_index = (uint16_t)i + 1;
         thread->chk_func = group->chk_func;
         thread->run_func = group->run_func;
         thread->stop_func = group->stop_func;


### PR DESCRIPTION
On linux systems, use `session->name` to set the pthreads-level thread name. 