### PR TITLE
WT-11434 Make foreground compaction check for interruption before a checkpoint

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -368,13 +368,7 @@ __wt_compact(WT_SESSION_IMPL *session)
             if (!first)
                 bm->compact_progress(bm, session, &msg_count);
             WT_ERR(__wt_session_compact_check_timeout(session));
-            if (session->event_handler->handle_general != NULL) {
-                ret = session->event_handler->handle_general(session->event_handler,
-                  &(S2C(session))->iface, &session->iface, WT_EVENT_COMPACT_CHECK, NULL);
-                /* If the user's handler returned non-zero we return WT_ERROR to the caller. */
-                if (ret != 0)
-                    WT_ERR_MSG(session, WT_ERROR, "compact interrupted by application");
-            }
+            WT_ERR(__wt_session_compact_check_interrupted(session));
 
             if (__wt_cache_stuck(session))
                 WT_ERR(EBUSY);

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -361,8 +361,11 @@ __wt_compact(WT_SESSION_IMPL *session)
           session, btree_compact_pages_rewritten_expected, stats_pages_rewritten_expected);
 
         /*
-         * Periodically check if we've timed out or eviction is stuck. Quit if eviction is stuck,
-         * we're making the problem worse.
+         * Periodically check if:
+         * - compaction has timed out,
+         * - eviction is stuck or,
+         * - compaction has been interrupted.
+         * Quit if any of the above is true.
          */
         if (first || ++i > 100) {
             if (!first)

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -361,16 +361,12 @@ __wt_compact(WT_SESSION_IMPL *session)
           session, btree_compact_pages_rewritten_expected, stats_pages_rewritten_expected);
 
         /*
-         * Periodically check if:
-         * - compaction has timed out,
-         * - eviction is stuck or,
-         * - compaction has been interrupted.
-         * Quit if any of the above is true.
+         * Periodically check if compaction has been interrupted or if eviction is stuck, quit if
+         * this is the case.
          */
         if (first || ++i > 100) {
             if (!first)
                 bm->compact_progress(bm, session, &msg_count);
-            WT_ERR(__wt_session_compact_check_timeout(session));
             WT_ERR(__wt_session_compact_check_interrupted(session));
 
             if (__wt_cache_stuck(session))

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1468,6 +1468,8 @@ extern int __wt_session_close_internal(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact(WT_SESSION *wt_session, const char *uri, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact_check_timeout(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact_readonly(WT_SESSION *wt_session, const char *uri,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1470,8 +1470,6 @@ extern int __wt_session_compact(WT_SESSION *wt_session, const char *uri, const c
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_session_compact_check_timeout(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_compact_readonly(WT_SESSION *wt_session, const char *uri,
   const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_copy_values(WT_SESSION_IMPL *session)

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -1222,7 +1222,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
          * Periodically check if we've timed out or eviction is stuck. Quit if eviction is stuck,
          * we're making the problem worse.
          */
-        WT_ERR(__wt_session_compact_check_timeout(session));
+        WT_ERR(__wt_session_compact_check_interrupted(session));
         if (__wt_cache_stuck(session))
             WT_ERR(EBUSY);
         __wt_sleep(1, 0);

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -178,11 +178,11 @@ __compact_handle_append(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
- * __wt_session_compact_check_timeout --
+ * __session_compact_check_timeout --
  *     Check if the timeout has been exceeded.
  */
 static int
-__wt_session_compact_check_timeout(WT_SESSION_IMPL *session)
+__session_compact_check_timeout(WT_SESSION_IMPL *session)
 {
     struct timespec end;
     WT_DECL_RET;
@@ -224,7 +224,7 @@ __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
     }
 
     /* Compaction can be interrupted if the timeout has exceeded. */
-    WT_RET(__wt_session_compact_check_timeout(session));
+    WT_RET(__session_compact_check_timeout(session));
 
     return (0);
 }

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -178,30 +178,10 @@ __compact_handle_append(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
- * __wt_session_compact_check_interrupted --
- *     Check if compaction has been interrupted.
- */
-int
-__wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
-{
-    WT_DECL_RET;
-
-    if (session->event_handler->handle_general != NULL) {
-        ret = session->event_handler->handle_general(session->event_handler, &(S2C(session))->iface,
-          &session->iface, WT_EVENT_COMPACT_CHECK, NULL);
-        /* If the user's handler returned non-zero we return WT_ERROR to the caller. */
-        if (ret != 0)
-            WT_RET_MSG(session, WT_ERROR, "compact interrupted by application");
-    }
-
-    return (0);
-}
-
-/*
  * __wt_session_compact_check_timeout --
  *     Check if the timeout has been exceeded.
  */
-int
+static int
 __wt_session_compact_check_timeout(WT_SESSION_IMPL *session)
 {
     struct timespec end;
@@ -226,6 +206,30 @@ __wt_session_compact_check_timeout(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wt_session_compact_check_interrupted --
+ *     Check if compaction has been interrupted.
+ */
+int
+__wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
+{
+    WT_DECL_RET;
+
+    /* Compaction can be interrupted through the event handler. */
+    if (session->event_handler->handle_general != NULL) {
+        ret = session->event_handler->handle_general(session->event_handler, &(S2C(session))->iface,
+          &session->iface, WT_EVENT_COMPACT_CHECK, NULL);
+        /* If the user's handler returned non-zero we return WT_ERROR to the caller. */
+        if (ret != 0)
+            WT_RET_MSG(session, WT_ERROR, "compact interrupted by application");
+    }
+
+    /* Compaction can be interrupted if the timeout has exceeded. */
+    WT_RET(__wt_session_compact_check_timeout(session));
+
+    return (0);
+}
+
+/*
  * __compact_checkpoint --
  *     This function does wait and force checkpoint.
  */
@@ -239,11 +243,7 @@ __compact_checkpoint(WT_SESSION_IMPL *session)
     const char *checkpoint_cfg[] = {
       WT_CONFIG_BASE(session, WT_SESSION_checkpoint), "force=1", NULL};
 
-    /*
-     * Checkpoints take a lot of time, check if we've run out of time or if compaction has been
-     * interrupted.
-     */
-    WT_RET(__wt_session_compact_check_timeout(session));
+    /* Checkpoints may take a lot of time, check if compaction has been interrupted. */
     WT_RET(__wt_session_compact_check_interrupted(session));
     return (__wt_txn_checkpoint(session, checkpoint_cfg, true));
 }

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -178,6 +178,26 @@ __compact_handle_append(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
+ * __wt_session_compact_check_interrupted --
+ *     Check if compaction has been interrupted.
+ */
+int
+__wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
+{
+    WT_DECL_RET;
+
+    if (session->event_handler->handle_general != NULL) {
+        ret = session->event_handler->handle_general(session->event_handler, &(S2C(session))->iface,
+          &session->iface, WT_EVENT_COMPACT_CHECK, NULL);
+        /* If the user's handler returned non-zero we return WT_ERROR to the caller. */
+        if (ret != 0)
+            WT_RET_MSG(session, WT_ERROR, "compact interrupted by application");
+    }
+
+    return (0);
+}
+
+/*
  * __wt_session_compact_check_timeout --
  *     Check if the timeout has been exceeded.
  */

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -239,8 +239,12 @@ __compact_checkpoint(WT_SESSION_IMPL *session)
     const char *checkpoint_cfg[] = {
       WT_CONFIG_BASE(session, WT_SESSION_checkpoint), "force=1", NULL};
 
-    /* Checkpoints take a lot of time, check if we've run out. */
+    /*
+     * Checkpoints take a lot of time, check if we've run out of time or if compaction has been
+     * interrupted.
+     */
     WT_RET(__wt_session_compact_check_timeout(session));
+    WT_RET(__wt_session_compact_check_interrupted(session));
     return (__wt_txn_checkpoint(session, checkpoint_cfg, true));
 }
 


### PR DESCRIPTION
The changes extend the work done in WT-9636:

- Creation of a new function `__wt_session_compact_check_interrupted` that checks if foreground compaction has been interrupted.
- Add a check in `__compact_checkpoint` where we check for the timeout as well.
- The code for LSM trees is performing those checks too.

This function will most likely be reused for the work in WT-11344. 