### PR TITLE
WT-8684 Fixes for logging direct I/O.

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -140,9 +140,11 @@ int
 __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
 {
 \tWT_ITEM *logrec;
+\tWT_LOG *log;
 
+\tlog = S2C(session)->log;
 \tWT_RET(
-\t    __wt_scr_alloc(session, WT_ALIGN(size + 1, WT_LOG_ALIGN), &logrec));
+\t    __wt_scr_alloc(session, WT_ALIGN(size + 1, log->allocsize), &logrec));
 \tWT_CLEAR(*(WT_LOG_RECORD *)logrec->data);
 \tlogrec->size = offsetof(WT_LOG_RECORD, record);
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -6,8 +6,10 @@ int
 __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
 {
     WT_ITEM *logrec;
+    WT_LOG *log;
 
-    WT_RET(__wt_scr_alloc(session, WT_ALIGN(size + 1, WT_LOG_ALIGN), &logrec));
+    log = S2C(session)->log;
+    WT_RET(__wt_scr_alloc(session, WT_ALIGN(size + 1, log->allocsize), &logrec));
     WT_CLEAR(*(WT_LOG_RECORD *)logrec->data);
     logrec->size = offsetof(WT_LOG_RECORD, record);
 

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -449,6 +449,7 @@ __wt_log_slot_init(WT_SESSION_IMPL *session, bool alloc)
         log->slot_buf_size =
           (uint32_t)WT_MIN((size_t)conn->log_file_max / 10, WT_LOG_SLOT_BUF_SIZE);
         for (i = 0; i < WT_SLOT_POOL; i++) {
+            F_SET(&log->slot_pool[i].slot_buf, WT_ITEM_ALIGNED);
             WT_ERR(__wt_buf_init(session, &log->slot_pool[i].slot_buf, log->slot_buf_size));
             F_SET_ATOMIC_16(&log->slot_pool[i], WT_SLOT_INIT_FLAGS);
         }

--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -220,7 +220,7 @@ __wt_realloc_aligned(
           (p == NULL && bytes_allocated == 0) ||
             (p != NULL && (bytes_allocated_ret == NULL || bytes_allocated != 0)));
         WT_ASSERT(session, bytes_to_allocate != 0);
-        WT_ASSERT(session, bytes_allocated < bytes_to_allocate);
+        WT_ASSERT(session, bytes_allocated <= bytes_to_allocate);
 
         /*
          * We are going to allocate an aligned buffer. When we do this repeatedly, the allocator is

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -406,7 +406,6 @@ static int
 __posix_file_read(
   WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t offset, size_t len, void *buf)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_FILE_HANDLE_POSIX *pfh;
     WT_SESSION_IMPL *session;
@@ -415,7 +414,6 @@ __posix_file_read(
     uint8_t *addr;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    conn = S2C(session);
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
     __wt_verbose_debug2(session, WT_VERB_READ,
@@ -424,9 +422,9 @@ __posix_file_read(
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
     WT_ASSERT(session,
-      !pfh->direct_io || conn->buffer_alignment == 0 ||
-        (!((uintptr_t)buf & (uintptr_t)(conn->buffer_alignment - 1)) &&
-          len >= conn->buffer_alignment && len % conn->buffer_alignment == 0));
+      !pfh->direct_io || S2C(session)->buffer_alignment == 0 ||
+        (!((uintptr_t)buf & (uintptr_t)(S2C(session)->buffer_alignment - 1)) &&
+          len >= S2C(session)->buffer_alignment && len % S2C(session)->buffer_alignment == 0));
 
     /* Break reads larger than 1GB into 1GB chunks. */
     nr = 0;
@@ -601,7 +599,6 @@ static int
 __posix_file_write(
   WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t offset, size_t len, const void *buf)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_FILE_HANDLE_POSIX *pfh;
     WT_SESSION_IMPL *session;
     size_t chunk;
@@ -609,7 +606,6 @@ __posix_file_write(
     const uint8_t *addr;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    conn = S2C(session);
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
     __wt_verbose_debug2(session, WT_VERB_WRITE,
@@ -618,9 +614,9 @@ __posix_file_write(
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
     WT_ASSERT(session,
-      !pfh->direct_io || conn->buffer_alignment == 0 ||
-        (!((uintptr_t)buf & (uintptr_t)(conn->buffer_alignment - 1)) &&
-          len >= conn->buffer_alignment && len % conn->buffer_alignment == 0));
+      !pfh->direct_io || S2C(session)->buffer_alignment == 0 ||
+        (!((uintptr_t)buf & (uintptr_t)(S2C(session)->buffer_alignment - 1)) &&
+          len >= S2C(session)->buffer_alignment && len % S2C(session)->buffer_alignment == 0));
 
     /* Break writes larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nw, len -= (size_t)nw, offset += nw) {

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -406,6 +406,7 @@ static int
 __posix_file_read(
   WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t offset, size_t len, void *buf)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_FILE_HANDLE_POSIX *pfh;
     WT_SESSION_IMPL *session;
@@ -414,6 +415,7 @@ __posix_file_read(
     uint8_t *addr;
 
     session = (WT_SESSION_IMPL *)wt_session;
+    conn = S2C(session);
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
     __wt_verbose_debug2(session, WT_VERB_READ,
@@ -422,9 +424,9 @@ __posix_file_read(
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
     WT_ASSERT(session,
-      !pfh->direct_io || S2C(session)->buffer_alignment == 0 ||
-        (!((uintptr_t)buf & (uintptr_t)(S2C(session)->buffer_alignment - 1)) &&
-          len >= S2C(session)->buffer_alignment && len % S2C(session)->buffer_alignment == 0));
+      !pfh->direct_io || conn->buffer_alignment == 0 ||
+        (!((uintptr_t)buf & (uintptr_t)(conn->buffer_alignment - 1)) &&
+          len >= conn->buffer_alignment && len % conn->buffer_alignment == 0));
 
     /* Break reads larger than 1GB into 1GB chunks. */
     nr = 0;
@@ -599,6 +601,7 @@ static int
 __posix_file_write(
   WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t offset, size_t len, const void *buf)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_FILE_HANDLE_POSIX *pfh;
     WT_SESSION_IMPL *session;
     size_t chunk;
@@ -606,6 +609,7 @@ __posix_file_write(
     const uint8_t *addr;
 
     session = (WT_SESSION_IMPL *)wt_session;
+    conn = S2C(session);
     pfh = (WT_FILE_HANDLE_POSIX *)file_handle;
 
     __wt_verbose_debug2(session, WT_VERB_WRITE,
@@ -614,9 +618,9 @@ __posix_file_write(
 
     /* Assert direct I/O is aligned and a multiple of the alignment. */
     WT_ASSERT(session,
-      !pfh->direct_io || S2C(session)->buffer_alignment == 0 ||
-        (!((uintptr_t)buf & (uintptr_t)(S2C(session)->buffer_alignment - 1)) &&
-          len >= S2C(session)->buffer_alignment && len % S2C(session)->buffer_alignment == 0));
+      !pfh->direct_io || conn->buffer_alignment == 0 ||
+        (!((uintptr_t)buf & (uintptr_t)(conn->buffer_alignment - 1)) &&
+          len >= conn->buffer_alignment && len % conn->buffer_alignment == 0));
 
     /* Break writes larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nw, len -= (size_t)nw, offset += nw) {

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -386,7 +386,7 @@ create_database(const char *home, WT_CONNECTION **connp)
         CONFIG_APPEND(p, ",mmap_all=1");
 
     if (GV(DISK_DIRECT_IO))
-        CONFIG_APPEND(p, ",direct_io=(data)");
+        CONFIG_APPEND(p, ",direct_io=(checkpoint,data,log)");
 
     if (GV(DISK_DATA_EXTEND))
         CONFIG_APPEND(p, ",file_extend=(data=8MB)");

--- a/test/suite/test_bug028.py
+++ b/test/suite/test_bug028.py
@@ -82,7 +82,6 @@ class test_bug028(wttest.WiredTigerTestCase, suite_subprocess):
             config += ',data'
         if self.log_directio:
             config += ',log'
-            self.skipTest('FIXME WT-8684 skipping test of logging with direct I/O')
         config += ')'
         if self.log_directio:
             config += ',log=(enabled=true)'


### PR DESCRIPTION
Here are fixes needed to make direct I/O work for logging. Apparently it has never worked, but this did uncover an actual bug that is also fixed.