### PR TITLE
WT-10878 Fix WT_PREFIX_MATCH to correctly handle empty prefix

### DIFF
--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -249,8 +249,7 @@
 #define WT_CLEAR(s) memset(&(s), 0, sizeof(s))
 
 /* Check if a string matches a prefix. */
-#define WT_PREFIX_MATCH(str, pfx) \
-    (((const char *)(str))[0] == ((const char *)(pfx))[0] && strncmp(str, pfx, strlen(pfx)) == 0)
+#define WT_PREFIX_MATCH(str, pfx) (strncmp(str, pfx, strlen(pfx)) == 0)
 
 /* Check if a string matches a suffix. */
 #define WT_SUFFIX_MATCH(str, sfx) \


### PR DESCRIPTION
Fixes WT_PREFIX_MATCH which was incorrectly returning false for empty prefix strings.