### PR TITLE
WT-11031 Fix RTS to skip tables with no time window information in the checkpoint

### DIFF
--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -152,7 +152,7 @@ __wt_rts_btree_walk_btree_apply(
     uint64_t rollback_txnid, write_gen;
     uint32_t btree_id;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
-    bool dhandle_allocated, durable_ts_found, has_txn_updates_gt_than_ckpt_snap, modified;
+    bool dhandle_allocated, has_txn_updates_gt_than_ckpt_snap, modified;
     bool prepared_updates;
 
     /* Ignore non-btree objects as well as the metadata and history store files. */
@@ -166,22 +166,18 @@ __wt_rts_btree_walk_btree_apply(
 
     /* Find out the max durable timestamp of the object from checkpoint. */
     newest_start_durable_ts = newest_stop_durable_ts = WT_TS_NONE;
-    durable_ts_found = prepared_updates = has_txn_updates_gt_than_ckpt_snap = false;
+    prepared_updates = has_txn_updates_gt_than_ckpt_snap = false;
 
     WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
     __wt_config_subinit(session, &ckptconf, &cval);
     for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
         ret = __wt_config_subgets(session, &cval, "newest_start_durable_ts", &value);
-        if (ret == 0) {
+        if (ret == 0)
             newest_start_durable_ts = WT_MAX(newest_start_durable_ts, (wt_timestamp_t)value.val);
-            durable_ts_found = true;
-        }
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "newest_stop_durable_ts", &value);
-        if (ret == 0) {
+        if (ret == 0)
             newest_stop_durable_ts = WT_MAX(newest_stop_durable_ts, (wt_timestamp_t)value.val);
-            durable_ts_found = true;
-        }
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "prepare", &value);
         if (ret == 0) {
@@ -248,8 +244,7 @@ __wt_rts_btree_walk_btree_apply(
      * 1. The dhandle is present in the cache and tree is modified.
      * 2. The checkpoint durable start/stop timestamp is greater than the rollback timestamp.
      * 3. The checkpoint has prepared updates written to disk.
-     * 4. There is no durable timestamp in any checkpoint.
-     * 5. The checkpoint newest txn is greater than snapshot min txn id.
+     * 4. The checkpoint newest txn is greater than checkpoint snapshot min txn id.
      */
     WT_WITHOUT_DHANDLE(session,
       WT_WITH_HANDLE_LIST_READ_LOCK(
@@ -257,7 +252,7 @@ __wt_rts_btree_walk_btree_apply(
 
     WT_ERR_NOTFOUND_OK(ret, false);
 
-    if (modified || max_durable_ts > rollback_timestamp || prepared_updates || !durable_ts_found ||
+    if (modified || max_durable_ts > rollback_timestamp || prepared_updates ||
       has_txn_updates_gt_than_ckpt_snap) {
         /*
          * Open a handle; we're potentially opening a lot of handles and there's no reason to cache
@@ -272,14 +267,13 @@ __wt_rts_btree_walk_btree_apply(
         __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
           WT_RTS_VERB_TAG_TREE
           "rolling back tree. modified=%s, durable_timestamp=%s > stable_timestamp=%s: %s, "
-          "has_prepared_updates=%s, durable_timestamp_not_found=%s, txnid=%" PRIu64
-          " > recovery_checkpoint_snap_min=%" PRIu64 ": %s",
+          "has_prepared_updates=%s, txnid=%" PRIu64 " > recovery_checkpoint_snap_min=%" PRIu64
+          ": %s",
           S2BT(session)->modified ? "true" : "false",
           __wt_timestamp_to_string(max_durable_ts, ts_string[0]),
           __wt_timestamp_to_string(rollback_timestamp, ts_string[1]),
           max_durable_ts > rollback_timestamp ? "true" : "false",
-          prepared_updates ? "true" : "false", !durable_ts_found ? "true" : "false", rollback_txnid,
-          S2C(session)->recovery_ckpt_snap_min,
+          prepared_updates ? "true" : "false", rollback_txnid, S2C(session)->recovery_ckpt_snap_min,
           has_txn_updates_gt_than_ckpt_snap ? "true" : "false");
 
         WT_ERR(__wt_rts_btree_walk_btree(session, rollback_timestamp));

--- a/tools/rts_verifier/checker.py
+++ b/tools/rts_verifier/checker.py
@@ -40,7 +40,6 @@ class Checker:
         if not(operation.modified or
                operation.durable_gt_stable or
                operation.has_prepared_updates or
-               operation.durable_ts_not_found or
                operation.txnid_gt_recov_ckpt_snap_min):
             raise Exception(f"unnecessary visit to {operation.file}")
 
@@ -48,9 +47,6 @@ class Checker:
             raise Exception(f"incorrect timestamp comparison: thought {operation.durable} > {operation.stable}, but it isn't")
         if not operation.durable_gt_stable and not operation.stable >= operation.durable:
             raise Exception(f"incorrect timestamp comparison: thought {operation.durable} <= {operation.stable}, but it isn't")
-
-        if operation.durable_ts_not_found and operation.durable != Timestamp(0, 0):
-            raise Exception("we thought we didn't have a durable timestamp, but we do")
 
         if operation.stable != self.stable:
             raise Exception(f"stable timestamp spuriously changed from {self.stable} to {operation.stable} while rolling back {operation.file}")

--- a/tools/rts_verifier/operation.py
+++ b/tools/rts_verifier/operation.py
@@ -131,9 +131,6 @@ class Operation:
         matches = re.search('has_prepared_updates=(\w+)', line)
         self.has_prepared_updates = matches.group(1).lower() == "true"
 
-        matches = re.search('durable_timestamp_not_found=(\w+)', line)
-        self.durable_ts_not_found = matches.group(1).lower() == "true"
-
         matches = re.search('txnid=(\d+).*>.*recovery_checkpoint_snap_min=(\d+): (\w+)', line)
         self.txnid = int(matches.group(1))
         self.recovery_ckpt_snap_min = int(matches.group(2))


### PR DESCRIPTION
The versions before 4.4 only write the checkpoint with no time window information and in those versions, only the stable data is written to the disk. There is no need to verify these tables as part of the rollback to stable as these tables contain only the stable data to avoid unnecessary verification.