### PR TITLE
WT-11317 Improving comments and asserts around pread executions

### DIFF
--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -431,8 +431,9 @@ __posix_file_read(
     for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
         chunk = WT_MIN(len, WT_GIGABYTE);
         /*
-         * The WT_SYSCALL_RETRY macro expects 0 for success. pread returns > 0 when successful,
-         * adjust the return value.
+         * The WT_SYSCALL_RETRY macro expects 0 for success. pread returns > 0 when it successfully
+         * reads bytes, adjust the return value. pread returns 0 when its EOF and if that is reached
+         * it is unexpected as we know how much we are reading.
          */
         WT_SYSCALL_RETRY((nr = pread(pfh->fd, addr, chunk, offset)) <= 0 ? -1 : 0, ret);
         if (ret != 0)

--- a/test/utility/file.c
+++ b/test/utility/file.c
@@ -299,11 +299,12 @@ copy_on_file(const char *path, const file_info_t *info, void *user_data)
     for (offset = 0, n = 0;; offset += n) {
         WT_SYSCALL_RETRY((n = pread(rfd, buf, COPY_BUF_SIZE, offset)) < 0 ? -1 : 0, ret);
         testutil_check(ret);
-        if (n == 0)
+        if (n == 0) {
+            testutil_assert(offset >= info->stat.st_size);
             break;
+        }
         testutil_assert_errno(write(wfd, buf, (size_t)n) == n);
     }
-
     testutil_assert_errno(close(rfd) == 0);
     testutil_assert_errno(close(wfd) == 0);
     free(buf);


### PR DESCRIPTION
Improved the message to include while EOF would be an error in os_fs.c
Added an assert that in file.c for tests that we copied at least the size of the current file. I believe it has to be at least the size because the file could get larger, I don't think it can get smaller in these cases.