### PR TITLE
WT-10823 Skip applying functions to tiered objects.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -716,7 +716,8 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
                 goto done;
 
             if (!F_ISSET(dhandle, WT_DHANDLE_OPEN) || F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
-              !WT_DHANDLE_BTREE(dhandle) || dhandle->checkpoint != NULL || WT_IS_METADATA(dhandle))
+              !WT_DHANDLE_BTREE(dhandle) || dhandle->checkpoint != NULL ||
+              WT_IS_METADATA(dhandle) || WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
                 continue;
             WT_ERR(__conn_btree_apply_internal(session, dhandle, file_func, name_func, cfg));
         }


### PR DESCRIPTION
I was able to reproduce this immediately. I think that the btree apply function should not operate on individual objects. The btree apply function is called from statistics logging and checkpoint only. Both should just operate on the actual btree. So this change skips objects.