### PR TITLE
WT-10978 Fix tiered drop after reopen

### DIFF
--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -180,7 +180,7 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE *tier;
     WT_DECL_RET;
-    WT_TIERED *tiered;
+    WT_TIERED *tiered, tiered_tmp;
     u_int i, localid;
     const char *filename, *name;
     bool exist, got_dhandle, remove_files, remove_shared;
@@ -202,75 +202,12 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE));
     got_dhandle = true;
     tiered = (WT_TIERED *)session->dhandle;
-
     /*
-     * We cannot remove the objects on shared storage as other systems may be accessing them too.
-     * Remove the current local file object, the tiered entry and all bucket objects from the
-     * metadata only.
+     * Save a copy because we cannot release the tiered resources until after the dhandle is
+     * released and closed. We have to know if the table is busy or if the close is successful
+     * before cleaning up the tiered information.
      */
-    tier = tiered->tiers[WT_TIERED_INDEX_LOCAL].tier;
-    localid = tiered->current_id;
-    if (tier != NULL) {
-        __wt_verbose_debug2(
-          session, WT_VERB_TIERED, "DROP_TIERED: drop %u local object %s", localid, tier->name);
-        WT_WITHOUT_DHANDLE(session,
-          WT_WITH_HANDLE_LIST_WRITE_LOCK(
-            session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
-        WT_ERR(ret);
-        WT_ERR(__wt_metadata_remove(session, tier->name));
-        if (remove_files) {
-            filename = tier->name;
-            WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
-            WT_ERR(__wt_meta_track_drop(session, filename));
-        }
-        tiered->tiers[WT_TIERED_INDEX_LOCAL].tier = NULL;
-    }
-
-    /* Close any dhandle and remove any tier: entry from metadata. */
-    tier = tiered->tiers[WT_TIERED_INDEX_SHARED].tier;
-    if (tier != NULL) {
-        __wt_verbose_debug2(
-          session, WT_VERB_TIERED, "DROP_TIERED: drop shared object %s", tier->name);
-        WT_WITHOUT_DHANDLE(session,
-          WT_WITH_HANDLE_LIST_WRITE_LOCK(
-            session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
-        WT_ERR(ret);
-        WT_ERR(__wt_metadata_remove(session, tier->name));
-        tiered->tiers[WT_TIERED_INDEX_SHARED].tier = NULL;
-    } else
-        /* If we don't have a shared tier we better be on the first object. */
-        WT_ASSERT(session, localid == 1);
-
-    /*
-     * We remove all metadata entries for both the file and object versions of an object. The local
-     * retention means we can have both versions in the metadata. Ignore WT_NOTFOUND.
-     */
-    for (i = tiered->oldest_id; i < tiered->current_id; ++i) {
-        WT_ERR(__wt_tiered_name(session, &tiered->iface, i, WT_TIERED_NAME_LOCAL, &name));
-        __wt_verbose_debug2(
-          session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
-        WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
-        __wt_free(session, name);
-        WT_ERR(__wt_tiered_name(session, &tiered->iface, i, WT_TIERED_NAME_OBJECT, &name));
-        __wt_verbose_debug2(
-          session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
-        WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
-        if (remove_files && tier != NULL) {
-            filename = name;
-            WT_PREFIX_SKIP_REQUIRED(session, filename, "object:");
-            WT_ERR(__wt_fs_exist(session, filename, &exist));
-            if (exist)
-                WT_ERR(__wt_meta_track_drop(session, filename));
-
-            /*
-             * If a drop operation on tiered storage is configured to force removal of shared
-             * objects, we want to remove these files after the drop operation is successful.
-             */
-            if (remove_shared)
-                WT_ERR(__wt_meta_track_drop_object(session, tiered->bstorage, filename));
-        }
-        __wt_free(session, name);
-    }
+    tiered_tmp = *tiered;
 
     /*
      * We are about to close the dhandle. If that is successful we need to remove any tiered work
@@ -289,11 +226,90 @@ __drop_tiered(WT_SESSION_IMPL *session, const char *uri, bool force, const char 
       session, ret = __wt_conn_dhandle_close_all(session, uri, true, force));
     WT_ERR(ret);
 
-    /* If everything is successful, remove any tiered work associated with this tiered handle. */
+    /*
+     * If closing the URI succeeded then we can remove tiered information using the saved tiered
+     * structure from above. We need the copy because the dhandle has been released.
+     */
+
+    /*
+     * We cannot remove the objects on shared storage as other systems may be accessing them too.
+     * Remove the current local file object, the tiered entry and all bucket objects from the
+     * metadata only.
+     */
+    tier = tiered_tmp.tiers[WT_TIERED_INDEX_LOCAL].tier;
+    localid = tiered_tmp.current_id;
+    if (tier != NULL) {
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: drop %u local object %s", localid, tier->name);
+        WT_WITHOUT_DHANDLE(session,
+          WT_WITH_HANDLE_LIST_WRITE_LOCK(
+            session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
+        WT_ERR(ret);
+        WT_ERR(__wt_metadata_remove(session, tier->name));
+        if (remove_files) {
+            filename = tier->name;
+            WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
+            WT_ERR(__wt_meta_track_drop(session, filename));
+        }
+        tiered_tmp.tiers[WT_TIERED_INDEX_LOCAL].tier = NULL;
+    }
+
+    /* Close any dhandle and remove any tier: entry from metadata. */
+    tier = tiered_tmp.tiers[WT_TIERED_INDEX_SHARED].tier;
+    if (tier != NULL) {
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: drop shared object %s", tier->name);
+        WT_WITHOUT_DHANDLE(session,
+          WT_WITH_HANDLE_LIST_WRITE_LOCK(
+            session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force)));
+        WT_ERR(ret);
+        WT_ERR(__wt_metadata_remove(session, tier->name));
+        tiered_tmp.tiers[WT_TIERED_INDEX_SHARED].tier = NULL;
+    } else
+        /* If we don't have a shared tier we better be on the first object. */
+        WT_ASSERT(session, localid == 1);
+
+    /*
+     * We remove all metadata entries for both the file and object versions of an object. The local
+     * retention means we can have both versions in the metadata. Ignore WT_NOTFOUND.
+     */
+    for (i = tiered_tmp.oldest_id; i < tiered_tmp.current_id; ++i) {
+        WT_ERR(__wt_tiered_name(session, &tiered_tmp.iface, i, WT_TIERED_NAME_LOCAL, &name));
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: remove local object %s from metadata", name);
+        WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
+        __wt_free(session, name);
+        WT_ERR(__wt_tiered_name(session, &tiered_tmp.iface, i, WT_TIERED_NAME_OBJECT, &name));
+        __wt_verbose_debug2(
+          session, WT_VERB_TIERED, "DROP_TIERED: remove object %s from metadata", name);
+        WT_ERR_NOTFOUND_OK(__wt_metadata_remove(session, name), false);
+        if (remove_files && tier != NULL) {
+            filename = name;
+            WT_PREFIX_SKIP_REQUIRED(session, filename, "object:");
+            WT_ERR(__wt_fs_exist(session, filename, &exist));
+            if (exist)
+                WT_ERR(__wt_meta_track_drop(session, filename));
+
+            /*
+             * If a drop operation on tiered storage is configured to force removal of shared
+             * objects, we want to remove these files after the drop operation is successful.
+             */
+            if (remove_shared)
+                WT_ERR(__wt_meta_track_drop_object(session, tiered_tmp.bstorage, filename));
+        }
+        __wt_free(session, name);
+    }
+
+    /*
+     * If everything is successful, remove any tiered work associated with this tiered handle. The
+     * dhandle has been released so the tiered pointer is stale but queued work still refers to it
+     * but removing it never dereferences the stale value. The worker never sees the stale value
+     * because we've been holding the lock the entire time it has been stale.
+     */
+    __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: remove work for %p", (void *)tiered);
     __wt_tiered_remove_work(session, tiered, true);
     __wt_spin_unlock(session, &conn->tiered_lock);
 
-    __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: remove tiered table %s from metadata", uri);
     ret = __wt_metadata_remove(session, uri);
 
 err:

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -481,6 +481,7 @@ err:
 int
 __wt_tiered_set_metadata(WT_SESSION_IMPL *session, WT_TIERED *tiered, WT_ITEM *buf)
 {
+    WT_TIERED_TIERS *t;
     uint32_t i;
     char hex_timestamp[WT_TS_HEX_STRING_SIZE];
 
@@ -489,14 +490,13 @@ __wt_tiered_set_metadata(WT_SESSION_IMPL *session, WT_TIERED *tiered, WT_ITEM *b
       ",flush_time=%" PRIu64 ",flush_timestamp=\"%s\",last=%" PRIu32 ",oldest=%" PRIu32 ",tiers=(",
       S2C(session)->flush_most_recent, hex_timestamp, tiered->current_id, tiered->oldest_id));
     for (i = 0; i < WT_TIERED_MAX_TIERS; ++i) {
-        if (tiered->tiers[i].name == NULL) {
-            __wt_verbose(session, WT_VERB_TIERED,
-              "TIER_SET_META: tiered %p names[%" PRIu32 "] NULL", (void *)tiered, i);
+        t = &tiered->tiers[i];
+        __wt_verbose(session, WT_VERB_TIERED,
+          "TIER_SET_META: tiered %p tiers[%d]: dhandle %p flags %" PRIx32 " name %s",
+          (void *)tiered, i, (void *)t->tier, t->flags, t->name == NULL ? "NULL" : t->name);
+        if (t->name == NULL)
             continue;
-        }
-        __wt_verbose(session, WT_VERB_TIERED, "TIER_SET_META: tiered %p names[%" PRIu32 "]: %s",
-          (void *)tiered, i, tiered->tiers[i].name);
-        WT_RET(__wt_buf_catfmt(session, buf, "%s\"%s\"", i == 0 ? "" : ",", tiered->tiers[i].name));
+        WT_RET(__wt_buf_catfmt(session, buf, "%s\"%s\"", i == 0 ? "" : ",", t->name));
     }
     WT_RET(__wt_buf_catfmt(session, buf, ")"));
     return (0);
@@ -839,6 +839,8 @@ __tiered_cleanup(WT_SESSION_IMPL *session, WT_TIERED *tiered, bool final)
     __wt_free(session, tiered->obj_config);
     tiered->current_id = tiered->next_id = tiered->oldest_id = 0;
     tiered->flags = 0;
+    __wt_verbose(
+      session, WT_VERB_TIERED, "TIERED_CLEANUP: tiered %p set bstorage NULL", (void *)tiered);
     tiered->bstorage = NULL;
 }
 
@@ -865,6 +867,17 @@ __wt_tiered_discard(WT_SESSION_IMPL *session, WT_TIERED *tiered, bool final)
 {
     __wt_verbose(session, WT_VERB_TIERED, "TIERED_DISCARD: tiered %p called final %d",
       (void *)tiered, (int) final);
+#if 0
+    /*
+     * We need to also remove any work associated with the tiered table we are discarding. Currently
+     * the work units contain a pointer to the tiered structure (the dhandle structure) and that
+     * pointer is about to be freed. That leaves a stale pointer. But right now removing the work
+     * units can result in a deadlock. The real solution is to get rid of the tiered structure in
+     * the work unit and save the URI instead and then use session_get_dhandle to acquire it if it
+     * still exists.
+     */
+    __wt_tiered_remove_work(session, tiered, false);
+#endif
     __tiered_cleanup(session, tiered, final);
     return (__wt_btree_discard(session));
 }

--- a/test/suite/test_tiered16.py
+++ b/test/suite/test_tiered16.py
@@ -31,7 +31,7 @@
 
 from helper_tiered import TieredConfigMixin, gen_tiered_storage_sources
 from wtscenario import make_scenarios
-import os, wiredtiger, wttest
+import errno, os, wiredtiger, wttest
 
 class test_tiered16(TieredConfigMixin, wttest.WiredTigerTestCase):
     tiered_storage_sources = gen_tiered_storage_sources()
@@ -54,6 +54,8 @@ class test_tiered16(TieredConfigMixin, wttest.WiredTigerTestCase):
         base_b = "tieredb-000000000"
         obj1file_b = base_b + "1.wtobj"
         obj2file_b = base_b + "2.wtobj"
+
+        uri_c = "table:tieredc"
 
         self.session.create(uri_a, "key_format=S,value_format=S")
         self.session.create(uri_b, "key_format=S,value_format=S")
@@ -102,5 +104,23 @@ class test_tiered16(TieredConfigMixin, wttest.WiredTigerTestCase):
             self.check_cache(cache_dir, [])
             self.check_bucket([])
 
+        # For any scenario, we should be able to do drops after reopens.
+        self.session.create(uri_c, 'key_format=S,value_format=S')
+
+        # Insert a record
+        cursor = self.session.open_cursor(uri_c, None)
+        cursor["a"] = "a"
+        cursor.close()
+
+        self.session.checkpoint('flush_tier=(enabled,force=true)')
+        self.reopen_conn()
+        #self.conn.reconfigure('verbose=(tiered:5)')
+
+        cursor = self.session.open_cursor(uri_c, None)
+        cursor["a"] = "b"
+        cursor.close()
+
+        self.dropUntilSuccess(self.session, uri_c)
+        
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Here are the fixes needed to get Don's test additions to pass. I've been trying to also run schema_abort but that fails pretty quickly but it seems worth getting this fix in. There is one commented out change that is the core of most schema_abort failures. Basically we need to not keep a pointer to a tiered structure as that can become stale and results in bad outcomes. But that is a larger change that should have its own ticket.