### PR TITLE
WT-10973 Clean up files causing noise in git diffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build/
 dist/clang-format
 /docs/
 test-compatibility-run/
+
+# Python artifacts
+**/*.pyc

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -106,7 +106,7 @@ spellchk()
         -e 's/__verify_dsk_/__verify_disk_/g' \
         -e 's/__wt_dsk_/__wt_disk_/g' \
         -e 's/__wt_verify_dsk/__wt_verify_disk/g' \
-       *.dox | tee yogbert | \
+       *.dox | \
     aspell --encoding=iso-8859-1 --lang=en_US --personal=./spell.ok list) |
     sort -u > $t
     test -s $t && {
@@ -204,6 +204,12 @@ EOF
             done
         done
         )
+    fi
+
+    # Clean up the doxygen.log if it is empty.
+    doxy_logfile=../src/docs/doxygen.log
+    if [ ! -s "${doxy_logfile}" ] ; then
+        rm -f "${doxy_logfile}"
     fi
 }
 


### PR DESCRIPTION
Clean up or gitignore files that cause noise when running `git status`/`git diff`. In particular:
- gitignore generated `.pyc` files 
- Delete `doxygen.log` only if the file is empty
- Stop creating the `src/docs/yogbert` file. This file is never used and contains the concatenated contents of all our `.dox` files. I believe it's a temporary debugging file left in accidentally

I also considered gitignoring IDE configuration folders such as `.vscode` but decided against it as this is on the individual developer to manage.