### PR TITLE
WT-9545 wt8246_compact_rts_data_correctness test read incorrect data on macOS (#9116) (#9199) (v6.0 backport)

### DIFF
--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -352,6 +352,7 @@ large_updates(WT_SESSION *session, const char *uri, char *value, int commit_ts)
         val = (uint64_t)__wt_random(&rnd);
         cursor->set_value(cursor, val, val, val, value);
         while (((ret = cursor->insert(cursor)) == WT_ROLLBACK) && retry_attempts < MAX_RETRIES) {
+            printf("Rollback transaction for key %d\n", i + 1);
             testutil_check(session->rollback_transaction(session, NULL));
             testutil_check(session->begin_transaction(session, NULL));
             ++retry_attempts;

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4196,14 +4196,12 @@ buildvariants:
   - macos-1014
   batchtime: 120 # 2 hours
   expansions:
-    posix_configure_flags:
-      -DCMAKE_C_FLAGS="-ggdb"
-      -DHAVE_DIAGNOSTIC=1
-      -DENABLE_PYTHON=1
-      -DENABLE_ZLIB=1
-      -DENABLE_STRICT=1 
-      -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
-    python_binary: 'python3'
+    # The cmake toolchain file is set to the mongodb toolchain gcc by default.
+    # Remove that configuration here and let MacOS use the default Xcode toolchain instead.
+    # We'll explicitly use the python3 in /usr/bin, we use the same in configuring cmake.
+    CMAKE_TOOLCHAIN_FILE:
+    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
+    python_binary: '/usr/bin/python3'
     smp_command: -j $(sysctl -n hw.logicalcpu)
     cmake_generator: "Unix Makefiles"
     make_command: make

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4196,12 +4196,15 @@ buildvariants:
   - macos-1014
   batchtime: 120 # 2 hours
   expansions:
-    # The cmake toolchain file is set to the mongodb toolchain gcc by default.
-    # Remove that configuration here and let MacOS use the default Xcode toolchain instead.
-    # We'll explicitly use the python3 in /usr/bin, we use the same in configuring cmake.
-    CMAKE_TOOLCHAIN_FILE:
-    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-    python_binary: '/usr/bin/python3'
+    posix_configure_flags:
+      -DCMAKE_C_FLAGS="-ggdb"
+      -DHAVE_DIAGNOSTIC=1
+      -DCC_OPTIMIZE_LEVEL=-O0
+      -DENABLE_PYTHON=1
+      -DENABLE_ZLIB=1
+      -DENABLE_STRICT=1 
+      -DCMAKE_INSTALL_PREFIX=$(pwd)/LOCAL_INSTALL
+    python_binary: 'python3'
     smp_command: -j $(sysctl -n hw.logicalcpu)
     cmake_generator: "Unix Makefiles"
     make_command: make


### PR DESCRIPTION
…

* WT-9545 wt8246_compact_rts_data_correctness test read incorrect data on macOS
* Updated the optimize level for the entire macos variant

(cherry picked from commit 46fb8317e1cfbbb72204596065d78d951fc36c82)

Co-authored-by: Ravi Giri <56813441+raviprakashgiri29@users.noreply.github.com>
(cherry picked from commit e9f6e2ef429317344c88a5cd57e0a53662f24132)