### PR TITLE
WT-11523 Do not check for background compact interruption when opening/closing the connection

### DIFF
--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -228,8 +228,12 @@ __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
     /* Compaction can be interrupted if the timeout has exceeded. */
     WT_RET(__session_compact_check_timeout(session));
 
-    /* Background compaction may have been disabled in the meantime. */
-    if (session == conn->background_compact.session) {
+    /*
+     * Background compaction may have been disabled in the meantime. Only check for interruption
+     * when the connection is not being opened/closed.
+     */
+    if (session == conn->background_compact.session &&
+      !F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_MINIMAL)) {
         __wt_spin_lock(session, &conn->background_compact.lock);
         if (!conn->background_compact.running)
             ret = WT_ERROR;


### PR DESCRIPTION
The `WT_CONN_MINIMAL` flag is used to cover the path when `__wt_compact_server_destroy` is called in `__conn_close`.
The `WT_CONN_CLOSING` flag is used to cover the path when `__wt_compact_server_destroy` is called in `__wt_connection_close` which is called in `wiredtiger_open` when things go wrong.