### PR TITLE
WT-11184 Use explicit transaction in test/huge to prevent pinning of large page

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1497,6 +1497,7 @@ __txn_mod_compare(const void *a, const void *b)
 int
 __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
 {
+    WT_CACHE *cache;
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
     WT_CURSOR *cursor;
@@ -1514,6 +1515,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     bool cannot_fail, locked, prepare, readonly, update_durable_ts;
 
     conn = S2C(session);
+    cache = conn->cache;
     cursor = NULL;
     txn = session->txn;
     txn_global = &conn->txn_global;
@@ -1651,7 +1653,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                  * transaction timestamp. Those records should already have the original time window
                  * when they are inserted into the history store.
                  */
-                if (conn->cache->hs_fileid != 0 && op->btree->id == conn->cache->hs_fileid)
+                if (cache->hs_fileid != 0 && op->btree->id == cache->hs_fileid)
                     break;
 
                 __wt_txn_op_set_timestamp(session, op);

--- a/test/huge/huge.c
+++ b/test/huge/huge.c
@@ -124,10 +124,11 @@ run(CONFIG *cp, int bigkey, size_t bytes)
     cursor->set_value(cursor, big);
 
     /*
-     * This test inserts very large single updates and a single page can hit eviction thresholds by itself.
-     * Auto-transactions leave the cursor positioned on the page which pins it and preventing eviction after committing.
-     * This can lead to a case where the transaction blocks on attempting to evict the same page it is pinning.
-     * Use an explicit transaction here to ensure we can reset the cursor and unpin the page.
+     * This test inserts very large single updates and a single page can hit eviction thresholds by
+     * itself. Auto-transactions leave the cursor positioned on the page which pins it and
+     * preventing eviction after committing. This can lead to a case where the transaction blocks on
+     * attempting to evict the same page it is pinning. Use an explicit transaction here to ensure
+     * we can reset the cursor and unpin the page.
      */
     testutil_check(session->begin_transaction(session, NULL));
 


### PR DESCRIPTION
**Description of the issue:** (why test_huge fails)
1) Application thread does some cursor operation (like update) which causes a page in the btree to be referenced (active hazard pointer maintained for it after the end of the btree search walk). The page referenced is the one updated during the operation, lets call it page A.
2) At the end of the operation (for example at the end of __curfile_update), a call to CURSOR_UPDATE_API_END_STAT is made. This causes the transaction associated with the operation to be committed.
3) At the end of the transaction commit operation, while a reference to A is still maintained from step 1), a check for cache eviction is made.
4) Assume A is very large, such that it alone exceeds a cache threshold (let it be clean/update/dirty thresholds). This causes the thread that runs the txn commit to decide it needs to block until enough space has been evicted from the cache (this decision is made in __wt_cache_eviction_check). The thread will loop until it manages to find a page to evict (or until timeout and hard abort)
5) But, since evicting A is required to free enough space in the cache on the one hand, but evicting it is impossible due to the active reference, we are in a deadlock. The txn thread will loop until timeout and cause hard abort.

The same description above could be relevant even if there isn't one single huge page, but several smaller pages that are being referenced by several different sessions in parallel, such that all those sessions call wt_txn_commit.

**Solution suggestion:**
Just started to get into WT, so there is a good chance I missed some important spots. Would love your opinion and help in coming up with possible alternative solutions.

The following are 4 possible options to deal with this. This PR implements idea number 2).

1) Do not call __wt_cache_eviction_check at all at the end of wt_txn_commit, or in any other location where the same thread that calls it could be the one that holds references to a large enough amount pages (by memory size) - such that those force the cache eviction

2) before calling __wt_cache_eviction_check, which is a blocking call if the cache is above thresholds, traverse the session's active hazard pointers, and sum up their memory footprint. using this memory footprint decide if there is a danger of a deadlock (relative to the cache thresholds). **We won't call eviction at the end of transactions of sessions that reference a "majority" of the cache**. a "majority" of the cache is considered everything that is more than (1 / number of sessions) part of any cache threshold trigger.
The reason for this calculation is that we need to protect ourselves from the worst case in which N sessions each have some pages referenced (locked from eviction), and then try to evict to free up cache in a blocking manner. If all other pages are themselves referenced by other sessions, we are in a deadlock between the session threads as no page will be found for eviction.

3) Same as 2) but insert this logic inside __wt_cache_eviction_check, and not inside specific txn functions.

4) instead of calculating memory footprint from the hazard pointers, simply say that if there is any active hazard pointer for the session, don't call eviction from application threads.

https://jira.mongodb.org/browse/WT-11184
