### PR TITLE
WT-11357 Convert page_state modification to use standard memory model

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1248,7 +1248,7 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
     if (split_gen != 0)
         WT_RET(ds->f(ds, ", split-gen=%" PRIu64, split_gen));
     if (mod != NULL)
-        WT_RET(ds->f(ds, ", page-state=%" PRIu32, mod->page_state));
+        WT_RET(ds->f(ds, ", page-state=%" PRIu32, atomic_load_explicit(&mod->page_state, memory_order_relaxed)));
     WT_RET(ds->f(ds, ", memory-size %" WT_SIZET_FMT, page->memory_footprint));
     return (ds->f(ds, "\n"));
 }

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -459,7 +459,7 @@ struct __wt_page_modify {
 #define WT_PAGE_CLEAN 0
 #define WT_PAGE_DIRTY_FIRST 1
 #define WT_PAGE_DIRTY 2
-    uint32_t page_state;
+    _Atomic uint32_t page_state;
 
 #define WT_PM_REC_EMPTY 1      /* Reconciliation: no replacement */
 #define WT_PM_REC_MULTIBLOCK 2 /* Reconciliation: multiple blocks */

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -46,6 +46,9 @@ extern "C" {
 #else
 #include <pthread.h>
 #endif
+#ifndef _WIN32
+#include <stdatomic.h>
+#endif
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>


### PR DESCRIPTION
Experiment  in modifying existing code to use the standard memory synchronization model.

Acquire-release appeared to be sufficient based on the existing code.

Based off WT-10965 branch that allows the use  <stdatomic.h>.