### PR TITLE
WT-10178 Fix timing stress causing format to time out with prepare-conflict

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1664,15 +1664,16 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                 if (!F_ISSET(op, WT_TXN_OP_KEY_REPEATED))
                     WT_ERR(__txn_resolve_prepared_op(session, op, true, &cursor));
 
-#ifdef HAVE_DIAGNOSTIC
                 /*
-                 * Sleep randomly between resolving prepared operations when configured, however,
-                 * avoid causing too much stress when there are a large number of updates.
+                 * Sleep for some number of updates between resolving prepared operations when
+                 * configured, however, avoid causing too much stress when there are a large number
+                 * of updates. Multiplying by 36 provides a reasonable chance of calling the stress
+                 * without exceeding a total of 36 calls over the total mod_count.
                  */
-                if (FLD_ISSET(conn->timing_stress_flags, WT_TIMING_STRESS_PREPARE_RESOLUTION) &&
-                  (i * 36) % txn->mod_count == 0) {
+                if ((i * 36) % txn->mod_count == 0) {
                     __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);
                 }
+#ifdef HAVE_DIAGNOSTIC
                 ++prepare_count;
 #endif
             }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1668,7 +1668,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                  * Sleep for some number of updates between resolving prepared operations when
                  * configured, however, avoid causing too much stress when there are a large number
                  * of updates. Multiplying by 36 provides a reasonable chance of calling the stress
-                 * without exceeding a total of 36 calls over the total mod_count.
+                 * (as it's a highly composite number) without exceeding a total of 36 calls over
+                 * the total mod_count.
                  */
                 if ((i * 36) % txn->mod_count == 0)
                     __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1665,7 +1665,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                     WT_ERR(__txn_resolve_prepared_op(session, op, true, &cursor));
 
                 /* Sleep between resolving prepared operations when configured. */
-                __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);
+                if (i < 100)
+                    __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);
 #ifdef HAVE_DIAGNOSTIC
                 ++prepare_count;
 #endif

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1670,9 +1670,9 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                  * of updates. Multiplying by 36 provides a reasonable chance of calling the stress
                  * without exceeding a total of 36 calls over the total mod_count.
                  */
-                if ((i * 36) % txn->mod_count == 0) {
+                if ((i * 36) % txn->mod_count == 0)
                     __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);
-                }
+
 #ifdef HAVE_DIAGNOSTIC
                 ++prepare_count;
 #endif

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1507,7 +1507,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     WT_UPDATE *upd;
     wt_timestamp_t candidate_durable_timestamp, prev_durable_timestamp;
 #ifdef HAVE_DIAGNOSTIC
-    uint32_t prepare_count;
+    uint32_t prepare_count, sleep_count;
 #endif
     uint8_t previous_state;
     u_int i;
@@ -1518,7 +1518,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     txn = session->txn;
     txn_global = &conn->txn_global;
 #ifdef HAVE_DIAGNOSTIC
-    prepare_count = 0;
+    sleep_count = prepare_count = 0;
 #endif
     prepare = F_ISSET(txn, WT_TXN_PREPARE);
     readonly = txn->mod_count == 0;
@@ -1664,10 +1664,17 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                 if (!F_ISSET(op, WT_TXN_OP_KEY_REPEATED))
                     WT_ERR(__txn_resolve_prepared_op(session, op, true, &cursor));
 
-                /* Sleep between resolving prepared operations when configured. */
-                if (i < 10)
-                    __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);
 #ifdef HAVE_DIAGNOSTIC
+                /*
+                 * Sleep randomly between resolving prepared operations when configured. Avoid
+                 * causing too much stress when there are a large number of updates.
+                 */
+                if (FLD_ISSET(
+                      S2C(session)->timing_stress_flags, WT_TIMING_STRESS_PREPARE_RESOLUTION) &&
+                  sleep_count < 10 && __wt_random(&session->rnd) % 4 == 0) {
+                    __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);
+                    ++sleep_count;
+                }
                 ++prepare_count;
 #endif
             }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1665,7 +1665,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                     WT_ERR(__txn_resolve_prepared_op(session, op, true, &cursor));
 
                 /* Sleep between resolving prepared operations when configured. */
-                if (i < 100)
+                if (i < 10)
                     __wt_timing_stress(session, WT_TIMING_STRESS_PREPARE_RESOLUTION, NULL);
 #ifdef HAVE_DIAGNOSTIC
                 ++prepare_count;


### PR DESCRIPTION
The timing stress added in [WT-10873](https://jira.mongodb.org/browse/WT-10873) caused test format to timeout with a prepare-conflict after two minutes. This was due to a high value for txn->mod_count caused by truncate operations. Limiting the timing stress to be called a maximum of 10 times resolves the timeout issue and prevents the thread to sleep for too long.