### PR TITLE
WT-11424 Revert back to using c stdlib qsort for modification sorting

### DIFF
--- a/dist/s_style
+++ b/dist/s_style
@@ -164,11 +164,11 @@ else
         cat $t
     }
 
-    if ! expr "$f" : 'src/include/misc.h' > /dev/null &&
-        grep '[[:space:]]qsort(' $f > $t; then
-        echo "$f: qsort call, use WiredTiger __wt_qsort instead"
-        cat $t
-    fi
+    # if ! expr "$f" : 'src/include/misc.h' > /dev/null &&
+    #     grep '[[:space:]]qsort(' $f > $t; then
+    #     echo "$f: qsort call, use WiredTiger __wt_qsort instead"
+    #     cat $t
+    # fi
 
     if ! expr "$f" : 'src/.*/os_setvbuf.c' > /dev/null &&
         egrep -w 'setvbuf' $f > $t; then


### PR DESCRIPTION
Should I change all our qsort calls back to this? There 20 or so other ones in the codebase, once this is merged `__wt_qsort` will be reverted, and then those calls would have to be moved back again. So probably fine to leave them as is for the time being.