### PR TITLE
WT-11198 Add WT_TXN_SHARED_FOREACH_BEGIN macro

### DIFF
--- a/dist/primitive_check.py
+++ b/dist/primitive_check.py
@@ -28,6 +28,7 @@ primitives = [
     "WT_REF_UNLOCK",
     "WT_STAT_DECRV_ATOMIC",
     "WT_STAT_INCRV_ATOMIC",
+    "WT_TXN_SHARED_FOREACH_BEGIN",
     "WT_WRITE_BARRIER",
 ]
 

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -171,7 +171,7 @@ struct __wt_txn_global {
 
     WT_TXN_SHARED *txn_shared_list; /* Per-session shared transaction states */
 
-#define WT_TXN_GLOBAL_FOREACH_SESSION_STATE(state, conn)                                           \
+#define WT_TXN_SHARED_FOREACH_BEGIN(state, conn)                                           \
     do {                                                                                           \
         /*                                                                                         \
          * No lock is required because the per-session transactions state array is fixed size, but \
@@ -185,7 +185,7 @@ struct __wt_txn_global {
         for (__i = 0, (state) = txn_global->txn_shared_list; __i < __session_cnt;                  \
              __i++, (state)++) {
 
-#define WT_TXN_GLOBAL_FOREACH_SESSION_STATE_END            \
+#define WT_TXN_SHARED_FOREACH_END            \
     }                                                      \
     WT_STAT_CONN_INCR(session, txn_walk_sessions);         \
     WT_STAT_CONN_INCRV(session, txn_sessions_walked, __i); \

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -171,7 +171,7 @@ struct __wt_txn_global {
 
     WT_TXN_SHARED *txn_shared_list; /* Per-session shared transaction states */
 
-#define WT_TXN_SHARED_FOREACH_BEGIN(state, conn)                                           \
+#define WT_TXN_SHARED_FOREACH_BEGIN(state, conn)                                                   \
     do {                                                                                           \
         /*                                                                                         \
          * No lock is required because the per-session transactions state array is fixed size, but \
@@ -185,7 +185,7 @@ struct __wt_txn_global {
         for (__i = 0, (state) = txn_global->txn_shared_list; __i < __session_cnt;                  \
              __i++, (state)++) {
 
-#define WT_TXN_SHARED_FOREACH_END            \
+#define WT_TXN_SHARED_FOREACH_END                          \
     }                                                      \
     WT_STAT_CONN_INCR(session, txn_walk_sessions);         \
     WT_STAT_CONN_INCRV(session, txn_sessions_walked, __i); \

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -168,13 +168,13 @@ __wt_txn_active(WT_SESSION_IMPL *session, uint64_t txnid)
     }
 
     /* Walk the array of concurrent transactions. */
-    WT_TXN_GLOBAL_FOREACH_SESSION_STATE(s, conn)
+    WT_TXN_SHARED_FOREACH_BEGIN(s, conn)
     {
         /* If the transaction is in the list, it is uncommitted. */
         if (s->id == txnid)
             goto done;
     }
-    WT_TXN_GLOBAL_FOREACH_SESSION_STATE_END;
+    WT_TXN_SHARED_FOREACH_END;
 
     active = false;
 done:
@@ -240,7 +240,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool publish)
     }
 
     /* Walk the array of concurrent transactions. */
-    WT_TXN_GLOBAL_FOREACH_SESSION_STATE(s, conn)
+    WT_TXN_SHARED_FOREACH_BEGIN(s, conn)
     {
         WT_STAT_CONN_INCR(session, txn_sessions_walked);
         /*
@@ -282,7 +282,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool publish)
             WT_PAUSE();
         }
     }
-    WT_TXN_GLOBAL_FOREACH_SESSION_STATE_END;
+    WT_TXN_SHARED_FOREACH_END;
 
     /*
      * If we got a new snapshot, update the published pinned ID for this session.
@@ -343,7 +343,7 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
 
     /* Walk the array of concurrent transactions. */
     i = 0;
-    WT_TXN_GLOBAL_FOREACH_SESSION_STATE(s, conn)
+    WT_TXN_SHARED_FOREACH_BEGIN(s, conn)
     {
         WT_STAT_CONN_INCR(session, txn_sessions_walked);
         /* Update the last running transaction ID. */
@@ -396,7 +396,7 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
          */
         i++;
     }
-    WT_TXN_GLOBAL_FOREACH_SESSION_STATE_END;
+    WT_TXN_SHARED_FOREACH_END;
 
     if (WT_TXNID_LT(last_running, oldest_id))
         oldest_id = last_running;

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -88,7 +88,6 @@ __wt_txn_get_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, uin
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *s;
     wt_timestamp_t tmp_read_ts, tmp_ts;
-    uint32_t i, session_cnt;
     bool include_oldest, txn_has_write_lock;
 
     conn = S2C(session);
@@ -113,8 +112,8 @@ __wt_txn_get_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, uin
         tmp_ts = txn_global->checkpoint_timestamp;
 
     /* Walk the array of concurrent transactions. */
-    WT_ORDERED_READ(session_cnt, conn->session_cnt);
-    for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
+    WT_TXN_GLOBAL_FOREACH_SESSION_STATE(s, conn)
+    {
         __txn_get_read_timestamp(s, &tmp_read_ts);
         /*
          * A zero timestamp is possible here only when the oldest timestamp is not accounted for.
@@ -122,12 +121,10 @@ __wt_txn_get_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, uin
         if (tmp_ts == WT_TS_NONE || (tmp_read_ts != WT_TS_NONE && tmp_read_ts < tmp_ts))
             tmp_ts = tmp_read_ts;
     }
+    WT_TXN_GLOBAL_FOREACH_SESSION_STATE_END;
 
     if (!txn_has_write_lock)
         __wt_readunlock(session, &txn_global->rwlock);
-
-    WT_STAT_CONN_INCR(session, txn_walk_sessions);
-    WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
 
     *tsp = tmp_ts;
 }
@@ -154,7 +151,6 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *s;
     wt_timestamp_t ts, tmpts;
-    uint32_t i, session_cnt;
 
     conn = S2C(session);
     txn_global = &conn->txn_global;
@@ -176,17 +172,16 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
         ts = txn_global->durable_timestamp;
 
         /* Walk the array of concurrent transactions. */
-        WT_ORDERED_READ(session_cnt, conn->session_cnt);
-        for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
+        WT_TXN_GLOBAL_FOREACH_SESSION_STATE(s, conn)
+        {
             __txn_get_durable_timestamp(s, &tmpts);
             if (tmpts != 0 && (ts == 0 || --tmpts < ts))
                 ts = tmpts;
         }
+        WT_TXN_GLOBAL_FOREACH_SESSION_STATE_END;
 
         __wt_readunlock(session, &txn_global->rwlock);
 
-        WT_STAT_CONN_INCR(session, txn_walk_sessions);
-        WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
     } else if (WT_STRING_MATCH("last_checkpoint", cval.str, cval.len)) {
         /* Read-only value forever. Make sure we don't used a cached version. */
         WT_BARRIER();
@@ -452,22 +447,22 @@ set:
 static void
 __txn_assert_after_reads(WT_SESSION_IMPL *session, const char *op, wt_timestamp_t ts)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *s;
     wt_timestamp_t tmp_timestamp;
-    uint32_t i, session_cnt;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
+    conn = S2C(session);
+
     if (EXTRA_DIAGNOSTICS_ENABLED(session, WT_DIAGNOSTIC_TXN_VISIBILITY)) {
-        txn_global = &S2C(session)->txn_global;
-        WT_ORDERED_READ(session_cnt, S2C(session)->session_cnt);
-        WT_STAT_CONN_INCR(session, txn_walk_sessions);
-        WT_STAT_CONN_INCRV(session, txn_sessions_walked, session_cnt);
+        txn_global = &conn->txn_global;
 
         __wt_readlock(session, &txn_global->rwlock);
 
         /* Walk the array of concurrent transactions. */
-        for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
+        WT_TXN_GLOBAL_FOREACH_SESSION_STATE(s, conn)
+        {
             __txn_get_read_timestamp(s, &tmp_timestamp);
             if (tmp_timestamp != WT_TS_NONE && tmp_timestamp >= ts) {
                 __wt_err(session, EINVAL,
@@ -479,6 +474,7 @@ __txn_assert_after_reads(WT_SESSION_IMPL *session, const char *op, wt_timestamp_
                 /* NOTREACHED */
             }
         }
+        WT_TXN_GLOBAL_FOREACH_SESSION_STATE_END;
         __wt_readunlock(session, &txn_global->rwlock);
     } else {
         WT_UNUSED(session);


### PR DESCRIPTION
Replace occurrences of the code snippet
```
WT_ORDERED_READ(session_cnt, conn->session_cnt);
for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
```
with the new macro `WT_TXN_GLOBAL_FOREACH_SESSION_STATE`.

This macro also establishes a common pattern for updating the `txn_walk_sessions` and `txn_sessions_walked` statistics at the end of loop iteration. Some locations would increment these fields before looping, others would increment `txn_sessions_walked` using `session_cnt` instead of the number of completed loops `i`. The new macro updates statistics using `i` at the end of iteration in case we decide to add break statements to these loops in future.