### PR TITLE
WT-11157 Add re.MULTILINE to regex search in primitive_check.py

### DIFF
--- a/dist/primitive_check.py
+++ b/dist/primitive_check.py
@@ -40,7 +40,7 @@ found = False
 found_primitives = []
 start_regex = "^(\+|-).*"
 for primitive in primitives:
-    if (re.search(start_regex + primitive, diff)):
+    if (re.search(start_regex + primitive, diff, re.MULTILINE)):
         found_primitives.append(primitive)
         found = True
 


### PR DESCRIPTION
Make the regex search in `primitive_check.py` use the `re.MULTILINE` flag. This allows the `^` start-of-line character to match both at the beginning of the string being searched and also after each `\n` character.