### PR TITLE
WT-11421 Prevent background compaction from processing incompatible files

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -107,14 +107,15 @@ __compact_server(void *arg)
             WT_ERR_NOTFOUND_OK(cursor->next(cursor), true);
         }
 
-        /* Always close the metadata cursor. */
-        WT_ERR(__wt_metadata_cursor_release(session, &cursor));
-
         /* All the keys with the specified prefix have been parsed. */
         if (ret == WT_NOTFOUND) {
+            WT_ERR(__wt_metadata_cursor_release(session, &cursor));
             full_iteration = true;
             continue;
         }
+
+        /* Always close the metadata cursor. */
+        WT_ERR(__wt_metadata_cursor_release(session, &cursor));
 
         /* Compact the file with the latest configuration. */
         __wt_free(session, config);

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -26,6 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import time
 import wiredtiger, wttest
 
 # test_compact06.py
@@ -53,6 +54,10 @@ class test_compact06(wttest.WiredTigerTestCase):
 
         #   4. Enable the background compaction server.
         self.session.compact(None, 'background=true')
+
+        # Need to pause to make sure the signal sent to the background compaction server has been
+        # processed.
+        time.sleep(2)
 
         #   5. We cannot reconfigure the background server.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -51,16 +51,18 @@ class test_compact06(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.compact(None, 'background=false'), '/Background compaction is already disabled/')
 
-        #   4. We cannot reconfigure the background server.
+        #   4. Enable the background compaction server.
         self.session.compact(None, 'background=true')
+
+        #   5. We cannot reconfigure the background server.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.compact(None, 'background=true,free_space_target=10MB'), '/Background compaction is already enabled/')
 
-        #   5. We cannot enable the background server when it is already enabled.
+        #   6. We cannot enable the background server when it is already enabled.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.compact(None, 'background=true'), '/Background compaction is already enabled/')
 
-        #   6. Disable the background compaction server.
+        #   7. Disable the background compaction server.
         self.session.compact(None, 'background=false')
 
 if __name__ == '__main__':

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -27,8 +27,6 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wiredtiger, wttest
-from wtscenario import make_scenarios
-from wtdataset import SimpleDataSet
 
 # test_compact06.py
 # Test background compaction API usage.
@@ -39,29 +37,31 @@ class test_compact06(wttest.WiredTigerTestCase):
         # Create a table.
         self.session.create(self.uri, 'key_format=i,value_format=S')
         
-        # Test for invalid uses of the compact API:
         #   1. We cannot trigger the background compaction on a specific API.
-        with self.expectedStderrPattern(
-            'Background compaction does not work on specific URIs.'):
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
-                self.session.compact(self.uri, 'background=true'))        
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            self.session.compact(self.uri, 'background=true'), '/Background compaction does not work on specific URIs/')
             
         #   2. We cannot set other configurations while turning off the background server.
-        with self.expectedStderrPattern(
-            'free_space_target configuration cannot be set when disabling the background compaction server.'):
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
-                self.session.compact(None, 'background=false,free_space_target=10MB'))
-        with self.expectedStderrPattern(
-            'timeout configuration cannot be set when disabling the background compaction server.'):
-            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
-                self.session.compact(None, 'background=false,timeout=60'))
-            
-        #   3. We cannot reconfigure the background server.
-        # FIXME: WT-11421 Enable once fix handles ret value being overridden in background compact.
-        # self.session.compact(None, 'background=true')
-        # with self.expectedStderrPattern('Background compaction is already'):
-        #     self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
-        #         self.session.compact(None, 'background=true,free_space_target=10MB'))
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            self.session.compact(None, 'background=false,free_space_target=10MB'), '/free_space_target configuration cannot be set when disabling the background compaction server/')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            self.session.compact(None, 'background=false,timeout=60'), '/timeout configuration cannot be set when disabling the background compaction server/')
+
+        #   3. We cannot disable the background server when it is already disabled.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            self.session.compact(None, 'background=false'), '/Background compaction is already disabled/')
+
+        #   4. We cannot reconfigure the background server.
+        self.session.compact(None, 'background=true')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            self.session.compact(None, 'background=true,free_space_target=10MB'), '/Background compaction is already enabled/')
+
+        #   5. We cannot enable the background server when it is already enabled.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+            self.session.compact(None, 'background=true'), '/Background compaction is already enabled/')
+
+        #   6. Disable the background compaction server.
+        self.session.compact(None, 'background=false')
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
The changes:

- Fix the background compaction algorithm so it does not call compact on incompatible files
- Update the tests with the method `assertRaisesWithMessage`
- Add more tests