### PR TITLE
WT-11258 Hide dram option in config

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -574,8 +574,9 @@ connection_runtime_config = [
         Config('hashsize', '1024', r'''
             number of buckets in the hashtable that keeps track of objects''',
             min='64', max='1048576'),
-        Config('type', '', r'''
-            cache location: DRAM or FILE (file system or block device)'''),
+        Config('type', 'FILE', r'''
+            cache location, defaults to the file system.''',
+            choices=['FILE', 'DRAM'], undoc=True),
         ]),
     Config('debug_mode', '', r'''
         control the settings of various extended debugging features''',

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -61,7 +61,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_chunk_cache_subconfigs[] = 
   {"chunk_cache_evict_trigger", "int", NULL, "min=0,max=100", NULL, 0},
   {"chunk_size", "int", NULL, "min=512KB,max=100GB", NULL, 0},
   {"device_path", "string", NULL, NULL, NULL, 0}, {"enabled", "boolean", NULL, NULL, NULL, 0},
-  {"hashsize", "int", NULL, "min=64,max=1048576", NULL, 0}, {"type", "string", NULL, NULL, NULL, 0},
+  {"hashsize", "int", NULL, "min=64,max=1048576", NULL, 0},
+  {"type", "string", NULL, "choices=[\"FILE\",\"DRAM\"]", NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure_compatibility_subconfigs[] = {
@@ -1282,7 +1283,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_stuck_timeout_ms=300000,checkpoint=(log_size=0,wait=0),"
     "checkpoint_cleanup=none,chunk_cache=(capacity=10GB,"
     "chunk_cache_evict_trigger=90,chunk_size=1MB,device_path=,"
-    "enabled=false,hashsize=1024,type=),compatibility=(release=),"
+    "enabled=false,hashsize=1024,type=FILE),compatibility=(release=),"
     "debug_mode=(checkpoint_retention=0,corruption_abort=true,"
     "cursor_copy=false,cursor_reposition=false,eviction=false,"
     "log_retention=0,realloc_exact=false,realloc_malloc=false,"
@@ -1569,8 +1570,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_stuck_timeout_ms=300000,checkpoint=(log_size=0,wait=0),"
     "checkpoint_cleanup=none,checkpoint_sync=true,"
     "chunk_cache=(capacity=10GB,chunk_cache_evict_trigger=90,"
-    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,type=),"
-    "compatibility=(release=,require_max=,require_min=),"
+    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,"
+    "type=FILE),compatibility=(release=,require_max=,require_min=),"
     "config_base=true,create=false,debug_mode=(checkpoint_retention=0"
     ",corruption_abort=true,cursor_copy=false,cursor_reposition=false"
     ",eviction=false,log_retention=0,realloc_exact=false,"
@@ -1615,8 +1616,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_stuck_timeout_ms=300000,checkpoint=(log_size=0,wait=0),"
     "checkpoint_cleanup=none,checkpoint_sync=true,"
     "chunk_cache=(capacity=10GB,chunk_cache_evict_trigger=90,"
-    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,type=),"
-    "compatibility=(release=,require_max=,require_min=),"
+    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,"
+    "type=FILE),compatibility=(release=,require_max=,require_min=),"
     "config_base=true,create=false,debug_mode=(checkpoint_retention=0"
     ",corruption_abort=true,cursor_copy=false,cursor_reposition=false"
     ",eviction=false,log_retention=0,realloc_exact=false,"
@@ -1661,8 +1662,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_stuck_timeout_ms=300000,checkpoint=(log_size=0,wait=0),"
     "checkpoint_cleanup=none,checkpoint_sync=true,"
     "chunk_cache=(capacity=10GB,chunk_cache_evict_trigger=90,"
-    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,type=),"
-    "compatibility=(release=,require_max=,require_min=),"
+    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,"
+    "type=FILE),compatibility=(release=,require_max=,require_min=),"
     "debug_mode=(checkpoint_retention=0,corruption_abort=true,"
     "cursor_copy=false,cursor_reposition=false,eviction=false,"
     "log_retention=0,realloc_exact=false,realloc_malloc=false,"
@@ -1705,8 +1706,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_stuck_timeout_ms=300000,checkpoint=(log_size=0,wait=0),"
     "checkpoint_cleanup=none,checkpoint_sync=true,"
     "chunk_cache=(capacity=10GB,chunk_cache_evict_trigger=90,"
-    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,type=),"
-    "compatibility=(release=,require_max=,require_min=),"
+    "chunk_size=1MB,device_path=,enabled=false,hashsize=1024,"
+    "type=FILE),compatibility=(release=,require_max=,require_min=),"
     "debug_mode=(checkpoint_retention=0,corruption_abort=true,"
     "cursor_copy=false,cursor_reposition=false,eviction=false,"
     "log_retention=0,realloc_exact=false,realloc_malloc=false,"

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2199,9 +2199,8 @@ struct __wt_connection {
      * \c false.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;hashsize, number of buckets in the hashtable that
      * keeps track of objects., an integer between \c 64 and \c 1048576; default \c 1024.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;type, cache location: DRAM or FILE (file system or block
-     * device)., a string; default empty.}
-     * @config{ ),,}
+     * @config{
+     * ),,}
      * @config{compatibility = (, set compatibility version of database.  Changing the compatibility
      * version requires that there are no active operations for the duration of the call., a set of
      * related configuration options defined as follows.}
@@ -2953,8 +2952,6 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;
  * hashsize, number of buckets in the hashtable that keeps track of objects., an integer between \c
  * 64 and \c 1048576; default \c 1024.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;type, cache location: DRAM
- * or FILE (file system or block device)., a string; default empty.}
  * @config{ ),,}
  * @config{compatibility = (, set compatibility version of database.  Changing the compatibility
  * version requires that there are no active operations for the duration of the call., a set of


### PR DESCRIPTION
Hiding the DRAM config. 

I had the assumption that putting `undoc` after choices would hid only the choices however in wiredtiger.in it shows that the whole config is hidden - do we need visibility of the chunk type selecting being 'FILE' if this is the default? Need to investigate further if only choices can be hidden.

An alternative solution if we cannot hide the whole config:


```
       Config('file', 'true', r'''
            set cache location to the file system.''',
            type='boolean'),
        Config('dram', 'false', r'''
            set cache location to the block device. This will override chunk_cache.file setting.''',
            type='boolean', undoc=True),
        ]),
```


This can separate the options from the config and hide the DRAM option - can nest this in a subconfig under type as well if that is more readable - but otherwise not much difference. 

