### PR TITLE
WT-11315 Remove const qualifier from WT_UPDATE::type

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -579,7 +579,6 @@ config
 configs
 conn
 connectionp
-const
 constantp
 consts
 cookiep

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1309,7 +1309,7 @@ struct __wt_update {
 #define WT_UPDATE_RESERVE 2   /* reserved */
 #define WT_UPDATE_STANDARD 3  /* complete value */
 #define WT_UPDATE_TOMBSTONE 4 /* deleted */
-    const uint8_t type;       /* type (one byte to conserve memory) */
+    uint8_t type; /* type (one byte to conserve memory); also read-only after initialization */
 
 /* If the update includes a complete value. */
 #define WT_UPDATE_DATA_VALUE(upd) \

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -963,11 +963,8 @@ __wt_upd_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, u_int modify_type
         upd->size = WT_STORE_SIZE(value->size);
         memcpy(upd->data, value->data, value->size);
     }
-    /*
-     * This field is const but we need to set it once at allocation time, to do so temporarily cast
-     * as a non-const.
-     */
-    *(uint8_t *)&upd->type = (uint8_t)modify_type;
+
+    upd->type = (uint8_t)modify_type;
 
     *updp = upd;
     if (sizep != NULL)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -963,7 +963,6 @@ __wt_upd_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value, u_int modify_type
         upd->size = WT_STORE_SIZE(value->size);
         memcpy(upd->data, value->data, value->size);
     }
-
     upd->type = (uint8_t)modify_type;
 
     *updp = upd;


### PR DESCRIPTION
C does not support for this usage of const, and the predicted cost of hiding this field behind an accessor is too high at this time.