### PR TITLE
WT-11244 Improve diagnostic information in MSan builds

### DIFF
--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -137,9 +137,11 @@ set(ubsan_compiler_c_flag "-fsanitize=undefined")
 set(ubsan_compiler_cxx_flag "-fsanitize=undefined")
 
 # MSAN build variant flags.
+# While -fsanitize-memory-track-origins=2 both slows the program, and increases memory needed by msan, it
+# provides extremely useful diagnostic information.
 set(msan_link_flags "-fsanitize=memory")
-set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
-set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
+set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
+set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
 
 # TSAN build variant flags.
 set(tsan_link_flags "-fsanitize=thread")

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5633,7 +5633,7 @@ buildvariants:
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
-      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:print_stacktrace=1"
+      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:verbosity=3"
       MSAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
       LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so
       WT_TOPDIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Increase diagnostic information avaialable in msan test failures by configuring msan track allocation origin. And increase the verbosity to 3.

Remove print_stacktrace option which is unrecognized by MSan.