### PR TITLE
WT-11136 Clone the new code coverage task into two

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3386,6 +3386,9 @@ tasks:
           checkpoint_args: -t r -n 1000000 -k 5000000 -C cache_size=100MB
 
   - name: coverage-report
+    # This task will measure code coverage across a range of tests, including, but not limited to,
+    # the Catch2-based unit tests.
+    # Currently, it only contains Catch2-based unit tests but that will change soon.
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -3411,6 +3414,7 @@ tasks:
       - func: "code coverage publish summary"
 
   - name: coverage-report-catch2
+    # This task measures code coverage achieved by only the Catch2-based unit tests.
     commands:
       - func: "get project"
       - func: "compile wiredtiger"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -551,6 +551,48 @@ functions:
         else
             ${test_env_vars|} ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${smp_command|} 2>&1
         fi
+
+  "code coverage analysis":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/cmake_build"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        virtualenv -p python3 venv
+        source venv/bin/activate
+        pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
+        mkdir -p ../coverage_report
+        GCOV=/opt/mongodbtoolchain/v4/bin/gcov gcovr -r .. -f ../src -e '.*/bt_(debug|dump|misc|salvage|vrfy).*' -e '.*/(log|progress|verify_build|strerror|env_msg|err_file|cur_config|os_abort)\..*' -e '.*_stat\..*' -e 'bench' -e 'examples' -e 'test' -e 'ext' -e 'dist' -e 'tools' -j 4 --html-self-contained --html-details ../coverage_report/2_coverage_report.html --json-summary-pretty --json-summary ../coverage_report/1_coverage_report_summary.json
+        python3 ../test/evergreen/code_coverage_analysis.py -c ../coverage_report/1_coverage_report_summary.json -t ../time.txt
+
+  "code coverage publish report":
+    command: s3.put
+    params:
+      aws_secret: ${aws_secret}
+      aws_key: ${aws_key}
+      local_files_include_filter: wiredtiger/coverage_report/*
+      bucket: build_external
+      permissions: public-read
+      content_type: text/html
+      remote_file: wiredtiger/${build_variant}/${revision}/coverage_report_${build_id}-${execution}/
+
+  "code coverage publish summary":
+    command: s3.put
+    params:
+      aws_secret: ${aws_secret}
+      aws_key: ${aws_key}
+      local_file: wiredtiger/coverage_report/2_coverage_report.html
+      bucket: build_external
+      permissions: public-read
+      content_type: text/html
+      # Ensure that the first character of the display_name is a space
+      # This will ensure that it sorts before the per-file report pages which also get a space
+      # at the start of their display name (why this happens is not yet clear).
+      display_name: " 1 Coverage report main page"
+      remote_file: wiredtiger/${build_variant}/${revision}/coverage_report_${build_id}-${execution}/1_coverage_report_main.html
+
   "format test":
     command: shell.exec
     params:
@@ -3345,10 +3387,6 @@ tasks:
 
   - name: coverage-report
     commands:
-      - command: timeout.update
-        params:
-          exec_timeout_secs: 43200 # 12 hrs
-          timeout_secs: 1800 # 30 mins
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
@@ -3362,12 +3400,24 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            # Record the start time
+            # Record the start time, in seconds
             date +%s > ../time.txt
             # Perform the tests to get code coverage metrics for
             ${test_env_vars|} test/unittest/unittests
-            # Record the end time
+            # Record the end time, in seconds
             date +%s >> ../time.txt
+      - func: "code coverage analysis"
+      - func: "code coverage publish report"
+      - func: "code coverage publish summary"
+
+  - name: coverage-report-catch2
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          HAVE_UNITTEST: -DHAVE_UNITTEST=1
+          <<: *configure_flags_with_builtins
+          CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=Coverage
       - command: shell.exec
         params:
           working_dir: "wiredtiger/cmake_build"
@@ -3375,34 +3425,15 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            virtualenv -p python3 venv
-            source venv/bin/activate
-            pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
-            mkdir -p ../coverage_report
-            GCOV=/opt/mongodbtoolchain/v4/bin/gcov gcovr -r .. -f ../src -e '.*/bt_(debug|dump|misc|salvage|vrfy).*' -e '.*/(log|progress|verify_build|strerror|env_msg|err_file|cur_config|os_abort)\..*' -e '.*_stat\..*' -e 'bench' -e 'examples' -e 'test' -e 'ext' -e 'dist' -e 'tools' -j 4 --html-self-contained --html-details ../coverage_report/2_coverage_report.html --json-summary-pretty --json-summary ../coverage_report/1_coverage_report_summary.json
-            python3 ../test/evergreen/code_coverage_analysis.py -c ../coverage_report/1_coverage_report_summary.json -t ../time.txt
-      - command: s3.put
-        params:
-          aws_secret: ${aws_secret}
-          aws_key: ${aws_key}
-          local_files_include_filter: wiredtiger/coverage_report/*
-          bucket: build_external
-          permissions: public-read
-          content_type: text/html
-          remote_file: wiredtiger/${build_variant}/${revision}/coverage_report_${build_id}-${execution}/
-      - command: s3.put
-        params:
-          aws_secret: ${aws_secret}
-          aws_key: ${aws_key}
-          local_file: wiredtiger/coverage_report/2_coverage_report.html
-          bucket: build_external
-          permissions: public-read
-          content_type: text/html
-          # Ensure that the first character of the display_name is a space
-          # This will ensure that it sorts before the per-file report pages which also get a space
-          # at the start of their display name (why this happens is not yet clear).
-          display_name: " 1 Coverage report main page"
-          remote_file: wiredtiger/${build_variant}/${revision}/coverage_report_${build_id}-${execution}/1_coverage_report_main.html
+            # Record the start time, in seconds
+            date +%s > ../time.txt
+            # Perform the tests to get code coverage metrics for
+            ${test_env_vars|} test/unittest/unittests
+            # Record the end time, in seconds
+            date +%s >> ../time.txt
+      - func: "code coverage analysis"
+      - func: "code coverage publish report"
+      - func: "code coverage publish summary"
 
   - name: s3-tiered-storage-extensions-test
     tags: ["python"]

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -129,6 +129,7 @@ buildvariants:
     CMAKE_INSTALL_PREFIX: -DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL
   tasks:
     - name: coverage-report
+    - name: coverage-report-catch2
     - name: cyclomatic-complexity
 
 - name: compatibility-tests-less-frequent


### PR DESCRIPTION
Refactored the code coverage task to make the steps reusable by turning the analysis and result publishing steps into functions. Cloned the refactored code coverage task to create 'code-coverage-catch2'.