### PR TITLE
WT-11272 Removing upd->type read barrier in the txn read path.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -576,6 +576,7 @@ config
 configs
 conn
 connectionp
+const
 constantp
 consts
 cookiep

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1315,7 +1315,7 @@ struct __wt_update {
 #define WT_UPDATE_RESERVE 2   /* reserved */
 #define WT_UPDATE_STANDARD 3  /* complete value */
 #define WT_UPDATE_TOMBSTONE 4 /* deleted */
-    uint8_t type;             /* type (one byte to conserve memory) */
+    const uint8_t type;       /* type (one byte to conserve memory) */
 
 /* If the update includes a complete value. */
 #define WT_UPDATE_DATA_VALUE(upd) \

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -929,7 +929,8 @@ __wt_upd_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, u_int modify_type
         upd->size = WT_STORE_SIZE(value->size);
         memcpy(upd->data, value->data, value->size);
     }
-    upd->type = (uint8_t)modify_type;
+    /* This field is a const, to get around that and still calloc the struct, we cast. */
+    *(uint8_t *)&upd->type = (uint8_t)modify_type;
 
     *updp = upd;
     if (sizep != NULL)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -929,7 +929,10 @@ __wt_upd_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, u_int modify_type
         upd->size = WT_STORE_SIZE(value->size);
         memcpy(upd->data, value->data, value->size);
     }
-    /* This field is a const, to get around that and still calloc the struct, we cast. */
+    /*
+     * This field is const but we need to set it once at allocation time, to do so temporarily cast
+     * as a non-const.
+     */
     *(uint8_t *)&upd->type = (uint8_t)modify_type;
 
     *updp = upd;


### PR DESCRIPTION
This barrier was paired with a write barrier on upd->type when it switched from WT_UPDATE_BIRTHMARK to WT_UPDATE_STANDARD. We no longer support birthmarks and we don't change upd types.