### PR TITLE
WT-10981 Move s-string task into PR testing

### DIFF
--- a/dist/s_string
+++ b/dist/s_string
@@ -76,7 +76,7 @@ while :
         sort -u -o $t $t
 
 	if ! diff $t s_string.ok >/dev/null 2>&1; then
-            echo "The string.ok list will be updated."
+            echo "The string.ok list will be updated to remove words that are no longer needed."
             cp $t s_string.ok
             exit_val=1
         else

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -995,7 +995,6 @@ nocase
 noclear
 nocrypto
 nolock
-nolongerneeded
 nonces
 nonliteral
 nontransactionally

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -995,6 +995,7 @@ nocase
 noclear
 nocrypto
 nolock
+nolongerneeded
 nonces
 nonliteral
 nontransactionally

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2788,8 +2788,9 @@ tasks:
 
   - name: s-string
     # Run the script with "-r" option to remove no-longer-needed words in s_string.ok
-    # This task only needs to be scheduled every a few months. A failure can remind us
-    # to keep the s_string.ok word list up-to-date.
+    # Run this task on every PR so we can update s_string.ok alongside the code changes 
+    # that make the word redundant.
+    tags: ["pull_request"]
     commands:
       - func: "get project"
       - command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2785,20 +2785,9 @@ tasks:
             set -o errexit
             set -o verbose
             sh -x s_all -A -E 2>&1
-
-  - name: s-string
-    # Run the script with "-r" option to remove no-longer-needed words in s_string.ok
-    # Run this task on every PR so we can update s_string.ok alongside the code changes 
-    # that make the word redundant.
-    tags: ["pull_request"]
-    commands:
-      - func: "get project"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/dist"
-          script: |
-            set -o errexit
-            set -o verbose
+            # Run s_string with the "-r" option to remove no-longer-needed words from s_string.ok
+            # This is run separately from s_all as it can be too proactive when run as part of 
+            # developers local workflow, but needs to be run in PR builds before the code is merged.
             sh s_string -r 2>&1
 
   - name: s-outdated-fixmes

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -173,6 +173,12 @@ buildvariants:
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja
     make_command: ninja
+  # As these tests run infrequently by the time they fail we may have had 
+  # a lot of prior commits that would also fail for the same test. This is acceptable 
+  # as our infrequent tests aren't tracking critical failures, but we don't want 
+  # to perform stepback as evergreen will run the same test on all of these older commits 
+  # and generate a lot of redundant BFGs.
+  stepback: false
   tasks:
     - name: memory-model-test
       batchtime: 40320 # 28 days

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -178,5 +178,3 @@ buildvariants:
       batchtime: 40320 # 28 days
     - name: s-outdated-fixmes
       batchtime: 10080 # 7 days
-    - name: s-string
-      batchtime: 129600 # 90 days


### PR DESCRIPTION
Move s-string from `infrequent-checks` into PR testing so we correct `s_string.ok` in the same PR that makes the `s_string.ok` updates necessary.
As part of this I've also: 
- merged `s-all` and `s-string` into a single task, and 
- set `stepback: false` for the `infrequent-checks` buildvariant. This will prevent any future cases of an infrequent test failing and evergreen generating a large amount of BFGs via the stepback process.