### PR TITLE
WT-11458 Review shared variable semantics in hazard pointer logic

### DIFF
--- a/src/include/session.h
+++ b/src/include/session.h
@@ -332,8 +332,8 @@ struct __wt_session_impl {
  */
 #define WT_SESSION_INITIAL_HAZARD_SLOTS 250
     uint32_t hazard_size;  /* Allocated size of the Hazard pointer array */
-    uint32_t hazard_inuse; /* Number of Hazard pointer array slots potentially in-use */
-    uint32_t nhazard;      /* Number of Hazard pointer array slots actively in-use */
+    uint32_t hazard_inuse; /* Number of hazard pointer array slots potentially in-use */
+    uint32_t nhazard;      /* Number of hazard pointer array slots actively in-use */
     WT_HAZARD *hazard;     /* Hazard pointer array */
 
     /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -331,9 +331,9 @@ struct __wt_session_impl {
  * The hazard pointer array grows as necessary, initialize with 250 slots.
  */
 #define WT_SESSION_INITIAL_HAZARD_SLOTS 250
-    uint32_t hazard_size;  /* Hazard pointer array slots */
-    uint32_t hazard_inuse; /* Hazard pointer array slots in-use */
-    uint32_t nhazard;      /* Count of active hazard pointers */
+    uint32_t hazard_size;  /* Allocated size of the Hazard pointer array */
+    uint32_t hazard_inuse; /* Number of Hazard pointer array slots potentially in-use */
+    uint32_t nhazard;      /* Number of Hazard pointer array slots actively in-use */
     WT_HAZARD *hazard;     /* Hazard pointer array */
 
     /*

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -22,7 +22,7 @@ hazard_grow(WT_SESSION_IMPL *session)
     WT_HAZARD *new_hazard;
     size_t size;
     uint64_t hazard_gen;
-    void *ohazard;
+    void *old_hazard;
 
     /*
      * Allocate a new, larger hazard pointer array and copy the contents of the original into place.
@@ -36,7 +36,7 @@ hazard_grow(WT_SESSION_IMPL *session)
      * must complete before eviction can see the new hazard pointer array), then schedule the
      * original to be freed.
      */
-    ohazard = session->hazard;
+    old_hazard = session->hazard;
     WT_PUBLISH(session->hazard, new_hazard);
 
     session->hazard_size = (uint32_t)(size * 2);
@@ -47,7 +47,7 @@ hazard_grow(WT_SESSION_IMPL *session)
      * leak the memory.
      */
     __wt_gen_next(session, WT_GEN_HAZARD, &hazard_gen);
-    WT_IGNORE_RET(__wt_stash_add(session, WT_GEN_HAZARD, hazard_gen, ohazard, 0));
+    WT_IGNORE_RET(__wt_stash_add(session, WT_GEN_HAZARD, hazard_gen, old_hazard, 0));
 
     return (0);
 }

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -246,7 +246,6 @@ __wt_hazard_close(WT_SESSION_IMPL *session)
 
 #ifdef HAVE_DIAGNOSTIC
     __hazard_dump(session);
-    __wt_abort(session);
 #endif
 
     /*


### PR DESCRIPTION
Some small changes after reviewing hazard pointer's shared variable semantics. There's only one change in which I've moved a barrier closer to where it's required. Otherwise there's some small cosmetic changes ID'd during the review.