### PR TITLE
WT-11051 Fix newest start durable timestamp comparison in aggregate timestamp validation (#9150) (v6.0 backport)

### DIFF
--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -245,6 +245,57 @@ __wt_time_aggregate_validate(
 {
     char time_string[2][WT_TIME_STRING_SIZE];
 
+    /*
+     * The aggregated time window values that are tracked at the page level.
+     *    newest_start_durable_ts - The default value is WT_TS_NONE. It tracks the maximum durable
+     timestamp of all the inserts, updates, or modify operations performed on a page.
+     *    newest_stop_durable_ts - The default value is WT_TS_NONE. It tracks the maximum durable
+     timestamp of all the the delete operations performed on a page.
+     *    oldest_start_ts - The default value is WT_TS_NONE. It tracks the minimum commit timestamp
+     of any inserts performed on a page.
+     *    newest_txn - The default value is WT_TXN_NONE. It tracks the maximum transaction id of any
+     modification (insert/delete) performed on a page.
+     *    newest_stop_ts - The default value is WT_TS_MAX. It tracks the maximum commit timestamp of
+     a delete operation on a page. If there is no removal for a key, this value will be WT_TS_MAX.
+     *    newest_stop_txn - The default value is WT_TXN_MAX. It tracks the maximum commit
+     transaction id of a delete operation on a page. If there is no removal for a key, this value
+     will be WT_TXN_MAX.
+     *
+     *
+     * Three scenarios might happen at any point of time.
+     * Scenario 1 - No deletes on the page, only inserts and updates.
+     *    newest_start_durable_ts will be some valid value (not WT_TS_MAX or WT_TS_NONE)
+     *    oldest_start_ts will be the minimum commit timestamp of any inserts performed on a page.
+     *    newest_stop_durable_ts will be WT_TS_NONE
+     *    newest_stop_ts will be WT_TS_MAX since there is no removal of any key.
+     *    newest_txn will be the maximum transaction id of any modification (insert/delete)
+     performed on a page.
+     *    newest_stop_txn will be WT_TXN_MAX.
+
+     * Scenario 2 - All the entries on the page are deleted.
+     *    newest_start_durable_ts will be some valid value (not WT_TS_MAX or WT_TS_NONE)
+     *    oldest_start_ts will be the minimum commit timestamp of any inserts performed on a page.
+     *    newest_stop_durable_ts will be some valid value (not WT_TS_MAX or WT_TS_NONE)
+     *    newest_stop_ts will be maximum commit timestamp of any delete operation on a page but not
+     WT_TS_MAX.
+     *    newest_txn will be the maximum transaction id of any modification (insert/delete)
+     performed on a page.
+     *    newest_stop_txn will be the maximum commit transaction id of any delete operation on a
+     page but cannot be WT_TXN_MAX
+
+     * Scenario 3 - Some entries are deleted, but not all.
+     *    newest_start_durable_ts will be some valid value (not WT_TS_MAX or WT_TS_NONE)
+     *    oldest_start_ts will be the minimum commit timestamp of any inserts performed on a page.
+     *    newest_stop_durable_ts will be the maximum durable timestamp of all the deletes performed
+     on a page.
+     *    newest_stop_ts can be WT_TS_MAX or any valid value
+     *    newest_txn will be the maximum transaction id of any modification (insert/delete)
+     performed on a page.
+     *    newest_stop_txn will be the maximum commit transaction id of any delete operation on a
+     page but cannot be WT_TXN_MAX
+     *
+     */
+
     if (ta->oldest_start_ts > ta->newest_stop_ts)
         WT_TIME_VALIDATE_RET(session,
           "aggregate time window has an oldest start time after its newest stop time; time "
@@ -270,14 +321,16 @@ __wt_time_aggregate_validate(
           __wt_time_aggregate_to_string(ta, time_string[0]));
 
     /*
-     * In the case of out of order timestamps, we assign the start point to the stop point and
-     * newest start durable timestamp may be larger than newest stop timestamp. Check whether start
-     * and stop are equal first.
+     * In the case of missing timestamps, we assign the start point to the stop point and newest
+     * start durable timestamp may be larger than newest stop timestamp. Check whether start and
+     * stop are equal first and then check the newest start durable timestamp against newest stop
+     * durable timestamp if all the data on the page are deleted.
      */
     if (ta->newest_start_durable_ts != ta->newest_stop_durable_ts &&
-      ta->newest_start_durable_ts > ta->newest_stop_ts)
+      ta->newest_stop_ts != WT_TS_MAX && ta->newest_start_durable_ts > ta->newest_stop_durable_ts)
         WT_TIME_VALIDATE_RET(session,
-          "aggregate time window has a newest stop durable time after its newest stop time; time "
+          "aggregate time window has a newest start durable time after its newest stop durable "
+          "time; time "
           "aggregate %s",
           __wt_time_aggregate_to_string(ta, time_string[0]));
 

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -250,7 +250,7 @@ __wt_time_aggregate_validate(
      *    newest_start_durable_ts - The default value is WT_TS_NONE. It tracks the maximum durable
      timestamp of all the inserts, updates, or modify operations performed on a page.
      *    newest_stop_durable_ts - The default value is WT_TS_NONE. It tracks the maximum durable
-     timestamp of all the the delete operations performed on a page.
+     timestamp of all the delete operations performed on a page.
      *    oldest_start_ts - The default value is WT_TS_NONE. It tracks the minimum commit timestamp
      of any inserts performed on a page.
      *    newest_txn - The default value is WT_TXN_NONE. It tracks the maximum transaction id of any


### PR DESCRIPTION

* WT-11051 Fix newest start durable timestamp comparison in aggregate timestamp validation.

(cherry picked from commit 2a63f4a39c3a74467005c2c7423823f22f5af394)