### PR TITLE
WT-11302 Enabling TCMALLOC for Ubuntu ARM64 and fixing failure configs scripting issue

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4077,7 +4077,6 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-
             ${test_env_vars|} ./run_format_configs.sh ${smp_command|}
 
   - name: static-wt-build-test
@@ -6221,7 +6220,9 @@ buildvariants:
       PATH=/opt/mongodbtoolchain/v4/bin:$PATH
       WT_TOPDIR=$(git rev-parse --show-toplevel)
       WT_BUILDDIR=$WT_TOPDIR/cmake_build
-      LD_LIBRARY_PATH=$WT_BUILDDIR
+      LD_LIBRARY_PATH=$WT_BUILDDIR:$WT_TOPDIR/TCMALLOC_LIB/lib
+      LD_PRELOAD=$WT_TOPDIR/TCMALLOC_LIB/lib/libtcmalloc.so
+    CMAKE_PREFIX_PATH: -DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"
     python_binary: '/opt/mongodbtoolchain/v4/bin/python3'
     smp_command: -j $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: Ninja

--- a/test/evergreen/run_format_configs.sh
+++ b/test/evergreen/run_format_configs.sh
@@ -41,7 +41,15 @@ wait_for_process()
 			ps $process > /dev/null; ps_exit_status=$?
 			if [ ${ps_exit_status} -eq "1" ] ; then
 				# The process is completed so remove the process id from the list of processes.
-				PID_LIST=(${PID_LIST[@]/$process})
+				# Need to use a loop to prevent partial regex matches.
+				unset NEW_PID_LIST
+				declare -a NEW_PID_LIST
+				for target in ${PID_LIST[@]};do
+					if [ $target -ne $process ]; then
+						NEW_PID_LIST+=("$target")
+					fi
+				done
+				PID_LIST=("${NEW_PID_LIST[@]}")
 
 				# Wait for the process to get the exit status.
 				wait $process


### PR DESCRIPTION
The format-failure-configs-test task was changed to run in parallel and that has triggered an OOM. This occurred on Ubuntu ARM64 which turned out not to have TCMALLOC enabled. Also while testing I ran into an issue with the script which runs the configs with removing via a regex which could have overlapping PIDs.