### PR TITLE
WT-11267 Disable failing tests after Python 3.9.5 upgrade

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3440,7 +3440,8 @@ tasks:
       - func: "code coverage publish summary"
 
   - name: s3-tiered-storage-extensions-test
-    tags: ["python"]
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # tags: ["python"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -3459,7 +3460,8 @@ tasks:
           python_binary: $(pwd)/venv/bin/python3
           tiered_storage_test_name: tiered
   - name: s3-tiered-test-small
-    tags: ["pull_request", "python"]
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # tags: ["pull_request", "python"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -3492,7 +3494,8 @@ tasks:
             # Run S3 extension unit testing.
             ext/storage_sources/s3_store/test/run_s3_unit_tests
   - name: azure-gcp-tiered-storage-extensions-test
-    tags: ["python"]
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # tags: ["python"]
     commands:
       - func: "get project"
       - func: "install gcp dependencies"
@@ -3543,7 +3546,8 @@ tasks:
             ext/storage_sources/azure_store/test/run_azure_unit_tests
 
   - name: azure-gcp-tiered-test-small
-    tags: ["pull_request", "python"]
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # tags: ["pull_request", "python"]
     commands:
       - func: "get project"
       - func: "install gcp dependencies"
@@ -5555,8 +5559,9 @@ buildvariants:
     - name: format-failure-configs-test
     - name: ".data-validation-stress-test"
     - name: unittest-test
-    - name: s3-tiered-storage-extensions-test
-    - name: azure-gcp-tiered-storage-extensions-test
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # - name: s3-tiered-storage-extensions-test
+    # - name: azure-gcp-tiered-storage-extensions-test
     - name: bench-tiered-push-pull
     - name: compile-nonstandalone
     - name: make-check-nonstandalone
@@ -5720,11 +5725,13 @@ buildvariants:
     - name: ".stress-test-4-nonstandalone"
     - name: ".stress-test-no-barrier-nonstandalone"
     - name: format-abort-recovery-stress-test-nonstandalone
-    - name: format-predictable-test
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # - name: format-predictable-test
     # FIXME-WT-10822
     # - name: format-tiered-test
-    - name: schema-abort-predictable-test
-    - name: checkpoint-filetypes-predictable-test
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # - name: schema-abort-predictable-test
+    # - name: checkpoint-filetypes-predictable-test
 
 
 # When running the Python tests on this variant tcmalloc must be preloaded otherwise the wiredtiger library
@@ -6050,7 +6057,8 @@ buildvariants:
     - name: long-test
     - name: configure-combinations
     - name: format-smoke-test
-    - name: s3-tiered-storage-extensions-test
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # - name: s3-tiered-storage-extensions-test
     - name: compile-nonstandalone
     - name: make-check-nonstandalone
     - name: unit-test-nonstandalone
@@ -6095,7 +6103,8 @@ buildvariants:
     - name: ftruncate-test
     - name: long-test
     - name: format-smoke-test
-    - name: s3-tiered-storage-extensions-test
+    # FIXME-WT-11226 - re-enable when tests can handle Python 3.9.5 on the platforms
+    # - name: s3-tiered-storage-extensions-test
     - name: compile-nonstandalone
     - name: make-check-nonstandalone
     - name: unit-test-nonstandalone


### PR DESCRIPTION
Disable tests that are failing in WT-11226 until WT-11226 is resolved.
@lukech I'll also open a backport ticket for 7.0, and possibly older branches if we see this occur