### PR TITLE
WT-9457 Preserve ckpt_most_recent value across restart

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3002,8 +3002,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
         WT_ERR(wt_session->salvage(wt_session, WT_METAFILE_URI, NULL));
     }
 
-    /* Initialize the connection's base write generation. */
-    WT_ERR(__wt_metadata_init_base_write_gen(session));
+    /* Initialize connection values from stored metadata. */
+    WT_ERR(__wt_metadata_load_prior_state(session));
 
     WT_ERR(__wt_metadata_cursor(session, NULL));
     /*

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -39,8 +39,6 @@ __wt_connection_open(WT_CONNECTION_IMPL *conn, const char *cfg[])
      */
     conn->default_session = session;
 
-    __wt_seconds(session, &conn->ckpt_most_recent);
-
     /*
      * Publish: there must be a barrier to ensure the connection structure fields are set before
      * other threads read from the pointer.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1103,9 +1103,9 @@ extern int __wt_metadata_cursor_release(WT_SESSION_IMPL *session, WT_CURSOR **cu
 extern int __wt_metadata_get_ckptlist(WT_SESSION *session, const char *name, WT_CKPT **ckptbasep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_metadata_init_base_write_gen(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_insert(WT_SESSION_IMPL *session, const char *key, const char *value)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_metadata_load_prior_state(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1115,7 +1115,7 @@ extern int __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *value)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_metadata_update_base_write_gen(WT_SESSION_IMPL *session, const char *config)
+extern int __wt_metadata_update_connection(WT_SESSION_IMPL *session, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_modify_apply_api(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -943,11 +943,12 @@ format:
 }
 
 /*
- * __wt_metadata_update_base_write_gen --
- *     Update the connection's base write generation from the config string.
+ * __wt_metadata_update_connection --
+ *     Update the connection's base write generation and most recent checkpoint time from the config
+ *     string.
  */
 int
-__wt_metadata_update_base_write_gen(WT_SESSION_IMPL *session, const char *config)
+__wt_metadata_update_connection(WT_SESSION_IMPL *session, const char *config)
 {
     WT_CKPT ckpt;
     WT_CONNECTION_IMPL *conn;
@@ -958,6 +959,7 @@ __wt_metadata_update_base_write_gen(WT_SESSION_IMPL *session, const char *config
 
     if ((ret = __ckpt_last(session, config, &ckpt)) == 0) {
         conn->base_write_gen = WT_MAX(ckpt.write_gen + 1, conn->base_write_gen);
+        conn->ckpt_most_recent = WT_MAX(ckpt.sec, conn->ckpt_most_recent);
         __wt_meta_checkpoint_free(session, &ckpt);
     } else
         WT_RET_NOTFOUND_OK(ret);
@@ -966,21 +968,26 @@ __wt_metadata_update_base_write_gen(WT_SESSION_IMPL *session, const char *config
 }
 
 /*
- * __wt_metadata_init_base_write_gen --
- *     Initialize the connection's base write generation.
+ * __wt_metadata_load_prior_state --
+ *     Initialize the connection's base write generation and most recent checkpoint time.
  */
 int
-__wt_metadata_init_base_write_gen(WT_SESSION_IMPL *session)
+__wt_metadata_load_prior_state(WT_SESSION_IMPL *session)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     char *config;
 
+    conn = S2C(session);
+
     /* Initialize the base write gen to 1 */
-    S2C(session)->base_write_gen = 1;
+    conn->base_write_gen = 1;
+    /* Initialize most recent checkpoint time with current clock */
+    __wt_seconds(session, &conn->ckpt_most_recent);
     /* Retrieve the metadata entry for the metadata file. */
     WT_ERR(__wt_metadata_search(session, WT_METAFILE_URI, &config));
-    /* Update base write gen to the write gen of metadata. */
-    WT_ERR(__wt_metadata_update_base_write_gen(session, config));
+    /* Update base write gen and most recent checkpoint time from the metadata. */
+    WT_ERR(__wt_metadata_update_connection(session, config));
 
 err:
     __wt_free(session, config);
@@ -1009,8 +1016,8 @@ __wt_metadata_correct_base_write_gen(WT_SESSION_IMPL *session)
 
         WT_ERR(cursor->get_value(cursor, &config));
 
-        /* Update base write gen to the write gen. */
-        WT_ERR(__wt_metadata_update_base_write_gen(session, config));
+        /* Update base write gen and most recent checkpoint time. */
+        WT_ERR(__wt_metadata_update_connection(session, config));
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -678,8 +678,8 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
       (WT_IS_MAX_LSN(&r->max_ckpt_lsn) || __wt_log_cmp(&lsn, &r->max_ckpt_lsn) > 0))
         WT_ASSIGN_LSN(&r->max_ckpt_lsn, &lsn);
 
-    /* Update the base write gen based on this file's configuration. */
-    if ((ret = __wt_metadata_update_base_write_gen(r->session, config)) != 0)
+    /* Update the base write gen and most recent checkpoint based on this file's configuration. */
+    if ((ret = __wt_metadata_update_connection(r->session, config)) != 0)
         WT_RET_MSG(r->session, ret, "Failed recovery setup for %s: cannot update write gen", uri);
     return (0);
 }

--- a/test/suite/test_bug029.py
+++ b/test/suite/test_bug029.py
@@ -1,0 +1,112 @@
+
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# checkpoint:recovery
+# [END_TAGS]
+
+import wttest
+import os, shutil
+
+# test_bug029.py
+#
+# Test that WT correctly propogates the most recent checkpoint time
+# across restarts. We validate this by reproducing the original bug
+# from WT-9457: frequent checkpoints pushed the checkpoint clock time
+# into the future such that immediately after a restart a backup could
+# see its checkpoint deleted out from under it. The result was fatal
+# read errors when restoring the backup.
+
+class test_bug029(wttest.WiredTigerTestCase):
+    conn_config = ("cache_size=50MB")
+    uri = "table:test_bug029"
+    bigvalue = "WiredTiger" * 100
+    backup_dir = "backup_dir"
+
+    def add_data(self, uri, start, count):
+        cursor = self.session.open_cursor(uri, None)
+        for i in range(start, start + count): 
+            cursor[i] = self.bigvalue
+        cursor.close()
+
+    def test_bug029(self):
+        # Create and populate table
+        self.session.create(self.uri, "key_format=i,value_format=S")
+        self.add_data(self.uri, 0, 2000)
+        self.session.checkpoint()
+
+        # Force the checkpoint time forward with a lot of quick checkpoints.
+        for i in range(100):
+            self.session.checkpoint("force=1")
+
+        # Add more data and checkpoint again. This creates a bunch of pages
+        # in the final checkpoint that can be deleted and reused if we hit
+        # the bug.
+        self.add_data(self.uri, 2000, 2000)
+        self.session.checkpoint()
+
+        # Shutdown and reopen.
+        self.reopen_conn()
+
+        self.add_data(self.uri, 0, 100)
+
+        # Open a backup cursor and force a few checkpoints. This will allow
+        # WT to delete older checkpoints, but as long as the backup cursor
+        # is open, it shouldn't delete the backup checkpoint---unless we hit
+        # the bug.
+        backup_cursor = self.session.open_cursor('backup:')
+
+        for i in range(10):
+            self.session.checkpoint("force=1")
+
+        # Write and checkpoint a bunch of data. If we erroneously deleted our 
+        # backup checkpoint this should overwrite some of that checkpoint's
+        # blocks.
+        self.add_data(self.uri, 1000, 2000)
+        self.session.checkpoint()
+
+        # Now do the backup.
+        os.mkdir(self.backup_dir)
+        while True:
+            ret = backup_cursor.next()
+            if ret != 0:
+                break
+            shutil.copy(backup_cursor.get_key(), self.backup_dir)
+        backup_cursor.close()
+
+        # Open the backup and read data. If the backup snapshot was corrupted
+        # we will panic and die here.
+        backup_conn = self.wiredtiger_open(self.backup_dir, self.conn_config)
+        session = backup_conn.open_session()
+        cur1 = session.open_cursor(self.uri)
+        for i in range(0, 4000, 10):
+            self.assertEqual(cur1[i], self.bigvalue)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -15,6 +15,7 @@
 |Checkpoint|History Store|[test_checkpoint03.py](../test/suite/test_checkpoint03.py)
 |Checkpoint|Metadata|[test_checkpoint_snapshot01.py](../test/suite/test_checkpoint_snapshot01.py)
 |Checkpoint|Obsolete Data|[test_checkpoint08.py](../test/suite/test_checkpoint08.py)
+|Checkpoint|Recovery|[test_bug029.py](../test/suite/test_bug029.py)
 |Compression||[test_dictionary.py](../test/suite/test_dictionary.py)
 |Config Api||[test_base02.py](../test/suite/test_base02.py), [test_config02.py](../test/suite/test_config02.py)
 |Connection Api||[test_version.py](../test/suite/test_version.py)


### PR DESCRIPTION
The core change here is to initialize conn->ckpt_most_recent from the time on the last checkpoint in the metadata. This ensures that new checkpoint and flush times after (re-)starting WT will be greater than those used before we shutdown. The change is just a couple lines of code to load this value at the same time we load the base write generation.