### PR TITLE
WT-10935 Change patch build Python unit tests to run on ubuntu2004-large

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5147,6 +5147,7 @@ buildvariants:
   tasks:
     - name: ".pull_request !.pull_request_compilers"
     - name: ".unit_test_long"
+      distros: ubuntu2004-large
     - name: compile
     - name: doc-compile
     - name: make-check-test


### PR DESCRIPTION
On Ubuntu 2004, post-merge Python unit tests are run on in the single Evergreen task 'unit-test-extra-long', which is executed on ubuntu2004-large instances.

However, PR/patch testing for the Python unit tests are run in a series of bucket tasks (named unit-test-long-bucket00 to unit-test-long-bucket11) on ubuntu2004-test (aka ubuntu2004-small) instances. Some test fail on the small instances. For example test_txn13.test_txn13.test_large_values(integer-row.4gb).

This change will fix this issue by changing the PR/patch Python unit tests to run on ubuntu2004-large instances.