### PR TITLE
WT-10914 Fix make-check-test on MacOS 11 (#9053)

### DIFF
--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -303,7 +303,7 @@ testutil_copy_data(const char *dir)
 void
 testutil_copy_data_opt(const char *dir, const char *readonly_prefix)
 {
-#if defined(__APPLE__) || defined(__linux__)
+#if defined(__linux__)
     struct dirent *e;
     char to_copy[2048];
     char to_link[2048];


### PR DESCRIPTION
On MacOS 11, the cp command doesn't support the -l option to link rather than copy files. This change stops testutil_copy_data_opt() from trying to link files on Macs.

(cherry picked from commit d1b22a118d77b4a7bac69123094854d4d5a7170e)