### PR TITLE
WT-11078 __wt_tiered_open_btree() should assert dhandle != NULL before using it

### DIFF
--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -885,8 +885,8 @@ __wt_tiered_tree_open(WT_SESSION_IMPL *session, const char *cfg[])
     /*
      * Set dhandle->handle with tiered tree structure, initialized.
      */
-    __wt_verbose(session, WT_VERB_TIERED, "TIERED_TREE_OPEN: Called %s", session->dhandle->name);
     WT_ASSERT(session, session->dhandle != NULL);
+    __wt_verbose(session, WT_VERB_TIERED, "TIERED_TREE_OPEN: Called %s", session->dhandle->name);
     WT_RET(__wt_metadata_cursor(session, &cursor));
     WT_ERR(__wt_tiered_name(
       session, session->dhandle, 0, WT_TIERED_NAME_OBJECT | WT_TIERED_NAME_PREFIX, &object));


### PR DESCRIPTION
@sueloverso: hope you don't mind looking at a very small, house cleaning PR.