### PR TITLE
WT-11365 Re-enabled testing on RHEL zSeries.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6277,7 +6277,6 @@ buildvariants:
 
 - name: rhel8-zseries
   display_name: "~ RHEL8 zSeries"
-  activate: false
   run_on:
   - rhel80-zseries-test
   batchtime: 120 # 2 hours


### PR DESCRIPTION
WT-11365 Re-enabled testing on RHEL zSeries, after it was disabled temporarily in WT-11364.