### PR TITLE
WT-10911 Investigate and update eviction timeline metrics that are showing up incorrectly (6.0 backport)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1351,6 +1351,7 @@ reconfiguring
 recsize
 rectype
 recurse
+reentrant
 refp
 regionp
 reinitialization

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1351,7 +1351,6 @@ reconfiguring
 recsize
 rectype
 recurse
-reentrant
 refp
 regionp
 reinitialization

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -266,7 +266,7 @@ conn_stats = [
     CacheStat('cache_eviction_internal_pages_already_queued', 'internal pages seen by eviction walk that are already queued'),
     CacheStat('cache_eviction_internal_pages_queued', 'internal pages queued for eviction'),
     CacheStat('cache_eviction_maximum_page_size', 'maximum page size seen at eviction', 'no_clear,no_scale,size'),
-    CacheStat('cache_eviction_maximum_seconds', 'maximum seconds spent at a single eviction', 'no_clear,no_scale,size'),
+    CacheStat('cache_eviction_maximum_milliseconds', 'maximum milliseconds spent at a single eviction', 'no_clear,no_scale,size'),
     CacheStat('cache_eviction_pages_queued', 'pages queued for eviction'),
     CacheStat('cache_eviction_pages_queued_oldest', 'pages queued for urgent eviction during walk'),
     CacheStat('cache_eviction_pages_queued_post_lru', 'pages queued for eviction post lru sorting'),
@@ -298,6 +298,7 @@ conn_stats = [
     CacheStat('cache_hazard_walks', 'hazard pointer check entries walked'),
     CacheStat('cache_hs_ondisk', 'history store table on-disk size', 'no_clear,no_scale,size'),
     CacheStat('cache_hs_ondisk_max', 'history store table max on-disk size', 'no_clear,no_scale,size'),
+    CacheStat('cache_reentry_hs_eviction_milliseconds', 'total milliseconds spent inside reentrant history store evictions in a reconciliation', 'no_clear,no_scale,size'),
     CacheStat('cache_overhead', 'percentage overhead', 'no_clear,no_scale'),
     CacheStat('cache_pages_dirty', 'tracked dirty pages in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse', 'pages currently held in the cache', 'no_clear,no_scale'),
@@ -499,9 +500,9 @@ conn_stats = [
     ##########################################
     # Reconciliation statistics
     ##########################################
-    RecStat('rec_maximum_hs_wrapup_seconds', 'maximum seconds spent in moving updates to the history store in a reconciliation', 'no_clear,no_scale,size'),
-    RecStat('rec_maximum_image_build_seconds', 'maximum seconds spent in building a disk image in a reconciliation', 'no_clear,no_scale,size'),
-    RecStat('rec_maximum_seconds', 'maximum seconds spent in a reconciliation call', 'no_clear,no_scale,size'),
+    RecStat('rec_maximum_hs_wrapup_milliseconds', 'maximum milliseconds spent in moving updates to the history store in a reconciliation', 'no_clear,no_scale,size'),
+    RecStat('rec_maximum_image_build_milliseconds', 'maximum milliseconds spent in building a disk image in a reconciliation', 'no_clear,no_scale,size'),
+    RecStat('rec_maximum_milliseconds', 'maximum milliseconds spent in a reconciliation call', 'no_clear,no_scale,size'),
     RecStat('rec_overflow_key_leaf', 'leaf-page overflow keys'),
     RecStat('rec_pages_with_prepare', 'page reconciliation calls that resulted in values with prepared transaction metadata'),
     RecStat('rec_pages_with_ts', 'page reconciliation calls that resulted in values with timestamps'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -266,7 +266,7 @@ conn_stats = [
     CacheStat('cache_eviction_internal_pages_already_queued', 'internal pages seen by eviction walk that are already queued'),
     CacheStat('cache_eviction_internal_pages_queued', 'internal pages queued for eviction'),
     CacheStat('cache_eviction_maximum_page_size', 'maximum page size seen at eviction', 'no_clear,no_scale,size'),
-    CacheStat('cache_eviction_maximum_milliseconds', 'maximum milliseconds spent at a single eviction', 'no_clear,no_scale,size'),
+    CacheStat('cache_eviction_maximum_seconds', 'maximum seconds spent at a single eviction', 'no_clear,no_scale,size'),
     CacheStat('cache_eviction_pages_queued', 'pages queued for eviction'),
     CacheStat('cache_eviction_pages_queued_oldest', 'pages queued for urgent eviction during walk'),
     CacheStat('cache_eviction_pages_queued_post_lru', 'pages queued for eviction post lru sorting'),
@@ -298,7 +298,6 @@ conn_stats = [
     CacheStat('cache_hazard_walks', 'hazard pointer check entries walked'),
     CacheStat('cache_hs_ondisk', 'history store table on-disk size', 'no_clear,no_scale,size'),
     CacheStat('cache_hs_ondisk_max', 'history store table max on-disk size', 'no_clear,no_scale,size'),
-    CacheStat('cache_reentry_hs_eviction_milliseconds', 'total milliseconds spent inside reentrant history store evictions in a reconciliation', 'no_clear,no_scale,size'),
     CacheStat('cache_overhead', 'percentage overhead', 'no_clear,no_scale'),
     CacheStat('cache_pages_dirty', 'tracked dirty pages in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse', 'pages currently held in the cache', 'no_clear,no_scale'),
@@ -500,9 +499,9 @@ conn_stats = [
     ##########################################
     # Reconciliation statistics
     ##########################################
-    RecStat('rec_maximum_hs_wrapup_milliseconds', 'maximum milliseconds spent in moving updates to the history store in a reconciliation', 'no_clear,no_scale,size'),
-    RecStat('rec_maximum_image_build_milliseconds', 'maximum milliseconds spent in building a disk image in a reconciliation', 'no_clear,no_scale,size'),
-    RecStat('rec_maximum_milliseconds', 'maximum milliseconds spent in a reconciliation call', 'no_clear,no_scale,size'),
+    RecStat('rec_maximum_hs_wrapup_seconds', 'maximum seconds spent in moving updates to the history store in a reconciliation', 'no_clear,no_scale,size'),
+    RecStat('rec_maximum_image_build_seconds', 'maximum seconds spent in building a disk image in a reconciliation', 'no_clear,no_scale,size'),
+    RecStat('rec_maximum_seconds', 'maximum seconds spent in a reconciliation call', 'no_clear,no_scale,size'),
     RecStat('rec_overflow_key_leaf', 'leaf-page overflow keys'),
     RecStat('rec_pages_with_prepare', 'page reconciliation calls that resulted in values with prepared transaction metadata'),
     RecStat('rec_pages_with_ts', 'page reconciliation calls that resulted in values with timestamps'),

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -320,7 +320,9 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(session, stats, cache_bytes_updates, __wt_cache_bytes_updates(cache));
 
     WT_STAT_SET(session, stats, cache_eviction_maximum_page_size, cache->evict_max_page_size);
-    WT_STAT_SET(session, stats, cache_eviction_maximum_seconds, cache->evict_max_seconds);
+    WT_STAT_SET(session, stats, cache_eviction_maximum_milliseconds, cache->evict_max_ms);
+    WT_STAT_SET(
+      session, stats, cache_reentry_hs_eviction_milliseconds, cache->reentry_hs_eviction_ms);
     WT_STAT_SET(
       session, stats, cache_pages_dirty, cache->pages_dirty_intl + cache->pages_dirty_leaf);
 
@@ -339,10 +341,11 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     if (conn->evict_server_running)
         WT_STAT_SET(session, stats, cache_eviction_walks_active, cache->walk_session->nhazard);
 
-    WT_STAT_SET(session, stats, rec_maximum_hs_wrapup_seconds, conn->rec_maximum_hs_wrapup_seconds);
     WT_STAT_SET(
-      session, stats, rec_maximum_image_build_seconds, conn->rec_maximum_image_build_seconds);
-    WT_STAT_SET(session, stats, rec_maximum_seconds, conn->rec_maximum_seconds);
+      session, stats, rec_maximum_hs_wrapup_milliseconds, conn->rec_maximum_hs_wrapup_milliseconds);
+    WT_STAT_SET(session, stats, rec_maximum_image_build_milliseconds,
+      conn->rec_maximum_image_build_milliseconds);
+    WT_STAT_SET(session, stats, rec_maximum_milliseconds, conn->rec_maximum_milliseconds);
 }
 
 /*

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -320,9 +320,7 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(session, stats, cache_bytes_updates, __wt_cache_bytes_updates(cache));
 
     WT_STAT_SET(session, stats, cache_eviction_maximum_page_size, cache->evict_max_page_size);
-    WT_STAT_SET(session, stats, cache_eviction_maximum_milliseconds, cache->evict_max_ms);
-    WT_STAT_SET(
-      session, stats, cache_reentry_hs_eviction_milliseconds, cache->reentry_hs_eviction_ms);
+    WT_STAT_SET(session, stats, cache_eviction_maximum_seconds, cache->evict_max_seconds);
     WT_STAT_SET(
       session, stats, cache_pages_dirty, cache->pages_dirty_intl + cache->pages_dirty_leaf);
 
@@ -341,11 +339,10 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     if (conn->evict_server_running)
         WT_STAT_SET(session, stats, cache_eviction_walks_active, cache->walk_session->nhazard);
 
+    WT_STAT_SET(session, stats, rec_maximum_hs_wrapup_seconds, conn->rec_maximum_hs_wrapup_seconds);
     WT_STAT_SET(
-      session, stats, rec_maximum_hs_wrapup_milliseconds, conn->rec_maximum_hs_wrapup_milliseconds);
-    WT_STAT_SET(session, stats, rec_maximum_image_build_milliseconds,
-      conn->rec_maximum_image_build_milliseconds);
-    WT_STAT_SET(session, stats, rec_maximum_milliseconds, conn->rec_maximum_milliseconds);
+      session, stats, rec_maximum_image_build_seconds, conn->rec_maximum_image_build_seconds);
+    WT_STAT_SET(session, stats, rec_maximum_seconds, conn->rec_maximum_seconds);
 }
 
 /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -85,6 +85,89 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     return (ret);
 }
 
+#define WT_EVICT_STATS_CLEAN 0x01
+#define WT_EVICT_STATS_FORCE_HS 0x02
+#define WT_EVICT_STATS_SUCCESS 0x04
+#define WT_EVICT_STATS_URGENT 0x08
+
+/*
+ * __evict_stats_update --
+ *     Update the stats of eviction.
+ *
+ */
+static void
+__evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
+{
+    WT_CONNECTION_IMPL *conn;
+    uint64_t eviction_time, eviction_time_milliseconds;
+
+    conn = S2C(session);
+
+    if (session->evict_timeline.reentry_hs_eviction) {
+        session->evict_timeline.reentry_hs_evict_finish = __wt_clock(session);
+        eviction_time = WT_CLOCKDIFF_US(session->evict_timeline.reentry_hs_evict_finish,
+          session->evict_timeline.reentry_hs_evict_start);
+    } else {
+        session->evict_timeline.evict_finish = __wt_clock(session);
+        eviction_time = WT_CLOCKDIFF_US(
+          session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
+    }
+    if (LF_ISSET(WT_EVICT_STATS_SUCCESS)) {
+        if (LF_ISSET(WT_EVICT_STATS_URGENT)) {
+            if (LF_ISSET(WT_EVICT_STATS_FORCE_HS))
+                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
+            if (LF_ISSET(WT_EVICT_STATS_CLEAN)) {
+                WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
+                WT_STAT_CONN_INCRV(session, cache_eviction_force_clean_time, eviction_time);
+            } else {
+                WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
+                WT_STAT_CONN_INCRV(session, cache_eviction_force_dirty_time, eviction_time);
+            }
+        }
+
+        if (LF_ISSET(WT_EVICT_STATS_CLEAN))
+            WT_STAT_CONN_DATA_INCR(session, cache_eviction_clean);
+        else
+            WT_STAT_CONN_DATA_INCR(session, cache_eviction_dirty);
+
+        /* Count page evictions in parallel with checkpoint. */
+        if (conn->txn_global.checkpoint_running)
+            WT_STAT_CONN_INCR(session, cache_eviction_pages_in_parallel_with_checkpoint);
+    } else {
+        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+            if (LF_ISSET(WT_EVICT_STATS_FORCE_HS))
+                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
+            WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
+            WT_STAT_CONN_INCRV(session, cache_eviction_force_fail_time, eviction_time);
+        }
+
+        WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);
+    }
+    if (!session->evict_timeline.reentry_hs_eviction) {
+        eviction_time_milliseconds = eviction_time / WT_THOUSAND;
+        if (eviction_time_milliseconds > conn->cache->evict_max_ms)
+            conn->cache->evict_max_ms = eviction_time_milliseconds;
+        if (eviction_time_milliseconds > WT_MINUTE * WT_THOUSAND)
+            __wt_verbose_warning(session, WT_VERB_EVICT,
+              "Eviction took more than 1 minute (%" PRIu64 "). Building disk image took %" PRIu64
+              "us. History store wrapup took %" PRIu64 "us.",
+              eviction_time,
+              WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,
+                session->reconcile_timeline.image_build_start),
+              WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
+                session->reconcile_timeline.hs_wrapup_start));
+    } else {
+        /*
+         * We are in the reentrant history store eviction inside a data store reconciliation. Add to
+         * the total time taken to do the reentrant history store eviction.
+         */
+        session->reconcile_timeline.total_reentry_hs_eviction_time +=
+          WT_CLOCKDIFF_MS(session->evict_timeline.reentry_hs_evict_finish,
+            session->evict_timeline.reentry_hs_evict_start);
+        session->evict_timeline.reentry_hs_eviction = false;
+    }
+}
+
 /*
  * __wt_evict --
  *     Evict a page.
@@ -95,15 +178,15 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_PAGE *page;
-    uint64_t eviction_time, eviction_time_seconds;
-    bool clean_page, closing, force_evict_hs, inmem_split, local_gen, tree_dead;
+    uint8_t stats_flags;
+    bool clean_page, closing, inmem_split, tree_dead, local_gen;
 
     conn = S2C(session);
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
-    force_evict_hs = false;
+    stats_flags = 0;
     local_gen = false;
-    eviction_time = eviction_time_seconds = 0;
+    clean_page = false;
 
     __wt_verbose(
       session, WT_VERB_EVICT, "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
@@ -121,21 +204,19 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         __wt_session_gen_enter(session, WT_GEN_EVICT);
     }
 
-    WT_CLEAR(session->reconcile_timeline);
-    WT_CLEAR(session->evict_timeline);
-    session->evict_timeline.evict_start = __wt_clock(session);
     /*
      * Immediately increment the forcible eviction counter, we might do an in-memory split and not
      * an eviction, which skips the other statistics.
      */
     if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+        FLD_SET(stats_flags, WT_EVICT_STATS_URGENT);
         WT_STAT_CONN_INCR(session, cache_eviction_force);
 
         /*
          * Track history store pages being force evicted while holding a history store cursor open.
          */
         if (session->hs_cursor_counter > 0 && WT_IS_HS(session->dhandle)) {
-            force_evict_hs = true;
+            FLD_SET(stats_flags, WT_EVICT_STATS_FORCE_HS);
             WT_STAT_CONN_INCR(session, cache_eviction_force_hs);
         }
     }
@@ -203,7 +284,10 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         conn->cache->evict_max_page_size = page->memory_footprint;
 
     /* Figure out whether reconciliation was done on the page */
-    clean_page = __wt_page_evict_clean(page);
+    if (__wt_page_evict_clean(page)) {
+        clean_page = true;
+        FLD_SET(stats_flags, WT_EVICT_STATS_CLEAN);
+    }
 
     /* Update the reference and discard the page. */
     if (__wt_ref_is_root(ref))
@@ -220,59 +304,18 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
      * We have loaded the new disk image and updated the tree structure. We can no longer fail after
      * this point.
      */
-    session->evict_timeline.evict_finish = __wt_clock(session);
-    eviction_time =
-      WT_CLOCKDIFF_US(session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
-    if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
-        if (force_evict_hs)
-            WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
-        if (clean_page) {
-            WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
-            WT_STAT_CONN_INCRV(session, cache_eviction_force_clean_time, eviction_time);
-        } else {
-            WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
-            WT_STAT_CONN_INCRV(session, cache_eviction_force_dirty_time, eviction_time);
-        }
-    }
-    if (clean_page)
-        WT_STAT_CONN_DATA_INCR(session, cache_eviction_clean);
-    else
-        WT_STAT_CONN_DATA_INCR(session, cache_eviction_dirty);
-
-    /* Count page evictions in parallel with checkpoint. */
-    if (conn->txn_global.checkpoint_running)
-        WT_STAT_CONN_INCR(session, cache_eviction_pages_in_parallel_with_checkpoint);
 
     if (0) {
 err:
         if (!closing)
             __evict_exclusive_clear(session, ref, previous_state);
-        session->evict_timeline.evict_finish = __wt_clock(session);
-        eviction_time = WT_CLOCKDIFF_US(
-          session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
-        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
-            if (force_evict_hs)
-                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
-            WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
-            WT_STAT_CONN_INCRV(session, cache_eviction_force_fail_time, eviction_time);
-        }
-
-        WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);
     }
 
 done:
-    eviction_time_seconds = eviction_time / WT_MILLION;
-    if (eviction_time_seconds > conn->cache->evict_max_seconds)
-        conn->cache->evict_max_seconds = eviction_time_seconds;
-    if (eviction_time_seconds > 60)
-        __wt_verbose_warning(session, WT_VERB_EVICT,
-          "Eviction took more than 1 minute (%" PRIu64 "). Building disk image took %" PRIu64
-          "us. History store wrapup took %" PRIu64 "us.",
-          eviction_time,
-          WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,
-            session->reconcile_timeline.image_build_start),
-          WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
-            session->reconcile_timeline.hs_wrapup_start));
+    if (ret == 0)
+        FLD_SET(stats_flags, WT_EVICT_STATS_SUCCESS);
+    __evict_stats_update(session, stats_flags);
+
     /* Leave any local eviction generation. */
     if (local_gen)
         __wt_session_gen_leave(session, WT_GEN_EVICT);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -85,6 +85,89 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     return (ret);
 }
 
+#define WT_EVICT_STATS_CLEAN 0x01
+#define WT_EVICT_STATS_FORCE_HS 0x02
+#define WT_EVICT_STATS_SUCCESS 0x04
+#define WT_EVICT_STATS_URGENT 0x08
+
+/*
+ * __evict_stats_update --
+ *     Update the stats of eviction.
+ *
+ */
+static void
+__evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
+{
+    WT_CONNECTION_IMPL *conn;
+    uint64_t eviction_time, eviction_time_milliseconds;
+
+    conn = S2C(session);
+
+    if (session->evict_timeline.reentry_hs_eviction) {
+        session->evict_timeline.reentry_hs_evict_finish = __wt_clock(session);
+        eviction_time = WT_CLOCKDIFF_US(session->evict_timeline.reentry_hs_evict_finish,
+          session->evict_timeline.reentry_hs_evict_start);
+    } else {
+        session->evict_timeline.evict_finish = __wt_clock(session);
+        eviction_time = WT_CLOCKDIFF_US(
+          session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
+    }
+    if (LF_ISSET(WT_EVICT_STATS_SUCCESS)) {
+        if (LF_ISSET(WT_EVICT_STATS_URGENT)) {
+            if (LF_ISSET(WT_EVICT_STATS_FORCE_HS))
+                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
+            if (LF_ISSET(WT_EVICT_STATS_CLEAN)) {
+                WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
+                WT_STAT_CONN_INCRV(session, cache_eviction_force_clean_time, eviction_time);
+            } else {
+                WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
+                WT_STAT_CONN_INCRV(session, cache_eviction_force_dirty_time, eviction_time);
+            }
+        }
+
+        if (LF_ISSET(WT_EVICT_STATS_CLEAN))
+            WT_STAT_CONN_DATA_INCR(session, cache_eviction_clean);
+        else
+            WT_STAT_CONN_DATA_INCR(session, cache_eviction_dirty);
+
+        /* Count page evictions in parallel with checkpoint. */
+        if (conn->txn_global.checkpoint_running)
+            WT_STAT_CONN_INCR(session, cache_eviction_pages_in_parallel_with_checkpoint);
+    } else {
+        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+            if (LF_ISSET(WT_EVICT_STATS_FORCE_HS))
+                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
+            WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
+            WT_STAT_CONN_INCRV(session, cache_eviction_force_fail_time, eviction_time);
+        }
+
+        WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);
+    }
+    if (!session->evict_timeline.reentry_hs_eviction) {
+        eviction_time_milliseconds = eviction_time / WT_THOUSAND;
+        if (eviction_time_milliseconds > conn->cache->evict_max_ms)
+            conn->cache->evict_max_ms = eviction_time_milliseconds;
+        if (eviction_time_milliseconds > WT_MINUTE * WT_THOUSAND)
+            __wt_verbose_warning(session, WT_VERB_EVICT,
+              "Eviction took more than 1 minute (%" PRIu64 "). Building disk image took %" PRIu64
+              "us. History store wrapup took %" PRIu64 "us.",
+              eviction_time,
+              WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,
+                session->reconcile_timeline.image_build_start),
+              WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
+                session->reconcile_timeline.hs_wrapup_start));
+    } else {
+        /*
+         * We are in the reentrant history store eviction inside a data store reconciliation. Add to
+         * the total time taken to do the reentrant history store eviction.
+         */
+        session->reconcile_timeline.total_reentry_hs_eviction_time +=
+          WT_CLOCKDIFF_MS(session->evict_timeline.reentry_hs_evict_finish,
+            session->evict_timeline.reentry_hs_evict_start);
+        session->evict_timeline.reentry_hs_eviction = false;
+    }
+}
+
 /*
  * __wt_evict --
  *     Evict a page.
@@ -95,15 +178,14 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_PAGE *page;
-    uint64_t eviction_time, eviction_time_seconds;
-    bool clean_page, closing, force_evict_hs, inmem_split, local_gen, tree_dead;
+    uint8_t stats_flags;
+    bool clean_page, closing, inmem_split, tree_dead, local_gen;
 
     conn = S2C(session);
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
-    force_evict_hs = false;
-    local_gen = false;
-    eviction_time = eviction_time_seconds = 0;
+    stats_flags = 0;
+    clean_page = local_gen = false;
 
     __wt_verbose(
       session, WT_VERB_EVICT, "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
@@ -112,30 +194,38 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     if (tree_dead)
         LF_SET(WT_EVICT_CALL_NO_SPLIT);
 
+    /* As re-entry into eviction is possible, only clear the statistics on the first entry. */
+    if (__wt_session_gen((session), (WT_GEN_EVICT)) == 0) {
+        WT_CLEAR(session->reconcile_timeline);
+        WT_CLEAR(session->evict_timeline);
+        session->evict_timeline.evict_start = __wt_clock(session);
+    } else {
+        session->evict_timeline.reentry_hs_eviction = true;
+        session->evict_timeline.reentry_hs_evict_start = __wt_clock(session);
+    }
+
     /*
-     * Enter the eviction generation. If we re-enter eviction, leave the previous eviction
-     * generation (which must be as low as the current generation), untouched.
+     * Enter the eviction generation. If we re-enter eviction, leave the previous generation (which
+     * must be as low as the current generation), untouched.
      */
     if (__wt_session_gen(session, WT_GEN_EVICT) == 0) {
         local_gen = true;
         __wt_session_gen_enter(session, WT_GEN_EVICT);
     }
 
-    WT_CLEAR(session->reconcile_timeline);
-    WT_CLEAR(session->evict_timeline);
-    session->evict_timeline.evict_start = __wt_clock(session);
     /*
      * Immediately increment the forcible eviction counter, we might do an in-memory split and not
      * an eviction, which skips the other statistics.
      */
     if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+        FLD_SET(stats_flags, WT_EVICT_STATS_URGENT);
         WT_STAT_CONN_INCR(session, cache_eviction_force);
 
         /*
          * Track history store pages being force evicted while holding a history store cursor open.
          */
         if (session->hs_cursor_counter > 0 && WT_IS_HS(session->dhandle)) {
-            force_evict_hs = true;
+            FLD_SET(stats_flags, WT_EVICT_STATS_FORCE_HS);
             WT_STAT_CONN_INCR(session, cache_eviction_force_hs);
         }
     }
@@ -203,7 +293,10 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         conn->cache->evict_max_page_size = page->memory_footprint;
 
     /* Figure out whether reconciliation was done on the page */
-    clean_page = __wt_page_evict_clean(page);
+    if (__wt_page_evict_clean(page)) {
+        clean_page = true;
+        FLD_SET(stats_flags, WT_EVICT_STATS_CLEAN);
+    }
 
     /* Update the reference and discard the page. */
     if (__wt_ref_is_root(ref))
@@ -220,59 +313,18 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
      * We have loaded the new disk image and updated the tree structure. We can no longer fail after
      * this point.
      */
-    session->evict_timeline.evict_finish = __wt_clock(session);
-    eviction_time =
-      WT_CLOCKDIFF_US(session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
-    if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
-        if (force_evict_hs)
-            WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
-        if (clean_page) {
-            WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
-            WT_STAT_CONN_INCRV(session, cache_eviction_force_clean_time, eviction_time);
-        } else {
-            WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
-            WT_STAT_CONN_INCRV(session, cache_eviction_force_dirty_time, eviction_time);
-        }
-    }
-    if (clean_page)
-        WT_STAT_CONN_DATA_INCR(session, cache_eviction_clean);
-    else
-        WT_STAT_CONN_DATA_INCR(session, cache_eviction_dirty);
-
-    /* Count page evictions in parallel with checkpoint. */
-    if (conn->txn_global.checkpoint_running)
-        WT_STAT_CONN_INCR(session, cache_eviction_pages_in_parallel_with_checkpoint);
 
     if (0) {
 err:
         if (!closing)
             __evict_exclusive_clear(session, ref, previous_state);
-        session->evict_timeline.evict_finish = __wt_clock(session);
-        eviction_time = WT_CLOCKDIFF_US(
-          session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
-        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
-            if (force_evict_hs)
-                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
-            WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
-            WT_STAT_CONN_INCRV(session, cache_eviction_force_fail_time, eviction_time);
-        }
-
-        WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);
     }
 
 done:
-    eviction_time_seconds = eviction_time / WT_MILLION;
-    if (eviction_time_seconds > conn->cache->evict_max_seconds)
-        conn->cache->evict_max_seconds = eviction_time_seconds;
-    if (eviction_time_seconds > 60)
-        __wt_verbose_warning(session, WT_VERB_EVICT,
-          "Eviction took more than 1 minute (%" PRIu64 "). Building disk image took %" PRIu64
-          "us. History store wrapup took %" PRIu64 "us.",
-          eviction_time,
-          WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,
-            session->reconcile_timeline.image_build_start),
-          WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
-            session->reconcile_timeline.hs_wrapup_start));
+    if (ret == 0)
+        FLD_SET(stats_flags, WT_EVICT_STATS_SUCCESS);
+    __evict_stats_update(session, stats_flags);
+
     /* Leave any local eviction generation. */
     if (local_gen)
         __wt_session_gen_leave(session, WT_GEN_EVICT);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -185,7 +185,8 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
     stats_flags = 0;
-    clean_page = local_gen = false;
+    clean_page = false;
+    local_gen = false;
 
     __wt_verbose(
       session, WT_VERB_EVICT, "page %p (%s)", (void *)page, __wt_page_type_string(page->type));

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -85,89 +85,6 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     return (ret);
 }
 
-#define WT_EVICT_STATS_CLEAN 0x01
-#define WT_EVICT_STATS_FORCE_HS 0x02
-#define WT_EVICT_STATS_SUCCESS 0x04
-#define WT_EVICT_STATS_URGENT 0x08
-
-/*
- * __evict_stats_update --
- *     Update the stats of eviction.
- *
- */
-static void
-__evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
-{
-    WT_CONNECTION_IMPL *conn;
-    uint64_t eviction_time, eviction_time_milliseconds;
-
-    conn = S2C(session);
-
-    if (session->evict_timeline.reentry_hs_eviction) {
-        session->evict_timeline.reentry_hs_evict_finish = __wt_clock(session);
-        eviction_time = WT_CLOCKDIFF_US(session->evict_timeline.reentry_hs_evict_finish,
-          session->evict_timeline.reentry_hs_evict_start);
-    } else {
-        session->evict_timeline.evict_finish = __wt_clock(session);
-        eviction_time = WT_CLOCKDIFF_US(
-          session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
-    }
-    if (LF_ISSET(WT_EVICT_STATS_SUCCESS)) {
-        if (LF_ISSET(WT_EVICT_STATS_URGENT)) {
-            if (LF_ISSET(WT_EVICT_STATS_FORCE_HS))
-                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
-            if (LF_ISSET(WT_EVICT_STATS_CLEAN)) {
-                WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
-                WT_STAT_CONN_INCRV(session, cache_eviction_force_clean_time, eviction_time);
-            } else {
-                WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
-                WT_STAT_CONN_INCRV(session, cache_eviction_force_dirty_time, eviction_time);
-            }
-        }
-
-        if (LF_ISSET(WT_EVICT_STATS_CLEAN))
-            WT_STAT_CONN_DATA_INCR(session, cache_eviction_clean);
-        else
-            WT_STAT_CONN_DATA_INCR(session, cache_eviction_dirty);
-
-        /* Count page evictions in parallel with checkpoint. */
-        if (conn->txn_global.checkpoint_running)
-            WT_STAT_CONN_INCR(session, cache_eviction_pages_in_parallel_with_checkpoint);
-    } else {
-        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
-            if (LF_ISSET(WT_EVICT_STATS_FORCE_HS))
-                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
-            WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
-            WT_STAT_CONN_INCRV(session, cache_eviction_force_fail_time, eviction_time);
-        }
-
-        WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);
-    }
-    if (!session->evict_timeline.reentry_hs_eviction) {
-        eviction_time_milliseconds = eviction_time / WT_THOUSAND;
-        if (eviction_time_milliseconds > conn->cache->evict_max_ms)
-            conn->cache->evict_max_ms = eviction_time_milliseconds;
-        if (eviction_time_milliseconds > WT_MINUTE * WT_THOUSAND)
-            __wt_verbose_warning(session, WT_VERB_EVICT,
-              "Eviction took more than 1 minute (%" PRIu64 "). Building disk image took %" PRIu64
-              "us. History store wrapup took %" PRIu64 "us.",
-              eviction_time,
-              WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,
-                session->reconcile_timeline.image_build_start),
-              WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
-                session->reconcile_timeline.hs_wrapup_start));
-    } else {
-        /*
-         * We are in the reentrant history store eviction inside a data store reconciliation. Add to
-         * the total time taken to do the reentrant history store eviction.
-         */
-        session->reconcile_timeline.total_reentry_hs_eviction_time +=
-          WT_CLOCKDIFF_MS(session->evict_timeline.reentry_hs_evict_finish,
-            session->evict_timeline.reentry_hs_evict_start);
-        session->evict_timeline.reentry_hs_eviction = false;
-    }
-}
-
 /*
  * __wt_evict --
  *     Evict a page.
@@ -178,15 +95,15 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_PAGE *page;
-    uint8_t stats_flags;
-    bool clean_page, closing, inmem_split, tree_dead, local_gen;
+    uint64_t eviction_time, eviction_time_seconds;
+    bool clean_page, closing, force_evict_hs, inmem_split, local_gen, tree_dead;
 
     conn = S2C(session);
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
-    stats_flags = 0;
+    force_evict_hs = false;
     local_gen = false;
-    clean_page = false;
+    eviction_time = eviction_time_seconds = 0;
 
     __wt_verbose(
       session, WT_VERB_EVICT, "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
@@ -204,19 +121,21 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         __wt_session_gen_enter(session, WT_GEN_EVICT);
     }
 
+    WT_CLEAR(session->reconcile_timeline);
+    WT_CLEAR(session->evict_timeline);
+    session->evict_timeline.evict_start = __wt_clock(session);
     /*
      * Immediately increment the forcible eviction counter, we might do an in-memory split and not
      * an eviction, which skips the other statistics.
      */
     if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
-        FLD_SET(stats_flags, WT_EVICT_STATS_URGENT);
         WT_STAT_CONN_INCR(session, cache_eviction_force);
 
         /*
          * Track history store pages being force evicted while holding a history store cursor open.
          */
         if (session->hs_cursor_counter > 0 && WT_IS_HS(session->dhandle)) {
-            FLD_SET(stats_flags, WT_EVICT_STATS_FORCE_HS);
+            force_evict_hs = true;
             WT_STAT_CONN_INCR(session, cache_eviction_force_hs);
         }
     }
@@ -284,10 +203,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
         conn->cache->evict_max_page_size = page->memory_footprint;
 
     /* Figure out whether reconciliation was done on the page */
-    if (__wt_page_evict_clean(page)) {
-        clean_page = true;
-        FLD_SET(stats_flags, WT_EVICT_STATS_CLEAN);
-    }
+    clean_page = __wt_page_evict_clean(page);
 
     /* Update the reference and discard the page. */
     if (__wt_ref_is_root(ref))
@@ -304,18 +220,59 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state, uint32
      * We have loaded the new disk image and updated the tree structure. We can no longer fail after
      * this point.
      */
+    session->evict_timeline.evict_finish = __wt_clock(session);
+    eviction_time =
+      WT_CLOCKDIFF_US(session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
+    if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+        if (force_evict_hs)
+            WT_STAT_CONN_INCR(session, cache_eviction_force_hs_success);
+        if (clean_page) {
+            WT_STAT_CONN_INCR(session, cache_eviction_force_clean);
+            WT_STAT_CONN_INCRV(session, cache_eviction_force_clean_time, eviction_time);
+        } else {
+            WT_STAT_CONN_INCR(session, cache_eviction_force_dirty);
+            WT_STAT_CONN_INCRV(session, cache_eviction_force_dirty_time, eviction_time);
+        }
+    }
+    if (clean_page)
+        WT_STAT_CONN_DATA_INCR(session, cache_eviction_clean);
+    else
+        WT_STAT_CONN_DATA_INCR(session, cache_eviction_dirty);
+
+    /* Count page evictions in parallel with checkpoint. */
+    if (conn->txn_global.checkpoint_running)
+        WT_STAT_CONN_INCR(session, cache_eviction_pages_in_parallel_with_checkpoint);
 
     if (0) {
 err:
         if (!closing)
             __evict_exclusive_clear(session, ref, previous_state);
+        session->evict_timeline.evict_finish = __wt_clock(session);
+        eviction_time = WT_CLOCKDIFF_US(
+          session->evict_timeline.evict_finish, session->evict_timeline.evict_start);
+        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+            if (force_evict_hs)
+                WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
+            WT_STAT_CONN_INCR(session, cache_eviction_force_fail);
+            WT_STAT_CONN_INCRV(session, cache_eviction_force_fail_time, eviction_time);
+        }
+
+        WT_STAT_CONN_DATA_INCR(session, cache_eviction_fail);
     }
 
 done:
-    if (ret == 0)
-        FLD_SET(stats_flags, WT_EVICT_STATS_SUCCESS);
-    __evict_stats_update(session, stats_flags);
-
+    eviction_time_seconds = eviction_time / WT_MILLION;
+    if (eviction_time_seconds > conn->cache->evict_max_seconds)
+        conn->cache->evict_max_seconds = eviction_time_seconds;
+    if (eviction_time_seconds > 60)
+        __wt_verbose_warning(session, WT_VERB_EVICT,
+          "Eviction took more than 1 minute (%" PRIu64 "). Building disk image took %" PRIu64
+          "us. History store wrapup took %" PRIu64 "us.",
+          eviction_time,
+          WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,
+            session->reconcile_timeline.image_build_start),
+          WT_CLOCKDIFF_US(session->reconcile_timeline.hs_wrapup_finish,
+            session->reconcile_timeline.hs_wrapup_start));
     /* Leave any local eviction generation. */
     if (local_gen)
         __wt_session_gen_leave(session, WT_GEN_EVICT);

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -97,9 +97,10 @@ struct __wt_cache {
     uint64_t app_waits;  /* User threads waited for cache */
     uint64_t app_evicts; /* Pages evicted by user threads */
 
-    uint64_t evict_max_page_size; /* Largest page seen at eviction */
-    uint64_t evict_max_seconds;   /* Longest seconds spent at a single eviction */
-    struct timespec stuck_time;   /* Stuck time */
+    uint64_t evict_max_page_size;    /* Largest page seen at eviction */
+    uint64_t evict_max_ms;           /* Longest milliseconds spent at a single eviction */
+    uint64_t reentry_hs_eviction_ms; /* Total milliseconds spent inside a nested eviction */
+    struct timespec stuck_time;      /* Stuck time */
 
     /*
      * Read information.

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -97,10 +97,9 @@ struct __wt_cache {
     uint64_t app_waits;  /* User threads waited for cache */
     uint64_t app_evicts; /* Pages evicted by user threads */
 
-    uint64_t evict_max_page_size;    /* Largest page seen at eviction */
-    uint64_t evict_max_ms;           /* Longest milliseconds spent at a single eviction */
-    uint64_t reentry_hs_eviction_ms; /* Total milliseconds spent inside a nested eviction */
-    struct timespec stuck_time;      /* Stuck time */
+    uint64_t evict_max_page_size; /* Largest page seen at eviction */
+    uint64_t evict_max_seconds;   /* Longest seconds spent at a single eviction */
+    struct timespec stuck_time;   /* Stuck time */
 
     /*
      * Read information.

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -398,11 +398,10 @@ struct __wt_connection_impl {
     uint32_t stat_flags; /* Options declared in flags.py */
 
     /* Connection statistics */
-    uint64_t rec_maximum_hs_wrapup_milliseconds; /* Maximum milliseconds moving updates to history
-                                                    store took. */
     uint64_t
-      rec_maximum_image_build_milliseconds; /* Maximum milliseconds building disk image took. */
-    uint64_t rec_maximum_milliseconds;      /* Maximum milliseconds reconciliation took. */
+      rec_maximum_hs_wrapup_seconds; /* Maximum seconds moving updates to history store took. */
+    uint64_t rec_maximum_image_build_seconds; /* Maximum seconds building disk image took. */
+    uint64_t rec_maximum_seconds;             /* Maximum seconds reconciliation took. */
     WT_CONNECTION_STATS *stats[WT_COUNTER_SLOTS];
     WT_CONNECTION_STATS *stat_array;
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -398,10 +398,11 @@ struct __wt_connection_impl {
     uint32_t stat_flags; /* Options declared in flags.py */
 
     /* Connection statistics */
+    uint64_t rec_maximum_hs_wrapup_milliseconds; /* Maximum milliseconds moving updates to history
+                                                    store took. */
     uint64_t
-      rec_maximum_hs_wrapup_seconds; /* Maximum seconds moving updates to history store took. */
-    uint64_t rec_maximum_image_build_seconds; /* Maximum seconds building disk image took. */
-    uint64_t rec_maximum_seconds;             /* Maximum seconds reconciliation took. */
+      rec_maximum_image_build_milliseconds; /* Maximum milliseconds building disk image took. */
+    uint64_t rec_maximum_milliseconds;      /* Maximum milliseconds reconciliation took. */
     WT_CONNECTION_STATS *stats[WT_COUNTER_SLOTS];
     WT_CONNECTION_STATS *stat_array;
 

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -144,6 +144,7 @@ struct __wt_session_impl {
         uint64_t hs_wrapup_start;
         uint64_t hs_wrapup_finish;
         uint64_t reconcile_finish;
+        uint64_t total_reentry_hs_eviction_time;
     } reconcile_timeline;
 
     /*
@@ -152,7 +153,10 @@ struct __wt_session_impl {
      */
     struct __wt_evict_timeline {
         uint64_t evict_start;
+        uint64_t reentry_hs_evict_start;
+        uint64_t reentry_hs_evict_finish;
         uint64_t evict_finish;
+        bool reentry_hs_eviction;
     } evict_timeline;
 
     WT_ITEM err; /* Error buffer */

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -144,7 +144,6 @@ struct __wt_session_impl {
         uint64_t hs_wrapup_start;
         uint64_t hs_wrapup_finish;
         uint64_t reconcile_finish;
-        uint64_t total_reentry_hs_eviction_time;
     } reconcile_timeline;
 
     /*
@@ -153,10 +152,7 @@ struct __wt_session_impl {
      */
     struct __wt_evict_timeline {
         uint64_t evict_start;
-        uint64_t reentry_hs_evict_start;
-        uint64_t reentry_hs_evict_finish;
         uint64_t evict_finish;
-        bool reentry_hs_eviction;
     } evict_timeline;
 
     WT_ITEM err; /* Error buffer */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -484,8 +484,8 @@ struct __wt_connection_stats {
     int64_t cache_eviction_split_internal;
     int64_t cache_eviction_split_leaf;
     int64_t cache_bytes_max;
+    int64_t cache_eviction_maximum_milliseconds;
     int64_t cache_eviction_maximum_page_size;
-    int64_t cache_eviction_maximum_seconds;
     int64_t cache_eviction_dirty;
     int64_t cache_eviction_app_dirty;
     int64_t cache_timed_out_ops;
@@ -517,6 +517,7 @@ struct __wt_connection_stats {
     int64_t cache_overhead;
     int64_t cache_hs_insert_full_update;
     int64_t cache_hs_insert_reverse_modify;
+    int64_t cache_reentry_hs_eviction_milliseconds;
     int64_t cache_bytes_internal;
     int64_t cache_bytes_leaf;
     int64_t cache_bytes_dirty;
@@ -706,9 +707,9 @@ struct __wt_connection_stats {
     int64_t rec_time_window_bytes_txn;
     int64_t rec_page_delete_fast;
     int64_t rec_overflow_key_leaf;
-    int64_t rec_maximum_seconds;
-    int64_t rec_maximum_image_build_seconds;
-    int64_t rec_maximum_hs_wrapup_seconds;
+    int64_t rec_maximum_milliseconds;
+    int64_t rec_maximum_image_build_milliseconds;
+    int64_t rec_maximum_hs_wrapup_milliseconds;
     int64_t rec_pages;
     int64_t rec_pages_eviction;
     int64_t rec_pages_with_prepare;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -484,8 +484,8 @@ struct __wt_connection_stats {
     int64_t cache_eviction_split_internal;
     int64_t cache_eviction_split_leaf;
     int64_t cache_bytes_max;
-    int64_t cache_eviction_maximum_milliseconds;
     int64_t cache_eviction_maximum_page_size;
+    int64_t cache_eviction_maximum_seconds;
     int64_t cache_eviction_dirty;
     int64_t cache_eviction_app_dirty;
     int64_t cache_timed_out_ops;
@@ -517,7 +517,6 @@ struct __wt_connection_stats {
     int64_t cache_overhead;
     int64_t cache_hs_insert_full_update;
     int64_t cache_hs_insert_reverse_modify;
-    int64_t cache_reentry_hs_eviction_milliseconds;
     int64_t cache_bytes_internal;
     int64_t cache_bytes_leaf;
     int64_t cache_bytes_dirty;
@@ -707,9 +706,9 @@ struct __wt_connection_stats {
     int64_t rec_time_window_bytes_txn;
     int64_t rec_page_delete_fast;
     int64_t rec_overflow_key_leaf;
-    int64_t rec_maximum_milliseconds;
-    int64_t rec_maximum_image_build_milliseconds;
-    int64_t rec_maximum_hs_wrapup_milliseconds;
+    int64_t rec_maximum_seconds;
+    int64_t rec_maximum_image_build_seconds;
+    int64_t rec_maximum_hs_wrapup_seconds;
     int64_t rec_pages;
     int64_t rec_pages_eviction;
     int64_t rec_pages_with_prepare;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5530,10 +5530,10 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1143
 /*! cache: maximum bytes configured */
 #define	WT_STAT_CONN_CACHE_BYTES_MAX			1144
+/*! cache: maximum milliseconds spent at a single eviction */
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1145
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1145
-/*! cache: maximum seconds spent at a single eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_SECONDS	1146
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1146
 /*! cache: modified pages evicted */
 #define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1147
 /*! cache: modified pages evicted by application threads */
@@ -5611,823 +5611,828 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1176
 /*! cache: the number of times reverse modify inserted to history store */
 #define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1177
+/*!
+ * cache: total milliseconds spent inside reentrant history store
+ * evictions in a reconciliation
+ */
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1178
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1178
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1179
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1179
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1180
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1180
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1181
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1181
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1182
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1182
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1183
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1183
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1184
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1184
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1185
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1185
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1186
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1186
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1187
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1187
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1188
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1188
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1189
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1189
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1190
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1190
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1191
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1191
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1192
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1192
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1193
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1193
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1194
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1194
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1195
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1195
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1196
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1196
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1197
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1197
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1198
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1198
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1199
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1199
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1200
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1200
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1201
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1201
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1202
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1202
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1203
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1203
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1204
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1204
+#define	WT_STAT_CONN_TIME_TRAVEL			1205
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1205
+#define	WT_STAT_CONN_FILE_OPEN				1206
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1206
+#define	WT_STAT_CONN_BUCKETS_DH				1207
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1207
+#define	WT_STAT_CONN_BUCKETS				1208
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1208
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1209
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1209
+#define	WT_STAT_CONN_MEMORY_FREE			1210
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1210
+#define	WT_STAT_CONN_MEMORY_GROW			1211
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1211
+#define	WT_STAT_CONN_COND_WAIT				1212
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1212
+#define	WT_STAT_CONN_RWLOCK_READ			1213
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1213
+#define	WT_STAT_CONN_RWLOCK_WRITE			1214
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1214
+#define	WT_STAT_CONN_FSYNC_IO				1215
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1215
+#define	WT_STAT_CONN_READ_IO				1216
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1216
+#define	WT_STAT_CONN_WRITE_IO				1217
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1217
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1218
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1218
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1219
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1219
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1220
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1220
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1221
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1221
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1222
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1222
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1223
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1223
+#define	WT_STAT_CONN_CURSOR_CACHE			1224
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1224
+#define	WT_STAT_CONN_CURSOR_CREATE			1225
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1225
+#define	WT_STAT_CONN_CURSOR_INSERT			1226
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1226
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1227
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1227
+#define	WT_STAT_CONN_CURSOR_MODIFY			1228
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1228
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1229
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1229
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1230
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1230
+#define	WT_STAT_CONN_CURSOR_NEXT			1231
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1231
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1232
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1232
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1233
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1233
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1234
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1234
+#define	WT_STAT_CONN_CURSOR_RESTART			1235
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1235
+#define	WT_STAT_CONN_CURSOR_PREV			1236
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1236
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1237
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1237
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1238
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1238
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1239
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1239
+#define	WT_STAT_CONN_CURSOR_REMOVE			1240
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1240
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1241
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1241
+#define	WT_STAT_CONN_CURSOR_RESERVE			1242
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1242
+#define	WT_STAT_CONN_CURSOR_RESET			1243
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1243
+#define	WT_STAT_CONN_CURSOR_SEARCH			1244
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1244
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1245
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1245
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1246
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1246
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1247
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1247
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1248
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1248
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1249
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1249
+#define	WT_STAT_CONN_CURSOR_SWEEP			1250
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1250
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1251
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1251
+#define	WT_STAT_CONN_CURSOR_UPDATE			1252
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1252
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1253
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1253
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1254
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1254
+#define	WT_STAT_CONN_CURSOR_REOPEN			1255
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1255
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1256
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1256
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1257
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1257
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1258
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1258
+#define	WT_STAT_CONN_DH_SWEEP_REF			1259
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1259
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1260
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1260
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1261
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1261
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1262
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1262
+#define	WT_STAT_CONN_DH_SWEEPS				1263
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1263
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1264
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1264
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1265
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1265
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1266
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1266
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1267
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1267
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1268
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1268
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1269
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1269
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1270
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1270
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1271
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1271
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1272
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1272
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1273
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1273
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1274
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1274
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1275
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1275
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1276
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1276
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1277
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1277
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1278
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1278
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1279
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1279
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1280
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1280
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1281
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1281
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1282
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1282
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1283
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1283
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1284
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1284
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1285
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1285
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1286
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1286
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1287
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1287
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1288
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1288
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1289
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1289
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1290
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1290
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1291
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1291
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1292
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1292
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1293
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1293
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1294
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1294
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1295
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1295
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1296
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1296
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1297
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1297
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1298
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1298
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1299
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1299
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1300
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1300
+#define	WT_STAT_CONN_LOG_FLUSH				1301
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1301
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1302
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1302
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1303
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1303
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1304
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1304
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1305
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1305
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1306
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1306
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1307
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1307
+#define	WT_STAT_CONN_LOG_SCANS				1308
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1308
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1309
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1309
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1310
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1310
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1311
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1311
+#define	WT_STAT_CONN_LOG_SYNC				1312
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1312
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1313
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1313
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1314
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1314
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1315
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1315
+#define	WT_STAT_CONN_LOG_WRITES				1316
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1316
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1317
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1317
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1318
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1318
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1319
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1319
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1320
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1320
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1321
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1321
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1322
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1322
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1323
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1323
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1324
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1324
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1325
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1325
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1326
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1326
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1327
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1327
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1328
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1328
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1329
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1329
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1330
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1330
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1331
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1331
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1332
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1332
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1333
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1333
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1334
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1334
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1335
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1335
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1336
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1336
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1337
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1337
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1338
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1338
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1339
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1339
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1340
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1340
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1341
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1341
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1342
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1342
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1343
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1343
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1344
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1344
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1345
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1345
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1346
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1346
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1347
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1347
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1348
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1348
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1349
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1349
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1350
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1350
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1351
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1351
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1352
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1352
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1353
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1353
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1354
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1354
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1355
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1355
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1356
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1356
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1357
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1357
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1358
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1358
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1359
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1359
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1360
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1360
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1361
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1361
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1362
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1362
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1363
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1363
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1364
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1364
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1365
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1365
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1366
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1366
-/*! reconciliation: maximum seconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_SECONDS		1367
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1367
+/*! reconciliation: maximum milliseconds spent in a reconciliation call */
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1368
 /*!
- * reconciliation: maximum seconds spent in building a disk image in a
- * reconciliation
+ * reconciliation: maximum milliseconds spent in building a disk image in
+ * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_SECONDS	1368
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1369
 /*!
- * reconciliation: maximum seconds spent in moving updates to the history
- * store in a reconciliation
+ * reconciliation: maximum milliseconds spent in moving updates to the
+ * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_SECONDS	1369
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1370
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1370
+#define	WT_STAT_CONN_REC_PAGES				1371
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1371
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1372
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1372
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1373
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1373
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1374
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1374
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1375
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1375
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1376
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1376
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1377
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1377
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1378
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1378
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1379
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1379
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1380
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1380
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1381
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1381
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1382
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1382
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1383
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1383
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1384
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1384
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1385
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1385
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1386
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1386
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1387
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1387
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1388
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1388
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1389
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1389
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1390
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1390
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1391
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1391
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1392
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1392
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1393
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1393
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1394
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1394
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1395
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1395
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1396
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1396
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1397
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1397
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1398
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1398
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1399
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1399
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1400
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1400
+#define	WT_STAT_CONN_FLUSH_TIER				1401
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1401
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1402
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1402
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1403
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1403
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1404
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1404
+#define	WT_STAT_CONN_SESSION_OPEN			1405
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1405
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1406
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1406
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1407
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1407
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1408
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1408
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1409
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1409
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1410
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1410
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1411
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1411
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1412
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1412
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1413
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1413
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1414
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1414
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1415
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1415
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1416
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1416
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1417
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1417
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1418
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1418
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1419
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1419
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1420
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1420
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1421
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1421
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1422
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1422
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1423
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1423
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1424
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1424
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1425
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1425
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1426
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1426
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1427
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1427
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1428
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1428
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1429
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1429
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1430
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1430
+#define	WT_STAT_CONN_TIERED_RETENTION			1431
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1431
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1432
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1432
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1433
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1433
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1434
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1434
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1435
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1435
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1436
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1436
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1437
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1437
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1438
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1438
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1439
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1439
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1440
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1440
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1441
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1441
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1442
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1442
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1443
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1443
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1444
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1444
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1445
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1445
+#define	WT_STAT_CONN_PAGE_SLEEP				1446
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1446
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1447
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1447
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1448
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1448
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1449
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1449
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1450
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1450
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1451
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1451
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1452
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1452
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1453
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1453
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1454
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1454
+#define	WT_STAT_CONN_TXN_PREPARE			1455
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1455
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1456
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1456
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1457
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1457
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1458
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1458
+#define	WT_STAT_CONN_TXN_QUERY_TS			1459
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1459
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1460
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1460
+#define	WT_STAT_CONN_TXN_RTS				1461
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1461
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1462
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1462
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1463
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1463
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1464
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1464
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1465
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1465
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1466
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1466
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1467
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1467
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1468
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1468
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1469
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1469
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1470
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1470
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1471
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1471
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1472
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1472
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1473
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1473
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1474
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1474
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1475
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1475
+#define	WT_STAT_CONN_TXN_SET_TS				1476
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1476
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1477
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1477
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1478
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1478
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1479
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1479
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1480
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1480
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1481
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1481
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1482
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1482
+#define	WT_STAT_CONN_TXN_BEGIN				1483
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1483
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1484
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1484
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1485
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1485
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1486
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1486
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1487
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1487
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1488
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1488
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1489
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1489
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1490
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1490
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1491
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1491
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1492
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1492
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1493
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1493
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1494
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1494
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1495
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1495
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1496
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1496
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1497
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1497
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1498
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1498
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1499
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1499
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1500
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1500
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1501
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1501
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1502
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1502
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1503
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1503
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1504
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1504
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1505
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1505
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1506
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1506
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1507
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1507
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1508
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1508
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1509
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1509
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1510
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1510
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1511
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1511
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1512
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1512
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1513
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1513
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1514
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1514
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1515
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1515
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1516
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1516
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1517
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1517
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1518
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1518
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1519
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1519
+#define	WT_STAT_CONN_TXN_COMMIT				1520
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1520
+#define	WT_STAT_CONN_TXN_ROLLBACK			1521
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1521
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1522
 
 /*!
  * @}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5530,10 +5530,10 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1143
 /*! cache: maximum bytes configured */
 #define	WT_STAT_CONN_CACHE_BYTES_MAX			1144
-/*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1145
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1146
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1145
+/*! cache: maximum seconds spent at a single eviction */
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_SECONDS	1146
 /*! cache: modified pages evicted */
 #define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1147
 /*! cache: modified pages evicted by application threads */
@@ -5611,828 +5611,823 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1176
 /*! cache: the number of times reverse modify inserted to history store */
 #define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1177
-/*!
- * cache: total milliseconds spent inside reentrant history store
- * evictions in a reconciliation
- */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1178
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1179
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1178
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1180
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1179
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1181
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1180
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1182
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1181
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1183
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1182
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1184
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1183
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1185
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1184
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1186
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1185
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1187
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1186
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1188
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1187
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1189
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1188
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1190
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1189
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1191
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1190
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1192
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1191
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1193
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1192
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1194
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1193
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1195
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1194
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1196
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1195
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1197
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1196
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1198
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1197
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1199
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1198
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1200
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1199
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1201
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1200
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1202
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1201
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1203
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1202
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1204
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1203
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1205
+#define	WT_STAT_CONN_TIME_TRAVEL			1204
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1206
+#define	WT_STAT_CONN_FILE_OPEN				1205
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1207
+#define	WT_STAT_CONN_BUCKETS_DH				1206
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1208
+#define	WT_STAT_CONN_BUCKETS				1207
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1209
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1208
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1210
+#define	WT_STAT_CONN_MEMORY_FREE			1209
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1211
+#define	WT_STAT_CONN_MEMORY_GROW			1210
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1212
+#define	WT_STAT_CONN_COND_WAIT				1211
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1213
+#define	WT_STAT_CONN_RWLOCK_READ			1212
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1214
+#define	WT_STAT_CONN_RWLOCK_WRITE			1213
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1215
+#define	WT_STAT_CONN_FSYNC_IO				1214
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1216
+#define	WT_STAT_CONN_READ_IO				1215
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1217
+#define	WT_STAT_CONN_WRITE_IO				1216
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1218
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1217
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1219
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1218
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1220
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1219
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1221
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1220
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1222
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1221
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1223
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1222
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1224
+#define	WT_STAT_CONN_CURSOR_CACHE			1223
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1225
+#define	WT_STAT_CONN_CURSOR_CREATE			1224
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1226
+#define	WT_STAT_CONN_CURSOR_INSERT			1225
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1227
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1226
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1228
+#define	WT_STAT_CONN_CURSOR_MODIFY			1227
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1229
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1228
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1230
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1229
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1231
+#define	WT_STAT_CONN_CURSOR_NEXT			1230
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1232
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1231
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1233
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1232
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1234
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1233
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1235
+#define	WT_STAT_CONN_CURSOR_RESTART			1234
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1236
+#define	WT_STAT_CONN_CURSOR_PREV			1235
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1237
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1236
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1238
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1237
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1239
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1238
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1240
+#define	WT_STAT_CONN_CURSOR_REMOVE			1239
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1241
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1240
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1242
+#define	WT_STAT_CONN_CURSOR_RESERVE			1241
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1243
+#define	WT_STAT_CONN_CURSOR_RESET			1242
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1244
+#define	WT_STAT_CONN_CURSOR_SEARCH			1243
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1245
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1244
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1246
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1245
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1247
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1246
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1248
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1247
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1249
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1248
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1250
+#define	WT_STAT_CONN_CURSOR_SWEEP			1249
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1251
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1250
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1252
+#define	WT_STAT_CONN_CURSOR_UPDATE			1251
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1253
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1252
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1254
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1253
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1255
+#define	WT_STAT_CONN_CURSOR_REOPEN			1254
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1256
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1255
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1257
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1256
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1258
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1257
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1259
+#define	WT_STAT_CONN_DH_SWEEP_REF			1258
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1260
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1259
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1261
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1260
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1262
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1261
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1263
+#define	WT_STAT_CONN_DH_SWEEPS				1262
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1264
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1263
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1265
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1264
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1266
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1265
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1267
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1266
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1268
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1267
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1269
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1268
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1270
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1269
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1271
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1270
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1272
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1271
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1273
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1272
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1274
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1273
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1275
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1274
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1276
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1275
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1277
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1276
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1278
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1277
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1279
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1278
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1280
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1279
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1281
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1280
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1282
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1281
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1283
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1282
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1284
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1283
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1285
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1284
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1286
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1285
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1287
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1286
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1288
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1287
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1289
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1288
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1290
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1289
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1291
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1290
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1292
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1291
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1293
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1292
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1294
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1293
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1295
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1294
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1296
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1295
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1297
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1296
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1298
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1297
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1299
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1298
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1300
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1299
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1301
+#define	WT_STAT_CONN_LOG_FLUSH				1300
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1302
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1301
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1303
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1302
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1304
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1303
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1305
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1304
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1306
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1305
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1307
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1306
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1308
+#define	WT_STAT_CONN_LOG_SCANS				1307
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1309
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1308
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1310
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1309
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1311
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1310
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1312
+#define	WT_STAT_CONN_LOG_SYNC				1311
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1313
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1312
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1314
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1313
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1315
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1314
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1316
+#define	WT_STAT_CONN_LOG_WRITES				1315
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1317
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1316
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1318
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1317
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1319
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1318
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1320
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1319
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1321
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1320
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1322
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1321
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1323
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1322
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1324
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1323
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1325
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1324
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1326
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1325
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1327
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1326
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1328
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1327
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1329
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1328
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1330
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1329
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1331
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1330
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1332
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1331
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1333
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1332
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1334
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1333
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1335
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1334
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1336
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1335
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1337
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1336
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1338
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1337
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1339
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1338
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1340
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1339
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1341
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1340
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1342
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1341
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1343
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1342
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1344
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1343
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1345
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1344
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1346
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1345
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1347
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1346
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1348
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1347
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1349
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1348
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1350
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1349
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1351
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1350
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1352
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1351
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1353
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1352
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1354
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1353
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1355
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1354
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1356
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1355
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1357
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1356
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1358
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1357
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1359
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1358
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1360
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1359
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1361
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1360
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1362
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1361
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1363
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1362
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1364
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1363
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1365
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1364
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1366
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1365
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1367
-/*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1368
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1366
+/*! reconciliation: maximum seconds spent in a reconciliation call */
+#define	WT_STAT_CONN_REC_MAXIMUM_SECONDS		1367
 /*!
- * reconciliation: maximum milliseconds spent in building a disk image in
- * a reconciliation
+ * reconciliation: maximum seconds spent in building a disk image in a
+ * reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1369
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_SECONDS	1368
 /*!
- * reconciliation: maximum milliseconds spent in moving updates to the
- * history store in a reconciliation
+ * reconciliation: maximum seconds spent in moving updates to the history
+ * store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1370
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_SECONDS	1369
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1371
+#define	WT_STAT_CONN_REC_PAGES				1370
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1372
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1371
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1373
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1372
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1374
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1373
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1375
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1374
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1376
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1375
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1377
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1376
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1378
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1377
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1379
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1378
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1380
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1379
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1381
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1380
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1382
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1381
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1383
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1382
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1384
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1383
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1385
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1384
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1386
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1385
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1387
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1386
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1388
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1387
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1389
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1388
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1390
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1389
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1391
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1390
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1392
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1391
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1393
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1392
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1394
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1393
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1395
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1394
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1396
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1395
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1397
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1396
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1398
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1397
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1399
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1398
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1400
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1399
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1401
+#define	WT_STAT_CONN_FLUSH_TIER				1400
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1402
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1401
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1403
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1402
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1404
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1403
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1405
+#define	WT_STAT_CONN_SESSION_OPEN			1404
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1406
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1405
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1407
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1406
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1408
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1407
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1409
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1408
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1410
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1409
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1411
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1410
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1412
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1411
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1413
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1412
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1414
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1413
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1415
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1414
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1416
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1415
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1417
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1416
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1418
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1417
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1419
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1418
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1420
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1419
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1421
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1420
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1422
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1421
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1423
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1422
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1424
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1423
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1425
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1424
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1426
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1425
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1427
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1426
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1428
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1427
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1429
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1428
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1430
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1429
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1431
+#define	WT_STAT_CONN_TIERED_RETENTION			1430
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1432
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1431
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1433
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1432
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1434
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1433
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1435
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1434
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1436
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1435
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1437
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1436
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1438
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1437
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1439
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1438
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1440
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1439
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1441
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1440
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1442
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1441
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1443
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1442
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1444
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1443
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1445
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1444
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1446
+#define	WT_STAT_CONN_PAGE_SLEEP				1445
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1447
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1446
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1448
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1447
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1449
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1448
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1450
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1449
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1451
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1450
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1452
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1451
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1453
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1452
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1454
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1453
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1455
+#define	WT_STAT_CONN_TXN_PREPARE			1454
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1456
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1455
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1457
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1456
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1458
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1457
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1459
+#define	WT_STAT_CONN_TXN_QUERY_TS			1458
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1460
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1459
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1461
+#define	WT_STAT_CONN_TXN_RTS				1460
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1462
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1461
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1463
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1462
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1464
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1463
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1465
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1464
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1466
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1465
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1467
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1466
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1468
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1467
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1469
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1468
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1470
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1469
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1471
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1470
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1472
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1471
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1473
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1472
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1474
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1473
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1475
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1474
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1476
+#define	WT_STAT_CONN_TXN_SET_TS				1475
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1477
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1476
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1478
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1477
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1479
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1478
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1480
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1479
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1481
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1480
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1482
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1481
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1483
+#define	WT_STAT_CONN_TXN_BEGIN				1482
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1484
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1483
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1485
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1484
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1486
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1485
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1487
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1486
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1488
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1487
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1489
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1488
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1490
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1489
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1491
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1490
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1492
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1491
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1493
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1492
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1494
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1493
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1495
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1494
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1496
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1495
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1497
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1496
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1498
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1497
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1499
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1498
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1500
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1499
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1501
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1500
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1502
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1501
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1503
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1502
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1504
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1503
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1505
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1504
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1506
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1505
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1507
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1506
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1508
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1507
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1509
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1508
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1510
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1509
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1511
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1510
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1512
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1511
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1513
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1512
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1514
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1513
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1515
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1514
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1516
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1515
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1517
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1516
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1518
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1517
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1519
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1518
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1520
+#define	WT_STAT_CONN_TXN_COMMIT				1519
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1521
+#define	WT_STAT_CONN_TXN_ROLLBACK			1520
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1522
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1521
 
 /*!
  * @}

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -111,21 +111,26 @@ err:
      * (it's just a statistic).
      */
     session->reconcile_timeline.reconcile_finish = __wt_clock(session);
-    if (WT_CLOCKDIFF_SEC(session->reconcile_timeline.hs_wrapup_finish,
-          session->reconcile_timeline.hs_wrapup_start) > conn->rec_maximum_hs_wrapup_seconds)
-        conn->rec_maximum_hs_wrapup_seconds =
-          WT_CLOCKDIFF_SEC(session->reconcile_timeline.hs_wrapup_finish,
+    if (WT_CLOCKDIFF_MS(session->reconcile_timeline.hs_wrapup_finish,
+          session->reconcile_timeline.hs_wrapup_start) > conn->rec_maximum_hs_wrapup_milliseconds)
+        conn->rec_maximum_hs_wrapup_milliseconds =
+          WT_CLOCKDIFF_MS(session->reconcile_timeline.hs_wrapup_finish,
             session->reconcile_timeline.hs_wrapup_start);
-    if (WT_CLOCKDIFF_SEC(session->reconcile_timeline.image_build_finish,
-          session->reconcile_timeline.image_build_start) > conn->rec_maximum_image_build_seconds)
-        conn->rec_maximum_image_build_seconds =
-          WT_CLOCKDIFF_SEC(session->reconcile_timeline.image_build_finish,
+    if (WT_CLOCKDIFF_MS(session->reconcile_timeline.image_build_finish,
+          session->reconcile_timeline.image_build_start) >
+      conn->rec_maximum_image_build_milliseconds)
+        conn->rec_maximum_image_build_milliseconds =
+          WT_CLOCKDIFF_MS(session->reconcile_timeline.image_build_finish,
             session->reconcile_timeline.image_build_start);
     if (WT_CLOCKDIFF_SEC(session->reconcile_timeline.reconcile_finish,
-          session->reconcile_timeline.reconcile_start) > conn->rec_maximum_seconds)
-        conn->rec_maximum_seconds = WT_CLOCKDIFF_SEC(session->reconcile_timeline.reconcile_finish,
-          session->reconcile_timeline.reconcile_start);
-
+          session->reconcile_timeline.reconcile_start) > conn->rec_maximum_milliseconds)
+        conn->rec_maximum_milliseconds =
+          WT_CLOCKDIFF_MS(session->reconcile_timeline.reconcile_finish,
+            session->reconcile_timeline.reconcile_start);
+    if (session->reconcile_timeline.total_reentry_hs_eviction_time >
+      conn->cache->reentry_hs_eviction_ms)
+        conn->cache->reentry_hs_eviction_ms =
+          session->reconcile_timeline.total_reentry_hs_eviction_time;
     return (ret);
 }
 
@@ -252,7 +257,9 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     WT_RET(__rec_init(session, ref, flags, salvage, &session->reconcile));
     r = session->reconcile;
 
-    session->reconcile_timeline.image_build_start = __wt_clock(session);
+    /* Only update if we are in the first entry into eviction. */
+    if (!session->evict_timeline.reentry_hs_eviction)
+        session->reconcile_timeline.image_build_start = __wt_clock(session);
 
     /* Reconcile the page. */
     switch (page->type) {
@@ -281,7 +288,8 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         break;
     }
 
-    session->reconcile_timeline.image_build_finish = __wt_clock(session);
+    if (!session->evict_timeline.reentry_hs_eviction)
+        session->reconcile_timeline.image_build_finish = __wt_clock(session);
 
     /*
      * If we failed, don't bail out yet; we still need to update stats and tidy up.

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -111,26 +111,21 @@ err:
      * (it's just a statistic).
      */
     session->reconcile_timeline.reconcile_finish = __wt_clock(session);
-    if (WT_CLOCKDIFF_MS(session->reconcile_timeline.hs_wrapup_finish,
-          session->reconcile_timeline.hs_wrapup_start) > conn->rec_maximum_hs_wrapup_milliseconds)
-        conn->rec_maximum_hs_wrapup_milliseconds =
-          WT_CLOCKDIFF_MS(session->reconcile_timeline.hs_wrapup_finish,
+    if (WT_CLOCKDIFF_SEC(session->reconcile_timeline.hs_wrapup_finish,
+          session->reconcile_timeline.hs_wrapup_start) > conn->rec_maximum_hs_wrapup_seconds)
+        conn->rec_maximum_hs_wrapup_seconds =
+          WT_CLOCKDIFF_SEC(session->reconcile_timeline.hs_wrapup_finish,
             session->reconcile_timeline.hs_wrapup_start);
-    if (WT_CLOCKDIFF_MS(session->reconcile_timeline.image_build_finish,
-          session->reconcile_timeline.image_build_start) >
-      conn->rec_maximum_image_build_milliseconds)
-        conn->rec_maximum_image_build_milliseconds =
-          WT_CLOCKDIFF_MS(session->reconcile_timeline.image_build_finish,
+    if (WT_CLOCKDIFF_SEC(session->reconcile_timeline.image_build_finish,
+          session->reconcile_timeline.image_build_start) > conn->rec_maximum_image_build_seconds)
+        conn->rec_maximum_image_build_seconds =
+          WT_CLOCKDIFF_SEC(session->reconcile_timeline.image_build_finish,
             session->reconcile_timeline.image_build_start);
     if (WT_CLOCKDIFF_SEC(session->reconcile_timeline.reconcile_finish,
-          session->reconcile_timeline.reconcile_start) > conn->rec_maximum_milliseconds)
-        conn->rec_maximum_milliseconds =
-          WT_CLOCKDIFF_MS(session->reconcile_timeline.reconcile_finish,
-            session->reconcile_timeline.reconcile_start);
-    if (session->reconcile_timeline.total_reentry_hs_eviction_time >
-      conn->cache->reentry_hs_eviction_ms)
-        conn->cache->reentry_hs_eviction_ms =
-          session->reconcile_timeline.total_reentry_hs_eviction_time;
+          session->reconcile_timeline.reconcile_start) > conn->rec_maximum_seconds)
+        conn->rec_maximum_seconds = WT_CLOCKDIFF_SEC(session->reconcile_timeline.reconcile_finish,
+          session->reconcile_timeline.reconcile_start);
+
     return (ret);
 }
 
@@ -257,9 +252,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     WT_RET(__rec_init(session, ref, flags, salvage, &session->reconcile));
     r = session->reconcile;
 
-    /* Only update if we are in the first entry into eviction. */
-    if (!session->evict_timeline.reentry_hs_eviction)
-        session->reconcile_timeline.image_build_start = __wt_clock(session);
+    session->reconcile_timeline.image_build_start = __wt_clock(session);
 
     /* Reconcile the page. */
     switch (page->type) {
@@ -288,8 +281,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         break;
     }
 
-    if (!session->evict_timeline.reentry_hs_eviction)
-        session->reconcile_timeline.image_build_finish = __wt_clock(session);
+    session->reconcile_timeline.image_build_finish = __wt_clock(session);
 
     /*
      * If we failed, don't bail out yet; we still need to update stats and tidy up.

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1220,8 +1220,8 @@ static const char *const __stats_connection_desc[] = {
   "cache: internal pages split during eviction",
   "cache: leaf pages split during eviction",
   "cache: maximum bytes configured",
+  "cache: maximum milliseconds spent at a single eviction",
   "cache: maximum page size seen at eviction",
-  "cache: maximum seconds spent at a single eviction",
   "cache: modified pages evicted",
   "cache: modified pages evicted by application threads",
   "cache: operations timed out waiting for space in cache",
@@ -1255,6 +1255,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: percentage overhead",
   "cache: the number of times full update inserted to history store",
   "cache: the number of times reverse modify inserted to history store",
+  "cache: total milliseconds spent inside reentrant history store evictions in a reconciliation",
   "cache: tracked bytes belonging to internal pages in the cache",
   "cache: tracked bytes belonging to leaf pages in the cache",
   "cache: tracked dirty bytes in the cache",
@@ -1444,9 +1445,9 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: approximate byte size of transaction IDs in pages written",
   "reconciliation: fast-path pages deleted",
   "reconciliation: leaf-page overflow keys",
-  "reconciliation: maximum seconds spent in a reconciliation call",
-  "reconciliation: maximum seconds spent in building a disk image in a reconciliation",
-  "reconciliation: maximum seconds spent in moving updates to the history store in a "
+  "reconciliation: maximum milliseconds spent in a reconciliation call",
+  "reconciliation: maximum milliseconds spent in building a disk image in a reconciliation",
+  "reconciliation: maximum milliseconds spent in moving updates to the history store in a "
   "reconciliation",
   "reconciliation: page reconciliation calls",
   "reconciliation: page reconciliation calls for eviction",
@@ -1788,8 +1789,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_eviction_split_internal = 0;
     stats->cache_eviction_split_leaf = 0;
     /* not clearing cache_bytes_max */
+    /* not clearing cache_eviction_maximum_milliseconds */
     /* not clearing cache_eviction_maximum_page_size */
-    /* not clearing cache_eviction_maximum_seconds */
     stats->cache_eviction_dirty = 0;
     stats->cache_eviction_app_dirty = 0;
     stats->cache_timed_out_ops = 0;
@@ -1821,6 +1822,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing cache_overhead */
     stats->cache_hs_insert_full_update = 0;
     stats->cache_hs_insert_reverse_modify = 0;
+    /* not clearing cache_reentry_hs_eviction_milliseconds */
     /* not clearing cache_bytes_internal */
     /* not clearing cache_bytes_leaf */
     /* not clearing cache_bytes_dirty */
@@ -2010,9 +2012,9 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->rec_time_window_bytes_txn = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_overflow_key_leaf = 0;
-    /* not clearing rec_maximum_seconds */
-    /* not clearing rec_maximum_image_build_seconds */
-    /* not clearing rec_maximum_hs_wrapup_seconds */
+    /* not clearing rec_maximum_milliseconds */
+    /* not clearing rec_maximum_image_build_milliseconds */
+    /* not clearing rec_maximum_hs_wrapup_milliseconds */
     stats->rec_pages = 0;
     stats->rec_pages_eviction = 0;
     stats->rec_pages_with_prepare = 0;
@@ -2347,8 +2349,9 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_split_internal += WT_STAT_READ(from, cache_eviction_split_internal);
     to->cache_eviction_split_leaf += WT_STAT_READ(from, cache_eviction_split_leaf);
     to->cache_bytes_max += WT_STAT_READ(from, cache_bytes_max);
+    to->cache_eviction_maximum_milliseconds +=
+      WT_STAT_READ(from, cache_eviction_maximum_milliseconds);
     to->cache_eviction_maximum_page_size += WT_STAT_READ(from, cache_eviction_maximum_page_size);
-    to->cache_eviction_maximum_seconds += WT_STAT_READ(from, cache_eviction_maximum_seconds);
     to->cache_eviction_dirty += WT_STAT_READ(from, cache_eviction_dirty);
     to->cache_eviction_app_dirty += WT_STAT_READ(from, cache_eviction_app_dirty);
     to->cache_timed_out_ops += WT_STAT_READ(from, cache_timed_out_ops);
@@ -2389,6 +2392,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_overhead += WT_STAT_READ(from, cache_overhead);
     to->cache_hs_insert_full_update += WT_STAT_READ(from, cache_hs_insert_full_update);
     to->cache_hs_insert_reverse_modify += WT_STAT_READ(from, cache_hs_insert_reverse_modify);
+    to->cache_reentry_hs_eviction_milliseconds +=
+      WT_STAT_READ(from, cache_reentry_hs_eviction_milliseconds);
     to->cache_bytes_internal += WT_STAT_READ(from, cache_bytes_internal);
     to->cache_bytes_leaf += WT_STAT_READ(from, cache_bytes_leaf);
     to->cache_bytes_dirty += WT_STAT_READ(from, cache_bytes_dirty);
@@ -2583,9 +2588,11 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_time_window_bytes_txn += WT_STAT_READ(from, rec_time_window_bytes_txn);
     to->rec_page_delete_fast += WT_STAT_READ(from, rec_page_delete_fast);
     to->rec_overflow_key_leaf += WT_STAT_READ(from, rec_overflow_key_leaf);
-    to->rec_maximum_seconds += WT_STAT_READ(from, rec_maximum_seconds);
-    to->rec_maximum_image_build_seconds += WT_STAT_READ(from, rec_maximum_image_build_seconds);
-    to->rec_maximum_hs_wrapup_seconds += WT_STAT_READ(from, rec_maximum_hs_wrapup_seconds);
+    to->rec_maximum_milliseconds += WT_STAT_READ(from, rec_maximum_milliseconds);
+    to->rec_maximum_image_build_milliseconds +=
+      WT_STAT_READ(from, rec_maximum_image_build_milliseconds);
+    to->rec_maximum_hs_wrapup_milliseconds +=
+      WT_STAT_READ(from, rec_maximum_hs_wrapup_milliseconds);
     to->rec_pages += WT_STAT_READ(from, rec_pages);
     to->rec_pages_eviction += WT_STAT_READ(from, rec_pages_eviction);
     to->rec_pages_with_prepare += WT_STAT_READ(from, rec_pages_with_prepare);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1220,8 +1220,8 @@ static const char *const __stats_connection_desc[] = {
   "cache: internal pages split during eviction",
   "cache: leaf pages split during eviction",
   "cache: maximum bytes configured",
-  "cache: maximum milliseconds spent at a single eviction",
   "cache: maximum page size seen at eviction",
+  "cache: maximum seconds spent at a single eviction",
   "cache: modified pages evicted",
   "cache: modified pages evicted by application threads",
   "cache: operations timed out waiting for space in cache",
@@ -1255,7 +1255,6 @@ static const char *const __stats_connection_desc[] = {
   "cache: percentage overhead",
   "cache: the number of times full update inserted to history store",
   "cache: the number of times reverse modify inserted to history store",
-  "cache: total milliseconds spent inside reentrant history store evictions in a reconciliation",
   "cache: tracked bytes belonging to internal pages in the cache",
   "cache: tracked bytes belonging to leaf pages in the cache",
   "cache: tracked dirty bytes in the cache",
@@ -1445,9 +1444,9 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: approximate byte size of transaction IDs in pages written",
   "reconciliation: fast-path pages deleted",
   "reconciliation: leaf-page overflow keys",
-  "reconciliation: maximum milliseconds spent in a reconciliation call",
-  "reconciliation: maximum milliseconds spent in building a disk image in a reconciliation",
-  "reconciliation: maximum milliseconds spent in moving updates to the history store in a "
+  "reconciliation: maximum seconds spent in a reconciliation call",
+  "reconciliation: maximum seconds spent in building a disk image in a reconciliation",
+  "reconciliation: maximum seconds spent in moving updates to the history store in a "
   "reconciliation",
   "reconciliation: page reconciliation calls",
   "reconciliation: page reconciliation calls for eviction",
@@ -1789,8 +1788,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_eviction_split_internal = 0;
     stats->cache_eviction_split_leaf = 0;
     /* not clearing cache_bytes_max */
-    /* not clearing cache_eviction_maximum_milliseconds */
     /* not clearing cache_eviction_maximum_page_size */
+    /* not clearing cache_eviction_maximum_seconds */
     stats->cache_eviction_dirty = 0;
     stats->cache_eviction_app_dirty = 0;
     stats->cache_timed_out_ops = 0;
@@ -1822,7 +1821,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing cache_overhead */
     stats->cache_hs_insert_full_update = 0;
     stats->cache_hs_insert_reverse_modify = 0;
-    /* not clearing cache_reentry_hs_eviction_milliseconds */
     /* not clearing cache_bytes_internal */
     /* not clearing cache_bytes_leaf */
     /* not clearing cache_bytes_dirty */
@@ -2012,9 +2010,9 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->rec_time_window_bytes_txn = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_overflow_key_leaf = 0;
-    /* not clearing rec_maximum_milliseconds */
-    /* not clearing rec_maximum_image_build_milliseconds */
-    /* not clearing rec_maximum_hs_wrapup_milliseconds */
+    /* not clearing rec_maximum_seconds */
+    /* not clearing rec_maximum_image_build_seconds */
+    /* not clearing rec_maximum_hs_wrapup_seconds */
     stats->rec_pages = 0;
     stats->rec_pages_eviction = 0;
     stats->rec_pages_with_prepare = 0;
@@ -2349,9 +2347,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_split_internal += WT_STAT_READ(from, cache_eviction_split_internal);
     to->cache_eviction_split_leaf += WT_STAT_READ(from, cache_eviction_split_leaf);
     to->cache_bytes_max += WT_STAT_READ(from, cache_bytes_max);
-    to->cache_eviction_maximum_milliseconds +=
-      WT_STAT_READ(from, cache_eviction_maximum_milliseconds);
     to->cache_eviction_maximum_page_size += WT_STAT_READ(from, cache_eviction_maximum_page_size);
+    to->cache_eviction_maximum_seconds += WT_STAT_READ(from, cache_eviction_maximum_seconds);
     to->cache_eviction_dirty += WT_STAT_READ(from, cache_eviction_dirty);
     to->cache_eviction_app_dirty += WT_STAT_READ(from, cache_eviction_app_dirty);
     to->cache_timed_out_ops += WT_STAT_READ(from, cache_timed_out_ops);
@@ -2392,8 +2389,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_overhead += WT_STAT_READ(from, cache_overhead);
     to->cache_hs_insert_full_update += WT_STAT_READ(from, cache_hs_insert_full_update);
     to->cache_hs_insert_reverse_modify += WT_STAT_READ(from, cache_hs_insert_reverse_modify);
-    to->cache_reentry_hs_eviction_milliseconds +=
-      WT_STAT_READ(from, cache_reentry_hs_eviction_milliseconds);
     to->cache_bytes_internal += WT_STAT_READ(from, cache_bytes_internal);
     to->cache_bytes_leaf += WT_STAT_READ(from, cache_bytes_leaf);
     to->cache_bytes_dirty += WT_STAT_READ(from, cache_bytes_dirty);
@@ -2588,11 +2583,9 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_time_window_bytes_txn += WT_STAT_READ(from, rec_time_window_bytes_txn);
     to->rec_page_delete_fast += WT_STAT_READ(from, rec_page_delete_fast);
     to->rec_overflow_key_leaf += WT_STAT_READ(from, rec_overflow_key_leaf);
-    to->rec_maximum_milliseconds += WT_STAT_READ(from, rec_maximum_milliseconds);
-    to->rec_maximum_image_build_milliseconds +=
-      WT_STAT_READ(from, rec_maximum_image_build_milliseconds);
-    to->rec_maximum_hs_wrapup_milliseconds +=
-      WT_STAT_READ(from, rec_maximum_hs_wrapup_milliseconds);
+    to->rec_maximum_seconds += WT_STAT_READ(from, rec_maximum_seconds);
+    to->rec_maximum_image_build_seconds += WT_STAT_READ(from, rec_maximum_image_build_seconds);
+    to->rec_maximum_hs_wrapup_seconds += WT_STAT_READ(from, rec_maximum_hs_wrapup_seconds);
     to->rec_pages += WT_STAT_READ(from, rec_pages);
     to->rec_pages_eviction += WT_STAT_READ(from, rec_pages_eviction);
     to->rec_pages_with_prepare += WT_STAT_READ(from, rec_pages_with_prepare);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -833,11 +833,10 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Reset the statistics tracked per checkpoint. */
     cache->evict_max_page_size = 0;
-    cache->evict_max_ms = 0;
-    cache->reentry_hs_eviction_ms = 0;
-    conn->rec_maximum_hs_wrapup_milliseconds = 0;
-    conn->rec_maximum_image_build_milliseconds = 0;
-    conn->rec_maximum_milliseconds = 0;
+    cache->evict_max_seconds = 0;
+    conn->rec_maximum_hs_wrapup_seconds = 0;
+    conn->rec_maximum_image_build_seconds = 0;
+    conn->rec_maximum_seconds = 0;
 
     /* Initialize the verbose tracking timer */
     __wt_epoch(session, &conn->ckpt_timer_start);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -833,10 +833,11 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Reset the statistics tracked per checkpoint. */
     cache->evict_max_page_size = 0;
-    cache->evict_max_seconds = 0;
-    conn->rec_maximum_hs_wrapup_seconds = 0;
-    conn->rec_maximum_image_build_seconds = 0;
-    conn->rec_maximum_seconds = 0;
+    cache->evict_max_ms = 0;
+    cache->reentry_hs_eviction_ms = 0;
+    conn->rec_maximum_hs_wrapup_milliseconds = 0;
+    conn->rec_maximum_image_build_milliseconds = 0;
+    conn->rec_maximum_milliseconds = 0;
 
     /* Initialize the verbose tracking timer */
     __wt_epoch(session, &conn->ckpt_timer_start);


### PR DESCRIPTION
v6.0 does not have split generation or some of the macros so I have kept the `local_gen` variable. 
Please review if the changes are appropriate for 6.0. 