### PR TITLE
WT-10488 Updated schema abort to set stable ts reliably (#8884) (v6.0 backport)

### DIFF
--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -57,7 +57,7 @@ static char home[1024]; /* Program working dir */
 #define INVALID_KEY UINT64_MAX
 #define MAX_CKPT_INVL 2 /* Maximum interval between checkpoints */
 /* Set large, some slow I/O systems take tens of seconds to fsync. */
-#define MAX_STARTUP 30 /* Seconds to start up and set stable */
+#define MAX_STARTUP 60 /* Seconds to start up and set stable */
 #define MAX_TH 12
 #define MAX_TIME 40
 #define MAX_VAL 1024
@@ -635,6 +635,10 @@ thread_run(void *arg)
     printf("Thread %" PRIu32 " starts at %" PRIu64 "\n", td->info, td->start);
     stable_ts = 0;
     for (i = td->start;; ++i) {
+        /* Give other threads a chance to run and move their timestamps forward. */
+        if (use_ts && !stable_set && (i + 1) % 100 == 0)
+            __wt_sleep(2, 0);
+
         /*
          * Allow some threads to skip schema operations so that they are generating sufficient dirty
          * data.


### PR DESCRIPTION
WT-10488 Added sleep to worker thread loop to give all threads a chance to progress and move the timestamp forward. Increased the max time to set the stable timestamp before first checkpoint.

(cherry picked from commit d68edf8a25c95f4f9e3d5a13e9023081605a6b0a)