### PR TITLE
WT-10862

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -594,13 +594,13 @@ __inmem_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, bool *preparedp, size_t
             page->pg_fix_numtws = entry_num;
 
         /*
-         * If we skipped "quite a few" entries (threshold is arbitrary), mark the page dirty so it
-         * gets rewritten without them.
+         * If we skipped "quite a few" entries (threshold is arbitrary), and the tree is already
+         * dirty and so will be written, mark the page dirty so it gets rewritten without them.
          */
-        if (!F_ISSET(btree, WT_BTREE_READONLY) && skipped >= auxhdr.entries / 4 &&
-          skipped >= dsk->u.entries / 100 && skipped > 4) {
+        if (btree->modified && skipped >= auxhdr.entries / 4 && skipped >= dsk->u.entries / 100 &&
+          skipped > 4) {
             WT_RET(__wt_page_modify_init(session, page));
-            __wt_page_modify_set(session, page);
+            __wt_page_only_modify_set(session, page);
         }
 
         break;
@@ -798,22 +798,18 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
             break;
         case WT_CELL_ADDR_DEL:
             /*
-             * A cell may reference a deleted leaf page: if a leaf page was deleted without being
-             * read (fast truncate), and the deletion committed, but older transactions in the
-             * system required the previous version of the page to remain available, a special
-             * deleted-address type cell is written. We'll see that cell on a page if we read from a
-             * checkpoint including a deleted cell or if we crash/recover and start off from such a
-             * checkpoint (absent running recovery, a version of the page without the deleted cell
-             * would eventually have been written). If we crash and recover to a page with a
-             * deleted-address cell, we want to discard the page from the backing store (it was
-             * never discarded), and, of course, by definition no earlier transaction will ever need
-             * it.
-             *
-             * Re-create the state of a deleted page.
+             * If a page was deleted without being read (fast truncate), and the delete committed,
+             * but older transactions in the system required the previous version of the page to
+             * remain available or the delete can still be rolled back by RTS, a deleted-address
+             * type cell is written. We'll see that cell on a page if we read from a checkpoint
+             * including a deleted cell or if we crash/recover and start off from such a checkpoint.
+             * Recreate the fast-delete state for the page.
              */
-            ref->addr = unpack.cell;
+            if (F_ISSET(page->dsk, WT_PAGE_FT_UPDATE)) {
+                WT_ERR(__wt_calloc_one(session, &ref->ft_info.del));
+                *ref->ft_info.del = unpack.page_del;
+            }
             WT_REF_SET_STATE(ref, WT_REF_DELETED);
-            ++refp;
 
             /*
              * If the tree is already dirty and so will be written, mark the page dirty. (We want to
@@ -822,8 +818,11 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
              */
             if (btree->modified) {
                 WT_ERR(__wt_page_modify_init(session, page));
-                __wt_page_modify_set(session, page);
+                __wt_page_only_modify_set(session, page);
             }
+
+            ref->addr = unpack.cell;
+            ++refp;
             break;
         case WT_CELL_ADDR_INT:
         case WT_CELL_ADDR_LEAF:

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -152,12 +152,13 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         WT_ERR(__wt_page_inmem_prepare(session, ref));
 
 skip_read:
-    switch (previous_state) {
-    case WT_REF_DELETED:
-        /* Move all records to a deleted state. */
+    /*
+     * In the case of a fast delete, move all of the page's records to a deleted state based on the
+     * fast-delete information. Skip for special commands that don't care about an in-memory state.
+     */
+    if (previous_state == WT_REF_DELETED &&
+      !F_ISSET(S2BT(session), WT_BTREE_SALVAGE | WT_BTREE_UPGRADE | WT_BTREE_VERIFY))
         WT_ERR(__wt_delete_page_instantiate(session, ref));
-        break;
-    }
 
     F_CLR(ref, WT_REF_FLAG_READING);
     WT_REF_SET_STATE(ref, WT_REF_MEM);

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -122,6 +122,8 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag, const WT_PAGE_H
         LF_CLR(WT_PAGE_ENCRYPTED);
     if (LF_ISSET(WT_PAGE_UNUSED))
         LF_CLR(WT_PAGE_UNUSED);
+    if (LF_ISSET(WT_PAGE_FT_UPDATE))
+        LF_CLR(WT_PAGE_FT_UPDATE);
     if (flags != 0)
         WT_RET_VRFY(session, "page at %s has invalid flags set: 0x%" PRIx8, tag, flags);
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -133,8 +133,8 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
             WT_ASSERT(session,
               !WT_IS_HS(S2BT(session)->dhandle) ||
                 (*upd_entry == NULL ||
-                  ((*upd_entry)->type == WT_UPDATE_TOMBSTONE && (*upd_entry)->txnid == WT_TS_NONE &&
-                    (*upd_entry)->start_ts == WT_TS_NONE)) ||
+                  ((*upd_entry)->type == WT_UPDATE_TOMBSTONE &&
+                    (*upd_entry)->txnid == WT_TXN_NONE && (*upd_entry)->start_ts == WT_TS_NONE)) ||
                 (upd_arg->type == WT_UPDATE_TOMBSTONE && upd_arg->start_ts == WT_TS_NONE &&
                   upd_arg->next == NULL) ||
                 (upd_arg->type == WT_UPDATE_TOMBSTONE && upd_arg->next != NULL &&

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -77,6 +77,7 @@ struct __wt_page_header {
 #define WT_PAGE_EMPTY_V_NONE 0x04u /* Page has no zero-length values */
 #define WT_PAGE_ENCRYPTED 0x08u    /* Page is encrypted on disk */
 #define WT_PAGE_UNUSED 0x10u       /* Historic lookaside store page updates, no longer used */
+#define WT_PAGE_FT_UPDATE 0x20u    /* Page contains updated fast-truncate information */
     uint8_t flags;                 /* 25: flags */
 
     /* A byte of padding, positioned to be added to the flags. */
@@ -858,20 +859,37 @@ struct __wt_page {
  *	Related information for truncated pages.
  */
 struct __wt_page_deleted {
+    /*
+     * Transaction IDs are set when updates are created (before they become visible) and only change
+     * when marked with WT_TXN_ABORTED. Transaction ID readers expect to copy a transaction ID into
+     * a local variable and see a stable value. In case a compiler might re-read the transaction ID
+     * from memory rather than using the local variable, mark the shared transaction IDs volatile to
+     * prevent unexpected repeated/reordered reads.
+     */
     volatile uint64_t txnid; /* Transaction ID */
 
     wt_timestamp_t timestamp; /* Timestamps */
     wt_timestamp_t durable_timestamp;
 
     /*
-     * The state is used for transaction prepare to manage visibility and inheriting prepare state
-     * to update_list.
+     * The prepare state is used for transaction prepare to manage visibility and inheriting prepare
+     * state to update_list.
      */
-    volatile uint8_t prepare_state; /* Prepare state. */
+    volatile uint8_t prepare_state;
 
-    uint8_t previous_state; /* Previous state */
+    /*
+     * The previous state of the WT_REF; if the fast-truncate transaction is rolled back without the
+     * page first being instantiated, this is the state to which the WT_REF returns.
+     */
+    uint8_t previous_ref_state;
 
-    uint8_t committed; /* Committed */
+    /*
+     * If the fast-truncate transaction has committed. If we're forced to instantiate the page, and
+     * the committed flag isn't set, we have to create an update structure list for the transaction
+     * to resolve in a subsequent commit. (This is tricky: if the transaction is rolled back, the
+     * entire structure is discarded, that is, the flag is set only on commit and not on rollback.)
+     */
+    bool committed;
 };
 
 /*
@@ -1136,6 +1154,13 @@ struct __wt_ikey {
  * WT_UPDATE structures are formed into a forward-linked list.
  */
 struct __wt_update {
+    /*
+     * Transaction IDs are set when updates are created (before they become visible) and only change
+     * when marked with WT_TXN_ABORTED. Transaction ID readers expect to copy a transaction ID into
+     * a local variable and see a stable value. In case a compiler might re-read the transaction ID
+     * from memory rather than using the local variable, mark the shared transaction IDs volatile to
+     * prevent unexpected repeated/reordered reads.
+     */
     volatile uint64_t txnid; /* transaction ID */
 
     wt_timestamp_t durable_ts; /* timestamps */

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -132,20 +132,21 @@
  */
 struct __wt_cell {
     /*
-     * Maximum of 71 bytes:
+     * Maximum of 98 bytes:
      *  1: cell descriptor byte
      *  1: prefix compression count
      *  1: secondary descriptor byte
      * 36: 4 timestamps		(uint64_t encoding, max 9 bytes)
      * 18: 2 transaction IDs	(uint64_t encoding, max 9 bytes)
      *  9: associated 64-bit value	(uint64_t encoding, max 9 bytes)
+     * 27: fast-delete information (transaction ID, 2 timestamps)
      *  5: data length		(uint32_t encoding, max 5 bytes)
      *
-     * This calculation is extremely pessimistic: the prefix compression
-     * count and 64V value overlap, and the validity window, 64V value
-     * and data length are all optional in some cases.
+     * This calculation is pessimistic: the prefix compression count and 64V value overlap, and the
+     * validity window, 64V value, fast-delete information and data length are all optional in some
+     * or even most cases.
      */
-    uint8_t __chunk[1 + 1 + 1 + 7 * WT_INTPACK64_MAXSIZE + WT_INTPACK32_MAXSIZE];
+    uint8_t __chunk[98];
 };
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
@@ -197,6 +198,8 @@ struct __wt_cell_unpack_addr {
     WT_CELL_COMMON_FIELDS;
 
     WT_TIME_AGGREGATE ta; /* Address validity window */
+
+    WT_PAGE_DELETED page_del; /* Fast-truncate information */
 };
 
 /*

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -206,28 +206,15 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
     __cell_pack_addr_validity(session, &p, ta);
 
     /*
-     * If passed fast-delete information, override the cell type and append the fast-delete
-     * information after the aggregated timestamp information.
+     * If passed fast-delete information, append the fast-delete information after the aggregated
+     * timestamp information.
      */
-    if (page_del != NULL) {
-        /*
-         * We only fast-truncate leaf pages without overflow items, however, we can write a proxy
-         * cell for a page, evict and then read the internal page, and then checkpoint is writing it
-         * again.
-         */
-        WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
-        cell_type = WT_CELL_ADDR_DEL;
+    if (page_del != NULL && __wt_process.fast_truncate_2022) {
+        WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL);
 
-        /* We should never be in an in-progress prepared state. */
-        WT_ASSERT(session,
-          page_del->prepare_state == WT_PREPARE_INIT ||
-            page_del->prepare_state == WT_PREPARE_RESOLVED);
-
-        if (__wt_process.fast_truncate_2022) {
-            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
-            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->timestamp));
-            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->durable_timestamp));
-        }
+        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
+        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->timestamp));
+        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->durable_timestamp));
     }
 
     if (recno == WT_RECNO_OOB)

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -27,6 +27,8 @@ struct __wt_process {
     double tsc_nsec_ratio; /* rdtsc ticks to nanoseconds */
     bool use_epochtime;    /* use expensive time */
 
+    bool fast_truncate_2022; /* fast-truncate fix run-time configuration */
+
     WT_CACHE_POOL *cache_pool; /* shared cache information */
 };
 extern WT_PROCESS __wt_process;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1274,8 +1274,6 @@ extern int __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_IT
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_search(WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key, bool insert, WT_REF *leaf,
   bool leaf_safe, bool *leaf_foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_rts_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, void *context,
-  bool visible_all, bool *skipp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_rwlock_init(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_salvage(WT_SESSION_IMPL *session, const char *cfg[])
@@ -2205,7 +2203,7 @@ static inline int __wt_vunpack_uint(const uint8_t **pp, size_t maxlen, uint64_t 
 static inline int __wt_write(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len,
   const void *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type,
-  uint64_t recno, WT_TIME_AGGREGATE *ta, size_t size)
+  uint64_t recno, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline size_t __wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell,
   WT_TIME_WINDOW *tw, uint64_t rle, uint64_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2319,7 +2317,7 @@ static inline void __wt_rec_auximage_copy(
 static inline void __wt_rec_auxincr(
   WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t v, size_t size);
 static inline void __wt_rec_cell_build_addr(WT_SESSION_IMPL *session, WT_RECONCILE *r,
-  WT_ADDR *addr, WT_CELL_UNPACK_ADDR *vpack, bool proxy_cell, uint64_t recno);
+  WT_ADDR *addr, WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del);
 static inline void __wt_rec_image_copy(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *kv);
 static inline void __wt_rec_incr(
   WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t v, size_t size);

--- a/src/include/reconcile_inline.h
+++ b/src/include/reconcile_inline.h
@@ -323,22 +323,20 @@ __wt_rec_auximage_copy(WT_SESSION_IMPL *session, WT_RECONCILE *r, uint32_t count
  */
 static inline void
 __wt_rec_cell_build_addr(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_ADDR *addr,
-  WT_CELL_UNPACK_ADDR *vpack, bool proxy_cell, uint64_t recno)
+  WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del)
 {
     WT_REC_KV *val;
+    WT_TIME_AGGREGATE *ta;
     u_int cell_type;
 
     val = &r->v;
 
     /*
-     * Our caller optionally specifies a cell type (deleted proxy cells), otherwise go with what we
-     * know.
+     * Caller includes fast-delete information in the case of fast-delete proxy cells, which both
+     * flags the fast-delete case and provides the additional information written in the parent's
+     * address cell.
      */
-    if (proxy_cell)
-        cell_type = WT_CELL_ADDR_DEL;
-    else if (vpack != NULL)
-        cell_type = vpack->type;
-    else {
+    if (vpack == NULL) {
         switch (addr->type) {
         case WT_ADDR_INT:
             cell_type = WT_CELL_ADDR_INT;
@@ -352,16 +350,12 @@ __wt_rec_cell_build_addr(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_ADDR *add
             break;
         }
         WT_ASSERT(session, addr->size != 0);
+        ta = &addr->ta;
+    } else {
+        cell_type = vpack->type;
+        ta = &vpack->ta;
     }
-
-    __rec_cell_addr_stats(r, vpack == NULL ? &addr->ta : &vpack->ta);
-
-    /*
-     * We don't check the address size because we can't store an address on an overflow page: if the
-     * address won't fit, the overflow page's address won't fit either. This possibility must be
-     * handled by Btree configuration, we have to disallow internal page sizes that are too small
-     * with respect to the largest address cookie the underlying block manager might return.
-     */
+    __rec_cell_addr_stats(r, ta);
 
     /*
      * We don't copy the data into the buffer, it's not necessary; just re-point the buffer's
@@ -371,16 +365,14 @@ __wt_rec_cell_build_addr(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_ADDR *add
         WT_ASSERT(session, addr != NULL);
         val->buf.data = addr->addr;
         val->buf.size = addr->size;
-        val->cell_len =
-          __wt_cell_pack_addr(session, &val->cell, cell_type, recno, &addr->ta, val->buf.size);
     } else {
         WT_ASSERT(session, addr == NULL);
         val->buf.data = vpack->data;
         val->buf.size = vpack->size;
-        val->cell_len =
-          __wt_cell_pack_addr(session, &val->cell, cell_type, recno, &vpack->ta, val->buf.size);
     }
 
+    val->cell_len =
+      __wt_cell_pack_addr(session, &val->cell, cell_type, recno, page_del, ta, val->buf.size);
     val->len = val->cell_len + val->buf.size;
 }
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -187,7 +187,7 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 
         /* Build the value cell. */
         addr = &multi->addr;
-        __wt_rec_cell_build_addr(session, r, addr, NULL, false, r->recno);
+        __wt_rec_cell_build_addr(session, r, addr, NULL, r->recno, NULL);
 
         /* Boundary: split or write the page. */
         if (__wt_rec_need_split(r, val->len))
@@ -296,7 +296,7 @@ __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
             if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED)) {
                 /* Need to rebuild the cell with the updated time info. */
-                __wt_rec_cell_build_addr(session, r, NULL, vpack, false, ref->ref_recno);
+                __wt_rec_cell_build_addr(session, r, NULL, vpack, ref->ref_recno, NULL);
             } else {
                 val->buf.data = ref->addr;
                 val->buf.size = __wt_cell_total_len(vpack);
@@ -305,7 +305,7 @@ __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
             }
             WT_TIME_AGGREGATE_COPY(&ta, &vpack->ta);
         } else {
-            __wt_rec_cell_build_addr(session, r, addr, NULL, false, ref->ref_recno);
+            __wt_rec_cell_build_addr(session, r, addr, NULL, ref->ref_recno, NULL);
             WT_TIME_AGGREGATE_COPY(&ta, &addr->ta);
         }
         WT_CHILD_RELEASE_ERR(session, hazard, ref);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1899,16 +1899,17 @@ __rec_split_write_header(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK
     dsk->type = page->type;
 
     dsk->flags = 0;
-
-    /* Set the zero-length value flag in the page header. */
+    /* Set the all/none zero-length value flags. */
     if (page->type == WT_PAGE_ROW_LEAF) {
-        F_CLR(dsk, WT_PAGE_EMPTY_V_ALL | WT_PAGE_EMPTY_V_NONE);
-
         if (chunk->entries != 0 && r->all_empty_value)
             F_SET(dsk, WT_PAGE_EMPTY_V_ALL);
         if (chunk->entries != 0 && !r->any_empty_value)
             F_SET(dsk, WT_PAGE_EMPTY_V_NONE);
     }
+
+    /* Set the fast-truncate proxy cell information flag. */
+    if (page->type == WT_PAGE_ROW_INT && __wt_process.fast_truncate_2022)
+        F_SET(dsk, WT_PAGE_FT_UPDATE);
 
     dsk->unused = 0;
     dsk->version = WT_PAGE_VERSION_TS;

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -123,6 +123,11 @@ __global_once(void)
     __wt_process.checksum = wiredtiger_crc32c_func();
 
     __global_calibrate_ticks();
+
+    /* Run-time configuration. */
+#ifdef WT_STANDALONE_BUILD
+    __wt_process.fast_truncate_2022 = true;
+#endif
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1705,7 +1705,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
         if (op->type == WT_TXN_OP_REF_DELETE) {
             WT_REF_LOCK(session, op->u.ref, &previous_state);
             if (previous_state == WT_REF_DELETED)
-                op->u.ref->ft_info.del->committed = 1;
+                op->u.ref->ft_info.del->committed = true;
             else
                 __wt_free(session, op->u.ref->ft_info.update);
             WT_REF_UNLOCK(op->u.ref, previous_state);

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1110,8 +1110,8 @@ __rollback_get_ref_max_durable_timestamp(WT_SESSION_IMPL *session, WT_TIME_AGGRE
 
 /*
  * __rollback_page_needs_abort --
- *     Check whether the page needs rollback. Return true if the page has modifications newer than
- *     the given timestamp Otherwise return false.
+ *     Check whether the page needs rollback, returning true if the page has modifications newer
+ *     than the given timestamp.
  */
 static bool
 __rollback_page_needs_abort(
@@ -1237,54 +1237,40 @@ __rollback_abort_updates(WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t r
 }
 
 /*
- * __rollback_abort_fast_truncate --
- *     Abort fast truncate for an internal page of leaf pages.
+ * __rollback_to_stable_page_skip --
+ *     Skip if rollback to stable doesn't require reading this page.
  */
 static int
-__rollback_abort_fast_truncate(
-  WT_SESSION_IMPL *session, WT_REF *ref, wt_timestamp_t rollback_timestamp)
-{
-    WT_REF *child_ref;
-
-    WT_INTL_FOREACH_BEGIN (session, ref->page, child_ref) {
-        /*
-         * A fast-truncate page is either in the WT_REF_DELETED state (where the WT_PAGE_DELETED
-         * structure has the timestamp information), or in an in-memory state where it started as a
-         * fast-truncate page which was then instantiated and the timestamp information moved to the
-         * individual WT_UPDATE structures. When reviewing internal pages, ignore the second case,
-         * an instantiated page is handled when the leaf page is visited.
-         */
-        if (child_ref->state == WT_REF_DELETED && child_ref->ft_info.del != NULL &&
-          rollback_timestamp < child_ref->ft_info.del->durable_timestamp) {
-            __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
-              "%p: deleted page rolled back", (void *)child_ref);
-            WT_RET(__wt_delete_page_rollback(session, child_ref));
-        }
-    }
-    WT_INTL_FOREACH_END;
-    return (0);
-}
-
-/*
- * __wt_rts_page_skip --
- *     Skip if rollback to stable doesn't requires to read this page.
- */
-int
-__wt_rts_page_skip(
+__rollback_to_stable_page_skip(
   WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool visible_all, bool *skipp)
 {
+    WT_PAGE_DELETED *page_del;
     wt_timestamp_t rollback_timestamp;
 
-    rollback_timestamp = *(wt_timestamp_t *)(context);
-    *skipp = false; /* Default to reading */
-
+    rollback_timestamp = *(wt_timestamp_t *)context;
     WT_UNUSED(visible_all);
 
-    /* If the page state is other than on disk, we want to look at it. */
+    *skipp = false; /* Default to reading */
+
+    /*
+     * Skip fast-truncate operations durable at or before the RTS timestamp (reading the page will
+     * delete it). A page without fast-truncate timestamp information is an old format page: skip
+     * them as there's no way to get correct behavior, and skipping them matches historic behavior.
+     */
+    if (ref->state == WT_REF_DELETED) {
+        page_del = ref->ft_info.del;
+        if (page_del == NULL ||
+          (__rollback_txn_visible_id(session, page_del->txnid) &&
+            page_del->durable_timestamp <= rollback_timestamp))
+            *skipp = true;
+        return (0);
+    }
+
+    /* Otherwise, if the page state is other than on disk, we want to look at it. */
     if (ref->state != WT_REF_DISK)
         return (0);
 
-    /* Check whether this ref has any possible updates to be aborted. */
+    /* Check whether this on-disk page has any updates to be aborted. */
     if (!__rollback_page_needs_abort(session, ref, rollback_timestamp)) {
         *skipp = true;
         __wt_verbose_multi(
@@ -1307,13 +1293,11 @@ __rollback_to_stable_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollbac
 
     /* Walk the tree, marking commits aborted where appropriate. */
     ref = NULL;
-    while ((ret = __wt_tree_walk_custom_skip(session, &ref, __wt_rts_page_skip, &rollback_timestamp,
-              WT_READ_NO_EVICT | WT_READ_WONT_NEED | WT_READ_VISIBLE_ALL)) == 0 &&
+    while (
+      (ret = __wt_tree_walk_custom_skip(session, &ref, __rollback_to_stable_page_skip,
+         &rollback_timestamp, WT_READ_NO_EVICT | WT_READ_WONT_NEED | WT_READ_VISIBLE_ALL)) == 0 &&
       ref != NULL)
-        if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
-            WT_WITH_PAGE_INDEX(
-              session, ret = __rollback_abort_fast_truncate(session, ref, rollback_timestamp));
-        else
+        if (F_ISSET(ref, WT_REF_FLAG_LEAF))
             WT_RET(__rollback_abort_updates(session, ref, rollback_timestamp));
 
     return (ret);

--- a/test/suite/test_rollback_to_stable34.py
+++ b/test/suite/test_rollback_to_stable34.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from helper import simulate_crash_restart
+from test_rollback_to_stable01 import test_rollback_to_stable_base
+from wiredtiger import stat, WT_NOTFOUND
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_rollback_to_stable33.py
+# Test interaction between fast-delete and RTS.
+class test_rollback_to_stable33(test_rollback_to_stable_base):
+    session_config = 'isolation=snapshot'
+    conn_config = 'cache_size=50MB,statistics=(all),log=(enabled=false)'
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='S', extraconfig='')),
+        ('column_fix', dict(key_format='r', value_format='8t',
+            extraconfig=',allocation_size=512,leaf_page_max=512')),
+        ('integer_row', dict(key_format='i', value_format='S', extraconfig='')),
+        ('string_row', dict(key_format='S', value_format='S', extraconfig='')),
+    ]
+    prepare_values = [
+        ('no_prepare', dict(prepare=False)),
+        ('prepare', dict(prepare=True)),
+    ]
+    second_checkpoint_values = [
+        ('second_checkpoint', dict(second_checkpoint=True)),
+        ('no_second_checkpoint', dict(second_checkpoint=False)),
+    ]
+    rollback_modes = [
+        ('runtime', dict(crash=False)),
+        ('recovery', dict(crash=True)),
+    ]
+
+    scenarios = make_scenarios(format_values, prepare_values, second_checkpoint_values,
+        rollback_modes)
+
+    # Make all the values different so it's easier to see what happens if ranges go missing.
+    def mkdata(self, basevalue, i):
+        if self.value_format == '8t':
+            return basevalue
+        return basevalue + str(i)
+
+    def evict(self, ds, lo, hi, basevalue):
+        evict_cursor = self.session.open_cursor(ds.uri, None, "debug=(release_evict)")
+        self.session.begin_transaction()
+
+        # Evict every 3rd key to make sure we get all the pages but not write them out
+        # over and over again any more than necessary. FUTURE: improve this to evict
+        # each page once when we get a suitable interface for that.
+        for i in range(lo, hi, 3):
+            evict_cursor.set_key(ds.key(i))
+            self.assertEquals(evict_cursor.search(), 0)
+            self.assertEquals(evict_cursor.get_value(), self.mkdata(basevalue, i))
+            evict_cursor.reset()
+        self.session.rollback_transaction()
+        evict_cursor.close()
+
+    # Call this checkx to distinguish it from the parent class's default check().
+    def checkx(self, ds, nrows, read_ts, basevalue):
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
+        cursor = self.session.open_cursor(ds.uri)
+        i = 1
+        for k, v in cursor:
+            self.assertEqual(v, self.mkdata(basevalue, i))
+            self.assertEqual(k, ds.key(i))
+            i += 1
+        self.session.commit_transaction()
+        self.assertEqual(i, nrows + 1)
+        cursor.close()
+
+    def test_rollback_to_stable(self):
+        # RTS will fail if there are uncommitted prepared transactions, so skip tests of prepare
+        # with a runtime call to RTS, that doesn't add useful testing scenarios.
+        if self.prepare and not self.crash:
+            return
+
+        nrows = 10000
+
+        # Create a table without logging.
+        uri = "table:rollback_to_stable33"
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config='log=(enabled=false)' + self.extraconfig)
+        ds.populate()
+
+        if self.value_format == '8t':
+            valuea = 97
+            valueb = 98
+        else:
+            valuea = "aaaaa" * 100
+            valueb = "bbbbb" * 100
+
+        # Pin oldest and stable timestamps to 10.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
+
+        cursor = self.session.open_cursor(uri)
+
+        # Write some baseline data out at time 20.
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = self.mkdata(valuea, i)
+            # Make a new transaction every 97 keys so the transactions don't get huge.
+            if i % 97 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        # Write some more data out at time 30.
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = self.mkdata(valueb, i)
+            # Make a new transaction every 97 keys so the transactions don't get huge.
+            if i % 97 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+
+        cursor.close()
+
+        # Evict the lot.
+        self.evict(ds, 1, nrows + 1, valueb)
+
+        # Move stable to 25 (after the baseline data).
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+
+        # Checkpoint.
+        self.session.checkpoint()
+
+        # Now fast-delete the lot at time 35.
+        # Use a separate session for this so that if we leave the truncate prepared it
+        # doesn't obstruct the rest of the test.
+        session2 = self.conn.open_session()
+        session2.begin_transaction()
+        lo_cursor = session2.open_cursor(uri)
+        lo_cursor.set_key(ds.key(nrows // 2 + 1))
+        hi_cursor = session2.open_cursor(uri)
+        hi_cursor.set_key(ds.key(nrows + 1))
+        session2.truncate(None, lo_cursor, hi_cursor, None)
+        if self.prepare:
+            session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(35))
+        else:
+            session2.commit_transaction('commit_timestamp=' + self.timestamp_str(35))
+        hi_cursor.close()
+        lo_cursor.close()
+
+        # Check stats to make sure we fast-deleted at least one page.
+        # Since VLCS and FLCS do not (yet) support fast-delete, instead assert we didn't.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        if self.key_format == 'r':
+            self.assertEqual(fastdelete_pages, 0)
+        else:
+            self.assertGreater(fastdelete_pages, 0)
+
+        if self.second_checkpoint:
+            # Checkpoint again with the deletion.
+            self.session.checkpoint()
+
+        # Roll back, either via crashing or by explicit RTS.
+        if self.crash:
+            simulate_crash_restart(self, ".", "RESTART")
+        else:
+            self.conn.rollback_to_stable()
+
+        # We should see the original data at read-ts 20 and 30.
+        self.checkx(ds, nrows, 20, valuea)
+        self.checkx(ds, nrows, 30, valuea)

--- a/test/suite/test_truncate09.py
+++ b/test/suite/test_truncate09.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_truncate09.py
+#   Check for fast-truncate rollback-to-stable timestamps.
+
+import wttest
+from helper import copy_wiredtiger_home, simulate_crash_restart
+from wtdataset import simple_key, simple_value
+from wtscenario import make_scenarios
+
+class test_truncate09(wttest.WiredTigerTestCase):
+    # We don't test FLCS, missing records return as 0 values.
+    format_values = [
+        ('column', dict(key_format='r')),
+        ('row_integer', dict(key_format='i')),
+    ]
+    scenarios = make_scenarios(format_values)
+
+    def test_truncate09(self):
+        # Create a large table with lots of pages.
+        uri = "table:test_truncate09"
+        format = 'key_format={},value_format=S'.format(self.key_format)
+        self.session.create(uri, 'allocation_size=512,leaf_page_max=512,' + format)
+
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, 80000):
+            cursor[simple_key(cursor, i)] = simple_value(cursor, i)
+        cursor.close()
+
+        # Force to disk.
+        self.reopen_conn()
+
+        # Set the oldest timestamp and the stable timestamp.
+        self.conn.set_timestamp('oldest_timestamp='+ self.timestamp_str(100))
+        self.conn.set_timestamp('stable_timestamp='+ self.timestamp_str(100))
+
+        # Start a transaction.
+        self.session.begin_transaction()
+
+        # Truncate a chunk.
+        c1 = self.session.open_cursor(uri, None)
+        c1.set_key(simple_key(c1, 20000))
+        c2 = self.session.open_cursor(uri, None)
+        c2.set_key(simple_key(c1, 40000))
+        self.session.truncate(None, c1, c2, None)
+
+        # Commit the transaction.
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(150))
+        self.session.commit_transaction()
+
+        # Move the stable timestamp to make the previous truncate operation permanent.
+        self.conn.set_timestamp('stable_timestamp='+ self.timestamp_str(200))
+
+        # Checkpoint
+        self.session.checkpoint()
+
+        # Start a transaction.
+        self.session.begin_transaction()
+
+        # Truncate a chunk.
+        c1.set_key(simple_key(c1, 50000))
+        c2.set_key(simple_key(c1, 70000))
+        self.session.truncate(None, c1, c2, None)
+
+        # Remove a single row.
+        c1.set_key(simple_key(c1, 75000))
+        c1.remove()
+
+        # Commit the transaction.
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(250))
+        self.session.commit_transaction()
+
+        # Checkpoint
+        self.session.checkpoint()
+
+        # Restart, testing RTS on the copy.
+        copy_wiredtiger_home(self, ".", "RESTART")
+        simulate_crash_restart(self, ".", "RESTART")
+
+        # Search for a key in the truncated range which is stabilised, hence should not find it.
+        cursor = self.session.open_cursor(uri)
+        cursor.set_key(simple_key(cursor, 30000))
+        self.assertNotEqual(cursor.search(), 0)
+
+        # Search for a key in the truncated range which is not stabilised, hence should find it.
+        cursor.set_key(simple_key(cursor, 60000))
+        self.assertEqual(cursor.search(), 0)
+
+        # Search for a removed key which is not stabilised, hence should find it.
+        cursor.set_key(simple_key(cursor, 75000))
+        self.assertEqual(cursor.search(), 0)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
WT-8447 Database corruption from RTS after fast-delete (#7289)

Merge fast-truncate timestamp information into the internal page's cell to support RTS of fast-truncate objects.

(cherry picked from commit ad0b418109f05284ecdc343683988388a1a7fd39)