### PR TITLE
WT-11131 Save test artifacts in a folder

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -40,7 +40,7 @@ functions:
       aws_secret: ${aws_secret}
       remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${dependent_task|compile}_${build_id}.tgz
       bucket: build_external
-      extract_to: ${destination|wiredtiger}
+      extract_to: ${destination|.}
   "fetch endian format artifacts" :
     - command: s3.get
       params:
@@ -768,9 +768,9 @@ functions:
     - command: archive.targz_pack
       params:
         target: ${upload_filename|wiredtiger.tgz}
-        source_dir: ${upload_source_dir|wiredtiger}
+        source_dir: ${upload_parent_dir|.}
         include:
-          - "./**"
+          - "${upload_include|wiredtiger/**}"
     - command: s3.put
       params:
         aws_secret: ${aws_secret}
@@ -5272,7 +5272,8 @@ tasks:
       - func: "upload artifact"
         vars:
           upload_filename: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+          upload_parent_dir: wiredtiger/cmake_build/bench/wtperf/
+          upload_include: WT_TEST_0_0/**
       # Call cleanup function to avoid duplicated artifact upload in the post-task stage.
       - func: "cleanup"
 
@@ -5291,7 +5292,7 @@ tasks:
       - func: "fetch artifacts"
         vars:
           dependent_task: perf-test-long-500m-btree-populate
-          destination: "wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0"
+          destination: "wiredtiger/cmake_build/bench/wtperf/"
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u.wtperf
@@ -5318,7 +5319,7 @@ tasks:
       - func: "fetch artifacts"
         vars:
           dependent_task: perf-test-long-500m-btree-populate
-          destination: "wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0"
+          destination: "wiredtiger/cmake_build/bench/wtperf/"
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-50r50u-backup.wtperf
@@ -5345,7 +5346,7 @@ tasks:
       - func: "fetch artifacts"
         vars:
           dependent_task: perf-test-long-500m-btree-populate
-          destination: "wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0"
+          destination: "wiredtiger/cmake_build/bench/wtperf/"
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-80r20u.wtperf
@@ -5372,7 +5373,7 @@ tasks:
       - func: "fetch artifacts"
         vars:
           dependent_task: perf-test-long-500m-btree-populate
-          destination: "wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0"
+          destination: "wiredtiger/cmake_build/bench/wtperf/"
       - func: "run-perf-test"
         vars:
           perf-test-name: 500m-btree-rdonly.wtperf


### PR DESCRIPTION
This is currently in draft mode as I'm not 100% happy with the implementation. Feedback is welcome.

This PR updates evergreen so that the tarballs produced by a default call to `upload artifact` extracts a single `wiredtiger` folder. Currently extracting our tarballs places all of wiredtiger's subfolders (`src`, `test`, `cmake_build`) into the local directory, polluting it.