### PR TITLE
WT-11273 Prevent hs_search stress point with pareto and predictable replay

### DIFF
--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -421,7 +421,7 @@ config_table(TABLE *table, void *arg)
         }
 
         /*
-         * We don't support the hs_search stress point with pareto distribution in predicatable
+         * We don't support the hs_search stress point with pareto distribution in predictable
          * replay as it prevents us stopping in time.
          */
         if (GV(STRESS_HS_SEARCH) && TV(OPS_PARETO)) {

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -419,6 +419,18 @@ config_table(TABLE *table, void *arg)
                   table->id);
             config_single(table, "ops.truncate=0", false);
         }
+
+        /*
+         * We don't support the hs_search stress point with pareto distribution in predicatable
+         * replay as it prevents us stopping in time.
+         */
+        if (GV(STRESS_HS_SEARCH) && TV(OPS_PARETO)) {
+            if (config_explicit(NULL, "stress.hs_search"))
+                WARN("turning off stress.hs_search to work with predictable replay as table%" PRIu32
+                     " has pareto enabled",
+                  table->id);
+            config_single(NULL, "stress.hs_search=0", false);
+        }
     }
 
     /*


### PR DESCRIPTION
The hs_search stress point impacts the performance of test format when pareto distribution is enabled for a table as it creates a lot of hot keys with history. When paired with predictable replay, test format will not stop on time. This is due to how predictable replay needs to stop a run (with a consistent timestamp). This change disables the combination to prevent this error. 