### PR TITLE
WT-11402 Discrepancies when calling the API_CALL macro

### DIFF
--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -129,7 +129,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
     cb = (WT_CURSOR_BACKUP *)cursor;
     btree = cb->incr_cursor == NULL ? NULL : CUR2BT(cb->incr_cursor);
     raw = F_MASK(cursor, WT_CURSTD_RAW);
-    CURSOR_API_CALL(cursor, session, get_value, btree);
+    CURSOR_API_CALL(cursor, session, next, btree);
     F_CLR(cursor, WT_CURSTD_RAW);
 
     if (!F_ISSET(cb, WT_CURBACKUP_INCR_INIT) &&

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -427,7 +427,7 @@ __wt_curfile_insert_check(WT_CURSOR *cursor)
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     tret = 0;
-    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, update);
+    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, insert_check);
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_checkkey(cursor));
 

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -299,7 +299,7 @@ __curindex_search_near(WT_CURSOR *cursor, int *exact)
 
     cindex = (WT_CURSOR_INDEX *)cursor;
     child = cindex->child;
-    JOINABLE_CURSOR_API_CALL(cursor, session, search, NULL);
+    JOINABLE_CURSOR_API_CALL(cursor, session, search_near, NULL);
 
     /*
      * We are searching using the application-specified key, which (usually) doesn't contain the

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -589,7 +589,7 @@ __wt_cursor_get_raw_key_value(WT_CURSOR *cursor, WT_ITEM *key, WT_ITEM *value)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
-    CURSOR_API_CALL(cursor, session, get_value, NULL);
+    CURSOR_API_CALL(cursor, session, get_raw_key_value, NULL);
 
     if ((key != NULL) && !F_ISSET(cursor, WT_CURSTD_KEY_SET))
         WT_ERR(__wt_cursor_kv_not_set(cursor, true));

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -714,7 +714,7 @@ __curtable_reserve(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
 
     ctable = (WT_CURSOR_TABLE *)cursor;
-    JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, update);
+    JOINABLE_CURSOR_UPDATE_API_CALL(cursor, session, reserve);
 
     /*
      * We don't have to open the indices here, but it makes the code similar to other cursor


### PR DESCRIPTION
__curbackup_incr_next API CALL error,  now it CALL "get_value", It is best to keep the style consistent with other interfaces，so It would be better to CALL "next".