### PR TITLE
WT-11065 Fix WT_STRING_MATCH macro

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -294,13 +294,13 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
         WT_CURSOR_BACKUP_CHECK_STOP(othercb);
 
     /* Special backup cursor to query incremental IDs. */
-    if (WT_STRING_MATCH("backup:query_id", uri, strlen("backup:query_id"))) {
+    if (WT_STRING_MATCH("backup:query_id", uri, strlen(uri))) {
         /* Top level cursor code does not allow a URI and cursor. We don't need to check here. */
         WT_ASSERT(session, othercb == NULL);
         if (!F_ISSET(S2C(session), WT_CONN_INCR_BACKUP))
             WT_RET_MSG(session, EINVAL, "Incremental backup is not configured");
         F_SET(cb, WT_CURBACKUP_QUERYID);
-    } else if (WT_STRING_MATCH("backup:export", uri, strlen("backup:export")))
+    } else if (WT_STRING_MATCH("backup:export", uri, strlen(uri)))
         /* Special backup cursor for export operation. */
         F_SET(cb, WT_CURBACKUP_EXPORT);
 

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -274,10 +274,24 @@
  */
 #define WT_STREQ(s, cs) (sizeof(cs) == 2 ? (s)[0] == (cs)[0] && (s)[1] == '\0' : strcmp(s, cs) == 0)
 
-/* Check if a string matches a byte string of len bytes. */
-#define WT_STRING_MATCH(str, bytes, len)                                                        \
-    (((const char *)(str))[0] == ((const char *)(bytes))[0] && strncmp(str, bytes, len) == 0 && \
-      (str)[len] == '\0')
+/*
+ * Check if a string matches a byte string of len bytes. This macro expects both strings to be of
+ * non-zero length in order to be a match - this means that strings cannot be a match if len
+ * == 0.
+ *
+ * Use an inline function as that tends to be safer and we can check for NULL values.
+ */
+#define WT_STRING_MATCH(str, bytes, len) __wt_string_match(str, bytes, len)
+
+static inline bool
+__wt_string_match(const char *str, const char *bytes, size_t len)
+{
+    if (str != NULL && bytes != NULL && len > 0 && (strlen(str) == len) &&
+      (strncmp(str, bytes, len) == 0))
+        return (true);
+    else
+        return (false);
+}
 
 /*
  * Macro that produces a string literal that isn't wrapped in quotes, to avoid tripping up spell

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -275,9 +275,9 @@
 #define WT_STREQ(s, cs) (sizeof(cs) == 2 ? (s)[0] == (cs)[0] && (s)[1] == '\0' : strcmp(s, cs) == 0)
 
 /*
- * Check if a string matches a byte string of len bytes. This macro expects both strings to be of
- * non-zero length in order to be a match - this means that strings cannot be a match if len
- * == 0.
+ * Check if a non-empty string matches a byte sequence of len bytes. Since the macro expects both
+ * strings to be of non-zero length in order to be a match, it will return false if len == 0. The
+ * bytes argument does not need to be null-terminated.
  *
  * Use an inline function as that tends to be safer and we can check for NULL values.
  */

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -275,22 +275,17 @@
 #define WT_STREQ(s, cs) (sizeof(cs) == 2 ? (s)[0] == (cs)[0] && (s)[1] == '\0' : strcmp(s, cs) == 0)
 
 /*
- * Check if a non-empty string matches a byte sequence of len bytes. Since the macro expects both
- * strings to be of non-zero length in order to be a match, it will return false if len == 0. The
- * bytes argument does not need to be null-terminated.
- *
- * Use an inline function as that tends to be safer and we can check for NULL values.
+ * Check if a non-empty string matches a byte sequence of len bytes. The macro expects both strings
+ * to be of non-zero length in order to be a match. The bytes argument does not need to be
+ * null-terminated. Similar to other string related functions, this is not expected to work on NULL
+ * values.
  */
 #define WT_STRING_MATCH(str, bytes, len) __wt_string_match(str, bytes, len)
 
 static inline bool
 __wt_string_match(const char *str, const char *bytes, size_t len)
 {
-    if (str != NULL && bytes != NULL && len > 0 && (strlen(str) == len) &&
-      (strncmp(str, bytes, len) == 0))
-        return (true);
-    else
-        return (false);
+    return (len > 0 && (strlen(str) == len) && (strncmp(str, bytes, len) == 0));
 }
 
 /*

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -502,7 +502,7 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
      * Test for the internal checkpoint name (WiredTigerCheckpoint). Note: must_resolve is true in a
      * subset of the cases where is_unnamed_ckpt is true.
      */
-    must_resolve = cval.len == strlen(WT_CHECKPOINT) && WT_PREFIX_MATCH(cval.str, WT_CHECKPOINT);
+    must_resolve = WT_STRING_MATCH(WT_CHECKPOINT, cval.str, cval.len);
     is_unnamed_ckpt = cval.len >= strlen(WT_CHECKPOINT) && WT_PREFIX_MATCH(cval.str, WT_CHECKPOINT);
 
     /* This is the top of a retry loop. */


### PR DESCRIPTION
The main changes are in the `WT_STRING_MATCH` macro. The changes prevent the macro from attempting to read past memory that is valid to read. I've also changed the `WT_STRING_MATCH` macro to call an inline function instead as that should provide more safety.

The other changes are fixing up some calls to `WT_STRING_MATCH` as strlen() was being called on the wrong argument, and a workaround where we previously used `WT_PREFIX_MATCH` instead of `WT_STRING_MATCH`.