### PR TITLE
WT-9117 Restricting runs.rows to 1,000,000 when runs.in_memory is auto enabled (#8541) (v6.0 backport)

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -256,8 +256,18 @@ config_table(TABLE *table, void *arg)
      * direct I/O can be so slow the additional I/O for overflow items causes eviction to stall).
      */
     if (GV(RUNS_IN_MEMORY) || GV(DISK_DIRECT_IO)) {
-        if (!config_explicit(table, "runs.rows") && TV(RUNS_ROWS) > 1000000)
+        /*
+         * Always limit the row count if its greater that 1,000,000 and in memory wasn't explicitly
+         * set. Direct IO is always explicitly set, never limit the row count because the user has
+         * taken control.
+         */
+        if (GV(RUNS_IN_MEMORY) && TV(RUNS_ROWS) > WT_MILLION &&
+          config_explicit(NULL, "runs.in_memory")) {
+            WARN("limiting table%" PRIu32
+                 ".runs.rows to 1,000,000 as runs.in_memory has been automatically enabled",
+              table->id)
             config_single(table, "runs.rows=1000000", false);
+        }
         if (!config_explicit(table, "btree.key_max"))
             config_single(table, "btree.key_max=32", false);
         if (!config_explicit(table, "btree.key_min"))
@@ -846,8 +856,15 @@ config_in_memory(void)
     if (config_explicit(NULL, "ops.verify"))
         return;
 
-    if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1)
+    if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1) {
         config_single(NULL, "runs.in_memory=1", false);
+        /* Use table[0] to access the global value (RUN_ROWS is a table value). */
+        if (NTV(tables[0], RUNS_ROWS) > WT_MILLION) {
+            WARN("%s",
+              "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");
+            config_single(NULL, "runs.rows=1000000", true);
+        }
+    }
 }
 
 /*

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -859,7 +859,7 @@ config_in_memory(void)
     if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1) {
         config_single(NULL, "runs.in_memory=1", false);
         /* Use table[0] to access the global value (RUN_ROWS is a table value). */
-        if (NTV(tables[0], RUNS_ROWS) > WT_MILLION) {
+        if ((tables[0]->v[V_TABLE_RUNS_ROWS].v) > WT_MILLION) {
             WARN("%s",
               "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");
             config_single(NULL, "runs.rows=1000000", true);

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -858,7 +858,7 @@ config_in_memory(void)
 
     if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1) {
         config_single(NULL, "runs.in_memory=1", false);
-        /* Use table[0] to access the global value (RUN_ROWS is a table value). */
+        /* Use table[0] to access the global value (RUNS_ROWS is a table value). */
         if ((tables[0]->v[V_TABLE_RUNS_ROWS].v) > WT_MILLION) {
             WARN("%s",
               "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");


### PR DESCRIPTION
The current version does not have the NTV macro ` #define NTV(table, off) ((table)->v[V_TABLE_##off].v)` so I have just substituted the values inline to keep the backport within scope (the `TV `and `GV `macro are not compatible here due to requiring `tables[0]` instead of `table`). 

If it reads better adding the NTV macro to the backport let me know and I can add that.