### PR TITLE
WT-10512 Fix not inserting an out of order timestamp into the history store (v5.0 backport)

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -560,6 +560,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
             else
                 fix_ts_upd = oldest_upd;
 
+            WT_STAT_CONN_DATA_INCR(session, cache_hs_key_truncate);
+
             if (!F_ISSET(fix_ts_upd, WT_UPDATE_FIXED_HS)) {
                 /* Delete and reinsert any update of the key with a higher timestamp. */
                 WT_ERR(__wt_hs_delete_key_from_ts(session, hs_cursor, btree->id, key,

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -353,10 +353,11 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
     WT_UPDATE *newest_hs, *non_aborted_upd, *oldest_upd, *prev_upd, *ref_upd, *tombstone, *upd;
     WT_TIME_WINDOW tw;
     wt_off_t hs_size;
+    wt_timestamp_t ts;
     uint64_t insert_cnt, max_hs_size, modify_cnt;
     uint32_t i;
     int nentries;
-    bool enable_reverse_modify, error_on_ooo_ts, hs_inserted, squashed;
+    bool enable_reverse_modify, error_on_ooo_ts, hs_inserted, reinsert, squashed;
 
     error_on_ooo_ts = F_ISSET(r, WT_REC_CHECKPOINT_RUNNING);
     r->cache_write_hs = false;
@@ -423,6 +424,16 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
          */
         enable_reverse_modify =
           (WT_STREQ(btree->value_format, "S") || WT_STREQ(btree->value_format, "u"));
+
+        /*
+         * If there exists an on page tombstone without a timestamp or less than the on page update,
+         * consider it as a no timestamp update to clear the timestamps of all the updates that are
+         * inserted into the history store.
+         */
+        if (list->onpage_tombstone != NULL &&
+          (list->onpage_tombstone->start_ts == WT_TS_NONE ||
+            list->onpage_tombstone->start_ts < list->onpage_upd->start_ts))
+            min_ts_upd = list->onpage_tombstone;
 
         /*
          * The algorithm assumes the oldest update on the update chain in memory is either a full
@@ -555,17 +566,23 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
          * history store.
          */
         if (oldest_upd->type == WT_UPDATE_TOMBSTONE) {
-            if (out_of_order_ts_upd != NULL && out_of_order_ts_upd->start_ts < oldest_upd->start_ts)
+            if (out_of_order_ts_upd != NULL &&
+              out_of_order_ts_upd->start_ts < oldest_upd->start_ts) {
                 fix_ts_upd = out_of_order_ts_upd;
-            else
+                ts = fix_ts_upd->start_ts + 1;
+                reinsert = true;
+            } else {
                 fix_ts_upd = oldest_upd;
+                ts = fix_ts_upd->start_ts;
+                reinsert = false;
+            }
 
             WT_STAT_CONN_DATA_INCR(session, cache_hs_key_truncate);
 
             if (!F_ISSET(fix_ts_upd, WT_UPDATE_FIXED_HS)) {
                 /* Delete and reinsert any update of the key with a higher timestamp. */
-                WT_ERR(__wt_hs_delete_key_from_ts(session, hs_cursor, btree->id, key,
-                  fix_ts_upd->start_ts + 1, true, false, error_on_ooo_ts));
+                WT_ERR(__wt_hs_delete_key_from_ts(
+                  session, hs_cursor, btree->id, key, ts, reinsert, error_on_ooo_ts));
                 F_SET(fix_ts_upd, WT_UPDATE_FIXED_HS);
             }
         }
@@ -762,15 +779,18 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
         }
 
         /*
-         * In the case that the onpage value is an out of order timestamp update and the update
-         * older than it is a tombstone, it remains in the stack.
+         * In the case that the onpage value/tombstone is an out of order timestamp update/tombstone
+         * it remains in the stack. Validate it is time window against on page value/tombstone.
          */
         WT_ASSERT(session, out_of_order_ts_updates.size <= 1);
 #ifdef HAVE_DIAGNOSTIC
         if (out_of_order_ts_updates.size == 1) {
             __wt_update_vector_peek(&out_of_order_ts_updates, &upd);
             WT_ASSERT(session,
-              upd->txnid == list->onpage_upd->txnid && upd->start_ts == list->onpage_upd->start_ts);
+              (upd->txnid == list->onpage_upd->txnid &&
+                upd->start_ts == list->onpage_upd->start_ts) ||
+                (upd->txnid == list->onpage_tombstone->txnid &&
+                  upd->start_ts == list->onpage_tombstone->start_ts));
         }
 #endif
     }
@@ -811,7 +831,7 @@ err:
  */
 int
 __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btree_id,
-  const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool ooo_tombstone, bool error_on_ooo_ts)
+  const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool error_on_ooo_ts)
 {
     WT_DECL_RET;
     WT_ITEM hs_key;
@@ -819,12 +839,6 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
     uint64_t hs_counter;
     uint32_t hs_btree_id;
     bool hs_read_all_flag;
-
-    /*
-     * If we delete all the updates of the key from the history store, we should not reinsert any
-     * update except when an out-of-order tombstone is not globally visible yet.
-     */
-    WT_ASSERT(session, ooo_tombstone || ts > WT_TS_NONE || !reinsert);
 
     hs_read_all_flag = F_ISSET(hs_cursor, WT_CURSTD_HS_READ_ALL);
 
@@ -844,8 +858,8 @@ __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint3
         ++hs_counter;
     }
 
-    WT_ERR(__hs_delete_reinsert_from_pos(session, hs_cursor, btree_id, key, ts, reinsert,
-      ooo_tombstone, error_on_ooo_ts, &hs_counter, NULL));
+    WT_ERR(__hs_delete_reinsert_from_pos(
+      session, hs_cursor, btree_id, key, ts, reinsert, true, error_on_ooo_ts, &hs_counter, NULL));
 
 done:
 err:

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -787,8 +787,8 @@ extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *
 extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_key_from_ts(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor,
-  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool ooo_tombstone,
-  bool error_on_ooo_ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint32_t btree_id, const WT_ITEM *key, wt_timestamp_t ts, bool reinsert, bool error_on_ooo_ts)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_delete_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2523,8 +2523,8 @@ __wt_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r, wt_tim
      * eviction starting its reconciliation as previous checks done while selecting an update will
      * detect that.
      */
-    WT_RET(__wt_hs_delete_key_from_ts(session, r->hs_cursor, btree->id, key, ts, reinsert, true,
-      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)));
+    WT_RET(__wt_hs_delete_key_from_ts(
+      session, r->hs_cursor, btree->id, key, ts, reinsert, F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)));
 
     /* Fail 0.01% of the time. */
     if (F_ISSET(r, WT_REC_EVICT) &&

--- a/test/suite/test_hs32.py
+++ b/test/suite/test_hs32.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+# test_hs32.py
+# Ensure that updates without timestamps clear the history store records.
+class test_hs32(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=500MB,statistics=(all)'
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        ('column-fix', dict(key_format='r', value_format='8t')),
+        ('integer-row', dict(key_format='i', value_format='S')),
+        ('string-row', dict(key_format='S', value_format='S')),
+    ]
+    update_type_values = [
+        ('deletion', dict(update_type='deletion')),
+        ('update', dict(update_type='update'))
+    ]
+    long_running_txn_values = [
+        ('no-long-run-txn', dict(long_run_txn=False)),
+        ('long-run-txn', dict(long_run_txn=True))
+    ]
+    scenarios = make_scenarios(format_values, update_type_values,long_running_txn_values)
+    nrows = 10000
+
+    def create_key(self, i):
+        if self.key_format == 'S':
+            return str(i)
+        return i
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def evict_cursor(self, uri, nrows):
+        s = self.conn.open_session()
+        s.begin_transaction()
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(self.create_key(i))
+            evict_cursor.search()
+            evict_cursor.reset()
+        s.rollback_transaction()
+        evict_cursor.close()
+
+    def test_non_ts_updates_tombstone_clears_hs(self):
+        uri = 'table:test_hs32'
+        create_params = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        self.session.create(uri, create_params)
+
+        if self.value_format == '8t':
+            value1 = 97
+            value2 = 98
+        else:
+            value1 = 'a' * 500
+            value2 = 'b' * 500
+
+        # Apply a series of updates from timestamps 1-4.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        cursor = self.session.open_cursor(uri)
+        for ts in range(1, 5):
+            for i in range(1, self.nrows):
+                with self.transaction(commit_timestamp = ts):
+                    cursor[self.create_key(i)] = value1
+
+        # Reconcile and flush versions 1-3 to the history store.
+        self.session.checkpoint()
+        self.evict_cursor(uri, self.nrows)
+
+        if self.long_run_txn:
+            # Apply a another update at timestamp 5.
+            for i in range(1, self.nrows):
+                with self.transaction(commit_timestamp = 5):
+                    cursor[self.create_key(i)] = value1
+
+            # Start a long running transaction to make tombstone not globally visible.
+            session2 = self.conn.open_session()
+            session2.begin_transaction('read_timestamp=5')
+
+        # Apply an update/delete without timestamp.
+        for i in range(1, self.nrows):
+            self.session.begin_transaction('no_timestamp=true')
+            if i % 2 == 0:
+                if self.update_type == 'deletion':
+                    cursor.set_key(self.create_key(i))
+                    cursor.remove()
+                else:
+                    cursor[self.create_key(i)] = value2
+            self.session.commit_transaction()
+
+        if self.long_run_txn:
+            # Reconcile and remove the obsolete entries.
+            self.session.checkpoint()
+            self.evict_cursor(uri, self.nrows)
+
+            # Rollback the long running transaction.
+            session2.rollback_transaction()
+
+        # Now apply an update at timestamp 10.
+        for i in range(1, self.nrows):
+            with self.transaction(commit_timestamp = 10):
+                cursor[self.create_key(i)] = value2
+
+        self.session.checkpoint()
+
+        # Ensure that we blew away history store content.
+        for ts in range(1, 5):
+            with self.transaction(read_timestamp = ts, rollback = True):
+                for i in range(1, self.nrows):
+                    if i % 2 == 0:
+                        if self.update_type == 'deletion':
+                            cursor.set_key(self.create_key(i))
+                            if self.value_format == '8t':
+                                self.assertEqual(cursor.search(), 0)
+                                self.assertEqual(cursor.get_value(), 0)
+                            else:
+                                self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+                        else:
+                            self.assertEqual(cursor[self.create_key(i)], value2)
+                    else:
+                        self.assertEqual(cursor[self.create_key(i)], value1)
+
+        if self.update_type == 'deletion':
+            cache_hs_key_truncate = self.get_stat(stat.conn.cache_hs_key_truncate)
+            self.assertGreater(cache_hs_key_truncate, 0)

--- a/test/suite/test_hs32.py
+++ b/test/suite/test_hs32.py
@@ -36,7 +36,7 @@ class test_hs32(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=500MB,statistics=(all)'
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
-        ('column-fix', dict(key_format='r', value_format='8t')),
+        # ('column-fix', dict(key_format='r', value_format='8t')),
         ('integer-row', dict(key_format='i', value_format='S')),
         ('string-row', dict(key_format='S', value_format='S')),
     ]


### PR DESCRIPTION
This change backports WT-10512 but also includes WT-10536 which fixes some issues that arose from that change. The fixed-length column store scenario will be disabled in the Python test as it is known to not work on v5.0.

[WT-10536](https://jira.mongodb.org/browse/WT-10536) Fix statistic check cache_hs_key_truncate_onpage_removal in test_hs32.py (v6.3 backport) (https://github.com/wiredtiger/wiredtiger/pull/8771) (https://github.com/wiredtiger/wiredtiger/pull/8975)

(cherry picked from commit https://github.com/wiredtiger/wiredtiger/commit/de4e9ae0b5c52c680ba9a86cb62b621f8f92e7c2)

Co-authored-by: Sean <41533874+Sean04@users.noreply.github.com>

[WT-10512](https://jira.mongodb.org/browse/WT-10512) Fix not inserting an out of order timestamp into the history store (6.0 backport) (https://github.com/wiredtiger/wiredtiger/pull/8833)

Earlier the out-of-order timestamp verification logic checks from the on-page
update and doesn't verify the on-page tombstone when it is without a timestamp.
Using the on-page tombstone avoids inserting a history store entry
with an out-of-order timestamp into the data store.

(cherry picked from commit https://github.com/wiredtiger/wiredtiger/commit/668aff46691b668305930dcfa104614bd4796903)