### PR TITLE
WT-10714 Use explicitly labelled perf distro for perf testing (#9500)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2628,7 +2628,7 @@ tasks:
     patch_only: true
     depends_on:
     - name: compile
-    run_on: ubuntu2004-medium
+    run_on: ubuntu2004-perf-testing
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
@@ -5393,7 +5393,7 @@ buildvariants:
     - name: ".stress-test-no-barrier"
     - name: ".stress-test-sanitizer"
       run_on:
-      - ubuntu2004-medium
+      - ubuntu2004-perf-testing
     - name: format-abort-recovery-stress-test
     - name: ".stress-test-1-nonstandalone"
     - name: ".stress-test-2-nonstandalone"
@@ -5411,7 +5411,7 @@ buildvariants:
 - name: ubuntu2004-stress-tests-arm64
   display_name: Ubuntu 20.04 Stress tests (ARM64)
   run_on:
-  - ubuntu2004-arm64-large
+  - ubuntu2004-arm64-perf-testing
   expansions:
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     make_command: ninja
@@ -5444,7 +5444,7 @@ buildvariants:
   batchtime: 720 # twice a day
   run_on:
   # We run on medium as small has too small a disk.
-  - ubuntu2004-medium
+  - ubuntu2004-perf-testing
   expansions:
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
@@ -5467,7 +5467,7 @@ buildvariants:
   display_name: "Cppsuite Stress Tests ARM64"
   batchtime: 720 # twice a day
   run_on:
-  - ubuntu2004-arm64-large
+  - ubuntu2004-arm64-perf-testing
   expansions:
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
@@ -5746,7 +5746,7 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: unit-test-zstd
     - name: unit-test-extra-long
-      distros: ubuntu2004-arm64-large
+      distros: ubuntu2004-arm64-perf-testing
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
     - name: wtperf-test
@@ -5759,7 +5759,7 @@ buildvariants:
     - name: make-check-nonstandalone
     - name: unit-test-nonstandalone
     - name: unit-test-extra-long-nonstandalone
-      distros: ubuntu2004-arm64-large
+      distros: ubuntu2004-arm64-perf-testing
     - name: memory-model-test
       batchtime: 40320 # 28 days
 

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -75,7 +75,7 @@ buildvariants:
   name: ubuntu2004-perf-tests
   display_name: Ubuntu 20.04 Performance tests
   run_on:
-    - ubuntu2004-medium
+    - ubuntu2004-perf-testing
   expansions:
     <<: *ubuntu2004-perf-tests-expansions-template
     collection: AllPerfTests
@@ -84,7 +84,7 @@ buildvariants:
   name: ubuntu2004-perf-tests-arm64
   display_name: Ubuntu 20.04 Performance tests (ARM64)
   run_on:
-    - ubuntu2004-arm64-large
+    - ubuntu2004-arm64-perf-testing
   expansions:
     <<: *ubuntu2004-perf-tests-expansions-template
     collection: AllPerfTestsARM64


### PR DESCRIPTION
- Create dedicated perf testing distros for both the ARM64 and Ubuntu2004 distros

(cherry picked from commit ad8cab39bf70840ed489c34a6915e0c88b7136b0)