### PR TITLE
WT-11482 Add extra 'echo' calls to output more information during "configure wiredtiger" in evergreen.yml.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -213,6 +213,7 @@ functions:
       script: |
         set -o errexit
         set -o verbose
+        echo "Starting 'make wiredtiger' step"
         if [ "$OS" = "Windows_NT" ]; then
           # Use the Windows powershell script to execute Ninja build (can't execute directly in a cygwin environment).
           powershell.exe '.\test\evergreen\build_windows.ps1 -build 1'
@@ -221,6 +222,7 @@ functions:
           cd cmake_build
           ${compile_env_vars|} ${make_command|ninja} ${smp_command|} 2>&1
         fi
+        echo "Ending 'make wiredtiger' step"
   "compile wiredtiger":
     - *configure_wiredtiger
     - *make_wiredtiger

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -181,15 +181,20 @@ functions:
             . automation-scripts/evergreen/find_gperftools.sh ${s3_access_key} ${s3_secret_key} ${build_variant} $is_cmake_build
           fi
           # Compiling with CMake.
+          echo "Find CMake"
           . test/evergreen/find_cmake.sh
           # If we've fetched the wiredtiger artifact from a previous compilation/build, it's best to remove
           # the previous build directory so we can create a fresh configuration. We can't use the the previous
           # CMake Cache configuration as its likely it will have absolute paths related to the previous build machine.
+          echo "Remove the cmake_build directory, if it already exists"
           if [ -d cmake_build ]; then rm -r cmake_build; fi
+          echo "Create a new cmake_build directory"
           mkdir -p cmake_build
           cd cmake_build
 
+          echo "Call CMake"
           ${configure_env_vars|} $CMAKE $DEFINED_EVERGREEN_CONFIG_FLAGS ${posix_configure_flags|} -G "${cmake_generator|Ninja}" ./..
+          echo "Completed CMake"
         fi
   "python config check":
     command: shell.exec


### PR DESCRIPTION
Should the build hang at this stage again, hopefully this extra info will assist with diagnosis.