### PR TITLE
WT-9481 Initialize variables to compile with -Og  (v6.0) (#8181)

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -227,11 +227,7 @@ set(default_optimize_level)
 if("${WT_OS}" STREQUAL "windows")
     set(default_optimize_level "/Od")
 else()
-    # Ideally this would choose an optimization level of Og. Which is the recommended configuration
-    # for build-debug cycles when using GCC and is a synonym in clang for O1.
-    # Unfortunately at the moment, WiredTiger code generates compiler warnings (as errors) when
-    # built with Og.
-    set(default_optimize_level "-O1")
+    set(default_optimize_level "-Og")
 endif()
 config_string(
     CC_OPTIMIZE_LEVEL

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1100,6 +1100,8 @@ __wt_block_extlist_read(
     const uint8_t *p;
     int (*func)(WT_SESSION_IMPL *, WT_BLOCK *, WT_EXTLIST *, wt_off_t, wt_off_t);
 
+    off = size = 0;
+
     /* If there isn't a list, we're done. */
     if (el->offset == WT_BLOCK_INVALID_OFFSET)
         return (0);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -132,6 +132,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
     WT_UPDATE *upd, *tombstone;
     size_t size, total_size;
 
+    size = 0;
     *sizep = 0;
 
     tombstone = upd = NULL;

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -44,6 +44,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     upd = upd_arg;
     prev_upd_ts = WT_TS_NONE;
     added_to_txn = append = inserted_to_update_chain = false;
+    upd_size = 0;
 
     /*
      * We should have one of the following:

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -69,6 +69,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
     upd = upd_arg;
     prev_upd_ts = WT_TS_NONE;
     added_to_txn = inserted_to_update_chain = false;
+    upd_size = 0;
 
     /*
      * We should have one of the following:

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -34,6 +34,10 @@ __ovfl_discard_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell, c
     WT_CELL_UNPACK_KV *unpack, _unpack;
     WT_DECL_ITEM(tmp);
 
+    /* Because we dereference the page pointer, it can't be NULL */
+    if (page == NULL)
+        WT_RET(EINVAL);
+
     WT_RET(__wt_scr_alloc(session, 512, &tmp));
 
     unpack = &_unpack;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -80,7 +80,7 @@ __rec_append_orig_value(
       session, upd != NULL && unpack != NULL && unpack->type != WT_CELL_DEL && !unpack->tw.prepare);
 
     append = oldest_upd = tombstone = NULL;
-    total_size = 0;
+    size = total_size = 0;
     tombstone_globally_visible = false;
 
     /* Review the current update list, checking conditions that mean no work is needed. */

--- a/src/schema/schema_project.c
+++ b/src/schema/schema_project.c
@@ -27,6 +27,7 @@ __wt_schema_project_in(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *pro
     const uint8_t *next;
     char *proj;
 
+    len = 0;
     p = end = NULL; /* -Wuninitialized */
 
     /* Reset any of the buffers we will be setting. */
@@ -218,6 +219,7 @@ __wt_schema_project_slice(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *
     char *proj;
     bool skip;
 
+    len = 0;
     p = end = NULL; /* -Wuninitialized */
 
     WT_RET(__pack_init(session, &vpack, vformat));
@@ -384,6 +386,7 @@ __wt_schema_project_merge(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *
     const uint8_t *p, *end;
     char *proj;
 
+    len = 0;
     p = end = NULL; /* -Wuninitialized */
 
     WT_RET(__wt_buf_init(session, value, 0));

--- a/test/unittest/tests/test_reconciliation_tracking.cpp
+++ b/test/unittest/tests/test_reconciliation_tracking.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Reconciliation tracking: ovfl_discard_verbose", "[reconciliation]")
 
     SECTION("handle null page and tag")
     {
-        REQUIRE(__ut_ovfl_discard_verbose(session, nullptr, nullptr, nullptr) == 0);
+        REQUIRE(__ut_ovfl_discard_verbose(session, nullptr, nullptr, nullptr) == EINVAL);
     }
 }
 


### PR DESCRIPTION
* Initialize variables
* Update CMake to default to -Og

(cherry picked from commit d10d9d24e544c4d0325f68af144543cea60e2c37)