### PR TITLE
WT-10117 Retry pread in file copy

### DIFF
--- a/test/utility/file.c
+++ b/test/utility/file.c
@@ -251,9 +251,11 @@ copy_on_file(const char *path, const file_info_t *info, void *user_data)
 #else
     struct utimbuf t;
 #endif
+    WT_DECL_RET;
     ssize_t n;
     int rfd, wfd;
     char *buf;
+    wt_off_t offset;
 #endif
     char dest_path[PATH_MAX];
 
@@ -294,8 +296,9 @@ copy_on_file(const char *path, const file_info_t *info, void *user_data)
       (wfd = open(dest_path, O_WRONLY | O_CREAT | O_TRUNC, info->stat.st_mode)) > 0);
 
     buf = dmalloc(COPY_BUF_SIZE);
-    for (;;) {
-        testutil_assert_errno((n = read(rfd, buf, COPY_BUF_SIZE)) >= 0);
+    for (offset = 0, n = 0;; offset += n) {
+        WT_SYSCALL_RETRY((n = pread(rfd, buf, COPY_BUF_SIZE, offset)) < 0 ? -1 : 0, ret);
+        testutil_assert_errno(ret == 0);
         if (n == 0)
             break;
         testutil_assert_errno(write(wfd, buf, (size_t)n) == n);

--- a/test/utility/file.c
+++ b/test/utility/file.c
@@ -298,7 +298,7 @@ copy_on_file(const char *path, const file_info_t *info, void *user_data)
     buf = dmalloc(COPY_BUF_SIZE);
     for (offset = 0, n = 0;; offset += n) {
         WT_SYSCALL_RETRY((n = pread(rfd, buf, COPY_BUF_SIZE, offset)) < 0 ? -1 : 0, ret);
-        testutil_assert_errno(ret == 0);
+        testutil_check(ret);
         if (n == 0)
             break;
         testutil_assert_errno(write(wfd, buf, (size_t)n) == n);


### PR DESCRIPTION
I added a retry mechanism for `pread` in file copy as suggested in the ticket. We don't have a record of the failure described in the ticket since we switched our mechanism for copying files in tests, but I still decided to make this change as it's straightforward and safe (given that now we have the ability to fix our own file copy). I used the same approach as in WT-8981 (#8308).