### PR TITLE
WT-10971 Fix truncate for tiered storage.

### DIFF
--- a/src/schema/schema_truncate.c
+++ b/src/schema/schema_truncate.c
@@ -41,23 +41,16 @@ err:
  *     Truncate for a tiered data source.
  */
 static int
-__truncate_tiered(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
+__truncate_tiered(WT_SESSION_IMPL *session, const char *uri)
 {
     WT_DECL_RET;
-    WT_TIERED *tiered;
-    u_int i;
 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE));
-    tiered = (WT_TIERED *)session->dhandle;
 
     WT_STAT_DATA_INCR(session, cursor_truncate);
 
-    /* Truncate the tiered entries. */
-    for (i = 0; i < WT_TIERED_MAX_TIERS; i++) {
-        if (tiered->tiers[i].tier == NULL)
-            continue;
-        WT_ERR(__wt_schema_truncate(session, tiered->tiers[i].name, cfg));
-    }
+    WT_WITHOUT_DHANDLE(session, ret = __wt_session_range_truncate(session, uri, NULL, NULL));
+    WT_ERR(ret);
 
 err:
     WT_TRET(__wt_session_release_dhandle(session));
@@ -112,7 +105,7 @@ __wt_schema_truncate(WT_SESSION_IMPL *session, const char *uri, const char *cfg[
     else if (WT_PREFIX_SKIP(tablename, "table:"))
         ret = __truncate_table(session, tablename, cfg);
     else if (WT_PREFIX_MATCH(uri, "tiered:"))
-        ret = __truncate_tiered(session, uri, cfg);
+        ret = __truncate_tiered(session, uri);
     else if ((dsrc = __wt_schema_get_source(session, uri)) != NULL)
         ret = dsrc->truncate == NULL ?
           __truncate_dsrc(session, uri) :

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -96,15 +96,15 @@ def wiredtiger_open_tiered(ignored_self, args):
     # however, we alter several other API methods that would do weird things with
     # a different tiered_storage configuration. So better to skip the test entirely.
     if 'tiered_storage=' in curconfig:
-        testcase.skipTest("cannot run tiered hook on a test that already uses tiered storage")
+        skipTest("cannot run tiered hook on a test that already uses tiered storage")
 
     # Similarly if this test is already set up to run tiered vs non-tiered scenario, let's
     # not get in the way.
     if hasattr(testcase, 'tiered_conn_config'):
-        testcase.skipTest("cannot run tiered hook on a test that already includes TieredConfigMixin")
+        skipTest("cannot run tiered hook on a test that already includes TieredConfigMixin")
 
     if 'in_memory=true' in curconfig:
-        testcase.skipTest("cannot run tiered hook on a test that is in-memory")
+        skipTest("cannot run tiered hook on a test that is in-memory")
 
     # Mark this test as readonly, but don't disallow it.  See testcase_is_readonly().
     if 'readonly=true' in curconfig:
@@ -159,6 +159,10 @@ def testcase_has_failed():
     testcase = WiredTigerTestCase.currentTestCase()
     return testcase.failed()
 
+def skipTest(comment):
+    testcase = WiredTigerTestCase.currentTestCase()
+    testcase.skipTest(comment)
+
 # Called to replace Connection.close
 # Insert a call to flush_tier before closing connection.
 def connection_close_replace(orig_connection_close, connection_self, config):
@@ -175,9 +179,16 @@ def connection_close_replace(orig_connection_close, connection_self, config):
     return ret
 
 # Called to replace Session.checkpoint.
-# We add a call to flush_tier after the checkpoint to make sure we are exercising tiered
+# We add a call to flush_tier during every checkpoint to make sure we are exercising tiered
 # functionality.
 def session_checkpoint_replace(orig_session_checkpoint, session_self, config):
+    # FIXME-WT-10771 We cannot do named checkpoints with tiered storage objects.
+    # We can't really continue the test without the name, as the name will certainly be used.
+    testcase = WiredTigerTestCase.currentTestCase()
+    if config == None:
+        config = ''
+    if 'name=' in config:
+        skipTest('named checkpoints do not work in tiered storage')
     # We cannot call flush_tier on a readonly connection.
     if not testcase_is_readonly():
         config += ',flush_tier=(enabled,force=true)'
@@ -219,11 +230,9 @@ def session_create_replace(orig_session_create, session_self, uri, config):
 # do statistics on (tiered) table data sources, as that is not yet supported.
 def session_open_cursor_replace(orig_session_open_cursor, session_self, uri, dupcursor, config):
     if uri != None and (uri.startswith("statistics:table:") or uri.startswith("statistics:file:")):
-        testcase = WiredTigerTestCase.currentTestCase()
-        testcase.skipTest("statistics on tiered tables not yet implemented")
+        skipTest("statistics on tiered tables not yet implemented")
     if uri != None and uri.startswith("backup:"):
-        testcase = WiredTigerTestCase.currentTestCase()
-        testcase.skipTest("backup on tiered tables not yet implemented")
+        skipTest("backup on tiered tables not yet implemented")
     return orig_session_open_cursor(session_self, uri, dupcursor, config)
 
 # Called to replace Session.rename
@@ -268,6 +277,16 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
 
         # Override some platform APIs
         self.platform_api = TieredPlatformAPI(arg)
+
+    # Our current tiered storage implementation has a slow version of truncate, and
+    # some tests are sensitive to that.
+    #
+    # FIXME-WT-11023: when we implement a fast truncate for tiered storage, we might remove
+    # this, and visit tests that are marked with @wttest.prevent(..."slow_truncate"...)
+    def uses(self, use_list):
+        if "slow_truncate" in use_list:
+            return True
+        return False
 
     # Is this test one we should skip?
     def skip_test(self, test):
@@ -336,19 +355,6 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
                 "test_rollback_to_stable36.test_rollback_to_stable",
                 "test_sweep03.test_disable_idle_timeout_drop",
                 "test_sweep03.test_disable_idle_timeout_drop_force",
-                "test_truncate01.test_truncate_cursor",
-                "test_truncate01.test_truncate_cursor_end",
-                "test_truncate01.test_truncate_timestamp",
-                "test_truncate01.test_truncate_uri",
-                "test_truncate10.test_truncate10",
-                "test_truncate12.test_truncate12",
-                "test_truncate13.test_truncate",
-                "test_truncate14.test_truncate",
-                "test_truncate16.test_truncate16",
-                "test_truncate18.test_truncate18",
-                "test_truncate15.test_truncate15",
-                "test_truncate19.test_truncate19",
-                "test_truncate20.test_truncate20",
                 "test_txn22.test_corrupt_meta",
                 "test_verbose01.test_verbose_single",
                 "test_verbose02.test_verbose_single",
@@ -373,6 +379,10 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
         orig_connection_close = self.Connection['close']
         self.Connection['close'] = (wthooks.HOOK_REPLACE, lambda s, config=None:
           connection_close_replace(orig_connection_close, s, config))
+
+        orig_session_checkpoint = self.Session['checkpoint']
+        self.Session['checkpoint'] =  (wthooks.HOOK_REPLACE, lambda s, config=None:
+          session_checkpoint_replace(orig_session_checkpoint, s, config))
 
         orig_session_compact = self.Session['compact']
         self.Session['compact'] =  (wthooks.HOOK_REPLACE, lambda s, uri, config=None:

--- a/test/suite/test_truncate10.py
+++ b/test/suite/test_truncate10.py
@@ -162,7 +162,11 @@ class test_truncate10(wttest.WiredTigerTestCase):
         # or running on FLCS where it isn't supported.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.value_format == '8t' or self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t' or self.trunc_with_remove:
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)

--- a/test/suite/test_truncate11.py
+++ b/test/suite/test_truncate11.py
@@ -47,6 +47,7 @@ class test_truncate11(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios(format_values)
 
+    @wttest.skip_for_hook("tiered", "test depends on regular checkpoints running")
     def test_truncate11(self):
         # Create a large table with lots of pages.
         uri = "table:test_truncate11"

--- a/test/suite/test_truncate12.py
+++ b/test/suite/test_truncate12.py
@@ -174,7 +174,11 @@ class test_truncate12(wttest.WiredTigerTestCase):
         # or running on FLCS where it isn't supported.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.value_format == '8t' or self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t' or self.trunc_with_remove:
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)

--- a/test/suite/test_truncate13.py
+++ b/test/suite/test_truncate13.py
@@ -223,7 +223,11 @@ class test_truncate13(wttest.WiredTigerTestCase):
         # (Or if we are running with trunc_with_remove.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.value_format == '8t' or self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t' or self.trunc_with_remove:
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)

--- a/test/suite/test_truncate14.py
+++ b/test/suite/test_truncate14.py
@@ -213,7 +213,11 @@ class test_truncate14(wttest.WiredTigerTestCase):
         # (Except if we're running with trunc_with_remove.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.trunc_with_remove:
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -163,7 +163,11 @@ class test_truncate15(wttest.WiredTigerTestCase):
         # support, so assert we didn't.
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.value_format == '8t':
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t':
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)

--- a/test/suite/test_truncate16.py
+++ b/test/suite/test_truncate16.py
@@ -145,7 +145,11 @@ class test_truncate16(wttest.WiredTigerTestCase):
         # or running on FLCS where it isn't supported.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.value_format == '8t' or self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t' or self.trunc_with_remove:
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)
@@ -168,7 +172,11 @@ class test_truncate16(wttest.WiredTigerTestCase):
         # (But not if we weren't fast-deleting.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         read_deleted = stat_cursor[stat.conn.cache_read_deleted][2]
-        if self.value_format == '8t' or self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t' or self.trunc_with_remove:
             self.assertEqual(read_deleted, 0)
         else:
             self.assertEqual(read_deleted, 1)

--- a/test/suite/test_truncate17.py
+++ b/test/suite/test_truncate17.py
@@ -168,7 +168,11 @@ class test_truncate17(wttest.WiredTigerTestCase):
         # or running on FLCS where it isn't supported.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.value_format == '8t' or self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t' or self.trunc_with_remove:
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)

--- a/test/suite/test_truncate18.py
+++ b/test/suite/test_truncate18.py
@@ -169,7 +169,11 @@ class test_truncate18(wttest.WiredTigerTestCase):
         # or running on FLCS where it isn't supported.)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
-        if self.value_format == '8t' or self.trunc_with_remove:
+        if self.runningHook('tiered'):
+            # There's no way the test can guess whether fast delete is possible when
+            # flush_tier calls are "randomly" inserted.
+            pass
+        elif self.value_format == '8t' or self.trunc_with_remove:
             self.assertEqual(fastdelete_pages, 0)
         else:
             self.assertGreater(fastdelete_pages, 0)

--- a/test/suite/test_truncate19.py
+++ b/test/suite/test_truncate19.py
@@ -56,6 +56,7 @@ class test_truncate19(wttest.WiredTigerTestCase):
         self.session.truncate(None, None, hicursor, None)
         self.session.commit_transaction()
 
+    @wttest.skip_for_hook("tiered", "test depends of sizes of associated file objects")
     def test_truncate19(self):
         uri = 'table:oplog'
         nrows = 1000000

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -348,6 +348,8 @@ class WiredTigerTestCase(unittest.TestCase):
         if seedw != 0 and seedz != 0:
             WiredTigerTestCase._randomseed = True
             WiredTigerTestCase._seeds = [seedw, seedz]
+        # We don't have a lot of output, but we want to see it right away.
+        sys.stdout.reconfigure(line_buffering=True)
         WiredTigerTestCase._globalSetup = True
 
     @staticmethod
@@ -676,6 +678,8 @@ class WiredTigerTestCase(unittest.TestCase):
         os.chdir(self.testdir)
         with open('testname.txt', 'w+') as namefile:
             namefile.write(str(self) + '\n')
+        if WiredTigerTestCase._verbose >= 2:
+            print("[pid:{}]: {}: starting".format(os.getpid(), str(self)))
         self.fdSetUp()
         self._threadLocal.currentTestCase = self
         self.ignoreTearDownLogs = False
@@ -830,6 +834,9 @@ class WiredTigerTestCase(unittest.TestCase):
         self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
         bkp_cursor.close()
 
+    def runningHook(self, name):
+        return name in WiredTigerTestCase.hook_names
+
     # Set a Python breakpoint.  When this function is called,
     # the python debugger will be called as described here:
     #   https://docs.python.org/3/library/pdb.html
@@ -981,6 +988,11 @@ class WiredTigerTestCase(unittest.TestCase):
         return '%x' % t
 
     def dropUntilSuccess(self, session, uri, config=None):
+        # Most test cases consider a drop, and especially a 'drop until success',
+        # to completely remove a file's artifacts, so that the name can be reused.
+        # For tiered storage, this means removing associated cloud objects.
+        if self.runningHook('tiered') and config == None:
+            config = 'force=true,remove_shared=true'
         while True:
             try:
                 session.drop(uri, config)


### PR DESCRIPTION
Fixed a bug in tiered truncate that tried to truncate the file:....-0000001.wtobj uri
Enable the vast group of truncate tests that were previous disabled in the tiered hook.
Individually skip a few truncate tests that rely on fast truncates.
Skip tests with named checkpoints for tiered storage.