### PR TITLE
WT-10424, WT-8340 v5.0 group backport

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -227,6 +227,7 @@ conn_stats = [
     CacheStat('cache_eviction_aggressive_set', 'eviction currently operating in aggressive mode', 'no_clear,no_scale'),
     CacheStat('cache_eviction_app', 'pages evicted by application threads'),
     CacheStat('cache_eviction_app_dirty', 'modified pages evicted by application threads'),
+    CacheStat('cache_eviction_clear_ordinary', 'pages removed from the ordinary queue to be queued for urgent eviction'),
     CacheStat('cache_eviction_empty_score', 'eviction empty score', 'no_clear,no_scale'),
     CacheStat('cache_eviction_fail', 'pages selected for eviction unable to be evicted'),
     CacheStat('cache_eviction_fail_active_children_on_an_internal_page', 'pages selected for eviction unable to be evicted because of active children on an internal page'),

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -83,7 +83,7 @@ __compact_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 
     /* If rewriting the page, have reconciliation write new blocks. */
     if (!*skipp)
-        F_SET_ATOMIC(ref->page, WT_PAGE_COMPACTION_WRITE);
+        F_SET_ATOMIC_16(ref->page, WT_PAGE_COMPACTION_WRITE);
 
     return (0);
 }

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1120,19 +1120,19 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
     WT_RET(ds->f(ds, ", entries %" PRIu32, entries));
     WT_RET(ds->f(ds, ", %s", __wt_page_is_modified(page) ? "dirty" : "clean"));
 
-    if (F_ISSET_ATOMIC(page, WT_PAGE_BUILD_KEYS))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_BUILD_KEYS))
         WT_RET(ds->f(ds, ", keys-built"));
-    if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))
         WT_RET(ds->f(ds, ", disk-alloc"));
-    if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_MAPPED))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_MAPPED))
         WT_RET(ds->f(ds, ", disk-mapped"));
-    if (F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU))
         WT_RET(ds->f(ds, ", evict-lru"));
-    if (F_ISSET_ATOMIC(page, WT_PAGE_INTL_OVERFLOW_KEYS))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_INTL_OVERFLOW_KEYS))
         WT_RET(ds->f(ds, ", overflow-keys"));
-    if (F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_INSERT))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_SPLIT_INSERT))
         WT_RET(ds->f(ds, ", split-insert"));
-    if (F_ISSET_ATOMIC(page, WT_PAGE_UPDATE_IGNORE))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_UPDATE_IGNORE))
         WT_RET(ds->f(ds, ", update-ignore"));
 
     if (mod != NULL)

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -74,7 +74,7 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
 
     /* Assert we never discard a dirty page or a page queue for eviction. */
     WT_ASSERT(session, !__wt_page_is_modified(page));
-    WT_ASSERT(session, !F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU));
+    WT_ASSERT(session, !F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU));
 
     /*
      * If a root page split, there may be one or more pages linked from the page; walk the list,
@@ -93,11 +93,11 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
     __wt_cache_page_evict(session, page);
 
     dsk = (WT_PAGE_HEADER *)page->dsk;
-    if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))
         __wt_cache_page_image_decr(session, page);
 
     /* Discard any mapped image. */
-    if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_MAPPED))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_MAPPED))
         (void)S2BT(session)->bm->map_discard(
           S2BT(session)->bm, session, dsk, (size_t)dsk->mem_size);
 
@@ -128,7 +128,7 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
     }
 
     /* Discard any allocated disk image. */
-    if (F_ISSET_ATOMIC(page, WT_PAGE_DISK_ALLOC))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))
         __wt_overwrite_and_free_len(session, dsk, dsk->mem_size);
 
     __wt_overwrite_and_free(session, page);
@@ -150,7 +150,7 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
     mod = page->modify;
 
     /* In some failed-split cases, we can't discard updates. */
-    update_ignore = F_ISSET_ATOMIC(page, WT_PAGE_UPDATE_IGNORE);
+    update_ignore = F_ISSET_ATOMIC_16(page, WT_PAGE_UPDATE_IGNORE);
 
     switch (mod->rec_result) {
     case WT_PM_REC_MULTIBLOCK:

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -361,7 +361,7 @@ __wt_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint32
     /* Allocate and initialize a new WT_PAGE. */
     WT_RET(__wt_page_alloc(session, dsk->type, alloc_entries, true, &page));
     page->dsk = dsk;
-    F_SET_ATOMIC(page, flags);
+    F_SET_ATOMIC_16(page, flags);
 
     /*
      * Track the memory allocated to build this page so we can update the cache statistics in a
@@ -664,7 +664,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
      * writes overflow cookies on internal pages, no matter the size of the key.)
      */
     if (overflow_keys)
-        F_SET_ATOMIC(page, WT_PAGE_INTL_OVERFLOW_KEYS);
+        F_SET_ATOMIC_16(page, WT_PAGE_INTL_OVERFLOW_KEYS);
 
 err:
     __wt_scr_free(session, &current);
@@ -852,7 +852,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *preparedp)
      * Mark the page as not needing that work if there aren't stretches of prefix-compressed keys.
      */
     if (best_prefix_count <= 10)
-        F_SET_ATOMIC(page, WT_PAGE_BUILD_KEYS);
+        F_SET_ATOMIC_16(page, WT_PAGE_BUILD_KEYS);
 
     if (preparedp != NULL && prepare)
         *preparedp = true;

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -160,7 +160,7 @@ __split_ovfl_key_cleanup(WT_SESSION_IMPL *session, WT_PAGE *page, WT_REF *ref)
     uint32_t cell_offset;
 
     /* There's a per-page flag if there are any overflow keys at all. */
-    if (!F_ISSET_ATOMIC(page, WT_PAGE_INTL_OVERFLOW_KEYS))
+    if (!F_ISSET_ATOMIC_16(page, WT_PAGE_INTL_OVERFLOW_KEYS))
         return (0);
 
     /*
@@ -1649,7 +1649,7 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
      */
     if (ref != NULL) {
         if (ref->page != NULL)
-            F_SET_ATOMIC(ref->page, WT_PAGE_UPDATE_IGNORE);
+            F_SET_ATOMIC_16(ref->page, WT_PAGE_UPDATE_IGNORE);
         __wt_free_ref(session, ref, orig->type, true);
     }
 }
@@ -1783,7 +1783,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ASSERT(session, __wt_page_is_modified(page));
     WT_ASSERT(session, ref->ft_info.del == NULL);
 
-    F_SET_ATOMIC(page, WT_PAGE_SPLIT_INSERT); /* Only split in-memory once. */
+    F_SET_ATOMIC_16(page, WT_PAGE_SPLIT_INSERT); /* Only split in-memory once. */
 
     /* Find the last item on the page. */
     if (type == WT_PAGE_ROW_LEAF)
@@ -2279,7 +2279,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
      */
     __wt_page_modify_clear(session, page);
     if (!F_ISSET(S2C(session)->cache, WT_CACHE_EVICT_SCRUB) || multi->supd_restore)
-        F_SET_ATOMIC(page, WT_PAGE_EVICT_NO_PROGRESS);
+        F_SET_ATOMIC_16(page, WT_PAGE_EVICT_NO_PROGRESS);
     __wt_ref_out(session, ref);
 
     /* Swap the new page into place. */

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -9,6 +9,7 @@
 #include "wt_internal.h"
 
 static int __evict_clear_all_walks(WT_SESSION_IMPL *);
+static void __evict_list_clear_page_locked(WT_SESSION_IMPL *, WT_REF *, bool);
 static int WT_CDECL __evict_lru_cmp(const void *, const void *);
 static int __evict_lru_pages(WT_SESSION_IMPL *, bool);
 static int __evict_lru_walk(WT_SESSION_IMPL *);
@@ -147,36 +148,31 @@ __evict_list_clear(WT_SESSION_IMPL *session, WT_EVICT_ENTRY *e)
 {
     if (e->ref != NULL) {
         WT_ASSERT(session, F_ISSET_ATOMIC_16(e->ref->page, WT_PAGE_EVICT_LRU));
-        F_CLR_ATOMIC_16(e->ref->page, WT_PAGE_EVICT_LRU);
+        F_CLR_ATOMIC_16(e->ref->page, WT_PAGE_EVICT_LRU | WT_PAGE_EVICT_LRU_URGENT);
     }
     e->ref = NULL;
     e->btree = WT_DEBUG_POINT;
 }
 
 /*
- * __wt_evict_list_clear_page --
- *     Make sure a page is not in the LRU eviction list. This called from the page eviction code to
- *     make sure there is no attempt to evict a child page multiple times.
+ * __evict_list_clear_page_locked --
+ *     This function searches for the page in all the eviction queues (skipping the urgent queue if
+ *     requested) and clears it if found. It does not take the eviction queue lock, so the caller
+ *     should hold the appropriate locks before calling this function.
  */
-void
-__wt_evict_list_clear_page(WT_SESSION_IMPL *session, WT_REF *ref)
+static void
+__evict_list_clear_page_locked(WT_SESSION_IMPL *session, WT_REF *ref, bool exclude_urgent)
 {
     WT_CACHE *cache;
     WT_EVICT_ENTRY *evict;
-    uint32_t i, elem, q;
+    uint32_t elem, i, q, last_queue_idx;
     bool found;
 
-    WT_ASSERT(session, __wt_ref_is_root(ref) || ref->state == WT_REF_LOCKED);
-
-    /* Fast path: if the page isn't on the queue, don't bother searching. */
-    if (!F_ISSET_ATOMIC_16(ref->page, WT_PAGE_EVICT_LRU))
-        return;
-
+    last_queue_idx = exclude_urgent ? WT_EVICT_URGENT_QUEUE : WT_EVICT_QUEUE_MAX;
     cache = S2C(session)->cache;
-    __wt_spin_lock(session, &cache->evict_queue_lock);
-
     found = false;
-    for (q = 0; q < WT_EVICT_QUEUE_MAX && !found; q++) {
+
+    for (q = 0; q < last_queue_idx && !found; q++) {
         __wt_spin_lock(session, &cache->evict_queues[q].evict_lock);
         elem = cache->evict_queues[q].evict_max;
         for (i = 0, evict = cache->evict_queues[q].evict_queue; i < elem; i++, evict++)
@@ -188,6 +184,30 @@ __wt_evict_list_clear_page(WT_SESSION_IMPL *session, WT_REF *ref)
         __wt_spin_unlock(session, &cache->evict_queues[q].evict_lock);
     }
     WT_ASSERT(session, !F_ISSET_ATOMIC_16(ref->page, WT_PAGE_EVICT_LRU));
+}
+
+/*
+ * __wt_evict_list_clear_page --
+ *     Check whether a page is present in the LRU eviction list. If the page is found in the list,
+ *     remove it. This is called from the page eviction code to make sure there is no attempt to
+ *     evict a child page multiple times.
+ */
+void
+__wt_evict_list_clear_page(WT_SESSION_IMPL *session, WT_REF *ref)
+{
+    WT_CACHE *cache;
+
+    WT_ASSERT(session, __wt_ref_is_root(ref) || ref->state == WT_REF_LOCKED);
+
+    /* Fast path: if the page isn't in the queue, don't bother searching. */
+    if (!F_ISSET_ATOMIC_16(ref->page, WT_PAGE_EVICT_LRU))
+        return;
+    cache = S2C(session)->cache;
+
+    __wt_spin_lock(session, &cache->evict_queue_lock);
+
+    /* Remove the reference from the eviction queues. */
+    __evict_list_clear_page_locked(session, ref, false);
 
     __wt_spin_unlock(session, &cache->evict_queue_lock);
 }
@@ -2486,17 +2506,34 @@ __wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ASSERT(session, !__wt_ref_is_root(ref));
 
     page = ref->page;
-    if (F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU) || S2BT(session)->evict_disabled > 0)
+    if (S2BT(session)->evict_disabled > 0 || F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU_URGENT))
+        return (false);
+
+    cache = S2C(session)->cache;
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU) && F_ISSET(cache, WT_CACHE_EVICT_ALL))
         return (false);
 
     /* Append to the urgent queue if we can. */
-    cache = S2C(session)->cache;
     urgent_queue = &cache->evict_queues[WT_EVICT_URGENT_QUEUE];
     queued = false;
 
     __wt_spin_lock(session, &cache->evict_queue_lock);
-    if (F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU) || S2BT(session)->evict_disabled > 0)
+
+    /* Check again, in case we raced with another thread. */
+    if (S2BT(session)->evict_disabled > 0 || F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU_URGENT))
         goto done;
+
+    /*
+     * If the page is already in the LRU eviction list, clear it from the list if eviction server is
+     * not running.
+     */
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU)) {
+        if (!F_ISSET(cache, WT_CACHE_EVICT_ALL)) {
+            __evict_list_clear_page_locked(session, ref, true);
+            WT_STAT_CONN_INCR(session, cache_eviction_clear_ordinary);
+        } else
+            goto done;
+    }
 
     __wt_spin_lock(session, &urgent_queue->evict_lock);
     if (__evict_queue_empty(urgent_queue, false)) {
@@ -2508,6 +2545,7 @@ __wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
       __evict_push_candidate(session, urgent_queue, evict, ref)) {
         ++urgent_queue->evict_candidates;
         queued = true;
+        FLD_SET(page->flags_atomic, WT_PAGE_EVICT_LRU_URGENT);
     }
     __wt_spin_unlock(session, &urgent_queue->evict_lock);
 

--- a/src/evict/evict_stat.c
+++ b/src/evict/evict_stat.c
@@ -52,7 +52,7 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
         if (!__wt_ref_is_root(next_walk) && !__wt_page_can_evict(session, next_walk, NULL))
             ++num_not_queueable;
 
-        if (F_ISSET_ATOMIC(page, WT_PAGE_EVICT_LRU))
+        if (F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_LRU))
             ++num_queued;
 
         if (size > max_pagesize)

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -670,10 +670,10 @@ struct __wt_page {
 #define WT_PAGE_INTL_OVERFLOW_KEYS 0x040u /* Internal page has overflow keys (historic only) */
 #define WT_PAGE_SPLIT_INSERT 0x080u       /* A leaf page was split for append */
 #define WT_PAGE_UPDATE_IGNORE 0x100u      /* Ignore updates on page discard */
-                                          /* AUTOMATIC FLAG VALUE GENERATION STOP 9 */
-    uint8_t flags_atomic;                 /* Atomic flags, use F_*_ATOMIC */
+                                          /* AUTOMATIC FLAG VALUE GENERATION STOP 16 */
+    uint16_t flags_atomic;                /* Atomic flags, use F_*_ATOMIC_16 */
 
-    uint8_t unused[2]; /* Unused padding */
+    uint8_t unused; /* Unused padding */
 
     size_t memory_footprint; /* Memory attached to the page */
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -666,10 +666,11 @@ struct __wt_page {
 #define WT_PAGE_DISK_ALLOC 0x004u         /* Disk image in allocated memory */
 #define WT_PAGE_DISK_MAPPED 0x008u        /* Disk image in mapped memory */
 #define WT_PAGE_EVICT_LRU 0x010u          /* Page is on the LRU queue */
-#define WT_PAGE_EVICT_NO_PROGRESS 0x020u  /* Eviction doesn't count as progress */
-#define WT_PAGE_INTL_OVERFLOW_KEYS 0x040u /* Internal page has overflow keys (historic only) */
-#define WT_PAGE_SPLIT_INSERT 0x080u       /* A leaf page was split for append */
-#define WT_PAGE_UPDATE_IGNORE 0x100u      /* Ignore updates on page discard */
+#define WT_PAGE_EVICT_LRU_URGENT 0x020u   /* Page is in the urgent queue */
+#define WT_PAGE_EVICT_NO_PROGRESS 0x040u  /* Eviction doesn't count as progress */
+#define WT_PAGE_INTL_OVERFLOW_KEYS 0x080u /* Internal page has overflow keys (historic only) */
+#define WT_PAGE_SPLIT_INSERT 0x100u       /* A leaf page was split for append */
+#define WT_PAGE_UPDATE_IGNORE 0x200u      /* Ignore updates on page discard */
                                           /* AUTOMATIC FLAG VALUE GENERATION STOP 16 */
     uint16_t flags_atomic;                /* Atomic flags, use F_*_ATOMIC_16 */
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -584,7 +584,7 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page)
      * Track if eviction makes progress. This is used in various places to determine whether
      * eviction is stuck.
      */
-    if (!F_ISSET_ATOMIC(page, WT_PAGE_EVICT_NO_PROGRESS))
+    if (!F_ISSET_ATOMIC_16(page, WT_PAGE_EVICT_NO_PROGRESS))
         (void)__wt_atomic_addv64(&cache->eviction_progress, 1);
 }
 
@@ -1259,9 +1259,9 @@ __wt_row_leaf_key_instantiate(WT_SESSION_IMPL *session, WT_PAGE *page)
      * doing a cursor previous call, and this page has never been checked for excessively long
      * stretches of prefix-compressed keys, do it now.
      */
-    if (F_ISSET_ATOMIC(page, WT_PAGE_BUILD_KEYS))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_BUILD_KEYS))
         return (0);
-    F_SET_ATOMIC(page, WT_PAGE_BUILD_KEYS);
+    F_SET_ATOMIC_16(page, WT_PAGE_BUILD_KEYS);
 
     /* Walk the keys, making sure there's something easy to work with periodically. */
     skip = 0;
@@ -1553,7 +1553,7 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
      * Only split a page once, otherwise workloads that update in the middle of the page could
      * continually split without benefit.
      */
-    if (F_ISSET_ATOMIC(page, WT_PAGE_SPLIT_INSERT))
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_SPLIT_INSERT))
         return (false);
 
     /*
@@ -1706,7 +1706,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * matter the size of the key.)
      */
     if (__wt_btree_syncing_by_other_session(session) &&
-      F_ISSET_ATOMIC(ref->home, WT_PAGE_INTL_OVERFLOW_KEYS))
+      F_ISSET_ATOMIC_16(ref->home, WT_PAGE_INTL_OVERFLOW_KEYS))
         return (false);
 
     /*

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -28,26 +28,27 @@
 /*
  * Atomic versions of the flag set/clear macros.
  */
-#define F_ISSET_ATOMIC(p, mask) ((p)->flags_atomic & (uint8_t)(mask))
 
-#define F_SET_ATOMIC(p, mask)                                                              \
-    do {                                                                                   \
-        uint8_t __orig;                                                                    \
-        if (F_ISSET_ATOMIC(p, mask))                                                       \
-            break;                                                                         \
-        do {                                                                               \
-            __orig = (p)->flags_atomic;                                                    \
-        } while (!__wt_atomic_cas8(&(p)->flags_atomic, __orig, __orig | (uint8_t)(mask))); \
+#define F_ISSET_ATOMIC_16(p, mask) ((p)->flags_atomic & (uint16_t)(mask))
+
+#define F_SET_ATOMIC_16(p, mask)                                                             \
+    do {                                                                                     \
+        uint16_t __orig;                                                                     \
+        if (F_ISSET_ATOMIC_16(p, mask))                                                      \
+            break;                                                                           \
+        do {                                                                                 \
+            __orig = (p)->flags_atomic;                                                      \
+        } while (!__wt_atomic_cas16(&(p)->flags_atomic, __orig, __orig | (uint16_t)(mask))); \
     } while (0)
 
-#define F_CLR_ATOMIC(p, mask)                                                               \
-    do {                                                                                    \
-        uint8_t __orig;                                                                     \
-        if (!F_ISSET_ATOMIC(p, mask))                                                       \
-            break;                                                                          \
-        do {                                                                                \
-            __orig = (p)->flags_atomic;                                                     \
-        } while (!__wt_atomic_cas8(&(p)->flags_atomic, __orig, __orig & ~(uint8_t)(mask))); \
+#define F_CLR_ATOMIC_16(p, mask)                                                              \
+    do {                                                                                      \
+        uint16_t __orig;                                                                      \
+        if (!F_ISSET_ATOMIC_16(p, mask))                                                      \
+            break;                                                                            \
+        do {                                                                                  \
+            __orig = (p)->flags_atomic;                                                       \
+        } while (!__wt_atomic_cas16(&(p)->flags_atomic, __orig, __orig & ~(uint16_t)(mask))); \
     } while (0)
 
 /*

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -503,6 +503,7 @@ struct __wt_connection_stats {
     int64_t cache_read;
     int64_t cache_read_deleted;
     int64_t cache_read_deleted_prepared;
+    int64_t cache_eviction_clear_ordinary;
     int64_t cache_pages_requested;
     int64_t cache_eviction_pages_seen;
     int64_t cache_eviction_pages_already_queued;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5547,857 +5547,862 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_READ_DELETED			1162
 /*! cache: pages read into cache after truncate in prepare state */
 #define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1163
+/*!
+ * cache: pages removed from the ordinary queue to be queued for urgent
+ * eviction
+ */
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1164
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1164
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1165
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1165
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1166
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1166
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1167
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1167
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1168
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1168
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1169
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1169
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1170
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and out of order timestamps handling
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_OUT_OF_ORDER_TS	1170
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_OUT_OF_ORDER_TS	1171
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1171
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1172
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1172
+#define	WT_STAT_CONN_CACHE_WRITE			1173
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1173
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1174
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1174
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1175
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1175
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1176
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1176
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1177
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1177
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1178
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1178
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1179
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1179
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1180
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1180
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1181
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1181
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1182
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1182
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1183
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1183
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1184
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1184
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1185
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1185
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1186
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1186
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1187
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1187
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1188
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1188
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1189
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1189
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1190
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1190
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1191
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1191
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1192
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1192
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1193
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1193
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1194
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1194
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1195
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1195
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1196
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1196
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1197
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1197
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1198
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1198
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1199
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1199
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1200
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1200
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1201
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1201
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1202
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1202
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1203
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1203
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1204
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1204
+#define	WT_STAT_CONN_TIME_TRAVEL			1205
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1205
+#define	WT_STAT_CONN_FILE_OPEN				1206
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1206
+#define	WT_STAT_CONN_BUCKETS_DH				1207
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1207
+#define	WT_STAT_CONN_BUCKETS				1208
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1208
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1209
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1209
+#define	WT_STAT_CONN_MEMORY_FREE			1210
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1210
+#define	WT_STAT_CONN_MEMORY_GROW			1211
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1211
+#define	WT_STAT_CONN_COND_WAIT				1212
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1212
+#define	WT_STAT_CONN_RWLOCK_READ			1213
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1213
+#define	WT_STAT_CONN_RWLOCK_WRITE			1214
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1214
+#define	WT_STAT_CONN_FSYNC_IO				1215
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1215
+#define	WT_STAT_CONN_READ_IO				1216
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1216
+#define	WT_STAT_CONN_WRITE_IO				1217
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1217
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1218
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1218
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1219
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1219
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1220
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1220
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1221
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1221
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1222
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1222
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1223
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1223
+#define	WT_STAT_CONN_CURSOR_CACHE			1224
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1224
+#define	WT_STAT_CONN_CURSOR_CREATE			1225
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1225
+#define	WT_STAT_CONN_CURSOR_INSERT			1226
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1226
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1227
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1227
+#define	WT_STAT_CONN_CURSOR_MODIFY			1228
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1228
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1229
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1229
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1230
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1230
+#define	WT_STAT_CONN_CURSOR_NEXT			1231
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1231
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1232
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1232
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1233
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1233
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1234
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1234
+#define	WT_STAT_CONN_CURSOR_RESTART			1235
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1235
+#define	WT_STAT_CONN_CURSOR_PREV			1236
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1236
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1237
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1237
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1238
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1238
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1239
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1239
+#define	WT_STAT_CONN_CURSOR_REMOVE			1240
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1240
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1241
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1241
+#define	WT_STAT_CONN_CURSOR_RESERVE			1242
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1242
+#define	WT_STAT_CONN_CURSOR_RESET			1243
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1243
+#define	WT_STAT_CONN_CURSOR_SEARCH			1244
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1244
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1245
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1245
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1246
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1246
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1247
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1247
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1248
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1248
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1249
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1249
+#define	WT_STAT_CONN_CURSOR_SWEEP			1250
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1250
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1251
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1251
+#define	WT_STAT_CONN_CURSOR_UPDATE			1252
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1252
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1253
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1253
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1254
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1254
+#define	WT_STAT_CONN_CURSOR_REOPEN			1255
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1255
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1256
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1256
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1257
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1257
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1258
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1258
+#define	WT_STAT_CONN_DH_SWEEP_REF			1259
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1259
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1260
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1260
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1261
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1261
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1262
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1262
+#define	WT_STAT_CONN_DH_SWEEPS				1263
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1263
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1264
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1264
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1265
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1265
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1266
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1266
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1267
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1267
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1268
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1268
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1269
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1269
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1270
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1270
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1271
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1271
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1272
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1272
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1273
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1273
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1274
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1274
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1275
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1275
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1276
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1276
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1277
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1277
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1278
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1278
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1279
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1279
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1280
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1280
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1281
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1281
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1282
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1282
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1283
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1283
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1284
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1284
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1285
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1285
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1286
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1286
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1287
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1287
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1288
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1288
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1289
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1289
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1290
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1290
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1291
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1291
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1292
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1292
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1293
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1293
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1294
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1294
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1295
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1295
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1296
 /*! log: force archive time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1296
+#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1297
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1297
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1298
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1298
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1299
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1299
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1300
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1300
+#define	WT_STAT_CONN_LOG_FLUSH				1301
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1301
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1302
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1302
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1303
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1303
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1304
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1304
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1305
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1305
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1306
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1306
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1307
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1307
+#define	WT_STAT_CONN_LOG_SCANS				1308
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1308
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1309
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1309
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1310
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1310
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1311
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1311
+#define	WT_STAT_CONN_LOG_SYNC				1312
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1312
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1313
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1313
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1314
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1314
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1315
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1315
+#define	WT_STAT_CONN_LOG_WRITES				1316
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1316
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1317
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1317
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1318
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1318
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1319
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1319
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1320
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1320
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1321
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1321
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1322
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1322
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1323
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1323
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1324
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1324
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1325
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1325
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1326
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1326
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1327
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1327
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1328
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1328
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1329
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1329
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1330
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1330
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1331
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1331
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1332
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1332
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1333
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1333
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1334
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1334
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1335
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1335
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1336
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1336
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1337
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1337
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1338
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1338
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1339
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1339
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1340
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1340
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1341
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1341
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1342
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1342
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1343
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1343
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1344
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1344
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1345
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1345
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1346
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1346
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1347
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1347
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1348
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1348
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1349
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1349
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1350
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1350
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1351
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1351
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1352
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1352
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1353
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1353
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1354
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1354
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1355
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1355
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1356
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1356
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1357
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1357
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1358
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1358
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1359
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1359
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1360
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1360
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1361
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1361
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1362
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1362
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1363
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1363
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1364
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1364
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1365
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1365
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1366
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1366
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1367
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1367
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1368
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1368
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1369
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1369
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1370
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1370
+#define	WT_STAT_CONN_REC_PAGES				1371
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1371
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1372
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1372
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1373
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1373
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1374
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1374
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1375
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1375
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1376
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1376
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1377
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1377
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1378
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1378
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1379
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1379
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1380
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1380
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1381
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1381
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1382
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1382
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1383
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1383
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1384
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1384
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1385
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1385
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1386
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1386
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1387
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1387
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1388
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1388
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1389
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1389
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1390
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1390
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1391
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1391
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1392
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1392
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1393
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1393
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1394
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1394
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1395
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1395
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1396
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1396
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1397
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1397
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1398
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1398
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1399
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1399
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1400
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1400
+#define	WT_STAT_CONN_FLUSH_TIER				1401
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1401
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1402
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1402
+#define	WT_STAT_CONN_SESSION_OPEN			1403
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1403
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1404
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1404
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1405
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1405
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1406
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1406
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1407
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1407
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1408
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1408
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1409
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1409
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1410
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1410
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1411
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1411
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1412
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1412
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1413
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1413
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1414
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1414
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1415
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1415
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1416
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1416
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1417
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1417
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1418
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1418
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1419
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1419
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1420
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1420
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1421
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1421
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1422
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1422
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1423
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1423
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1424
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1424
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1425
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1425
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1426
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1426
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1427
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1427
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1428
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1428
+#define	WT_STAT_CONN_TIERED_RETENTION			1429
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1429
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1430
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1430
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1431
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1431
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1432
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1432
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1433
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1433
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1434
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1434
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1435
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1435
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1436
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1436
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1437
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1437
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1438
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1438
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1439
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1439
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1440
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1440
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1441
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1441
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1442
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1442
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1443
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1443
+#define	WT_STAT_CONN_PAGE_SLEEP				1444
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1444
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1445
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1445
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1446
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1446
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1447
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1447
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1448
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1448
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1449
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1449
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1450
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1450
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1451
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1451
+#define	WT_STAT_CONN_TXN_PREPARE			1452
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1452
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1453
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1453
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1454
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1454
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1455
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1455
+#define	WT_STAT_CONN_TXN_QUERY_TS			1456
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1456
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1457
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1457
+#define	WT_STAT_CONN_TXN_RTS				1458
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1458
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1459
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1459
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1460
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1460
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1461
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1461
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1462
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1462
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1463
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1463
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1464
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1464
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1465
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1465
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1466
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1466
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1467
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1467
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1468
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1468
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1469
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1469
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1470
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1470
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1471
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1471
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1472
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1472
+#define	WT_STAT_CONN_TXN_SET_TS				1473
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1473
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1474
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1474
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1475
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1475
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1476
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1476
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1477
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1477
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1478
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1478
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1479
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1479
+#define	WT_STAT_CONN_TXN_BEGIN				1480
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1480
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1481
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1481
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1482
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1482
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1483
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1483
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1484
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1484
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1485
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1485
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1486
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1486
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1487
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1487
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1488
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1488
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1489
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1489
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1490
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1490
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1491
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1491
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1492
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1492
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1493
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1493
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1494
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1494
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1495
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1495
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1496
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1496
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1497
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1497
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1498
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1498
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1499
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1499
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1500
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1500
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1501
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1501
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1502
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1502
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1503
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1503
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1504
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1504
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1505
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1505
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1506
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1506
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1507
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1507
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1508
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1508
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1509
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1509
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1510
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1510
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1511
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1511
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1512
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1512
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1513
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1513
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1514
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1514
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1515
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1515
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1516
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1516
+#define	WT_STAT_CONN_TXN_COMMIT				1517
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1517
+#define	WT_STAT_CONN_TXN_ROLLBACK			1518
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1518
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1519
 
 /*!
  * @}

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -98,7 +98,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     ret = __reconcile(session, ref, salvage, flags, &page_locked);
 
     /* If writing a page in service of compaction, we're done, clear the flag. */
-    F_CLR_ATOMIC(ref->page, WT_PAGE_COMPACTION_WRITE);
+    F_CLR_ATOMIC_16(ref->page, WT_PAGE_COMPACTION_WRITE);
 
 err:
     if (page_locked)
@@ -480,7 +480,7 @@ __rec_root_write(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t flags)
      * discard these pages.
      */
     WT_RET(__wt_page_alloc(session, page->type, mod->mod_multi_entries, false, &next));
-    F_SET_ATOMIC(next, WT_PAGE_EVICT_NO_PROGRESS);
+    F_SET_ATOMIC_16(next, WT_PAGE_EVICT_NO_PROGRESS);
 
     WT_INTL_INDEX_GET(session, next, pindex);
     for (i = 0; i < mod->mod_multi_entries; ++i) {
@@ -1741,7 +1741,7 @@ __rec_split_write_reuse(
      * those blocks. Check after calculating the checksum, there's a possibility the calculated
      * checksum will be useful in the future.
      */
-    if (F_ISSET_ATOMIC(r->page, WT_PAGE_COMPACTION_WRITE))
+    if (F_ISSET_ATOMIC_16(r->page, WT_PAGE_COMPACTION_WRITE))
         return (false);
 
     /*

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1223,6 +1223,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: pages read into cache",
   "cache: pages read into cache after truncate",
   "cache: pages read into cache after truncate in prepare state",
+  "cache: pages removed from the ordinary queue to be queued for urgent eviction",
   "cache: pages requested from the cache",
   "cache: pages seen by eviction walk",
   "cache: pages seen by eviction walk that are already queued",
@@ -1788,6 +1789,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_read = 0;
     stats->cache_read_deleted = 0;
     stats->cache_read_deleted_prepared = 0;
+    stats->cache_eviction_clear_ordinary = 0;
     stats->cache_pages_requested = 0;
     stats->cache_eviction_pages_seen = 0;
     stats->cache_eviction_pages_already_queued = 0;
@@ -2350,6 +2352,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_read += WT_STAT_READ(from, cache_read);
     to->cache_read_deleted += WT_STAT_READ(from, cache_read_deleted);
     to->cache_read_deleted_prepared += WT_STAT_READ(from, cache_read_deleted_prepared);
+    to->cache_eviction_clear_ordinary += WT_STAT_READ(from, cache_eviction_clear_ordinary);
     to->cache_pages_requested += WT_STAT_READ(from, cache_pages_requested);
     to->cache_eviction_pages_seen += WT_STAT_READ(from, cache_eviction_pages_seen);
     to->cache_eviction_pages_already_queued +=


### PR DESCRIPTION
This backport is for WT-10424 but the changes increase the size of `WT_PAGE::flags_atomic` from `uint8_t` to `uint16_t`. To handle this we're also we're also backporting WT-8340 which updates our `ATOMIC` macros to handle 16 bits. 

------------------

[WT-8340](https://jira.mongodb.org/browse/WT-8340) Fix overflowed value in Btree atomic flags of 8 bit type (https://github.com/wiredtiger/wiredtiger/pull/7178)

* [WT-8340](https://jira.mongodb.org/browse/WT-8340) Fix overflowed value in Btree atomic flags of 8-bit type
* Added a new macro F_SET_ATOMIC_16  to support 16-bit integer.
* Read next line of flags and return an error if the number of flags is greater than the size of the field

(cherry picked from commit https://github.com/wiredtiger/wiredtiger/commit/180c9bfa728620b9e59399eb49dc9e837539f8aa)

------------------

[WT-10424](https://jira.mongodb.org/browse/WT-10424) Prioritize Urgent Candidates - Remove from Ordinary Queue (https://github.com/wiredtiger/wiredtiger/pull/8950) (https://github.com/wiredtiger/wiredtiger/pull/9212)

(cherry picked from commit https://github.com/wiredtiger/wiredtiger/commit/c448c5453bef6e00f4db327bb31eaa361448ff2b)

Co-authored-by: Siddhartha Mahajan <55784503+Siddhartha8899@users.noreply.github.com>
(cherry picked from commit https://github.com/wiredtiger/wiredtiger/commit/24435aa8fc162934502729d9ef02d35b94c68258)