### PR TITLE
WT-10940 Ignore system calls to set thread name in test/syscall.

### DIFF
--- a/test/syscall/wt2336_base/base.run
+++ b/test/syscall/wt2336_base/base.run
@@ -110,7 +110,7 @@ fdatasync(fd);
 close(fd);
 rename("./WiredTiger.turtle.set", "./WiredTiger.turtle");
 
-...  // There is a second open of turtle here, is it important?
+...  // There is a second open of turtle here, is it important? We also set two thread names.
 
 fd = OPEN("./WiredTigerHS.wt", O_RDWR|O_CREAT|O_EXCL|O_NOATIME|O_CLOEXEC, 0666);
 
@@ -150,6 +150,7 @@ dir = OPEN("./", O_RDONLY|O_CLOEXEC);
 fdatasync(dir);
 close(dir);
 fdatasync(wt);
+... // Calls to open /proc/self/task/... in order to set names of internal threads.
 #endif /* __linux__ */
 
 OUTPUT("--------------open_session");


### PR DESCRIPTION
WT-10777 added code to set thread names on WiredTiger internal threads. The pthreads library implements this by opening `/proc/self/task/<TID>/comm`, where `<TID>` is the threadID. As a result these operations get picked up by our `syscall` test. This change updates the template used to match system calls to it ignores these pthread-based operations.