### PR TITLE
WT-11336 Check chunk cache pinned list when admitting chunks

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -893,6 +893,7 @@ len
 lengthp
 lenp
 lex
+lexically
 lexicographically
 lf
 lfence

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -360,6 +360,7 @@ __wt_chunkcache_get(WT_SESSION_IMPL *session, WT_BLOCK *block, uint32_t objectid
     bool chunk_cached, found;
 
     chunkcache = &S2C(session)->chunkcache;
+    chunk = NULL;
     already_read = 0;
     remains_to_read = size;
     retries = 0;

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -276,11 +276,11 @@ __chunkcache_arr_free(WT_SESSION_IMPL *session, char ***arr)
 }
 
 /*
- * __config_gets_pinned_objects --
+ * __config_get_sorted_pinned_objects --
  *     Get sorted array of pinned objects from the config.
  */
 static int
-__config_gets_pinned_objects(WT_SESSION_IMPL *session, const char *cfg[],
+__config_get_sorted_pinned_objects(WT_SESSION_IMPL *session, const char *cfg[],
   char ***pinned_objects_list, unsigned int *pinned_entries)
 {
     WT_CONFIG targetconf;
@@ -608,7 +608,7 @@ __wt_chunkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig
 #endif
     }
 
-    WT_RET(__config_gets_pinned_objects(session, cfg, &pinned_objects, &cnt));
+    WT_RET(__config_get_sorted_pinned_objects(session, cfg, &pinned_objects, &cnt));
     chunkcache->pinned_objects = pinned_objects;
     chunkcache->pinned_entries = cnt;
 

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -250,6 +250,87 @@ __chunkcache_eviction_thread(void *arg)
 }
 
 /*
+ * __chunkcache_str_cmp --
+ *     Qsort function: sort string array.
+ */
+static int WT_CDECL
+__chunkcache_str_cmp(const void *a, const void *b)
+{
+    return (strcmp(*(const char **)a, *(const char **)b));
+}
+
+/*
+ * __chunkcache_arr_free --
+ *     Free the array of strings.
+ */
+static void
+__chunkcache_arr_free(WT_SESSION_IMPL *session, char ***arr)
+{
+    char **p;
+
+    if ((p = (*arr)) != NULL) {
+        for (; *p != NULL; ++p)
+            __wt_free(session, *p);
+        __wt_free(session, *arr);
+    }
+}
+
+/*
+ * __config_gets_pinned_objects --
+ *     Get sorted array of pinned objects from the config.
+ */
+static int
+__config_gets_pinned_objects(WT_SESSION_IMPL *session, const char *cfg[],
+  char ***pinned_objects_list, unsigned int *pinned_entries)
+{
+    WT_CONFIG targetconf;
+    WT_CONFIG_ITEM cval, k, v;
+    WT_DECL_ITEM(tmp);
+    WT_DECL_RET;
+    char **pinned_objects;
+    unsigned int cnt;
+
+    pinned_objects = NULL;
+
+    WT_RET(__wt_config_gets(session, cfg, "chunk_cache.pinned", &cval));
+    __wt_config_subinit(session, &targetconf, &cval);
+    for (cnt = 0; (ret = __wt_config_next(&targetconf, &k, &v)) == 0; ++cnt)
+        ;
+    *pinned_entries = cnt;
+    WT_RET_NOTFOUND_OK(ret);
+
+    if (cnt != 0) {
+        WT_ERR(__wt_scr_alloc(session, 0, &tmp));
+        WT_ERR(__wt_calloc_def(session, cnt + 1, &pinned_objects));
+        __wt_config_subinit(session, &targetconf, &cval);
+        for (cnt = 0; (ret = __wt_config_next(&targetconf, &k, &v)) == 0; ++cnt) {
+            if (!WT_PREFIX_MATCH(k.str, "table:"))
+                WT_ERR_MSG(session, EINVAL,
+                  "chunk cache pinned configuration only supports objects of type \"table\"");
+
+            if (v.len != 0)
+                WT_ERR_MSG(session, EINVAL,
+                  "invalid chunk cache pinned config %.*s: URIs may require quoting", (int)cval.len,
+                  (char *)cval.str);
+
+            WT_PREFIX_SKIP_REQUIRED(session, k.str, "table:");
+            WT_ERR(__wt_buf_fmt(session, tmp, "%.*s.wt", (int)(k.len - strlen("table:")), k.str));
+            WT_ERR(__wt_strndup(session, tmp->data, tmp->size, &pinned_objects[cnt]));
+        }
+        WT_ERR_NOTFOUND_OK(ret, false);
+        __wt_qsort(pinned_objects, cnt, sizeof(char *), __chunkcache_str_cmp);
+        *pinned_objects_list = pinned_objects;
+    }
+
+err:
+    __wt_scr_free(session, &tmp);
+    if (ret != 0)
+        __chunkcache_arr_free(session, &pinned_objects);
+
+    return (ret);
+}
+
+/*
  * __wt_chunkcache_get --
  *     Return the data to the caller if we have it. Otherwise read it from storage and cache it.
  *
@@ -276,7 +357,7 @@ __wt_chunkcache_get(WT_SESSION_IMPL *session, WT_BLOCK *block, uint32_t objectid
     WT_DECL_RET;
     size_t already_read, remains_to_read, readable_in_chunk, size_copied;
     uint64_t bucket_id, retries, sleep_usec;
-    bool chunk_cached;
+    bool chunk_cached, found;
 
     chunkcache = &S2C(session)->chunkcache;
     already_read = 0;
@@ -383,6 +464,13 @@ retry:
             goto retry;
         }
     }
+
+    /* Mark chunk as pinned if the chunk belongs to the object in pinned object array. */
+    WT_BINARY_SEARCH_STRING(
+      chunk->hash_id.objectname, chunkcache->pinned_objects, chunkcache->pinned_entries, found);
+    if (found)
+        F_SET(chunk, WT_CHUNK_PINNED);
+
     *cache_hit = true;
     return (0);
 }
@@ -464,15 +552,14 @@ int
 __wt_chunkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 {
     WT_CHUNKCACHE *chunkcache;
-    WT_CONFIG targetconf;
-    WT_CONFIG_ITEM cval, k, v;
-    WT_DECL_RET;
+    WT_CONFIG_ITEM cval;
     unsigned int cnt, i;
     wt_thread_t evict_thread_tid;
     char **pinned_objects;
 
     chunkcache = &S2C(session)->chunkcache;
     pinned_objects = NULL;
+    cnt = 0;
 
     if (chunkcache->type != WT_CHUNKCACHE_UNCONFIGURED && !reconfig)
         WT_RET_MSG(session, EINVAL, "chunk cache setup requested, but cache is already configured");
@@ -521,30 +608,9 @@ __wt_chunkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig
 #endif
     }
 
-    WT_RET(__wt_config_gets(session, cfg, "chunk_cache.pinned", &cval));
-    __wt_config_subinit(session, &targetconf, &cval);
-    for (cnt = 0; (ret = __wt_config_next(&targetconf, &k, &v)) == 0; ++cnt)
-        ;
-    WT_RET_NOTFOUND_OK(ret);
-
-    if (cnt != 0) {
-        WT_RET(__wt_calloc_def(session, cnt + 1, &pinned_objects));
-        chunkcache->pinned_objects = pinned_objects;
-        __wt_config_subinit(session, &targetconf, &cval);
-        for (cnt = 0; (ret = __wt_config_next(&targetconf, &k, &v)) == 0; ++cnt) {
-            if (!WT_PREFIX_MATCH(k.str, "table:"))
-                WT_RET_MSG(session, EINVAL,
-                  "chunk cache pinned configuration only supports objects of type \"table\"");
-
-            if (v.len != 0)
-                WT_RET_MSG(session, EINVAL,
-                  "invalid chunk cache pinned config %.*s: URIs may require quoting", (int)cval.len,
-                  (char *)cval.str);
-
-            WT_RET(__wt_strndup(session, k.str, k.len, &pinned_objects[cnt]));
-        }
-    }
-    WT_RET_NOTFOUND_OK(ret);
+    WT_RET(__config_gets_pinned_objects(session, cfg, &pinned_objects, &cnt));
+    chunkcache->pinned_objects = pinned_objects;
+    chunkcache->pinned_entries = cnt;
 
     WT_RET(__wt_calloc_def(session, chunkcache->hashtable_size, &chunkcache->hashtable));
 

--- a/src/include/block_chunkcache.h
+++ b/src/include/block_chunkcache.h
@@ -40,6 +40,11 @@ struct __wt_chunkcache_chunk {
     wt_off_t chunk_offset;
     size_t chunk_size;
     volatile uint32_t valid;
+
+/* AUTOMATIC FLAG VALUE GENERATION START 0 */
+#define WT_CHUNK_PINNED 0x1u
+    /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
+    uint8_t flags;
 };
 
 struct __wt_chunkcache_bucket {
@@ -68,6 +73,7 @@ struct __wt_chunkcache {
     char *dev_path;             /* the storage path if we are on a file system or a block device */
     unsigned int evict_trigger; /* When this percent of cache is full, we trigger eviction. */
     unsigned int hashtable_size;
-    int type;              /* location of the chunk cache (volatile memory or file) */
-    char **pinned_objects; /* list of objects we wish to pin in chunk cache */
+    int type;                /* location of the chunk cache (volatile memory or file) */
+    char **pinned_objects;   /* list of objects we wish to pin in chunk cache */
+    uint32_t pinned_entries; /* count of pinned objects */
 };

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -238,7 +238,7 @@
     } while (0)
 
 /*
- * Binary search for an string key.
+ * Binary search for a string key.
  */
 #define WT_BINARY_SEARCH_STRING(key, arrayp, n, found)                 \
     do {                                                               \

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -238,7 +238,8 @@
     } while (0)
 
 /*
- * Binary search for a string key.
+ * Binary search for a string key. Note: For the binary search to function correctly, the array
+ * should not contain NULL values.
  */
 #define WT_BINARY_SEARCH_STRING(key, arrayp, n, found)                 \
     do {                                                               \

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -237,6 +237,25 @@
         }                                                              \
     } while (0)
 
+/*
+ * Binary search for an string key.
+ */
+#define WT_BINARY_SEARCH_STRING(key, arrayp, n, found)                 \
+    do {                                                               \
+        uint32_t __base, __indx, __limit;                              \
+        (found) = false;                                               \
+        for (__base = 0, __limit = (n); __limit != 0; __limit >>= 1) { \
+            __indx = __base + (__limit >> 1);                          \
+            if (strcmp((arrayp)[__indx], (key)) < 0) {                 \
+                __base = __indx + 1;                                   \
+                --__limit;                                             \
+            } else if (strcmp((arrayp)[__indx], (key)) == 0) {         \
+                (found) = true;                                        \
+                break;                                                 \
+            }                                                          \
+        }                                                              \
+    } while (0)
+
 #define WT_CLEAR(s) memset(&(s), 0, sizeof(s))
 
 /* Check if a string matches a prefix. */

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -6,6 +6,7 @@ if(HAVE_UNITTEST_ASSERTS)
     set(unittests tests/test_assertions.cpp)
 else()
     set(unittests
+        tests/test_binary_search_string.cpp
         tests/test_bounds_restore.cpp
         tests/test_crc32.cpp
         tests/test_extent_list.cpp

--- a/test/unittest/tests/test_binary_search_string.cpp
+++ b/test/unittest/tests/test_binary_search_string.cpp
@@ -98,4 +98,60 @@ TEST_CASE("Binary Search String: WT_BINARY_SEARCH_STRING", "[search]")
         WT_BINARY_SEARCH_STRING("elderberry", array, n, found);
         REQUIRE(found == true);
     }
+
+    SECTION("Prefixes in array and search for full string")
+    {
+        const char *array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("apples", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Full strings in array and search for prefix")
+    {
+        const char *array[] = {"apples", "bananas", "cherries", "dates", "elderberries"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("apple", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Empty string")
+    {
+        const char *array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Empty string in array with empty string")
+    {
+        /* Empty strings will be considered lexically smaller than any non-empty string. */
+        const char *array[] = {"", "apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("", array, n, found);
+        REQUIRE(found == true);
+    }
+
+    SECTION("Empty string in array")
+    {
+        /* Empty strings will be considered lexically smaller than any non-empty string. */
+        const char *array[] = {"", "apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("apples", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Empty string in array with only empty strings")
+    {
+        const char *array[] = {"", "", "", "", ""};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("", array, n, found);
+        REQUIRE(found == true);
+    }
 }

--- a/test/unittest/tests/test_binary_search_string.cpp
+++ b/test/unittest/tests/test_binary_search_string.cpp
@@ -1,0 +1,100 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+
+TEST_CASE("Binary Search String: WT_BINARY_SEARCH_STRING", "[search]")
+{
+    bool found;
+
+    SECTION("Key exists in the array")
+    {
+        const char* array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array)/sizeof(array[0]);
+        
+        WT_BINARY_SEARCH_STRING("banana", array, n, found);
+        REQUIRE(found == true);
+        
+        WT_BINARY_SEARCH_STRING("elderberry", array, n, found);
+        REQUIRE(found == true);
+        
+        WT_BINARY_SEARCH_STRING("apple", array, n, found);
+        REQUIRE(found == true);
+    }
+
+    SECTION("Key does not exist in the array")
+    {
+        const char* array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array)/sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("grape", array, n, found);
+        REQUIRE(found == false);
+
+        WT_BINARY_SEARCH_STRING("kiwi", array, n, found);
+        REQUIRE(found == false);
+
+        WT_BINARY_SEARCH_STRING("fig", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Empty array")
+    {
+        const char* array[] = {};
+        const uint32_t n = sizeof(array)/sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("apple", array, n, found);
+        REQUIRE(found == false);
+
+        WT_BINARY_SEARCH_STRING("banana", array, n, found);
+        REQUIRE(found == false);
+
+        WT_BINARY_SEARCH_STRING("cherry", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Single element array")
+    {
+        const char* array[] = {"apple"};
+        const uint32_t n = sizeof(array)/sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("apple", array, n, found);
+        REQUIRE(found == true);
+
+        WT_BINARY_SEARCH_STRING("banana", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Array with duplicate elements")
+    {
+        const char* array[] = {"apple", "banana", "banana", "cherry", "date", "elderberry", "elderberry"};
+        const uint32_t n = sizeof(array)/sizeof(array[0]);
+
+        WT_BINARY_SEARCH_STRING("banana", array, n, found);
+        REQUIRE(found == true);
+
+        WT_BINARY_SEARCH_STRING("elderberry", array, n, found);
+        REQUIRE(found == true);
+        
+        WT_BINARY_SEARCH_STRING("fig", array, n, found);
+        REQUIRE(found == false);
+    }
+
+    SECTION("Key exists in the array and is the first or last element")
+    {
+        const char* array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array)/sizeof(array[0]);
+        
+        WT_BINARY_SEARCH_STRING("apple", array, n, found);
+        REQUIRE(found == true);
+
+        WT_BINARY_SEARCH_STRING("elderberry", array, n, found);
+        REQUIRE(found == true);
+    }
+}

--- a/test/unittest/tests/test_binary_search_string.cpp
+++ b/test/unittest/tests/test_binary_search_string.cpp
@@ -46,8 +46,8 @@ TEST_CASE("Binary Search String: WT_BINARY_SEARCH_STRING", "[search]")
 
     SECTION("Empty array")
     {
-        const char *array[] = {};
-        const uint32_t n = sizeof(array) / sizeof(array[0]);
+        const char *array[] = {NULL};
+        const uint32_t n = 0;
 
         WT_BINARY_SEARCH_STRING("apple", array, n, found);
         REQUIRE(found == false);

--- a/test/unittest/tests/test_binary_search_string.cpp
+++ b/test/unittest/tests/test_binary_search_string.cpp
@@ -16,23 +16,23 @@ TEST_CASE("Binary Search String: WT_BINARY_SEARCH_STRING", "[search]")
 
     SECTION("Key exists in the array")
     {
-        const char* array[] = {"apple", "banana", "cherry", "date", "elderberry"};
-        const uint32_t n = sizeof(array)/sizeof(array[0]);
-        
+        const char *array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
         WT_BINARY_SEARCH_STRING("banana", array, n, found);
         REQUIRE(found == true);
-        
+
         WT_BINARY_SEARCH_STRING("elderberry", array, n, found);
         REQUIRE(found == true);
-        
+
         WT_BINARY_SEARCH_STRING("apple", array, n, found);
         REQUIRE(found == true);
     }
 
     SECTION("Key does not exist in the array")
     {
-        const char* array[] = {"apple", "banana", "cherry", "date", "elderberry"};
-        const uint32_t n = sizeof(array)/sizeof(array[0]);
+        const char *array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
 
         WT_BINARY_SEARCH_STRING("grape", array, n, found);
         REQUIRE(found == false);
@@ -46,8 +46,8 @@ TEST_CASE("Binary Search String: WT_BINARY_SEARCH_STRING", "[search]")
 
     SECTION("Empty array")
     {
-        const char* array[] = {};
-        const uint32_t n = sizeof(array)/sizeof(array[0]);
+        const char *array[] = {};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
 
         WT_BINARY_SEARCH_STRING("apple", array, n, found);
         REQUIRE(found == false);
@@ -61,8 +61,8 @@ TEST_CASE("Binary Search String: WT_BINARY_SEARCH_STRING", "[search]")
 
     SECTION("Single element array")
     {
-        const char* array[] = {"apple"};
-        const uint32_t n = sizeof(array)/sizeof(array[0]);
+        const char *array[] = {"apple"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
 
         WT_BINARY_SEARCH_STRING("apple", array, n, found);
         REQUIRE(found == true);
@@ -73,24 +73,25 @@ TEST_CASE("Binary Search String: WT_BINARY_SEARCH_STRING", "[search]")
 
     SECTION("Array with duplicate elements")
     {
-        const char* array[] = {"apple", "banana", "banana", "cherry", "date", "elderberry", "elderberry"};
-        const uint32_t n = sizeof(array)/sizeof(array[0]);
+        const char *array[] = {
+          "apple", "banana", "banana", "cherry", "date", "elderberry", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
 
         WT_BINARY_SEARCH_STRING("banana", array, n, found);
         REQUIRE(found == true);
 
         WT_BINARY_SEARCH_STRING("elderberry", array, n, found);
         REQUIRE(found == true);
-        
+
         WT_BINARY_SEARCH_STRING("fig", array, n, found);
         REQUIRE(found == false);
     }
 
     SECTION("Key exists in the array and is the first or last element")
     {
-        const char* array[] = {"apple", "banana", "cherry", "date", "elderberry"};
-        const uint32_t n = sizeof(array)/sizeof(array[0]);
-        
+        const char *array[] = {"apple", "banana", "cherry", "date", "elderberry"};
+        const uint32_t n = sizeof(array) / sizeof(array[0]);
+
         WT_BINARY_SEARCH_STRING("apple", array, n, found);
         REQUIRE(found == true);
 


### PR DESCRIPTION
The following work has been done in the ticket:

1. A new function was created to handle the pinned configuration due to the increasing size of the setup function and the potential needed to reconfigure this specific config in the future.
2. The pinned objects were extracted from the config and sorted into an array. Additionally, the name of each object was changed (example: from `table:abcd` to` abcd.wt`), as this is the required format for storing object names.
3. With a sorted array of pinned objects in place, a binary search is now performed every time a chunk is requested. This search determines whether the chunk belongs to any of the pinned objects.
4. Added unit testing for binary search.