### PR TITLE
WT-11232 qsort_r support

### DIFF
--- a/dist/filelist
+++ b/dist/filelist
@@ -218,6 +218,8 @@ src/support/lock_ext.c
 src/support/modify.c
 src/support/mtx_rw.c
 src/support/pow.c
+src/support/qsort.c
+src/support/qsort_r.c
 src/support/rand.c
 src/support/scratch.c
 src/support/stat.c

--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -30,6 +30,7 @@ __wt_log_scan
 __wt_nlpo2
 __wt_nlpo2_round
 __wt_print_huffman_code
+__wt_qsort_r
 __wt_session_breakpoint
 __wt_stat_join_aggregate
 __wt_stat_join_clear_all

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -236,6 +236,7 @@ MacOS
 MapViewOfFile
 Marsaglia
 Marsaglia's
+McIlroy
 Mellor
 Mewhort
 Mitzenmacher
@@ -323,6 +324,7 @@ RXB
 ReadFile
 Readonly
 Realloc
+Recurse
 RedHat
 Redistributions
 Rogerio

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1103,6 +1103,7 @@ qrrSS
 qsort
 quartile
 queueable
+quicksort
 quiesce
 qup
 rN

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1909,6 +1909,10 @@ extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern void __wt_ovfl_reuse_free(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern void __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep);
 extern void __wt_print_huffman_code(void *huffman_arg, uint16_t symbol);
+extern void __wt_qsort(
+  void *a, size_t nmemb, size_t elem_sz, int (*cmp)(const void *, const void *));
+extern void __wt_qsort_r(void *a, size_t nmemb, size_t elem_sz,
+  int (*cmp)(const void *, const void *, void *), void *context);
 extern void __wt_random_init(WT_RAND_STATE volatile *rnd_state)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_random_init_custom_seed(WT_RAND_STATE volatile *rnd_state, uint64_t v)

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -219,15 +219,6 @@
     } while (0)
 
 /*
- * Some C compiler address sanitizers complain if qsort is passed a NULL base reference, even if
- * there are no elements to compare (note zero elements is allowed by the IEEE Std 1003.1-2017
- * standard). Avoid the complaint.
- */
-#define __wt_qsort(base, nmemb, size, compar) \
-    if ((nmemb) != 0)                         \
-    qsort(base, nmemb, size, compar)
-
-/*
  * Binary search for an integer key.
  */
 #define WT_BINARY_SEARCH(key, arrayp, n, found)                        \

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -92,26 +92,24 @@ __med3(void *a, void *b, void *c, wt_cmp_t cmp, void *context)
 /*
  * __wt_qsort_r --
  *     Sort an array using a user-supplied comparator function and a context argument.
- *
- * DO NOT EDIT
- *
- * This is originally from "Engineering a Sort Function", by Jon L. Bentley and Douglas M. McIlroy
- * ("Software - Practice and Experience, Vol. 23(11)", November 1993). It's been massaged into a
- * form suitable for WiredTiger, initially by Luke Pearson.
- *
- * It's not simple, so some description of where all these variables point is in order:
- *
- * -----------------------------------------------
- * | = |        <         | ? |      >       | = |
- * -----------------------------------------------
- *      ^                  ^ ^              ^
- *      |                  | |              |
- *      lowest_lt_median   | hi_unknown     highest_gt_median
- *                         lo_unknown
  */
 static void
 __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
 {
+    /*
+     * This is originally from "Engineering a Sort Function", by Jon L. Bentley and Douglas
+     * M. McIlroy ("Software - Practice and Experience, Vol. 23(11)", November 1993). It's been
+     * massaged into a form suitable for WiredTiger, initially by Luke Pearson.
+     *
+     * It's not simple, so some description of where all these variables point is in order:
+     * -----------------------------------------------
+     * | = |        <         | ? |      >       | = |
+     * -----------------------------------------------
+     *      ^                  ^ ^              ^
+     *      |                  | |              |
+     *      lowest_lt_median   | hi_unknown     highest_gt_median
+     *                         lo_unknown
+     */
     size_t lhs_unsorted, rhs_unsorted;
     int cmp_result;
     bool swapped;

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -49,7 +49,7 @@ typedef int wt_cmp_t(const void *, const void *);
  *     Swap the contents of two arbitrary values of a given size.
  */
 static inline void
-__swap_bytes(uint8_t *a, uint8_t *b, size_t size)
+__swap_bytes(uint8_t *restrict a, uint8_t *restrict b, size_t size)
 {
     uint8_t tmp;
 

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -90,7 +90,7 @@ __med3(void *a, void *b, void *c, wt_cmp_t cmp, void *context)
 }
 
 /*
- * __wt_qsort_r --
+ * __qsort --
  *     Sort an array using a user-supplied comparator function and a context argument.
  */
 static void
@@ -110,9 +110,9 @@ __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
      *      lowest_lt_median   | hi_unknown     highest_gt_median
      *                         lo_unknown
      */
-    size_t lhs_unsorted, rhs_unsorted;
-    int cmp_result;
     bool swapped;
+    int cmp_result;
+    size_t lhs_unsorted, rhs_unsorted;
     uint8_t *a, *hi_pseudomedian, *highest_gt_median, *lo_pseudomedian, *lowest_lt_median,
       *pseudomedian, *hi_unknown, *lo_unknown;
 

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -73,17 +73,15 @@ __med3(void *a, void *b, void *c, wt_cmp_t cmp, void *context)
 #endif
 
     if (CMP(a, b, context) < 0) {
-        if (CMP(b, c, context) < 0) {
+        if (CMP(b, c, context) < 0)
             return (b);
-        } else {
+        else
             return (CMP(a, c, context) < 0 ? c : a);
-        }
     } else {
-        if (CMP(b, c, context) > 0) {
+        if (CMP(b, c, context) > 0)
             return (b);
-        } else {
+        else
             return (CMP(a, c, context) < 0 ? a : c);
-        }
     }
 }
 
@@ -203,7 +201,15 @@ __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
         WT_ASSERT(NULL, highest_gt_median >= hi_unknown);
         WT_ASSERT(NULL, hi_pseudomedian >= (highest_gt_median + elem_sz));
 
-        /* Swap our pivot back into the correct place. */
+        /*
+         * Swap our pivot back into the correct place. We need the size_t casts because subtracting
+         * pointers yields a ptrdiff_t, which is signed, but we're assigning to a size_t (because
+         * we're measuring the size of an object) and having this signed makes no logical sense. It
+         * would also break the arithmetic we do later on. The compiler (correctly) complains about
+         * this, but we know a little bit more. Specifically, we know that the right hand side is
+         * always less than the left-hand side (modulo bugs - see assertions above), so we can get
+         * away with a cast.
+         */
         lhs_unsorted =
           WT_MIN((size_t)(lowest_lt_median - a), (size_t)(lo_unknown - lowest_lt_median));
         __swap_bytes(a, lo_unknown - lhs_unsorted, lhs_unsorted);

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -49,7 +49,7 @@ typedef int wt_cmp_t(const void *, const void *);
  *     Swap the contents of two arbitrary values of a given size.
  */
 static inline void
-__swap_bytes(uint8_t *restrict a, uint8_t *restrict b, size_t size)
+__swap_bytes(uint8_t *a, uint8_t *b, size_t size)
 {
     uint8_t tmp;
 
@@ -93,9 +93,10 @@ static void
 __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
 {
     /*
-     * This is originally from "Engineering a Sort Function", by Jon L. Bentley and Douglas
-     * M. McIlroy ("Software - Practice and Experience, Vol. 23(11)", November 1993). It's been
-     * massaged into a form suitable for WiredTiger, initially by Luke Pearson.
+     * This is very similar to the version in FreeBSD, which itself is originally from "Engineering
+     * a Sort Function", by Jon L. Bentley and Douglas M. McIlroy ("Software - Practice and
+     * Experience, Vol. 23(11)", November 1993). From there it was massaged into a form suitable for
+     * WiredTiger.
      *
      * It's not simple, so some description of where all these variables point is in order:
      * -----------------------------------------------

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -1,0 +1,261 @@
+/*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright (c) 1992, 1993
+ *    The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "wt_internal.h"
+
+#define WT_QSORT_INSERT_THRESHOLD 7
+#define WT_QSORT_LARGE_THRESHOLD 40
+
+#ifdef WT_QSORT_R_DEF
+typedef int wt_cmp_t(const void *, const void *, void *);
+#else
+typedef int wt_cmp_t(const void *, const void *);
+#endif
+
+#ifdef WT_QSORT_R_DEF
+#define CMP(x, y, t) (cmp((x), (y), (t)))
+#else
+#define CMP(x, y, t) (cmp((x), (y)))
+#endif
+
+/*
+ * __swap_bytes --
+ *     Swap the contents of two arbitrary values of a given size.
+ */
+static inline void
+__swap_bytes(uint8_t *a, uint8_t *b, size_t size)
+{
+    uint8_t tmp;
+
+    while (size > 0) {
+        tmp = *a;
+        *a++ = *b;
+        *b++ = tmp;
+        --size;
+    }
+}
+
+/*
+ * __med3 --
+ *     Find the median of three values, using the user-supplied comparator.
+ */
+static inline void *
+__med3(void *a, void *b, void *c, wt_cmp_t cmp, void *context)
+{
+#ifndef WT_QSORT_R_DEF
+    WT_UNUSED(context);
+#endif
+
+    if (CMP(a, b, context) < 0) {
+        if (CMP(b, c, context) < 0) {
+            return (b);
+        } else {
+            return (CMP(a, c, context) < 0 ? c : a);
+        }
+    } else {
+        if (CMP(b, c, context) > 0) {
+            return (b);
+        } else {
+            return (CMP(a, c, context) < 0 ? a : c);
+        }
+    }
+}
+
+/*
+ * __wt_qsort_r --
+ *     Sort an array using a user-supplied comparator function and a context argument.
+ *
+ * DO NOT EDIT
+ *
+ * This is originally from "Engineering a Sort Function", by Jon L. Bentley and Douglas M. McIlroy
+ * ("Software - Practice and Experience, Vol. 23(11)", November 1993). It's been massaged into a
+ * form suitable for WiredTiger, initially by Luke Pearson.
+ *
+ * It's not simple, so some description of where all these variables point is in order:
+ *
+ * -----------------------------------------------
+ * | = |        <         | ? |      >       | = |
+ * -----------------------------------------------
+ *      ^                  ^ ^              ^
+ *      |                  | |              |
+ *      lowest_lt_median   | hi_unknown     highest_gt_median
+ *                         lo_unknown
+ */
+static void
+__qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
+{
+    size_t lhs_unsorted, rhs_unsorted;
+    int cmp_result;
+    bool swapped;
+    uint8_t *a, *hi_pseudomedian, *highest_gt_median, *lo_pseudomedian, *lowest_lt_median, *pseudomedian,
+      *hi_unknown, *lo_unknown;
+
+    WT_ASSERT(NULL, cmp != NULL);
+    if (nmemb < 2)
+        return;
+
+    a = arr; /* Avoid arithmetic on void pointers. */
+
+    for (;;) {
+        swapped = false;
+
+        /* Insertion sort for small arrays. */
+        if (nmemb < WT_QSORT_INSERT_THRESHOLD) {
+            for (hi_unknown = a + elem_sz; hi_unknown < a + nmemb * elem_sz; hi_unknown += elem_sz)
+                for (lo_unknown = hi_unknown;
+                     lo_unknown > a && CMP(lo_unknown - elem_sz, lo_unknown, context) > 0;
+                     lo_unknown -= elem_sz)
+                    __swap_bytes(lo_unknown, lo_unknown - elem_sz, elem_sz);
+            return;
+        }
+
+        /* Take middle element as median for small arrays. */
+        pseudomedian = a + (nmemb / 2) * elem_sz;
+        lo_pseudomedian = a;
+        hi_pseudomedian = a + (nmemb - 1) * elem_sz;
+
+        /*
+         * For larger arrays, do more work to find a good median - here, it's a "pseudo-median" of
+         * nine samples.
+         */
+        if (nmemb > WT_QSORT_LARGE_THRESHOLD) {
+            size_t median_dist = (nmemb / 8) * elem_sz;
+
+            lo_pseudomedian = __med3(lo_pseudomedian, lo_pseudomedian + median_dist,
+              lo_pseudomedian + 2 * median_dist, cmp, context);
+            pseudomedian = __med3(
+              pseudomedian - median_dist, pseudomedian, pseudomedian + median_dist, cmp, context);
+            hi_pseudomedian = __med3(hi_pseudomedian - 2 * median_dist,
+              hi_pseudomedian - median_dist, hi_pseudomedian, cmp, context);
+        }
+        pseudomedian = __med3(lo_pseudomedian, pseudomedian, hi_pseudomedian, cmp, context);
+
+        __swap_bytes(a, pseudomedian, elem_sz);
+        lowest_lt_median = lo_unknown = a + elem_sz;
+        hi_unknown = highest_gt_median = a + (nmemb - 1) * elem_sz;
+        for (;;) {
+            while (lo_unknown <= hi_unknown && (cmp_result = CMP(lo_unknown, a, context)) <= 0) {
+                if (cmp_result == 0) {
+                    swapped = true;
+                    __swap_bytes(lowest_lt_median, lo_unknown, elem_sz);
+                    lowest_lt_median += elem_sz;
+                }
+                lo_unknown += elem_sz;
+            }
+
+            while (lo_unknown <= hi_unknown && (cmp_result = CMP(hi_unknown, a, context)) >= 0) {
+                if (cmp_result == 0) {
+                    swapped = true;
+                    __swap_bytes(hi_unknown, highest_gt_median, elem_sz);
+                    highest_gt_median -= elem_sz;
+                }
+                hi_unknown -= elem_sz;
+            }
+
+            if (lo_unknown > hi_unknown)
+                break;
+            __swap_bytes(lo_unknown, hi_unknown, elem_sz);
+            swapped = true;
+            lo_unknown += elem_sz;
+            hi_unknown -= elem_sz;
+        }
+
+        if (!swapped) {
+            /* Switch to insertion sort. */
+            for (hi_unknown = a + elem_sz; hi_unknown < a + nmemb * elem_sz; hi_unknown += elem_sz)
+                for (lo_unknown = hi_unknown;
+                     lo_unknown > a && CMP(lo_unknown - elem_sz, lo_unknown, context) > 0;
+                     lo_unknown -= elem_sz)
+                    __swap_bytes(lo_unknown, lo_unknown - elem_sz, elem_sz);
+            return;
+        }
+
+        hi_pseudomedian = a + nmemb * elem_sz;
+
+        WT_ASSERT(NULL, lowest_lt_median >= a);
+        WT_ASSERT(NULL, lo_unknown >= lowest_lt_median);
+        WT_ASSERT(NULL, highest_gt_median >= hi_unknown);
+        WT_ASSERT(NULL, hi_pseudomedian >= (highest_gt_median + elem_sz));
+
+        /* Swap our pivot back into the correct place. */
+        lhs_unsorted = WT_MIN((size_t)(lowest_lt_median - a), (size_t)(lo_unknown - lowest_lt_median));
+        __swap_bytes(a, lo_unknown - lhs_unsorted, lhs_unsorted);
+        lhs_unsorted = WT_MIN((size_t)(highest_gt_median - hi_unknown),
+          (size_t)(hi_pseudomedian - (highest_gt_median - elem_sz)));
+        __swap_bytes(lo_unknown, hi_pseudomedian - lhs_unsorted, lhs_unsorted);
+
+        lhs_unsorted = (size_t)(lo_unknown - lowest_lt_median);
+        rhs_unsorted = (size_t)(highest_gt_median - hi_unknown);
+        if (lhs_unsorted <= rhs_unsorted) {
+            /* Recurse on left partition, then iterate on right partition. */
+            if (lhs_unsorted > elem_sz)
+                __qsort(a, lhs_unsorted / elem_sz, elem_sz, cmp, context);
+
+            if (rhs_unsorted > elem_sz) {
+                a = hi_pseudomedian - rhs_unsorted;
+                nmemb = rhs_unsorted / elem_sz;
+            } else
+                break;
+        } else {
+            /* Recurse on right partition, then iterate on left partition. */
+            if (rhs_unsorted > elem_sz)
+                __qsort(
+                  hi_pseudomedian - rhs_unsorted, rhs_unsorted / elem_sz, elem_sz, cmp, context);
+
+            if (lhs_unsorted > elem_sz)
+                nmemb = lhs_unsorted / elem_sz;
+            else
+                break;
+        }
+    }
+}
+
+#ifdef WT_QSORT_R_DEF
+/*
+ * __wt_qsort_r --
+ *     Sort an array using a user-supplied comparator function and context argument.
+ */
+void
+__wt_qsort_r(void *a, size_t nmemb, size_t elem_sz, int (*cmp)(const void *, const void *, void *), void *context)
+{
+    __qsort(a, nmemb, elem_sz, cmp, context);
+}
+#else
+/*
+ * __wt_qsort --
+ *     Sort an array using a user-supplied comparator function.
+ */
+void
+__wt_qsort(void *a, size_t nmemb, size_t elem_sz, int (*cmp)(const void *, const void *))
+{
+    __qsort(a, nmemb, elem_sz, cmp, NULL);
+}
+#endif

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -113,8 +113,8 @@ __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
     size_t lhs_unsorted, rhs_unsorted;
     int cmp_result;
     bool swapped;
-    uint8_t *a, *hi_pseudomedian, *highest_gt_median, *lo_pseudomedian, *lowest_lt_median, *pseudomedian,
-      *hi_unknown, *lo_unknown;
+    uint8_t *a, *hi_pseudomedian, *highest_gt_median, *lo_pseudomedian, *lowest_lt_median,
+      *pseudomedian, *hi_unknown, *lo_unknown;
 
     WT_ASSERT(NULL, cmp != NULL);
     if (nmemb < 2)
@@ -204,7 +204,8 @@ __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
         WT_ASSERT(NULL, hi_pseudomedian >= (highest_gt_median + elem_sz));
 
         /* Swap our pivot back into the correct place. */
-        lhs_unsorted = WT_MIN((size_t)(lowest_lt_median - a), (size_t)(lo_unknown - lowest_lt_median));
+        lhs_unsorted =
+          WT_MIN((size_t)(lowest_lt_median - a), (size_t)(lo_unknown - lowest_lt_median));
         __swap_bytes(a, lo_unknown - lhs_unsorted, lhs_unsorted);
         lhs_unsorted = WT_MIN((size_t)(highest_gt_median - hi_unknown),
           (size_t)(hi_pseudomedian - (highest_gt_median - elem_sz)));
@@ -242,7 +243,8 @@ __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
  *     Sort an array using a user-supplied comparator function and context argument.
  */
 void
-__wt_qsort_r(void *a, size_t nmemb, size_t elem_sz, int (*cmp)(const void *, const void *, void *), void *context)
+__wt_qsort_r(void *a, size_t nmemb, size_t elem_sz, int (*cmp)(const void *, const void *, void *),
+  void *context)
 {
     __qsort(a, nmemb, elem_sz, cmp, context);
 }

--- a/src/support/qsort.c
+++ b/src/support/qsort.c
@@ -1,6 +1,4 @@
 /*-
- * SPDX-License-Identifier: BSD-3-Clause
- *
  * Copyright (c) 1992, 1993
  *    The Regents of the University of California.  All rights reserved.
  *
@@ -113,8 +111,8 @@ __qsort(void *arr, size_t nmemb, size_t elem_sz, wt_cmp_t cmp, void *context)
     bool swapped;
     int cmp_result;
     size_t lhs_unsorted, rhs_unsorted;
-    uint8_t *a, *hi_pseudomedian, *highest_gt_median, *lo_pseudomedian, *lowest_lt_median,
-      *pseudomedian, *hi_unknown, *lo_unknown;
+    uint8_t *a, *hi_pseudomedian, *hi_unknown, *highest_gt_median, *lo_pseudomedian, *lo_unknown,
+      *lowest_lt_median, *pseudomedian;
 
     WT_ASSERT(NULL, cmp != NULL);
     if (nmemb < 2)

--- a/src/support/qsort_r.c
+++ b/src/support/qsort_r.c
@@ -6,5 +6,10 @@
  * See the file LICENSE for redistribution information.
  */
 
+/*
+ * The two variants are almost identical modulo function signatures. Define the macro that causes
+ * the normal version to use signatures compatible with the _r variant, and include the source file
+ * directly. This doesn't hide the "regular" quicksort since this is a different compilation unit.
+ */
 #define WT_QSORT_R_DEF
 #include "qsort.c"

--- a/src/support/qsort_r.c
+++ b/src/support/qsort_r.c
@@ -1,0 +1,10 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#define WT_QSORT_R_DEF
+#include "qsort.c"

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -11,6 +11,7 @@ else()
         tests/test_extent_list.cpp
         tests/test_fnv.cpp
         tests/test_pow.cpp
+        tests/test_qsort.cpp
         tests/test_reconciliation_tracking.cpp
         tests/test_tailq.cpp
         tests/block/test_bitstring.cpp

--- a/test/unittest/tests/test_qsort.cpp
+++ b/test/unittest/tests/test_qsort.cpp
@@ -23,20 +23,14 @@ struct compound_test_type {
     uint8_t b;
     uint64_t c;
 
-    compound_test_type()
-        : a(0)
-        , b(COMPOUND_MAGIC_B)
-        , c(COMPOUND_MAGIC_C)
-    {}
+    compound_test_type() : a(0), b(COMPOUND_MAGIC_B), c(COMPOUND_MAGIC_C) {}
 
-    compound_test_type(int val)
-        : a(val)
-        , b(COMPOUND_MAGIC_B)
-        , c(COMPOUND_MAGIC_C)
-    {}
+    compound_test_type(int val) : a(val), b(COMPOUND_MAGIC_B), c(COMPOUND_MAGIC_C) {}
 };
 
-bool operator<(const compound_test_type &lhs, const compound_test_type &rhs) {
+bool
+operator<(const compound_test_type &lhs, const compound_test_type &rhs)
+{
     return lhs.a < rhs.a;
 }
 

--- a/test/unittest/tests/test_qsort.cpp
+++ b/test/unittest/tests/test_qsort.cpp
@@ -92,7 +92,8 @@ transposable_cmp(const void *a, const void *b, void *ctx)
     return *lhs - *rhs;
 };
 
-int counting_cmp(const void *a, const void *b, void *ctx)
+int
+counting_cmp(const void *a, const void *b, void *ctx)
 {
     auto count = static_cast<int *>(ctx);
     (*count)++;
@@ -112,7 +113,7 @@ TEST_CASE("Safe to invoke on an empty array", "[qsort]")
 
 TEST_CASE("Single element", "[qsort]")
 {
-    std::vector<int> input = { 123 };
+    std::vector<int> input = {123};
     __wt_qsort_r(&input[0], input.size(), sizeof(input[0]), transposable_cmp, nullptr);
     CHECK(input[0] == 123);
 }

--- a/test/unittest/tests/test_qsort.cpp
+++ b/test/unittest/tests/test_qsort.cpp
@@ -1,0 +1,170 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <algorithm>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+
+namespace {
+
+const uint8_t COMPOUND_MAGIC_B = 123;
+const uint64_t COMPOUND_MAGIC_C = 0xdeadbeefBAADF00D;
+struct compound_test_type {
+    uint64_t a;
+    uint8_t b;
+    uint64_t c;
+};
+
+class random_generator {
+    std::random_device rnd_device;
+    std::mt19937 mersenne_engine;
+    std::uniform_int_distribution<int> dist;
+
+public:
+    random_generator() = default;
+    random_generator(const random_generator &) = delete;
+    random_generator &operator=(const random_generator &) = delete;
+    ~random_generator() = default;
+
+    std::vector<int>
+    make_vector(size_t size)
+    {
+        std::vector<int> rv(size);
+        auto rnd = [this]() { return this->dist(this->mersenne_engine); };
+        std::generate(begin(rv), end(rv), rnd);
+        return rv;
+    }
+
+    std::vector<struct compound_test_type>
+    make_compound_vector(size_t size)
+    {
+        std::vector<struct compound_test_type> rv(size);
+        auto rnd = [this]() {
+            struct compound_test_type t;
+            t.a = this->dist(this->mersenne_engine);
+            t.b = COMPOUND_MAGIC_B;
+            t.c = COMPOUND_MAGIC_C;
+
+            return t;
+        };
+
+        std::generate(begin(rv), end(rv), rnd);
+
+        return rv;
+    }
+};
+
+int
+simple_cmp(const void *a, const void *b)
+{
+    auto lhs = static_cast<const int *>(a);
+    auto rhs = static_cast<const int *>(b);
+
+    return *lhs - *rhs;
+}
+
+int
+compound_cmp(const void *a, const void *b)
+{
+    auto lhs = *(static_cast<const struct compound_test_type *>(a));
+    auto rhs = *(static_cast<const struct compound_test_type *>(b));
+
+    return lhs.a - rhs.a;
+}
+
+int
+transposable_cmp(const void *a, const void *b, void *ctx)
+{
+    bool reverse = ctx ? *(static_cast<bool *>(ctx)) : false;
+    auto lhs = static_cast<const int *>(a);
+    auto rhs = static_cast<const int *>(b);
+
+    if (reverse)
+        return *rhs - *lhs;
+    return *lhs - *rhs;
+};
+
+int counting_cmp(const void *a, const void *b, void *ctx)
+{
+    auto count = static_cast<int *>(ctx);
+    (*count)++;
+
+    auto lhs = static_cast<const int *>(a);
+    auto rhs = static_cast<const int *>(b);
+    return *lhs - *rhs;
+};
+} // namespace
+
+TEST_CASE("Safe to invoke on an empty array", "[qsort]")
+{
+    std::vector<int> input;
+    __wt_qsort_r(&input[0], input.size(), sizeof(input[0]), transposable_cmp, nullptr);
+    __wt_qsort(&input[0], input.size(), sizeof(input[0]), simple_cmp);
+}
+
+TEST_CASE("Single element", "[qsort]")
+{
+    std::vector<int> input = { 123 };
+    __wt_qsort_r(&input[0], input.size(), sizeof(input[0]), transposable_cmp, nullptr);
+    CHECK(input[0] == 123);
+}
+
+TEST_CASE("Compound type", "[qsort]")
+{
+    random_generator rand_gen;
+    std::vector<struct compound_test_type> input{rand_gen.make_compound_vector(1000)};
+
+    __wt_qsort(&input[0], input.size(), sizeof(input[0]), compound_cmp);
+
+    for (int i = 0; i < 1000; i++) {
+        if (i != 0)
+            CHECK(input[i - 1].a < input[i].a);
+        CHECK(input[i].b == COMPOUND_MAGIC_B);
+        CHECK(input[i].c == COMPOUND_MAGIC_C);
+    }
+}
+
+TEST_CASE("Check contents", "[qsort]")
+{
+    random_generator rand_gen;
+    std::vector<int> input{rand_gen.make_vector(10000)};
+    std::vector<int> input_copy{input};
+
+    __wt_qsort(&input[0], input.size(), sizeof(input[0]), simple_cmp);
+
+    CHECK(std::is_sorted(input.begin(), input.end()));
+    for (int i = 0; i < 10000; i++)
+        CHECK(std::find(input_copy.begin(), input_copy.end(), input[i]) != input_copy.end());
+}
+
+TEST_CASE("Test context argument for comparator", "[qsort]")
+{
+    random_generator rand_gen;
+    std::vector<int> input{rand_gen.make_vector(100)};
+    bool reverse;
+
+    reverse = false;
+    __wt_qsort_r(&input[0], input.size(), sizeof(input[0]), transposable_cmp, &reverse);
+    CHECK(std::is_sorted(input.begin(), input.end()));
+
+    reverse = true;
+    __wt_qsort_r(&input[0], input.size(), sizeof(input[0]), transposable_cmp, &reverse);
+    CHECK(std::is_sorted(input.rbegin(), input.rend()));
+}
+
+TEST_CASE("Test context is mutable", "[qsort]")
+{
+    std::vector<int> input{1, 2, 3, 4, 5};
+
+    int count = 0;
+    __wt_qsort_r(&input[0], input.size(), sizeof(input[0]), counting_cmp, &count);
+    CHECK(count > 0);
+}

--- a/test/unittest/tests/test_qsort.cpp
+++ b/test/unittest/tests/test_qsort.cpp
@@ -18,7 +18,7 @@ namespace {
 const uint8_t COMPOUND_MAGIC_B = 123;
 const uint64_t COMPOUND_MAGIC_C = 0xdeadbeefBAADF00D;
 struct compound_test_type {
-    uint64_t a;
+    int a;
     uint8_t b;
     uint64_t c;
 };

--- a/test/unittest/tests/test_qsort.cpp
+++ b/test/unittest/tests/test_qsort.cpp
@@ -127,7 +127,7 @@ TEST_CASE("Compound type", "[qsort]")
 
     for (int i = 0; i < 1000; i++) {
         if (i != 0)
-            CHECK(input[i - 1].a < input[i].a);
+            CHECK(input[i - 1].a <= input[i].a);
         CHECK(input[i].b == COMPOUND_MAGIC_B);
         CHECK(input[i].c == COMPOUND_MAGIC_C);
     }

--- a/test/unittest/tests/test_qsort.cpp
+++ b/test/unittest/tests/test_qsort.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <algorithm>
+#include <list>
 #include <vector>
 
 #include <catch2/catch.hpp>
@@ -139,13 +140,17 @@ TEST_CASE("Check contents", "[qsort]")
 {
     random_generator rand_gen;
     std::vector<int> input{rand_gen.make_vector(10000)};
-    std::vector<int> input_copy{input};
+    std::list<int> input_copy(input.begin(), input.end());
 
     __wt_qsort(&input[0], input.size(), sizeof(input[0]), simple_cmp);
 
     CHECK(std::is_sorted(input.begin(), input.end()));
-    for (int i = 0; i < 10000; i++)
-        CHECK(std::find(input_copy.begin(), input_copy.end(), input[i]) != input_copy.end());
+
+    for (int i = 0; i < 10000; i++) {
+        auto match = std::find(input_copy.begin(), input_copy.end(), input[i]);
+        CHECK(match != input_copy.end());
+        input_copy.erase(match);
+    }
 }
 
 TEST_CASE("Test context argument for comparator", "[qsort]")


### PR DESCRIPTION
A few things worth noting:
* The tests are largely based on the work @marcbutler did for WT-11060 - thanks!
* The initial cleanup work (over what was in the paper) was Luke's
* I also did some performance testing, it's definitely O(n log n) but the standard library `qsort` is still ~15% faster
* Original license for the qsort from the paper is retained