### PR TITLE
WT-11332 Add the free_space_target option to compact

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1336,6 +1336,9 @@ methods = {
 'WT_SESSION.close' : Method([]),
 
 'WT_SESSION.compact' : Method([
+    Config('free_space_target', '20MB', r'''
+        minimum amount of space recoverable for compaction to proceed''',
+        min='0'),
     Config('timeout', '1200', r'''
         maximum amount of time to allow for compact in seconds. The actual amount of time spent
         in compact may exceed the configured value. A value of zero disables the timeout''',

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -182,23 +182,25 @@ __block_compact_skip_internal(WT_SESSION_IMPL *session, WT_BLOCK *block, bool es
     if (free_space_target > avail_ninety)
         __wt_verbose_level(session, WT_VERB_COMPACT,
           (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
-          "%s:%s Minimum amount of space required to be recovered %" PRIuMAX
-          "B cannot be recovered",
-          block->name, estimate ? " estimating --" : "", (uintmax_t)free_space_target);
-    else {
-        __wt_verbose_level(session, WT_VERB_COMPACT,
-          (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
-          "%s:%s require 10%% or %" PRIuMAX "MB (%" PRIuMAX
-          ") in the first 90%% of the file to perform compaction, criteria %s. ",
-          block->name, estimate ? " estimating --" : "", (uintmax_t)(file_size / 10) / WT_MEGABYTE,
-          (uintmax_t)(file_size / 10), *compact_pct_tenths_p == 2 ? "met" : "unmet");
-        __wt_verbose_level(session, WT_VERB_COMPACT,
-          (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
-          "%s:%s require 20%% or %" PRIuMAX "MB (%" PRIuMAX
-          ") in the first 80%% of the file to perform compaction, criteria %s. ",
+          "%s:%s minimum target %" PRIuMAX "MB (%" PRIuMAX
+          "B) not available in the first 90%% of the file",
           block->name, estimate ? " estimating --" : "",
-          (uintmax_t)((file_size / 10) * 2) / WT_MEGABYTE, (uintmax_t)((file_size / 10) * 2),
-          *compact_pct_tenths_p == 1 ? "met" : "unmet");
+          (uintmax_t)(free_space_target) / WT_MEGABYTE, (uintmax_t)(free_space_target));
+    else if (*compact_pct_tenths_p > 0) {
+        __wt_verbose_level(session, WT_VERB_COMPACT,
+          (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
+          "%s:%s target %" PRIuMAX "MB (%" PRIuMAX
+          "B) available in the first %d%% of the file to perform compaction, criteria met.",
+          block->name, estimate ? " estimating --" : "",
+          (uintmax_t)(free_space_target) / WT_MEGABYTE, (uintmax_t)(free_space_target),
+          *compact_pct_tenths_p == 1 ? 90 : 80);
+    } else {
+        __wt_verbose_level(session, WT_VERB_COMPACT,
+          (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
+          "%s:%s target %" PRIuMAX "MB (%" PRIuMAX
+          ") not available in the first 80%% of the file to perform compaction.",
+          block->name, estimate ? " estimating --" : "",
+          (uintmax_t)(free_space_target) / WT_MEGABYTE, (uintmax_t)(free_space_target));
     }
     __wt_verbose_level(session, WT_VERB_COMPACT,
       (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1), "%s:%s compaction %s. ", block->name,
@@ -692,8 +694,8 @@ __block_dump_file_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, bool start)
     }
 
     __wt_verbose_debug1(session, WT_VERB_COMPACT,
-      "file size %" PRIuMAX "MB (%" PRIuMAX ") with %" PRIuMAX "%% space available %" PRIuMAX
-      "MB (%" PRIuMAX ")",
+      "file size %" PRIuMAX "MB (%" PRIuMAX "B) with %" PRIuMAX "%% space available %" PRIuMAX
+      "MB (%" PRIuMAX "B)",
       (uintmax_t)size / WT_MEGABYTE, (uintmax_t)size,
       ((uintmax_t)el->bytes * 100) / (uintmax_t)size, (uintmax_t)el->bytes / WT_MEGABYTE,
       (uintmax_t)el->bytes);

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -145,21 +145,17 @@ __block_compact_skip_internal(WT_SESSION_IMPL *session, WT_BLOCK *block, bool es
     }
 
     /*
-     * Skip files where we can't recover the minimum amount configured.
-     *
      * WiredTiger uses first-fit compaction: It finds space in the beginning of the file and moves
-     * data from the end of the file into that space. If at least 20% of the total file is available
-     * and in the first 80% of the file, we'll try compaction on the last 20% of the file; else, if
-     * at least 10% of the total file is available and in the first 90% of the file, we'll try
-     * compaction on the last 10% of the file.
+     * data from the end of the file into that space. If the configured target is available in the
+     * first 80%/90% of the file, we'll try compaction on the last 20%/10% of the file.
      *
      * We could push this further, but there's diminishing returns, a mostly empty file can be
      * processed quickly, so more aggressive compaction is less useful.
      */
-    if (avail_eighty > free_space_target && avail_eighty >= ((file_size / 10) * 2)) {
+    if (avail_eighty > free_space_target) {
         *skipp = false;
         *compact_pct_tenths_p = 2;
-    } else if (avail_ninety > free_space_target && avail_ninety >= file_size / 10) {
+    } else if (avail_ninety > free_space_target) {
         *skipp = false;
         *compact_pct_tenths_p = 1;
     } else {

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -470,8 +470,9 @@ __wt_block_compact_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, bool *skipp)
      */
     if (block->size <= (wt_off_t)session->compact->free_space_target) {
         __wt_verbose_debug1(session, WT_VERB_COMPACT,
-          "%s: skipping because the file size (%" PRIu64 "B) must be greater than %" PRIuMAX "B.",
-          block->name, session->compact->free_space_target, (uintmax_t)block->size);
+          "%s: skipping because the file size (%" PRIu64
+          "B) must be greater than the minimum recoverable space (%" PRIu64 "B).",
+          block->name, (uintmax_t)block->size, session->compact->free_space_target);
 
         return (0);
     }

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -122,6 +122,7 @@ __block_compact_skip_internal(WT_SESSION_IMPL *session, WT_BLOCK *block, bool es
 {
     WT_EXT *ext;
     wt_off_t avail_eighty, avail_ninety, free_space_target, off, size, eighty, ninety;
+    uintmax_t free_space_target_mb;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &block->live_lock);
 
@@ -131,6 +132,7 @@ __block_compact_skip_internal(WT_SESSION_IMPL *session, WT_BLOCK *block, bool es
     eighty = file_size - ((file_size / 10) * 2);
 
     free_space_target = (wt_off_t)session->compact->free_space_target;
+    free_space_target_mb = (uintmax_t)(free_space_target / WT_MEGABYTE);
 
     WT_EXT_FOREACH_FROM_OFFSET_INCL(ext, &block->live.avail, start_offset)
     {
@@ -184,24 +186,22 @@ __block_compact_skip_internal(WT_SESSION_IMPL *session, WT_BLOCK *block, bool es
           (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
           "%s:%s minimum target %" PRIuMAX "MB (%" PRIuMAX
           "B) not available in the first 90%% of the file",
-          block->name, estimate ? " estimating --" : "",
-          (uintmax_t)(free_space_target) / WT_MEGABYTE, (uintmax_t)(free_space_target));
-    else if (*compact_pct_tenths_p > 0) {
+          block->name, estimate ? " estimating --" : "", free_space_target_mb,
+          (uintmax_t)free_space_target);
+    else if (*compact_pct_tenths_p > 0)
         __wt_verbose_level(session, WT_VERB_COMPACT,
           (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
           "%s:%s target %" PRIuMAX "MB (%" PRIuMAX
           "B) available in the first %d%% of the file to perform compaction, criteria met.",
-          block->name, estimate ? " estimating --" : "",
-          (uintmax_t)(free_space_target) / WT_MEGABYTE, (uintmax_t)(free_space_target),
-          *compact_pct_tenths_p == 1 ? 90 : 80);
-    } else {
+          block->name, estimate ? " estimating --" : "", free_space_target_mb,
+          (uintmax_t)free_space_target, *compact_pct_tenths_p == 1 ? 90 : 80);
+    else
         __wt_verbose_level(session, WT_VERB_COMPACT,
           (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1),
           "%s:%s target %" PRIuMAX "MB (%" PRIuMAX
           ") not available in the first 80%% of the file to perform compaction.",
-          block->name, estimate ? " estimating --" : "",
-          (uintmax_t)(free_space_target) / WT_MEGABYTE, (uintmax_t)(free_space_target));
-    }
+          block->name, estimate ? " estimating --" : "", free_space_target_mb,
+          (uintmax_t)free_space_target);
     __wt_verbose_level(session, WT_VERB_COMPACT,
       (estimate ? WT_VERBOSE_DEBUG_3 : WT_VERBOSE_DEBUG_1), "%s:%s compaction %s. ", block->name,
       estimate ? " estimating --" : "", *skipp ? "skipped" : "proceeding");

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -288,7 +288,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_commit_transaction[] = {
   {"sync", "string", NULL, "choices=[\"off\",\"on\"]", NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_compact[] = {
-  {"timeout", "int", NULL, NULL, NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
+  {"free_space_target", "int", NULL, "min=0", NULL, 0}, {"timeout", "int", NULL, NULL, NULL, 0},
+  {NULL, NULL, NULL, NULL, NULL, 0}};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_create_encryption_subconfigs[] = {
   {"keyid", "string", NULL, NULL, NULL, 0}, {"name", "string", NULL, NULL, NULL, 0},
@@ -1339,7 +1340,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "commit_timestamp=,durable_timestamp=,operation_timeout_ms=0,"
     "sync=",
     confchk_WT_SESSION_commit_transaction, 4},
-  {"WT_SESSION.compact", "timeout=1200", confchk_WT_SESSION_compact, 1},
+  {"WT_SESSION.compact", "free_space_target=20MB,timeout=1200", confchk_WT_SESSION_compact, 2},
   {"WT_SESSION.create",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"

--- a/src/include/compact.h
+++ b/src/include/compact.h
@@ -7,9 +7,10 @@
  */
 
 struct __wt_compact_state {
-    uint32_t lsm_count;  /* Number of LSM trees seen */
-    uint32_t file_count; /* Number of files seen */
-    uint64_t max_time;   /* Configured timeout */
+    uint32_t lsm_count;         /* Number of LSM trees seen */
+    uint32_t file_count;        /* Number of files seen */
+    uint64_t free_space_target; /* Configured minimum space recoverable in MB */
+    uint64_t max_time;          /* Configured timeout */
 
     struct timespec begin; /* Starting time */
 };

--- a/src/include/compact.h
+++ b/src/include/compact.h
@@ -7,8 +7,8 @@
  */
 
 struct __wt_compact_state {
-    uint32_t lsm_count;         /* Number of LSM trees seen */
     uint32_t file_count;        /* Number of files seen */
+    uint32_t lsm_count;         /* Number of LSM trees seen */
     uint64_t free_space_target; /* Configured minimum space recoverable in MB */
     uint64_t max_time;          /* Configured timeout */
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1391,6 +1391,8 @@ struct __wt_session {
      * @param name the URI of the object to compact, such as
      * \c "table:stock"
      * @configstart{WT_SESSION.compact, see dist/api_data.py}
+     * @config{free_space_target, minimum amount of space recoverable for compaction to proceed., an
+     * integer greater than or equal to \c 0; default \c 20MB.}
      * @config{timeout, maximum amount of time to allow for compact in seconds.  The actual amount
      * of time spent in compact may exceed the configured value.  A value of zero disables the
      * timeout., an integer; default \c 1200.}

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -380,6 +380,10 @@ __wt_session_compact(WT_SESSION *wt_session, const char *uri, const char *config
     memset(&compact, 0, sizeof(WT_COMPACT_STATE));
     session->compact = &compact;
 
+    /* Configure the minimum amount of space recoverable. */
+    WT_ERR(__wt_config_gets(session, cfg, "free_space_target", &cval));
+    session->compact->free_space_target = (uint64_t)cval.val;
+
     /* Compaction can be time-limited. */
     WT_ERR(__wt_config_gets(session, cfg, "timeout", &cval));
     session->compact->max_time = (uint64_t)cval.val;

--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -97,18 +97,20 @@ class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
         c1.close()
         c2.close()
 
-        # Compact it, using either the session method or the utility.
+        # Compact it, using either the session method or the utility. Generated files are ~2MB, set
+        # the minimum threshold to a low value to make sure compaction can be executed.
+        compact_cfg = "free_space_target=1MB"
         if self.utility == 1:
             self.session.checkpoint(None)
             self.close_conn()
-            self.runWt(["compact", uri])
+            self.runWt(["compact", uri, compact_cfg])
         else:
             # Optionally reopen the connection so we do more on-disk tests.
             if self.reopen == 1:
                 self.session.checkpoint(None)
                 self.reopen_conn()
 
-            self.session.compact(uri, None)
+            self.session.compact(uri, compact_cfg)
 
         # Verify compact progress stats. We can't do this with utility method as reopening the
         # connection would reset the stats.

--- a/test/suite/test_compact01.py
+++ b/test/suite/test_compact01.py
@@ -103,7 +103,7 @@ class test_compact(wttest.WiredTigerTestCase, suite_subprocess):
         if self.utility == 1:
             self.session.checkpoint(None)
             self.close_conn()
-            self.runWt(["compact", uri, compact_cfg])
+            self.runWt(["compact", "-c", compact_cfg, uri])
         else:
             # Optionally reopen the connection so we do more on-disk tests.
             if self.reopen == 1:

--- a/test/suite/test_compact02.py
+++ b/test/suite/test_compact02.py
@@ -161,10 +161,11 @@ class test_compact02(wttest.WiredTigerTestCase):
         # 5. Call compact.
         # Compact can collide with eviction, if that happens we retry. Wait for
         # a long time, the check for EBUSY means we're not retrying on any real
-        # errors.
+        # errors. Set the minimum threshold to make sure compaction can be executed.
+        compact_cfg = "free_space_target=1MB"
         for i in range(1, 100):
             if not self.raisesBusy(
-              lambda: self.session.compact(self.uri, None)):
+              lambda: self.session.compact(self.uri, compact_cfg)):
                 break
             time.sleep(6)
 

--- a/test/suite/test_compact03.py
+++ b/test/suite/test_compact03.py
@@ -71,7 +71,7 @@ class test_compact03(wttest.WiredTigerTestCase):
     #
     # We want to have around 20000 leaf pages. With minimum 1KB page allocation size, the table
     # is expected to have at least 25 MByte worth of data. We can then experiment with deleting
-    # range of keys in middle to test how comapction works.
+    # range of keys in middle to test how compaction works.
 
     normalValue = "abcde" * 10
     overflowValue = "abcde" * 1000

--- a/test/suite/test_compact04.py
+++ b/test/suite/test_compact04.py
@@ -45,8 +45,8 @@ class test_compact04(wttest.WiredTigerTestCase):
     ]
     scenarios = make_scenarios(free_space_target)
 
-    # Keep debug messages on by default. This is useful for diagnosing spurious test failures.
-    conn_config = 'statistics=(all),cache_size=100MB,verbose=(compact_progress,compact:4)'
+    # Keep debug messages on by default, this is useful for diagnosing spurious test failures.
+    conn_config = 'statistics=(all),cache_size=100MB,verbose=(compact_progress,compact)'
     create_params = 'key_format=i,value_format=S,allocation_size=4KB,leaf_page_max=32KB,'
     table_numkv = 100 * 1000
     table_uri_prefix='table:test_compact04-'

--- a/test/suite/test_compact04.py
+++ b/test/suite/test_compact04.py
@@ -30,7 +30,7 @@
 #   Test the accuracy of compact work estimation.
 #
 
-import time, wiredtiger, wttest
+import wiredtiger, wttest
 from wiredtiger import stat
 
 # Test the accuracy of compact work estimation.

--- a/test/suite/test_compact04.py
+++ b/test/suite/test_compact04.py
@@ -40,7 +40,7 @@ class test_compact04(wttest.WiredTigerTestCase):
 
     free_space_target = [
         ('1MB', dict(compact_config='1MB', expected_stdout=None)),
-        ('100MB', dict(compact_config='100MB', expected_stdout='Minimum amount of space required to be recovered.*cannot be recovered')),
+        ('100MB', dict(compact_config='100MB', expected_stdout='minimum target 100MB.*not available')),
         ('200MB', dict(compact_config='200MB', expected_stdout='skipping because the file size.*must be greater than')),
     ]
     scenarios = make_scenarios(free_space_target)


### PR DESCRIPTION
- New option for the compact session API called `free_space_target`. This defines the minimum of space that needs to be recovered by compaction to proceed.
- Update of the `session->compact` structure to save that new option.
- The default value is `20MB`. This impacts the test `test_compact01.py` as it was relying on previously hardcoded value `1MB`. In order to get back to the previous behaviour, we can set `free_space_target` to `1MB` when calling `session->compact()`
- Attempt at improving the verbose messages related to compaction

I am not a big fan of the [cast](https://github.com/wiredtiger/wiredtiger/compare/wt-11332-free-space-target-compact?expand=1#diff-c35c1a35035394e853a7468560e8b8a7f2090630c1831196a78cf1a2a5b9b317R133) to `wt_off_t` but it had to be done as most of the variables are using the `wt_off_t` type in this area.