### PR TITLE
WT-11241 Skip current transaction snap_min visible deleted pages as part of the tree walk

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2350,7 +2350,8 @@ __wt_btcur_skip_page(
          * point added to the page during the last reconciliation.
          */
         if (addr.ta.newest_stop_txn != WT_TXN_MAX && addr.ta.newest_stop_ts != WT_TS_MAX &&
-          __wt_txn_visible_all(session, addr.ta.newest_stop_txn, addr.ta.newest_stop_durable_ts)) {
+          __wt_txn_snap_min_visible(session, addr.ta.newest_stop_txn, addr.ta.newest_stop_ts,
+            addr.ta.newest_stop_durable_ts)) {
             *skipp = true;
             goto unlock;
         }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2350,8 +2350,7 @@ __wt_btcur_skip_page(
          * point added to the page during the last reconciliation.
          */
         if (addr.ta.newest_stop_txn != WT_TXN_MAX && addr.ta.newest_stop_ts != WT_TS_MAX &&
-          __wt_txn_visible(session, addr.ta.newest_stop_txn, addr.ta.newest_stop_ts,
-            addr.ta.newest_stop_durable_ts)) {
+          __wt_txn_visible_all(session, addr.ta.newest_stop_txn, addr.ta.newest_stop_durable_ts)) {
             *skipp = true;
             goto unlock;
         }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2095,6 +2095,12 @@ static inline bool __wt_spin_owned(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_split_descent_race(WT_SESSION_IMPL *session, WT_REF *ref,
   WT_PAGE_INDEX *saved_pindex) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_txn_snap_min_visible(
+  WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_txn_timestamp_visible(
+  WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2098,9 +2098,8 @@ static inline bool __wt_split_descent_race(WT_SESSION_IMPL *session, WT_REF *ref
 static inline bool __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline bool __wt_txn_timestamp_visible(
-  WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_txn_timestamp_visible(WT_SESSION_IMPL *session, wt_timestamp_t timestamp,
+  wt_timestamp_t durable_timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -793,11 +793,11 @@ __txn_visible_id(WT_SESSION_IMPL *session, uint64_t id)
 }
 
 /*
- * __wt_txn_visible --
- *     Can the current transaction see the given ID / timestamp?
+ * __wt_txn_timestamp_visible --
+ *     Can the current transaction can see the given timestamp?
  */
 static inline bool
-__wt_txn_visible(
+__wt_txn_timestamp_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
 {
     WT_TXN *txn;
@@ -805,9 +805,6 @@ __wt_txn_visible(
 
     txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
-
-    if (!__txn_visible_id(session, id))
-        return (false);
 
     /* Transactions read their writes, regardless of timestamps. */
     if (F_ISSET(session->txn, WT_TXN_HAS_ID) && id == session->txn->id)
@@ -830,6 +827,37 @@ __wt_txn_visible(
           (durable_timestamp <= txn->checkpoint_stable_timestamp));
 
     return (timestamp <= txn_shared->read_timestamp);
+}
+
+/*
+ * __wt_txn_snap_min_visible --
+ *     Can the current transaction snapshot minimum/read timestamp see the given ID/timestamp?
+ */
+static inline bool
+__wt_txn_snap_min_visible(
+  WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
+{
+    /* Transaction snapshot minimum check. */
+    if (!WT_TXNID_LT(id, session->txn->snap_min))
+        return (false);
+
+    /* Timestamp check. */
+    return (__wt_txn_timestamp_visible(session, id, timestamp, durable_timestamp));
+}
+
+/*
+ * __wt_txn_visible --
+ *     Can the current transaction see the given ID/timestamp?
+ */
+static inline bool
+__wt_txn_visible(
+  WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
+{
+    if (!__txn_visible_id(session, id))
+        return (false);
+
+    /* Timestamp check. */
+    return (__wt_txn_timestamp_visible(session, id, timestamp, durable_timestamp));
 }
 
 /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -794,21 +794,17 @@ __txn_visible_id(WT_SESSION_IMPL *session, uint64_t id)
 
 /*
  * __wt_txn_timestamp_visible --
- *     Can the current transaction can see the given timestamp?
+ *     Can the current transaction see the given timestamp?
  */
 static inline bool
 __wt_txn_timestamp_visible(
-  WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
+  WT_SESSION_IMPL *session, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
 {
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
 
     txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
-
-    /* Transactions read their writes, regardless of timestamps. */
-    if (F_ISSET(session->txn, WT_TXN_HAS_ID) && id == session->txn->id)
-        return (true);
 
     /* Timestamp check. */
     if (!F_ISSET(txn, WT_TXN_SHARED_TS_READ) || timestamp == WT_TS_NONE)
@@ -831,7 +827,9 @@ __wt_txn_timestamp_visible(
 
 /*
  * __wt_txn_snap_min_visible --
- *     Can the current transaction snapshot minimum/read timestamp see the given ID/timestamp?
+ *     Can the current transaction snapshot minimum/read timestamp see the given ID/timestamp? This
+ *     visibility check should only be used when assessing broader visibility based on aggregated
+ *     time window. It does not reflect whether a specific update is visible to a transaction.
  */
 static inline bool
 __wt_txn_snap_min_visible(
@@ -841,8 +839,12 @@ __wt_txn_snap_min_visible(
     if (!WT_TXNID_LT(id, session->txn->snap_min))
         return (false);
 
+    /* Transactions read their writes, regardless of timestamps. */
+    if (F_ISSET(session->txn, WT_TXN_HAS_ID) && id == session->txn->id)
+        return (true);
+
     /* Timestamp check. */
-    return (__wt_txn_timestamp_visible(session, id, timestamp, durable_timestamp));
+    return (__wt_txn_timestamp_visible(session, timestamp, durable_timestamp));
 }
 
 /*
@@ -856,8 +858,12 @@ __wt_txn_visible(
     if (!__txn_visible_id(session, id))
         return (false);
 
+    /* Transactions read their writes, regardless of timestamps. */
+    if (F_ISSET(session->txn, WT_TXN_HAS_ID) && id == session->txn->id)
+        return (true);
+
     /* Timestamp check. */
-    return (__wt_txn_timestamp_visible(session, id, timestamp, durable_timestamp));
+    return (__wt_txn_timestamp_visible(session, timestamp, durable_timestamp));
 }
 
 /*

--- a/test/suite/test_checkpoint30.py
+++ b/test/suite/test_checkpoint30.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading, time
+import wttest
+import wiredtiger
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_checkpoint30.py
+#
+# Test reading a cursor when the aggregate time window is visible to the snapshot
+# but not all deleted keys on-disk version are not visible.
+class test_checkpoint(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=50MB,statistics=(all)'
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='S', extraconfig='')),
+        ('string_row', dict(key_format='S', value_format='S', extraconfig='')),
+    ]
+    scenarios = make_scenarios(format_values)
+
+    def large_updates(self, uri, ds, nrows, value, ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = value
+            if i % 101 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        cursor.close()
+
+    def large_removes(self, uri, ds, start_row, nrows, ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        for i in range(start_row, nrows + 1):
+            cursor.set_key(ds.key(i))
+            cursor.remove()
+            if i % 101 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        cursor.close()
+
+    def evict(self, ds, lo, hi, value, ts):
+        evict_cursor = self.session.open_cursor(ds.uri, None, "debug=(release_evict)")
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(ts))
+        # Evict every 10th key. FUTURE: when that's possible, evict each page exactly once.
+        for k in range(lo, hi, 10):
+            v = evict_cursor[ds.key(k)]
+            self.assertEqual(v, value)
+            self.assertEqual(evict_cursor.reset(), 0)
+        self.session.rollback_transaction()
+
+    def check(self, session_local, ds, nrows, value, ts):
+        cursor = session_local.open_cursor(ds.uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, value)
+            count += 1
+        self.assertEqual(count, nrows)
+        cursor.close()
+
+    def test_checkpoint(self):
+        uri = 'table:checkpoint30'
+        nrows = 100
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        value_a = "aaaaa" * 100
+        value_b = "bbbbb" * 100
+
+        # Pin oldest and stable timestamps to 5.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5) +
+            ',stable_timestamp=' + self.timestamp_str(5))
+
+        # Write some data at time 10.
+        self.large_updates(uri, ds, nrows, value_a, 10)
+        self.check(self.session, ds, nrows, value_a, 10)
+
+        # Remove the key-1 at time 20 and keep this transaction open until a reader is started.
+        session2 = self.conn.open_session()
+        cursor = session2.open_cursor(uri)
+        session2.begin_transaction()
+        cursor.set_key(ds.key(1))
+        cursor.remove()
+
+        # Remove the remaining keys with another transaction and commit.
+        self.large_removes(uri, ds, 2, nrows, 20)
+        self.check(self.session, ds, 1, value_a, 20)
+
+        # Start the reader transaction. According to the snapshot visibility, except key-1
+        # rest of the keys are removed ignoring the read timestamp.
+        session3 = self.conn.open_session()
+        session3.begin_transaction()
+
+        # Commit the key-1 remove transaction.
+        session2.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor.close()
+
+        # Reader transaction cannot see the remove on key-1.
+        self.check(session3, ds, 1, value_a, 25)
+
+        # Evict the data.
+        self.evict(ds, 1, nrows + 1, value_a, 10)
+
+        # Reader transaction cannot see the remove on key-1 after eviction.
+        self.check(session3, ds, 1, value_a, 25)
+
+        # Checkpoint.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+        self.session.checkpoint()
+
+        # Reader transaction cannot see the remove on key-1 after the checkpoint.
+        self.check(session3, ds, 1, value_a, 25)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
The aggregated time window of a page is calculated based on the maximum transaction/timestamp values present on each individual key/value pair. It is possible that a page can have a key that removal operation may not be visible to the reader snapshot.