### PR TITLE
WT-11187 Create WT_CONN_SESSION_FOREACH macro

### DIFF
--- a/dist/primitive_check.py
+++ b/dist/primitive_check.py
@@ -15,6 +15,7 @@ primitives = [
     "REF_SET_STATE",
     "volatile",
     "WT_BARRIER",
+    "WT_CONN_SESSION_FOREACH",
     "WT_DHANDLE_ACQUIRE",
     "WT_DHANDLE_RELEASE",
     "WT_FULL_BARRIER",

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -348,7 +348,7 @@ struct __wt_connection_impl {
      */
     WT_SESSION_IMPL *sessions; /* Session reference */
 
-#define WT_CONNECTION_FOREACH_SESSION(session, conn)                                             \
+#define WT_CONN_SESSION_FOREACH(session, conn)                                                   \
     do {                                                                                         \
         /*                                                                                       \
          * No lock is required because the session array is fixed size, but it may contain       \
@@ -361,9 +361,9 @@ struct __wt_connection_impl {
         WT_ORDERED_READ(__session_cnt, (conn)->session_cnt);                                     \
         for (__i = 0, (session) = conn->sessions; __i < __session_cnt; __i++, (session)++) {
 
-#define WT_CONNECTION_FOREACH_SESSION_END \
-    }                                     \
-    }                                     \
+#define WT_CONN_SESSION_FOREACH_END \
+    }                               \
+    }                               \
     while (0)
 
     uint32_t session_size; /* Session array size */

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -18,7 +18,6 @@ __wt_rts_check(WT_SESSION_IMPL *session)
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_SESSION_IMPL *session_in_list;
-    uint32_t i, session_cnt;
     bool cursor_active, txn_active;
 
     conn = S2C(session);
@@ -36,9 +35,8 @@ __wt_rts_check(WT_SESSION_IMPL *session)
      */
     __wt_spin_lock(session, &conn->api_lock);
 
-    WT_ORDERED_READ(session_cnt, conn->session_cnt);
-    for (i = 0, session_in_list = conn->sessions; i < session_cnt; i++, session_in_list++) {
-
+    WT_CONNECTION_FOREACH_SESSION(session_in_list, conn)
+    {
         /* Skip inactive or internal sessions. */
         if (!session_in_list->active || F_ISSET(session_in_list, WT_SESSION_INTERNAL))
             continue;
@@ -55,6 +53,8 @@ __wt_rts_check(WT_SESSION_IMPL *session)
             break;
         }
     }
+    WT_CONNECTION_FOREACH_SESSION_END;
+
     __wt_spin_unlock(session, &conn->api_lock);
 
     /*

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -35,7 +35,7 @@ __wt_rts_check(WT_SESSION_IMPL *session)
      */
     __wt_spin_lock(session, &conn->api_lock);
 
-    WT_CONNECTION_FOREACH_SESSION(session_in_list, conn)
+    WT_CONN_SESSION_FOREACH(session_in_list, conn)
     {
         /* Skip inactive or internal sessions. */
         if (!session_in_list->active || F_ISSET(session_in_list, WT_SESSION_INTERNAL))
@@ -53,7 +53,7 @@ __wt_rts_check(WT_SESSION_IMPL *session)
             break;
         }
     }
-    WT_CONNECTION_FOREACH_SESSION_END;
+    WT_CONN_SESSION_FOREACH_END;
 
     __wt_spin_unlock(session, &conn->api_lock);
 

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -121,7 +121,7 @@ __wt_gen_drain(WT_SESSION_IMPL *session, int which, uint64_t generation)
 
     minutes = 0;
     pause_cnt = 0;
-    WT_CONNECTION_FOREACH_SESSION(s, conn)
+    WT_CONN_SESSION_FOREACH(s, conn)
     {
         if (!s->active)
             continue;
@@ -204,7 +204,7 @@ __wt_gen_drain(WT_SESSION_IMPL *session, int which, uint64_t generation)
             }
         }
     }
-    WT_CONNECTION_FOREACH_SESSION_END;
+    WT_CONN_SESSION_FOREACH_END;
 }
 
 /*
@@ -221,7 +221,7 @@ __gen_oldest(WT_SESSION_IMPL *session, int which)
     conn = S2C(session);
 
     oldest = conn->generations[which];
-    WT_CONNECTION_FOREACH_SESSION(s, conn)
+    WT_CONN_SESSION_FOREACH(s, conn)
     {
         if (!s->active)
             continue;
@@ -232,7 +232,7 @@ __gen_oldest(WT_SESSION_IMPL *session, int which)
         if (v != 0 && v < oldest)
             oldest = v;
     }
-    WT_CONNECTION_FOREACH_SESSION_END;
+    WT_CONN_SESSION_FOREACH_END;
 
     return (oldest);
 }
@@ -250,7 +250,7 @@ __wt_gen_active(WT_SESSION_IMPL *session, int which, uint64_t generation)
 
     conn = S2C(session);
 
-    WT_CONNECTION_FOREACH_SESSION(s, conn)
+    WT_CONN_SESSION_FOREACH(s, conn)
     {
         if (!s->active)
             continue;
@@ -261,7 +261,7 @@ __wt_gen_active(WT_SESSION_IMPL *session, int which, uint64_t generation)
         if (v != 0 && generation >= v)
             return (true);
     }
-    WT_CONNECTION_FOREACH_SESSION_END;
+    WT_CONN_SESSION_FOREACH_END;
 
     WT_ASSERT_OPTIONAL(session, WT_DIAGNOSTIC_GENERATION_CHECK,
       generation < __gen_oldest(session, which), "Generation is older than gen_oldest");

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -297,6 +297,8 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
     WT_SESSION_IMPL *s;
     uint32_t j, hazard_inuse, max, walk_cnt;
 
+    max = walk_cnt = 0;
+
     /* If a file can never be evicted, hazard pointers aren't required. */
     if (F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
         return (NULL);
@@ -311,7 +313,6 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
      */
     __wt_session_gen_enter(session, WT_GEN_HAZARD);
 
-    max = walk_cnt = 0;
     WT_CONNECTION_FOREACH_SESSION(s, conn)
     {
         if (!s->active)

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -295,7 +295,7 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
     WT_CONNECTION_IMPL *conn;
     WT_HAZARD *hp;
     WT_SESSION_IMPL *s;
-    uint32_t j, hazard_inuse, max, walk_cnt;
+    uint32_t i, hazard_inuse, max, walk_cnt;
 
     max = walk_cnt = 0;
 
@@ -325,7 +325,7 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
             WT_STAT_CONN_SET(session, cache_hazard_max, max);
         }
 
-        for (j = 0; j < hazard_inuse; ++hp, ++j) {
+        for (i = 0; i < hazard_inuse; ++hp, ++i) {
             ++walk_cnt;
             if (hp->ref == ref) {
                 WT_STAT_CONN_INCRV(session, cache_hazard_walks, walk_cnt);

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -313,7 +313,7 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
      */
     __wt_session_gen_enter(session, WT_GEN_HAZARD);
 
-    WT_CONNECTION_FOREACH_SESSION(s, conn)
+    WT_CONN_SESSION_FOREACH(s, conn)
     {
         if (!s->active)
             continue;
@@ -335,7 +335,7 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
             }
         }
     }
-    WT_CONNECTION_FOREACH_SESSION_END;
+    WT_CONN_SESSION_FOREACH_END;
 
     WT_STAT_CONN_INCRV(session, cache_hazard_walks, walk_cnt);
     hp = NULL;


### PR DESCRIPTION
Take existing occurrences of the code snippet
```
WT_ORDERED_READ(session_cnt, conn->session_cnt);
for (i = 0, session = conn->sessions; i < session_cnt; i++, session++) {
```
and replace them with a new `WT_CONNECTION_FOREACH_SESSION` macro that wraps this behaviour.

There are further cases where this pattern found, but they're for the `txn_global->txn_shared_list` array. This has a few flow-on impacts around incrementing statistics so I've moved those changes into their own ticket (WT-11198)