### PR TITLE
WT-10802 Handle EBUSY error when checkpointing in test/format

### DIFF
--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -98,8 +98,7 @@ checkpoint(void *arg)
          */
         ckpt_config = NULL;
         ckpt_vrfy_name = "WiredTigerCheckpoint";
-        backup_locked = false;
-        ebusy_ok = false;
+        backup_locked = ebusy_ok = false;
 
         /*
          * Use checkpoint with flush_tier as often as configured. Don't mix with named checkpoints,

--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -144,8 +144,7 @@ checkpoint(void *arg)
         /*
          * Because of the concurrent activity of the sweep server, it is possible to get EBUSY when
          * we are trying to remove an existing checkpoint as the sweep server may be interacting
-         * with a dhandle associated with the checkpoint being removed. There is a specific scenario
-         * where we remove an existing checkpoint if we create one with the same name.
+         * with a dhandle associated with the checkpoint being removed.
          */
         if (ret == EBUSY)
             testutil_assert(!WT_PREFIX_MATCH(ckpt_vrfy_name, WT_CHECKPOINT) ||


### PR DESCRIPTION
When checkpointing, it is possible to get an `EBUSY` error for various reasons. One of them is when we are trying to drop a checkpoint while a dhandle referring to it is being used by a reader or the sweep server for instance.

The current code of test/format assumes checkpoints always succeed. The suggested changes cover the `EBUSY` scenario.