### PR TITLE
WT-11046 Adjust format keyno if necessary.

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1186,8 +1186,8 @@ rollback_retry:
                       (tinfo->last == 0 || tinfo->last == max_rows)) {
                         tinfo->last = max_rows - 1;
                         /*
-                         * It is possible that keyno was set to max rows so make sure we don't send
-                         * in poorly set truncate cursor keys.
+                         * It is possible that the key number was set to max rows so make sure we
+                         * don't send in poorly set truncate cursor keys.
                          */
                         if (tinfo->keyno > tinfo->last)
                             tinfo->keyno = tinfo->last;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1183,8 +1183,15 @@ rollback_retry:
                      * and have both a VLCS and FLCS table.
                      */
                     if (g.base_mirror != NULL && g.mirror_fix_var &&
-                      (tinfo->last == 0 || tinfo->last == max_rows))
+                      (tinfo->last == 0 || tinfo->last == max_rows)) {
                         tinfo->last = max_rows - 1;
+                        /*
+                         * It is possible that keyno was set to max rows so make sure we don't send
+                         * in poorly set truncate cursor keys.
+                         */
+                        if (tinfo->keyno > tinfo->last)
+                            tinfo->keyno = tinfo->last;
+                    }
                 }
             } else {
                 if (TV(BTREE_REVERSE)) {


### PR DESCRIPTION
Although I haven't been able to reproduce it, it is possible for test/format to choose `max_rows` as the starting key number. If we adjust `last` down in the truncate edge case, we also need to possibly adjust the starting key too.