### PR TITLE
WT-11134 Add extra assertions around cell unpacking

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -240,9 +240,9 @@ static inline size_t
 __wt_cell_pack_value(
   WT_SESSION_IMPL *session, WT_CELL *cell, WT_TIME_WINDOW *tw, uint64_t rle, size_t size)
 {
+    WT_DECL_RET;
     uint8_t byte, *p;
     bool validity;
-    WT_DECL_RET;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
@@ -375,8 +375,8 @@ static inline size_t
 __wt_cell_pack_copy(
   WT_SESSION_IMPL *session, WT_CELL *cell, WT_TIME_WINDOW *tw, uint64_t rle, uint64_t v)
 {
-    uint8_t *p;
     WT_DECL_RET;
+    uint8_t *p;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
@@ -406,8 +406,8 @@ __wt_cell_pack_copy(
 static inline size_t
 __wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell, WT_TIME_WINDOW *tw, uint64_t rle)
 {
-    uint8_t *p;
     WT_DECL_RET;
+    uint8_t *p;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
@@ -504,8 +504,8 @@ static inline size_t
 __wt_cell_pack_ovfl(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t type, WT_TIME_WINDOW *tw,
   uint64_t rle, size_t size)
 {
-    uint8_t *p;
     WT_DECL_RET;
+    uint8_t *p;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1167,6 +1167,7 @@ __wt_cell_unpack_addr(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CE
 
     ret = __wt_cell_unpack_safe(session, dsk, cell, unpack_addr, NULL, NULL);
     WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
 
     __cell_unpack_window_cleanup(session, dsk, unpack_addr, NULL);
 }
@@ -1205,6 +1206,7 @@ __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL
 
     ret = __wt_cell_unpack_safe(session, dsk, cell, NULL, unpack_value, NULL);
     WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
 
     __cell_unpack_window_cleanup(session, dsk, NULL, unpack_value);
 }

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1163,7 +1163,11 @@ static inline void
 __wt_cell_unpack_addr(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL *cell,
   WT_CELL_UNPACK_ADDR *unpack_addr)
 {
-    WT_IGNORE_RET(__wt_cell_unpack_safe(session, dsk, cell, unpack_addr, NULL, NULL));
+    WT_DECL_RET;
+
+    ret = __wt_cell_unpack_safe(session, dsk, cell, unpack_addr, NULL, NULL);
+    WT_ASSERT(session, ret == 0);
+
     __cell_unpack_window_cleanup(session, dsk, unpack_addr, NULL);
 }
 
@@ -1175,6 +1179,8 @@ static inline void
 __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL *cell,
   WT_CELL_UNPACK_KV *unpack_value)
 {
+    WT_DECL_RET;
+
     /*
      * Row-store doesn't store zero-length values on pages, but this allows us to pretend.
      */
@@ -1197,7 +1203,9 @@ __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL
         return;
     }
 
-    WT_IGNORE_RET(__wt_cell_unpack_safe(session, dsk, cell, NULL, unpack_value, NULL));
+    ret = __wt_cell_unpack_safe(session, dsk, cell, NULL, unpack_value, NULL);
+    WT_ASSERT(session, ret == 0);
+
     __cell_unpack_window_cleanup(session, dsk, NULL, unpack_value);
 }
 

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -32,7 +32,7 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, bool e
  * __cell_pack_value_validity --
  *     Pack the validity window for a value.
  */
-static inline void
+static inline int
 __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDOW *tw)
 {
     uint8_t flags, *flagsp;
@@ -40,10 +40,10 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
     /* Globally visible values have no associated validity window. */
     if (WT_TIME_WINDOW_IS_EMPTY(tw)) {
         ++*pp;
-        return;
+        return (0);
     }
 
-    WT_IGNORE_RET(__cell_check_value_validity(session, tw, false));
+    WT_RET(__cell_check_value_validity(session, tw, false));
 
     **pp |= WT_CELL_SECOND_DESC;
     ++*pp;
@@ -52,42 +52,44 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
 
     flags = 0;
     if (tw->start_ts != WT_TS_NONE) {
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0, tw->start_ts));
+        WT_RET(__wt_vpack_uint(pp, 0, tw->start_ts));
         LF_SET(WT_CELL_TS_START);
     }
     if (tw->start_txn != WT_TXN_NONE) {
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0, tw->start_txn));
+        WT_RET(__wt_vpack_uint(pp, 0, tw->start_txn));
         LF_SET(WT_CELL_TXN_START);
     }
     if (tw->durable_start_ts != WT_TS_NONE) {
         WT_ASSERT(session, tw->start_ts <= tw->durable_start_ts);
         /* Store differences if any, not absolutes. */
         if (tw->durable_start_ts - tw->start_ts > 0) {
-            WT_IGNORE_RET(__wt_vpack_uint(pp, 0, tw->durable_start_ts - tw->start_ts));
+            WT_RET(__wt_vpack_uint(pp, 0, tw->durable_start_ts - tw->start_ts));
             LF_SET(WT_CELL_TS_DURABLE_START);
         }
     }
     if (tw->stop_ts != WT_TS_MAX) {
         /* Store differences, not absolutes. */
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0, tw->stop_ts - tw->start_ts));
+        WT_RET(__wt_vpack_uint(pp, 0, tw->stop_ts - tw->start_ts));
         LF_SET(WT_CELL_TS_STOP);
     }
     if (tw->stop_txn != WT_TXN_MAX) {
         /* Store differences, not absolutes. */
-        WT_IGNORE_RET(__wt_vpack_uint(pp, 0, tw->stop_txn - tw->start_txn));
+        WT_RET(__wt_vpack_uint(pp, 0, tw->stop_txn - tw->start_txn));
         LF_SET(WT_CELL_TXN_STOP);
     }
     if (tw->durable_stop_ts != WT_TS_NONE) {
         WT_ASSERT(session, tw->stop_ts <= tw->durable_stop_ts);
         /* Store differences if any, not absolutes. */
         if (tw->durable_stop_ts - tw->stop_ts > 0) {
-            WT_IGNORE_RET(__wt_vpack_uint(pp, 0, tw->durable_stop_ts - tw->stop_ts));
+            WT_RET(__wt_vpack_uint(pp, 0, tw->durable_stop_ts - tw->stop_ts));
             LF_SET(WT_CELL_TS_DURABLE_STOP);
         }
     }
     if (tw->prepare)
         LF_SET(WT_CELL_PREPARE);
     *flagsp = flags;
+
+    return (0);
 }
 
 /*
@@ -240,12 +242,15 @@ __wt_cell_pack_value(
 {
     uint8_t byte, *p;
     bool validity;
+    WT_DECL_RET;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_value_validity(session, &p, tw);
+    ret = __cell_pack_value_validity(session, &p, tw);
+    WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
 
     /*
      * Short data cells without a validity window or run-length encoding have 6 bits of data length
@@ -371,12 +376,15 @@ __wt_cell_pack_copy(
   WT_SESSION_IMPL *session, WT_CELL *cell, WT_TIME_WINDOW *tw, uint64_t rle, uint64_t v)
 {
     uint8_t *p;
+    WT_DECL_RET;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_value_validity(session, &p, tw);
+    ret = __cell_pack_value_validity(session, &p, tw);
+    WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
 
     if (rle < 2)
         cell->__chunk[0] |= WT_CELL_VALUE_COPY; /* Type */
@@ -399,12 +407,15 @@ static inline size_t
 __wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell, WT_TIME_WINDOW *tw, uint64_t rle)
 {
     uint8_t *p;
+    WT_DECL_RET;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_value_validity(session, &p, tw);
+    ret = __cell_pack_value_validity(session, &p, tw);
+    WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
 
     if (rle < 2)
         cell->__chunk[0] |= WT_CELL_DEL; /* Type */
@@ -494,6 +505,7 @@ __wt_cell_pack_ovfl(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t type, WT_TI
   uint64_t rle, size_t size)
 {
     uint8_t *p;
+    WT_DECL_RET;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
@@ -507,9 +519,12 @@ __wt_cell_pack_ovfl(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t type, WT_TI
         break;
     case WT_CELL_VALUE_OVFL:
     case WT_CELL_VALUE_OVFL_RM:
-        __cell_pack_value_validity(session, &p, tw);
+        ret = __cell_pack_value_validity(session, &p, tw);
         break;
     }
+
+    WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
 
     if (rle < 2)
         cell->__chunk[0] |= type; /* Type */


### PR DESCRIPTION
These are just the basic ones, I spent some time trying to add some assertions on the packing side but (a) that code is more complex and I was less convinced my assertions were correct, and (b) we strongly suspect the bugs we've seen are on the unpacking side.

Note that we don't think the unpacking code is itself wrong - rather, we think something is using it incorrectly, but these assertions should still help with that.