### PR TITLE
Revert "WT-10949 Allow truncate operation with no timestamp for MongoDB"

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -2153,13 +2153,6 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop, WT_ITEM
     WT_STAT_DATA_INCR(session, cursor_truncate);
 
     /*
-     * FIXME WT-10887: Allow performing truncate operation without a timestamp on non logged tables
-     * for non standalone builds (MongoDB). MongoDB do perform truncate operation only on a table
-     * that do not have historical versions to avoid the problem. Remove this standalone build
-     * specific code when a proper solution is implemented.
-     */
-#ifdef WT_STANDALONE_BUILD
-    /*
      * All historical versions must be removed when a key is updated with no timestamp, but that
      * isn't possible in fast truncate operations. Disallow fast truncate in transactions configured
      * to commit without a timestamp (excluding logged tables as timestamps cannot be relevant to
@@ -2170,7 +2163,6 @@ __wt_btcur_range_truncate(WT_CURSOR_BTREE *start, WT_CURSOR_BTREE *stop, WT_ITEM
           "truncate operations may not yet be included in transactions that can commit without a "
           "timestamp. If your use case encounters this error, please reach out to the WiredTiger "
           "team");
-#endif
 
     WT_RET(__wt_txn_autocommit_check(session));
 


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#9064