### PR TITLE
WT-11031 Fix RTS to skip tables with no time window information in the checkpoint (#9216) (#9391) (4.4 backport)

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1445,9 +1445,9 @@ __rollback_to_stable_btree_apply(
     wt_timestamp_t max_durable_ts, newest_start_durable_ts, newest_stop_durable_ts;
     size_t addr_size;
     uint64_t rollback_txnid;
-    uint32_t btree_id, handle_open_flags;
+    uint32_t btree_id;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
-    bool dhandle_allocated, durable_ts_found, has_txn_updates_gt_than_ckpt_snap, perform_rts;
+    bool dhandle_allocated, has_txn_updates_gt_than_ckpt_snap, perform_rts;
     bool prepared_updates;
 
     /* Ignore non-btree objects as well as the metadata and history store files. */
@@ -1461,22 +1461,18 @@ __rollback_to_stable_btree_apply(
 
     /* Find out the max durable timestamp of the object from checkpoint. */
     newest_start_durable_ts = newest_stop_durable_ts = WT_TS_NONE;
-    durable_ts_found = prepared_updates = has_txn_updates_gt_than_ckpt_snap = false;
+    prepared_updates = has_txn_updates_gt_than_ckpt_snap = false;
 
     WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
     __wt_config_subinit(session, &ckptconf, &cval);
     for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
         ret = __wt_config_subgets(session, &cval, "newest_start_durable_ts", &value);
-        if (ret == 0) {
+        if (ret == 0)
             newest_start_durable_ts = WT_MAX(newest_start_durable_ts, (wt_timestamp_t)value.val);
-            durable_ts_found = true;
-        }
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "newest_stop_durable_ts", &value);
-        if (ret == 0) {
+        if (ret == 0)
             newest_stop_durable_ts = WT_MAX(newest_stop_durable_ts, (wt_timestamp_t)value.val);
-            durable_ts_found = true;
-        }
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "prepare", &value);
         if (ret == 0) {
@@ -1522,8 +1518,7 @@ __rollback_to_stable_btree_apply(
      * 1. The dhandle is present in the cache and tree is modified.
      * 2. The checkpoint durable start/stop timestamp is greater than the rollback timestamp.
      * 3. The checkpoint has prepared updates written to disk.
-     * 4. There is no durable timestamp in any checkpoint.
-     * 5. The checkpoint newest txn is greater than snapshot min txn id.
+     * 4. The checkpoint newest txn is greater than snapshot min txn id.
      */
     WT_WITH_HANDLE_LIST_READ_LOCK(session, (ret = __wt_conn_dhandle_find(session, uri, NULL)));
 
@@ -1532,17 +1527,8 @@ __rollback_to_stable_btree_apply(
     WT_ERR_NOTFOUND_OK(ret, false);
 
     if (perform_rts || max_durable_ts > rollback_timestamp || prepared_updates ||
-      !durable_ts_found || has_txn_updates_gt_than_ckpt_snap) {
-        /*
-         * MongoDB does not close all open handles before calling rollback-to-stable; otherwise,
-         * don't permit that behavior, the application is likely making a mistake.
-         */
-#ifdef WT_STANDALONE_BUILD
-        handle_open_flags = WT_DHANDLE_DISCARD | WT_DHANDLE_EXCLUSIVE;
-#else
-        handle_open_flags = 0;
-#endif
-        ret = __wt_session_get_dhandle(session, uri, NULL, NULL, handle_open_flags);
+      has_txn_updates_gt_than_ckpt_snap) {
+        ret = __wt_session_get_dhandle(session, uri, NULL, NULL, 0);
         if (ret != 0)
             WT_ERR_MSG(session, ret, "%s: unable to open handle%s", uri,
               ret == EBUSY ? ", error indicates handle is unavailable due to concurrent use" : "");
@@ -1550,12 +1536,11 @@ __rollback_to_stable_btree_apply(
 
         __wt_verbose(session, WT_VERB_RECOVERY_RTS(session),
           "tree rolled back with durable timestamp: %s, or when tree is modified: %s or "
-          "prepared updates: %s or when durable time is not found: %s or txnid: %" PRIu64
+          "prepared updates: %s or txnid: %" PRIu64
           " is greater than recovery checkpoint snap min: %s",
           __wt_timestamp_to_string(max_durable_ts, ts_string[0]),
           S2BT(session)->modified ? "true" : "false", prepared_updates ? "true" : "false",
-          !durable_ts_found ? "true" : "false", rollback_txnid,
-          has_txn_updates_gt_than_ckpt_snap ? "true" : "false");
+          rollback_txnid, has_txn_updates_gt_than_ckpt_snap ? "true" : "false");
         WT_ERR(__rollback_to_stable_btree(session, rollback_timestamp));
     } else
         __wt_verbose(session, WT_VERB_RECOVERY_RTS(session),


### PR DESCRIPTION
This change is a reimplementation for older branches from the commit af1fb31f4ecfa4d8e267c1856d159e84e70c70b4

(cherry picked from commit ccde00ad5b5b48a827cd0101bcf1714d27fe38cd)
(cherry picked from commit 5f734cefc93076fad704b244b58cee64b31c9670)