### PR TITLE
WT-11338 Pinned chunk cache content statistics

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -339,9 +339,10 @@ conn_stats = [
     # Chunk cache statistics
     ##########################################
     ChunkCacheStat('chunk_cache_bytes_inuse', 'total bytes used by the cache'),
+    ChunkCacheStat('chunk_cache_bytes_inuse_pinned', 'total bytes used by the cache for pinned chunks'),
     ChunkCacheStat('chunk_cache_chunks_evicted', 'chunks evicted'),
     ChunkCacheStat('chunk_cache_chunks_inuse', 'total chunks held by the chunk cache'),
-    ChunkCacheStat('chunk_cache_chunks_pinned', 'total number of pinned chunks cached in the chunk cache'),
+    ChunkCacheStat('chunk_cache_chunks_pinned', 'total pinned chunks held by the chunk cache'),
     ChunkCacheStat('chunk_cache_exceeded_capacity', 'could not allocate due to exceeding capacity'),
     ChunkCacheStat('chunk_cache_io_failed', 'number of times a read from storage failed'),
     ChunkCacheStat('chunk_cache_lookups', 'lookups'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -339,8 +339,9 @@ conn_stats = [
     # Chunk cache statistics
     ##########################################
     ChunkCacheStat('chunk_cache_bytes_inuse', 'total bytes used by the cache'),
-    ChunkCacheStat('chunk_cache_chunks_inuse', 'total chunks held by the chunk cache'),
     ChunkCacheStat('chunk_cache_chunks_evicted', 'chunks evicted'),
+    ChunkCacheStat('chunk_cache_chunks_inuse', 'total chunks held by the chunk cache'),
+    ChunkCacheStat('chunk_cache_chunks_pinned', 'total number of pinned chunks cached in the chunk cache'),
     ChunkCacheStat('chunk_cache_exceeded_capacity', 'could not allocate due to exceeding capacity'),
     ChunkCacheStat('chunk_cache_io_failed', 'number of times a read from storage failed'),
     ChunkCacheStat('chunk_cache_lookups', 'lookups'),

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -59,6 +59,27 @@ __chunkcache_bitmap_find_free(WT_SESSION_IMPL *session, size_t *bit_index)
 }
 
 /*
+ * __chunkcache_should_pin_chunk --
+ *     Return true if the chunk belongs to the object in pinned object array.
+ */
+static inline bool
+__chunkcache_should_pin_chunk(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
+{
+    WT_CHUNKCACHE *chunkcache;
+    bool found;
+
+    chunkcache = &S2C(session)->chunkcache;
+    found = false;
+
+    __wt_readlock(session, &chunkcache->pinned_objects.array_lock);
+    WT_BINARY_SEARCH_STRING(chunk->hash_id.objectname, chunkcache->pinned_objects.array,
+      chunkcache->pinned_objects.entries, found);
+    __wt_readunlock(session, &chunkcache->pinned_objects.array_lock);
+
+    return (found);
+}
+
+/*
  * __chunkcache_alloc --
  *     Allocate memory for the chunk in the cache.
  */
@@ -87,9 +108,17 @@ retry:
         /* Allocate the free memory in the chunk cache. */
         chunk->chunk_memory = chunkcache->memory + chunkcache->chunk_size * bit_index;
     }
+
+    /* Increment chunk's disk usage and update statistics. */
     __wt_atomic_add64(&chunkcache->bytes_used, chunk->chunk_size);
     WT_STAT_CONN_INCR(session, chunk_cache_chunks_inuse);
     WT_STAT_CONN_INCRV(session, chunk_cache_bytes_inuse, chunk->chunk_size);
+    if (__chunkcache_should_pin_chunk(session, chunk)) {
+        F_SET(chunk, WT_CHUNK_PINNED);
+        __wt_atomic_add64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
+        WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
+        WT_STAT_CONN_INCRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
+    }
 
     return (0);
 }
@@ -197,11 +226,15 @@ __chunkcache_free_chunk(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
 
     chunkcache = &S2C(session)->chunkcache;
 
+    /* Decrement chunk's disk usage and update statistics. */
     (void)__wt_atomic_sub64(&chunkcache->bytes_used, chunk->chunk_size);
-    WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse, chunk->chunk_size);
     WT_STAT_CONN_DECR(session, chunk_cache_chunks_inuse);
-    if (F_ISSET(chunk, WT_CHUNK_PINNED))
+    WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse, chunk->chunk_size);
+    if (F_ISSET(chunk, WT_CHUNK_PINNED)) {
+        __wt_atomic_sub64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
         WT_STAT_CONN_DECR(session, chunk_cache_chunks_pinned);
+        WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
+    }
 
     if (chunkcache->type == WT_CHUNKCACHE_IN_VOLATILE_MEMORY)
         __wt_free(session, chunk->chunk_memory);
@@ -287,27 +320,6 @@ __chunkcache_should_evict(WT_CHUNKCACHE_CHUNK *chunk)
     if (--(chunk->access_count) == 0)
         return (true);
     return (false);
-}
-
-/*
- * __chunkcache_should_pin_chunk --
- *     Return true if the chunk belongs to the object in pinned object array.
- */
-static inline bool
-__chunkcache_should_pin_chunk(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
-{
-    WT_CHUNKCACHE *chunkcache;
-    bool found;
-
-    chunkcache = &S2C(session)->chunkcache;
-    found = false;
-
-    __wt_readlock(session, &chunkcache->pinned_objects.array_lock);
-    WT_BINARY_SEARCH_STRING(chunk->hash_id.objectname, chunkcache->pinned_objects.array,
-      chunkcache->pinned_objects.entries, found);
-    __wt_readunlock(session, &chunkcache->pinned_objects.array_lock);
-
-    return (found);
 }
 
 /*
@@ -558,11 +570,6 @@ retry:
                 return (ret);
             }
 
-            if (__chunkcache_should_pin_chunk(session, chunk)) {
-                F_SET(chunk, WT_CHUNK_PINNED);
-                WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
-            }
-
             /*
              * Mark chunk as valid. The only thread that could be executing this code is the thread
              * that won the race and inserted this (invalid) chunk into the hash table. This thread
@@ -700,13 +707,19 @@ __wt_chunkcache_reconfig(WT_SESSION_IMPL *session, const char **cfg)
         {
             if (__chunkcache_should_pin_chunk(session, chunk)) {
                 /* Increment the stat when a chunk that was initially unpinned becomes pinned. */
-                if (!F_ISSET(chunk, WT_CHUNK_PINNED))
+                if (!F_ISSET(chunk, WT_CHUNK_PINNED)) {
+                    __wt_atomic_add64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
                     WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
+                    WT_STAT_CONN_INCRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
+                }
                 F_SET(chunk, WT_CHUNK_PINNED);
             } else {
                 /* Decrement the stat when a chunk that was initially pinned becomes unpinned. */
-                if (F_ISSET(chunk, WT_CHUNK_PINNED))
+                if (F_ISSET(chunk, WT_CHUNK_PINNED)) {
+                    __wt_atomic_sub64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
                     WT_STAT_CONN_DECR(session, chunk_cache_chunks_pinned);
+                    WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
+                }
                 F_CLR(chunk, WT_CHUNK_PINNED);
             }
         }

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -699,18 +699,12 @@ __wt_chunkcache_reconfig(WT_SESSION_IMPL *session, const char **cfg)
         TAILQ_FOREACH_SAFE(chunk, WT_BUCKET_CHUNKS(chunkcache, i), next_chunk, chunk_tmp)
         {
             if (__chunkcache_should_pin_chunk(session, chunk)) {
-                /*
-                 * Increment the stat only when a chunk, which was initially unpinned, becomes
-                 * pinned.
-                 */
+                /* Increment the stat when a chunk that was initially unpinned becomes pinned. */
                 if (!F_ISSET(chunk, WT_CHUNK_PINNED))
                     WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
                 F_SET(chunk, WT_CHUNK_PINNED);
             } else {
-                /*
-                 * Decrement the stat only when a chunk, which was initially pinned, becomes
-                 * unpinned.
-                 */
+                /* Decrement the stat when a chunk that was initially pinned becomes unpinned. */
                 if (F_ISSET(chunk, WT_CHUNK_PINNED))
                     WT_STAT_CONN_DECR(session, chunk_cache_chunks_pinned);
                 F_CLR(chunk, WT_CHUNK_PINNED);

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -200,6 +200,8 @@ __chunkcache_free_chunk(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
     (void)__wt_atomic_sub64(&chunkcache->bytes_used, chunk->chunk_size);
     WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse, chunk->chunk_size);
     WT_STAT_CONN_DECR(session, chunk_cache_chunks_inuse);
+    if (F_ISSET(chunk, WT_CHUNK_PINNED))
+        WT_STAT_CONN_DECR(session, chunk_cache_chunks_pinned);
 
     if (chunkcache->type == WT_CHUNKCACHE_IN_VOLATILE_MEMORY)
         __wt_free(session, chunk->chunk_memory);
@@ -556,8 +558,10 @@ retry:
                 return (ret);
             }
 
-            if (__chunkcache_should_pin_chunk(session, chunk))
+            if (__chunkcache_should_pin_chunk(session, chunk)) {
                 F_SET(chunk, WT_CHUNK_PINNED);
+                WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
+            }
 
             /*
              * Mark chunk as valid. The only thread that could be executing this code is the thread
@@ -694,10 +698,23 @@ __wt_chunkcache_reconfig(WT_SESSION_IMPL *session, const char **cfg)
         __wt_spin_lock(session, &chunkcache->hashtable[i].bucket_lock);
         TAILQ_FOREACH_SAFE(chunk, WT_BUCKET_CHUNKS(chunkcache, i), next_chunk, chunk_tmp)
         {
-            if (__chunkcache_should_pin_chunk(session, chunk))
+            if (__chunkcache_should_pin_chunk(session, chunk)) {
+                /*
+                 * Increment the stat only when a chunk, which was initially unpinned, becomes
+                 * pinned.
+                 */
+                if (!F_ISSET(chunk, WT_CHUNK_PINNED))
+                    WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
                 F_SET(chunk, WT_CHUNK_PINNED);
-            else
+            } else {
+                /*
+                 * Decrement the stat only when a chunk, which was initially pinned, becomes
+                 * unpinned.
+                 */
+                if (F_ISSET(chunk, WT_CHUNK_PINNED))
+                    WT_STAT_CONN_DECR(session, chunk_cache_chunks_pinned);
                 F_CLR(chunk, WT_CHUNK_PINNED);
+            }
         }
         __wt_spin_unlock(session, &chunkcache->hashtable[i].bucket_lock);
     }

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -115,7 +115,6 @@ retry:
     WT_STAT_CONN_INCRV(session, chunk_cache_bytes_inuse, chunk->chunk_size);
     if (__chunkcache_should_pin_chunk(session, chunk)) {
         F_SET(chunk, WT_CHUNK_PINNED);
-        __wt_atomic_add64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
         WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
         WT_STAT_CONN_INCRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
     }
@@ -231,7 +230,6 @@ __chunkcache_free_chunk(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
     WT_STAT_CONN_DECR(session, chunk_cache_chunks_inuse);
     WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse, chunk->chunk_size);
     if (F_ISSET(chunk, WT_CHUNK_PINNED)) {
-        __wt_atomic_sub64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
         WT_STAT_CONN_DECR(session, chunk_cache_chunks_pinned);
         WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
     }
@@ -708,7 +706,6 @@ __wt_chunkcache_reconfig(WT_SESSION_IMPL *session, const char **cfg)
             if (__chunkcache_should_pin_chunk(session, chunk)) {
                 /* Increment the stat when a chunk that was initially unpinned becomes pinned. */
                 if (!F_ISSET(chunk, WT_CHUNK_PINNED)) {
-                    __wt_atomic_add64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
                     WT_STAT_CONN_INCR(session, chunk_cache_chunks_pinned);
                     WT_STAT_CONN_INCRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
                 }
@@ -716,7 +713,6 @@ __wt_chunkcache_reconfig(WT_SESSION_IMPL *session, const char **cfg)
             } else {
                 /* Decrement the stat when a chunk that was initially pinned becomes unpinned. */
                 if (F_ISSET(chunk, WT_CHUNK_PINNED)) {
-                    __wt_atomic_sub64(&chunkcache->pinned_bytes_used, chunk->chunk_size);
                     WT_STAT_CONN_DECR(session, chunk_cache_chunks_pinned);
                     WT_STAT_CONN_DECRV(session, chunk_cache_bytes_inuse_pinned, chunk->chunk_size);
                 }

--- a/src/include/block_chunkcache.h
+++ b/src/include/block_chunkcache.h
@@ -64,9 +64,10 @@ struct __wt_chunkcache {
     /* Cache-wide. */
 #define WT_CHUNKCACHE_FILE 1
 #define WT_CHUNKCACHE_IN_VOLATILE_MEMORY 2
-    uint8_t type;        /* Location of the chunk cache (volatile memory or file) */
-    uint64_t bytes_used; /* Amount of data currently in cache */
-    uint64_t capacity;   /* Maximum allowed capacity */
+    uint8_t type;               /* Location of the chunk cache (volatile memory or file) */
+    uint64_t bytes_used;        /* Amount of data currently in cache */
+    uint64_t pinned_bytes_used; /* Amount of pinned data currently in cache */
+    uint64_t capacity;          /* Maximum allowed capacity */
 
 #define WT_CHUNKCACHE_DEFAULT_CHUNKSIZE 1024 * 1024
     size_t chunk_size;

--- a/src/include/block_chunkcache.h
+++ b/src/include/block_chunkcache.h
@@ -64,10 +64,9 @@ struct __wt_chunkcache {
     /* Cache-wide. */
 #define WT_CHUNKCACHE_FILE 1
 #define WT_CHUNKCACHE_IN_VOLATILE_MEMORY 2
-    uint8_t type;               /* Location of the chunk cache (volatile memory or file) */
-    uint64_t bytes_used;        /* Amount of data currently in cache */
-    uint64_t pinned_bytes_used; /* Amount of pinned data currently in cache */
-    uint64_t capacity;          /* Maximum allowed capacity */
+    uint8_t type;        /* Location of the chunk cache (volatile memory or file) */
+    uint64_t bytes_used; /* Amount of data currently in cache */
+    uint64_t capacity;   /* Maximum allowed capacity */
 
 #define WT_CHUNKCACHE_DEFAULT_CHUNKSIZE 1024 * 1024
     size_t chunk_size;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -563,6 +563,7 @@ struct __wt_connection_stats {
     int64_t chunk_cache_retries;
     int64_t chunk_cache_toomany_retries;
     int64_t chunk_cache_bytes_inuse;
+    int64_t chunk_cache_bytes_inuse_pinned;
     int64_t chunk_cache_chunks_inuse;
     int64_t chunk_cache_chunks_pinned;
     int64_t cond_auto_wait_reset;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -564,6 +564,7 @@ struct __wt_connection_stats {
     int64_t chunk_cache_toomany_retries;
     int64_t chunk_cache_bytes_inuse;
     int64_t chunk_cache_chunks_inuse;
+    int64_t chunk_cache_chunks_pinned;
     int64_t cond_auto_wait_reset;
     int64_t cond_auto_wait;
     int64_t cond_auto_wait_skipped;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5874,914 +5874,916 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CHUNK_CACHE_TOOMANY_RETRIES	1222
 /*! chunk-cache: total bytes used by the cache */
 #define	WT_STAT_CONN_CHUNK_CACHE_BYTES_INUSE		1223
+/*! chunk-cache: total bytes used by the cache for pinned chunks */
+#define	WT_STAT_CONN_CHUNK_CACHE_BYTES_INUSE_PINNED	1224
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_INUSE		1224
-/*! chunk-cache: total number of pinned chunks cached in the chunk cache */
-#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_PINNED		1225
+#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_INUSE		1225
+/*! chunk-cache: total pinned chunks held by the chunk cache */
+#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_PINNED		1226
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1226
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1227
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1227
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1228
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1228
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1229
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1229
+#define	WT_STAT_CONN_TIME_TRAVEL			1230
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1230
+#define	WT_STAT_CONN_FILE_OPEN				1231
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1231
+#define	WT_STAT_CONN_BUCKETS_DH				1232
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1232
+#define	WT_STAT_CONN_BUCKETS				1233
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1233
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1234
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1234
+#define	WT_STAT_CONN_MEMORY_FREE			1235
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1235
+#define	WT_STAT_CONN_MEMORY_GROW			1236
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1236
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1237
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1237
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1238
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1238
+#define	WT_STAT_CONN_COND_WAIT				1239
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1239
+#define	WT_STAT_CONN_RWLOCK_READ			1240
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1240
+#define	WT_STAT_CONN_RWLOCK_WRITE			1241
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1241
+#define	WT_STAT_CONN_FSYNC_IO				1242
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1242
+#define	WT_STAT_CONN_READ_IO				1243
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1243
+#define	WT_STAT_CONN_WRITE_IO				1244
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1244
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1245
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1245
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1246
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1246
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1247
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1247
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1248
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1248
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1249
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1249
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1250
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1250
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1251
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1251
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1252
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1252
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1253
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1253
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1254
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1254
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1255
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1255
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1256
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1256
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1257
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1257
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1258
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1258
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1259
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1259
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1260
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1260
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1261
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1261
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1262
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1262
+#define	WT_STAT_CONN_CURSOR_CACHE			1263
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1263
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1264
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1264
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1265
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1265
+#define	WT_STAT_CONN_CURSOR_CREATE			1266
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1266
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1267
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1267
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1268
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1268
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1269
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1269
+#define	WT_STAT_CONN_CURSOR_INSERT			1270
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1270
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1271
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1271
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1272
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1272
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1273
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1273
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1274
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1274
+#define	WT_STAT_CONN_CURSOR_MODIFY			1275
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1275
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1276
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1276
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1277
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1277
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1278
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1278
+#define	WT_STAT_CONN_CURSOR_NEXT			1279
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1279
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1280
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1280
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1281
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1281
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1282
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1282
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1283
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1283
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1284
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1284
+#define	WT_STAT_CONN_CURSOR_RESTART			1285
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1285
+#define	WT_STAT_CONN_CURSOR_PREV			1286
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1286
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1287
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1287
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1288
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1288
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1289
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1289
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1290
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1290
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1291
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1291
+#define	WT_STAT_CONN_CURSOR_REMOVE			1292
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1292
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1293
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1293
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1294
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1294
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1295
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1295
+#define	WT_STAT_CONN_CURSOR_RESERVE			1296
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1296
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1297
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1297
+#define	WT_STAT_CONN_CURSOR_RESET			1298
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1298
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1299
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1299
+#define	WT_STAT_CONN_CURSOR_SEARCH			1300
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1300
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1301
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1301
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1302
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1302
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1303
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1303
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1304
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1304
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1305
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1305
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1306
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1306
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1307
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1307
+#define	WT_STAT_CONN_CURSOR_SWEEP			1308
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1308
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1309
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1309
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1310
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1310
+#define	WT_STAT_CONN_CURSOR_UPDATE			1311
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1311
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1312
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1312
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1313
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1313
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1314
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1314
+#define	WT_STAT_CONN_CURSOR_REOPEN			1315
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1315
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1316
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1316
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1317
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1317
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1318
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1318
+#define	WT_STAT_CONN_DH_SWEEP_REF			1319
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1319
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1320
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1320
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1321
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1321
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1322
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1322
+#define	WT_STAT_CONN_DH_SWEEPS				1323
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1323
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1324
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1324
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1325
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1325
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1326
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1326
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1327
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1327
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1328
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1328
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1329
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1329
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1330
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1330
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1331
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1331
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1332
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1332
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1333
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1333
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1334
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1334
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1335
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1335
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1336
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1336
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1337
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1337
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1338
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1338
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1339
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1339
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1340
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1340
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1341
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1341
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1342
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1342
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1343
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1343
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1344
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1344
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1345
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1345
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1346
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1346
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1347
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1347
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1348
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1348
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1349
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1349
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1350
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1350
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1351
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1351
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1352
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1352
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1353
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1353
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1354
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1354
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1355
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1355
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1356
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1356
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1357
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1357
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1358
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1358
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1359
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1359
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1360
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1360
+#define	WT_STAT_CONN_LOG_FLUSH				1361
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1361
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1362
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1362
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1363
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1363
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1364
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1364
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1365
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1365
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1366
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1366
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1367
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1367
+#define	WT_STAT_CONN_LOG_SCANS				1368
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1368
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1369
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1369
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1370
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1370
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1371
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1371
+#define	WT_STAT_CONN_LOG_SYNC				1372
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1372
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1373
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1373
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1374
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1374
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1375
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1375
+#define	WT_STAT_CONN_LOG_WRITES				1376
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1376
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1377
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1377
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1378
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1378
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1379
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1379
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1380
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1380
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1381
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1381
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1382
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1382
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1383
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1383
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1384
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1384
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1385
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1385
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1386
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1386
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1387
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1387
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1388
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1388
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1389
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1389
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1390
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1390
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1391
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1391
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1392
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1392
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1393
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1393
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1394
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1394
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1395
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1395
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1396
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1396
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1397
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1397
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1398
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1398
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1399
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1399
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1400
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1400
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1401
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1401
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1402
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1402
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1403
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1403
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1404
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1404
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1405
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1405
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1406
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1406
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1407
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1407
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1408
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1408
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1409
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1409
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1410
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1410
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1411
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1411
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1412
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1412
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1413
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1413
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1414
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1414
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1415
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1415
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1416
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1416
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1417
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1417
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1418
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1418
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1419
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1419
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1420
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1420
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1421
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1421
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1422
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1422
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1423
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1423
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1424
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1424
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1425
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1425
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1426
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1426
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1427
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1427
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1428
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1428
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1429
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1429
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1430
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1430
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1431
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1431
+#define	WT_STAT_CONN_REC_PAGES				1432
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1432
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1433
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1433
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1434
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1434
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1435
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1435
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1436
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1436
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1437
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1437
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1438
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1438
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1439
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1439
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1440
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1440
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1441
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1441
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1442
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1442
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1443
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1443
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1444
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1444
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1445
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1445
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1446
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1446
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1447
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1447
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1448
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1448
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1449
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1449
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1450
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1450
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1451
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1451
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1452
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1452
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1453
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1453
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1454
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1454
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1455
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1456
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1457
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1457
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1458
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1458
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1459
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1459
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1460
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1460
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1461
 /*! session: background compact running */
-#define	WT_STAT_CONN_SESSION_BACKGROUND_COMPACT_RUNNING	1461
+#define	WT_STAT_CONN_SESSION_BACKGROUND_COMPACT_RUNNING	1462
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1462
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1463
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1463
+#define	WT_STAT_CONN_FLUSH_TIER				1464
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1464
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1465
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1465
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1466
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1466
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1467
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1467
+#define	WT_STAT_CONN_SESSION_OPEN			1468
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1468
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1469
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1469
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1470
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1470
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1471
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1471
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1472
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1472
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1473
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1473
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1474
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1474
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1475
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1475
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1476
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1476
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1477
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1477
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1478
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1478
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1479
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1479
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1480
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1480
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1481
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1481
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1482
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1482
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1483
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1483
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1484
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1484
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1485
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1485
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1486
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1486
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1487
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1487
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1488
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1488
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1489
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1489
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1490
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1490
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1491
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1491
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1492
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1492
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1493
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1493
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1494
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1494
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1495
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1495
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1496
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1496
+#define	WT_STAT_CONN_TIERED_RETENTION			1497
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1497
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1498
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1498
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1499
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1499
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1500
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1500
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1501
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1501
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1502
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1502
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1503
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1503
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1504
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1504
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1505
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1505
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1506
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1506
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1507
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1507
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1508
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1508
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1509
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1509
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1510
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1510
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1511
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1511
+#define	WT_STAT_CONN_PAGE_SLEEP				1512
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1512
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1513
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1513
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1514
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1514
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1515
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1515
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1516
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1516
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1517
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1517
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1518
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1518
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1519
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1519
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1520
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1520
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1521
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1521
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1522
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1522
+#define	WT_STAT_CONN_TXN_PREPARE			1523
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1523
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1524
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1524
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1525
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1525
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1526
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1526
+#define	WT_STAT_CONN_TXN_QUERY_TS			1527
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1527
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1528
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1528
+#define	WT_STAT_CONN_TXN_RTS				1529
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1529
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1530
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1530
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1531
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1531
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1532
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1532
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1533
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1533
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1534
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1534
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1535
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1535
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1536
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1536
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1537
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1537
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1538
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1538
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1539
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1539
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1540
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1540
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1541
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1541
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1542
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1542
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1543
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1543
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1544
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1544
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1545
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1545
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1546
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1546
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1547
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1547
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1548
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1548
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1549
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1549
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1550
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1550
+#define	WT_STAT_CONN_TXN_SET_TS				1551
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1551
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1552
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1552
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1553
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1553
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1554
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1554
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1555
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1555
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1556
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1556
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1557
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1557
+#define	WT_STAT_CONN_TXN_BEGIN				1558
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1558
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1559
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1559
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1560
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1560
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1561
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1561
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1562
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1562
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1563
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1563
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1564
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1564
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1565
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1565
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1566
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1566
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1567
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1567
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1568
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1568
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1569
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1569
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1570
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1570
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1571
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1571
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1572
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1572
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1573
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1573
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1574
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1574
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1575
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1575
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1576
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1576
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1577
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1577
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1578
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1578
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1579
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1579
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1580
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1580
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1581
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1581
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1582
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1582
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1583
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1583
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1584
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1584
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1585
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1585
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1586
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1586
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1587
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1587
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1588
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1588
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1589
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1589
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1590
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1590
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1591
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1591
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1592
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1592
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1593
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1593
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1594
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1594
+#define	WT_STAT_CONN_TXN_COMMIT				1595
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1595
+#define	WT_STAT_CONN_TXN_ROLLBACK			1596
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1596
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1597
 
 /*!
  * @}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5876,910 +5876,912 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CHUNK_CACHE_BYTES_INUSE		1223
 /*! chunk-cache: total chunks held by the chunk cache */
 #define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_INUSE		1224
+/*! chunk-cache: total number of pinned chunks cached in the chunk cache */
+#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_PINNED		1225
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1225
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1226
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1226
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1227
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1227
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1228
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1228
+#define	WT_STAT_CONN_TIME_TRAVEL			1229
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1229
+#define	WT_STAT_CONN_FILE_OPEN				1230
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1230
+#define	WT_STAT_CONN_BUCKETS_DH				1231
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1231
+#define	WT_STAT_CONN_BUCKETS				1232
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1232
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1233
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1233
+#define	WT_STAT_CONN_MEMORY_FREE			1234
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1234
+#define	WT_STAT_CONN_MEMORY_GROW			1235
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1235
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1236
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1236
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1237
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1237
+#define	WT_STAT_CONN_COND_WAIT				1238
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1238
+#define	WT_STAT_CONN_RWLOCK_READ			1239
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1239
+#define	WT_STAT_CONN_RWLOCK_WRITE			1240
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1240
+#define	WT_STAT_CONN_FSYNC_IO				1241
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1241
+#define	WT_STAT_CONN_READ_IO				1242
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1242
+#define	WT_STAT_CONN_WRITE_IO				1243
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1243
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1244
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1244
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1245
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1245
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1246
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1246
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1247
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1247
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1248
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1248
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1249
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1249
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1250
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1250
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1251
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1251
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1252
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1252
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1253
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1253
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1254
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1254
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1255
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1255
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1256
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1256
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1257
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1257
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1258
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1258
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1259
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1259
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1260
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1260
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1261
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1261
+#define	WT_STAT_CONN_CURSOR_CACHE			1262
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1262
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1263
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1263
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1264
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1264
+#define	WT_STAT_CONN_CURSOR_CREATE			1265
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1265
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1266
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1266
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1267
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1267
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1268
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1268
+#define	WT_STAT_CONN_CURSOR_INSERT			1269
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1269
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1270
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1270
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1271
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1271
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1272
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1272
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1273
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1273
+#define	WT_STAT_CONN_CURSOR_MODIFY			1274
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1274
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1275
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1275
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1276
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1276
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1277
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1277
+#define	WT_STAT_CONN_CURSOR_NEXT			1278
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1278
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1279
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1279
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1280
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1280
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1281
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1281
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1282
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1282
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1283
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1283
+#define	WT_STAT_CONN_CURSOR_RESTART			1284
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1284
+#define	WT_STAT_CONN_CURSOR_PREV			1285
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1285
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1286
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1286
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1287
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1287
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1288
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1288
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1289
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1289
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1290
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1290
+#define	WT_STAT_CONN_CURSOR_REMOVE			1291
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1291
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1292
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1292
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1293
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1293
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1294
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1294
+#define	WT_STAT_CONN_CURSOR_RESERVE			1295
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1295
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1296
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1296
+#define	WT_STAT_CONN_CURSOR_RESET			1297
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1297
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1298
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1298
+#define	WT_STAT_CONN_CURSOR_SEARCH			1299
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1299
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1300
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1300
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1301
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1301
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1302
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1302
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1303
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1303
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1304
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1304
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1305
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1305
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1306
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1306
+#define	WT_STAT_CONN_CURSOR_SWEEP			1307
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1307
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1308
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1308
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1309
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1309
+#define	WT_STAT_CONN_CURSOR_UPDATE			1310
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1310
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1311
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1311
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1312
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1312
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1313
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1313
+#define	WT_STAT_CONN_CURSOR_REOPEN			1314
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1314
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1315
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1315
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1316
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1316
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1317
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1317
+#define	WT_STAT_CONN_DH_SWEEP_REF			1318
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1318
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1319
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1319
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1320
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1320
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1321
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1321
+#define	WT_STAT_CONN_DH_SWEEPS				1322
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1322
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1323
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1323
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1324
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1324
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1325
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1325
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1326
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1326
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1327
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1327
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1328
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1328
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1329
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1329
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1330
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1330
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1331
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1331
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1332
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1332
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1333
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1333
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1334
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1334
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1335
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1335
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1336
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1336
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1337
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1337
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1338
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1338
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1339
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1339
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1340
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1340
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1341
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1341
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1342
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1342
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1343
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1343
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1344
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1344
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1345
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1345
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1346
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1346
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1347
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1347
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1348
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1348
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1349
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1349
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1350
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1350
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1351
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1351
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1352
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1352
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1353
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1353
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1354
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1354
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1355
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1355
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1356
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1356
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1357
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1357
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1358
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1358
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1359
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1359
+#define	WT_STAT_CONN_LOG_FLUSH				1360
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1360
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1361
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1361
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1362
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1362
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1363
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1363
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1364
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1364
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1365
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1365
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1366
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1366
+#define	WT_STAT_CONN_LOG_SCANS				1367
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1367
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1368
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1368
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1369
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1369
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1370
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1370
+#define	WT_STAT_CONN_LOG_SYNC				1371
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1371
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1372
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1372
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1373
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1373
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1374
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1374
+#define	WT_STAT_CONN_LOG_WRITES				1375
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1375
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1376
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1376
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1377
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1377
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1378
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1378
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1379
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1379
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1380
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1380
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1381
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1381
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1382
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1382
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1383
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1383
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1384
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1384
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1385
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1385
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1386
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1386
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1387
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1387
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1388
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1388
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1389
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1389
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1390
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1390
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1391
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1391
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1392
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1392
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1393
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1393
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1394
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1394
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1395
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1395
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1396
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1396
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1397
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1397
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1398
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1398
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1399
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1399
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1400
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1400
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1401
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1401
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1402
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1402
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1403
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1403
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1404
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1404
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1405
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1405
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1406
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1406
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1407
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1407
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1408
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1408
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1409
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1409
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1410
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1410
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1411
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1411
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1412
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1412
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1413
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1413
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1414
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1414
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1415
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1415
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1416
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1416
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1417
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1417
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1418
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1418
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1419
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1419
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1420
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1420
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1421
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1421
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1422
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1422
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1423
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1423
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1424
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1424
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1425
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1425
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1426
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1426
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1427
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1427
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1428
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1428
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1429
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1429
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1430
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1430
+#define	WT_STAT_CONN_REC_PAGES				1431
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1431
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1432
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1432
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1433
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1433
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1434
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1434
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1435
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1435
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1436
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1436
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1437
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1437
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1438
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1438
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1439
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1439
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1440
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1440
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1441
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1441
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1442
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1442
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1443
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1443
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1444
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1444
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1445
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1445
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1446
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1446
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1447
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1447
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1448
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1448
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1449
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1449
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1450
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1450
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1451
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1451
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1452
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1452
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1453
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1453
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1454
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1454
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1455
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1456
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1457
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1457
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1458
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1458
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1459
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1459
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1460
 /*! session: background compact running */
-#define	WT_STAT_CONN_SESSION_BACKGROUND_COMPACT_RUNNING	1460
+#define	WT_STAT_CONN_SESSION_BACKGROUND_COMPACT_RUNNING	1461
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1461
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1462
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1462
+#define	WT_STAT_CONN_FLUSH_TIER				1463
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1463
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1464
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1464
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1465
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1465
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1466
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1466
+#define	WT_STAT_CONN_SESSION_OPEN			1467
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1467
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1468
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1468
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1469
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1469
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1470
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1470
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1471
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1471
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1472
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1472
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1473
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1473
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1474
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1474
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1475
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1475
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1476
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1476
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1477
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1477
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1478
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1478
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1479
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1479
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1480
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1480
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1481
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1481
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1482
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1482
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1483
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1483
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1484
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1484
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1485
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1485
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1486
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1486
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1487
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1487
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1488
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1488
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1489
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1489
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1490
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1490
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1491
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1491
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1492
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1492
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1493
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1493
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1494
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1494
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1495
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1495
+#define	WT_STAT_CONN_TIERED_RETENTION			1496
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1496
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1497
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1497
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1498
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1498
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1499
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1499
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1500
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1500
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1501
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1501
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1502
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1502
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1503
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1503
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1504
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1504
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1505
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1505
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1506
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1506
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1507
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1507
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1508
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1508
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1509
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1509
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1510
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1510
+#define	WT_STAT_CONN_PAGE_SLEEP				1511
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1511
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1512
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1512
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1513
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1513
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1514
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1514
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1515
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1515
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1516
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1516
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1517
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1517
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1518
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1518
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1519
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1519
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1520
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1520
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1521
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1521
+#define	WT_STAT_CONN_TXN_PREPARE			1522
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1522
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1523
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1523
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1524
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1524
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1525
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1525
+#define	WT_STAT_CONN_TXN_QUERY_TS			1526
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1526
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1527
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1527
+#define	WT_STAT_CONN_TXN_RTS				1528
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1528
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1529
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1529
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1530
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1530
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1531
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1531
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1532
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1532
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1533
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1533
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1534
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1534
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1535
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1535
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1536
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1536
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1537
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1537
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1538
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1538
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1539
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1539
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1540
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1540
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1541
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1541
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1542
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1542
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1543
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1543
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1544
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1544
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1545
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1545
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1546
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1546
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1547
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1547
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1548
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1548
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1549
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1549
+#define	WT_STAT_CONN_TXN_SET_TS				1550
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1550
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1551
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1551
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1552
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1552
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1553
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1553
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1554
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1554
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1555
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1555
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1556
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1556
+#define	WT_STAT_CONN_TXN_BEGIN				1557
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1557
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1558
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1558
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1559
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1559
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1560
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1560
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1561
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1561
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1562
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1562
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1563
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1563
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1564
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1564
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1565
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1565
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1566
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1566
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1567
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1567
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1568
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1568
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1569
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1569
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1570
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1570
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1571
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1571
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1572
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1572
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1573
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1573
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1574
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1574
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1575
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1575
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1576
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1576
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1577
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1577
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1578
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1578
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1579
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1579
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1580
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1580
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1581
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1581
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1582
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1582
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1583
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1583
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1584
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1584
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1585
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1585
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1586
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1586
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1587
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1587
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1588
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1588
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1589
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1589
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1590
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1590
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1591
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1591
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1592
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1592
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1593
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1593
+#define	WT_STAT_CONN_TXN_COMMIT				1594
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1594
+#define	WT_STAT_CONN_TXN_ROLLBACK			1595
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1595
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1596
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1519,6 +1519,7 @@ static const char *const __stats_connection_desc[] = {
   "chunk-cache: timed out due to too many retries",
   "chunk-cache: total bytes used by the cache",
   "chunk-cache: total chunks held by the chunk cache",
+  "chunk-cache: total number of pinned chunks cached in the chunk cache",
   "connection: auto adjusting condition resets",
   "connection: auto adjusting condition wait calls",
   "connection: auto adjusting condition wait raced to update timeout and skipped updating",
@@ -2165,6 +2166,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->chunk_cache_toomany_retries = 0;
     stats->chunk_cache_bytes_inuse = 0;
     stats->chunk_cache_chunks_inuse = 0;
+    stats->chunk_cache_chunks_pinned = 0;
     stats->cond_auto_wait_reset = 0;
     stats->cond_auto_wait = 0;
     stats->cond_auto_wait_skipped = 0;
@@ -2815,6 +2817,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->chunk_cache_toomany_retries += WT_STAT_READ(from, chunk_cache_toomany_retries);
     to->chunk_cache_bytes_inuse += WT_STAT_READ(from, chunk_cache_bytes_inuse);
     to->chunk_cache_chunks_inuse += WT_STAT_READ(from, chunk_cache_chunks_inuse);
+    to->chunk_cache_chunks_pinned += WT_STAT_READ(from, chunk_cache_chunks_pinned);
     to->cond_auto_wait_reset += WT_STAT_READ(from, cond_auto_wait_reset);
     to->cond_auto_wait += WT_STAT_READ(from, cond_auto_wait);
     to->cond_auto_wait_skipped += WT_STAT_READ(from, cond_auto_wait_skipped);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1518,8 +1518,9 @@ static const char *const __stats_connection_desc[] = {
   "chunk-cache: retried accessing a chunk while I/O was in progress",
   "chunk-cache: timed out due to too many retries",
   "chunk-cache: total bytes used by the cache",
+  "chunk-cache: total bytes used by the cache for pinned chunks",
   "chunk-cache: total chunks held by the chunk cache",
-  "chunk-cache: total number of pinned chunks cached in the chunk cache",
+  "chunk-cache: total pinned chunks held by the chunk cache",
   "connection: auto adjusting condition resets",
   "connection: auto adjusting condition wait calls",
   "connection: auto adjusting condition wait raced to update timeout and skipped updating",
@@ -2165,6 +2166,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->chunk_cache_retries = 0;
     stats->chunk_cache_toomany_retries = 0;
     stats->chunk_cache_bytes_inuse = 0;
+    stats->chunk_cache_bytes_inuse_pinned = 0;
     stats->chunk_cache_chunks_inuse = 0;
     stats->chunk_cache_chunks_pinned = 0;
     stats->cond_auto_wait_reset = 0;
@@ -2816,6 +2818,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->chunk_cache_retries += WT_STAT_READ(from, chunk_cache_retries);
     to->chunk_cache_toomany_retries += WT_STAT_READ(from, chunk_cache_toomany_retries);
     to->chunk_cache_bytes_inuse += WT_STAT_READ(from, chunk_cache_bytes_inuse);
+    to->chunk_cache_bytes_inuse_pinned += WT_STAT_READ(from, chunk_cache_bytes_inuse_pinned);
     to->chunk_cache_chunks_inuse += WT_STAT_READ(from, chunk_cache_chunks_inuse);
     to->chunk_cache_chunks_pinned += WT_STAT_READ(from, chunk_cache_chunks_pinned);
     to->cond_auto_wait_reset += WT_STAT_READ(from, cond_auto_wait_reset);


### PR DESCRIPTION
The only stat that seemed relevant to add was `Total number of pinned chunks in the cache`. Many other things about the system in regard to the pinned content can be known by simple math b/w stats.

For instance, this stat added can answer the following questions by looking at the FTDC - 

- How many pinned chunks in the cache?
- How many non-pinned chunks are in the cache? (Total chunks - pinned chunks)
- How many pinned chunks were evicted?
- How many non-pinned chunks were evicted?