### PR TITLE
WT-11255 Tiered storage performance scenario

### DIFF
--- a/bench/wtperf/runners/chunk_cache_reads.wtperf
+++ b/bench/wtperf/runners/chunk_cache_reads.wtperf
@@ -1,5 +1,5 @@
 conn_config="statistics=(all),statistics_log=(json=true,on_close=true,wait=1),cache_size=50MB,eviction=(threads_max=8)"
-chunkcache_config="chunk_cache=[enabled=true,chunk_size=100MB,capacity=25GB]"
+chunk_cache_config="chunk_cache=[enabled=true,chunk_size=100MB,capacity=25GB]"
 readonly=false
 table_count=5
 icount=25000000

--- a/bench/wtperf/runners/chunkcache_reads.wtperf
+++ b/bench/wtperf/runners/chunkcache_reads.wtperf
@@ -1,0 +1,11 @@
+conn_config="statistics=(all),statistics_log=(json=true,on_close=true,wait=1),cache_size=50MB,eviction=(threads_max=8)"
+chunkcache_config="chunk_cache=[enabled=true,chunk_size=100MB,capacity=25GB]"
+readonly=false
+table_count=5
+icount=25000000
+key_sz=1024
+value_sz=1024
+threads=((count=10,reads=1))
+run_time=120
+verbose=2
+populate_threads=4

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1680,6 +1680,14 @@ execute_populate(WTPERF *wtperf)
     return (0);
 }
 
+static bool
+need_reopen(CONFIG_OPTS *opts)
+{
+    return opts->readonly
+        || opts->reopen_connection
+        || (strlen(opts->chunkcache_config) != 0);
+}
+
 static int
 close_reopen(WTPERF *wtperf)
 {
@@ -1691,7 +1699,7 @@ close_reopen(WTPERF *wtperf)
     if (opts->in_memory)
         return (0);
 
-    if (!opts->readonly && !opts->reopen_connection)
+    if (!need_reopen(opts))
         return (0);
     /*
      * Reopen the connection. We do this so that the workload phase always starts with the on-disk
@@ -2642,20 +2650,9 @@ main(int argc, char *argv[])
         testutil_snprintf(
           wtperf->partial_config, req_len, "%s%s", opts->table_config, LOG_PARTIAL_CONFIG);
     }
-    /*
-     * Set the config for reopen. If readonly add in that string. If not readonly then just copy the
-     * original conn_config.
-     */
-    if (opts->readonly)
-        req_len = strlen(opts->conn_config) + strlen(READONLY_CONFIG) + 1;
-    else
-        req_len = strlen(opts->conn_config) + 1;
-    wtperf->reopen_config = dmalloc(req_len);
-    if (opts->readonly)
-        testutil_snprintf(
-          wtperf->reopen_config, req_len, "%s%s", opts->conn_config, READONLY_CONFIG);
-    else
-        testutil_snprintf(wtperf->reopen_config, req_len, "%s", opts->conn_config);
+
+    /* Generate config for the close/reopen after populating. */
+    wtperf->reopen_config = config_reopen(opts);
 
     /* Sanity-check the configuration. */
     if ((ret = config_sanity(wtperf)) != 0)

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -1683,9 +1683,7 @@ execute_populate(WTPERF *wtperf)
 static bool
 need_reopen(CONFIG_OPTS *opts)
 {
-    return opts->readonly
-        || opts->reopen_connection
-        || (strlen(opts->chunkcache_config) != 0);
+    return opts->readonly || opts->reopen_connection || (strlen(opts->chunk_cache_config) != 0);
 }
 
 static int

--- a/bench/wtperf/wtperf.h
+++ b/bench/wtperf/wtperf.h
@@ -299,6 +299,7 @@ int config_opt_name_value(WTPERF *, const char *, const char *);
 void config_opt_print(WTPERF *);
 int config_opt_str(WTPERF *, const char *);
 void config_opt_usage(void);
+char *config_reopen(CONFIG_OPTS *);
 int config_sanity(WTPERF *);
 void latency_insert(WTPERF *, uint32_t *, uint32_t *, uint32_t *);
 void latency_modify(WTPERF *, uint32_t *, uint32_t *, uint32_t *);

--- a/bench/wtperf/wtperf_config.c
+++ b/bench/wtperf/wtperf_config.c
@@ -828,8 +828,8 @@ config_sanity(WTPERF *wtperf)
             }
         }
 
-    if (opts->chunkcache_config == NULL) {
-        fprintf(stderr, "chunkcache_config was null, somehow.\n");
+    if (opts->chunk_cache_config == NULL) {
+        fprintf(stderr, "chunk_cache_config was null, somehow.\n");
         return (EINVAL);
     }
 
@@ -943,11 +943,11 @@ config_opt_print(WTPERF *wtperf)
       "\t"
       "Connection configuration: %s\n",
       opts->conn_config);
-    if (opts->chunkcache_config != NULL)
+    if (opts->chunk_cache_config != NULL)
         printf(
           "\t"
           "Chunk cache configuration: %s\n",
-          opts->chunkcache_config);
+          opts->chunk_cache_config);
     if (opts->sess_config != NULL)
         printf(
           "\t"
@@ -1084,25 +1084,24 @@ char *
 config_reopen(CONFIG_OPTS *opts)
 {
     char *ret;
-    size_t chunkcache_cfg_len, req_len;
+    size_t chunk_cache_cfg_len, req_len;
 
-    chunkcache_cfg_len = strlen(opts->chunkcache_config);
-    req_len = strlen(opts->conn_config) + 2; /* Spare null bytes from the two extra config strings. */
+    chunk_cache_cfg_len = strlen(opts->chunk_cache_config);
+    req_len = strlen(opts->conn_config) + 1;
     opts->reopen_connection = true;
     if (opts->readonly)
         req_len += strlen(READONLY_CONFIG);
-    if (chunkcache_cfg_len != 0)
-        req_len += chunkcache_cfg_len;
+    if (chunk_cache_cfg_len != 0)
+        req_len += chunk_cache_cfg_len;
 
     ret = dmalloc(req_len);
-    if (opts->readonly && chunkcache_cfg_len != 0)
+    if (opts->readonly && chunk_cache_cfg_len != 0)
         testutil_snprintf(
-          ret, req_len, "%s%s%s", opts->conn_config, READONLY_CONFIG, opts->chunkcache_config);
+          ret, req_len, "%s%s%s", opts->conn_config, READONLY_CONFIG, opts->chunk_cache_config);
     else if (opts->readonly)
-        testutil_snprintf(
-          ret, req_len, "%s%s", opts->conn_config, READONLY_CONFIG);
-    else if (chunkcache_cfg_len != 0)
-        testutil_snprintf(ret, req_len, "%s%s", opts->conn_config, opts->chunkcache_config);
+        testutil_snprintf(ret, req_len, "%s%s", opts->conn_config, READONLY_CONFIG);
+    else if (chunk_cache_cfg_len != 0)
+        testutil_snprintf(ret, req_len, "%s%s", opts->conn_config, opts->chunk_cache_config);
     else
         testutil_snprintf(ret, req_len, "%s", opts->conn_config);
 

--- a/bench/wtperf/wtperf_config.c
+++ b/bench/wtperf/wtperf_config.c
@@ -827,6 +827,12 @@ config_sanity(WTPERF *wtperf)
                 return (EINVAL);
             }
         }
+
+    if (opts->chunkcache_config == NULL) {
+        fprintf(stderr, "chunkcache_config was null, somehow.\n");
+        return (EINVAL);
+    }
+
     return (0);
 }
 
@@ -937,6 +943,11 @@ config_opt_print(WTPERF *wtperf)
       "\t"
       "Connection configuration: %s\n",
       opts->conn_config);
+    if (opts->chunkcache_config != NULL)
+        printf(
+          "\t"
+          "Chunk cache configuration: %s\n",
+          opts->chunkcache_config);
     if (opts->sess_config != NULL)
         printf(
           "\t"
@@ -965,7 +976,7 @@ config_opt_print(WTPERF *wtperf)
           "Workload configuration(s):\n");
         for (i = 0, workp = wtperf->workload; i < wtperf->workload_cnt; ++i, ++workp)
             printf("\t\t%" PRId64 " threads (inserts=%" PRId64 ", reads=%" PRId64
-                   ", updates=%" PRId64 ", truncates=% " PRId64 ")\n",
+                   ", updates=%" PRId64 ", truncates=%" PRId64 ")\n",
               workp->threads, workp->insert, workp->read, workp->update, workp->truncate);
     }
 
@@ -1063,4 +1074,37 @@ config_opt_usage(void)
         printf("%s (%s, default=%s)\n", config_opts_desc[i].name, typestr, defaultval);
         pretty_print(config_opts_desc[i].description, "\t");
     }
+}
+
+/*
+ * config_reopen --
+ *     Set the config string for reopen from the given options structure.
+ */
+char *
+config_reopen(CONFIG_OPTS *opts)
+{
+    char *ret;
+    size_t chunkcache_cfg_len, req_len;
+
+    chunkcache_cfg_len = strlen(opts->chunkcache_config);
+    req_len = strlen(opts->conn_config) + 2; /* Spare null bytes from the two extra config strings. */
+    opts->reopen_connection = true;
+    if (opts->readonly)
+        req_len += strlen(READONLY_CONFIG);
+    if (chunkcache_cfg_len != 0)
+        req_len += chunkcache_cfg_len;
+
+    ret = dmalloc(req_len);
+    if (opts->readonly && chunkcache_cfg_len != 0)
+        testutil_snprintf(
+          ret, req_len, "%s%s%s", opts->conn_config, READONLY_CONFIG, opts->chunkcache_config);
+    else if (opts->readonly)
+        testutil_snprintf(
+          ret, req_len, "%s%s", opts->conn_config, READONLY_CONFIG);
+    else if (chunkcache_cfg_len != 0)
+        testutil_snprintf(ret, req_len, "%s%s", opts->conn_config, opts->chunkcache_config);
+    else
+        testutil_snprintf(ret, req_len, "%s", opts->conn_config);
+
+    return (ret);
 }

--- a/bench/wtperf/wtperf_opt_inline.h
+++ b/bench/wtperf/wtperf_opt_inline.h
@@ -88,6 +88,8 @@ DEF_OPT_AS_UINT32(checkpoint_stress_rate, 0,
   "checkpoint every rate operations during the populate phase in the populate thread(s), 0 to "
   "disable")
 DEF_OPT_AS_UINT32(checkpoint_threads, 0, "number of checkpoint threads")
+DEF_OPT_AS_CONFIG_STRING(chunkcache_config, "",
+  "extra configuration options for chunk cache. Applied only after restart.")
 DEF_OPT_AS_CONFIG_STRING(conn_config, "create,statistics=(fast),statistics_log=(json,wait=1)",
   "connection configuration string")
 DEF_OPT_AS_BOOL(close_conn, 1,

--- a/bench/wtperf/wtperf_opt_inline.h
+++ b/bench/wtperf/wtperf_opt_inline.h
@@ -88,7 +88,7 @@ DEF_OPT_AS_UINT32(checkpoint_stress_rate, 0,
   "checkpoint every rate operations during the populate phase in the populate thread(s), 0 to "
   "disable")
 DEF_OPT_AS_UINT32(checkpoint_threads, 0, "number of checkpoint threads")
-DEF_OPT_AS_CONFIG_STRING(chunkcache_config, "",
+DEF_OPT_AS_CONFIG_STRING(chunk_cache_config, "",
   "extra configuration options for chunk cache. Applied only after restart.")
 DEF_OPT_AS_CONFIG_STRING(conn_config, "create,statistics=(fast),statistics_log=(json,wait=1)",
   "connection configuration string")

--- a/bench/wtperf/wtperf_opt_inline.h
+++ b/bench/wtperf/wtperf_opt_inline.h
@@ -88,8 +88,8 @@ DEF_OPT_AS_UINT32(checkpoint_stress_rate, 0,
   "checkpoint every rate operations during the populate phase in the populate thread(s), 0 to "
   "disable")
 DEF_OPT_AS_UINT32(checkpoint_threads, 0, "number of checkpoint threads")
-DEF_OPT_AS_CONFIG_STRING(chunk_cache_config, "",
-  "extra configuration options for chunk cache. Applied only after restart.")
+DEF_OPT_AS_CONFIG_STRING(
+  chunk_cache_config, "", "extra configuration options for chunk cache. Applied only after restart")
 DEF_OPT_AS_CONFIG_STRING(conn_config, "create,statistics=(fast),statistics_log=(json,wait=1)",
   "connection configuration string")
 DEF_OPT_AS_BOOL(close_conn, 1,

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -137,7 +137,7 @@ checkpoint every rate operations during the populate phase in the populate threa
 @par checkpoint_threads (unsigned int, default=0)
 number of checkpoint threads
 @par chunk_cache_config (string, default="")
-extra configuration options for chunk cache. Applied only after restart.
+extra configuration options for chunk cache. Applied only after restart
 @par conn_config (string, default="create,statistics=(fast),statistics_log=(json,wait=1)")
 connection configuration string
 @par close_conn (boolean, default=true)

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -136,6 +136,8 @@ checkpoint every interval seconds during the workload phase.
 checkpoint every rate operations during the populate phase in the populate thread(s), 0 to  disable
 @par checkpoint_threads (unsigned int, default=0)
 number of checkpoint threads
+@par chunk_cache_config (string, default="")
+extra configuration options for chunk cache. Applied only after restart.
 @par conn_config (string, default="create,statistics=(fast),statistics_log=(json,wait=1)")
 connection configuration string
 @par close_conn (boolean, default=true)


### PR DESCRIPTION
This adds scenarios to measure throughput, both with and without the chunk cache. This also makes it a lot more difficult to mis-use the chunk cache, by adding a separate `wtperf` config item for the config that implies a restart. This way, we don't run into the issue where changing a file under the chunk cache causes the block manager to see stale data (and, thankfully, invalid checksums).