### PR TITLE
WT-11145 Clear unused wt_internal import in gcp_storage_source.cpp

### DIFF
--- a/ext/storage_sources/gcp_store/gcp_storage_source.cpp
+++ b/ext/storage_sources/gcp_store/gcp_storage_source.cpp
@@ -35,7 +35,6 @@
 
 #include "gcp_connection.h"
 #include "gcp_log_system.h"
-#include "wt_internal.h"
 
 struct gcp_file_system;
 struct gcp_file_handle;


### PR DESCRIPTION
The file imports `wt_internal.h` but it is never used.