### PR TITLE
WT-11036 Add test of incremental backup after files are closed (5.0)

### DIFF
--- a/test/suite/test_backup29.py
+++ b/test/suite/test_backup29.py
@@ -37,8 +37,8 @@ from wtbackup import backup_base
 #
 class test_backup29(backup_base):
     create_config = 'allocation_size=512,key_format=i,value_format=S'
-    # Backup directory name
-    dir='backup.dir'
+    # Backup directory name. Uncomment if actually taking a backup.
+    # dir='backup.dir'
     uri = 'test_backup29'
     uri2 = 'test_other'
     value_base = '-abcdefghijkl'
@@ -60,7 +60,6 @@ class test_backup29(backup_base):
         return blocks
 
     def test_backup29(self):
-        os.mkdir(self.dir)
 
         # Create and populate the table.
         file_uri = 'file:' + self.uri + '.wt'
@@ -79,13 +78,17 @@ class test_backup29(backup_base):
             c2[i] = val
         self.session.checkpoint()
 
-        # Take the initial full backup for incremental.
+        # Take the initial full backup for incremental. We don't actually need to
+        # take the backup, we only need to open and close the backup cursor to have
+        # the library keep track of the bitmaps.
         config = 'incremental=(enabled,granularity=4k,this_id="ID1")'
         bkup_c = self.session.open_cursor('backup:', None, config)
-        self.take_full_backup(self.dir, bkup_c)
+        # Uncomment these lines if actually taking the full backup is helpful for debugging.
+        # os.mkdir(self.dir)
+        # self.take_full_backup(self.dir, bkup_c)
         bkup_c.close()
 
-        # Add a lot more data to both tables to generate a filled in block mod bitmap.
+        # Add a lot more data to both tables to generate a filled-in block mod bitmap.
         last_i = self.few
         self.pr("Write: " + str(self.nentries) + " additional data items")
         for i in range(self.few, self.nentries):

--- a/test/suite/test_backup29.py
+++ b/test/suite/test_backup29.py
@@ -26,25 +26,41 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, re
+import os, re, time
 from wtscenario import make_scenarios
 from wtbackup import backup_base
+from wiredtiger import stat
 
 # test_backup29.py
-#    Test interaction between restart, checkpoint and incremental backup. There was a bug in
-# maintaining the incremental backup bitmaps correctly across restarts in specific conditions
-# that this test can reproduce.
-#
+#    Test interaction between checkpoint and incremental backup. There was a bug in
+# maintaining the incremental backup bitmaps correctly after opening an uncached dhandle.
+# This test reconstructs the failure scenario and verifies correct behavior both when a
+# restart and when dhandle sweep lead to opening an uncached dhandle.
 class test_backup29(backup_base):
+    conn_config = 'file_manager=(close_handle_minimum=0,' + \
+              'close_idle_time=3,close_scan_interval=1),' + \
+              'statistics=(fast)'
     create_config = 'allocation_size=512,key_format=i,value_format=S'
     # Backup directory name. Uncomment if actually taking a backup.
     # dir='backup.dir'
     uri1 = 'test_first'
     uri2 = 'test_second'
+    file1_uri = 'file:' + uri1 + '.wt'
+    file2_uri = 'file:' + uri2 + '.wt'
+    table1_uri = 'table:' + uri1
+    table2_uri = 'table:' + uri2
+    active_uri = 'table:active.wt'
+
     value_base = '-abcdefghijkl'
 
     few = 100
     nentries = 5000
+
+    def get_open_file_count(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        n = stat_cursor[stat.conn.file_open][2]
+        stat_cursor.close()
+        return n
 
     def parse_blkmods(self, uri):
         meta_cursor = self.session.open_cursor('metadata:')
@@ -74,17 +90,12 @@ class test_backup29(backup_base):
             if o_bit != '0':
                 self.assertTrue(n_bit != '0')
 
-    def test_backup29(self):
-
-        # Create and populate the table.
-        file1_uri = 'file:' + self.uri1 + '.wt'
-        file2_uri = 'file:' + self.uri2 + '.wt'
-        table1_uri = 'table:' + self.uri1
-        table2_uri = 'table:' + self.uri2
-        self.session.create(table1_uri, self.create_config)
-        self.session.create(table2_uri, self.create_config)
-        c1 = self.session.open_cursor(table1_uri)
-        c2 = self.session.open_cursor(table2_uri)
+    def setup_test(self):
+        # Create and populate the tables.
+        self.session.create(self.table1_uri, self.create_config)
+        self.session.create(self.table2_uri, self.create_config)
+        c1 = self.session.open_cursor(self.table1_uri)
+        c2 = self.session.open_cursor(self.table2_uri)
         # Only add a few entries.
         self.pr("Write: " + str(self.few) + " initial data items")
         for i in range(1, self.few):
@@ -110,41 +121,86 @@ class test_backup29(backup_base):
             val = str(i) + self.value_base
             c1[i] = val
             c2[i] = val
-        last_i = self.nentries
         c1.close()
         c2.close()
         self.session.checkpoint()
         # Get the block mod bitmap from the file URI.
-        orig1_bitmap = self.parse_blkmods(file1_uri)
-        orig2_bitmap = self.parse_blkmods(file2_uri)
-        self.pr("CLOSE and REOPEN conn")
-        self.reopen_conn()
-        self.pr("Reopened conn")
+        self.orig1_bitmap = self.parse_blkmods(self.file1_uri)
+        self.orig2_bitmap = self.parse_blkmods(self.file2_uri)
 
+
+    def incr_backup_and_validate(self):
         # After reopening we want to open both tables, but only modify one of them for
         # the first checkpoint. Then modify the other table, checkpoint, and then check the
         # that the block mod bitmap remains correct for the other table.
-        c1 = self.session.open_cursor(table1_uri)
-        c2 = self.session.open_cursor(table2_uri)
+        c1 = self.session.open_cursor(self.table1_uri)
+        c2 = self.session.open_cursor(self.table2_uri)
+        last_i = self.nentries
 
         # Change the first table and checkpoint. Keep the second table clean.
         self.pr("Update only table 1: " + str(last_i))
         val = str(last_i) + self.value_base
         c1[last_i] = val
         self.session.checkpoint()
-        new1_bitmap = self.parse_blkmods(file1_uri)
+        new1_bitmap = self.parse_blkmods(self.file1_uri)
 
         # Now change the second table and checkpoint again.
         self.pr("Update second table: " + str(last_i))
         c2[last_i] = val
         self.session.checkpoint()
-        new2_bitmap = self.parse_blkmods(file2_uri)
+        new2_bitmap = self.parse_blkmods(self.file2_uri)
 
         c1.close()
         c2.close()
 
-        self.compare_bitmap(orig1_bitmap, new1_bitmap)
-        self.compare_bitmap(orig2_bitmap, new2_bitmap)
+        self.compare_bitmap(self.orig1_bitmap, new1_bitmap)
+        self.compare_bitmap(self.orig2_bitmap, new2_bitmap)
+
+    def test_backup29_reopen(self):
+        self.setup_test()
+
+        self.pr("CLOSE and REOPEN conn")
+        self.reopen_conn()
+        self.pr("Reopened conn")
+
+        self.incr_backup_and_validate()
+
+    def test_backup29_sweep(self):
+        self.setup_test()
+
+        self.pr("Waiting to sweep handles")
+        # Create another table and populate it, and checkpoint. 
+        self.session.create(self.active_uri, self.create_config)
+        c = self.session.open_cursor(self.active_uri)
+        for i in range(1, self.few):
+            c[i] = str(i) + self.value_base
+        self.session.checkpoint()
+
+        sleep = 0
+        max = 20
+        # The only files sweep won't close should be the metadata, the history store, the
+        # lock file, and our active file.
+        final_nfile = 4
+        
+        # Keep updating and checkpointing this table until all other handles have been swept.
+        # The checkpoints have the side effect of sweeping the session cache, which will allow
+        # dhandles to be closed.
+        while sleep < max:
+            i = i + 1
+            c[i] = str(i) + self.value_base
+            self.session.checkpoint()
+            sleep += 0.5
+            time.sleep(0.5)
+            nfile = self.get_open_file_count()
+            if nfile == final_nfile:
+                break
+        c.close()
+
+        # Make sure we swept everything before we ran out of time.
+        self.assertEqual(nfile, final_nfile)
+        self.pr("Sweep done")
+
+        self.incr_backup_and_validate()
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
I had to backport [WT-10909](https://jira.mongodb.org/browse/WT-10909) and [WT-10920](https://jira.mongodb.org/browse/WT-10920) to have a clean backport of [WT-11036](https://jira.mongodb.org/browse/WT-11036).