### PR TITLE
WT-11327 Delay writing of checkpoint done file by child until oldest timestamp is set

### DIFF
--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -117,9 +117,9 @@ thread_ckpt_run(void *arg)
         fflush(stdout);
         /*
          * Create the checkpoint file so that the parent process knows at least one checkpoint has
-         * finished and can start its timer.
+         * finished with the oldest timestamp set so it can start its timer.
          */
-        if (first_ckpt) {
+        if (first_ckpt && stable > MAX_DATA) {
             testutil_assert_errno((fp = fopen(ckpt_file, "w")) != NULL);
             first_ckpt = false;
             testutil_assert_errno(fclose(fp) == 0);


### PR DESCRIPTION
WT-11327 Ensure writing of checkpoint done file by child occurs after the oldest timestamp has been set at least once. On very slow machines, this can be an issue causing a failure in setting the oldest timestamp on verification to 0 as it was not set.