### PR TITLE
WT-10469 Fix no timestamp tombstones not removing history store entries (#8727) (#8832) (v5.0 backport)

### DIFF
--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -479,6 +479,8 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 {
     WT_BTREE *btree;
     WT_CURSOR_BTREE *cbt;
+    WT_DECL_ITEM(tmpkey);
+    WT_DECL_RET;
     WT_REC_KV *key, *val;
     WT_TIME_WINDOW tw;
     WT_UPDATE *upd;
@@ -495,8 +497,11 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
 
     upd = NULL;
 
+    /* Temporary buffer in which to instantiate any uninstantiated keys or value items we need. */
+    WT_RET(__wt_scr_alloc(session, 0, &tmpkey));
+
     for (; ins != NULL; ins = WT_SKIP_NEXT(ins)) {
-        WT_RET(__wt_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
+        WT_ERR(__wt_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
         if ((upd = upd_select.upd) == NULL) {
             /*
              * In cases where a page has grown so large we are trying to force evict it (there is
@@ -509,8 +514,8 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
             if (!upd_select.upd_saved || !__wt_rec_need_split(r, 0))
                 continue;
 
-            WT_RET(__wt_buf_set(session, r->cur, WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins)));
-            WT_RET(__wt_rec_split_crossing_bnd(session, r, 0));
+            WT_ERR(__wt_buf_set(session, r->cur, WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins)));
+            WT_ERR(__wt_rec_split_crossing_bnd(session, r, 0));
 
             /*
              * Turn off prefix and suffix compression until a full key is written into the new page.
@@ -539,9 +544,9 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
              * Impossible slot, there's no backing on-page item.
              */
             cbt->slot = UINT32_MAX;
-            WT_RET(__wt_modify_reconstruct_from_upd_list(session, cbt, upd, cbt->upd_value));
-            WT_RET(__wt_value_return(cbt, cbt->upd_value));
-            WT_RET(__wt_rec_cell_build_val(
+            WT_ERR(__wt_modify_reconstruct_from_upd_list(session, cbt, upd, cbt->upd_value));
+            WT_ERR(__wt_value_return(cbt, cbt->upd_value));
+            WT_ERR(__wt_rec_cell_build_val(
               session, r, cbt->iface.value.data, cbt->iface.value.size, &tw, 0));
             break;
         case WT_UPDATE_STANDARD:
@@ -549,15 +554,30 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
                 val->len = 0;
             else
                 /* Take the value from the update. */
-                WT_RET(__wt_rec_cell_build_val(session, r, upd->data, upd->size, &tw, 0));
+                WT_ERR(__wt_rec_cell_build_val(session, r, upd->data, upd->size, &tw, 0));
             break;
         case WT_UPDATE_TOMBSTONE:
-            continue;
+            break;
         default:
-            WT_RET(__wt_illegal_value(session, upd->type));
+            WT_ERR(__wt_illegal_value(session, upd->type));
         }
+
+        /*
+         * When a tombstone without a timestamp is written to disk, remove any historical versions
+         * that are greater in the history store for this key.
+         */
+        if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone) {
+            tmpkey->data = WT_INSERT_KEY(ins);
+            tmpkey->size = WT_INSERT_KEY_SIZE(ins);
+            WT_ERR(__wt_rec_hs_clear_on_tombstone(session, r, upd_select.tw.durable_stop_ts,
+              WT_RECNO_OOB, tmpkey, upd->type == WT_UPDATE_TOMBSTONE ? false : true));
+        }
+
+        if (upd->type == WT_UPDATE_TOMBSTONE)
+            continue;
+
         /* Build key cell. */
-        WT_RET(__rec_cell_build_leaf_key(
+        WT_ERR(__rec_cell_build_leaf_key(
           session, r, WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins), &ovfl_key));
 
         /* Boundary: split or write the page. */
@@ -570,10 +590,10 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
                 r->key_pfx_compress = false;
                 r->key_pfx_last = 0;
                 if (!ovfl_key)
-                    WT_RET(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key));
+                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key));
             }
 
-            WT_RET(__wt_rec_split_crossing_bnd(session, r, key->len + val->len));
+            WT_ERR(__wt_rec_split_crossing_bnd(session, r, key->len + val->len));
         }
 
         /* Copy the key/value pair onto the page. */
@@ -583,7 +603,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
         else {
             r->all_empty_value = false;
             if (btree->dictionary)
-                WT_RET(__wt_rec_dict_replace(session, r, &tw, 0, val));
+                WT_ERR(__wt_rec_dict_replace(session, r, &tw, 0, val));
             __wt_rec_image_copy(session, r, val);
         }
         WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &tw);
@@ -592,7 +612,9 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
         __rec_key_state_update(r, ovfl_key);
     }
 
-    return (0);
+err:
+    __wt_scr_free(session, &tmpkey);
+    return (ret);
 }
 
 /*
@@ -819,15 +841,6 @@ __wt_rec_row_leaf(
             case WT_UPDATE_STANDARD:
                 /* Take the value from the update. */
                 WT_ERR(__wt_rec_cell_build_val(session, r, upd->data, upd->size, twp, 0));
-                /*
-                 * When an out-of-order or mixed-mode tombstone is getting written to disk, remove
-                 * any historical versions that are greater in the history store for that key.
-                 */
-                if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone) {
-                    WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
-                    WT_ERR(__wt_rec_hs_clear_on_tombstone(
-                      session, r, twp->durable_stop_ts, WT_RECNO_OOB, tmpkey, true));
-                }
                 dictionary = true;
                 break;
             case WT_UPDATE_TOMBSTONE:
@@ -852,26 +865,28 @@ __wt_rec_row_leaf(
                 }
 
                 /*
-                 * When an out-of-order or mixed-mode tombstone is getting written to disk, remove
-                 * any historical versions that are greater in the history store for this key.
-                 */
-                if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone) {
-                    WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
-                    WT_ERR(__wt_rec_hs_clear_on_tombstone(
-                      session, r, twp->durable_stop_ts, WT_RECNO_OOB, tmpkey, false));
-                }
-
-                /*
                  * We aren't creating a key so we can't use bytes from this key to provide prefix
                  * information for a subsequent key.
                  */
                 tmpkey->size = 0;
-
-                /* Proceed with appended key/value pairs. */
-                goto leaf_insert;
+                break;
             default:
                 WT_ERR(__wt_illegal_value(session, upd->type));
             }
+
+            /*
+             * When an out-of-order or mixed-mode tombstone is getting written to disk, remove any
+             * historical versions that are greater in the history store for this key.
+             */
+            if (upd_select.ooo_tombstone && r->hs_clear_on_tombstone) {
+                WT_ERR(__wt_row_leaf_key(session, page, rip, tmpkey, true));
+                WT_ERR(__wt_rec_hs_clear_on_tombstone(session, r, twp->durable_stop_ts,
+                  WT_RECNO_OOB, tmpkey, upd->type == WT_UPDATE_TOMBSTONE ? false : true));
+            }
+
+            /* Proceed with appended key/value pairs. */
+            if (upd->type == WT_UPDATE_TOMBSTONE)
+                goto leaf_insert;
         }
 
         /*

--- a/test/suite/test_hs11.py
+++ b/test/suite/test_hs11.py
@@ -44,8 +44,20 @@ class test_hs11(wttest.WiredTigerTestCase):
         ('deletion', dict(update_type='deletion')),
         ('update', dict(update_type='update'))
     ]
-    scenarios = make_scenarios(key_format_values, update_type_values)
-    nrows = 10000
+    long_running_txn_values = [
+       ('long-running', dict(long_run_txn=True)),
+        ('no-long-running', dict(long_run_txn=False))
+    ]
+    last_update_type_values = [
+        ('modify', dict(modify=True)),
+        ('no-modify', dict(modify=False))
+    ]
+    nrows = [
+        ('small-nrows', dict(nrows=100)),
+        ('large-nrows', dict(nrows=10000))
+    ]
+    scenarios = make_scenarios(key_format_values, update_type_values,long_running_txn_values, last_update_type_values, nrows)
+    timestamps = 5
 
     def create_key(self, i):
         if self.key_format == 'S':
@@ -58,6 +70,18 @@ class test_hs11(wttest.WiredTigerTestCase):
         stat_cursor.close()
         return val
 
+    def evict_cursor(self, uri, nrows):
+        s = self.conn.open_session()
+        s.begin_transaction()
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(self.create_key(i))
+            evict_cursor.search()
+            evict_cursor.reset()
+        s.rollback_transaction()
+        evict_cursor.close()
+
     def test_non_ts_updates_clears_hs(self):
         uri = 'table:test_hs11'
         create_params = 'key_format={},value_format=S'.format(self.key_format)
@@ -65,11 +89,12 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         value1 = 'a' * 500
         value2 = 'b' * 500
+        mod_value = 'm' + 'a' * 499
 
         # Apply a series of updates from timestamps 1-4.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
-        for ts in range(1, 5):
+        for ts in range(1, self.timestamps):
             for i in range(1, self.nrows):
                 self.session.begin_transaction()
                 cursor[self.create_key(i)] = value1
@@ -77,8 +102,24 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
+        self.evict_cursor(uri, self.nrows)
 
-        # Apply an update without timestamp.
+        # Apply a modify update at timestamp 5.
+        if self.modify:
+            for i in range(1, self.nrows):
+                self.session.begin_transaction()
+                cursor.set_key(self.create_key(i))
+                cursor.modify([wiredtiger.Modify("m", 0, 1)])
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+            self.timestamps += 1
+
+        # Start a long running transaction at timestamp 5. 
+        if self.long_run_txn:
+            session2 = self.conn.open_session()
+            session2.begin_transaction('read_timestamp=5')
+
+        # Apply an update without timestamp. If we have a long running transaction this update 
+        # should not be globally visible until that transaction has ended.
         for i in range(1, self.nrows):
             if i % 2 == 0:
                 if self.update_type == 'deletion':
@@ -89,6 +130,11 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Reconcile and remove the obsolete entries.
         self.session.checkpoint()
+        if self.long_run_txn:
+            session2.rollback_transaction()
+            
+        # At this point any updates with no timestamp should be globally visible.
+        self.evict_cursor(uri, self.nrows)
 
         # Now apply an update at timestamp 10.
         for i in range(1, self.nrows):
@@ -96,8 +142,10 @@ class test_hs11(wttest.WiredTigerTestCase):
             cursor[self.create_key(i)] = value2
             self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
+        self.session.checkpoint()
+
         # Ensure that we blew away history store content.
-        for ts in range(1, 5):
+        for ts in range(1, self.timestamps):
             self.session.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
             for i in range(1, self.nrows):
                 if i % 2 == 0:
@@ -107,7 +155,10 @@ class test_hs11(wttest.WiredTigerTestCase):
                     else:
                         self.assertEqual(cursor[self.create_key(i)], value2)
                 else:
-                    self.assertEqual(cursor[self.create_key(i)], value1)
+                    if ts == 5 and self.modify:
+                        self.assertEqual(cursor[self.create_key(i)], mod_value)
+                    else:
+                        self.assertEqual(cursor[self.create_key(i)], value1)            
             self.session.rollback_transaction()
 
         if self.update_type == 'deletion':
@@ -121,11 +172,12 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         value1 = 'a' * 500
         value2 = 'b' * 500
+        mod_value = 'm' + 'a' * 499
 
         # Apply a series of updates from timestamps 1-4.
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(uri)
-        for ts in range(1, 5):
+        for ts in range(1, self.timestamps):
             for i in range(1, self.nrows):
                 self.session.begin_transaction()
                 cursor[self.create_key(i)] = value1
@@ -133,6 +185,15 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
+
+        # Apply a modify update at timestamp 5.
+        if self.modify:
+            for i in range(1, self.nrows):
+                self.session.begin_transaction()
+                cursor.set_key(self.create_key(i))
+                cursor.modify([wiredtiger.Modify("m", 0, 1)])
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+            self.timestamps += 1
 
         # Remove the key with timestamp 10.
         for i in range(1, self.nrows):
@@ -159,7 +220,10 @@ class test_hs11(wttest.WiredTigerTestCase):
                 cursor.set_key(self.create_key(i))
                 self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
             else:
-                self.assertEqual(cursor[self.create_key(i)], value1)
+                if self.modify:
+                    self.assertEqual(cursor[self.create_key(i)], mod_value)
+                else:
+                    self.assertEqual(cursor[self.create_key(i)], value1)
         self.session.rollback_transaction()
 
         hs_truncate = self.get_stat(stat.conn.cache_hs_key_truncate_onpage_removal)


### PR DESCRIPTION
* WT-10469 Fix no timestamp tombstones not removing history store entries (#8727)

(cherry picked from commit ede3bedaa1e5bfd03b51857608843c00dabc03d5)

* Fix ooo_tombstone check.

* Fix retry transaction in test_hs11

(cherry picked from commit 3c695aff6bb1c62f553f7c2514c3a34d7deb0db8)