### PR TITLE
WT-11449 Increase task timeout for csuite-long-running (MSan)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2629,6 +2629,8 @@ tasks:
             done
 
   - name: csuite-long-running
+    # Set 5 hours timeout (60 * 60 * 5)
+    exec_timeout_secs: 18000
     commands:
       - func: "get project"
       - func: "compile wiredtiger"


### PR DESCRIPTION
This task has been on the border of failing and this will give it the time to complete.