### PR TITLE
WT-11430 Make background compaction use a dedicated buffer for the URI and handle ENOENT

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -129,8 +129,7 @@ __compact_server(void *arg)
         if (config == NULL || !WT_STREQ(config, conn->background_compact.config)) {
             __wt_free(session, config);
             ret = __wt_strndup(session, conn->background_compact.config,
-              conn->background_compact.config == NULL ? 0 : strlen(conn->background_compact.config),
-              &config);
+              strlen(conn->background_compact.config), &config);
         }
         __wt_spin_unlock(session, &conn->background_compact.lock);
 

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -31,7 +31,7 @@ __compact_server(void *arg)
     WT_SESSION *wt_session;
     WT_SESSION_IMPL *session;
     int exact;
-    const char *config, *key, *prefix;
+    const char *config, *key, *prefix, *uri;
     bool full_iteration, running, signalled;
 
     session = arg;
@@ -39,8 +39,10 @@ __compact_server(void *arg)
     wt_session = (WT_SESSION *)session;
     cursor = NULL;
     config = NULL;
+    key = NULL;
+    uri = NULL;
+    /* The compact operation is only applied URIs with a specific prefix. */
     prefix = "file:";
-    key = prefix;
     exact = 0;
     full_iteration = running = signalled = false;
 
@@ -56,7 +58,8 @@ __compact_server(void *arg)
              * FIXME-WT-11409: Depending on the previous state, we may not want to clear out the
              * last key used. This could be useful if the server was paused to be resumed later.
              */
-            key = prefix;
+            __wt_free(session, uri);
+            WT_ERR(__wt_strndup(session, prefix, strlen(prefix), &uri));
             /* Check every 10 seconds in case the signal was missed. */
             __wt_cond_wait(
               session, conn->background_compact.cond, 10 * WT_MILLION, __compact_server_run_chk);
@@ -84,7 +87,7 @@ __compact_server(void *arg)
         /* Open a metadata cursor. */
         WT_ERR(__wt_metadata_cursor(session, &cursor));
 
-        cursor->set_key(cursor, key);
+        cursor->set_key(cursor, uri);
         WT_ERR(cursor->search_near(cursor, &exact));
 
         /* Make sure not to go backwards. */
@@ -114,20 +117,26 @@ __compact_server(void *arg)
             continue;
         }
 
+        /* Make a copy of the key has it can be freed once the cursor is released. */
+        __wt_free(session, uri);
+        WT_ERR(__wt_strndup(session, key, strlen(key), &uri));
+
         /* Always close the metadata cursor. */
         WT_ERR(__wt_metadata_cursor_release(session, &cursor));
 
         /* Compact the file with the latest configuration. */
-        __wt_free(session, config);
         __wt_spin_lock(session, &conn->background_compact.lock);
-        ret = __wt_strndup(session, conn->background_compact.config,
-          conn->background_compact.config == NULL ? 0 : strlen(conn->background_compact.config),
-          &config);
+        if (config == NULL || !WT_STREQ(config, conn->background_compact.config)) {
+            __wt_free(session, config);
+            ret = __wt_strndup(session, conn->background_compact.config,
+              conn->background_compact.config == NULL ? 0 : strlen(conn->background_compact.config),
+              &config);
+        }
         __wt_spin_unlock(session, &conn->background_compact.lock);
 
         WT_ERR(ret);
 
-        ret = wt_session->compact(wt_session, key, config);
+        ret = wt_session->compact(wt_session, uri, config);
 
         /* FIXME-WT-11343: compaction is done, update the data structure for this table. */
         /*
@@ -146,6 +155,7 @@ __compact_server(void *arg)
     WT_ERR(__wt_metadata_cursor_close(session));
     __wt_free(session, config);
     __wt_free(session, conn->background_compact.config);
+    __wt_free(session, uri);
 
     if (0) {
 err:

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -41,7 +41,7 @@ __compact_server(void *arg)
     config = NULL;
     key = NULL;
     uri = NULL;
-    /* The compact operation is only applied URIs with a specific prefix. */
+    /* The compact operation is only applied on URIs with a specific prefix. */
     prefix = "file:";
     exact = 0;
     full_iteration = running = signalled = false;
@@ -117,7 +117,7 @@ __compact_server(void *arg)
             continue;
         }
 
-        /* Make a copy of the key has it can be freed once the cursor is released. */
+        /* Make a copy of the key as it can be freed once the cursor is released. */
         __wt_free(session, uri);
         WT_ERR(__wt_strndup(session, key, strlen(key), &uri));
 

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -141,11 +141,10 @@ __compact_server(void *arg)
         /*
          * Compact may return:
          * - EBUSY or WT_ROLLBACK for various reasons.
-         * - ETIMEDOUT if the timer has been configured and compaction took too long.
-         * - ENOENT or WT_NOTFOUND if the underlying file does not exist.
+         * - ETIMEDOUT if the configured timer has elapsed.
+         * - ENOENT if the underlying file does not exist.
          */
-        if (ret == EBUSY || ret == ENOENT || ret == ETIMEDOUT || ret == WT_NOTFOUND ||
-          ret == WT_ROLLBACK)
+        if (ret == EBUSY || ret == ENOENT || ret == ETIMEDOUT || ret == WT_ROLLBACK)
             ret = 0;
         WT_ERR(ret);
     }

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -141,11 +141,12 @@ __compact_server(void *arg)
         /* FIXME-WT-11343: compaction is done, update the data structure for this table. */
         /*
          * Compact may return:
-         * - EBUSY and WT_ROLLBACK for various reasons.
+         * - EBUSY or WT_ROLLBACK for various reasons.
          * - ETIMEDOUT if the timer has been configured and compaction took too long.
-         * - WT_NOTFOUND if the underlying file has been deleted.
+         * - ENOENT or WT_NOTFOUND if the underlying file does not exist.
          */
-        if (ret == EBUSY || ret == ETIMEDOUT || ret == WT_NOTFOUND || ret == WT_ROLLBACK)
+        if (ret == EBUSY || ret == ENOENT || ret == ETIMEDOUT || ret == WT_NOTFOUND ||
+          ret == WT_ROLLBACK)
             ret = 0;
         WT_ERR(ret);
     }


### PR DESCRIPTION
- Use a dedicated buffer for the URI used for compaction. We used to rely on the buffer associated with the cursor but this one can be freed as soon as the cursor is released.
- Handle `ENOENT` instead of `WT_NOTFOUND` as the error `WT_NOTFOUND` is always mapped to `ENOENT` in `__wt_session_compact`.