### PR TITLE
WT-11181 Make block unreachable when closing

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -115,7 +115,6 @@ __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    uint64_t bucket, hash;
 
     conn = S2C(session);
 
@@ -123,13 +122,6 @@ __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
         return (0);
 
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s", block->name == NULL ? "" : block->name);
-
-    /* If we failed during allocation, the block won't have been linked. */
-    if (block->linked) {
-        hash = __wt_hash_city64(block->name, strlen(block->name));
-        bucket = hash & (conn->hash_size - 1);
-        WT_CONN_BLOCK_REMOVE(conn, block, bucket);
-    }
 
     __wt_free(session, block->name);
 

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -31,9 +31,7 @@ __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
     }
 
     if (block->linked) {
-        /*
-         * Make the block unreachable. Resource cleanup is handled in __wt_block_close().
-         */
+        /* Make the block unreachable. Resource cleanup is handled in __wt_block_close(). */
         hash = __wt_hash_city64(block->name, strlen(block->name));
         bucket = hash & (conn->hash_size - 1);
         WT_CONN_BLOCK_REMOVE(conn, block, bucket);


### PR DESCRIPTION
Make block unreachable in the connection before releasing associated resources.