### PR TITLE
WT-11454 Add background compaction operation config to cppsuite

### DIFF
--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -125,6 +125,15 @@ checkpoint_operation_thread_config = [
     Config('op_rate', '60s', r'''
         The rate at which checkpoint is executed.''')
 ]
+
+background_compact_thread_config = [
+    Config('thread_count', 0, r'''
+        Specifies the number of threads that will be used to perform background compaction
+           operation.''',
+        min=0, max=1),
+    Config('free_space_target_mb', '20', r'''
+        Minimum amount of space in MB recoverable for compaction to proceed.''')
+]
 custom_operation_thread_config = thread_count + transaction_config + throttle_config + record_config
 read_thread_config = thread_count + throttle_config + transaction_config + record_config
 remove_thread_config = thread_count + transaction_config + throttle_config
@@ -177,6 +186,9 @@ operation_tracker = enabled_config_true + component_config + tracking_config
 # Configuration that applies to the workload_manager component.
 #
 workload_manager = enabled_config_true + component_config + [
+    Config('background_compact_config', '',r'''
+        Config that specifies if background compaction is enabled and its behaviour.''',
+        type='category', subconfig=background_compact_thread_config),
     Config('checkpoint_config', '',r'''
         Config that specifies if the checkpoint thread is enabled and its behaviour.''',
         type='category', subconfig=checkpoint_operation_thread_config),

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -146,6 +146,19 @@ static const uint8_t confchk_timestamp_manager_subconfigs_jump[WT_CONFIG_JUMP_TA
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
 
+static const WT_CONFIG_CHECK confchk_background_compact_config_subconfigs[] = {
+  {"free_space_target_mb", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
+    INT64_MIN, INT64_MAX, NULL},
+  {"thread_count", "int", NULL, "min=0,max=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 0, 1,
+    NULL},
+  {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
+
+static const uint8_t confchk_background_compact_config_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] =
+  {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+
 static const WT_CONFIG_CHECK confchk_checkpoint_config_subconfigs[] = {
   {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, INT64_MIN,
     INT64_MAX, NULL},
@@ -287,6 +300,10 @@ static const uint8_t confchk_update_config_subconfigs_jump[WT_CONFIG_JUMP_TABLE_
   0, 0, 0, 0, 0, 1, 1, 1, 1, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const WT_CONFIG_CHECK confchk_workload_manager_subconfigs[] = {
+  {"background_compact_config", "category", NULL, NULL,
+    confchk_background_compact_config_subconfigs, 2,
+    confchk_background_compact_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
+    INT64_MAX, NULL},
   {"checkpoint_config", "category", NULL, NULL, confchk_checkpoint_config_subconfigs, 2,
     confchk_checkpoint_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
@@ -317,8 +334,8 @@ static const WT_CONFIG_CHECK confchk_workload_manager_subconfigs[] = {
 static const uint8_t confchk_workload_manager_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2,
-  3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 6, 6, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9};
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 3,
+  4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 6, 7, 7, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10};
 
 static const WT_CONFIG_CHECK confchk_bounded_cursor_perf[] = {
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 0,
@@ -345,7 +362,7 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_perf[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -381,7 +398,7 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_indices[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -417,7 +434,7 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_search_near[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -455,7 +472,7 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_stat[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -491,7 +508,7 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_stress[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -529,7 +546,7 @@ static const WT_CONFIG_CHECK confchk_burst_inserts[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -565,7 +582,7 @@ static const WT_CONFIG_CHECK confchk_cache_resize[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -601,7 +618,7 @@ static const WT_CONFIG_CHECK confchk_hs_cleanup[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -637,7 +654,7 @@ static const WT_CONFIG_CHECK confchk_operations_test[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -673,7 +690,7 @@ static const WT_CONFIG_CHECK confchk_reverse_split[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -711,7 +728,7 @@ static const WT_CONFIG_CHECK confchk_search_near_01[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -747,7 +764,7 @@ static const WT_CONFIG_CHECK confchk_search_near_02[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -783,7 +800,7 @@ static const WT_CONFIG_CHECK confchk_search_near_03[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -819,7 +836,7 @@ static const WT_CONFIG_CHECK confchk_test_template[] = {
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
     confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
-  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 9,
+  {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
     confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -844,9 +861,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -870,9 +888,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -896,9 +915,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -922,18 +942,20 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,search_near_threads=10,"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
-    "stable_lag=1),workload_manager=(checkpoint_config=(op_rate=60s,"
-    "thread_count=1),custom_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
-    "enabled=true,insert_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
-    "op_rate=1s,populate_config=(collection_count=1,"
-    "key_count_per_collection=0,key_size=5,thread_count=1,"
-    "value_size=5),read_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
-    "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
-    "thread_count=0),update_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
+    "stable_lag=1),"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
+    "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),op_rate=1s,"
+    "populate_config=(collection_count=1,key_count_per_collection=0,"
+    "key_size=5,thread_count=1,value_size=5),read_config=(key_size=5,"
+    "op_rate=1s,ops_per_transaction=(max=1,min=0),thread_count=0,"
+    "value_size=5),remove_config=(op_rate=1s,"
+    "ops_per_transaction=(max=1,min=0),thread_count=0),"
+    "update_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5))",
     confchk_bounded_cursor_prefix_stat, 12, confchk_bounded_cursor_prefix_stat_jump},
   {"bounded_cursor_stress",
     "cache_max_wait_ms=0,cache_size_mb=0,compression_enabled=false,"
@@ -948,9 +970,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -975,9 +998,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -1001,9 +1025,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -1027,9 +1052,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -1053,9 +1079,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -1079,9 +1106,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -1105,18 +1133,20 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,search_near_threads=10,"
     "statistics_config=(enable_logging=true,type=all),"
     "timestamp_manager=(enabled=true,oldest_lag=1,op_rate=1s,"
-    "stable_lag=1),workload_manager=(checkpoint_config=(op_rate=60s,"
-    "thread_count=1),custom_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
-    "enabled=true,insert_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
-    "op_rate=1s,populate_config=(collection_count=1,"
-    "key_count_per_collection=0,key_size=5,thread_count=1,"
-    "value_size=5),read_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5),"
-    "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
-    "thread_count=0),update_config=(key_size=5,op_rate=1s,"
-    "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
+    "stable_lag=1),"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
+    "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),op_rate=1s,"
+    "populate_config=(collection_count=1,key_count_per_collection=0,"
+    "key_size=5,thread_count=1,value_size=5),read_config=(key_size=5,"
+    "op_rate=1s,ops_per_transaction=(max=1,min=0),thread_count=0,"
+    "value_size=5),remove_config=(op_rate=1s,"
+    "ops_per_transaction=(max=1,min=0),thread_count=0),"
+    "update_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5))",
     confchk_search_near_01, 12, confchk_search_near_01_jump},
   {"search_near_02",
     "cache_max_wait_ms=0,cache_size_mb=0,compression_enabled=false,"
@@ -1131,9 +1161,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -1157,9 +1188,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"
@@ -1183,9 +1215,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "reverse_collator=false,statistics_config=(enable_logging=true,"
     "type=all),timestamp_manager=(enabled=true,oldest_lag=1,"
     "op_rate=1s,stable_lag=1),"
-    "workload_manager=(checkpoint_config=(op_rate=60s,thread_count=1)"
-    ",custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1"
-    ",min=0),thread_count=0,value_size=5),enabled=true,"
+    "workload_manager=(background_compact_config=(free_space_target_mb=20"
+    ",thread_count=0),checkpoint_config=(op_rate=60s,thread_count=1),"
+    "custom_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
+    "min=0),thread_count=0,value_size=5),enabled=true,"
     "insert_config=(key_size=5,op_rate=1s,ops_per_transaction=(max=1,"
     "min=0),thread_count=0,value_size=5),op_rate=1s,"
     "populate_config=(collection_count=1,key_count_per_collection=0,"

--- a/test/cppsuite/configs/operations_test_default.txt
+++ b/test/cppsuite/configs/operations_test_default.txt
@@ -38,6 +38,11 @@ timestamp_manager=
 ),
 workload_manager=
 (
+    background_compact_config=
+    (
+        thread_count=1,
+        free_space_target_mb=20,
+    ),
     checkpoint_config=
     (
         op_rate=5s,

--- a/test/cppsuite/configs/operations_test_stress.txt
+++ b/test/cppsuite/configs/operations_test_stress.txt
@@ -19,6 +19,11 @@ timestamp_manager=
 ),
 workload_manager=
 (
+    background_compact_config=
+    (
+        thread_count=1,
+        free_space_target_mb=1,
+    ),
     checkpoint_config=
     (
         op_rate=120s,

--- a/test/cppsuite/src/common/constants.cpp
+++ b/test/cppsuite/src/common/constants.cpp
@@ -38,6 +38,7 @@ const std::string TIMESTAMP_MANAGER = "timestamp_manager";
 const std::string WORKLOAD_MANAGER = "workload_manager";
 
 /* Configuration API consts. */
+const std::string BACKGROUND_COMPACT_OP_CONFIG = "background_compact_config";
 const std::string CACHE_HS_INSERT = "cache_hs_insert";
 const std::string CACHE_MAX_WAIT_MS = "cache_max_wait_ms";
 const std::string CACHE_SIZE_MB = "cache_size_mb";
@@ -49,6 +50,7 @@ const std::string CUSTOM_OP_CONFIG = "custom_config";
 const std::string DURATION_SECONDS = "duration_seconds";
 const std::string ENABLED = "enabled";
 const std::string ENABLE_LOGGING = "enable_logging";
+const std::string FREE_SPACE_TARGET_MB = "free_space_target_mb";
 const std::string INSERT_OP_CONFIG = "insert_config";
 const std::string KEY_COUNT_PER_COLLECTION = "key_count_per_collection";
 const std::string KEY_SIZE = "key_size";

--- a/test/cppsuite/src/common/constants.h
+++ b/test/cppsuite/src/common/constants.h
@@ -41,6 +41,7 @@ extern const std::string TIMESTAMP_MANAGER;
 extern const std::string WORKLOAD_MANAGER;
 
 /* Configuration API consts. */
+extern const std::string BACKGROUND_COMPACT_OP_CONFIG;
 extern const std::string CACHE_HS_INSERT;
 extern const std::string CACHE_MAX_WAIT_MS;
 extern const std::string CACHE_SIZE_MB;
@@ -52,6 +53,7 @@ extern const std::string CUSTOM_OP_CONFIG;
 extern const std::string DURATION_SECONDS;
 extern const std::string ENABLED;
 extern const std::string ENABLE_LOGGING;
+extern const std::string FREE_SPACE_TARGET_MB;
 extern const std::string INSERT_OP_CONFIG;
 extern const std::string KEY_COUNT_PER_COLLECTION;
 extern const std::string KEY_SIZE;

--- a/test/cppsuite/src/component/workload_manager.cpp
+++ b/test/cppsuite/src/component/workload_manager.cpp
@@ -65,6 +65,8 @@ workload_manager::run()
 
     /* Retrieve useful parameters from the test configuration. */
     operation_configs.push_back(operation_configuration(
+      _config->get_subconfig(BACKGROUND_COMPACT_OP_CONFIG), thread_type::BACKGROUND_COMPACT));
+    operation_configs.push_back(operation_configuration(
       _config->get_subconfig(CHECKPOINT_OP_CONFIG), thread_type::CHECKPOINT));
     operation_configs.push_back(
       operation_configuration(_config->get_subconfig(CUSTOM_OP_CONFIG), thread_type::CUSTOM));

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -128,7 +128,7 @@ void
 database_operation::background_compact_operation(thread_worker *tc)
 {
     logger::log_msg(
-      LOG_ERROR, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
+      LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
     /* This needs to be executed only once in the workload. */
     if (tc->running()) {

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -125,6 +125,20 @@ database_operation::populate(
 }
 
 void
+database_operation::background_compact_operation(thread_worker *tc)
+{
+    logger::log_msg(
+      LOG_ERROR, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
+
+    /* This needs to be executed only once in the workload. */
+    if (tc->running()) {
+        const std::string compact_cfg(
+          "background=true,free_space_target=" + std::to_string(tc->free_space_target_mb) + "MB");
+        testutil_check(tc->session->compact(tc->session.get(), nullptr, compact_cfg.c_str()));
+    }
+}
+
+void
 database_operation::checkpoint_operation(thread_worker *tc)
 {
     logger::log_msg(

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -131,11 +131,9 @@ database_operation::background_compact_operation(thread_worker *tc)
       LOG_INFO, type_string(tc->type) + " thread {" + std::to_string(tc->id) + "} commencing.");
 
     /* This needs to be executed only once in the workload. */
-    if (tc->running()) {
-        const std::string compact_cfg(
-          "background=true,free_space_target=" + std::to_string(tc->free_space_target_mb) + "MB");
-        testutil_check(tc->session->compact(tc->session.get(), nullptr, compact_cfg.c_str()));
-    }
+    const std::string compact_cfg(
+      "background=true,free_space_target=" + std::to_string(tc->free_space_target_mb) + "MB");
+    testutil_check(tc->session->compact(tc->session.get(), nullptr, compact_cfg.c_str()));
 }
 
 void

--- a/test/cppsuite/src/main/database_operation.h
+++ b/test/cppsuite/src/main/database_operation.h
@@ -47,6 +47,9 @@ public:
     virtual void populate(database &database, timestamp_manager *tsm, configuration *config,
       operation_tracker *op_tracker);
 
+    /* Enabled the background compaction server. */
+    virtual void background_compact_operation(thread_worker *tc);
+
     /* Performs a checkpoint periodically. */
     virtual void checkpoint_operation(thread_worker *tc);
 

--- a/test/cppsuite/src/main/operation_configuration.cpp
+++ b/test/cppsuite/src/main/operation_configuration.cpp
@@ -40,6 +40,9 @@ std::function<void(thread_worker *)>
 operation_configuration::get_func(database_operation *dbo)
 {
     switch (type) {
+    case thread_type::BACKGROUND_COMPACT:
+        return (
+          std::bind(&database_operation::background_compact_operation, dbo, std::placeholders::_1));
     case thread_type::CHECKPOINT:
         return (std::bind(&database_operation::checkpoint_operation, dbo, std::placeholders::_1));
     case thread_type::CUSTOM:

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -41,6 +41,8 @@ const std::string
 type_string(thread_type type)
 {
     switch (type) {
+    case thread_type::BACKGROUND_COMPACT:
+        return ("background_compact");
     case thread_type::CHECKPOINT:
         return ("checkpoint");
     case thread_type::CUSTOM:
@@ -70,6 +72,7 @@ thread_worker::thread_worker(uint64_t id, thread_type type, configuration *confi
   operation_tracker *op_tracker, database &dbase, std::shared_ptr<barrier> barrier_ptr)
     : /* These won't exist for certain threads which is why we use optional here. */
       collection_count(config->get_optional_int(COLLECTION_COUNT, 1)),
+      free_space_target_mb(config->get_optional_int(FREE_SPACE_TARGET_MB, 1)),
       key_count(config->get_optional_int(KEY_COUNT_PER_COLLECTION, 1)),
       key_size(config->get_optional_int(KEY_SIZE, 1)),
       value_size(config->get_optional_int(VALUE_SIZE, 1)),

--- a/test/cppsuite/src/main/thread_worker.h
+++ b/test/cppsuite/src/main/thread_worker.h
@@ -43,7 +43,7 @@
 #include "src/util/barrier.h"
 
 namespace test_harness {
-enum class thread_type { CHECKPOINT, CUSTOM, INSERT, READ, REMOVE, UPDATE };
+enum class thread_type { BACKGROUND_COMPACT, CHECKPOINT, CUSTOM, INSERT, READ, REMOVE, UPDATE };
 
 const std::string type_string(thread_type type);
 
@@ -105,6 +105,7 @@ public:
 
 public:
     const int64_t collection_count;
+    const int64_t free_space_target_mb;
     const int64_t key_count;
     const int64_t key_size;
     const int64_t value_size;

--- a/test/cppsuite/tests/test_template.cpp
+++ b/test/cppsuite/tests/test_template.cpp
@@ -79,6 +79,12 @@ public:
     }
 
     void
+    background_compact_operation(thread_worker *) override final
+    {
+        logger::log_msg(LOG_WARN, "background_compact_operation: nothing done");
+    }
+
+    void
     checkpoint_operation(thread_worker *) override final
     {
         logger::log_msg(LOG_WARN, "checkpoint_operation: nothing done");


### PR DESCRIPTION
The changes:

- Add the possibility of adding a thread to a cppsuite workload that would enable background compaction.
- Update the default testing configuration with background compaction.

Note: a new test using that feature may come with WT-11346.