### PR TITLE
WT-11455 Add background compaction setting to Workgen

### DIFF
--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -463,6 +463,7 @@ struct WorkloadOptions {
     bool random_table_values;
     bool mirror_tables;
     std::string mirror_suffix;
+    int background_compact;
 
     WorkloadOptions();
     WorkloadOptions(const WorkloadOptions &other);


### PR DESCRIPTION
With those changes, we can enable/disable background compaction and set a specific threshold for compaction in Workgen.