### PR TITLE
WT-8728 Remove FIXME comment regarding tiered storage and memory mapped files

### DIFF
--- a/src/block_cache/block_map.c
+++ b/src/block_cache/block_map.c
@@ -94,7 +94,7 @@ __wt_blkcache_map_read(
 
     bm = S2BT(session)->bm;
 
-    if (!bm->map) /* FIXME WT-8728. */
+    if (!bm->map)
         return (0);
 
     WT_ASSERT(session, !bm->is_multi_handle);


### PR DESCRIPTION
WT-8728 was closed as "Won't Do" but there is a FIXME comment in the code base. Using the ticket to remove it.