### PR TITLE
WT-10849 Work around edge case for mirrors with FLCS, VLCS and truncate.

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -242,7 +242,8 @@ typedef struct {
 
     char *config_open; /* Command-line configuration */
 
-    TABLE *base_mirror; /* First mirrored table */
+    TABLE *base_mirror;  /* First mirrored table */
+    bool mirror_fix_var; /* Special case if mirroring both FIX and VAR tables */
 
     RWLOCK backup_lock; /* Backup running */
     uint64_t backup_id; /* Block incremental id */

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1158,12 +1158,18 @@ config_mirrors(void)
 {
     u_int available_tables, i, mirrors;
     char buf[100];
-    bool already_set, explicit_mirror;
+    bool already_set, explicit_mirror, fix, var;
 
+    fix = var = false;
+    g.mirror_fix_var = false;
     /* Check for a CONFIG file that's already set up for mirroring. */
     for (already_set = false, i = 1; i <= ntables; ++i)
         if (NTV(tables[i], RUNS_MIRROR)) {
             already_set = tables[i]->mirror = true;
+            if (tables[i]->type == FIX)
+                fix = true;
+            if (tables[i]->type == VAR)
+                var = true;
             if (g.base_mirror == NULL && tables[i]->type != FIX)
                 g.base_mirror = tables[i];
         }
@@ -1177,6 +1183,8 @@ config_mirrors(void)
          * it lets us avoid a bunch of extra logic around figuring out whether we have an acceptable
          * minimum number of tables.
          */
+        if (fix && var)
+            g.mirror_fix_var = true;
         return;
     }
 
@@ -1253,7 +1261,8 @@ config_mirrors(void)
     tables[i]->mirror = true;
     config_single(tables[i], "runs.mirror=1", false);
     g.base_mirror = tables[i];
-
+    if (tables[i]->type == VAR)
+        var = true;
     /*
      * Pick some number of tables to mirror, then turn on mirroring the next (n-1) tables, where
      * allowed.
@@ -1264,11 +1273,21 @@ config_mirrors(void)
         if (tables[i] != g.base_mirror) {
             tables[i]->mirror = true;
             config_single(tables[i], "runs.mirror=1", false);
+            if (tables[i]->type == FIX)
+                fix = true;
+            if (tables[i]->type == VAR)
+                var = true;
             if (--mirrors == 0)
                 break;
         }
     }
 
+    /*
+     * There is an edge case that is possible only when we are mirroring both VLCS and FLCS tables.
+     * Note if that is true now.
+     */
+    if (fix && var)
+        g.mirror_fix_var = true;
     /*
      * Give each mirror the same number of rows (it's not necessary, we could treat end-of-table on
      * a mirror as OK, but this lets us assert matching rows).

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1165,14 +1165,14 @@ rollback_retry:
                         tinfo->last = 0;
                     /*
                      * Edge case: There is a case where we cannot detect a proper mirror mismatch.
-                     * Say we truncated the tail end key range of all the mirrors from N-max_rows.
-                     * This truncate happened before any thread added another non-mirrored
+                     * Say we truncated the tail end key range of all the mirrors from N to
+                     * max_rows. This truncate happened before any thread added another non-mirrored
                      * append/insert to a VLCS table and the data in that truncated key range was
                      * sufficient to delete the pages at the end of the VLCS table. Then when a VLCS
                      * non-mirrored insert happened, it appended the new item at key N instead of at
                      * max_rows + 1.
                      *
-                     * Then the next mirror check hit will mismatch if there is an FLCS table
+                     * Then the next mirror check will detect a mismatch if there is an FLCS table
                      * because the appended value does not match the FLCS truncated value. The
                      * mismatch does not trigger with row-store tables because the row-store code to
                      * get the next mirror key in format returns WT_NOTFOUND because all those


### PR DESCRIPTION
The VLCS characteristic of appending to the end of a table means that a truncate at the end of a table and then an append-insert can overwrite the mirror space. It is correctly handled except when both FLCS and VLCS exist as mirrors. In that case I adjust the truncate range to leave the last mirror element in the table.