### PR TITLE
WT-7401 Fix silent failures in evergreen (v6.0) (#9183)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -443,8 +443,15 @@ functions:
       script: |
         set -o errexit
         set -o verbose
+        # Fail, show the configuration file.
+        fail() {
+          echo "======= FAILURE =========="
+          [ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG
+          exit 1
+        }
+
         for i in $(seq ${times|1}); do
-          ./t -c ${config|../../../test/format/CONFIG.stress} ${extra_args|} || ( [ -f RUNDIR/CONFIG ] && cat RUNDIR/CONFIG ) 2>&1
+          ./t -c ${config|../../../test/format/CONFIG.stress} ${extra_args|} || fail
         done
   "format test script":
     command: shell.exec


### PR DESCRIPTION
Fixed ignoring format exit.

Co-authored-by: Mick Graham <99703363+mickgraham-mongodb@users.noreply.github.com>
(cherry picked from commit 62f0a8764f9ddd868fc97f491f3317a2bb6993c1)