### PR TITLE
WT-11221 Ignore unexpected Eviction took more than 1 minute warning in stdout (v7.0) (#9399)

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -158,7 +158,7 @@ __evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
             conn->cache->evict_max_ms = eviction_time_milliseconds;
         if (eviction_time_milliseconds > WT_MINUTE * WT_THOUSAND)
             __wt_verbose_warning(session, WT_VERB_EVICT,
-              "Eviction took more than 1 minute (%" PRIu64 "). Building disk image took %" PRIu64
+              "Eviction took more than 1 minute (%" PRIu64 "us). Building disk image took %" PRIu64
               "us. History store wrapup took %" PRIu64 "us.",
               eviction_time,
               WT_CLOCKDIFF_US(session->reconcile_timeline.image_build_finish,

--- a/test/suite/test_hs07.py
+++ b/test/suite/test_hs07.py
@@ -225,5 +225,7 @@ class test_hs07(wttest.WiredTigerTestCase):
         # Check that the new updates are only seen after the update timestamp
         self.check(bigvalue, uri, nrows, 300)
 
+        self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_prepare_hs01.py
+++ b/test/suite/test_prepare_hs01.py
@@ -152,5 +152,7 @@ class test_prepare_hs01(wttest.WiredTigerTestCase):
         nkeys = 4000
         self.prepare_updates(uri, ds, nrows, nsessions, nkeys)
 
+        self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_txn13.py
+++ b/test/suite/test_txn13.py
@@ -90,6 +90,7 @@ class test_txn13(wttest.WiredTigerTestCase, suite_subprocess):
         else:
             self.session.commit_transaction()
 
+        self.ignoreStdoutPatternIfExists('Eviction took more than 1 minute')
         self.assertTrue(gotException == self.expect_err)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added a 'us' unit to the eviction time in the "Eviction took more than 1 minute" warning message. Ignore more cases of the "Eviction took more than 1 minute" warnings in the standard output.

(cherry picked from commit 5b7de4cb3e22a351d79b045ad9af1bdac374f309)