### PR TITLE
WT-11278 Add msan origin tracking

### DIFF
--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -138,8 +138,8 @@ set(ubsan_compiler_cxx_flag "-fsanitize=undefined")
 
 # MSAN build variant flags.
 set(msan_link_flags "-fsanitize=memory")
-set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
-set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
+set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
+set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
 
 # TSAN build variant flags.
 set(tsan_link_flags "-fsanitize=thread")

--- a/dist/s_export
+++ b/dist/s_export
@@ -28,6 +28,8 @@ check()
     # Functions beginning with __ut are intentionally exposed to support unit testing when
     # Wiredtiger is compiled with HAVE_UNITTEST=1.
     egrep -v '^__ut' |
+    # MSan injected symbol present when origin tracking is enabled.
+    egrep -v '^__msan_track_origins' |
     egrep -v '^__wt') |
     sort |
     uniq -u |

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -21,3 +21,5 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
+# MSan instrumentation that appears when -fsanitize-memory-track-origins is used.
+__msan_track_origins

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -21,5 +21,3 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
-# MSan instrumentation that appears when -fsanitize-memory-track-origins is used.
-__msan_track_origins

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5801,7 +5801,7 @@ buildvariants:
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
-      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:print_stacktrace=1"
+      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:verbosity=3"
       MSAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
       LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so
       WT_TOPDIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Add necessary compiler flags to enable msan origin tracking.

Update msan environment in CI to remove unrecoginzed flag and increase verbosity to aid debugging.