### PR TITLE
WT-11120 Update code coverage task to execute only Catch2 based unit tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3353,10 +3353,6 @@ tasks:
           HAVE_UNITTEST: -DHAVE_UNITTEST=1
           <<: *configure_flags_with_builtins
           CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=Coverage
-      - func: "unit test"
-        vars:
-          unit_test_args: -v 2
-          check_coverage: true
       - command: shell.exec
         params:
           working_dir: "wiredtiger/cmake_build"

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -129,7 +129,6 @@ buildvariants:
     CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL
   tasks:
     - name: coverage-report
-      batchtime: 10080 # 7 days
     - name: cyclomatic-complexity
 
 - name: compatibility-tests-less-frequent


### PR DESCRIPTION
Changed the WiredTiger code coverage tests to (a) execute only the Catch2 based tests, and (b) run in every post-merge test cycle.