### PR TITLE
WT-10887 Table configuration for specify insert-only behaviour

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -233,6 +233,10 @@ file_runtime_config = common_runtime_config + [
         do not ever evict the object's pages from cache. Not compatible with LSM tables; see
         @ref tuning_cache_resident for more information''',
         type='boolean'),
+    Config('insert_only', 'false', r'''
+        configure to allow insert-only operations when the table is created. An error is returned
+        when an update operation is performed''',
+        type='boolean'),
     Config('log', '', r'''
         the transaction log configuration for this object. Only valid if \c log is enabled in
         ::wiredtiger_open''',

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -420,6 +420,12 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
         F_CLR(btree, WT_BTREE_LOGGED);
     }
 
+    WT_RET(__wt_config_gets(session, cfg, "insert_only", &cval));
+    if (cval.val)
+        F_SET(btree, WT_BTREE_INSERT_ONLY);
+    else
+        F_CLR(btree, WT_BTREE_INSERT_ONLY);
+
     WT_RET(__wt_config_gets(session, cfg, "tiered_object", &cval));
     if (cval.val)
         F_SET(btree, WT_BTREE_NO_CHECKPOINT);

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -235,6 +235,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_alter[] = {
   {"assert", "category", NULL, NULL, confchk_WT_SESSION_create_assert_subconfigs, 4},
   {"cache_resident", "boolean", NULL, NULL, NULL, 0}, {"checkpoint", "string", NULL, NULL, NULL, 0},
   {"exclusive_refreshed", "boolean", NULL, NULL, NULL, 0},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"log", "category", NULL, NULL, confchk_WT_SESSION_create_log_subconfigs, 1},
   {"os_cache_dirty_max", "int", NULL, "min=0", NULL, 0},
   {"os_cache_max", "int", NULL, "min=0", NULL, 0},
@@ -344,6 +345,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_create[] = {
   {"ignore_in_memory_cache_size", "boolean", NULL, NULL, NULL, 0},
   {"immutable", "boolean", NULL, NULL, NULL, 0},
   {"import", "category", NULL, NULL, confchk_WT_SESSION_create_import_subconfigs, 5},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"internal_item_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_truncate", "boolean", NULL, NULL, NULL, 0},
@@ -505,6 +507,7 @@ static const WT_CONFIG_CHECK confchk_file_config[] = {
   {"format", "string", NULL, "choices=[\"btree\"]", NULL, 0},
   {"huffman_key", "string", NULL, NULL, NULL, 0}, {"huffman_value", "string", NULL, NULL, NULL, 0},
   {"ignore_in_memory_cache_size", "boolean", NULL, NULL, NULL, 0},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"internal_item_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_truncate", "boolean", NULL, NULL, NULL, 0},
@@ -555,6 +558,7 @@ static const WT_CONFIG_CHECK confchk_file_meta[] = {
   {"huffman_key", "string", NULL, NULL, NULL, 0}, {"huffman_value", "string", NULL, NULL, NULL, 0},
   {"id", "string", NULL, NULL, NULL, 0},
   {"ignore_in_memory_cache_size", "boolean", NULL, NULL, NULL, 0},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"internal_item_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_truncate", "boolean", NULL, NULL, NULL, 0},
@@ -621,6 +625,7 @@ static const WT_CONFIG_CHECK confchk_lsm_meta[] = {
   {"format", "string", NULL, "choices=[\"btree\"]", NULL, 0},
   {"huffman_key", "string", NULL, NULL, NULL, 0}, {"huffman_value", "string", NULL, NULL, NULL, 0},
   {"ignore_in_memory_cache_size", "boolean", NULL, NULL, NULL, 0},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"internal_item_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_truncate", "boolean", NULL, NULL, NULL, 0},
@@ -674,6 +679,7 @@ static const WT_CONFIG_CHECK confchk_object_meta[] = {
   {"huffman_key", "string", NULL, NULL, NULL, 0}, {"huffman_value", "string", NULL, NULL, NULL, 0},
   {"id", "string", NULL, NULL, NULL, 0},
   {"ignore_in_memory_cache_size", "boolean", NULL, NULL, NULL, 0},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"internal_item_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_truncate", "boolean", NULL, NULL, NULL, 0},
@@ -743,6 +749,7 @@ static const WT_CONFIG_CHECK confchk_tier_meta[] = {
   {"huffman_key", "string", NULL, NULL, NULL, 0}, {"huffman_value", "string", NULL, NULL, NULL, 0},
   {"id", "string", NULL, NULL, NULL, 0},
   {"ignore_in_memory_cache_size", "boolean", NULL, NULL, NULL, 0},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"internal_item_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_truncate", "boolean", NULL, NULL, NULL, 0},
@@ -797,6 +804,7 @@ static const WT_CONFIG_CHECK confchk_tiered_meta[] = {
   {"huffman_key", "string", NULL, NULL, NULL, 0}, {"huffman_value", "string", NULL, NULL, NULL, 0},
   {"id", "string", NULL, NULL, NULL, 0},
   {"ignore_in_memory_cache_size", "boolean", NULL, NULL, NULL, 0},
+  {"insert_only", "boolean", NULL, NULL, NULL, 0},
   {"internal_item_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_max", "int", NULL, "min=0", NULL, 0},
   {"internal_key_truncate", "boolean", NULL, NULL, NULL, 0},
@@ -1301,10 +1309,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "access_pattern_hint=none,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"
     "read_timestamp=none,write_timestamp=off),cache_resident=false,"
-    "checkpoint=,exclusive_refreshed=true,log=(enabled=true),"
-    "os_cache_dirty_max=0,os_cache_max=0,verbose=[],"
-    "write_timestamp_usage=none",
-    confchk_WT_SESSION_alter, 11},
+    "checkpoint=,exclusive_refreshed=true,insert_only=false,"
+    "log=(enabled=true),os_cache_dirty_max=0,os_cache_max=0,"
+    "verbose=[],write_timestamp_usage=none",
+    confchk_WT_SESSION_alter, 12},
   {"WT_SESSION.begin_transaction",
     "ignore_prepare=false,isolation=,name=,no_timestamp=false,"
     "operation_timeout_ms=0,priority=0,read_timestamp=,"
@@ -1329,12 +1337,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "exclusive=false,extractor=,format=btree,huffman_key=,"
     "huffman_value=,ignore_in_memory_cache_size=false,immutable=false"
     ",import=(compare_timestamp=oldest_timestamp,enabled=false,"
-    "file_metadata=,metadata_file=,repair=false),internal_item_max=0,"
-    "internal_key_max=0,internal_key_truncate=true,"
-    "internal_page_max=4KB,key_format=u,key_gap=10,leaf_item_max=0,"
-    "leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=0,"
-    "log=(enabled=true),lsm=(auto_throttle=true,bloom=true,"
-    "bloom_bit_count=16,bloom_config=,bloom_hash_count=8,"
+    "file_metadata=,metadata_file=,repair=false),insert_only=false,"
+    "internal_item_max=0,internal_key_max=0,"
+    "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
+    "key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
+    "leaf_value_max=0,log=(enabled=true),lsm=(auto_throttle=true,"
+    "bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,"
     "bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,"
     "chunk_size=10MB,merge_custom=(prefix=,start_generation=0,"
     "suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,"
@@ -1345,7 +1353,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_directory=,local_retention=300,name=,object_target_size=0,"
     "shared=false),type=file,value_format=u,verbose=[],"
     "write_timestamp_usage=none",
-    confchk_WT_SESSION_create, 48},
+    confchk_WT_SESSION_create, 49},
   {"WT_SESSION.drop",
     "checkpoint_wait=true,force=false,lock_wait=true,"
     "remove_files=true,remove_shared=false",
@@ -1408,7 +1416,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "block_compressor=,cache_resident=false,checksum=on,collator=,"
     "columns=,dictionary=0,encryption=(keyid=,name=),format=btree,"
     "huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,"
-    "internal_item_max=0,internal_key_max=0,"
+    "insert_only=false,internal_item_max=0,internal_key_max=0,"
     "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
     "key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
     "leaf_value_max=0,log=(enabled=true),memory_page_image_max=0,"
@@ -1419,7 +1427,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_directory=,local_retention=300,name=,object_target_size=0,"
     "shared=false),value_format=u,verbose=[],"
     "write_timestamp_usage=none",
-    confchk_file_config, 40},
+    confchk_file_config, 41},
   {"file.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"
@@ -1428,19 +1436,19 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "checkpoint_backup_info=,checkpoint_lsn=,checksum=on,collator=,"
     "columns=,dictionary=0,encryption=(keyid=,name=),format=btree,"
     "huffman_key=,huffman_value=,id=,"
-    "ignore_in_memory_cache_size=false,internal_item_max=0,"
-    "internal_key_max=0,internal_key_truncate=true,"
-    "internal_page_max=4KB,key_format=u,key_gap=10,leaf_item_max=0,"
-    "leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=0,"
-    "log=(enabled=true),memory_page_image_max=0,memory_page_max=5MB,"
-    "os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,"
-    "prefix_compression_min=4,readonly=false,split_deepen_min_child=0"
-    ",split_deepen_per_child=0,split_pct=90,tiered_object=false,"
-    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
-    "cache_directory=,local_retention=300,name=,object_target_size=0,"
-    "shared=false),value_format=u,verbose=[],version=(major=0,"
-    "minor=0),write_timestamp_usage=none",
-    confchk_file_meta, 47},
+    "ignore_in_memory_cache_size=false,insert_only=false,"
+    "internal_item_max=0,internal_key_max=0,"
+    "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
+    "key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
+    "leaf_value_max=0,log=(enabled=true),memory_page_image_max=0,"
+    "memory_page_max=5MB,os_cache_dirty_max=0,os_cache_max=0,"
+    "prefix_compression=false,prefix_compression_min=4,readonly=false"
+    ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
+    "tiered_object=false,tiered_storage=(auth_token=,bucket=,"
+    "bucket_prefix=,cache_directory=,local_retention=300,name=,"
+    "object_target_size=0,shared=false),value_format=u,verbose=[],"
+    "version=(major=0,minor=0),write_timestamp_usage=none",
+    confchk_file_meta, 48},
   {"index.meta",
     "app_metadata=,assert=(commit_timestamp=none,"
     "durable_timestamp=none,read_timestamp=none,write_timestamp=off),"
@@ -1455,23 +1463,24 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "block_compressor=,cache_resident=false,checksum=on,chunks=,"
     "collator=,columns=,dictionary=0,encryption=(keyid=,name=),"
     "format=btree,huffman_key=,huffman_value=,"
-    "ignore_in_memory_cache_size=false,internal_item_max=0,"
-    "internal_key_max=0,internal_key_truncate=true,"
-    "internal_page_max=4KB,key_format=u,key_gap=10,last=0,"
-    "leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
-    "leaf_value_max=0,log=(enabled=true),lsm=(auto_throttle=true,"
-    "bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,"
-    "bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,"
-    "chunk_size=10MB,merge_custom=(prefix=,start_generation=0,"
-    "suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,"
-    "memory_page_max=5MB,old_chunks=,os_cache_dirty_max=0,"
-    "os_cache_max=0,prefix_compression=false,prefix_compression_min=4"
-    ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
+    "ignore_in_memory_cache_size=false,insert_only=false,"
+    "internal_item_max=0,internal_key_max=0,"
+    "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
+    "key_gap=10,last=0,leaf_item_max=0,leaf_key_max=0,"
+    "leaf_page_max=32KB,leaf_value_max=0,log=(enabled=true),"
+    "lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,"
+    "bloom_config=,bloom_hash_count=8,bloom_oldest=false,"
+    "chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,"
+    "merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,"
+    "merge_min=0),memory_page_image_max=0,memory_page_max=5MB,"
+    "old_chunks=,os_cache_dirty_max=0,os_cache_max=0,"
+    "prefix_compression=false,prefix_compression_min=4,"
+    "split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,local_retention=300,name=,object_target_size=0,"
     "shared=false),value_format=u,verbose=[],"
     "write_timestamp_usage=none",
-    confchk_lsm_meta, 44},
+    confchk_lsm_meta, 45},
   {"object.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"
@@ -1480,19 +1489,19 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "checkpoint_backup_info=,checkpoint_lsn=,checksum=on,collator=,"
     "columns=,dictionary=0,encryption=(keyid=,name=),flush_time=0,"
     "flush_timestamp=0,format=btree,huffman_key=,huffman_value=,id=,"
-    "ignore_in_memory_cache_size=false,internal_item_max=0,"
-    "internal_key_max=0,internal_key_truncate=true,"
-    "internal_page_max=4KB,key_format=u,key_gap=10,leaf_item_max=0,"
-    "leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=0,"
-    "log=(enabled=true),memory_page_image_max=0,memory_page_max=5MB,"
-    "os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,"
-    "prefix_compression_min=4,readonly=false,split_deepen_min_child=0"
-    ",split_deepen_per_child=0,split_pct=90,tiered_object=false,"
-    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
-    "cache_directory=,local_retention=300,name=,object_target_size=0,"
-    "shared=false),value_format=u,verbose=[],version=(major=0,"
-    "minor=0),write_timestamp_usage=none",
-    confchk_object_meta, 49},
+    "ignore_in_memory_cache_size=false,insert_only=false,"
+    "internal_item_max=0,internal_key_max=0,"
+    "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
+    "key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
+    "leaf_value_max=0,log=(enabled=true),memory_page_image_max=0,"
+    "memory_page_max=5MB,os_cache_dirty_max=0,os_cache_max=0,"
+    "prefix_compression=false,prefix_compression_min=4,readonly=false"
+    ",split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,"
+    "tiered_object=false,tiered_storage=(auth_token=,bucket=,"
+    "bucket_prefix=,cache_directory=,local_retention=300,name=,"
+    "object_target_size=0,shared=false),value_format=u,verbose=[],"
+    "version=(major=0,minor=0),write_timestamp_usage=none",
+    confchk_object_meta, 50},
   {"table.meta",
     "app_metadata=,assert=(commit_timestamp=none,"
     "durable_timestamp=none,read_timestamp=none,write_timestamp=off),"
@@ -1508,7 +1517,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "checkpoint_lsn=,checksum=on,collator=,columns=,dictionary=0,"
     "encryption=(keyid=,name=),format=btree,huffman_key=,"
     "huffman_value=,id=,ignore_in_memory_cache_size=false,"
-    "internal_item_max=0,internal_key_max=0,"
+    "insert_only=false,internal_item_max=0,internal_key_max=0,"
     "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
     "key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
     "leaf_value_max=0,log=(enabled=true),memory_page_image_max=0,"
@@ -1519,7 +1528,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "bucket_prefix=,cache_directory=,local_retention=300,name=,"
     "object_target_size=0,shared=false),value_format=u,verbose=[],"
     "version=(major=0,minor=0),write_timestamp_usage=none",
-    confchk_tier_meta, 50},
+    confchk_tier_meta, 51},
   {"tiered.meta",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"
@@ -1528,19 +1537,20 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "checkpoint_backup_info=,checkpoint_lsn=,checksum=on,collator=,"
     "columns=,dictionary=0,encryption=(keyid=,name=),flush_time=0,"
     "flush_timestamp=0,format=btree,huffman_key=,huffman_value=,id=,"
-    "ignore_in_memory_cache_size=false,internal_item_max=0,"
-    "internal_key_max=0,internal_key_truncate=true,"
-    "internal_page_max=4KB,key_format=u,key_gap=10,last=0,"
-    "leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,"
-    "leaf_value_max=0,log=(enabled=true),memory_page_image_max=0,"
-    "memory_page_max=5MB,oldest=1,os_cache_dirty_max=0,os_cache_max=0"
-    ",prefix_compression=false,prefix_compression_min=4,"
-    "readonly=false,split_deepen_min_child=0,split_deepen_per_child=0"
-    ",split_pct=90,tiered_object=false,tiered_storage=(auth_token=,"
-    "bucket=,bucket_prefix=,cache_directory=,local_retention=300,"
-    "name=,object_target_size=0,shared=false),tiers=,value_format=u,"
-    "verbose=[],version=(major=0,minor=0),write_timestamp_usage=none",
-    confchk_tiered_meta, 52},
+    "ignore_in_memory_cache_size=false,insert_only=false,"
+    "internal_item_max=0,internal_key_max=0,"
+    "internal_key_truncate=true,internal_page_max=4KB,key_format=u,"
+    "key_gap=10,last=0,leaf_item_max=0,leaf_key_max=0,"
+    "leaf_page_max=32KB,leaf_value_max=0,log=(enabled=true),"
+    "memory_page_image_max=0,memory_page_max=5MB,oldest=1,"
+    "os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,"
+    "prefix_compression_min=4,readonly=false,split_deepen_min_child=0"
+    ",split_deepen_per_child=0,split_pct=90,tiered_object=false,"
+    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
+    "cache_directory=,local_retention=300,name=,object_target_size=0,"
+    "shared=false),tiers=,value_format=u,verbose=[],version=(major=0,"
+    "minor=0),write_timestamp_usage=none",
+    confchk_tiered_meta, 53},
   {"wiredtiger_open",
     "backup_restore_target=,"
     "block_cache=(blkcache_eviction_aggression=1800,"

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -82,6 +82,13 @@ __hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *btree,
 
     counter = hs_counter = 0;
 
+    /*
+     * Ensure that there are no history store inserts performed for the table configured for
+     * insert only.
+     */
+    WT_ASSERT_ALWAYS(session, !F_ISSET(btree, WT_BTREE_INSERT_ONLY),
+      "History store insert is performed on a table configured with insert only.");
+
     /* Verify that the timestamps are in increasing order. */
     WT_ASSERT(session, tw->stop_ts >= tw->start_ts && tw->durable_stop_ts >= tw->durable_start_ts);
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -258,15 +258,16 @@ struct __wt_btree {
 #define WT_BTREE_BULK 0x0002000u           /* Bulk-load handle */
 #define WT_BTREE_CLOSED 0x0004000u         /* Handle closed */
 #define WT_BTREE_IGNORE_CACHE 0x0008000u   /* Cache-resident object */
-#define WT_BTREE_IN_MEMORY 0x0010000u      /* Cache-resident object */
-#define WT_BTREE_LOGGED 0x0020000u         /* Commit-level durability without timestamps */
-#define WT_BTREE_NO_CHECKPOINT 0x0040000u  /* Disable checkpoints */
-#define WT_BTREE_OBSOLETE_PAGES 0x0080000u /* Handle has obsolete pages */
-#define WT_BTREE_READONLY 0x0100000u       /* Handle is readonly */
-#define WT_BTREE_SALVAGE 0x0200000u        /* Handle is for salvage */
-#define WT_BTREE_SKIP_CKPT 0x0400000u      /* Handle skipped checkpoint */
-#define WT_BTREE_UPGRADE 0x0800000u        /* Handle is for upgrade */
-#define WT_BTREE_VERIFY 0x1000000u         /* Handle is for verify */
+#define WT_BTREE_INSERT_ONLY 0x0010000u    /* Handle is insert-only */
+#define WT_BTREE_IN_MEMORY 0x0020000u      /* Cache-resident object */
+#define WT_BTREE_LOGGED 0x0040000u         /* Commit-level durability without timestamps */
+#define WT_BTREE_NO_CHECKPOINT 0x0080000u  /* Disable checkpoints */
+#define WT_BTREE_OBSOLETE_PAGES 0x0100000u /* Handle has obsolete pages */
+#define WT_BTREE_READONLY 0x0200000u       /* Handle is readonly */
+#define WT_BTREE_SALVAGE 0x0400000u        /* Handle is for salvage */
+#define WT_BTREE_SKIP_CKPT 0x0800000u      /* Handle skipped checkpoint */
+#define WT_BTREE_UPGRADE 0x1000000u        /* Handle is for upgrade */
+#define WT_BTREE_VERIFY 0x2000000u         /* Handle is for verify */
                                            /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t flags;
 };

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1145,8 +1145,8 @@ retry:
         }
     }
 
-    /* If there's no visible update in the update chain or ondisk, check the history store file. */
-    if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
+    /* If there's no visible update in the update chain or ondisk, check the history store file for files not configured for insert only. */
+    if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(session->dhandle, WT_DHANDLE_HS) && !F_ISSET(S2BT(session), WT_BTREE_INSERT_ONLY)) {
         __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
         WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,
           cbt->upd_value, &cbt->upd_value->buf));

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1111,6 +1111,8 @@ struct __wt_session {
      * @config{cache_resident, do not ever evict the object's pages from cache.  Not compatible with
      * LSM tables; see @ref tuning_cache_resident for more information., a boolean flag; default \c
      * false.}
+     * @config{insert_only, configure to allow insert-only operations when the table is created.  An
+     * error is returned when an update operation is performed., a boolean flag; default \c false.}
      * @config{log = (, the transaction log configuration for this object.  Only valid if \c log is
      * enabled in ::wiredtiger_open., a set of related configuration options defined as follows.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, if false\, this object has checkpoint-level
@@ -1253,6 +1255,8 @@ struct __wt_session {
      * whether to reconstruct the metadata from the raw file content., a boolean flag; default \c
      * false.}
      * @config{ ),,}
+     * @config{insert_only, configure to allow insert-only operations when the table is created.  An
+     * error is returned when an update operation is performed., a boolean flag; default \c false.}
      * @config{internal_key_max, This option is no longer supported\, retained for backward
      * compatibility., an integer greater than or equal to \c 0; default \c 0.}
      * @config{internal_key_truncate, configure internal key truncation\, discarding unnecessary

--- a/test/suite/test_alter06.py
+++ b/test/suite/test_alter06.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper_tiered import TieredConfigMixin, gen_tiered_storage_sources
+from wtscenario import make_scenarios
+
+# test_alter06.py
+#    Check the alter command in changing the table from insert only to update.
+class test_alter05(TieredConfigMixin, wttest.WiredTigerTestCase):
+    name = "alter06"
+    tiered_storage_sources = gen_tiered_storage_sources()
+    scenarios = make_scenarios(tiered_storage_sources)
+
+    # Setup custom connection config.
+    def conn_config(self):
+        conf = self.tiered_conn_config()
+        if conf != '':
+            conf += ','
+        conf += 'statistics=(all)'
+        return conf
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def verify_metadata(self, metastr):
+        c = self.session.open_cursor('metadata:', None, None)
+
+        # We must find a file type entry for this object and its value
+        # should contain the provided file meta string.
+        c.set_key('file:' + self.name)
+        self.assertNotEqual(c.search(), wiredtiger.WT_NOTFOUND)
+        value = c.get_value()
+        self.assertTrue(value.find(metastr) != -1)
+
+        c.close()
+
+    # Alter file to change the metadata and verify.
+    def test_alter06(self):
+        uri = "file:" + self.name
+        entries = 100
+        create_params = 'key_format=i,value_format=i,'
+
+        self.session.create(uri, create_params + "insert_only=true")
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        # Verify the string in the metadata.
+        self.verify_metadata('insert_only=true')
+
+        # Put some data in table.
+        self.session.begin_transaction()
+        c = self.session.open_cursor(uri, None)
+        for k in range(entries):
+            c[k+1] = 1
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+        c.close()
+
+        prev_alter_checkpoints = self.get_stat(wiredtiger.stat.conn.session_table_alter_trigger_checkpoint)
+
+        # Alter the table and verify.
+        self.session.alter(uri, 'insert_only=false')
+        self.verify_metadata('insert_only=false')
+
+        alter_checkpoints = self.get_stat(wiredtiger.stat.conn.session_table_alter_trigger_checkpoint)
+        self.assertEqual(prev_alter_checkpoints + 1, alter_checkpoints)
+        prev_alter_checkpoints = alter_checkpoints
+
+        # Open a cursor, insert some data and try to alter with cursor open.
+        c = self.session.open_cursor(uri, None)
+        self.session.begin_transaction()
+        for k in range(entries):
+            c[k+1] = 2
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: self.session.alter(uri, 'insert_only=true'))
+        self.verify_metadata('insert_only=false')
+
+        alter_checkpoints = self.get_stat(wiredtiger.stat.conn.session_table_alter_trigger_checkpoint)
+        self.assertEqual(prev_alter_checkpoints + 1, alter_checkpoints)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
The tables configured for insert-only doesn't generate any historical versions and these tables are allowed to perform truncate with no timestamp as there doesn't exist any historical versions.