### PR TITLE
WT-11312 Fix incorrect flag check for accurate force eviction stat (v7.0) (#9403)

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -143,7 +143,7 @@ __evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
         if (conn->txn_global.checkpoint_running)
             WT_STAT_CONN_INCR(session, cache_eviction_pages_in_parallel_with_checkpoint);
     } else {
-        if (LF_ISSET(WT_EVICT_CALL_URGENT)) {
+        if (LF_ISSET(WT_EVICT_STATS_URGENT)) {
             if (LF_ISSET(WT_EVICT_STATS_FORCE_HS))
                 WT_STAT_CONN_INCR(session, cache_eviction_force_hs_fail);
             WT_STAT_CONN_INCR(session, cache_eviction_force_fail);


### PR DESCRIPTION
Co-authored-by: Siddhartha Mahajan <siddhartha.mahajan8899@mongodb.com>
(cherry picked from commit 7ef518cd7c8c0f8e4a608a13ebcf6d2484e049ad)