### PR TITLE
WT-11303 Move the debug mode retention flags behind a lock

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2042,11 +2042,7 @@ __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
         FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
     } else
         FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
-    /*
-     * We need to make sure all writes to other fields are visible before setting the count because
-     * the log removal thread may walk the array using this value.
-     */
-    WT_PUBLISH(conn->debug_ckpt_cnt, (uint32_t)cval.val);
+    conn->debug_ckpt_cnt = (uint32_t)cval.val;
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.corruption_abort", &cval));
     if (cval.val)

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2013,6 +2013,47 @@ __wt_extra_diagnostics_config(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
+ * __debug_mode_log_retention_config --
+ *     Set the log retention fields of the debugging configuration. These fields are protected by a
+ *     lock.
+ */
+static int
+__debug_mode_log_retention_config(WT_SESSION_IMPL *session, const char *cfg[])
+{
+    WT_CONFIG_ITEM cval;
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+
+    conn = S2C(session);
+
+    __wt_writelock(session, &conn->debug_log_retention_lock);
+
+    WT_ERR(__wt_config_gets(session, cfg, "debug_mode.checkpoint_retention", &cval));
+
+    /*
+     * Checkpoint retention has some rules to simplify usage. You can turn it on to some value. You
+     * can turn it off. You can reconfigure to the same value again. You cannot change the non-zero
+     * value. Once it was on in the past and then turned off, you cannot turn it back on again.
+     */
+    if (cval.val != 0) {
+        if (conn->debug_ckpt_cnt != 0 && cval.val != conn->debug_ckpt_cnt)
+            WT_ERR_MSG(session, EINVAL, "Cannot change value for checkpoint retention");
+        WT_ERR(
+          __wt_realloc_def(session, &conn->debug_ckpt_alloc, (size_t)cval.val, &conn->debug_ckpt));
+        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
+    } else
+        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
+    conn->debug_ckpt_cnt = (uint32_t)cval.val;
+
+    WT_ERR(__wt_config_gets(session, cfg, "debug_mode.log_retention", &cval));
+    conn->debug_log_cnt = (uint32_t)cval.val;
+
+err:
+    __wt_writeunlock(session, &conn->debug_log_retention_lock);
+    return (ret);
+}
+
+/*
  * __wt_debug_mode_config --
  *     Set debugging configuration.
  */
@@ -2026,28 +2067,7 @@ __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
     conn = S2C(session);
     txn_global = &conn->txn_global;
 
-    WT_RET(__wt_config_gets(session, cfg, "debug_mode.checkpoint_retention", &cval));
-
-    __wt_writelock(session, &conn->debug_log_retention_lock);
-    /*
-     * Checkpoint retention has some rules to simplify usage. You can turn it on to some value. You
-     * can turn it off. You can reconfigure to the same value again. You cannot change the non-zero
-     * value. Once it was on in the past and then turned off, you cannot turn it back on again.
-     */
-    if (cval.val != 0) {
-        if (conn->debug_ckpt_cnt != 0 && cval.val != conn->debug_ckpt_cnt)
-            WT_RET_MSG(session, EINVAL, "Cannot change value for checkpoint retention");
-        WT_RET(
-          __wt_realloc_def(session, &conn->debug_ckpt_alloc, (size_t)cval.val, &conn->debug_ckpt));
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
-    } else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
-    conn->debug_ckpt_cnt = (uint32_t)cval.val;
-
-    WT_RET(__wt_config_gets(session, cfg, "debug_mode.log_retention", &cval));
-    conn->debug_log_cnt = (uint32_t)cval.val;
-
-    __wt_writeunlock(session, &conn->debug_log_retention_lock);
+    WT_RET(__debug_mode_log_retention_config(session, cfg));
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.corruption_abort", &cval));
     if (cval.val)

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2014,8 +2014,8 @@ __wt_extra_diagnostics_config(WT_SESSION_IMPL *session, const char *cfg[])
 
 /*
  * __debug_mode_log_retention_config --
- *     Set the log retention fields of the debugging configuration. These fields are protected by a
- *     lock.
+ *     Set the log retention fields of the debugging configuration. These fields are protected by
+ *     the debug log retention lock.
  */
 static int
 __debug_mode_log_retention_config(WT_SESSION_IMPL *session, const char *cfg[])

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -53,15 +53,16 @@ __wt_connection_init(WT_CONNECTION_IMPL *conn)
     WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
     WT_RET(__wt_spin_init(session, &conn->flush_tier_lock, "flush tier"));
     WT_SPIN_INIT_TRACKED(session, &conn->metadata_lock, metadata);
+    WT_RET(__wt_spin_init(session, &conn->reconfig_lock, "reconfigure"));
     WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
     WT_RET(__wt_spin_init(session, &conn->storage_lock, "tiered storage"));
     WT_RET(__wt_spin_init(session, &conn->tiered_lock, "tiered work unit list"));
     WT_RET(__wt_spin_init(session, &conn->turtle_lock, "turtle file"));
 
     /* Read-write locks */
+    WT_RET(__wt_rwlock_init(session, &conn->debug_log_retention_lock));
     WT_RWLOCK_INIT_SESSION_TRACKED(session, &conn->dhandle_lock, dhandle);
     WT_RET(__wt_rwlock_init(session, &conn->hot_backup_lock));
-    WT_RET(__wt_rwlock_init(session, &conn->reconfig_lock));
     WT_RWLOCK_INIT_TRACKED(session, &conn->table_lock, table);
 
     /* Setup serialization for the LSM manager queues. */
@@ -114,13 +115,14 @@ __wt_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_spin_destroy(session, &conn->api_lock);
     __wt_spin_destroy(session, &conn->block_lock);
     __wt_spin_destroy(session, &conn->checkpoint_lock);
+    __wt_rwlock_destroy(session, &conn->debug_log_retention_lock);
     __wt_rwlock_destroy(session, &conn->dhandle_lock);
     __wt_spin_destroy(session, &conn->encryptor_lock);
     __wt_spin_destroy(session, &conn->fh_lock);
     __wt_spin_destroy(session, &conn->flush_tier_lock);
     __wt_rwlock_destroy(session, &conn->hot_backup_lock);
     __wt_spin_destroy(session, &conn->metadata_lock);
-    __wt_rwlock_destroy(session, &conn->reconfig_lock);
+    __wt_spin_destroy(session, &conn->reconfig_lock);
     __wt_spin_destroy(session, &conn->schema_lock);
     __wt_spin_destroy(session, &conn->storage_lock);
     __wt_rwlock_destroy(session, &conn->table_lock);

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -53,7 +53,6 @@ __wt_connection_init(WT_CONNECTION_IMPL *conn)
     WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
     WT_RET(__wt_spin_init(session, &conn->flush_tier_lock, "flush tier"));
     WT_SPIN_INIT_TRACKED(session, &conn->metadata_lock, metadata);
-    WT_RET(__wt_spin_init(session, &conn->reconfig_lock, "reconfigure"));
     WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
     WT_RET(__wt_spin_init(session, &conn->storage_lock, "tiered storage"));
     WT_RET(__wt_spin_init(session, &conn->tiered_lock, "tiered work unit list"));
@@ -62,6 +61,7 @@ __wt_connection_init(WT_CONNECTION_IMPL *conn)
     /* Read-write locks */
     WT_RWLOCK_INIT_SESSION_TRACKED(session, &conn->dhandle_lock, dhandle);
     WT_RET(__wt_rwlock_init(session, &conn->hot_backup_lock));
+    WT_RET(__wt_rwlock_init(session, &conn->reconfig_lock));
     WT_RWLOCK_INIT_TRACKED(session, &conn->table_lock, table);
 
     /* Setup serialization for the LSM manager queues. */
@@ -120,7 +120,7 @@ __wt_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_spin_destroy(session, &conn->flush_tier_lock);
     __wt_rwlock_destroy(session, &conn->hot_backup_lock);
     __wt_spin_destroy(session, &conn->metadata_lock);
-    __wt_spin_destroy(session, &conn->reconfig_lock);
+    __wt_rwlock_destroy(session, &conn->reconfig_lock);
     __wt_spin_destroy(session, &conn->schema_lock);
     __wt_spin_destroy(session, &conn->storage_lock);
     __wt_rwlock_destroy(session, &conn->table_lock);

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -374,24 +374,17 @@ __log_remove_once_int(
 }
 
 /*
- * __log_remove_once --
- *     Perform one iteration of log removal. Must be called with the log removal lock held.
+ * __compute_min_lognum --
+ *     Determine the number of the earliest log file we must keep.
  */
-static int
-__log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
+static uint32_t
+__compute_min_lognum(WT_SESSION_IMPL *session, WT_LOG *log, uint32_t backup_file)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_DECL_RET;
-    WT_LOG *log;
     uint32_t dbg_ckpt_cnt, dbg_log_cnt, min_lognum;
-    u_int logcount;
-    char **logfiles;
     bool dbg_ckpt_retain;
 
     conn = S2C(session);
-    log = conn->log;
-    logcount = 0;
-    logfiles = NULL;
 
     /*
      * If we're coming from a backup cursor we want the smaller of the last full log file copied in
@@ -401,20 +394,16 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
     min_lognum = backup_file == 0 ? WT_MIN(log->ckpt_lsn.l.file, log->sync_lsn.l.file) :
                                     WT_MIN(log->ckpt_lsn.l.file, backup_file);
 
-    /*
-     * Take a consistent view of the current configuration. If another thread reconfigures the
-     * connection in parallel we'll handle that change on the next call to this function.
-     */
     __wt_readlock(session, &conn->debug_log_retention_lock);
+
+    /* Adjust the number of log files to retain based on debugging options. */
 
     dbg_ckpt_cnt = conn->debug_ckpt_cnt;
     dbg_ckpt_retain = FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
-    dbg_log_cnt = conn->debug_log_cnt;
-
-    /* Adjust the number of log files to retain based on debugging options. */
     if (dbg_ckpt_retain && dbg_ckpt_cnt != 0)
         min_lognum = WT_MIN(conn->debug_ckpt[dbg_ckpt_cnt - 1].l.file, min_lognum);
 
+    dbg_log_cnt = conn->debug_log_cnt;
     if (dbg_log_cnt != 0) {
         /*
          * If we're performing checkpoints, apply the retain value as a minimum, increasing the
@@ -426,14 +415,40 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
          * Check for N+1, that is, we retain N full log files, and one partial.
          */
         if ((dbg_log_cnt + 1) >= log->fileid)
-            return (0);
-        if (WT_IS_INIT_LSN(&log->ckpt_lsn))
+            min_lognum = 0;
+        else if (WT_IS_INIT_LSN(&log->ckpt_lsn))
             min_lognum = log->fileid - (dbg_log_cnt + 1);
         else
             min_lognum = WT_MIN(log->fileid - (dbg_log_cnt + 1), min_lognum);
     }
 
     __wt_readunlock(session, &conn->debug_log_retention_lock);
+    return (min_lognum);
+}
+
+/*
+ * __log_remove_once --
+ *     Perform one iteration of log removal. Must be called with the log removal lock held.
+ */
+static int
+__log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_LOG *log;
+    uint32_t min_lognum;
+    u_int logcount;
+    char **logfiles;
+
+    conn = S2C(session);
+    log = conn->log;
+    logcount = 0;
+    logfiles = NULL;
+
+    min_lognum = __compute_min_lognum(session, log, backup_file);
+    if (min_lognum == 0)
+        /* We want to retain all log files. Nothing to do here. */
+        return (0);
 
     __wt_verbose(session, WT_VERB_LOG, "log_remove: remove to log number %" PRIu32, min_lognum);
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -405,11 +405,11 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
      * Take a consistent view of the current configuration. If another thread reconfigures the
      * connection in parallel we'll handle that change on the next call to this function.
      */
-    __wt_spin_lock(session, &conn->reconfig_lock);
+    __wt_readlock(session, &conn->reconfig_lock);
     dbg_ckpt_cnt = conn->debug_ckpt_cnt;
     dbg_ckpt_retain = FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
     dbg_log_cnt = conn->debug_log_cnt;
-    __wt_spin_unlock(session, &conn->reconfig_lock);
+    __wt_readunlock(session, &conn->reconfig_lock);
 
     /* Adjust the number of log files to retain based on debugging options. */
     if (dbg_ckpt_retain && dbg_ckpt_cnt != 0)

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -405,7 +405,7 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
      * Take a consistent view of the current configuration. If another thread reconfigures the
      * connection in parallel we'll handle that change on the next call to this function.
      */
-    __wt_readlock(session, &conn->reconfig_lock);
+    __wt_readlock(session, &conn->debug_log_retention_lock);
 
     dbg_ckpt_cnt = conn->debug_ckpt_cnt;
     dbg_ckpt_retain = FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
@@ -433,7 +433,7 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
             min_lognum = WT_MIN(log->fileid - (dbg_log_cnt + 1), min_lognum);
     }
 
-    __wt_readunlock(session, &conn->reconfig_lock);
+    __wt_readunlock(session, &conn->debug_log_retention_lock);
 
     __wt_verbose(session, WT_VERB_LOG, "log_remove: remove to log number %" PRIu32, min_lognum);
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -406,10 +406,10 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
      * connection in parallel we'll handle that change on the next call to this function.
      */
     __wt_readlock(session, &conn->reconfig_lock);
+
     dbg_ckpt_cnt = conn->debug_ckpt_cnt;
     dbg_ckpt_retain = FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
     dbg_log_cnt = conn->debug_log_cnt;
-    __wt_readunlock(session, &conn->reconfig_lock);
 
     /* Adjust the number of log files to retain based on debugging options. */
     if (dbg_ckpt_retain && dbg_ckpt_cnt != 0)
@@ -432,6 +432,9 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
         else
             min_lognum = WT_MIN(log->fileid - (dbg_log_cnt + 1), min_lognum);
     }
+
+    __wt_readunlock(session, &conn->reconfig_lock);
+
     __wt_verbose(session, WT_VERB_LOG, "log_remove: remove to log number %" PRIu32, min_lognum);
 
     /*

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -384,9 +384,9 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
     WT_DECL_RET;
     WT_LOG *log;
     uint32_t dbg_ckpt_cnt, dbg_log_cnt, min_lognum;
-    bool dbg_ckpt_retain;
     u_int logcount;
     char **logfiles;
+    bool dbg_ckpt_retain;
 
     conn = S2C(session);
     log = conn->log;
@@ -402,9 +402,8 @@ __log_remove_once(WT_SESSION_IMPL *session, uint32_t backup_file)
                                     WT_MIN(log->ckpt_lsn.l.file, backup_file);
 
     /*
-     * Take a consistent view of the current configuration. 
-     * If another thread reconfigures the connection in parallel we'll handle that 
-     * change on the next call to this function.
+     * Take a consistent view of the current configuration. If another thread reconfigures the
+     * connection in parallel we'll handle that change on the next call to this function.
      */
     __wt_spin_lock(session, &conn->reconfig_lock);
     dbg_ckpt_cnt = conn->debug_ckpt_cnt;

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -377,7 +377,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
     conn = S2C(session);
 
     /* Serialize reconfiguration. */
-    __wt_writelock(session, &conn->reconfig_lock);
+    __wt_spin_lock(session, &conn->reconfig_lock);
     F_SET(conn, WT_CONN_RECONFIGURING);
 
     /*
@@ -430,7 +430,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
 
 err:
     F_CLR(conn, WT_CONN_RECONFIGURING);
-    __wt_writeunlock(session, &conn->reconfig_lock);
+    __wt_spin_unlock(session, &conn->reconfig_lock);
 
     return (ret);
 }

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -377,7 +377,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
     conn = S2C(session);
 
     /* Serialize reconfiguration. */
-    __wt_spin_lock(session, &conn->reconfig_lock);
+    __wt_writelock(session, &conn->reconfig_lock);
     F_SET(conn, WT_CONN_RECONFIGURING);
 
     /*
@@ -430,7 +430,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
 
 err:
     F_CLR(conn, WT_CONN_RECONFIGURING);
-    __wt_spin_unlock(session, &conn->reconfig_lock);
+    __wt_writeunlock(session, &conn->reconfig_lock);
 
     return (ret);
 }

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -253,7 +253,7 @@ struct __wt_connection_impl {
     WT_SPINLOCK fh_lock;         /* File handle queue spinlock */
     WT_SPINLOCK flush_tier_lock; /* Flush tier spinlock */
     WT_SPINLOCK metadata_lock;   /* Metadata update spinlock */
-    WT_SPINLOCK reconfig_lock;   /* Single thread reconfigure */
+    WT_RWLOCK reconfig_lock;     /* Single thread reconfigure */
     WT_SPINLOCK schema_lock;     /* Schema operation spinlock */
     WT_RWLOCK table_lock;        /* Table list lock */
     WT_SPINLOCK tiered_lock;     /* Tiered work queue spinlock */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -573,6 +573,7 @@ struct __wt_connection_impl {
     bool mmap_all; /* use mmap for all I/O on data files */
     int page_size; /* OS page size for mmap alignment */
 
+    /* Access to these fields is protected by the reconfig_lock. */
     WT_LSN *debug_ckpt;      /* Debug mode checkpoint LSNs. */
     size_t debug_ckpt_alloc; /* Checkpoint retention allocated. */
     uint32_t debug_ckpt_cnt; /* Checkpoint retention number. */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -248,17 +248,18 @@ struct __wt_connection_impl {
 
     const char *cfg; /* Connection configuration */
 
-    WT_SPINLOCK api_lock;        /* Connection API spinlock */
-    WT_SPINLOCK checkpoint_lock; /* Checkpoint spinlock */
-    WT_SPINLOCK fh_lock;         /* File handle queue spinlock */
-    WT_SPINLOCK flush_tier_lock; /* Flush tier spinlock */
-    WT_SPINLOCK metadata_lock;   /* Metadata update spinlock */
-    WT_RWLOCK reconfig_lock;     /* Single thread reconfigure */
-    WT_SPINLOCK schema_lock;     /* Schema operation spinlock */
-    WT_RWLOCK table_lock;        /* Table list lock */
-    WT_SPINLOCK tiered_lock;     /* Tiered work queue spinlock */
-    WT_SPINLOCK turtle_lock;     /* Turtle file spinlock */
-    WT_RWLOCK dhandle_lock;      /* Data handle list lock */
+    WT_SPINLOCK api_lock;               /* Connection API spinlock */
+    WT_SPINLOCK checkpoint_lock;        /* Checkpoint spinlock */
+    WT_RWLOCK debug_log_retention_lock; /* Log retention reconfiguration lock */
+    WT_SPINLOCK fh_lock;                /* File handle queue spinlock */
+    WT_SPINLOCK flush_tier_lock;        /* Flush tier spinlock */
+    WT_SPINLOCK metadata_lock;          /* Metadata update spinlock */
+    WT_SPINLOCK reconfig_lock;          /* Single thread reconfigure */
+    WT_SPINLOCK schema_lock;            /* Schema operation spinlock */
+    WT_RWLOCK table_lock;               /* Table list lock */
+    WT_SPINLOCK tiered_lock;            /* Tiered work queue spinlock */
+    WT_SPINLOCK turtle_lock;            /* Turtle file spinlock */
+    WT_RWLOCK dhandle_lock;             /* Data handle list lock */
 
     /* Connection queue */
     TAILQ_ENTRY(__wt_connection_impl) q;
@@ -573,7 +574,7 @@ struct __wt_connection_impl {
     bool mmap_all; /* use mmap for all I/O on data files */
     int page_size; /* OS page size for mmap alignment */
 
-    /* Access to these fields is protected by the reconfig_lock. */
+    /* Access to these fields is protected by the debug_log_retention_lock. */
     WT_LSN *debug_ckpt;      /* Debug mode checkpoint LSNs. */
     size_t debug_ckpt_alloc; /* Checkpoint retention allocated. */
     uint32_t debug_ckpt_cnt; /* Checkpoint retention number. */

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -313,13 +313,13 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
      * If we are storing debugging LSNs to retain additional log files from removal, then rotate the
      * newest LSN into the array.
      */
-    __wt_readlock(session, &conn->reconfig_lock);
+    __wt_readlock(session, &conn->debug_log_retention_lock);
     if (conn->debug_ckpt_cnt != 0) {
         for (i = (int)conn->debug_ckpt_cnt - 1; i > 0; --i)
             conn->debug_ckpt[i] = conn->debug_ckpt[i - 1];
         conn->debug_ckpt[0] = *ckpt_lsn;
     }
-    __wt_readunlock(session, &conn->reconfig_lock);
+    __wt_readunlock(session, &conn->debug_log_retention_lock);
 }
 
 /*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -313,11 +313,13 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
      * If we are storing debugging LSNs to retain additional log files from removal, then rotate the
      * newest LSN into the array.
      */
+    __wt_spin_lock(session, &conn->reconfig_lock);
     if (conn->debug_ckpt_cnt != 0) {
         for (i = (int)conn->debug_ckpt_cnt - 1; i > 0; --i)
             conn->debug_ckpt[i] = conn->debug_ckpt[i - 1];
         conn->debug_ckpt[0] = *ckpt_lsn;
     }
+    __wt_spin_unlock(session, &conn->reconfig_lock);
 }
 
 /*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -313,13 +313,13 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
      * If we are storing debugging LSNs to retain additional log files from removal, then rotate the
      * newest LSN into the array.
      */
-    __wt_readlock(session, &conn->debug_log_retention_lock);
+    __wt_writelock(session, &conn->debug_log_retention_lock);
     if (conn->debug_ckpt_cnt != 0) {
         for (i = (int)conn->debug_ckpt_cnt - 1; i > 0; --i)
             conn->debug_ckpt[i] = conn->debug_ckpt[i - 1];
         conn->debug_ckpt[0] = *ckpt_lsn;
     }
-    __wt_readunlock(session, &conn->debug_log_retention_lock);
+    __wt_writeunlock(session, &conn->debug_log_retention_lock);
 }
 
 /*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -313,13 +313,13 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
      * If we are storing debugging LSNs to retain additional log files from removal, then rotate the
      * newest LSN into the array.
      */
-    __wt_spin_lock(session, &conn->reconfig_lock);
+    __wt_readlock(session, &conn->reconfig_lock);
     if (conn->debug_ckpt_cnt != 0) {
         for (i = (int)conn->debug_ckpt_cnt - 1; i > 0; --i)
             conn->debug_ckpt[i] = conn->debug_ckpt[i - 1];
         conn->debug_ckpt[0] = *ckpt_lsn;
     }
-    __wt_spin_unlock(session, &conn->reconfig_lock);
+    __wt_readunlock(session, &conn->reconfig_lock);
 }
 
 /*


### PR DESCRIPTION
Take the existing uses of `debug_log_cnt` and `debug_ckpt_cnt` (`debug_mode.log_retention` and `debug_mode.checkpoint_retention` in the connection config) and change them from using memory barriers to locks.

Since this is the first PR in PM-3221 which migrates a barrier to using locks these a few questions to discuss. I'll 
flag them with comments.

The git diff for this PR is a bit hard to read. The main changes are as follows:
- Add a new lock (exact name tbd) which protects reads and writes to `debug_ckpt`, `debug_ckpt_alloc`, `debug_ckpt_cnt`, `debug_log_cnt`
- Pull the logic that reads and writes these fields into subfunctions where needed. This makes it easier to correctly set and release the new lock.