### PR TITLE
WT-10487 Fixed V4 toolchain path for many-collection-test (#8703) (v6.0 backport)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3993,6 +3993,24 @@ buildvariants:
   batchtime: 480 # 3 times a day
   run_on:
   - ubuntu2004-test
+  expansions:
+    make_command: ninja
+    cmake_generator: Ninja
+    posix_configure_flags:
+      -DENABLE_PYTHON=1
+      -DENABLE_ZLIB=1
+      -DENABLE_SNAPPY=1
+      -DENABLE_STRICT=1
+      -DENABLE_STATIC=1
+      -DENABLE_TCMALLOC=1
+      -DCMAKE_PREFIX_PATH="$(pwd)/../TCMALLOC_LIB"
+    test_env_vars:
+      PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+      WT_TOPDIR=$(git rev-parse --show-toplevel)
+      WT_BUILDDIR=$WT_TOPDIR/cmake_build
+      LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib
+    upload_source_dir: mongo-tests/largescale/many-collection-artifacts
+    upload_filename: many-collection.tgz
   tasks:
     - name: many-collection-test
       distros: ubuntu2004-wt-large

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2833,29 +2833,22 @@ tasks:
         params:
           working_dir: mongo-tests/largescale
           shell: bash
+          include_expansions_in_env:
+            - atlas_wt_perf_test_user
+            - atlas_wt_perf_pass
           script: |
             set -o errexit
             set -o verbose
             export "PATH=/opt/mongodbtoolchain/v3/bin:$PATH"
             virtualenv -p python3 venv
             source venv/bin/activate
-            pip3 install lorem pymongo==3.12.2
+            # Need both pymongo and pymongo[srv] as upload-results-atlas.py uses mongo+srv for the URI.
+            pip3 install lorem pymongo==3.12.2 "pymongo[srv]==3.12.2"
             mongod_path=$(find ../../mongo/build -executable -type f -path \*/bin/mongod)
             ./run_many_coll.sh $mongod_path mongodb.log config/many-collection-testing many-collection clean-and-populate
-
-      - command: shell.exec
-        params:
-          working_dir: mongo-tests/largescale
-          shell: bash
-          silent: true
-          script: |
-            set -o errexit
-            set -o verbose
-            virtualenv -p python3 venv
-            source venv/bin/activate
-            pip3 install "pymongo[srv]==3.12.2"
+            # upload the results
             res_dir=`find ./ -type d -name "many-collection-artifacts" -print`
-            ./upload-results-atlas.py ${atlas_wt_perf_test_user} ${atlas_wt_perf_pass} wt-perf-tests many-collection-test ${branch_name} $res_dir/results/results.json
+            ./upload-results-atlas.py wt-perf-tests many-collection-test ${branch_name} $res_dir/results/results.json
 
   - name: cyclomatic-complexity
     commands:
@@ -4000,24 +3993,6 @@ buildvariants:
   batchtime: 480 # 3 times a day
   run_on:
   - ubuntu2004-test
-  expansions:
-    make_command: ninja
-    cmake_generator: Ninja
-    posix_configure_flags:
-      -DENABLE_PYTHON=1
-      -DENABLE_ZLIB=1
-      -DENABLE_SNAPPY=1
-      -DENABLE_STRICT=1
-      -DENABLE_STATIC=1
-      -DENABLE_TCMALLOC=1
-      -DCMAKE_PREFIX_PATH="$(pwd)/../TCMALLOC_LIB"
-    test_env_vars:
-      PATH=/opt/mongodbtoolchain/v3/bin:$PATH
-      WT_TOPDIR=$(git rev-parse --show-toplevel)
-      WT_BUILDDIR=$WT_TOPDIR/cmake_build
-      LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib
-    upload_source_dir: mongo-tests/largescale/many-collection-artifacts
-    upload_filename: many-collection.tgz
   tasks:
     - name: many-collection-test
       distros: ubuntu2004-wt-large


### PR DESCRIPTION
WT-10487 Fixed V4 toolchain path env for many-collection-test. Updated many-collection-test to use env var for the username/password to allow for better debugging on failures.

(cherry picked from commit 16242574607a2837de1a1f1192871160353479fc)