### PR TITLE
WT-11514 Fix chunkcache tests to cache only tiered readonly objects

### DIFF
--- a/bench/workgen/runner/chunkcache.py
+++ b/bench/workgen/runner/chunkcache.py
@@ -41,12 +41,19 @@ def get_stat(session, stat):
     stat_cursor.close()
     return val
 
-# Set up the WiredTiger connection.
+def tiered_config(home):
+    bucket_path = home + "/" + "bucket2"
+    if not os.path.isdir(bucket_path):
+        os.mkdir(bucket_path)
+
+# Set up the WiredTiger connection
 context = Context()
-dir = os.getcwd()
-conn_config = 'create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true)'
-chunkcache_config = conn_config + f',chunk_cache=[enabled=true,chunk_size=10MB,capacity=1GB,type=FILE,storage_path={dir}/chunkcache_tmp]'
-conn = context.wiredtiger_open(conn_config)
+dir = os.getcwd()   
+conn_config = 'create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),\
+    tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),\
+        extensions=(./ext/storage_sources/dir_store/libwiredtiger_dir_store.so=(early_load=true))'
+chunkcache_config =  conn_config + f',chunk_cache=[enabled=true,chunk_size=10MB,capacity=1GB,type=FILE,storage_path={dir}/chunkcache_tmp]'
+conn = context.wiredtiger_open(conn_config, tiered_config)
 s = conn.open_session()
 tname = 'table:chunkcache'
 s.create(tname, 'key_format=S,value_format=S')
@@ -59,6 +66,8 @@ insert_ops = Operation(Operation.OP_INSERT, table)
 insert_thread = Thread(insert_ops * 100000)
 populate_workload = Workload(context, insert_thread * 40)
 ret = populate_workload.run(conn)
+s.checkpoint()
+s.checkpoint('flush_tier=(enabled)')
 assert ret == 0, ret
 
 # Reopen the connection and reconfigure

--- a/bench/workgen/runner/chunkcache.py
+++ b/bench/workgen/runner/chunkcache.py
@@ -48,11 +48,13 @@ def tiered_config(home):
 
 # Set up the WiredTiger connection
 context = Context()
-dir = os.getcwd()   
-conn_config = 'create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),\
+wt_builddir = os.getenv('WT_BUILDDIR')
+if not wt_builddir:
+    wt_builddir = os.getcwd()
+conn_config = f'create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),\
     tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),\
-        extensions=(./ext/storage_sources/dir_store/libwiredtiger_dir_store.so=(early_load=true))'
-chunkcache_config =  conn_config + f',chunk_cache=[enabled=true,chunk_size=10MB,capacity=1GB,type=FILE,storage_path={dir}/chunkcache_tmp]'
+        extensions=({wt_builddir}/ext/storage_sources/dir_store/libwiredtiger_dir_store.so=(early_load=true))'
+chunkcache_config =  conn_config + f',chunk_cache=[enabled=true,chunk_size=10MB,capacity=1GB,type=FILE,storage_path={wt_builddir}/chunkcache_tmp]'
 conn = context.wiredtiger_open(conn_config, tiered_config)
 s = conn.open_session()
 tname = 'table:chunkcache'

--- a/test/suite/test_chunkcache02.py
+++ b/test/suite/test_chunkcache02.py
@@ -26,12 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os
+import os, sys
 import random
 import threading
 import time
 import wiredtiger, wttest
 
+from random import randrange
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -45,25 +46,30 @@ class test_chunkcache02(wttest.WiredTigerTestCase):
     uri = "table:test_chunkcache02"
     rows = 10000
     num_threads = 5
-    current_directory = os.getcwd()
 
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
         ('row_string', dict(key_format='S', value_format='S')),
     ]
 
-    cache_types = [
-        ('in-memory', dict(chunk_cache_extra_config='type=DRAM')),
-        ('on-disk', dict(chunk_cache_extra_config=f'type=FILE,storage_path={current_directory}/chunk-cache-tmp'))
-    ]
+    cache_types = [('in-memory', dict(chunk_cache_type='dram'))]
+    if sys.byteorder == 'little':
+        # WT's filesystem layer doesn't support mmap on big-endian platforms.
+        cache_types.append(('on-disk', dict(chunk_cache_type='file')))
 
     scenarios = make_scenarios(format_values, cache_types)
 
     def conn_config(self):
         if not os.path.exists('bucket2'):
             os.mkdir('bucket2')
+
+        if self.chunk_cache_type == 'dram':
+            chunk_cache_extra_config = 'type=DRAM'
+        else:
+            chunk_cache_extra_config = 'type=FILE,storage_path=/tmp/chunk_cache_{}'.format(randrange(0, 1000000000))
+        self.prout(chunk_cache_extra_config)
         return 'tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),' \
-            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=20MB,{}],'.format(self.chunk_cache_extra_config)
+            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=20MB,{}],'.format(chunk_cache_extra_config)
 
     def conn_extensions(self, extlist):
         if os.name == 'nt':

--- a/test/suite/test_chunkcache02.py
+++ b/test/suite/test_chunkcache02.py
@@ -79,7 +79,7 @@ class test_chunkcache02(wttest.WiredTigerTestCase):
     def read_and_verify(self, rows, ds):
         session = self.conn.open_session()
         cursor = session.open_cursor(self.uri)
-        for i in range(1, rows):
+        for i in range(1, rows * 10):
             key = random.randint(1, rows - 1)
             cursor.set_key(ds.key(key))
             cursor.search()

--- a/test/suite/test_chunkcache02.py
+++ b/test/suite/test_chunkcache02.py
@@ -67,7 +67,7 @@ class test_chunkcache02(wttest.WiredTigerTestCase):
             chunk_cache_extra_config = 'type=DRAM'
         else:
             chunk_cache_extra_config = 'type=FILE,storage_path=/tmp/chunk_cache_{}'.format(randrange(0, 1000000000))
-        self.prout(chunk_cache_extra_config)
+
         return 'tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),' \
             'chunk_cache=[enabled=true,chunk_size=512KB,capacity=20MB,{}],'.format(chunk_cache_extra_config)
 


### PR DESCRIPTION
Currently chunkcache tests merged in WT-11261 is failing after the changes in WT-10799, this ticket fixes the bugs introduced. 