### PR TITLE
WT-11057 Fix potential out of bounds read in __wt_session_get_btree_ckpt

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -502,7 +502,7 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
      * Test for the internal checkpoint name (WiredTigerCheckpoint). Note: must_resolve is true in a
      * subset of the cases where is_unnamed_ckpt is true.
      */
-    must_resolve = WT_STRING_MATCH(WT_CHECKPOINT, cval.str, cval.len);
+    must_resolve = cval.len == strlen(WT_CHECKPOINT) && WT_PREFIX_MATCH(cval.str, WT_CHECKPOINT);
     is_unnamed_ckpt = cval.len >= strlen(WT_CHECKPOINT) && WT_PREFIX_MATCH(cval.str, WT_CHECKPOINT);
 
     /* This is the top of a retry loop. */


### PR DESCRIPTION
@etienneptl @marcbutler I'm going to put you down as reviewers - please let me know if you disagree with the change or you think that there's a better way to do it. 