### PR TITLE
Revert "WT-11278 Add msan origin tracking"

### DIFF
--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -138,8 +138,8 @@ set(ubsan_compiler_cxx_flag "-fsanitize=undefined")
 
 # MSAN build variant flags.
 set(msan_link_flags "-fsanitize=memory")
-set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
-set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
+set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
+set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
 
 # TSAN build variant flags.
 set(tsan_link_flags "-fsanitize=thread")

--- a/dist/s_export
+++ b/dist/s_export
@@ -28,8 +28,6 @@ check()
     # Functions beginning with __ut are intentionally exposed to support unit testing when
     # Wiredtiger is compiled with HAVE_UNITTEST=1.
     egrep -v '^__ut' |
-    # MSan injected symbol present when origin tracking is enabled.
-    egrep -v '^__msan_track_origins' |
     egrep -v '^__wt') |
     sort |
     uniq -u |

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5790,7 +5790,7 @@ buildvariants:
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
-      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:verbosity=3"
+      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:print_stacktrace=1"
       MSAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
       LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so
       WT_TOPDIR=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#9383

To allow fixing format.sh and updating evergreen.yml