### PR TITLE
WT-9545 wt8246_compact_rts_data_correctness test read incorrect data on macOS

### DIFF
--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -340,6 +340,7 @@ large_updates(WT_SESSION *session, const char *uri, char *value, int commit_ts)
         val = (uint64_t)__wt_random(&rnd);
         cursor->set_value(cursor, val, val, val, value);
         while (((ret = cursor->insert(cursor)) == WT_ROLLBACK) && retry_attempts < MAX_RETRIES) {
+            printf("Rollback transaction for key %d\n", i + 1);
             testutil_check(session->rollback_transaction(session, NULL));
             testutil_check(session->begin_transaction(session, NULL));
             ++retry_attempts;

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1280,6 +1280,14 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check all"
 
+  - name: make-check-test-debug
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
+      - func: "make check all"
+
   - name: make-check-linux-no-ftruncate-test
     commands:
       - func: "get project"
@@ -5658,7 +5666,7 @@ buildvariants:
     posix_configure_flags: -DENABLE_TCMALLOC=0
   tasks:
     - name: compile
-    - name: make-check-test
+    - name: make-check-test-debug
     # FIXME: WT-9575
     # Using a special version of unit test for macOS to reduce the concurrency level.
     - name: unit-test-macos

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1280,14 +1280,6 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check all"
 
-  - name: make-check-test-debug
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-      - func: "make check all"
-
   - name: make-check-linux-no-ftruncate-test
     commands:
       - func: "get project"
@@ -5655,6 +5647,7 @@ buildvariants:
     # Remove that configuration here and let MacOS use the default Xcode toolchain instead.
     # We'll explicitly use the python3 in /usr/bin, we use the same in configuring cmake.
     CMAKE_TOOLCHAIN_FILE:
+    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
     python_binary: '/usr/bin/python3'
     smp_command: -j $(sysctl -n hw.logicalcpu)
     cmake_generator: "Unix Makefiles"
@@ -5666,7 +5659,7 @@ buildvariants:
     posix_configure_flags: -DENABLE_TCMALLOC=0
   tasks:
     - name: compile
-    - name: make-check-test-debug
+    - name: make-check-test
     # FIXME: WT-9575
     # Using a special version of unit test for macOS to reduce the concurrency level.
     - name: unit-test-macos


### PR DESCRIPTION
The test wt8246_compact_rts_data_correctness had a bug that I fixed in [WT-10528](https://jira.mongodb.org/browse/WT-10528) and I think this failure also was because of the bug. I tried to reproduce this issue after [WT-10528](https://jira.mongodb.org/browse/WT-10528) but could not reproduce it after running the wt8246_compact_rts_data_correctness and make-check-test for a couple of days.

This ticket is used to do some changes in the make-check-test task and also in the test that could help us to debug faster if it fails again.