### PR TITLE
WT-10934 Process missing mirrors when starting from an existing database in workgen

### DIFF
--- a/bench/workgen/validate_mirror_tables.py
+++ b/bench/workgen/validate_mirror_tables.py
@@ -64,7 +64,12 @@ def get_mirrors(db_dir, db_files):
             continue
         db_files_remaining.remove(filename)
         mirror_filename = get_mirror_file(db_dir, f'table:{filename}')
-        if mirror_filename is not None:
+
+        # At this point, there is no guarantee that the database contains all the base/mirror pairs.
+        # It is possible to have a base and no associated mirror and vice-versa. This may happen
+        # when a drop was occurring when a snapshot of the database was taken and fed into this
+        # script.
+        if mirror_filename is not None and mirror_filename in db_files_remaining:
             db_files_remaining.remove(mirror_filename)
             mirrors.append([f'{db_dir}/table:{filename}',
                             f'{db_dir}/table:{mirror_filename}'])

--- a/bench/workgen/validate_mirror_tables.py
+++ b/bench/workgen/validate_mirror_tables.py
@@ -67,7 +67,7 @@ def get_mirrors(db_dir, db_files):
 
         # At this point, there is no guarantee that the database contains all the base/mirror pairs.
         # It is possible to have a base and no associated mirror and vice-versa. This may happen
-        # when a drop was occurring when a snapshot of the database was taken and fed into this
+        # when a drop is occurring when a snapshot of the database is taken and fed into this
         # script.
         if mirror_filename is not None and mirror_filename in db_files_remaining:
             db_files_remaining.remove(mirror_filename)

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -944,7 +944,6 @@ ContextInternal::create_all(WT_CONNECTION *conn)
     /* Delete the leftover. */
     for (const auto &id : to_delete) {
         const std::string uri(_dyn_table_names[id]);
-        VERBOSE(*this, "Deleting table " << uri << " as its mirror is missing.");
         _dyn_tint.erase(uri);
         _dyn_table_names.erase(id);
         _dyn_table_runtime.erase(id);

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -944,6 +944,7 @@ ContextInternal::create_all(WT_CONNECTION *conn)
     /* Delete the leftover. */
     for (const auto &id : to_delete) {
         const std::string uri(_dyn_table_names[id]);
+        VERBOSE(*this, "Deleting table " << uri << " as its mirror is missing.");
         _dyn_tint.erase(uri);
         _dyn_table_names.erase(id);
         _dyn_table_runtime.erase(id);

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1871,18 +1871,6 @@ err:
         const std::shared_lock lock(*_icontext->_dyn_mutex);
         // For operations on random tables, if a table has been selected, decrement the
         // reference counter.
-        if(_icontext->_dyn_table_runtime[tint]._in_use == 0) {
-            std::cout << "_in_use should be greater than 0 but is not." << std::endl;
-            std::cout << "The id is " << tint << " which corresponds to the uri " << _icontext->_dyn_table_names[tint] << std::endl;
-            if(_icontext->_dyn_table_runtime[tint].has_mirror()) {
-                std::cout << "The mirror is " << _icontext->_dyn_table_runtime[tint]._mirror << std::endl;
-                std::cout << "The mirror id is " << _icontext->_dyn_tint[_icontext->_dyn_table_runtime[tint]._mirror] << std::endl;
-            } else {
-                std::cout << "No mirror!" << std::endl;
-            }
-            std::cout << "The operation type is " << op->_optype << std::endl;
-            op->describe(std::cout);
-        }
         ASSERT(_icontext->_dyn_table_runtime[tint]._in_use > 0);
         // Use atomic here as we can race with another thread that acquires the shared lock.
         (void)workgen_atomic_sub32(&_icontext->_dyn_table_runtime[tint]._in_use, 1);

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1871,6 +1871,18 @@ err:
         const std::shared_lock lock(*_icontext->_dyn_mutex);
         // For operations on random tables, if a table has been selected, decrement the
         // reference counter.
+        if(_icontext->_dyn_table_runtime[tint]._in_use == 0) {
+            std::cout << "_in_use should be greater than 0 but is not." << std::endl;
+            std::cout << "The id is " << tint << " which corresponds to the uri " << _icontext->_dyn_table_names[tint] << std::endl;
+            if(_icontext->_dyn_table_runtime[tint].has_mirror()) {
+                std::cout << "The mirror is " << _icontext->_dyn_table_runtime[tint]._mirror << std::endl;
+                std::cout << "The mirror id is " << _icontext->_dyn_tint[_icontext->_dyn_table_runtime[tint]._mirror] << std::endl;
+            } else {
+                std::cout << "No mirror!" << std::endl;
+            }
+            std::cout << "The operation type is " << op->_optype << std::endl;
+            op->describe(std::cout);
+        }
         ASSERT(_icontext->_dyn_table_runtime[tint]._in_use > 0);
         // Use atomic here as we can race with another thread that acquires the shared lock.
         (void)workgen_atomic_sub32(&_icontext->_dyn_table_runtime[tint]._in_use, 1);


### PR DESCRIPTION
We can probably do better but that's the algorithm in two steps::

(0) Once we have parsed the metadata, we know all the tables.

(1) For each table, if it has a mirror (`has_mirror()` returns `true`), retrieve the URI of the mirror. If the map `_dyn_tint` does not contain the URI, then the entry is missing. Add it to `to_delete`.

(2) Delete all entries in `to_delete`.

Note: this is safe as we are single-threaded at this time.