### PR TITLE
WT-11564 Fix RTS to read the newest_txn value only when it exists in the checkpoint

### DIFF
--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -196,7 +196,7 @@ __wt_rts_btree_walk_btree_apply(
         }
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "newest_txn", &value);
-        if (value.len != 0)
+        if (ret == 0)
             rollback_txnid = (uint64_t)value.val;
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "addr", &value);


### PR DESCRIPTION
Reading the value when it doesn't exist has a junk value and it lead to open the file unnecesary for rollback to stable operation to validate it for correctness. This can cause problem when the database has large number of files.