### PR TITLE
WT-10536 Fix statistic check cache_hs_key_truncate_onpage_removal in test_hs32.py (v6.0 backport) (#8771) (#8975)

### DIFF
--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -578,6 +578,8 @@ __wt_hs_insert_updates(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_MULTI *mult
                 reinsert = false;
             }
 
+            WT_STAT_CONN_DATA_INCR(session, cache_hs_key_truncate);
+
             if (!F_ISSET(fix_ts_upd, WT_UPDATE_FIXED_HS)) {
                 /* Delete and reinsert any update of the key with a higher timestamp. */
                 WT_ERR(__wt_hs_delete_key_from_ts(

--- a/test/suite/test_hs32.py
+++ b/test/suite/test_hs32.py
@@ -33,7 +33,7 @@ from wiredtiger import stat
 # test_hs32.py
 # Ensure that updates without timestamps clear the history store records.
 class test_hs32(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB,statistics=(all)'
+    conn_config = 'cache_size=500MB,statistics=(all)'
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
         ('column-fix', dict(key_format='r', value_format='8t')),
@@ -155,6 +155,6 @@ class test_hs32(wttest.WiredTigerTestCase):
                         else:
                             self.assertEqual(cursor[self.create_key(i)], value1)
 
-        if self.long_run_txn and self.update_type == 'deletion':
-            hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)
-            self.assertGreater(hs_truncate, 0)
+        if self.update_type == 'deletion':
+            cache_hs_key_truncate = self.get_stat(stat.conn.cache_hs_key_truncate)
+            self.assertGreater(cache_hs_key_truncate, 0)


### PR DESCRIPTION
(cherry picked from commit de4e9ae0b5c52c680ba9a86cb62b621f8f92e7c2)