### PR TITLE
WT-10913 Python teardown failures not reflected in test suite return value

### DIFF
--- a/test/suite/rollback_to_stable_util.py
+++ b/test/suite/rollback_to_stable_util.py
@@ -51,9 +51,9 @@ def verify_rts_logs():
     stdout_path = os.path.join(os.getcwd(), 'stdout.txt')
 
     if os.name == 'nt':
-        output = subprocess.run(['python.exe', binary_path, stdout_path])
+        output = subprocess.run(['python.exe', binary_path, stdout_path], capture_output=True)
     else:
-        output = subprocess.run([binary_path, stdout_path])
+        output = subprocess.run([binary_path, stdout_path], capture_output=True)
 
     stderr = b'' if output.stderr is None else output.stderr
     return (output.returncode, stderr.strip().decode('utf-8'))

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -726,12 +726,14 @@ class WiredTigerTestCase(unittest.TestCase):
 
     def tearDown(self, dueToRetry=False):
         teardown_failed = False
+        teardown_msg = None
         if not dueToRetry:
             for action in self.teardown_actions:
                 tmp = action()
                 if tmp[0] != 0:
                     self.pr('ERROR: teardown action failed, message=' + tmp[1])
                     teardown_failed = True
+                    teardown_msg = tmp[1]
 
         # This approach works for all our support Python versions and
         # is suggested by one of the answers in:
@@ -800,6 +802,8 @@ class WiredTigerTestCase(unittest.TestCase):
         elapsed = time.time() - self.starttime
         if elapsed > 0.001 and WiredTigerTestCase._verbose >= 2:
             print("[pid:{}]: {}: {:.2f} seconds".format(os.getpid(), str(self), elapsed))
+        if teardown_failed:
+            self.fail(f'Teardown failed with message: {teardown_msg}')
         if (not passed) and (not self.skipped):
             print("[pid:{}]: ERROR in {}".format(os.getpid(), str(self)))
             self.pr('FAIL')


### PR DESCRIPTION
The main problem here is that the test suite needs `self.fail` to be called for the test to be registered as a failure - setting `passed` is not adequate. However, this still needs to be done after the `os.chdir` call in `tearDown`, otherwise that call doesn't run and future tests get into a messed-up state where they run from another test's directory.

This also fixes the verifier's `stderr` not getting echoed. This is a nice-to-have since it was already getting saved in the log, but now it'll be clearer when looking at Evergreen.