### PR TITLE
WT-10919 Add diagnostic assert in _hs_delete_reinsert_from_pos

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -975,6 +975,16 @@ __hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, ui
     WT_ERR(ret);
 
     /*
+     * If we find a history store update with a timestamp larger than or equal to that of
+     * the update we're inserting, we've hit one of two cases:
+     *   1. We're inserting a mixed-mode timestamp and this is expected behavior
+     *   2. We're not inserting a mixed-mode timestamp and the history store is out of order.
+     * If we reach here we've found a more recent history store update, so assert the update we're
+     * inserting is mixed-mode.
+     */
+    WT_ASSERT(session, ts == 1 || ts == WT_TS_NONE);
+
+    /*
      * Fail the eviction if we detect out of order timestamps when we've passed the error return
      * flag. We cannot modify the history store to fix the out of order timestamp updates as it may
      * make the history store checkpoint inconsistent.


### PR DESCRIPTION
Note that this PR is targeting 6.0 and **not** develop.

This PR adds an assertion originally added to develop in WT-9752, however since the main change of WT-9752 is upgrading an assertion to WT_ASSERT_ALWAYS which is not available on 6.0 we've decided to just deliver the relevant assertion in its own ticket.

Add an assertion in `__hs_delete_reinsert_from_pos` that ensures when we find a more recent update in the history store it's because the update we're inserting is mixed mode.