### PR TITLE
WT-11337 Don't evict pinned chunks from chunk cache

### DIFF
--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -237,6 +237,8 @@ __chunkcache_should_evict(WT_CHUNKCACHE_CHUNK *chunk)
     /* Do not evict chunks that are in the process of being added to the cache. */
     if (!chunk->valid)
         return (false);
+    if (F_ISSET(chunk, WT_CHUNK_PINNED))
+        return (false);
     if (--(chunk->access_count) == 0)
         return (true);
     return (false);


### PR DESCRIPTION
I'm not sure why I thought this would be harder - oops. (Bear in mind this is the dumb version, it's a known issue that this can let the chunk cache fill up.)