### PR TITLE
WT-11181 Fix errors in block open and close

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -127,6 +127,9 @@ __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s", block->name == NULL ? "" : block->name);
 
+    /* We shouldn't have any read requests in progress. */
+    WT_ASSERT(session, block->read_count == 0);
+
     __wt_free(session, block->name);
 
     WT_TRET(__wt_close(session, &block->fh));

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -120,26 +120,12 @@ err:
 int
 __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    uint64_t bucket, hash;
-
-    conn = S2C(session);
 
     if (block == NULL) /* Safety check, if failed to initialize. */
         return (0);
 
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s", block->name == NULL ? "" : block->name);
-
-    /* We shouldn't have any read requests in progress. */
-    WT_ASSERT(session, block->read_count == 0);
-
-    /* If we failed during allocation, the block won't have been linked. */
-    if (block->linked) {
-        hash = __wt_hash_city64(block->name, strlen(block->name));
-        bucket = hash & (conn->hash_size - 1);
-        WT_CONN_BLOCK_REMOVE(conn, block, bucket);
-    }
 
     __wt_free(session, block->name);
 
@@ -211,8 +197,6 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     WT_ERR(__wt_strdup(session, filename, &block->name));
     block->objectid = objectid;
     block->ref = 1;
-    WT_CONN_BLOCK_INSERT(conn, block, bucket);
-    block->linked = true;
 
     /* If not passed an allocation size, get one from the configuration. */
     if (allocsize == 0) {
@@ -282,6 +266,9 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
      */
     if (!forced_salvage)
         WT_ERR(__desc_read(session, allocsize, block));
+
+    /* Block is valid, so make it visible in the connection. */
+    WT_CONN_BLOCK_INSERT(conn, block, bucket);
 
     __wt_spin_unlock(session, &conn->block_lock);
 

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -18,16 +18,24 @@ int
 __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_CONNECTION_IMPL *conn;
-
-    conn = S2C(session);
+    uint64_t bucket, hash;
 
     __wt_verbose(session, WT_VERB_BLKCACHE, "close: %s", block->name);
 
+    /* We shouldn't have any read requests in progress. */
+    WT_ASSERT(session, block->read_count == 0);
+
+    conn = S2C(session);
     __wt_spin_lock(session, &conn->block_lock);
     if (block->ref > 0 && --block->ref > 0) {
         __wt_spin_unlock(session, &conn->block_lock);
         return (0);
     }
+
+    /* Make the block unreachable. */
+    hash = __wt_hash_city64(block->name, strlen(block->name));
+    bucket = hash & (conn->hash_size - 1);
+    WT_CONN_BLOCK_REMOVE(conn, block, bucket);
     __wt_spin_unlock(session, &conn->block_lock);
 
     /* You can't close files during a checkpoint. */
@@ -37,6 +45,7 @@ __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
     if (block->sync_on_checkpoint)
         WT_RET(__wt_fsync(session, block->fh, true));
 
+    /* If fsync fails WT panics so failure to reach __wt_block_close() is irrelevant. */
     return (__wt_block_close(session, block));
 }
 

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -22,9 +22,6 @@ __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
 
     __wt_verbose(session, WT_VERB_BLKCACHE, "close: %s", block->name);
 
-    /* We shouldn't have any read requests in progress. */
-    WT_ASSERT(session, block->read_count == 0);
-
     conn = S2C(session);
     __wt_spin_lock(session, &conn->block_lock);
     if (block->ref > 0 && --block->ref > 0) {

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -249,7 +249,6 @@ struct __wt_block {
 
     TAILQ_ENTRY(__wt_block) q;     /* Linked list of handles */
     TAILQ_ENTRY(__wt_block) hashq; /* Hashed list of handles */
-    bool linked;
 
     WT_FH *fh;            /* Backing file handle */
     wt_off_t size;        /* File size */


### PR DESCRIPTION
Fix race condition where blocks with a non-zero ref count could be freed.

Fix race condition where block from a failed open could be acquired and then freed with a non-zero ref count.

Fix potential corruption of block lists in connection: due to modification without holding the associated lock.