### PR TITLE
WT-10975 Remove redundant entries in the s_string.ok whitelist

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -55,8 +55,6 @@ CBT
 CCCCCCCCCCCCCCCCCC
 CELLs
 CET
-CFLAGS
-CHECKKEY
 CHUNKCACHE
 CKPT
 CLOEXEC
@@ -77,7 +75,6 @@ Checksums
 CityHash
 CloseHandle
 CmP
-CmPTh
 Comparator
 Config
 Coverity
@@ -858,8 +855,6 @@ isprint
 isrc
 isspace
 iter
-iteratively
-iters
 jemalloc
 jjj
 js
@@ -1047,7 +1042,6 @@ pT
 packv
 pageref
 pagesize
-pagestat
 param
 pareto
 parserp


### PR DESCRIPTION
Drop words from s_string.ok that are no longer in the code base and don't need to be whitelisted anymore.
We've run `sh s_string.ok -r` on both an `ubuntu2204` and `ubuntu1804` to confirm that this is correct for both older and more recent versions of aspell.