### PR TITLE
WT-11427 Create stats for the background compaction server

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -35,6 +35,12 @@ class AutoCommitStat(Stat):
     prefix = 'autocommit'
     def __init__(self, name, desc, flags=''):
         Stat.__init__(self, name, AutoCommitStat.prefix, desc, flags)
+
+class BackgroundCompactStat(Stat):
+    prefix = 'background-compact'
+    def __init__(self, name, desc, flags=''):
+        Stat.__init__(self, name, BackgroundCompactStat.prefix, desc, flags)
+
 class BlockCacheStat(Stat):
     prefix = 'block-cache'
     def __init__(self, name, desc, flags=''):
@@ -189,6 +195,16 @@ conn_stats = [
     ConnStat('rwlock_write', 'pthread mutex shared lock write-lock calls'),
     ConnStat('time_travel', 'detected system time went backwards'),
     ConnStat('write_io', 'total write I/Os'),
+    
+    ##########################################
+    # Background compaction statistics
+    ##########################################
+    BackgroundCompactStat('background_compact_fail', 'background compact failed calls', 'no_scale'),
+    BackgroundCompactStat('background_compact_fail_cache_pressure', 'background compact failed calls due to cache pressure', 'no_scale'),
+    BackgroundCompactStat('background_compact_running', 'background compact running', 'no_scale'),
+    BackgroundCompactStat('background_compact_skipped', 'background compact skipped as process would not reduce file size', 'no_scale'),
+    BackgroundCompactStat('background_compact_success', 'background compact successful calls', 'no_scale'),
+    BackgroundCompactStat('background_compact_timeout', 'background compact timeout', 'no_scale'),
 
     ##########################################
     # Block cache statistics
@@ -541,7 +557,6 @@ conn_stats = [
     ##########################################
     # Session operations
     ##########################################
-    SessionOpStat('session_background_compact_running', 'background compact running', 'no_clear,no_scale'),
     SessionOpStat('session_open', 'open session count', 'no_clear,no_scale'),
     SessionOpStat('session_query_ts', 'session query timestamp calls'),
     SessionOpStat('session_table_alter_fail', 'table alter failed calls', 'no_clear,no_scale'),

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -334,6 +334,11 @@ __wt_compact(WT_SESSION_IMPL *session)
         WT_STAT_CONN_INCR(session, session_table_compact_skipped);
         WT_STAT_DATA_INCR(session, btree_compact_skipped);
 
+        /* If we're an internal session we must've been called by the background compact server. */
+        if (F_ISSET(session, WT_SESSION_INTERNAL)) {
+            WT_STAT_CONN_INCR(session, background_compact_skipped);
+        }
+
         /*
          * Print the "skipping compaction" message only if this is the first time we are working on
          * this table.

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -334,10 +334,8 @@ __wt_compact(WT_SESSION_IMPL *session)
         WT_STAT_CONN_INCR(session, session_table_compact_skipped);
         WT_STAT_DATA_INCR(session, btree_compact_skipped);
 
-        /* If we're an internal session we must've been called by the background compact server. */
-        if (F_ISSET(session, WT_SESSION_INTERNAL)) {
+        if (session == S2C(session)->background_compact.session)
             WT_STAT_CONN_INCR(session, background_compact_skipped);
-        }
 
         /*
          * Print the "skipping compaction" message only if this is the first time we are working on

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -351,6 +351,12 @@ struct __wt_connection_stats {
     int64_t lsm_work_queue_max;
     int64_t autocommit_readonly_retry;
     int64_t autocommit_update_retry;
+    int64_t background_compact_fail;
+    int64_t background_compact_fail_cache_pressure;
+    int64_t background_compact_running;
+    int64_t background_compact_skipped;
+    int64_t background_compact_success;
+    int64_t background_compact_timeout;
     int64_t block_cache_blocks_update;
     int64_t block_cache_bytes_update;
     int64_t block_cache_blocks_evicted;
@@ -799,7 +805,6 @@ struct __wt_connection_stats {
     int64_t rec_split_stashed_bytes;
     int64_t rec_split_stashed_objects;
     int64_t local_objects_inuse;
-    int64_t session_background_compact_running;
     int64_t flush_tier_fail;
     int64_t flush_tier;
     int64_t flush_tier_skipped;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5351,1448 +5351,1464 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_AUTOCOMMIT_READONLY_RETRY		1010
 /*! autocommit: retries for update operations */
 #define	WT_STAT_CONN_AUTOCOMMIT_UPDATE_RETRY		1011
+/*! background-compact: background compact failed calls */
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_FAIL		1012
+/*!
+ * background-compact: background compact failed calls due to cache
+ * pressure
+ */
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_FAIL_CACHE_PRESSURE	1013
+/*! background-compact: background compact running */
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_RUNNING		1014
+/*!
+ * background-compact: background compact skipped as process would not
+ * reduce file size
+ */
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_SKIPPED		1015
+/*! background-compact: background compact successful calls */
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_SUCCESS		1016
+/*! background-compact: background compact timeout */
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_TIMEOUT		1017
 /*! block-cache: cached blocks updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1012
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1018
 /*! block-cache: cached bytes updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1013
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1019
 /*! block-cache: evicted blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1014
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1020
 /*! block-cache: file size causing bypass */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1015
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1021
 /*! block-cache: lookups */
-#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1016
+#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1022
 /*! block-cache: number of blocks not evicted due to overhead */
-#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1017
+#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1023
 /*!
  * block-cache: number of bypasses because no-write-allocate setting was
  * on
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1018
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1024
 /*! block-cache: number of bypasses due to overhead on put */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1019
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1025
 /*! block-cache: number of bypasses on get */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1020
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1026
 /*! block-cache: number of bypasses on put because file is too small */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1021
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1027
 /*! block-cache: number of eviction passes */
-#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1022
+#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1028
 /*! block-cache: number of hits */
-#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1023
+#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1029
 /*! block-cache: number of misses */
-#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1024
+#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1030
 /*! block-cache: number of put bypasses on checkpoint I/O */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1025
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1031
 /*! block-cache: removed blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1026
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1032
 /*! block-cache: time sleeping to remove block (usecs) */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1027
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1033
 /*! block-cache: total blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1028
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1034
 /*! block-cache: total blocks inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1029
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1035
 /*! block-cache: total blocks inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1030
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1036
 /*! block-cache: total bytes */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1031
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1037
 /*! block-cache: total bytes inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1032
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1038
 /*! block-cache: total bytes inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1033
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1039
 /*! block-manager: blocks pre-loaded */
-#define	WT_STAT_CONN_BLOCK_PRELOAD			1034
+#define	WT_STAT_CONN_BLOCK_PRELOAD			1040
 /*! block-manager: blocks read */
-#define	WT_STAT_CONN_BLOCK_READ				1035
+#define	WT_STAT_CONN_BLOCK_READ				1041
 /*! block-manager: blocks written */
-#define	WT_STAT_CONN_BLOCK_WRITE			1036
+#define	WT_STAT_CONN_BLOCK_WRITE			1042
 /*! block-manager: bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ			1037
+#define	WT_STAT_CONN_BLOCK_BYTE_READ			1043
 /*! block-manager: bytes read via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1038
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1044
 /*! block-manager: bytes read via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1039
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1045
 /*! block-manager: bytes written */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1040
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1046
 /*! block-manager: bytes written for checkpoint */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1041
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1047
 /*! block-manager: bytes written via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1042
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1048
 /*! block-manager: bytes written via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1043
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1049
 /*! block-manager: mapped blocks read */
-#define	WT_STAT_CONN_BLOCK_MAP_READ			1044
+#define	WT_STAT_CONN_BLOCK_MAP_READ			1050
 /*! block-manager: mapped bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1045
+#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1051
 /*!
  * block-manager: number of times the file was remapped because it
  * changed size via fallocate or truncate
  */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1046
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1052
 /*! block-manager: number of times the region was remapped via write */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1047
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1053
 /*! cache: application threads page read from disk to cache count */
-#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1048
+#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1054
 /*! cache: application threads page read from disk to cache time (usecs) */
-#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1049
+#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1055
 /*! cache: application threads page write from cache to disk count */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1050
+#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1056
 /*! cache: application threads page write from cache to disk time (usecs) */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1051
+#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1057
 /*! cache: bytes allocated for updates */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1052
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1058
 /*! cache: bytes belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1053
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1059
 /*! cache: bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS			1054
+#define	WT_STAT_CONN_CACHE_BYTES_HS			1060
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1055
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1061
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1056
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1062
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1057
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1063
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1058
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1064
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1059
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1065
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1060
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1066
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1061
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1067
 /*! cache: eviction calls to get a page */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1062
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1068
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1063
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1069
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1064
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1070
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1065
+#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1071
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1066
+#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1072
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1067
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1073
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1068
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1074
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1069
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1075
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1070
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1076
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1071
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1077
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1072
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1078
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1073
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1079
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1074
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1080
 /*! cache: eviction server evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1075
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1081
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1076
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1082
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1077
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1083
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1078
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1084
 /*! cache: eviction state */
-#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1079
+#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1085
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1080
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1086
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1081
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1087
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1082
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1088
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1083
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1089
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1084
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1090
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1085
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1091
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1086
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1092
 /*! cache: eviction walk target strategy both clean and dirty pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1087
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1093
 /*! cache: eviction walk target strategy only clean pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1088
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1094
 /*! cache: eviction walk target strategy only dirty pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1089
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1095
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1090
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1096
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1091
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1097
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1092
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1098
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1093
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1099
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1094
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1100
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1095
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1101
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1096
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1102
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1097
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1103
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1098
+#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1104
 /*! cache: eviction worker thread created */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1099
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1105
 /*! cache: eviction worker thread evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1100
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1106
 /*! cache: eviction worker thread removed */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1101
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1107
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1108
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1109
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1104
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1110
 /*! cache: force re-tuning of eviction workers once in a while */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1105
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1111
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1106
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1112
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1107
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1113
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1108
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1114
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1109
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1115
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1110
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1116
 /*! cache: forced eviction - pages evicted that were clean time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1111
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1117
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1112
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1118
 /*! cache: forced eviction - pages evicted that were dirty time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1113
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1119
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1114
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1120
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1115
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1121
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1116
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1122
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1117
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1123
 /*! cache: forced eviction - pages selected unable to be evicted time */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1118
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1124
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1119
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1125
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1120
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1126
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1121
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1127
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1122
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1128
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1123
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1129
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1124
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1130
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1125
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1131
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1126
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1132
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1127
+#define	WT_STAT_CONN_CACHE_HS_READ			1133
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1128
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1134
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1129
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1135
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1130
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1136
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1131
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1137
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1132
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1138
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1133
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1139
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1134
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1140
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1135
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1141
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1136
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1142
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1137
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1143
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1138
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1144
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1139
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1145
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1140
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1146
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1141
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1147
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1142
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1148
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1143
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1149
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1144
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1150
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1145
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1151
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1146
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1152
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1147
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1153
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1148
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1154
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1149
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1155
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1150
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1156
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1151
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1157
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1152
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1158
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1153
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1159
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1154
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1160
 /*! cache: modified pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1155
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1161
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1156
+#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1162
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1157
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1163
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1158
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1164
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1159
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1165
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1160
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1166
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1161
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1167
 /*! cache: pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP			1162
+#define	WT_STAT_CONN_CACHE_EVICTION_APP			1168
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1163
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1169
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1164
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1170
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1165
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1171
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1166
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1172
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1167
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1173
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1168
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1174
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1169
+#define	WT_STAT_CONN_CACHE_READ				1175
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1170
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1176
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1171
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1177
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1172
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1178
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1173
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1179
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1174
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1180
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1175
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1181
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1176
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1182
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1177
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1183
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1178
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1184
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1179
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1185
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1180
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1186
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1181
+#define	WT_STAT_CONN_CACHE_WRITE			1187
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1182
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1188
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1183
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1189
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1184
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1190
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1185
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1191
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1186
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1192
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1187
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1193
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1188
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1194
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1189
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1195
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1190
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1196
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1191
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1197
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1192
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1198
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1193
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1199
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1194
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1200
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1195
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1201
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1196
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1202
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1197
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1203
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1198
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1204
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1199
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1205
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1200
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1206
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1201
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1207
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1202
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1208
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1203
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1209
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1204
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1210
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1205
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1211
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1206
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1212
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1207
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1213
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1208
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1214
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1209
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1215
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1210
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1216
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1211
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1217
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1212
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1218
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1213
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1219
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNK_CACHE_SPANS_CHUNKS_READ	1214
+#define	WT_STAT_CONN_CHUNK_CACHE_SPANS_CHUNKS_READ	1220
 /*! chunk-cache: aggregate number of spanned chunks on remove */
-#define	WT_STAT_CONN_CHUNK_CACHE_SPANS_CHUNKS_REMOVE	1215
+#define	WT_STAT_CONN_CHUNK_CACHE_SPANS_CHUNKS_REMOVE	1221
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_EVICTED		1216
+#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_EVICTED		1222
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNK_CACHE_EXCEEDED_CAPACITY	1217
+#define	WT_STAT_CONN_CHUNK_CACHE_EXCEEDED_CAPACITY	1223
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNK_CACHE_LOOKUPS		1218
+#define	WT_STAT_CONN_CHUNK_CACHE_LOOKUPS		1224
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNK_CACHE_MISSES			1219
+#define	WT_STAT_CONN_CHUNK_CACHE_MISSES			1225
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNK_CACHE_IO_FAILED		1220
+#define	WT_STAT_CONN_CHUNK_CACHE_IO_FAILED		1226
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNK_CACHE_RETRIES		1221
+#define	WT_STAT_CONN_CHUNK_CACHE_RETRIES		1227
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNK_CACHE_TOOMANY_RETRIES	1222
+#define	WT_STAT_CONN_CHUNK_CACHE_TOOMANY_RETRIES	1228
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNK_CACHE_BYTES_INUSE		1223
+#define	WT_STAT_CONN_CHUNK_CACHE_BYTES_INUSE		1229
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_INUSE		1224
+#define	WT_STAT_CONN_CHUNK_CACHE_CHUNKS_INUSE		1230
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1225
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1231
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1226
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1232
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1227
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1233
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1228
+#define	WT_STAT_CONN_TIME_TRAVEL			1234
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1229
+#define	WT_STAT_CONN_FILE_OPEN				1235
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1230
+#define	WT_STAT_CONN_BUCKETS_DH				1236
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1231
+#define	WT_STAT_CONN_BUCKETS				1237
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1232
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1238
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1233
+#define	WT_STAT_CONN_MEMORY_FREE			1239
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1234
+#define	WT_STAT_CONN_MEMORY_GROW			1240
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1235
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1241
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1236
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1242
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1237
+#define	WT_STAT_CONN_COND_WAIT				1243
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1238
+#define	WT_STAT_CONN_RWLOCK_READ			1244
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1239
+#define	WT_STAT_CONN_RWLOCK_WRITE			1245
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1240
+#define	WT_STAT_CONN_FSYNC_IO				1246
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1241
+#define	WT_STAT_CONN_READ_IO				1247
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1242
+#define	WT_STAT_CONN_WRITE_IO				1248
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1243
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1249
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1244
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1250
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1245
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1251
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1246
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1252
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1247
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1253
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1248
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1254
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1249
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1255
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1250
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1256
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1251
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1257
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1252
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1258
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1253
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1259
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1254
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1260
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1255
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1261
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1256
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1262
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1257
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1263
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1258
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1264
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1259
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1265
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1260
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1266
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1261
+#define	WT_STAT_CONN_CURSOR_CACHE			1267
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1262
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1268
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1263
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1269
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1264
+#define	WT_STAT_CONN_CURSOR_CREATE			1270
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1265
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1271
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1266
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1272
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1267
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1273
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1268
+#define	WT_STAT_CONN_CURSOR_INSERT			1274
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1269
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1275
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1270
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1276
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1271
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1277
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1272
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1278
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1273
+#define	WT_STAT_CONN_CURSOR_MODIFY			1279
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1274
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1280
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1275
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1281
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1276
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1282
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1277
+#define	WT_STAT_CONN_CURSOR_NEXT			1283
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1278
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1284
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1279
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1285
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1280
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1286
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1281
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1287
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1282
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1288
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1283
+#define	WT_STAT_CONN_CURSOR_RESTART			1289
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1284
+#define	WT_STAT_CONN_CURSOR_PREV			1290
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1285
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1291
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1286
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1292
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1287
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1293
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1288
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1294
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1289
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1295
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1290
+#define	WT_STAT_CONN_CURSOR_REMOVE			1296
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1291
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1297
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1292
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1298
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1293
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1299
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1294
+#define	WT_STAT_CONN_CURSOR_RESERVE			1300
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1295
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1301
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1296
+#define	WT_STAT_CONN_CURSOR_RESET			1302
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1297
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1303
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1298
+#define	WT_STAT_CONN_CURSOR_SEARCH			1304
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1299
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1305
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1300
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1306
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1301
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1307
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1302
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1308
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1303
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1309
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1304
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1310
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1305
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1311
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1306
+#define	WT_STAT_CONN_CURSOR_SWEEP			1312
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1307
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1313
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1308
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1314
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1309
+#define	WT_STAT_CONN_CURSOR_UPDATE			1315
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1310
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1316
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1311
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1317
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1312
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1318
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1313
+#define	WT_STAT_CONN_CURSOR_REOPEN			1319
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1314
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1320
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1315
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1321
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1316
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1322
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1317
+#define	WT_STAT_CONN_DH_SWEEP_REF			1323
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1318
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1324
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1319
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1325
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1320
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1326
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1321
+#define	WT_STAT_CONN_DH_SWEEPS				1327
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1322
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1328
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1323
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1329
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1324
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1330
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1325
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1331
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1326
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1332
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1327
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1333
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1328
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1334
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1329
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1335
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1330
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1336
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1331
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1337
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1332
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1338
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1333
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1339
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1334
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1340
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1335
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1341
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1336
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1342
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1337
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1343
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1338
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1344
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1339
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1345
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1340
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1346
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1341
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1347
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1342
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1348
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1343
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1349
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1344
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1350
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1345
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1351
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1346
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1352
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1347
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1353
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1348
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1354
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1349
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1355
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1350
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1356
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1351
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1357
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1352
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1358
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1353
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1359
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1354
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1360
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1355
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1361
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1356
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1362
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1357
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1363
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1358
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1364
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1359
+#define	WT_STAT_CONN_LOG_FLUSH				1365
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1360
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1366
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1361
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1367
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1362
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1368
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1363
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1369
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1364
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1370
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1365
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1371
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1366
+#define	WT_STAT_CONN_LOG_SCANS				1372
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1367
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1373
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1368
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1374
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1369
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1375
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1370
+#define	WT_STAT_CONN_LOG_SYNC				1376
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1371
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1377
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1372
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1378
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1373
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1379
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1374
+#define	WT_STAT_CONN_LOG_WRITES				1380
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1375
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1381
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1376
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1382
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1377
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1383
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1378
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1384
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1379
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1385
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1380
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1386
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1381
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1387
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1382
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1388
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1383
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1389
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1384
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1390
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1385
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1391
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1386
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1392
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1387
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1393
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1388
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1394
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1389
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1395
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1390
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1396
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1391
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1397
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1392
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1398
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1393
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1399
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1394
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1400
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1395
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1401
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1396
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1402
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1397
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1403
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1398
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1404
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1399
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1405
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1400
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1406
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1401
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1407
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1402
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1408
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1403
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1409
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1404
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1410
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1405
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1411
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1406
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1412
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1407
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1413
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1408
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1414
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1409
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1415
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1410
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1416
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1411
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1417
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1412
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1418
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1413
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1419
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1414
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1420
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1415
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1421
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1416
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1422
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1417
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1423
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1418
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1424
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1419
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1425
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1420
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1426
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1421
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1427
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1422
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1428
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1423
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1429
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1424
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1430
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1425
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1431
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1426
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1432
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1427
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1433
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1428
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1434
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1429
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1435
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1430
+#define	WT_STAT_CONN_REC_PAGES				1436
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1431
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1437
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1432
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1438
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1433
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1439
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1434
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1440
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1435
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1441
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1436
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1442
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1437
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1443
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1438
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1444
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1439
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1445
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1440
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1446
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1441
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1447
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1442
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1448
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1443
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1449
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1444
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1450
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1445
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1451
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1446
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1452
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1447
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1453
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1448
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1454
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1449
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1455
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1450
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1456
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1451
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1457
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1452
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1458
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1453
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1459
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1454
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1460
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1461
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1462
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1457
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1463
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1458
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1464
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1459
-/*! session: background compact running */
-#define	WT_STAT_CONN_SESSION_BACKGROUND_COMPACT_RUNNING	1460
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1465
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1461
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1466
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1462
+#define	WT_STAT_CONN_FLUSH_TIER				1467
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1463
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1468
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1464
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1469
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1465
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1470
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1466
+#define	WT_STAT_CONN_SESSION_OPEN			1471
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1467
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1472
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1468
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1473
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1469
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1474
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1470
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1475
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1471
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1476
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1472
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1477
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1473
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1478
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1474
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1479
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1475
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1480
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1476
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1481
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1477
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1482
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1478
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1483
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1479
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1484
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1480
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1485
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1481
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1486
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1482
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1487
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1483
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1488
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1484
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1489
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1485
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1490
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1486
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1491
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1487
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1492
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1488
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1493
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1489
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1494
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1490
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1495
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1491
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1496
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1492
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1497
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1493
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1498
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1494
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1499
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1495
+#define	WT_STAT_CONN_TIERED_RETENTION			1500
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1496
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1501
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1497
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1502
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1498
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1503
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1499
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1504
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1500
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1505
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1501
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1506
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1502
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1507
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1503
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1508
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1504
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1509
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1505
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1510
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1506
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1511
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1507
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1512
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1508
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1513
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1509
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1514
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1510
+#define	WT_STAT_CONN_PAGE_SLEEP				1515
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1511
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1516
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1512
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1517
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1513
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1518
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1514
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1519
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1515
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1520
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1516
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1521
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1517
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1522
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1518
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1523
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1519
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1524
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1520
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1525
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1521
+#define	WT_STAT_CONN_TXN_PREPARE			1526
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1522
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1527
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1523
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1528
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1524
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1529
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1525
+#define	WT_STAT_CONN_TXN_QUERY_TS			1530
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1526
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1531
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1527
+#define	WT_STAT_CONN_TXN_RTS				1532
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1528
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1533
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1529
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1534
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1530
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1535
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1531
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1536
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1532
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1537
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1533
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1538
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1534
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1539
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1535
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1540
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1536
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1541
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1537
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1542
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1538
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1543
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1539
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1544
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1540
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1545
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1541
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1546
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1542
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1547
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1543
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1548
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1544
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1549
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1545
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1550
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1546
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1551
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1547
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1552
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1548
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1553
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1549
+#define	WT_STAT_CONN_TXN_SET_TS				1554
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1550
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1555
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1551
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1556
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1552
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1557
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1553
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1558
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1554
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1559
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1555
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1560
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1556
+#define	WT_STAT_CONN_TXN_BEGIN				1561
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1557
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1562
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1558
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1563
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1559
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1564
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1560
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1565
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1561
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1566
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1562
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1567
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1563
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1568
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1564
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1569
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1565
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1570
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1566
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1571
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1567
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1572
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1568
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1573
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1569
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1574
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1570
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1575
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1571
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1576
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1572
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1577
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1573
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1578
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1574
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1579
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1575
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1580
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1576
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1581
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1577
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1582
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1578
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1583
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1579
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1584
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1580
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1585
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1581
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1586
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1582
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1587
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1583
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1588
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1584
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1589
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1585
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1590
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1586
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1591
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1587
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1592
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1588
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1593
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1589
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1594
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1590
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1595
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1591
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1596
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1592
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1597
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1593
+#define	WT_STAT_CONN_TXN_COMMIT				1598
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1594
+#define	WT_STAT_CONN_TXN_ROLLBACK			1599
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1595
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1600
 
 /*!
  * @}

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -271,9 +271,11 @@ __compact_worker(WT_SESSION_IMPL *session)
              * work, skip this file in the future.
              */
             if (ret == 0) {
-                if (session->compact_state == WT_COMPACT_SUCCESS)
+                if (session->compact_state == WT_COMPACT_SUCCESS) {
+                    if (F_ISSET(session, WT_SESSION_INTERNAL))
+                        WT_STAT_CONN_INCR(session, background_compact_success);
                     another_pass = true;
-                else
+                } else
                     session->op_handle[i]->compact_skip = true;
                 continue;
             }

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -272,7 +272,7 @@ __compact_worker(WT_SESSION_IMPL *session)
              */
             if (ret == 0) {
                 if (session->compact_state == WT_COMPACT_SUCCESS) {
-                    if (F_ISSET(session, WT_SESSION_INTERNAL))
+                    if (session == S2C(session)->background_compact.session)
                         WT_STAT_CONN_INCR(session, background_compact_success);
                     another_pass = true;
                 } else

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1288,6 +1288,12 @@ static const char *const __stats_connection_desc[] = {
   "LSM: tree queue hit maximum",
   "autocommit: retries for readonly operations",
   "autocommit: retries for update operations",
+  "background-compact: background compact failed calls",
+  "background-compact: background compact failed calls due to cache pressure",
+  "background-compact: background compact running",
+  "background-compact: background compact skipped as process would not reduce file size",
+  "background-compact: background compact successful calls",
+  "background-compact: background compact timeout",
   "block-cache: cached blocks updated",
   "block-cache: cached bytes updated",
   "block-cache: evicted blocks",
@@ -1758,7 +1764,6 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: split bytes currently awaiting free",
   "reconciliation: split objects currently awaiting free",
   "session: attempts to remove a local object and the object is in use",
-  "session: background compact running",
   "session: flush_tier failed calls",
   "session: flush_tier operation calls",
   "session: flush_tier tables skipped due to no checkpoint",
@@ -1952,6 +1957,12 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->lsm_work_queue_max = 0;
     stats->autocommit_readonly_retry = 0;
     stats->autocommit_update_retry = 0;
+    stats->background_compact_fail = 0;
+    stats->background_compact_fail_cache_pressure = 0;
+    stats->background_compact_running = 0;
+    stats->background_compact_skipped = 0;
+    stats->background_compact_success = 0;
+    stats->background_compact_timeout = 0;
     stats->block_cache_blocks_update = 0;
     stats->block_cache_bytes_update = 0;
     stats->block_cache_blocks_evicted = 0;
@@ -2400,7 +2411,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing rec_split_stashed_bytes */
     /* not clearing rec_split_stashed_objects */
     stats->local_objects_inuse = 0;
-    /* not clearing session_background_compact_running */
     stats->flush_tier_fail = 0;
     stats->flush_tier = 0;
     stats->flush_tier_skipped = 0;
@@ -2564,6 +2574,13 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->lsm_work_queue_max += WT_STAT_READ(from, lsm_work_queue_max);
     to->autocommit_readonly_retry += WT_STAT_READ(from, autocommit_readonly_retry);
     to->autocommit_update_retry += WT_STAT_READ(from, autocommit_update_retry);
+    to->background_compact_fail += WT_STAT_READ(from, background_compact_fail);
+    to->background_compact_fail_cache_pressure +=
+      WT_STAT_READ(from, background_compact_fail_cache_pressure);
+    to->background_compact_running += WT_STAT_READ(from, background_compact_running);
+    to->background_compact_skipped += WT_STAT_READ(from, background_compact_skipped);
+    to->background_compact_success += WT_STAT_READ(from, background_compact_success);
+    to->background_compact_timeout += WT_STAT_READ(from, background_compact_timeout);
     to->block_cache_blocks_update += WT_STAT_READ(from, block_cache_blocks_update);
     to->block_cache_bytes_update += WT_STAT_READ(from, block_cache_bytes_update);
     to->block_cache_blocks_evicted += WT_STAT_READ(from, block_cache_blocks_evicted);
@@ -3062,8 +3079,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_split_stashed_bytes += WT_STAT_READ(from, rec_split_stashed_bytes);
     to->rec_split_stashed_objects += WT_STAT_READ(from, rec_split_stashed_objects);
     to->local_objects_inuse += WT_STAT_READ(from, local_objects_inuse);
-    to->session_background_compact_running +=
-      WT_STAT_READ(from, session_background_compact_running);
     to->flush_tier_fail += WT_STAT_READ(from, flush_tier_fail);
     to->flush_tier += WT_STAT_READ(from, flush_tier);
     to->flush_tier_skipped += WT_STAT_READ(from, flush_tier_skipped);


### PR DESCRIPTION
I've added stats to track the status of the background compaction server. These stats mostly duplicate the existing session compact operation statistics that are tracked on individual calls to compact. I've created a new category of stats under the connection statistics labelled `BackgroundCompactStat`, let me know if there is a preference for creating a new category vs adding them to an existing one. 

One notable difference to the existing session compact operation statistics is the definition of the `background_compact_success` statistic. This is incremented after a round of compaction that has made some progress. On the other hand, the session operation statistic is incremented on any successful call to `wt_compact` regardless of whether any work was done. I've left this as is for now.