### PR TITLE
WT-11282 Fix build for GCC 13

### DIFF
--- a/test/cppsuite/src/common/logger.cpp
+++ b/test/cppsuite/src/common/logger.cpp
@@ -75,7 +75,7 @@ get_time(char *time_buf, size_t buf_size)
 
 /* Used to print out traces for debugging purpose. */
 void
-logger::log_msg(int64_t trace_type, const std::string_view &str)
+logger::log_msg(int64_t trace_type, std::string_view str)
 {
     if (logger::trace_level >= trace_type) {
         testutil_assert(

--- a/test/cppsuite/src/common/logger.cpp
+++ b/test/cppsuite/src/common/logger.cpp
@@ -75,7 +75,7 @@ get_time(char *time_buf, size_t buf_size)
 
 /* Used to print out traces for debugging purpose. */
 void
-logger::log_msg(int64_t trace_type, const std::string &str)
+logger::log_msg(int64_t trace_type, const std::string_view &str)
 {
     if (logger::trace_level >= trace_type) {
         testutil_assert(

--- a/test/cppsuite/src/common/logger.h
+++ b/test/cppsuite/src/common/logger.h
@@ -38,6 +38,7 @@
 #endif
 
 #include <mutex>
+#include <string_view>
 
 /* Define helpful functions related to debugging. */
 namespace test_harness {
@@ -64,7 +65,7 @@ public:
 
 public:
     /* Used to print out traces for debugging purpose. */
-    static void log_msg(int64_t trace_type, const std::string &str);
+    static void log_msg(int64_t trace_type, const std::string_view &str);
 
     /* Make sure the class will not be instantiated. */
     logger() = delete;

--- a/test/cppsuite/src/common/logger.h
+++ b/test/cppsuite/src/common/logger.h
@@ -65,7 +65,7 @@ public:
 
 public:
     /* Used to print out traces for debugging purpose. */
-    static void log_msg(int64_t trace_type, const std::string_view &str);
+    static void log_msg(int64_t trace_type, std::string_view str);
 
     /* Make sure the class will not be instantiated. */
     logger() = delete;

--- a/test/cppsuite/src/util/execution_timer.cpp
+++ b/test/cppsuite/src/util/execution_timer.cpp
@@ -26,6 +26,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <cstdint>
+
 #include "execution_timer.h"
 
 #include "src/component/metrics_writer.h"

--- a/test/simulator/timestamp/src/include/session_simulator.h
+++ b/test/simulator/timestamp/src/include/session_simulator.h
@@ -28,8 +28,9 @@
 
 #pragma once
 
-#include <string>
+#include <cstdint>
 #include <map>
+#include <string>
 
 class session_simulator {
     /* Methods */


### PR DESCRIPTION
Couple of minor fixes, all in test code. The `std::string_view` thing is a way to accept either a `char *` or a `std::string`, since there are lots of places that used both it seemed better to fix it like this.