### PR TITLE
WT-11535 Create a dedicated file truncate function for chunkcache

### DIFF
--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -425,6 +425,22 @@ __chunkcache_eviction_thread(void *arg)
 }
 
 /*
+ * __chunkcache_truncate_file --
+ *     Truncate a chunkcache file to the specified offset. If the underlying file system doesn't
+ *     support truncate then we need to zero out the rest of the file, doing an effective truncate.
+ */
+static int
+__chunkcache_truncate_file(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset)
+{
+    WT_DECL_RET;
+
+    if ((ret = __wt_ftruncate(session, fh, offset)) != ENOTSUP)
+        return (ret);
+
+    return (__wt_file_zero(session, fh, (wt_off_t)0, (wt_off_t)offset, NULL));
+}
+
+/*
  * __chunkcache_str_cmp --
  *     Qsort function: sort string array.
  */
@@ -851,8 +867,7 @@ __wt_chunkcache_setup(WT_SESSION_IMPL *session, const char *cfg[])
         WT_RET(__wt_open(session, chunkcache->storage_path, WT_FS_OPEN_FILE_TYPE_DATA,
           WT_FS_OPEN_CREATE | WT_FS_OPEN_FORCE_MMAP, &chunkcache->fh));
 
-        WT_RET(chunkcache->fh->handle->fh_truncate(
-          chunkcache->fh->handle, &session->iface, (wt_off_t)chunkcache->capacity));
+        WT_RET(__chunkcache_truncate_file(session, chunkcache->fh, (wt_off_t)chunkcache->capacity));
 
         if (chunkcache->fh->handle->fh_map == NULL) {
             WT_IGNORE_RET(__wt_close(session, &chunkcache->fh));

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -437,7 +437,7 @@ __chunkcache_truncate_file(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset)
     if ((ret = __wt_ftruncate(session, fh, offset)) != ENOTSUP)
         return (ret);
 
-    return (__wt_file_zero(session, fh, (wt_off_t)0, (wt_off_t)offset, NULL));
+    return (__wt_file_zero(session, fh, (wt_off_t)0, (wt_off_t)offset, WT_THROTTLE_CHUNKCACHE));
 }
 
 /*

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -289,6 +289,9 @@ __wt_capacity_throttle(WT_SESSION_IMPL *session, uint64_t bytes, WT_THROTTLE_TYP
     capacity = steal_capacity = 0;
     reservation = steal = NULL;
     switch (type) {
+    case WT_THROTTLE_CHUNKCACHE:
+        /* At the moment, chunk cache usages are not throttled. */
+        return;
     case WT_THROTTLE_CKPT:
         capacity = cap->ckpt;
         reservation = &cap->reservation_ckpt;
@@ -410,6 +413,13 @@ again:
             WT_STAT_CONN_INCRV(session, capacity_time_total, sleep_us);
         else
             switch (type) {
+            case WT_THROTTLE_CHUNKCACHE:
+                /*
+                 * This section is not expected to be reached as we should have already returned
+                 * earlier in case of chunk cache usage throttling.
+                 */
+                WT_ASSERT(session, false);
+                break;
             case WT_THROTTLE_CKPT:
                 WT_STAT_CONN_INCRV(session, capacity_time_ckpt, sleep_us);
                 break;

--- a/src/include/capacity.h
+++ b/src/include/capacity.h
@@ -7,10 +7,11 @@
  */
 
 typedef enum {
-    WT_THROTTLE_CKPT,  /* Checkpoint throttle */
-    WT_THROTTLE_EVICT, /* Eviction throttle */
-    WT_THROTTLE_LOG,   /* Logging throttle */
-    WT_THROTTLE_READ   /* Read throttle */
+    WT_THROTTLE_CHUNKCACHE, /* Chunkcache throttle */
+    WT_THROTTLE_CKPT,       /* Checkpoint throttle */
+    WT_THROTTLE_EVICT,      /* Eviction throttle */
+    WT_THROTTLE_LOG,        /* Logging throttle */
+    WT_THROTTLE_READ        /* Read throttle */
 } WT_THROTTLE_TYPE;
 
 #define WT_THROTTLE_MIN WT_MEGABYTE /* Config minimum size */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -812,8 +812,8 @@ extern int __wt_extra_diagnostics_config(WT_SESSION_IMPL *session, const char *c
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_extractor_config(WT_SESSION_IMPL *session, const char *uri, const char *config,
   WT_EXTRACTOR **extractorp, int *ownp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_file_zero(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_file_zero(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size,
+  WT_THROTTLE_TYPE *type) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_filename(WT_SESSION_IMPL *session, const char *name, char **path)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_filename_construct(WT_SESSION_IMPL *session, const char *path,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -813,7 +813,7 @@ extern int __wt_extra_diagnostics_config(WT_SESSION_IMPL *session, const char *c
 extern int __wt_extractor_config(WT_SESSION_IMPL *session, const char *uri, const char *config,
   WT_EXTRACTOR **extractorp, int *ownp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_file_zero(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size,
-  WT_THROTTLE_TYPE *type) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_THROTTLE_TYPE type) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_filename(WT_SESSION_IMPL *session, const char *name, char **path)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_filename_construct(WT_SESSION_IMPL *session, const char *path,

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -636,8 +636,11 @@ __log_prealloc(WT_SESSION_IMPL *session, WT_FH *fh)
      * If the user configured zero filling, pre-allocate the log file manually. Otherwise use the
      * file extension method to create and zero the log file based on what is available.
      */
-    if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ZERO_FILL))
-        return (__wt_file_zero(session, fh, log->first_record, conn->log_file_max));
+    if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ZERO_FILL)) {
+        WT_STAT_CONN_INCR(session, log_zero_fills);
+        return (__wt_file_zero(session, fh, log->first_record, conn->log_file_max,
+          &(WT_THROTTLE_TYPE){WT_THROTTLE_LOG}));
+    }
 
     /* If configured to not extend the file, we're done. */
     if (conn->log_extend_len == 0)
@@ -1408,7 +1411,9 @@ __log_truncate_file(WT_SESSION_IMPL *session, WT_FH *log_fh, wt_off_t offset)
         }
     }
 
-    return (__wt_file_zero(session, log_fh, offset, conn->log_file_max));
+    WT_STAT_CONN_INCR(session, log_zero_fills);
+    return (__wt_file_zero(
+      session, log_fh, offset, conn->log_file_max, &(WT_THROTTLE_TYPE){WT_THROTTLE_LOG}));
 }
 
 /*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -638,8 +638,8 @@ __log_prealloc(WT_SESSION_IMPL *session, WT_FH *fh)
      */
     if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ZERO_FILL)) {
         WT_STAT_CONN_INCR(session, log_zero_fills);
-        return (__wt_file_zero(session, fh, log->first_record, conn->log_file_max,
-          &(WT_THROTTLE_TYPE){WT_THROTTLE_LOG}));
+        return (
+          __wt_file_zero(session, fh, log->first_record, conn->log_file_max, WT_THROTTLE_LOG));
     }
 
     /* If configured to not extend the file, we're done. */
@@ -1412,8 +1412,7 @@ __log_truncate_file(WT_SESSION_IMPL *session, WT_FH *log_fh, wt_off_t offset)
     }
 
     WT_STAT_CONN_INCR(session, log_zero_fills);
-    return (__wt_file_zero(
-      session, log_fh, offset, conn->log_file_max, &(WT_THROTTLE_TYPE){WT_THROTTLE_LOG}));
+    return (__wt_file_zero(session, log_fh, offset, conn->log_file_max, WT_THROTTLE_LOG));
 }
 
 /*

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -517,21 +517,16 @@ __wt_close_connection_close(WT_SESSION_IMPL *session)
  *     Zero out the file from offset for size bytes.
  */
 int
-__wt_file_zero(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size)
+__wt_file_zero(
+  WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size, WT_THROTTLE_TYPE *type)
 {
     WT_DECL_ITEM(zerobuf);
     WT_DECL_RET;
-    WT_THROTTLE_TYPE type;
     uint64_t bufsz, off, partial, wrlen;
 
     zerobuf = NULL;
     bufsz = WT_MIN((uint64_t)size, WT_MEGABYTE);
-    /*
-     * For now logging is the only type and statistic. This needs updating if block manager decides
-     * to use this function.
-     */
-    type = WT_THROTTLE_LOG;
-    WT_STAT_CONN_INCR(session, log_zero_fills);
+
     WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
     memset(zerobuf->mem, 0, zerobuf->memsize);
     off = (uint64_t)start_off;
@@ -551,7 +546,10 @@ __wt_file_zero(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t
          */
         if ((uint64_t)size - off < bufsz)
             wrlen = (uint64_t)size - off;
-        __wt_capacity_throttle(session, wrlen, type);
+
+        if (type != NULL)
+            __wt_capacity_throttle(session, wrlen, *type);
+
         WT_ERR(__wt_write(session, fh, (wt_off_t)off, (size_t)wrlen, zerobuf->mem));
         off += wrlen;
     }

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -518,7 +518,7 @@ __wt_close_connection_close(WT_SESSION_IMPL *session)
  */
 int
 __wt_file_zero(
-  WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size, WT_THROTTLE_TYPE *type)
+  WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t start_off, wt_off_t size, WT_THROTTLE_TYPE type)
 {
     WT_DECL_ITEM(zerobuf);
     WT_DECL_RET;
@@ -526,7 +526,6 @@ __wt_file_zero(
 
     zerobuf = NULL;
     bufsz = WT_MIN((uint64_t)size, WT_MEGABYTE);
-
     WT_RET(__wt_scr_alloc(session, bufsz, &zerobuf));
     memset(zerobuf->mem, 0, zerobuf->memsize);
     off = (uint64_t)start_off;
@@ -546,10 +545,7 @@ __wt_file_zero(
          */
         if ((uint64_t)size - off < bufsz)
             wrlen = (uint64_t)size - off;
-
-        if (type != NULL)
-            __wt_capacity_throttle(session, wrlen, *type);
-
+        __wt_capacity_throttle(session, wrlen, type);
         WT_ERR(__wt_write(session, fh, (wt_off_t)off, (size_t)wrlen, zerobuf->mem));
         off += wrlen;
     }


### PR DESCRIPTION
This PR was created to deal with a recent failure in a chunkcache test on `Linux noftruncate`  build variant.

To enable the successful operation of the chunkcache on `Linux noftruncate`  build variants, the following has been done:

- A function for truncating the chunkcache file.
- Within this function, an attempt is made to truncate the file, depending on its support.
- In cases where support is absent, a manual process of resetting the file to a zeroed state is executed.

There are some modifications made to the existing function `__wt_file_zero`. @sueloverso it would be great if you could review the same.