### PR TITLE
WT-11432 Prevent parallel compaction on the same URI

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -23,6 +23,7 @@ __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
     __wt_block_configure_first_fit(block, true);
 
     /* Reset the compaction state information. */
+    block->compacting = true;
     block->compact_pct_tenths = 0;
     block->compact_bytes_reviewed = 0;
     block->compact_bytes_rewritten = 0;
@@ -44,6 +45,7 @@ __wt_block_compact_end(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     /* Restore the original allocation plan. */
     __wt_block_configure_first_fit(block, false);
+    block->compacting = false;
 
     /* Dump the results of the compaction pass. */
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_COMPACT, WT_VERBOSE_DEBUG_1)) {
@@ -51,6 +53,7 @@ __wt_block_compact_end(WT_SESSION_IMPL *session, WT_BLOCK *block)
         __block_dump_file_stat(session, block, false);
         __wt_spin_unlock(session, &block->live_lock);
     }
+
     return (0);
 }
 

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -19,14 +19,14 @@ __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_UNUSED(session);
 
-    if (block->compacting)
+    if (block->compact_session_id != WT_SESSION_ID_INVALID)
         return (EBUSY);
 
     /* Switch to first-fit allocation. */
     __wt_block_configure_first_fit(block, true);
 
     /* Reset the compaction state information. */
-    block->compacting = true;
+    block->compact_session_id = session->id;
     block->compact_pct_tenths = 0;
     block->compact_bytes_reviewed = 0;
     block->compact_bytes_rewritten = 0;
@@ -48,7 +48,7 @@ __wt_block_compact_end(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     /* Restore the original allocation plan. */
     __wt_block_configure_first_fit(block, false);
-    block->compacting = false;
+    block->compact_session_id = WT_SESSION_ID_INVALID;
 
     /* Dump the results of the compaction pass. */
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_COMPACT, WT_VERBOSE_DEBUG_1)) {

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -48,6 +48,9 @@ __wt_block_compact_end(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     /* Restore the original allocation plan. */
     __wt_block_configure_first_fit(block, false);
+
+    /* Ensure this the same session that started compaction. */
+    WT_ASSERT(session, block->compact_session_id == session->id);
     block->compact_session_id = WT_SESSION_ID_INVALID;
 
     /* Dump the results of the compaction pass. */

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -19,6 +19,9 @@ __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     WT_UNUSED(session);
 
+    if (block->compacting)
+        return (EBUSY);
+
     /* Switch to first-fit allocation. */
     __wt_block_configure_first_fit(block, true);
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -272,6 +272,9 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     if (!forced_salvage)
         WT_ERR(__desc_read(session, allocsize, block));
 
+    /* The block should not be compacted at that time. */
+    block->compact_session_id = WT_SESSION_ID_INVALID;
+
     /* Block is valid, so make it visible in the connection. */
     WT_CONN_BLOCK_INSERT(conn, block, bucket);
 

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -198,6 +198,7 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     /* Basic structure allocation, initialization. */
     WT_ERR(__wt_calloc_one(session, &block));
     WT_ERR(__wt_strdup(session, filename, &block->name));
+    block->compact_session_id = WT_SESSION_ID_INVALID;
     block->objectid = objectid;
     block->ref = 1;
 
@@ -271,9 +272,6 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
      */
     if (!forced_salvage)
         WT_ERR(__desc_read(session, allocsize, block));
-
-    /* The block should not be compacted at that time. */
-    block->compact_session_id = WT_SESSION_ID_INVALID;
 
     /* Block is valid, so make it visible in the connection. */
     WT_CONN_BLOCK_INSERT(conn, block, bucket);

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -285,7 +285,6 @@ struct __wt_block {
     WT_CKPT *final_ckpt; /* Final live checkpoint write */
 
     /* Compaction support */
-    bool compacting;                           /* Compaction in progress */
     int compact_pct_tenths;                    /* Percent to compact */
     uint64_t compact_bytes_reviewed;           /* Bytes reviewed */
     uint64_t compact_bytes_rewritten;          /* Bytes rewritten */
@@ -294,6 +293,7 @@ struct __wt_block {
     uint64_t compact_pages_rewritten;          /* Pages rewritten */
     uint64_t compact_pages_rewritten_expected; /* The expected number of pages to rewrite */
     uint64_t compact_pages_skipped;            /* Pages skipped */
+    uint32_t compact_session_id;               /* Session compacting */
 
     /* Salvage support */
     wt_off_t slvg_off; /* Salvage file offset */

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -285,6 +285,7 @@ struct __wt_block {
     WT_CKPT *final_ckpt; /* Final live checkpoint write */
 
     /* Compaction support */
+    bool compacting;                           /* Compaction in progress */
     int compact_pct_tenths;                    /* Percent to compact */
     uint64_t compact_bytes_reviewed;           /* Bytes reviewed */
     uint64_t compact_bytes_rewritten;          /* Bytes rewritten */

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -234,9 +234,14 @@ thread_run(void *arg)
         if (compaction && i >= (100 * WT_THOUSAND) && i % (100 * WT_THOUSAND) == 0) {
             printf("Running compaction in Thread %" PRIu32 "\n", td->id);
             if (columnar_table)
-                testutil_check(session->compact(session, col_uri, NULL));
+                ret = session->compact(session, col_uri, NULL);
             else
-                testutil_check(session->compact(session, uri, NULL));
+                ret = session->compact(session, uri, NULL);
+            /*
+             * We may have several sessions trying to compact the same URI, in this case, EBUSY is
+             * returned.
+             */
+            testutil_assert(ret == 0 || ret == EBUSY);
         }
 
         /*

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -2252,12 +2252,6 @@ config_compact(void)
 {
     char buf[128];
 
-    /* FIXME-WT-11432: Background and foreground compaction should not be executed in parallel. */
-    if (config_explicit(NULL, "background_compact") && GV(BACKGROUND_COMPACT) &&
-      config_explicit(NULL, "ops.compaction") && GV(OPS_COMPACTION))
-        testutil_die(EINVAL,
-          "%s: Background and foreground compaction cannot be enabled at the same time", progname);
-
     /* Compaction does not work on in-memory databases, disable it. */
     if (GV(RUNS_IN_MEMORY)) {
         if (config_explicit(NULL, "background_compact") && GV(BACKGROUND_COMPACT))
@@ -2268,21 +2262,6 @@ config_compact(void)
               EINVAL, "%s: Foreground compaction cannot be enabled for in-memory runs", progname);
         config_off(NULL, "background_compact");
         config_off(NULL, "ops.compaction");
-    }
-
-    /*
-     * FIXME-WT-11432: If both are enabled, disable the one that is not explicitly set or choose one
-     * randomly.
-     */
-    if (GV(BACKGROUND_COMPACT) && GV(OPS_COMPACTION)) {
-        if (config_explicit(NULL, "background_compact"))
-            config_off(NULL, "ops.compaction");
-        else if (config_explicit(NULL, "ops.compaction"))
-            config_off(NULL, "background_compact");
-        else if (mmrand(&g.data_rnd, 1, 2) == 1)
-            config_off(NULL, "background_compact");
-        else
-            config_off(NULL, "ops.compaction");
     }
 
     /* Generate values if not explicit set. */

--- a/test/suite/test_compact07.py
+++ b/test/suite/test_compact07.py
@@ -176,7 +176,7 @@ class test_compact07(wttest.WiredTigerTestCase):
         # Check that foreground compaction has done some work on the small table.
         self.assertGreater(self.get_pages_rewritten(uri_small), 0)
 
-        # Stop the background compaction server before proceeding.
+        # Stop the background compaction server.
         self.session.compact(None, 'background=false')
 
         # Wait for the background compaction server to stop running.

--- a/test/suite/test_compact07.py
+++ b/test/suite/test_compact07.py
@@ -129,10 +129,9 @@ class test_compact07(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Delete the first 90%.
-        delete_range = 90 * self.table_numkv // 100
         for i in range(self.n_tables):
             uri = self.uri_prefix + f'_{i}'
-            self.delete_range(uri, delete_range)
+            self.delete_range(uri, 90 * self.table_numkv // 100)
 
         # Write to disk.
         self.session.checkpoint()
@@ -169,8 +168,15 @@ class test_compact07(wttest.WiredTigerTestCase):
         self.assertGreater(success, 0)
         stat_cursor.close()
 
-        # FIXME-WT-11432: Background and foreground compaction should not run in parallel, stop the
-        # background compaction server before proceeding.
+        # Perform foreground compaction on the remaining file by setting a free_space_target value
+        # that is guaranteed to run on it. This call might return EBUSY if background compaction is
+        # inspecting it at the same time.
+        self.compactUntilSuccess(self.session, uri_small, 'free_space_target=1MB')
+
+        # Check that foreground compaction has done some work on the small table.
+        self.assertGreater(self.get_pages_rewritten(uri_small), 0)
+
+        # Stop the background compaction server before proceeding.
         self.session.compact(None, 'background=false')
 
         # Wait for the background compaction server to stop running.
@@ -183,13 +189,6 @@ class test_compact07(wttest.WiredTigerTestCase):
         # Background compaction may be have been inspecting a table when disabled which is
         # considered as an interruption, ignore that message.
         self.ignoreStderrPatternIfExists('background compact interrupted by application')
-
-        # Perform foreground compaction on the remaining file by setting a free_space_target value
-        # that is guaranteed to run on it.
-        self.session.compact(uri_small, f'free_space_target=1MB')
-
-        # Check that foreground compaction has done some work on the small table.
-        self.assertGreater(self.get_pages_rewritten(uri_small), 0)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -1021,6 +1021,15 @@ class WiredTigerTestCase(unittest.TestCase):
         if self.runningHook('tiered'):
             self.skipTest('Test requires removal from cloud storage, which is not yet permitted')
 
+    def compactUntilSuccess(self, session, uri, config=None):
+        while True:
+            try:
+                session.compact(uri, config)
+                return
+            except wiredtiger.WiredTigerError as err:
+                if str(err) != os.strerror(errno.EBUSY):
+                    raise err
+
     def dropUntilSuccess(self, session, uri, config=None):
         # Most test cases consider a drop, and especially a 'drop until success',
         # to completely remove a file's artifacts, so that the name can be reused.


### PR DESCRIPTION
The new changes since #9547 are in the commit b57b76f44249cd13dcd86aea077f38e25bb3a9b3. The test `test/csuite/random_abort/main.c` is updated as parallel compaction occurs in this test and `EBUSY` can be returned.