### PR TITLE
WT-10935 Move to a larger distro for unit-test-long task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4295,6 +4295,7 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: unit-test-zstd
     - name: unit-test-long
+      distros: ubuntu2004-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
     - name: compile-wtperf


### PR DESCRIPTION
Though the solution is the same, on the mongodb-6.0 branch we only need to switch distro for the `unit-test-long` task in the `ubuntu2004-arm64` builder.