### PR TITLE
WT-11121 Remove the op timer check from __wt_txn_is_blocking.

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2490,10 +2490,9 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
      * FIXME: SERVER-44870
      *
      * MongoDB can't (yet) handle rolling back read only transactions. For this reason, don't check
-     * unless there's at least one update or we're configured to time out thread operations (a way
-     * to confirm our caller is prepared for rollback).
+     * unless there's at least one update.
      */
-    if (txn->mod_count == 0 && !__wt_op_timer_fired(session))
+    if (txn->mod_count == 0)
         return (0);
 #else
     /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2499,10 +2499,10 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     /*
      * Most applications that are not using transactions to read/walk with a cursor cannot handle
      * having rollback returned nor should the API reset and retry the operation, losing the
-     * cursor's position. Skip the check if there are no updates, the thread operation did not time
-     * out and the operation is not running in a transaction.
+     * cursor's position. Skip the check if there are no updates and the operation is not running in
+     * a transaction.
      */
-    if (txn->mod_count == 0 && !__wt_op_timer_fired(session) && !F_ISSET(txn, WT_TXN_RUNNING))
+    if (txn->mod_count == 0 && !F_ISSET(txn, WT_TXN_RUNNING))
         return (0);
 #endif
 


### PR DESCRIPTION
One alternative here could be to change the RETRY mechanism to respect op_timers. Either change feels like it is trying to handle a layer of the stack that it shouldn't have knowledge of so I'm still on the fence about this.