### PR TITLE
WT-10688 Review chunk cache barrier usage

### DIFF
--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -598,9 +598,9 @@ __wt_chunkcache_remove(
     WT_CHUNKCACHE *chunkcache;
     WT_CHUNKCACHE_CHUNK *chunk, *chunk_tmp;
     WT_CHUNKCACHE_HASHID hash_id;
-    bool valid;
     size_t already_removed, remains_to_remove, removable_in_chunk, size_removed;
     uint64_t bucket_id;
+    bool valid;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &block->live_lock);
 

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -279,7 +279,12 @@ __chunkcache_should_evict(WT_CHUNKCACHE_CHUNK *chunk)
 {
     bool valid;
 
-    /* Do not evict chunks that are in the process of being added to the cache. */
+    /*
+     * Do not evict chunks that are in the process of being added to the cache. The ordered read,
+     * and matching publish, are required since populating the chunk itself isn't protected by the
+     * bucket lock. Ergo, we need to make sure that reads or writes to the valid field are not
+     * reordered relative to reads or writes of other fields.
+     */
     WT_ORDERED_READ(valid, chunk->valid);
     if (!valid)
         return (false);

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -595,12 +595,12 @@ void
 __wt_chunkcache_remove(
   WT_SESSION_IMPL *session, WT_BLOCK *block, uint32_t objectid, wt_off_t offset, uint32_t size)
 {
-    bool valid;
-    size_t already_removed, remains_to_remove, removable_in_chunk, size_removed;
-    uint64_t bucket_id;
     WT_CHUNKCACHE *chunkcache;
     WT_CHUNKCACHE_CHUNK *chunk, *chunk_tmp;
     WT_CHUNKCACHE_HASHID hash_id;
+    bool valid;
+    size_t already_removed, remains_to_remove, removable_in_chunk, size_removed;
+    uint64_t bucket_id;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &block->live_lock);
 


### PR DESCRIPTION
Readers of `chunk->valid` need to ensure that reading other `chunk` fields happens strictly after checking validity, and writers need to ensure that it is the last field written to.

Unfortunately locking doesn't really solve the problem here - this reordering can still happen while holding the bucket lock, and there can be a large number of chunks so finer-grained locking just for `valid` field would be wasteful. Locking is also likely to have a measurable performance impact - significant work has gone into minimising the critical section, and since the lock is at the bucket level, reading or writing `valid` with the bucket lock will prevent anyone else looking at the entire bucket.

Use `ORDERED_READ`/`PUBLISH` as the longer-term solution of acquire/release isn't ready yet.