### PR TITLE
WT11554 Generate comments for log_auto.c

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import os, re, sys, textwrap
 from dist import compare_srcfile, format_srcfile
 import log_data
 
@@ -136,6 +135,10 @@ tfile.write('/* DO NOT EDIT: automatically built by dist/log.py. */\n')
 tfile.write('''
 #include "wt_internal.h"
 
+/*
+ * __wt_logrec_alloc --
+ *\tAllocate a new WT_ITEM structure.
+ */
 int
 __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
 {
@@ -152,12 +155,20 @@ __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
 \treturn (0);
 }
 
+/*
+ * __wt_logrec_free --
+ *\tFree the given WT_ITEM structure.
+ */
 void
 __wt_logrec_free(WT_SESSION_IMPL *session, WT_ITEM **logrecp)
 {
 \t__wt_scr_free(session, logrecp);
 }
 
+/*
+ * __wt_logrec_read --
+ *\tRead the record type.
+ */
 int
 __wt_logrec_read(WT_SESSION_IMPL *session,
     const uint8_t **pp, const uint8_t *end, uint32_t *rectypep)
@@ -170,6 +181,10 @@ __wt_logrec_read(WT_SESSION_IMPL *session,
 \treturn (0);
 }
 
+/*
+ * __wt_logop_read --
+ *\tRead the operation type.
+ */
 int
 __wt_logop_read(WT_SESSION_IMPL *session,
     const uint8_t **pp, const uint8_t *end,
@@ -179,6 +194,10 @@ __wt_logop_read(WT_SESSION_IMPL *session,
 \t    session, *pp, WT_PTRDIFF(end, *pp), "II", optypep, opsizep));
 }
 
+/*
+ * __logrec_make_json_str --
+ *\tUnpack a string into JSON escaped format.
+ */
 static int
 __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *item)
 {
@@ -195,6 +214,10 @@ __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *it
 \treturn (0);
 }
 
+/*
+ * __logrec_make_hex_str --
+ *\tConvert data to a hexadecimal representation.
+ */
 static int
 __logrec_make_hex_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *item)
 {
@@ -214,6 +237,10 @@ __logrec_make_hex_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *ite
 # Emit code to read, write and print log operations (within a log record)
 for optype in log_data.optypes:
     tfile.write('''
+/*
+ * __wt_logop_%(name)s_pack --
+ *\tPack the log operation %(name)s.
+ */
 int
 __wt_logop_%(name)s_pack(
     WT_SESSION_IMPL *session, WT_ITEM *logrec%(comma)s
@@ -249,6 +276,10 @@ __wt_logop_%(name)s_pack(
 })
 
     tfile.write('''
+/*
+ * __wt_logop_%(name)s_unpack --
+ *\tUnpack the log operation %(name)s.
+ */
 int
 __wt_logop_%(name)s_unpack(
     WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end%(comma)s
@@ -277,6 +308,10 @@ __wt_logop_%(name)s_unpack(
 })
 
     tfile.write('''
+/*
+ * __wt_logop_%(name)s_print --
+ *\tPrint the log operation %(name)s.
+ */
 int
 __wt_logop_%(name)s_print(WT_SESSION_IMPL *session,
     const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -308,6 +343,10 @@ __wt_logop_%(name)s_print(WT_SESSION_IMPL *session,
 
 # Emit the printlog entry point
 tfile.write('''
+/*
+ * __wt_txn_op_printlog --
+ *\tPrint operation from a log cookie.
+ */
 int
 __wt_txn_op_printlog(WT_SESSION_IMPL *session,
     const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -2,6 +2,10 @@
 
 #include "wt_internal.h"
 
+/*
+ * __wt_logrec_alloc --
+ *     Allocate a new WT_ITEM structure.
+ */
 int
 __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
 {
@@ -17,12 +21,20 @@ __wt_logrec_alloc(WT_SESSION_IMPL *session, size_t size, WT_ITEM **logrecp)
     return (0);
 }
 
+/*
+ * __wt_logrec_free --
+ *     Free the given WT_ITEM structure.
+ */
 void
 __wt_logrec_free(WT_SESSION_IMPL *session, WT_ITEM **logrecp)
 {
     __wt_scr_free(session, logrecp);
 }
 
+/*
+ * __wt_logrec_read --
+ *     Read the record type.
+ */
 int
 __wt_logrec_read(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, uint32_t *rectypep)
@@ -35,6 +47,10 @@ __wt_logrec_read(
     return (0);
 }
 
+/*
+ * __wt_logop_read --
+ *     Read the operation type.
+ */
 int
 __wt_logop_read(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, uint32_t *optypep,
   uint32_t *opsizep)
@@ -42,6 +58,10 @@ __wt_logop_read(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end
     return (__wt_struct_unpack(session, *pp, WT_PTRDIFF(end, *pp), "II", optypep, opsizep));
 }
 
+/*
+ * __logrec_make_json_str --
+ *     Unpack a string into JSON escaped format.
+ */
 static int
 __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *item)
 {
@@ -58,6 +78,10 @@ __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *it
     return (0);
 }
 
+/*
+ * __logrec_make_hex_str --
+ *     Convert data to a hexadecimal representation.
+ */
 static int
 __logrec_make_hex_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *item)
 {
@@ -73,6 +97,10 @@ __logrec_make_hex_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *ite
     return (0);
 }
 
+/*
+ * __wt_logop_col_modify_pack --
+ *     Pack the log operation col_modify.
+ */
 int
 __wt_logop_col_modify_pack(
   WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid, uint64_t recno, WT_ITEM *value)
@@ -94,6 +122,10 @@ __wt_logop_col_modify_pack(
     return (0);
 }
 
+/*
+ * __wt_logop_col_modify_unpack --
+ *     Unpack the log operation col_modify.
+ */
 int
 __wt_logop_col_modify_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, uint64_t *recnop, WT_ITEM *valuep)
@@ -111,6 +143,10 @@ __wt_logop_col_modify_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
     return (0);
 }
 
+/*
+ * __wt_logop_col_modify_print --
+ *     Print the log operation col_modify.
+ */
 int
 __wt_logop_col_modify_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -143,6 +179,10 @@ err:
     return (ret);
 }
 
+/*
+ * __wt_logop_col_put_pack --
+ *     Pack the log operation col_put.
+ */
 int
 __wt_logop_col_put_pack(
   WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid, uint64_t recno, WT_ITEM *value)
@@ -164,6 +204,10 @@ __wt_logop_col_put_pack(
     return (0);
 }
 
+/*
+ * __wt_logop_col_put_unpack --
+ *     Unpack the log operation col_put.
+ */
 int
 __wt_logop_col_put_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, uint64_t *recnop, WT_ITEM *valuep)
@@ -181,6 +225,10 @@ __wt_logop_col_put_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const ui
     return (0);
 }
 
+/*
+ * __wt_logop_col_put_print --
+ *     Print the log operation col_put.
+ */
 int
 __wt_logop_col_put_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -213,6 +261,10 @@ err:
     return (ret);
 }
 
+/*
+ * __wt_logop_col_remove_pack --
+ *     Pack the log operation col_remove.
+ */
 int
 __wt_logop_col_remove_pack(
   WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid, uint64_t recno)
@@ -234,6 +286,10 @@ __wt_logop_col_remove_pack(
     return (0);
 }
 
+/*
+ * __wt_logop_col_remove_unpack --
+ *     Unpack the log operation col_remove.
+ */
 int
 __wt_logop_col_remove_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, uint64_t *recnop)
@@ -251,6 +307,10 @@ __wt_logop_col_remove_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
     return (0);
 }
 
+/*
+ * __wt_logop_col_remove_print --
+ *     Print the log operation col_remove.
+ */
 int
 __wt_logop_col_remove_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -270,6 +330,10 @@ __wt_logop_col_remove_print(
     return (0);
 }
 
+/*
+ * __wt_logop_col_truncate_pack --
+ *     Pack the log operation col_truncate.
+ */
 int
 __wt_logop_col_truncate_pack(
   WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid, uint64_t start, uint64_t stop)
@@ -291,6 +355,10 @@ __wt_logop_col_truncate_pack(
     return (0);
 }
 
+/*
+ * __wt_logop_col_truncate_unpack --
+ *     Unpack the log operation col_truncate.
+ */
 int
 __wt_logop_col_truncate_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, uint64_t *startp, uint64_t *stopp)
@@ -308,6 +376,10 @@ __wt_logop_col_truncate_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, con
     return (0);
 }
 
+/*
+ * __wt_logop_col_truncate_print --
+ *     Print the log operation col_truncate.
+ */
 int
 __wt_logop_col_truncate_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -329,6 +401,10 @@ __wt_logop_col_truncate_print(
     return (0);
 }
 
+/*
+ * __wt_logop_row_modify_pack --
+ *     Pack the log operation row_modify.
+ */
 int
 __wt_logop_row_modify_pack(
   WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid, WT_ITEM *key, WT_ITEM *value)
@@ -350,6 +426,10 @@ __wt_logop_row_modify_pack(
     return (0);
 }
 
+/*
+ * __wt_logop_row_modify_unpack --
+ *     Unpack the log operation row_modify.
+ */
 int
 __wt_logop_row_modify_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, WT_ITEM *keyp, WT_ITEM *valuep)
@@ -367,6 +447,10 @@ __wt_logop_row_modify_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
     return (0);
 }
 
+/*
+ * __wt_logop_row_modify_print --
+ *     Print the log operation row_modify.
+ */
 int
 __wt_logop_row_modify_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -405,6 +489,10 @@ err:
     return (ret);
 }
 
+/*
+ * __wt_logop_row_put_pack --
+ *     Pack the log operation row_put.
+ */
 int
 __wt_logop_row_put_pack(
   WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid, WT_ITEM *key, WT_ITEM *value)
@@ -426,6 +514,10 @@ __wt_logop_row_put_pack(
     return (0);
 }
 
+/*
+ * __wt_logop_row_put_unpack --
+ *     Unpack the log operation row_put.
+ */
 int
 __wt_logop_row_put_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, WT_ITEM *keyp, WT_ITEM *valuep)
@@ -443,6 +535,10 @@ __wt_logop_row_put_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const ui
     return (0);
 }
 
+/*
+ * __wt_logop_row_put_print --
+ *     Print the log operation row_put.
+ */
 int
 __wt_logop_row_put_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -481,6 +577,10 @@ err:
     return (ret);
 }
 
+/*
+ * __wt_logop_row_remove_pack --
+ *     Pack the log operation row_remove.
+ */
 int
 __wt_logop_row_remove_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid, WT_ITEM *key)
 {
@@ -501,6 +601,10 @@ __wt_logop_row_remove_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t f
     return (0);
 }
 
+/*
+ * __wt_logop_row_remove_unpack --
+ *     Unpack the log operation row_remove.
+ */
 int
 __wt_logop_row_remove_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, WT_ITEM *keyp)
@@ -518,6 +622,10 @@ __wt_logop_row_remove_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
     return (0);
 }
 
+/*
+ * __wt_logop_row_remove_print --
+ *     Print the log operation row_remove.
+ */
 int
 __wt_logop_row_remove_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -548,6 +656,10 @@ err:
     return (ret);
 }
 
+/*
+ * __wt_logop_row_truncate_pack --
+ *     Pack the log operation row_truncate.
+ */
 int
 __wt_logop_row_truncate_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t fileid,
   WT_ITEM *start, WT_ITEM *stop, uint32_t mode)
@@ -569,6 +681,10 @@ __wt_logop_row_truncate_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint32_t
     return (0);
 }
 
+/*
+ * __wt_logop_row_truncate_unpack --
+ *     Unpack the log operation row_truncate.
+ */
 int
 __wt_logop_row_truncate_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint32_t *fileidp, WT_ITEM *startp, WT_ITEM *stopp, uint32_t *modep)
@@ -586,6 +702,10 @@ __wt_logop_row_truncate_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, con
     return (0);
 }
 
+/*
+ * __wt_logop_row_truncate_print --
+ *     Print the log operation row_truncate.
+ */
 int
 __wt_logop_row_truncate_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -626,6 +746,10 @@ err:
     return (ret);
 }
 
+/*
+ * __wt_logop_checkpoint_start_pack --
+ *     Pack the log operation checkpoint_start.
+ */
 int
 __wt_logop_checkpoint_start_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec)
 {
@@ -646,6 +770,10 @@ __wt_logop_checkpoint_start_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec)
     return (0);
 }
 
+/*
+ * __wt_logop_checkpoint_start_unpack --
+ *     Unpack the log operation checkpoint_start.
+ */
 int
 __wt_logop_checkpoint_start_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end)
 {
@@ -661,6 +789,10 @@ __wt_logop_checkpoint_start_unpack(WT_SESSION_IMPL *session, const uint8_t **pp,
     return (0);
 }
 
+/*
+ * __wt_logop_checkpoint_start_print --
+ *     Print the log operation checkpoint_start.
+ */
 int
 __wt_logop_checkpoint_start_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -673,6 +805,10 @@ __wt_logop_checkpoint_start_print(
     return (0);
 }
 
+/*
+ * __wt_logop_prev_lsn_pack --
+ *     Pack the log operation prev_lsn.
+ */
 int
 __wt_logop_prev_lsn_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, WT_LSN *prev_lsn)
 {
@@ -693,6 +829,10 @@ __wt_logop_prev_lsn_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, WT_LSN *prev
     return (0);
 }
 
+/*
+ * __wt_logop_prev_lsn_unpack --
+ *     Unpack the log operation prev_lsn.
+ */
 int
 __wt_logop_prev_lsn_unpack(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_LSN *prev_lsnp)
@@ -710,6 +850,10 @@ __wt_logop_prev_lsn_unpack(
     return (0);
 }
 
+/*
+ * __wt_logop_prev_lsn_print --
+ *     Print the log operation prev_lsn.
+ */
 int
 __wt_logop_prev_lsn_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -724,6 +868,10 @@ __wt_logop_prev_lsn_print(
     return (0);
 }
 
+/*
+ * __wt_logop_txn_timestamp_pack --
+ *     Pack the log operation txn_timestamp.
+ */
 int
 __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint64_t time_sec,
   uint64_t time_nsec, uint64_t commit_ts, uint64_t durable_ts, uint64_t first_commit_ts,
@@ -747,6 +895,10 @@ __wt_logop_txn_timestamp_pack(WT_SESSION_IMPL *session, WT_ITEM *logrec, uint64_
     return (0);
 }
 
+/*
+ * __wt_logop_txn_timestamp_unpack --
+ *     Unpack the log operation txn_timestamp.
+ */
 int
 __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   uint64_t *time_secp, uint64_t *time_nsecp, uint64_t *commit_tsp, uint64_t *durable_tsp,
@@ -766,6 +918,10 @@ __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, co
     return (0);
 }
 
+/*
+ * __wt_logop_txn_timestamp_print --
+ *     Print the log operation txn_timestamp.
+ */
 int
 __wt_logop_txn_timestamp_print(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)
@@ -793,6 +949,10 @@ __wt_logop_txn_timestamp_print(
     return (0);
 }
 
+/*
+ * __wt_txn_op_printlog --
+ *     Print operation from a log cookie.
+ */
 int
 __wt_txn_op_printlog(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, WT_TXN_PRINTLOG_ARGS *args)


### PR DESCRIPTION
The comments have been updated in `dist/log.py` and `s_all` took care of updating `log_auto.c`.