### PR TITLE
WT-11524 Log a warning instead of an error when compaction is interrupted

### DIFF
--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -208,8 +208,7 @@ __session_compact_check_timeout(WT_SESSION_IMPL *session)
 /*
  * __wt_session_compact_check_interrupted --
  *     Check if compaction has been interrupted. Foreground compaction can be interrupted through an
- *     event handler while background compaction can be disabled at any time using the compact
- *     session API.
+ *     event handler while background compaction can be disabled at any time using the compact API.
  */
 int
 __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -228,9 +228,6 @@ __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
         }
     }
 
-    /* Compaction can be interrupted if the timeout has exceeded. */
-    WT_RET(__session_compact_check_timeout(session));
-
     /* Background compaction may have been disabled in the meantime. */
     if (session == conn->background_compact.session) {
         __wt_spin_lock(session, &conn->background_compact.lock);
@@ -242,6 +239,9 @@ __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
         __wt_spin_unlock(session, &conn->background_compact.lock);
         WT_RET(ret);
     }
+
+    /* Compaction can be interrupted if the timeout has exceeded. */
+    WT_RET(__session_compact_check_timeout(session));
 
     return (0);
 }

--- a/test/csuite/wt10897_compact_quick_interrupt/main.c
+++ b/test/csuite/wt10897_compact_quick_interrupt/main.c
@@ -50,24 +50,6 @@ static bool skipped_compaction = false;
 static bool do_interrupt_compaction = false;
 
 /*
- * error_handler --
- *     Error handler.
- */
-static int
-error_handler(WT_EVENT_HANDLER *handler, WT_SESSION *session, int error, const char *message)
-{
-    (void)(handler);
-    (void)(session);
-    (void)(error);
-
-    if (strstr(message, "compact interrupted") != NULL)
-        interrupted_compaction = true;
-
-    fprintf(stderr, "%s\n", message);
-    return (0);
-}
-
-/*
  * message_handler --
  *     Message handler.
  */
@@ -79,6 +61,8 @@ message_handler(WT_EVENT_HANDLER *handler, WT_SESSION *session, const char *mess
 
     if (strstr(message, "skipping compaction") != NULL)
         skipped_compaction = true;
+    else if (strstr(message, "compact interrupted") != NULL)
+        interrupted_compaction = true;
 
     fprintf(stderr, "%s\n", message);
     return (0);
@@ -104,10 +88,10 @@ handle_general(WT_EVENT_HANDLER *handler, WT_CONNECTION *conn, WT_SESSION *sessi
 }
 
 static WT_EVENT_HANDLER event_handler = {
-  error_handler, message_handler, /* Message handlers */
-  NULL,                           /* Progress handler */
-  NULL,                           /* Close handler */
-  handle_general                  /* General handler */
+  NULL, message_handler, /* Message handlers */
+  NULL,                  /* Progress handler */
+  NULL,                  /* Close handler */
+  handle_general         /* General handler */
 };
 
 /*

--- a/test/csuite/wt8057_compact_stress/main.c
+++ b/test/csuite/wt8057_compact_stress/main.c
@@ -97,7 +97,7 @@ handle_general(WT_EVENT_HANDLER *handler, WT_CONNECTION *conn, WT_SESSION *sessi
      * often. We don't want to change the nature of the test too much.
      */
     if (++compact_event % 8 == 0) {
-        printf(" *** Compact check interrupting compact with error\n");
+        printf(" *** Compact check interrupting compact with warning\n");
         compact_error = true;
         return (-1);
     }

--- a/test/suite/test_compact07.py
+++ b/test/suite/test_compact07.py
@@ -182,7 +182,7 @@ class test_compact07(wttest.WiredTigerTestCase):
 
         # Background compaction may be have been inspecting a table when disabled which is
         # considered as an interruption, ignore that message.
-        self.ignoreStderrPatternIfExists('background compact interrupted by application')
+        self.ignoreStdoutPatternIfExists('background compact interrupted by application')
 
         # Perform foreground compaction on the remaining file by setting a free_space_target value
         # that is guaranteed to run on it.


### PR DESCRIPTION
In WT-11519, we are discussing why an error message can be seen as a false positive. WT-11524 was then created to change from an error to a warning by replacing `WT_RET_MSG` with `__wt_verbose_warning`. However, interruption still returns `WT_ERROR` to be able to exit the compaction loop.