### PR TITLE
WT-10614 Coverity analysis defect 135089: Dereference before null check

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -350,6 +350,7 @@ __wt_update_obsolete_check(
     page = cbt->ref->page;
     txn_global = &S2C(session)->txn_global;
 
+    WT_ASSERT(session, page->modify != NULL);
     /* If we can't lock it, don't scan, that's okay. */
     if (WT_PAGE_TRYLOCK(session, page) != 0)
         return;
@@ -432,11 +433,9 @@ __wt_update_obsolete_check(
     else {
         /*
          * If the list is long, don't retry checks on this page until the transaction state has
-         * moved forwards. This function is used to trim update lists independently of the page
-         * state, ensure there is a modify structure.
+         * moved forwards.
          */
         if (count > 20) {
-            WT_ASSERT(session, page->modify != NULL);
             page->modify->obsolete_check_txn = txn_global->last_running;
             if (txn_global->has_pinned_timestamp)
                 page->modify->obsolete_check_timestamp = txn_global->pinned_timestamp;

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -435,7 +435,8 @@ __wt_update_obsolete_check(
          * moved forwards. This function is used to trim update lists independently of the page
          * state, ensure there is a modify structure.
          */
-        if (count > 20 && page->modify != NULL) {
+        if (count > 20) {
+            WT_ASSERT(session, page->modify != NULL);
             page->modify->obsolete_check_txn = txn_global->last_running;
             if (txn_global->has_pinned_timestamp)
                 page->modify->obsolete_check_timestamp = txn_global->pinned_timestamp;


### PR DESCRIPTION
page->modify is valid