### PR TITLE
WT-11359 Update spinlock tasks to limit disk usage

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3576,10 +3576,11 @@ tasks:
         vars:
           SPINLOCK_TYPE: -DSPINLOCK_TYPE=gcc
       - func: "make check all"
+      - func: "unit test"
       - func: "format test"
         vars:
           times: 3
-      - func: "unit test"
+          extra_args: runs.rows=1000000:2500000
 
   - name: spinlock-pthread-adaptive-test
     commands:
@@ -3588,10 +3589,11 @@ tasks:
         vars:
           SPINLOCK_TYPE: -DSPINLOCK_TYPE=pthread_adaptive
       - func: "make check all"
+      - func: "unit test"
       - func: "format test"
         vars:
           times: 3
-      - func: "unit test"
+          extra_args: runs.rows=1000000:2500000
 
   - name: wtperf-test
     depends_on:


### PR DESCRIPTION
Limiting the number of rows used by format (when combined with backup, salvage, and no compression can cause out of disk). Also moving the unit test to before format which is more likely to use more disk space and means we don't need to clean up.