### PR TITLE
WT-11108 Fix typos in the code base

### DIFF
--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -6,7 +6,7 @@ include(CheckTypeSize)
 # Helper function for evaluating a list of dependencies. Mostly used by the
 # "config_X" helpers to evaluate the dependencies required to enable the config
 # option.
-#   depends - a list (semicolon seperated) of dependencies to evaluate.
+#   depends - a list (semicolon separated) of dependencies to evaluate.
 #   enabled - name of the output variable set with either 'ON' or 'OFF' (based
 #             on evaluated dependencies). Output variable is set in the callers scope.
 function(eval_dependency depends enabled)
@@ -34,7 +34,7 @@ endfunction()
 #   description - docstring to describe the configuration option (viewable in the cmake-gui).
 #   DEFAULT <default string> -  Default value of the configuration string. Used when not manually set
 #       by a cmake script or in the cmake-gui.
-#   DEPENDS <deps> - list of dependencies (semicolon seperated) required for the configuration string
+#   DEPENDS <deps> - list of dependencies (semicolon separated) required for the configuration string
 #       to be present and set in the cache. If any of the dependencies aren't met, the
 #       configuration value won't be present in the cache.
 #   INTERNAL - hides the configuration option from the cmake-gui by default. Useful if you don't want
@@ -84,7 +84,7 @@ endfunction()
 #   config_name - name of the configuration option.
 #   description - docstring to describe the configuration option (viewable in the cmake-gui).
 #   OPTIONS - a list of option values that the configuration option can be set to. Each option is itself a semicolon
-#       seperated list consisting of "<option-name>;<config-name>;<option-dependencies>".
+#       separated list consisting of "<option-name>;<config-name>;<option-dependencies>".
 #       * option-name: name of the given option stored in the ${config_name} cache variable and presented
 #           to users in the gui (usually something understandable).
 #       * config-name: an additional cached configuration variable that is made available if the option is selected.
@@ -172,7 +172,7 @@ endfunction()
 #   description - docstring to describe the configuration option (viewable in the cmake-gui).
 #   DEFAULT <default-value> -  default value of the configuration bool (ON/OFF). Used when not manually set
 #       by a cmake script or in the cmake-gui or when dependencies aren't met.
-#   DEPENDS <deps> - list of dependencies (semicolon seperated) required for the configuration bool
+#   DEPENDS <deps> - list of dependencies (semicolon separated) required for the configuration bool
 #       to be set to the desired value. If any of the dependencies aren't met the configuration value
 #       will be set to its default value.
 #   DEPENDS_ERROR <config-val> <error-string> - specifically throw a fatal error when the configuration option is set to
@@ -251,7 +251,7 @@ endfunction()
 #   description - docstring to describe the configuration option (viewable in the cmake-gui).
 #   FUNC <function-symbol> - function symbol we want to search for.
 #   FILE <include-header> - header we expect the function symbol to be defined e.g a std header.
-#   DEPENDS <deps> - list of dependencies (semicolon seperated) required for the configuration to be evaluated.
+#   DEPENDS <deps> - list of dependencies (semicolon separated) required for the configuration to be evaluated.
 #       If any of the dependencies aren't met the configuration value will be set to '0' (false).
 #   LIBS <library-dependencies> - a list of any additional library dependencies needed to successfully link with the function symbol.
 function(config_func config_name description)
@@ -318,7 +318,7 @@ endfunction()
 #   config_name - name of the configuration option.
 #   description - docstring to describe the configuration option (viewable in the cmake-gui).
 #   FILE <include-header> - header we want to search for e.g a std header.
-#   DEPENDS <deps> - list of dependencies (semicolon seperated) required for the configuration to be evaluated.
+#   DEPENDS <deps> - list of dependencies (semicolon separated) required for the configuration to be evaluated.
 #       If any of the dependencies aren't met the configuration value will be set to '0' (false).
 function(config_include config_name description)
     cmake_parse_arguments(
@@ -381,7 +381,7 @@ endfunction()
 #   description - docstring to describe the configuration option (viewable in the cmake-gui).
 #   LIB <library> - library we are searching for (defined as if we are linking against it e.g -lpthread).
 #   FUNC <function-symbol> - function symbol we expect to be available to link against within the library.
-#   DEPENDS <deps> - list of dependencies (semicolon seperated) required for the configuration to be evaluated.
+#   DEPENDS <deps> - list of dependencies (semicolon separated) required for the configuration to be evaluated.
 #       If any of the dependencies aren't met the configuration value will be set to '0' (false).
 function(config_lib config_name description)
     cmake_parse_arguments(
@@ -460,7 +460,7 @@ endfunction()
 #   config_name - name of the configuration option.
 #   description - docstring to describe the configuration option (viewable in the cmake-gui).
 #   SOURCE <source-file> - specific source file we want to test compile.
-#   DEPENDS <deps> - list of dependencies (semicolon seperated) required for the configuration to be evaluated.
+#   DEPENDS <deps> - list of dependencies (semicolon separated) required for the configuration to be evaluated.
 #       If any of the dependencies aren't met the configuration value will be set to '0' (false).
 #   LIBS <library-dependencies> - a list of any additional library dependencies needed to successfully compile the source.
 function(config_compile config_name description)

--- a/test/suite/README
+++ b/test/suite/README
@@ -9,5 +9,5 @@ based on history runtime of each test, and generate the Evergreen configuration
 dynamically before each Evergreen build variant run, so that no mental overhead
 is required when new tests is introduced into test/suite. (WT-4441)
 
-Before the above mentioned mechansim is put into place, please double check
+Before the above mentioned mechanism is put into place, please double check
 test/evergreen.yml and test run logs to make sure new test are covered.

--- a/test/suite/helper_tiered.py
+++ b/test/suite/helper_tiered.py
@@ -173,7 +173,7 @@ def gen_tiered_storage_sources(random_prefix='', test_name='', tiered_only=False
             bucket_prefix2 = generate_prefix(random_prefix, test_name),
             num_ops=100,
             ss_name = 'azure_store')),
-        # This must be the last item as we seperate the non-tiered from the tiered items later on.
+        # This must be the last item as we separate the non-tiered from the tiered items later on.
         ('non_tiered', dict(is_tiered = False)),
     ]
 

--- a/test/suite/test_backup10.py
+++ b/test/suite/test_backup10.py
@@ -95,7 +95,7 @@ class test_backup10(backup_base):
         self.assertFalse(log4 in dup_set)
 
         # Test a few error cases now.
-        # - We cannot make multiple duplcate backup cursors.
+        # - We cannot make multiple duplicate backup cursors.
         # - We cannot duplicate the duplicate backup cursor.
         # - We must use the log target.
         msg = "/already a duplicate backup cursor open/"

--- a/test/suite/test_backup11.py
+++ b/test/suite/test_backup11.py
@@ -106,7 +106,7 @@ class test_backup11(backup_base):
             lambda:self.assertEquals(self.session.open_cursor(None,
             bkup_c, config), 0), msg)
 
-        # - We cannot make multiple incremental duplcate backup cursors.
+        # - We cannot make multiple incremental duplicate backup cursors.
         # - We cannot duplicate the duplicate backup cursor.
         config = 'incremental=(file=test.wt)'
         dupc = self.session.open_cursor(None, bkup_c, config)

--- a/test/suite/test_checkpoint_snapshot04.py
+++ b/test/suite/test_checkpoint_snapshot04.py
@@ -135,7 +135,7 @@ class test_checkpoint_snapshot04(backup_base):
         session1.rollback_transaction()
 
         self.compare_backups(self.uri, self.dir, './')
-        # Due to unavailibility of history store file in targetted backup scenarios,
+        # Due to unavailability of history store file in targeted backup scenarios,
         # RTS doesn't get performed during the first restart, so compare the backup again
         # to confirm that RTS doesn't change the backup contents.
         self.compare_backups(self.uri, self.dir, './')

--- a/test/suite/test_compat02.py
+++ b/test/suite/test_compat02.py
@@ -87,7 +87,7 @@ class test_compat02(wttest.WiredTigerTestCase, suite_subprocess):
     # log_max=3 as such we don't need 3.1 in this list.
     # However the exemption to this rule is versions which include a patch
     # number as the patch number will get removed in the conn_reconfig.c
-    # This rule exemption applies to the minimum verison check as well.
+    # This rule exemption applies to the minimum version check as well.
     compat_max = [
         ('future_max', dict(max_req=future_rel, log_max=future_logv)),
         ('def_max', dict(max_req='none', log_max=5)),
@@ -148,7 +148,7 @@ class test_compat02(wttest.WiredTigerTestCase, suite_subprocess):
         # useful. Test for success or failure based on the relative versions
         # configured.
 
-        # Turn on checkpoint verbose to debug a rare occurence of a test
+        # Turn on checkpoint verbose to debug a rare occurrence of a test
         # hanging, most likely during the checkpoint of conn.close.
         self.pr("Closing connection")
         self.conn.reconfigure('verbose=(checkpoint)')

--- a/test/suite/test_compat03.py
+++ b/test/suite/test_compat03.py
@@ -75,7 +75,7 @@ class test_compat03(wttest.WiredTigerTestCase, suite_subprocess):
     # log_max=3 as such we don't need 3.1 in this list.
     # However the exemption to this rule is versions which include a patch
     # number as the patch number will get removed in the conn_reconfig.c
-    # This rule exemption applies to the minimum verison check as well.
+    # This rule exemption applies to the minimum version check as well.
     compat_max = [
         ('future_max', dict(max_req=future_rel, log_max=future_logv)),
         ('def_max', dict(max_req='none', log_max=5)),

--- a/test/suite/test_cursor_bound19.py
+++ b/test/suite/test_cursor_bound19.py
@@ -32,7 +32,7 @@ from wtbound import bound_base
 
 # test_cursor_bound19.py
 #    Test basic cursor index bounds operations. To test index table formats the populate function
-# has duplicate pair values for each key. This will construct an index table that needs to seperate
+# has duplicate pair values for each key. This will construct an index table that needs to separate
 # the duplicate values.
 class test_cursor_bound19(bound_base):
     file_name = 'test_cursor_bound19'

--- a/test/suite/test_cursor_bound_fuzz.py
+++ b/test/suite/test_cursor_bound_fuzz.py
@@ -433,7 +433,7 @@ class test_cursor_bound_fuzz(wttest.WiredTigerTestCase):
                     # We returned a key within the range, validate that key is the one that
                     # should've been returned.
                     if (key_found == search_key):
-                        # We've already deteremined the key matches. We can return.
+                        # We've already determined the key matches. We can return.
                         pass
                     if (key_found > search_key):
                         # Walk left and validate that all isn't visible to the search key.

--- a/test/suite/test_debug_mode02.py
+++ b/test/suite/test_debug_mode02.py
@@ -82,7 +82,7 @@ class test_debug_mode02(wttest.WiredTigerTestCase, suite_subprocess):
         for i in range(1, self.retain):
             cur_set = self.log_set()
             self.advance_log_checkpoint()
-            # We don't accomodate slow machines here because we don't expect
+            # We don't accommodate slow machines here because we don't expect
             # the files the change and there is no way to know if log removal ran
             # otherwise.
             time.sleep(1.0)

--- a/test/suite/test_hs21.py
+++ b/test/suite/test_hs21.py
@@ -136,11 +136,11 @@ class test_hs21(wttest.WiredTigerTestCase):
             # Load data at timestamp 2.
             self.large_updates(ds.uri, value1, ds, self.nrows // 2 , 2)
 
-        # We want to create a long running read transaction in a seperate session which we will persist over the closing and
+        # We want to create a long running read transaction in a separate session which we will persist over the closing and
         # re-opening of handles. We want to ensure the correct data gets read throughout this time period.
         session_read = self.conn.open_session()
         session_read.begin_transaction('read_timestamp=' + self.timestamp_str(2))
-        # Check our inital set of updates are seen at the read timestamp.
+        # Check our initial set of updates are seen at the read timestamp.
         for (_, ds) in active_files:
             # Check that all updates at timestamp 2 are seen.
             self.check(session_read, value1, ds.uri, self.nrows // 2)

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -161,7 +161,7 @@ class test_import01(test_import_base):
         # Copy over the datafiles for the object we want to import.
         self.copy_file(self.original_db_file, '.', newdir)
 
-        # Contruct the config string.
+        # Construct the config string.
         import_config = 'import=(enabled,repair=false,file_metadata=(' + \
             original_db_file_config + '))'
 
@@ -224,7 +224,7 @@ class test_import01(test_import_base):
         # Now copy it back to our database directory.
         self.copy_file(self.original_db_file, backup_dir, '.')
 
-        # Contruct the config string.
+        # Construct the config string.
         import_config = 'import=(enabled,repair=false,file_metadata=(' + \
             original_db_file_config + '))'
 

--- a/test/suite/test_import02.py
+++ b/test/suite/test_import02.py
@@ -107,7 +107,7 @@ class test_import02(test_import_base):
         # Bring forward the oldest to be past or equal to the timestamps we'll be importing.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(self.ts[-1]))
 
-        # Contruct the config string.
+        # Construct the config string.
         import_config = 'import=(enabled,repair=false,file_metadata=(' + \
             original_db_file_config + '))'
 
@@ -132,7 +132,7 @@ class test_import02(test_import_base):
 
         self.printVerbose(3, '\nFile configuration:\n' + example_db_file_config)
 
-        # Contruct the config string.
+        # Construct the config string.
         import_config = 'import=(enabled,repair=false,file_metadata=(' + \
             example_db_file_config + '))'
 

--- a/test/suite/test_import03.py
+++ b/test/suite/test_import03.py
@@ -100,7 +100,7 @@ class test_import03(test_import_base):
         self.printVerbose(3, '\nFile configuration:\n' + original_db_file_config)
         self.printVerbose(3, '\nTable configuration:\n' + original_db_table_config)
 
-        # Contruct the config string.
+        # Construct the config string.
         import_config = '{},import=(enabled,repair=false,file_metadata=({}))'.format(
             original_db_table_config, original_db_file_config)
 

--- a/test/suite/test_import05.py
+++ b/test/suite/test_import05.py
@@ -103,7 +103,7 @@ class test_import05(test_import_base):
         # Copy over the datafiles for the object we want to import.
         self.copy_file(original_db_file, '.', newdir)
 
-        # Contruct the config string.
+        # Construct the config string.
         if self.repair:
             if self.global_ts == 'stable':
                 import_config = 'import=(enabled,repair=true,compare_timestamp=stable_timestamp)'

--- a/test/suite/test_import07.py
+++ b/test/suite/test_import07.py
@@ -59,7 +59,7 @@ class test_import07(test_import_base):
                 break
         cursor.close()
 
-        # Contruct the config string.
+        # Construct the config string.
         import_config = 'import=(enabled,repair=false,file_metadata=(' + \
             example_db_file_config + '))'
 

--- a/test/suite/test_import08.py
+++ b/test/suite/test_import08.py
@@ -131,7 +131,7 @@ class test_import08(test_import_base):
         # Copy over the datafiles for the object we want to import.
         self.copy_file(self.original_db_file, '.', newdir)
 
-        # Contruct the config string.
+        # Construct the config string.
         if self.repair:
             import_config = 'import=(enabled,repair=true)'
         else:

--- a/test/suite/test_stat01.py
+++ b/test/suite/test_stat01.py
@@ -142,7 +142,7 @@ class test_stat01(wttest.WiredTigerTestCase):
         cursor.close()
 
     # Test simple per-checkpoint statistics.
-    @wttest.skip_for_hook("timestamp", "__txn_visiable_all_id assertion hit")    # FIXME-WT-9809
+    @wttest.skip_for_hook("timestamp", "__txn_visible_all_id assertion hit")    # FIXME-WT-9809
     def test_checkpoint_stats(self):
         ds = SimpleDataSet(self, self.uri, self.nentries,
             config=self.config, key_format=self.keyfmt)

--- a/test/suite/test_tiered13.py
+++ b/test/suite/test_tiered13.py
@@ -96,7 +96,7 @@ class test_tiered13(test_import_base, TieredConfigMixin):
                 table_config = cursor[k]
         cursor.close()
         self.close_conn()
-        # Contruct the config strings.
+        # Construct the config strings.
         import_enabled = 'import=(enabled,repair=true)'
         import_meta = 'import=(enabled,repair=false,file_metadata=(' + \
             fileobj_config + '))'

--- a/test/suite/test_timestamp14.py
+++ b/test/suite/test_timestamp14.py
@@ -95,7 +95,7 @@ class test_timestamp14(wttest.WiredTigerTestCase, suite_subprocess):
         # a greater timestamp already existing.
         self.assertTimestampsEqual(self.conn.query_timestamp('get=all_durable'), "3")
 
-        # Senario 3: Commit with a commit timestamp of 5 and then begin a
+        # Scenario 3: Commit with a commit timestamp of 5 and then begin a
         # transaction intending to commit at 4, the all_durable timestamp
         # should move back to 3. Until the transaction at 4 completes.
         session1.begin_transaction()

--- a/test/suite/test_timestamp26.py
+++ b/test/suite/test_timestamp26.py
@@ -308,7 +308,7 @@ class test_timestamp26_inconsistent_update(wttest.WiredTigerTestCase):
         c[key] = ds.value(1)
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
 
-        # Upate the data item at timestamp 1, which should fail.
+        # Update the data item at timestamp 1, which should fail.
         self.session.begin_transaction()
         self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(1))
         c[key] = ds.value(2)

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -536,7 +536,7 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
             #
             #  But, immediately after the corruption, if we run
             #  wiredtiger_open with salvage, it will fail.
-            # This anomoly should be fixed or explained.
+            # This anomaly should be fixed or explained.
             if self.kind == 'removal' and self.filename == 'WiredTiger.turtle':
                 continue
 

--- a/test/suite/test_txn22.py
+++ b/test/suite/test_txn22.py
@@ -139,7 +139,7 @@ class test_txn22(wttest.WiredTigerTestCase, suite_subprocess):
             #
             #  But, immediately after the corruption, if we run
             #  wiredtiger_open with salvage, it will fail.
-            # This anomoly should be fixed or explained.
+            # This anomaly should be fixed or explained.
             if self.filename == 'WiredTiger.turtle':
                 continue
 

--- a/test/suite/wtbackup.py
+++ b/test/suite/wtbackup.py
@@ -185,7 +185,7 @@ class backup_base(wttest.WiredTigerTestCase, suite_subprocess):
     # on each incremental directory as a starting base.
     # Optional arguments:
     # backup_cur: A backup cursor that can be given into the function, but function caller
-    #    holds reponsibility of closing the cursor.
+    #    holds responsibility of closing the cursor.
     #
     def take_full_backup(self, backup_dir, backup_cur=None):
         self.pr('Full backup to ' + backup_dir + ': ')


### PR DESCRIPTION
These typos were detected with `cspell`. There are lots of false positives, I may have missed a few real ones.