### PR TITLE
WT-10767 Have WT utility use the same allocator as the main WiredTiger library

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1106,6 +1106,7 @@ readlock
 readonly
 readunlock
 realloc
+reallocations
 recency
 recno
 recnos

--- a/dist/s_style
+++ b/dist/s_style
@@ -198,9 +198,9 @@ else
     if ! expr "$f" : 'bench/.*' > /dev/null &&
        ! expr "$f" : 'examples/.*' > /dev/null &&
        ! expr "$f" : 'ext/.*' > /dev/null &&
-       ! expr "$f" : 'test/.*' > /dev/null &&
-       ! expr "$f" : '.*/utilities/.*' > /dev/null; then
+       ! expr "$f" : 'test/.*' > /dev/null; then
         if ! expr "$f" : '.*/os_alloc.c' > /dev/null &&
+           ! expr "$f" : '.*/util_misc.c' > /dev/null &&
              egrep '[[:space:]]free[(]|[[:space:]]strdup[(]|[[:space:]]strndup[(]|[[:space:]]malloc[(]|[[:space:]]calloc[(]|[[:space:]]realloc[(]|[[:space:]]sprintf[(]' $f > $t; then
             test -s $t && {
                 echo "$f: call to illegal function"

--- a/src/utilities/util.h
+++ b/src/utilities/util.h
@@ -55,3 +55,7 @@ char *util_uri(WT_SESSION *, const char *, const char *);
 void util_usage(const char *, const char *, const char *[]);
 int util_verify(WT_SESSION *, int, char *[]);
 int util_write(WT_SESSION *, int, char *[]);
+void *util_malloc(size_t);
+void *util_realloc(void *, size_t);
+void *util_calloc(size_t, size_t);
+void util_free(void *);

--- a/src/utilities/util.h
+++ b/src/utilities/util.h
@@ -59,3 +59,4 @@ void *util_malloc(size_t);
 void *util_realloc(void *, size_t);
 void *util_calloc(size_t, size_t);
 void util_free(void *);
+char *util_strdup(const char *);

--- a/src/utilities/util_backup.c
+++ b/src/utilities/util_backup.c
@@ -115,7 +115,7 @@ copy(WT_SESSION *session, const char *directory, const char *name)
 
     /* Build the target pathname. */
     len = strlen(directory) + strlen(name) + 2;
-    if ((to = malloc(len)) == NULL) {
+    if ((to = util_malloc(len)) == NULL) {
         fprintf(stderr, "%s: %s\n", progname, strerror(errno));
         return (1);
     }
@@ -138,6 +138,6 @@ copy(WT_SESSION *session, const char *directory, const char *name)
           session->strerror(session, ret));
 
 err:
-    free(to);
+    util_free(to);
     return (ret);
 }

--- a/src/utilities/util_compact.c
+++ b/src/utilities/util_compact.c
@@ -53,6 +53,6 @@ util_compact(WT_SESSION *session, int argc, char *argv[])
     if ((ret = session->compact(session, uri, NULL)) != 0)
         (void)util_err(session, ret, "session.compact: %s", uri);
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_create.c
+++ b/src/utilities/util_create.c
@@ -60,6 +60,6 @@ util_create(WT_SESSION *session, int argc, char *argv[])
     if ((ret = session->create(session, uri, config)) != 0)
         (void)util_err(session, ret, "session.create: %s", uri);
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_drop.c
+++ b/src/utilities/util_drop.c
@@ -54,6 +54,6 @@ util_drop(WT_SESSION *session, int argc, char *argv[])
     if ((ret = session->drop(session, uri, "force")) != 0)
         (void)util_err(session, ret, "session.drop: %s", uri);
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -213,8 +213,8 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
         if (json && i > 0)
             if (dump_json_separator(session) != 0)
                 goto err;
-        free(uri);
-        free(simpleuri);
+        util_free(uri);
+        util_free(simpleuri);
         uri = simpleuri = NULL;
 
         if ((uri = util_uri(session, argv[i], "table")) == NULL)
@@ -317,8 +317,8 @@ err:
         ret = util_err(session, errno, NULL);
 
     __wt_scr_free(session_impl, &tmp);
-    free(uri);
-    free(simpleuri);
+    util_free(uri);
+    util_free(simpleuri);
 
     return (ret);
 }
@@ -480,7 +480,7 @@ dump_projection(WT_SESSION *session, const char *config, WT_CURSOR *cursor, char
     const char *keyformat, *p;
 
     len = strlen(config) + strlen(cursor->value_format) + strlen(cursor->uri) + 20;
-    if ((newconfig = malloc(len)) == NULL)
+    if ((newconfig = util_malloc(len)) == NULL)
         return (util_err(session, errno, NULL));
     *newconfigp = newconfig;
     wt_api = session->connection->get_extension_api(session->connection);
@@ -575,7 +575,7 @@ dump_table_config(
     WT_ERR(dump_table_parts_config(session, mcursor, name, "index:", json));
 
 err:
-    free(proj_config);
+    util_free(proj_config);
     return (ret);
 }
 
@@ -611,10 +611,10 @@ dump_table_parts_config(
     }
 
     len = strlen(entry) + strlen(name) + 1;
-    if ((uriprefix = malloc(len)) == NULL)
+    if ((uriprefix = util_malloc(len)) == NULL)
         return (util_err(session, errno, NULL));
     if ((ret = __wt_snprintf(uriprefix, len, "%s%s", entry, name)) != 0) {
-        free(uriprefix);
+        util_free(uriprefix);
         return (util_err(session, ret, NULL));
     }
 
@@ -625,7 +625,7 @@ dump_table_parts_config(
      */
     cursor->set_key(cursor, uriprefix);
     ret = cursor->search_near(cursor, &exact);
-    free(uriprefix);
+    util_free(uriprefix);
     if (ret == WT_NOTFOUND)
         return (0);
     if (ret != 0)
@@ -906,7 +906,7 @@ dump_explore_bookmark_save(WT_CURSOR *cursor, char **bookmarks)
         if (bookmarks[i] != NULL)
             continue;
         key_size = strlen(key) + 1;
-        if ((bookmarks[i] = malloc(key_size)) == NULL)
+        if ((bookmarks[i] = util_malloc(key_size)) == NULL)
             return (util_err(session, errno, NULL));
         memmove(bookmarks[i], key, key_size);
         printf("Added bookmark %" PRIu64 ": %s.\n", i, key);
@@ -1013,7 +1013,7 @@ dump_explore(WT_CURSOR *cursor, const char *uri, bool reverse, bool pretty, bool
         if (current_arg == NULL)
             continue;
         while (current_arg != NULL) {
-            if ((args[i] = malloc(ARG_BUF_SIZE)) == NULL)
+            if ((args[i] = util_malloc(ARG_BUF_SIZE)) == NULL)
                 WT_ERR(util_err(session, errno, NULL));
             memmove(args[i++], current_arg, strlen(current_arg) + 1);
             ++num_args;
@@ -1268,7 +1268,7 @@ dup_json_string(const char *str, char **result)
     char *q;
 
     nchars = __wt_json_unpack_str(NULL, 0, (const u_char *)str, strlen(str)) + 1;
-    q = malloc(nchars);
+    q = util_malloc(nchars);
     if (q == NULL)
         return (1);
     WT_IGNORE_RET(__wt_json_unpack_str((u_char *)q, nchars, (const u_char *)str, strlen(str)));
@@ -1310,7 +1310,7 @@ print_config(WT_SESSION *session, const char *key, const char *cfg, bool json, b
               key, jsonconfig);
     } else
         ret = fprintf(fp, "%s\n%s\n", key, cfg);
-    free(jsonconfig);
+    util_free(jsonconfig);
     if (ret < 0)
         return (util_err(session, EIO, NULL));
     return (0);

--- a/src/utilities/util_dump.c
+++ b/src/utilities/util_dump.c
@@ -240,7 +240,7 @@ util_dump(WT_SESSION *session, int argc, char *argv[])
             goto err;
         }
 
-        if ((simpleuri = strdup(uri)) == NULL) {
+        if ((simpleuri = util_strdup(uri)) == NULL) {
             (void)util_err(session, errno, NULL);
             goto err;
         }

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -72,7 +72,7 @@ util_list(WT_SESSION *session, int argc, char *argv[])
 
     ret = list_print(session, uri, cflag, vflag);
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }
 
@@ -118,7 +118,7 @@ err:
             ret = tret;
     }
 
-    free(config);
+    util_free(config);
     return (ret);
 }
 

--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -176,8 +176,8 @@ err:
         ret = util_flush(session, uri);
 
     for (tlist = list; *tlist != NULL; ++tlist)
-        free(*tlist);
-    free(list);
+        util_free(*tlist);
+    util_free(list);
 
     return (ret == 0 ? 0 : 1);
 }
@@ -205,8 +205,8 @@ int
 config_list_add(WT_SESSION *session, CONFIG_LIST *clp, char *val)
 {
     if (clp->entry + 1 >= clp->max_entry)
-        if ((clp->list = realloc(clp->list, (size_t)(clp->max_entry += 100) * sizeof(char *))) ==
-          NULL)
+        if ((clp->list =
+                util_realloc(clp->list, (size_t)(clp->max_entry += 100) * sizeof(char *))) == NULL)
             /* List already freed by realloc. */
             return (util_err(session, errno, NULL));
 
@@ -226,8 +226,8 @@ config_list_free(CONFIG_LIST *clp)
 
     if (clp->list != NULL)
         for (entry = &clp->list[0]; *entry != NULL; entry++)
-            free(*entry);
-    free(clp->list);
+            util_free(*entry);
+    util_free(clp->list);
     clp->list = NULL;
     clp->entry = 0;
     clp->max_entry = 0;
@@ -291,7 +291,7 @@ config_read(WT_SESSION *session, char ***listp, bool *hexp)
          * termination.
          */
         if (entry + 1 >= max_entry) {
-            if ((tlist = realloc(list, (size_t)(max_entry += 100) * sizeof(char *))) == NULL) {
+            if ((tlist = util_realloc(list, (size_t)(max_entry += 100) * sizeof(char *))) == NULL) {
                 ret = util_err(session, errno, NULL);
 
                 /*
@@ -316,16 +316,16 @@ config_read(WT_SESSION *session, char ***listp, bool *hexp)
     }
     *listp = list;
 
-    free(l.mem);
+    util_free(l.mem);
     return (0);
 
 err:
     if (list != NULL) {
         for (tlist = list; *tlist != NULL; ++tlist)
-            free(*tlist);
-        free(list);
+            util_free(*tlist);
+        util_free(list);
     }
-    free(l.mem);
+    util_free(l.mem);
     return (ret);
 }
 
@@ -447,7 +447,7 @@ config_update(WT_SESSION *session, char **list)
      */
     for (cnt = 0, configp = cmdconfig; cmdconfig != NULL && *configp != NULL; configp += 2)
         ++cnt;
-    if ((cfg = calloc(cnt + 10, sizeof(cfg[0]))) == NULL)
+    if ((cfg = util_calloc(cnt + 10, sizeof(cfg[0]))) == NULL)
         return (util_err(session, errno, NULL));
 
     /*
@@ -472,10 +472,10 @@ config_update(WT_SESSION *session, char **list)
                &p)) != 0)
             break;
 
-        free(listp[1]);
+        util_free(listp[1]);
         listp[1] = (char *)p;
     }
-    free(cfg);
+    util_free(cfg);
     return (ret);
 }
 
@@ -492,20 +492,20 @@ config_rename(WT_SESSION *session, char **urip, const char *name)
 
     /* Allocate room. */
     len = strlen(*urip) + strlen(name) + 10;
-    if ((buf = malloc(len)) == NULL)
+    if ((buf = util_malloc(len)) == NULL)
         return (util_err(session, errno, NULL));
 
     /*
      * Find the separating colon characters, but note the trailing one may not be there.
      */
     if ((p = strchr(*urip, ':')) == NULL) {
-        free(buf);
+        util_free(buf);
         return (format(session));
     }
     *p = '\0';
     p = strchr(p + 1, ':');
     if ((ret = __wt_snprintf(buf, len, "%s:%s%s", *urip, name, p == NULL ? "" : p)) != 0) {
-        free(buf);
+        util_free(buf);
         return (util_err(session, ret, NULL));
     }
     *urip = buf;
@@ -575,8 +575,8 @@ insert(WT_CURSOR *cursor, const char *name)
         printf("\r\t%s: %" PRIu64 "\n", name, insert_count);
 
 err:
-    free(key.mem);
-    free(value.mem);
+    util_free(key.mem);
+    util_free(value.mem);
 
     return (ret);
 }

--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -302,7 +302,7 @@ config_read(WT_SESSION *session, char ***listp, bool *hexp)
             }
             list = tlist;
         }
-        if ((list[entry] = strdup(l.mem)) == NULL) {
+        if ((list[entry] = util_strdup(l.mem)) == NULL) {
             ret = util_err(session, errno, NULL);
             goto err;
         }

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -147,16 +147,16 @@ json_kvraw_append(WT_SESSION *session, JSON_INPUT_STATE *ins, const char *str, s
 
     if (len > 0) {
         needsize = strlen(ins->kvraw) + len + 2;
-        if ((tmp = malloc(needsize)) == NULL)
+        if ((tmp = util_malloc(needsize)) == NULL)
             return (util_err(session, errno, NULL));
         WT_ERR(__wt_snprintf(tmp, needsize, "%s %.*s", ins->kvraw, (int)len, str));
-        free(ins->kvraw);
+        util_free(ins->kvraw);
         ins->kvraw = tmp;
     }
     return (0);
 
 err:
-    free(tmp);
+    util_free(tmp);
     return (util_err(session, ret, NULL));
 }
 
@@ -182,7 +182,7 @@ json_strdup(WT_SESSION *session, JSON_INPUT_STATE *ins, char **resultp)
         goto err;
     }
     resultlen += 1;
-    if ((result = malloc((size_t)resultlen)) == NULL) {
+    if ((result = util_malloc((size_t)resultlen)) == NULL) {
         ret = util_err(session, errno, NULL);
         goto err;
     }
@@ -197,7 +197,7 @@ json_strdup(WT_SESSION *session, JSON_INPUT_STATE *ins, char **resultp)
 err:
         if (ret == 0)
             ret = EINVAL;
-        free(result);
+        util_free(result);
         *resultp = NULL;
     }
     return (ret);
@@ -256,7 +256,7 @@ json_data(WT_SESSION *session, JSON_INPUT_STATE *ins, CONFIG_LIST *clp, uint32_t
         nfield = 0;
         JSON_EXPECT(session, ins, '{');
         if (ins->kvraw == NULL) {
-            if ((ins->kvraw = malloc(1)) == NULL) {
+            if ((ins->kvraw = util_malloc(1)) == NULL) {
                 ret = util_err(session, errno, NULL);
                 goto err;
             }
@@ -356,7 +356,7 @@ json_top_level(WT_SESSION *session, JSON_INPUT_STATE *ins, uint32_t flags)
     JSON_EXPECT(session, ins, '{');
     while (json_peek(session, ins) == 's') {
         JSON_EXPECT(session, ins, 's');
-        tableuri = realloc(tableuri, ins->toklen);
+        tableuri = util_realloc(tableuri, ins->toklen);
         if ((ret = __wt_snprintf(
                tableuri, ins->toklen, "%.*s", (int)(ins->toklen - 2), ins->tokstart + 1)) != 0) {
             ret = util_err(session, ret, NULL);
@@ -447,7 +447,7 @@ err:
             ret = EINVAL;
     }
     config_list_free(&cl);
-    free(tableuri);
+    util_free(tableuri);
     return (ret);
 }
 
@@ -575,7 +575,7 @@ util_load_json(WT_SESSION *session, const char *filename, uint32_t flags)
         ret = json_top_level(session, &instate, flags);
     }
 
-    free(instate.line.mem);
-    free(instate.kvraw);
+    util_free(instate.line.mem);
+    util_free(instate.kvraw);
     return (ret);
 }

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -420,7 +420,7 @@ json_top_level(WT_SESSION *session, JSON_INPUT_STATE *ins, uint32_t flags)
                 if ((ret = json_data(session, ins, &cl, flags)) != 0)
                     goto err;
                 config_list_free(&cl);
-                free(ins->kvraw);
+                util_free(ins->kvraw);
                 ins->kvraw = NULL;
                 config_list_free(&cl);
                 break;

--- a/src/utilities/util_loadtext.c
+++ b/src/utilities/util_loadtext.c
@@ -61,7 +61,7 @@ util_loadtext(WT_SESSION *session, int argc, char *argv[])
 
     ret = text(session, uri);
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }
 
@@ -163,8 +163,8 @@ insert(WT_CURSOR *cursor, const char *name, bool readkey)
             fflush(stdout);
         }
     }
-    free(key.mem);
-    free(value.mem);
+    util_free(key.mem);
+    util_free(value.mem);
 
     if (verbose)
         printf("\r\t%s: %" PRIu64 "\n", name, insert_count);

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -125,7 +125,7 @@ main(int argc, char *argv[])
             if (secretkey != NULL)
                 wt_explicit_zero(secretkey, strlen(secretkey));
             util_free(secretkey); /* lint: set more than once */
-            if ((secretkey = strdup(__wt_optarg)) == NULL) {
+            if ((secretkey = util_strdup(__wt_optarg)) == NULL) {
                 (void)util_err(NULL, errno, NULL);
                 goto err;
             }

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -124,7 +124,7 @@ main(int argc, char *argv[])
         case 'E': /* secret key */
             if (secretkey != NULL)
                 wt_explicit_zero(secretkey, strlen(secretkey));
-            free(secretkey); /* lint: set more than once */
+            util_free(secretkey); /* lint: set more than once */
             if ((secretkey = strdup(__wt_optarg)) == NULL) {
                 (void)util_err(NULL, errno, NULL);
                 goto err;
@@ -293,7 +293,7 @@ open:
         p3 = ")";
     }
     len += strlen(rec_config);
-    if ((p = malloc(len)) == NULL) {
+    if ((p = util_malloc(len)) == NULL) {
         (void)util_err(NULL, errno, NULL);
         goto err;
     }
@@ -316,8 +316,8 @@ open:
         wt_explicit_zero(p, strlen(p));
         wt_explicit_zero(secretkey, strlen(secretkey));
     }
-    free(p);
-    free(secretkey);
+    util_free(p);
+    util_free(secretkey);
     secretkey = p = NULL;
 
     /* If we only want to verify the metadata, that is done in wiredtiger_open. We're done. */
@@ -342,11 +342,11 @@ done:
     if (p != NULL) {
         /* p may contain a copy of secretkey, so zero before freeing */
         wt_explicit_zero(p, strlen(p));
-        free(p);
+        util_free(p);
     }
     if (secretkey != NULL) {
         wt_explicit_zero(secretkey, strlen(secretkey));
-        free(secretkey);
+        util_free(secretkey);
     }
 
     if (conn != NULL) {
@@ -381,7 +381,7 @@ util_uri(WT_SESSION *session, const char *s, const char *type)
     }
 
     len = strlen(type) + strlen(s) + 2;
-    if ((name = calloc(len, 1)) == NULL) {
+    if ((name = util_calloc(len, 1)) == NULL) {
         (void)util_err(session, errno, NULL);
         return (NULL);
     }
@@ -397,7 +397,7 @@ util_uri(WT_SESSION *session, const char *s, const char *type)
     return (name);
 
 err:
-    free(name);
+    util_free(name);
     (void)util_err(session, ret, NULL);
     return (NULL);
 }

--- a/src/utilities/util_misc.c
+++ b/src/utilities/util_misc.c
@@ -191,7 +191,7 @@ util_usage(const char *usage, const char *tag, const char *list[])
 
 /*
  * util_malloc --
- *     Convenience wrapper for memory allocations. Pairs with util_free.
+ *     Convenience and correctness wrapper for memory allocations. Pairs with util_free.
  */
 void *
 util_malloc(size_t len)
@@ -205,7 +205,7 @@ util_malloc(size_t len)
 
 /*
  * util_calloc --
- *     Convenience wrapper for array allocations. Pairs with util_free.
+ *     Convenience and correctness wrapper for array allocations. Pairs with util_free.
  */
 void *
 util_calloc(size_t members, size_t sz)
@@ -219,7 +219,7 @@ util_calloc(size_t members, size_t sz)
 
 /*
  * util_realloc --
- *     Convenience wrapper for memory reallocations. Pairs with util_free.
+ *     Convenience and correctness wrapper for memory reallocations. Pairs with util_free.
  */
 void *
 util_realloc(void *p, size_t len)
@@ -234,7 +234,7 @@ util_realloc(void *p, size_t len)
 /*
  * util_free --
  *     Convenience and correctness wrapper for freeing memory. Pairs with
- *     util_alloc/util_realloc/util_calloc.
+ *     util_malloc/util_realloc/util_calloc.
  */
 void
 util_free(void *p)

--- a/src/utilities/util_read.c
+++ b/src/utilities/util_read.c
@@ -58,7 +58,7 @@ util_read(WT_SESSION *session, int argc, char *argv[])
      */
     if ((ret = session->open_cursor(session, uri, NULL, NULL, &cursor)) != 0)
         (void)util_err(session, ret, "%s: session.open_cursor", uri);
-    free(uri);
+    util_free(uri);
     if (ret != 0)
         return (ret);
 

--- a/src/utilities/util_rename.c
+++ b/src/utilities/util_rename.c
@@ -54,6 +54,6 @@ util_rename(WT_SESSION *session, int argc, char *argv[])
     if ((ret = session->rename(session, uri, newuri, NULL)) != 0)
         (void)util_err(session, ret, "session.rename: %s, %s", uri, newuri);
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_salvage.c
+++ b/src/utilities/util_salvage.c
@@ -67,6 +67,6 @@ util_salvage(WT_SESSION *session, int argc, char *argv[])
             printf("\n");
     }
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_stat.c
+++ b/src/utilities/util_stat.c
@@ -80,7 +80,7 @@ util_stat(WT_SESSION *session, int argc, char *argv[])
     }
 
     urilen = strlen("statistics:") + strlen(objname) + 1;
-    if ((uri = calloc(urilen, 1)) == NULL) {
+    if ((uri = util_calloc(urilen, 1)) == NULL) {
         fprintf(stderr, "%s: %s\n", progname, strerror(errno));
         goto err;
     }
@@ -116,8 +116,8 @@ err:
         ret = 1;
     }
     if (objname_free)
-        free(objname);
-    free(uri);
+        util_free(objname);
+    util_free(uri);
 
     return (ret);
 }

--- a/src/utilities/util_truncate.c
+++ b/src/utilities/util_truncate.c
@@ -54,6 +54,6 @@ util_truncate(WT_SESSION *session, int argc, char *argv[])
     if ((ret = session->truncate(session, uri, NULL, NULL, NULL)) != 0)
         (void)util_err(session, ret, "session.truncate: %s", uri);
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_upgrade.c
+++ b/src/utilities/util_upgrade.c
@@ -60,6 +60,6 @@ util_upgrade(WT_SESSION *session, int argc, char *argv[])
             printf("\n");
     }
 
-    free(uri);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -119,7 +119,7 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
           strlen("dump_pages,") + strlen("dump_offsets[],") +
           (dump_offsets == NULL ? 0 : strlen(dump_offsets)) + strlen("history_store") +
           +strlen("read_corrupt,") + strlen("stable_timestamp,") + 20;
-        if ((config = malloc(size)) == NULL) {
+        if ((config = util_malloc(size)) == NULL) {
             ret = util_err(session, errno, NULL);
             goto err;
         }
@@ -177,7 +177,7 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
     }
 
 err:
-    free(config);
-    free(uri);
+    util_free(config);
+    util_free(uri);
     return (ret);
 }

--- a/src/utilities/util_write.c
+++ b/src/utilities/util_write.c
@@ -84,12 +84,12 @@ util_write(WT_SESSION *session, int argc, char *argv[])
      */
     if ((ret = __wt_snprintf(config, sizeof(config), "append=%s,overwrite=%s",
            append ? "true" : "false", overwrite ? "true" : "false")) != 0) {
-        free(uri);
+        util_free(uri);
         return (util_err(session, ret, NULL));
     }
     if ((ret = session->open_cursor(session, uri, NULL, config, &cursor)) != 0)
         (void)util_err(session, ret, "%s: session.open_cursor", uri);
-    free(uri);
+    util_free(uri);
     if (ret != 0)
         return (ret);
 


### PR DESCRIPTION
Convert wt utility allocations/frees to tcmalloc, when we build with it.

There are a few alternative designs here:
1. `#define malloc tc_malloc` (and so forth). This is the approach that the main WiredTiger library uses, and it would work here - but I find it to be in slightly bad taste, and I don't particularly like it being used in the main library. It definitely doesn't feel right to extend that approach here, and it also doesn't fix the `strdup` case.
2. Have the ifdef around the function definitions, and have a tcmalloc section and "normal" section. This was slightly more duplicated code, but I don't dislike it.

There are a couple of higher-level changes discussed on the ticket, but they were undesirable for other reasons (e.g. an API change to describe how WT allocated memory, or ignoring the problem by just suppressing the ASAN errors - but that's still incorrect).