### PR TITLE
WT-11098 Fix memory leak in wt load

### DIFF
--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -508,6 +508,9 @@ config_rename(WT_SESSION *session, char **urip, const char *name)
         util_free(buf);
         return (util_err(session, ret, NULL));
     }
+    
+    /* Replace the uri. */
+    util_free(*urip);
     *urip = buf;
 
     return (0);

--- a/src/utilities/util_load.c
+++ b/src/utilities/util_load.c
@@ -508,7 +508,7 @@ config_rename(WT_SESSION *session, char **urip, const char *name)
         util_free(buf);
         return (util_err(session, ret, NULL));
     }
-    
+
     /* Replace the uri. */
     util_free(*urip);
     *urip = buf;


### PR DESCRIPTION
Fixed leak config_rename() where string array entry was replaced without being freed.