### PR TITLE
WT-11142 Use the right Windows toolchain path

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5872,13 +5872,13 @@ buildvariants:
     # Remove the default configurations for the toolchain and install prefix.
     CMAKE_TOOLCHAIN_FILE:
     CMAKE_INSTALL_PREFIX:
-    python_binary: '/cygdrive/c/Python311/python'
+    python_binary: '/cygdrive/c/python/Python311/python'
     configure_env_vars:
-      PATH=/cygdrive/c/Python311:/cygdrive/c/Python311/Scripts:$PATH
+      PATH=/cygdrive/c/python/Python311:/cygdrive/c/python/Python311/Scripts:$PATH
     test_env_vars:
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
-      PATH=/cygdrive/c/Python311:/cygdrive/c/Python311/Scripts:$PATH
+      PATH=/cygdrive/c/python/Python311:/cygdrive/c/python/Python311/Scripts:$PATH
       PYTHONPATH=($WT_TOPDIR/lang/python/wiredtiger):$(cygpath -w $WT_TOPDIR/lang/python)
   tasks:
     - name: compile


### PR DESCRIPTION
In `/cygdrive/c/python`, all the binaries are preserved, we should have used that path from the start.