### PR TITLE
WT-10528 test_wt8246_compact_rts_data_correctness retry to insert thedata during WT_ROLLBACK (#9099) (#9192) (v6.0 backport)

### DIFF
--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -30,6 +30,7 @@
 #include <signal.h>
 
 #define TIMEOUT 1
+#define MAX_RETRIES 5
 
 #define NUM_RECORDS 800000
 
@@ -334,11 +335,13 @@ static void
 large_updates(WT_SESSION *session, const char *uri, char *value, int commit_ts)
 {
     WT_CURSOR *cursor;
+    WT_DECL_RET;
     WT_RAND_STATE rnd;
     uint64_t val;
-    int i;
+    int i, retry_attempts;
     char tscfg[64];
 
+    retry_attempts = 0;
     __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
     testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
@@ -348,7 +351,16 @@ large_updates(WT_SESSION *session, const char *uri, char *value, int commit_ts)
         cursor->set_key(cursor, i + 1);
         val = (uint64_t)__wt_random(&rnd);
         cursor->set_value(cursor, val, val, val, value);
-        testutil_check(cursor->insert(cursor));
+        while (((ret = cursor->insert(cursor)) == WT_ROLLBACK) && retry_attempts < MAX_RETRIES) {
+            testutil_check(session->rollback_transaction(session, NULL));
+            testutil_check(session->begin_transaction(session, NULL));
+            ++retry_attempts;
+        }
+
+        if (retry_attempts == MAX_RETRIES)
+            testutil_die(ret, "Cursor insert returned WT_ROLLBACK for %d times", MAX_RETRIES);
+
+        testutil_check(ret);
         testutil_check(session->commit_transaction(session, tscfg));
     }
 


### PR DESCRIPTION
… 

* Retry 5 times and then abort the test

(cherry picked from commit 1daa7d05a761f3968fbcefa46f2d71803c3cc17d)

Co-authored-by: Ravi Giri <56813441+raviprakashgiri29@users.noreply.github.com>
(cherry picked from commit 880c9703e9018c3aea3d7bfb48ce82ee8fa1bd22)