### PR TITLE
WT-9117 Restricting runs.rows to 1,000,000 when runs.in_memory is auto enabled (#8541)(v5.0 backport)

### DIFF
--- a/test/format/config.c
+++ b/test/format/config.c
@@ -252,10 +252,6 @@ config_table(TABLE *table, void *arg)
      * Keep the number of rows and keys/values small for in-memory runs (overflow items aren't an
      * issue for in-memory configurations and it helps prevents cache overflow).
      */
-<<<<<<< HEAD
-    if (GV(RUNS_IN_MEMORY)) {
-        if (!config_explicit(table, "runs.rows") && TV(RUNS_ROWS) > 1000000)
-=======
     if (GV(RUNS_IN_MEMORY) || GV(DISK_DIRECT_IO)) {
         /*
          * Always limit the row count if its greater that 1,000,000 and in memory wasn't explicitly
@@ -267,7 +263,6 @@ config_table(TABLE *table, void *arg)
             WARN("limiting table%" PRIu32
                  ".runs.rows to 1,000,000 as runs.in_memory has been automatically enabled",
               table->id)
->>>>>>> 78017d23d... WT-9117 Restricting runs.rows to 1,000,000 when runs.in_memory is auto enabled (#8541)
             config_single(table, "runs.rows=1000000", false);
         }
         if (!config_explicit(table, "btree.key_max"))
@@ -860,8 +855,8 @@ config_in_memory(void)
 
     if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1) {
         config_single(NULL, "runs.in_memory=1", false);
-        /* Use table[0] to access the global value (RUN_ROWS is a table value). */
-        if (NTV(tables[0], RUNS_ROWS) > WT_MILLION) {
+        /* Use table[0] to access the global value (RUNS_ROWS is a table value). */
+        if ((tables[0]->v[V_TABLE_RUNS_ROWS].v) > WT_MILLION) {
             WARN("%s",
               "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");
             config_single(NULL, "runs.rows=1000000", true);

--- a/test/format/config.c
+++ b/test/format/config.c
@@ -252,9 +252,24 @@ config_table(TABLE *table, void *arg)
      * Keep the number of rows and keys/values small for in-memory runs (overflow items aren't an
      * issue for in-memory configurations and it helps prevents cache overflow).
      */
+<<<<<<< HEAD
     if (GV(RUNS_IN_MEMORY)) {
         if (!config_explicit(table, "runs.rows") && TV(RUNS_ROWS) > 1000000)
+=======
+    if (GV(RUNS_IN_MEMORY) || GV(DISK_DIRECT_IO)) {
+        /*
+         * Always limit the row count if its greater that 1,000,000 and in memory wasn't explicitly
+         * set. Direct IO is always explicitly set, never limit the row count because the user has
+         * taken control.
+         */
+        if (GV(RUNS_IN_MEMORY) && TV(RUNS_ROWS) > WT_MILLION &&
+          config_explicit(NULL, "runs.in_memory")) {
+            WARN("limiting table%" PRIu32
+                 ".runs.rows to 1,000,000 as runs.in_memory has been automatically enabled",
+              table->id)
+>>>>>>> 78017d23d... WT-9117 Restricting runs.rows to 1,000,000 when runs.in_memory is auto enabled (#8541)
             config_single(table, "runs.rows=1000000", false);
+        }
         if (!config_explicit(table, "btree.key_max"))
             config_single(table, "btree.key_max=32", false);
         if (!config_explicit(table, "btree.key_min"))
@@ -843,8 +858,15 @@ config_in_memory(void)
     if (config_explicit(NULL, "ops.verify"))
         return;
 
-    if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1)
+    if (!config_explicit(NULL, "runs.in_memory") && mmrand(NULL, 1, 20) == 1) {
         config_single(NULL, "runs.in_memory=1", false);
+        /* Use table[0] to access the global value (RUN_ROWS is a table value). */
+        if (NTV(tables[0], RUNS_ROWS) > WT_MILLION) {
+            WARN("%s",
+              "limiting runs.rows to 1,000,000 as runs.in_memory has been automatically enabled");
+            config_single(NULL, "runs.rows=1000000", true);
+        }
+    }
 }
 
 /*


### PR DESCRIPTION
[WT-9117](https://jira.mongodb.org/browse/WT-9117) Restricting runs.rows to 1,000,000 when runs.in_memory is automatically enabled. Removing restriction on runs.rows when direct IO is enabled (as it most likely never used).

(cherry picked from commit https://github.com/wiredtiger/wiredtiger/commit/78017d23df44a069ef6f224dfc8b27887acf4073)