### PR TITLE
WT-11492 Fix false positive failure in test_checkpoint_snapshot05

### DIFF
--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -112,10 +112,6 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
         s.close()
 
     def test_checkpoint_snapshot(self):
-        # FIXME - WT-11492 Re-enable this test once WT-11492 is fixed.
-        if os.name == 'nt':
-            self.skipTest('Skip this test on Windows until WT-11492 is fixed')
-
         self.moresetup()
 
         ds = SimpleDataSet(self, self.uri, 0, \
@@ -147,7 +143,7 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
 
         # Create a checkpoint thread
         done = threading.Event()
-        ckpt = checkpoint_thread(self.conn, done)
+        ckpt = checkpoint_thread(self.conn, done, checkpoint_count_max=1)
         try:
             ckpt.start()
             

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -30,17 +30,40 @@ import os, queue, random, shutil, threading, time, wiredtiger, wttest
 from helper import compare_tables
 
 class checkpoint_thread(threading.Thread):
-    def __init__(self, conn, done):
+    def __init__(self, conn, done, **kwargs):
+        """
+        Keyword Args:
+            checkpoint_count_max (int): Maximum number of checkpoints to initiate. Must be greater
+                than zero. Thread will exit if done is signalled, or maximum number of checkpoints
+                is reached.
+        """
         self.conn = conn
         self.done = done
+
+        self.continue_checkpointing = lambda: True
+        self.checkpoint_count = 0
+        
+        if "checkpoint_count_max" in kwargs:
+            count_max = int(kwargs["checkpoint_count_max"])
+            if count_max <= 0:
+                raise ValueError("checkpoint_count_max must be a positive integer")
+            self._max_count = count_max
+        else:
+            # Infinite checkpoints, so run until signalled.
+            self._max_count = 0
+
         threading.Thread.__init__(self)
+
+    def reached_max_count(self):
+        return self._max_count > 0 and self.checkpoint_count >= self._max_count
 
     def run(self):
         sess = self.conn.open_session()
-        while not self.done.is_set():
+        while not self.done.is_set() and not self.reached_max_count():
             # Sleep for 10 milliseconds.
             time.sleep(0.001)
             sess.checkpoint()
+            self.checkpoint_count += 1
         sess.close()
 
 class named_checkpoint_thread(threading.Thread):

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -39,8 +39,6 @@ class checkpoint_thread(threading.Thread):
         """
         self.conn = conn
         self.done = done
-
-        self.continue_checkpointing = lambda: True
         self.checkpoint_count = 0
         
         if "checkpoint_count_max" in kwargs:

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -47,7 +47,7 @@ class checkpoint_thread(threading.Thread):
                 raise ValueError("checkpoint_count_max must be a positive integer")
             self._max_count = count_max
         else:
-            # Infinite checkpoints, so run until signalled.
+            # Infinite checkpoints: run until signalled.
             self._max_count = 0
 
         threading.Thread.__init__(self)


### PR DESCRIPTION
Test fails due to the presence of more than 1 checkpoint.
Add new interface to allow tests to specify maximum checkpoint count.