### PR TITLE
WT-11181 Make block unreachable when closing

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -120,7 +120,6 @@ err:
 int
 __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
 
     conn = S2C(session);

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -120,8 +120,8 @@ err:
 int
 __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
-    WT_DECL_RET;
     WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
     uint64_t bucket, hash;
 
     conn = S2C(session);
@@ -142,7 +142,6 @@ __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
         WT_CONN_BLOCK_REMOVE(conn, block, bucket);
     }
     __wt_spin_unlock(session, &conn->block_lock);
-
 
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s", block->name == NULL ? "" : block->name);
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -122,8 +122,6 @@ __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_DECL_RET;
 
-    conn = S2C(session);
-
     if (block == NULL) /* Safety check, if failed to initialize. */
         return (0);
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -196,6 +196,7 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     WT_ERR(__wt_calloc_one(session, &block));
     WT_ERR(__wt_strdup(session, filename, &block->name));
     block->objectid = objectid;
+    block->ref = 1;
 
     /* If not passed an allocation size, get one from the configuration. */
     if (allocsize == 0) {

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -120,28 +120,10 @@ err:
 int
 __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    uint64_t bucket, hash;
-
-    conn = S2C(session);
 
     if (block == NULL) /* Safety check, if failed to initialize. */
         return (0);
-
-    __wt_spin_lock(session, &conn->block_lock);
-    if (block->ref > 0 && --block->ref > 0) {
-        __wt_spin_unlock(session, &conn->block_lock);
-        return (0);
-    }
-
-    if (block->linked) {
-        /* Make the block unreachable. */
-        hash = __wt_hash_city64(block->name, strlen(block->name));
-        bucket = hash & (conn->hash_size - 1);
-        WT_CONN_BLOCK_REMOVE(conn, block, bucket);
-    }
-    __wt_spin_unlock(session, &conn->block_lock);
 
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s", block->name == NULL ? "" : block->name);
 
@@ -214,9 +196,6 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     WT_ERR(__wt_calloc_one(session, &block));
     WT_ERR(__wt_strdup(session, filename, &block->name));
     block->objectid = objectid;
-    block->ref = 1;
-    WT_CONN_BLOCK_INSERT(conn, block, bucket);
-    block->linked = true;
 
     /* If not passed an allocation size, get one from the configuration. */
     if (allocsize == 0) {
@@ -286,6 +265,9 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
      */
     if (!forced_salvage)
         WT_ERR(__desc_read(session, allocsize, block));
+
+    /* Block is valid, so make it visible in the connection. */
+    WT_CONN_BLOCK_INSERT(conn, block, bucket);
 
     __wt_spin_unlock(session, &conn->block_lock);
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -215,10 +215,8 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     WT_ERR(__wt_strdup(session, filename, &block->name));
     block->objectid = objectid;
     block->ref = 1;
-    __wt_spin_lock(session, &conn->block_lock);
     WT_CONN_BLOCK_INSERT(conn, block, bucket);
     block->linked = true;
-    __wt_spin_unlock(session, &conn->block_lock);
 
     /* If not passed an allocation size, get one from the configuration. */
     if (allocsize == 0) {

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -122,7 +122,6 @@ __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    uint64_t bucket, hash;
 
     conn = S2C(session);
 
@@ -130,16 +129,6 @@ __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
         return (0);
 
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s", block->name == NULL ? "" : block->name);
-
-    /* We shouldn't have any read requests in progress. */
-    WT_ASSERT(session, block->read_count == 0);
-
-    /* If we failed during allocation, the block won't have been linked. */
-    if (block->linked) {
-        hash = __wt_hash_city64(block->name, strlen(block->name));
-        bucket = hash & (conn->hash_size - 1);
-        WT_CONN_BLOCK_REMOVE(conn, block, bucket);
-    }
 
     __wt_free(session, block->name);
 

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -17,6 +17,9 @@ static void __bm_method_set(WT_BM *, bool);
 int
 __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
+    WT_CONNECTION_IMPL *conn;
+    uint64_t bucket, hash;
+
     __wt_verbose(session, WT_VERB_BLKCACHE, "close: %s", block->name);
 
     /* We shouldn't have any read requests in progress. */
@@ -26,9 +29,23 @@ __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
     WT_ASSERT(
       session, block->ckpt_state == WT_CKPT_NONE || block->ckpt_state == WT_CKPT_PANIC_ON_FAILURE);
 
+    conn = S2C(session);
+    __wt_spin_lock(session, &conn->block_lock);
+    if (block->ref > 0 && --block->ref > 0) {
+        __wt_spin_unlock(session, &conn->block_lock);
+        return (0);
+    }
+
+    /* Make the block unreachable. */
+    hash = __wt_hash_city64(block->name, strlen(block->name));
+    bucket = hash & (conn->hash_size - 1);
+    WT_CONN_BLOCK_REMOVE(conn, block, bucket);
+    __wt_spin_unlock(session, &conn->block_lock);
+
     if (block->sync_on_checkpoint)
         WT_RET(__wt_fsync(session, block->fh, true));
 
+    /* If fsync fails WT panics so failure to reach __wt_block_close() is irrelevant. */
     return (__wt_block_close(session, block));
 }
 

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -18,15 +18,26 @@ int
 __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_CONNECTION_IMPL *conn;
+    uint64_t bucket, hash;
 
     conn = S2C(session);
 
     __wt_verbose(session, WT_VERB_BLKCACHE, "close: %s", block->name);
 
+    /* We shouldn't have any read requests in progress. */
+    WT_ASSERT(session, block->read_count == 0);
+
     __wt_spin_lock(session, &conn->block_lock);
     if (block->ref > 0 && --block->ref > 0) {
         __wt_spin_unlock(session, &conn->block_lock);
         return (0);
+    }
+
+    if (block->linked) {
+        /* Make the block unreachable. Resource cleanup is done in __wt_block_close(). */
+        hash = __wt_hash_city64(block->name, strlen(block->name));
+        bucket = hash & (conn->hash_size - 1);
+        WT_CONN_BLOCK_REMOVE(conn, block, bucket);
     }
     __wt_spin_unlock(session, &conn->block_lock);
 

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -27,6 +27,12 @@ __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
     /* We shouldn't have any read requests in progress. */
     WT_ASSERT(session, block->read_count == 0);
 
+    if (block->linked) {
+        /* The block needs to be removed from the connection. Prepare outside of the spinlock. */
+        hash = __wt_hash_city64(block->name, strlen(block->name));
+        bucket = hash & (conn->hash_size - 1);
+    }
+
     __wt_spin_lock(session, &conn->block_lock);
     if (block->ref > 0 && --block->ref > 0) {
         __wt_spin_unlock(session, &conn->block_lock);
@@ -35,8 +41,6 @@ __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
 
     if (block->linked) {
         /* Make the block unreachable. Resource cleanup is done in __wt_block_close(). */
-        hash = __wt_hash_city64(block->name, strlen(block->name));
-        bucket = hash & (conn->hash_size - 1);
         WT_CONN_BLOCK_REMOVE(conn, block, bucket);
     }
     __wt_spin_unlock(session, &conn->block_lock);

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -249,7 +249,6 @@ struct __wt_block {
 
     TAILQ_ENTRY(__wt_block) q;     /* Linked list of handles */
     TAILQ_ENTRY(__wt_block) hashq; /* Hashed list of handles */
-    bool linked;
 
     WT_FH *fh;            /* Backing file handle */
     wt_off_t size;        /* File size */


### PR DESCRIPTION
Make block unreachable in the connection object
prior to releasing any resources.