### PR TITLE
WT-11281 Limit runs timer to limit disk space usage

### DIFF
--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1405,15 +1405,16 @@ config_run_length(void)
             config_single(NULL, "runs.timer=360", false);
     }
 
-    /* There are combinations that can cause out of disk space issues. Prevent that if possible.
-     * Due to CONFIG.stress, runs.timer is often considered explicit so override if absolutely
-     * needed.
+    /*
+     * There are combinations that can cause out of disk space issues and here we try to prevent
+     * those. CONFIG.stress causes runs.timer to be considered explicit which limits when we can
+     * override the run length to extreme cases.
      */
     if (GV(RUNS_TIMER) > 10 && GV(LOGGING) && !GV(LOGGING_REMOVE) && GV(BACKUP) &&
       GV(OPS_SALVAGE)) {
-        config_single(NULL, "runs.timer=10", true);
         WARN(
           "limiting runs.timer=%d as logging=1, backup=1, ops.salvage=1, and logging.remove=0", 10);
+        config_single(NULL, "runs.timer=10", true);
     }
 }
 

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -503,27 +503,6 @@ config_run(void)
 
     /* Adjust run length if needed. */
     config_run_length();
-    /*
-     * Run-length is configured by a number of operations and a timer.
-     *
-     * If the operation count and the timer are both configured, do nothing. If only the timer is
-     * configured, clear the operations count. If only the operation count is configured, limit the
-     * run to 6 hours. If neither is configured, leave the operations count alone and limit the run
-     * to 30 minutes.
-     *
-     * In other words, if we rolled the dice on everything, do a short run. If we chose a number of
-     * operations but the rest of the configuration means operations take a long time to complete
-     * (for example, a small cache and many worker threads), don't let it run forever.
-     */
-    if (config_explicit(NULL, "runs.timer")) {
-        if (!config_explicit(NULL, "runs.ops"))
-            config_single(NULL, "runs.ops=0", false);
-    } else {
-        if (!config_explicit(NULL, "runs.ops"))
-            config_single(NULL, "runs.timer=30", false);
-        else
-            config_single(NULL, "runs.timer=360", false);
-    }
 
     config_random_generators_before_run();
 }


### PR DESCRIPTION
The combination of logging, backup, and salvage can use a large amount of disk space, especially when logging.remove=0. As such, this PR will limit the length of the run to 10 mins if these are all true.