### PR TITLE
WT-11278 Add MSan origin tracking

### DIFF
--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -138,8 +138,8 @@ set(ubsan_compiler_cxx_flag "-fsanitize=undefined")
 
 # MSAN build variant flags.
 set(msan_link_flags "-fsanitize=memory")
-set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
-set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls")
+set(msan_compiler_c_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
+set(msan_compiler_cxx_flag "-fsanitize=memory" "-fno-optimize-sibling-calls" "-fsanitize-memory-track-origins=2")
 
 # TSAN build variant flags.
 set(tsan_link_flags "-fsanitize=thread")

--- a/dist/s_export
+++ b/dist/s_export
@@ -28,6 +28,8 @@ check()
     # Functions beginning with __ut are intentionally exposed to support unit testing when
     # Wiredtiger is compiled with HAVE_UNITTEST=1.
     egrep -v '^__ut' |
+    # MSan injected symbol present when origin tracking is enabled.
+    egrep -v '^__msan_track_origins' |
     egrep -v '^__wt') |
     sort |
     uniq -u |

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -21,3 +21,5 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
+# MSan instrumentation that appears when -fsanitize-memory-track-origins is used.
+__msan_track_origins

--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -21,5 +21,3 @@ wiredtiger_unpack_start
 wiredtiger_unpack_str
 wiredtiger_unpack_uint
 wiredtiger_version
-# MSan instrumentation that appears when -fsanitize-memory-track-origins is used.
-__msan_track_origins

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1208,7 +1208,7 @@ variables:
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
           format_test_script_args: -t 360 -- -C "mmap=false,mmap_all=false"
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
 
   - &format-stress-sanitizer-test
@@ -1222,7 +1222,7 @@ variables:
         vars:
           format_test_script_args: -t 360
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
 
   - &race-condition-stress-sanitizer-test
@@ -1236,7 +1236,7 @@ variables:
         vars:
           format_test_script_args: -R -t 360
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
 
   - &recovery-stress-test
@@ -3773,13 +3773,13 @@ tasks:
       - func: "format test script"
         vars:
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           format_test_script_args: -S
       - func: "format test"
         vars:
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           extra_args: -C "verbose=(checkpoint_cleanup:1)"
 
@@ -4111,7 +4111,7 @@ tasks:
       - func: "format test script"
         vars:
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
           # Run for 30 mins, and explicitly set data_source to LSM with a large cache
           format_test_script_args: -t 30 data_source=lsm cache_minimum=5000
@@ -4351,7 +4351,7 @@ tasks:
         vars:
           format_test_script_args: -t 360
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
 
   - name: race-condition-stress-sanitizer-test-no-barrier
@@ -4367,7 +4367,7 @@ tasks:
         vars:
           format_test_script_args: -R -t 360
           test_env_vars:
-            ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
+            ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
             ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
 
   - name: recovery-stress-test-no-barrier
@@ -5745,8 +5745,8 @@ buildvariants:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
-      ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1"
-      LSAN_OPTIONS="print_suppressions=0:suppressions=$WT_TOPDIR/test/evergreen/asan_leaks.supp"
+      ASAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:unmap_shadow_on_exit=1"
+      LSAN_OPTIONS="abort_on_error=1:print_suppressions=0:suppressions=$WT_TOPDIR/test/evergreen/asan_leaks.supp"
       ASAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
       TESTUTIL_BYPASS_ASAN=1
       LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so:$WT_TOPDIR/TCMALLOC_LIB/lib/libtcmalloc.so
@@ -5790,7 +5790,7 @@ buildvariants:
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
-      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:print_stacktrace=1"
+      MSAN_OPTIONS="abort_on_error=1:disable_coredump=0:verbosity=3"
       MSAN_SYMBOLIZER_PATH=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer
       LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libeatmydata.so
       WT_TOPDIR=$(git rev-parse --show-toplevel)
@@ -5823,7 +5823,7 @@ buildvariants:
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
-      UBSAN_OPTIONS="detect_leaks=1:disable_coredump=0:external_symbolizer_path=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer:abort_on_error=1:print_stacktrace=1"
+      UBSAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:external_symbolizer_path=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer:abort_on_error=1:print_stacktrace=1"
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
       LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5823,7 +5823,7 @@ buildvariants:
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
-      UBSAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:external_symbolizer_path=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer:abort_on_error=1:print_stacktrace=1"
+      UBSAN_OPTIONS="abort_on_error=1:detect_leaks=1:disable_coredump=0:external_symbolizer_path=/opt/mongodbtoolchain/v4/bin/llvm-symbolizer:print_stacktrace=1"
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
       LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -467,11 +467,11 @@ resolve()
 		# give the parent recording binary a chance to complete if we are using it
 		[[ ! -z $live_record_binary ]] && sleep 2
 
-		# Process group leader dumped core: so it is a bug, in contrast to spurious cores
-		# from killing zombifieed child processes. This is to guard against spuriously
+		# Process group leader dumped core: so it is a bug, in contrast to any spurious cores
+		# from killing zombified child processes. This is to guard against spuriously
 		# missing memory sanitizer errors, which has occured historically even when
 		# abort_on_error=1 was passed to MSan.
-		[[ -f "dump_t.${pid}.core" ]] {
+		[[ -f "dump_t.${pid}.core" ]] && {
 		    report_failure $dir
 		    continue
 		}

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -467,12 +467,6 @@ resolve()
 		# give the parent recording binary a chance to complete if we are using it
 		[[ ! -z $live_record_binary ]] && sleep 2
 
-		# Check for Sanitizer failures, have to do this prior to success because both can be reported.
-		grep -E -i 'Sanitizer' $log > /dev/null && {
-			report_failure $dir
-			continue
-		}
-
 		# Remove successful jobs.
 		grep 'successful run completed' $log > /dev/null && {
 			rm -rf $dir $log $rec_dir

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -467,7 +467,7 @@ resolve()
 		# give the parent recording binary a chance to complete if we are using it
 		[[ ! -z $live_record_binary ]] && sleep 2
 
-		# Process group leader dumped core: so it is a bug, in contrast to any spurious cores
+		# Process group leader core dump indicates a bug, in contrast to any spurious cores
 		# from killing zombified child processes. This is to guard against spuriously
 		# missing memory sanitizer errors, which has occured historically even when
 		# abort_on_error=1 was passed to MSan.

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -467,6 +467,15 @@ resolve()
 		# give the parent recording binary a chance to complete if we are using it
 		[[ ! -z $live_record_binary ]] && sleep 2
 
+		# Process group leader dumped core: so it is a bug, in contrast to spurious cores
+		# from killing zombifieed child processes. This is to guard against spuriously
+		# missing memory sanitizer errors, which has occured historically even when
+		# abort_on_error=1 was passed to MSan.
+		[[ -f "dump_t.${pid}.core" ]] {
+		    report_failure $dir
+		    continue
+		}
+
 		# Remove successful jobs.
 		grep 'successful run completed' $log > /dev/null && {
 			rm -rf $dir $log $rec_dir


### PR DESCRIPTION
Add necessary compiler flags to enable msan origin tracking.

Update msan environment in CI to remove unrecoginzed flag and increase verbosity to aid debugging.

Remove grepping for format.sh error output from format.sh, and ensure all sanitizers are passed abort_on_error=1 env var in evergreen.