### PR TITLE
WT-11181 Fix errors in block open and close

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -113,23 +113,12 @@ err:
 int
 __wt_block_close(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    uint64_t bucket, hash;
-
-    conn = S2C(session);
 
     if (block == NULL) /* Safety check, if failed to initialize. */
         return (0);
 
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s", block->name == NULL ? "" : block->name);
-
-    /* If we failed during allocation, the block won't have been linked. */
-    if (block->linked) {
-        hash = __wt_hash_city64(block->name, strlen(block->name));
-        bucket = hash & (conn->hash_size - 1);
-        WT_CONN_BLOCK_REMOVE(conn, block, bucket);
-    }
 
     __wt_free(session, block->name);
 
@@ -201,8 +190,6 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     WT_ERR(__wt_strdup(session, filename, &block->name));
     block->objectid = objectid;
     block->ref = 1;
-    WT_CONN_BLOCK_INSERT(conn, block, bucket);
-    block->linked = true;
 
     /* If not passed an allocation size, get one from the configuration. */
     if (allocsize == 0) {
@@ -272,6 +259,9 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
      */
     if (!forced_salvage)
         WT_ERR(__desc_read(session, allocsize, block));
+
+    /* Block is valid, so make it visible in the connection. */
+    WT_CONN_BLOCK_INSERT(conn, block, bucket);
 
     __wt_spin_unlock(session, &conn->block_lock);
 

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -240,7 +240,6 @@ struct __wt_block {
 
     TAILQ_ENTRY(__wt_block) q;     /* Linked list of handles */
     TAILQ_ENTRY(__wt_block) hashq; /* Hashed list of handles */
-    bool linked;
 
     WT_FH *fh;            /* Backing file handle */
     wt_off_t size;        /* File size */


### PR DESCRIPTION
Fix race condition where blocks with a non-zero ref count could be freed.

Fix race condition where block from a failed open could be acquired and then freed with a non-zero ref count.

Fix potential corruption of block lists in connection, due to modification without holding the associated lock.

(cherry picked from commit d69e7c31e723ba9916e234996f6991e355356600)