### PR TITLE
WT-11490 Improved Readability: Introduced WT_MIN_PAGES macro for memory_page config

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -949,12 +949,12 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
  * have been set.  Don't forget to update the API documentation if you
  * alter the bounds for any of the parameters here.
  */
-#define WT_MIN_PAGES  10
+#define WT_MIN_PAGES 10
     WT_RET(__wt_config_gets(session, cfg, "memory_page_max", &cval));
     btree->maxmempage = (uint64_t)cval.val;
     if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)
-        btree->maxmempage = (uint64_t)WT_MIN(
-          btree->maxmempage, ((conn->cache->eviction_dirty_trigger * cache_size) / 100) / WT_MIN_PAGES);
+        btree->maxmempage = (uint64_t)WT_MIN(btree->maxmempage,
+          ((conn->cache->eviction_dirty_trigger * cache_size) / 100) / WT_MIN_PAGES);
 
     /* Enforce a lower bound of a single disk leaf page */
     btree->maxmempage = WT_MAX(btree->maxmempage, btree->maxleafpage);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -951,9 +951,10 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      */
     WT_RET(__wt_config_gets(session, cfg, "memory_page_max", &cval));
     btree->maxmempage = (uint64_t)cval.val;
+    int min_pages_num = 10;
     if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)
         btree->maxmempage = (uint64_t)WT_MIN(
-          btree->maxmempage, (conn->cache->eviction_dirty_trigger * cache_size) / 100);
+          btree->maxmempage, ((conn->cache->eviction_dirty_trigger * cache_size) / 100) / min_pages_num);
 
     /* Enforce a lower bound of a single disk leaf page */
     btree->maxmempage = WT_MAX(btree->maxmempage, btree->maxleafpage);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -939,19 +939,20 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
           "B < %" PRIu32 "B)",
           btree->maxmempage_image, max);
 
-/*
- * Don't let pages grow large compared to the cache size or we can end
- * up in a situation where nothing can be evicted.  Make sure at least
- * 10 pages fit in cache when it is at the dirty trigger where threads
- * stall.
- *
- * Take care getting the cache size: with a shared cache, it may not
- * have been set.  Don't forget to update the API documentation if you
- * alter the bounds for any of the parameters here.
- */
-#define WT_MIN_PAGES 10
+    /*
+     * Don't let pages grow large compared to the cache size or we can end
+     * up in a situation where nothing can be evicted.  Make sure at least
+     * 10 pages fit in cache when it is at the dirty trigger where threads
+     * stall.
+     *
+     * Take care getting the cache size: with a shared cache, it may not
+     * have been set.  Don't forget to update the API documentation if you
+     * alter the bounds for any of the parameters here.
+     */
     WT_RET(__wt_config_gets(session, cfg, "memory_page_max", &cval));
     btree->maxmempage = (uint64_t)cval.val;
+
+#define WT_MIN_PAGES 10
     if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)
         btree->maxmempage = (uint64_t)WT_MIN(btree->maxmempage,
           ((conn->cache->eviction_dirty_trigger * cache_size) / 100) / WT_MIN_PAGES);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -952,7 +952,9 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      */
     WT_RET(__wt_config_gets(session, cfg, "memory_page_max", &cval));
     btree->maxmempage = (uint64_t)cval.val;
-    min_pages_num = 10;
+//at least 10 pages can fit into the cache when it reaches the eviction_dirty_trigger level.
+#define WT_MIN_PAGES  10
+    min_pages_num = WT_MIN_PAGES;
     if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)
         btree->maxmempage = (uint64_t)WT_MIN(
           btree->maxmempage, ((conn->cache->eviction_dirty_trigger * cache_size) / 100) / min_pages_num);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -953,7 +953,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
     btree->maxmempage = (uint64_t)cval.val;
     if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)
         btree->maxmempage = (uint64_t)WT_MIN(
-          btree->maxmempage, (conn->cache->eviction_dirty_trigger * cache_size) / WT_THOUSAND);
+          btree->maxmempage, (conn->cache->eviction_dirty_trigger * cache_size) / 100);
 
     /* Enforce a lower bound of a single disk leaf page */
     btree->maxmempage = WT_MAX(btree->maxmempage, btree->maxleafpage);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -952,7 +952,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      */
     WT_RET(__wt_config_gets(session, cfg, "memory_page_max", &cval));
     btree->maxmempage = (uint64_t)cval.val;
-//at least 10 pages can fit into the cache when it reaches the eviction_dirty_trigger level.
+//make sure that at least 10 pages can fit into the cache when it reaches the eviction_dirty_trigger level.
 #define WT_MIN_PAGES  10
     min_pages_num = WT_MIN_PAGES;
     if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -887,6 +887,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
     uint64_t cache_size;
     uint32_t leaf_split_size, max;
     const char **cfg;
+    int min_pages_num;
 
     btree = S2BT(session);
     conn = S2C(session);
@@ -951,7 +952,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      */
     WT_RET(__wt_config_gets(session, cfg, "memory_page_max", &cval));
     btree->maxmempage = (uint64_t)cval.val;
-    int min_pages_num = 10;
+    min_pages_num = 10;
     if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)
         btree->maxmempage = (uint64_t)WT_MIN(
           btree->maxmempage, ((conn->cache->eviction_dirty_trigger * cache_size) / 100) / min_pages_num);


### PR DESCRIPTION
maxmempage bug fix, eviction_dirty_trigger,s percentage usage error, It will cause the btree->maxmempage to become invalid

if (!F_ISSET(conn, WT_CONN_CACHE_POOL) && (cache_size = conn->cache_size) > 0)
   btree->maxmempage = (uint64_t)WT_MIN(
     btree->maxmempage, (conn->cache->eviction_dirty_trigger * cache_size) / WT_THOUSAND);

#define WT_THOUSAND (1000)

The denominator should be 100， not 1000.
