### PR TITLE
WT-11196 Clean up deprecated functions in python tests

### DIFF
--- a/test/3rdparty/testtools-0.9.34/testtools/distutilscmd.py
+++ b/test/3rdparty/testtools-0.9.34/testtools/distutilscmd.py
@@ -4,8 +4,8 @@
 
 import sys
 
-from setuptools import Command
-from setuptools.errors import OptionError
+from distutils.core import Command
+from distutils.errors import DistutilsOptionError
 
 from testtools.run import TestProgram, TestToolsTestRunner
 
@@ -19,14 +19,15 @@ class TestCommand(Command):
         ('catch', 'c', "Catch ctrl-C and display results so far"),
         ('buffer', 'b', "Buffer stdout and stderr during tests"),
         ('failfast', 'f', "Stop on first fail or error"),
-        ('test-module=', 'm', "Run 'test_suite' in specified module"),
-        ('test-suite=', 's',
+        ('test-module=','m', "Run 'test_suite' in specified module"),
+        ('test-suite=','s',
          "Test suite to run (e.g. 'some_module.test_suite')")
     ]
 
     def __init__(self, dist):
         Command.__init__(self, dist)
         self.runner = TestToolsTestRunner(sys.stdout)
+
 
     def initialize_options(self):
         self.test_suite = None
@@ -38,12 +39,12 @@ class TestCommand(Command):
     def finalize_options(self):
         if self.test_suite is None:
             if self.test_module is None:
-                raise OptionError(
+                raise DistutilsOptionError(
                     "You must specify a module or a suite to run tests from")
             else:
                 self.test_suite = self.test_module+".test_suite"
         elif self.test_module:
-            raise OptionError(
+            raise DistutilsOptionError(
                 "You may specify a module or a suite, but not both")
         self.test_args = [self.test_suite]
         if self.verbose:

--- a/test/3rdparty/testtools-0.9.34/testtools/distutilscmd.py
+++ b/test/3rdparty/testtools-0.9.34/testtools/distutilscmd.py
@@ -4,8 +4,8 @@
 
 import sys
 
-from distutils.core import Command
-from distutils.errors import DistutilsOptionError
+from setuptools import Command
+from setuptools.errors import OptionError
 
 from testtools.run import TestProgram, TestToolsTestRunner
 
@@ -19,15 +19,14 @@ class TestCommand(Command):
         ('catch', 'c', "Catch ctrl-C and display results so far"),
         ('buffer', 'b', "Buffer stdout and stderr during tests"),
         ('failfast', 'f', "Stop on first fail or error"),
-        ('test-module=','m', "Run 'test_suite' in specified module"),
-        ('test-suite=','s',
+        ('test-module=', 'm', "Run 'test_suite' in specified module"),
+        ('test-suite=', 's',
          "Test suite to run (e.g. 'some_module.test_suite')")
     ]
 
     def __init__(self, dist):
         Command.__init__(self, dist)
         self.runner = TestToolsTestRunner(sys.stdout)
-
 
     def initialize_options(self):
         self.test_suite = None
@@ -39,12 +38,12 @@ class TestCommand(Command):
     def finalize_options(self):
         if self.test_suite is None:
             if self.test_module is None:
-                raise DistutilsOptionError(
+                raise OptionError(
                     "You must specify a module or a suite to run tests from")
             else:
                 self.test_suite = self.test_module+".test_suite"
         elif self.test_module:
-            raise DistutilsOptionError(
+            raise OptionError(
                 "You may specify a module or a suite, but not both")
         self.test_args = [self.test_suite]
         if self.verbose:

--- a/test/suite/test_bug001.py
+++ b/test/suite/test_bug001.py
@@ -59,7 +59,7 @@ class test_bug001(wttest.WiredTigerTestCase):
 
         # Check cursor next inside trailing implicit keys.
         cursor.set_key(60)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(0, 5):
             self.assertEqual(cursor.get_key(), 60 + i)
             self.assertEqual(cursor.get_value(), 0x00)
@@ -67,13 +67,13 @@ class test_bug001(wttest.WiredTigerTestCase):
 
         # Check cursor prev inside trailing implicit keys.
         cursor.set_key(60)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(0, 5):
             self.assertEqual(cursor.get_key(), 60 - i)
             self.assertEqual(cursor.get_value(), 0x00)
             self.assertEqual(cursor.prev(), 0)
 
-        self.assertEquals(cursor.close(), 0)
+        self.assertEqual(cursor.close(), 0)
         self.dropUntilSuccess(self.session, uri)
         cursor = self.create_implicit(uri, 20, 50, 0)
 
@@ -83,7 +83,7 @@ class test_bug001(wttest.WiredTigerTestCase):
 
         # Check cursor next inside leading implicit keys.
         cursor.set_key(10)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(0, 5):
             self.assertEqual(cursor.get_key(), 10 + i)
             self.assertEqual(cursor.get_value(), 0x00)
@@ -91,13 +91,13 @@ class test_bug001(wttest.WiredTigerTestCase):
 
         # Check cursor prev inside leading implicit keys.
         cursor.set_key(10)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(0, 5):
             self.assertEqual(cursor.get_key(), 10 - i)
             self.assertEqual(cursor.get_value(), 0x00)
             self.assertEqual(cursor.prev(), 0)
 
-        self.assertEquals(cursor.close(), 0)
+        self.assertEqual(cursor.close(), 0)
         self.dropUntilSuccess(self.session, uri)
 
     # Test a bug where cursor remove inside implicit records looped infinitely.
@@ -107,45 +107,45 @@ class test_bug001(wttest.WiredTigerTestCase):
 
         # Check cursor next/remove inside trailing implicit keys.
         cursor.set_key(60)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(1, 5):
-            self.assertEquals(cursor.next(), 0)
+            self.assertEqual(cursor.next(), 0)
             self.assertEqual(cursor.get_key(), 60 + i)
             self.assertEqual(cursor.get_value(), 0x00)
-            self.assertEquals(cursor.remove(), 0)
+            self.assertEqual(cursor.remove(), 0)
 
         # Check cursor prev/remove inside trailing implicit keys.
         cursor.set_key(70)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(1, 5):
-            self.assertEquals(cursor.prev(), 0)
+            self.assertEqual(cursor.prev(), 0)
             self.assertEqual(cursor.get_key(), 70 - i)
             self.assertEqual(cursor.get_value(), 0x00)
-            self.assertEquals(cursor.remove(), 0)
+            self.assertEqual(cursor.remove(), 0)
 
-        self.assertEquals(cursor.close(), 0)
+        self.assertEqual(cursor.close(), 0)
         self.dropUntilSuccess(self.session, uri)
         cursor = self.create_implicit(uri, 20, 50, 0)
 
         # Check cursor next/remove inside leading implicit keys.
         cursor.set_key(2)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(1, 5):
-            self.assertEquals(cursor.next(), 0)
+            self.assertEqual(cursor.next(), 0)
             self.assertEqual(cursor.get_key(), 2 + i)
             self.assertEqual(cursor.get_value(), 0x00)
-            self.assertEquals(cursor.remove(), 0)
+            self.assertEqual(cursor.remove(), 0)
 
         # Check cursor prev/remove inside leading implicit keys.
         cursor.set_key(18)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
         for i in range(1, 5):
-            self.assertEquals(cursor.prev(), 0)
+            self.assertEqual(cursor.prev(), 0)
             self.assertEqual(cursor.get_key(), 18 - i)
             self.assertEqual(cursor.get_value(), 0x00)
-            self.assertEquals(cursor.remove(), 0)
+            self.assertEqual(cursor.remove(), 0)
 
-        self.assertEquals(cursor.close(), 0)
+        self.assertEqual(cursor.close(), 0)
         self.dropUntilSuccess(self.session, uri)
 
 if __name__ == '__main__':

--- a/test/suite/test_bug004.py
+++ b/test/suite/test_bug004.py
@@ -104,9 +104,9 @@ class test_bug004(wttest.WiredTigerTestCase):
         c1.search()
         for i in range(2, self.nentries):
             c1.next()
-            self.assertEquals(
+            self.assertEqual(
                 c1.get_key(), self.make_key(c1, i))
-            self.assertEquals(
+            self.assertEqual(
                 c1.get_value(), simple_value(c1, i) + 'abcdef' * 100)
 
 if __name__ == '__main__':

--- a/test/suite/test_bug010.py
+++ b/test/suite/test_bug010.py
@@ -85,7 +85,7 @@ class test_bug010(wttest.WiredTigerTestCase):
                 c = self.session.open_cursor(
                     self.uri + str(i), None, 'checkpoint=WiredTigerCheckpoint')
                 c.next()
-                self.assertEquals(c.get_value(), expected_val,
+                self.assertEqual(c.get_value(), expected_val,
                     msg='Mismatch on iteration ' + str(its) +\
                                         ' for table ' + str(i))
                 c.close()

--- a/test/suite/test_bug016.py
+++ b/test/suite/test_bug016.py
@@ -41,7 +41,7 @@ class test_bug016(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri, None, 'append')
         cursor.set_value('value')
         cursor.insert()
-        self.assertEquals(cursor.get_key(), 1)
+        self.assertEqual(cursor.get_key(), 1)
 
     # Insert a row into a simple column-store table.
     # WT_CURSOR.get_key should fail.
@@ -76,7 +76,7 @@ class test_bug016(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri, None, 'append')
         cursor.set_value('value')
         cursor.insert()
-        self.assertEquals(cursor.get_key(), 1)
+        self.assertEqual(cursor.get_key(), 1)
 
     # Insert a row into a complex column-store table.
     # WT_CURSOR.get_key should fail.

--- a/test/suite/test_bug031.py
+++ b/test/suite/test_bug031.py
@@ -143,7 +143,7 @@ class test_bug_031(wttest.WiredTigerTestCase):
         # previous eviction.
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
         cursor.set_key(key)
-        self.assertEquals(cursor.search(), 0)
+        self.assertEqual(cursor.search(), 0)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -215,7 +215,7 @@ class test_checkpoint_target(wttest.WiredTigerTestCase):
 
     def check(self, uri, ds, value):
         cursor = ds.open_cursor(uri, None, "checkpoint=checkpoint-1")
-        self.assertEquals(cursor[ds.key(10)], value)
+        self.assertEqual(cursor[ds.key(10)], value)
         cursor.close()
 
     # FIXME-WT-10836
@@ -307,7 +307,7 @@ class test_checkpoint_last(wttest.WiredTigerTestCase):
             # Verify the "last" checkpoint sees the correct value.
             cursor = ds.open_cursor(
                 uri, None, "checkpoint=WiredTigerCheckpoint")
-            self.assertEquals(cursor[ds.key(10)], value)
+            self.assertEqual(cursor[ds.key(10)], value)
             # Don't close the checkpoint cursor, we want it to remain open until
             # the test completes.
 
@@ -404,7 +404,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
         self.session.create(self.uri, "key_format=S,value_format=S")
         self.session.checkpoint('name=ckpt')
         cursor = self.session.open_cursor(self.uri, None, "checkpoint=ckpt")
-        self.assertEquals(cursor.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
         cursor.close()
 
         cursor = self.session.open_cursor(self.uri, None)
@@ -412,7 +412,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         cursor = self.session.open_cursor(self.uri, None, "checkpoint=ckpt")
-        self.assertEquals(cursor.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
 
     # Check that if we create an unnamed and then a named checkpoint, opening
     # WiredTigerCheckpoint opens the most recent (the named) checkpoint.
@@ -421,7 +421,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         cursor = self.session.open_cursor(
             self.uri, None, "checkpoint=WiredTigerCheckpoint")
-        self.assertEquals(cursor.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
         cursor.close()
 
         cursor = self.session.open_cursor(self.uri, None)
@@ -430,7 +430,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
 
         cursor = self.session.open_cursor(
             self.uri, None, "checkpoint=WiredTigerCheckpoint")
-        self.assertEquals(cursor.next(), 0)
+        self.assertEqual(cursor.next(), 0)
 
     # Check that if we create a named and then an unnamed checkpoint, opening
     # WiredTigerCheckpoint opens the most recent (the named) checkpoint.
@@ -439,7 +439,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
         self.session.checkpoint('name=ckpt')
         cursor = self.session.open_cursor(
             self.uri, None, "checkpoint=WiredTigerCheckpoint")
-        self.assertEquals(cursor.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
         cursor.close()
 
         cursor = self.session.open_cursor(self.uri, None)
@@ -448,7 +448,7 @@ class test_checkpoint_empty(wttest.WiredTigerTestCase):
 
         cursor = self.session.open_cursor(
             self.uri, None, "checkpoint=WiredTigerCheckpoint")
-        self.assertEquals(cursor.next(), 0)
+        self.assertEqual(cursor.next(), 0)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint09.py
+++ b/test/suite/test_checkpoint09.py
@@ -81,7 +81,7 @@ class test_checkpoint09(wttest.WiredTigerTestCase):
         evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
         for i in range(1, nrows + 1):
             evict_cursor.set_key(ds.key(i))
-            self.assertEquals(evict_cursor.search(), 0)
+            self.assertEqual(evict_cursor.search(), 0)
             evict_cursor.reset()
         s.rollback_transaction()
         evict_cursor.close()

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -37,7 +37,7 @@ class checkpoint_thread(threading.Thread):
 
     def run(self):
         sess = self.conn.open_session()
-        while not self.done.isSet():
+        while not self.done.is_set():
             # Sleep for 10 milliseconds.
             time.sleep(0.001)
             sess.checkpoint()
@@ -52,7 +52,7 @@ class named_checkpoint_thread(threading.Thread):
 
     def run(self):
         sess = self.conn.open_session()
-        while not self.done.isSet():
+        while not self.done.is_set():
             # Sleep for 10 milliseconds.
             time.sleep(0.001)
             sess.checkpoint('name=' + self.ckpt_name)
@@ -67,7 +67,7 @@ class flush_checkpoint_thread(threading.Thread):
 
     def run(self):
         sess = self.conn.open_session()
-        while not self.done.isSet():
+        while not self.done.is_set():
             # Sleep for 10 milliseconds.
             time.sleep(0.001)
             if random.randint(0, 100) < self.flush_probability:
@@ -85,7 +85,7 @@ class backup_thread(threading.Thread):
 
     def run(self):
         sess = self.conn.open_session()
-        while not self.done.isSet():
+        while not self.done.is_set():
             # Sleep for 2 seconds.
             time.sleep(2)
             sess.checkpoint()
@@ -153,7 +153,7 @@ class op_thread(threading.Thread):
             cursors = list()
             for next_uri in self.uris:
                 cursors.append(sess.open_cursor(next_uri, None, None))
-        while not self.done.isSet():
+        while not self.done.is_set():
             try:
                 op, key, value = self.work_queue.get_nowait()
                 if op == 'gi': # Group insert a number of tables.


### PR DESCRIPTION
Dealt with a few DeprecationWarnings:

* Replaced `assertEquals()` with `assertEqual()`
* Replaced `isSet()` with `is_set()`
* Favoured `setuptools` over `distutils` module in compliance with [PEP-632](https://peps.python.org/pep-0632/)

Should be no more now