### PR TITLE
WT-11063 Protect against trace session closure on test format error

### DIFF
--- a/test/format/format_util.c
+++ b/test/format/format_util.c
@@ -414,7 +414,7 @@ wt_wrap_close_session(WT_SESSION *session)
     WT_SESSION *trace;
 
     trace = NULL;
-    if ((sap = session->app_private) != NULL) {
+    if (g.trace_conn != NULL && (sap = session->app_private) != NULL) {
         trace = sap->trace;
         if (trace != NULL)
             testutil_check(trace->close(trace, NULL));

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -107,7 +107,7 @@ handle_message(WT_EVENT_HANDLER *handler, WT_SESSION *session, const char *messa
      * can be generated in the library when we don't have a session. There's a global session we can
      * use, but that requires locking.
      */
-    if ((sap = session->app_private) != NULL && sap->trace != NULL) {
+    if (g.trace_conn != NULL && (sap = session->app_private) != NULL && sap->trace != NULL) {
         testutil_check(sap->trace->log_printf(sap->trace, "%s", message));
         if (!printf_msg)
             return (0);


### PR DESCRIPTION
 Check if test format trace conn is NULL prior to using the trace sessions in the event it has been closed due to an error.