### PR TITLE
WT-11499 Add "force_stop" test to timestamp_abort

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -1712,7 +1712,10 @@ main(int argc, char *argv[])
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
 
-    /* FIXME-WT-11297 Enable force_stop testing after this issue is fixed. */
+    /*
+     * FIXME-WT-11297 Enable force_stop testing after this issue is fixed. We can set this value to
+     * 3 if we would like more frequent testing, but also something larger such as 5 would work too.
+     */
     backup_force_stop_interval = 0;
     backup_full_interval = 4;
     backup_granularity_kb = 1024;

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -666,7 +666,7 @@ backup_delete_old_backups(int retain)
 
                 /* Check if this is a full backup - we'd like to keep at least one. */
                 testutil_snprintf(buf, sizeof(buf), "%s/full", dir->d_name);
-                if (stat(buf, &sb) != 0 && errno == ENOENT)
+                if (stat(buf, &sb) == 0)
                     last_full = WT_MAX(last_full, i);
 
                 /* If we have too many backups, finish next time. */

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -71,7 +71,7 @@ static char home[1024]; /* Program working dir */
 #define BACKUP_BASE "backup."
 #define CHECK_BASE "check."
 #define INVALID_KEY UINT64_MAX
-#define MAX_BACKUP_INVL 5 /* Maximum interval between backups */
+#define MAX_BACKUP_INVL 4 /* Maximum interval between backups */
 #define MAX_CKPT_INVL 5   /* Maximum interval between checkpoints */
 #define MAX_TH 200        /* Maximum configurable threads */
 #define MAX_TIME 40
@@ -96,9 +96,9 @@ static const char *const uri_shadow = "shadow";
 
 static const char *const ckpt_file = "checkpoint_done";
 
-static bool backup_test_force_stop, backup_verify_immediately, backup_verify_quick;
+static bool backup_verify_immediately, backup_verify_quick;
 static bool columns, stress, use_backups, use_lazyfs, use_ts;
-static uint32_t backup_full_interval, backup_granularity_kb;
+static uint32_t backup_force_stop_interval, backup_full_interval, backup_granularity_kb;
 
 static TEST_OPTS *opts, _opts;
 
@@ -166,9 +166,6 @@ extern char *__wt_optarg;
 
 /* Get back the workload iteration number from a backup index. */
 #define BACKUP_INDEX_TO_ITERATION(index) ((index) / WT_THOUSAND)
-
-/* Get back the sequence number from a backup index. */
-#define BACKUP_INDEX_TO_SEQUENCE(index) ((index) % WT_THOUSAND)
 
 typedef struct {
     uint64_t absent_key; /* Last absent key */
@@ -299,7 +296,8 @@ handle_error(WT_EVENT_HANDLER *handler, WT_SESSION *session, int error, const ch
     (void)(error);
 
     /* Ignore complaints about incremental backup not being configured. */
-    if (backup_test_force_stop && strstr(errmsg, "Incremental backup is not configured") != NULL)
+    if (backup_force_stop_interval > 0 &&
+      strstr(errmsg, "Incremental backup is not configured") != NULL)
         return (0);
 
     return (fprintf(stderr, "%s\n", errmsg) < 0 ? -1 : 0);
@@ -469,6 +467,11 @@ backup_create_full(WT_CONNECTION *conn, bool consolidate, uint32_t index)
     testutil_check(cursor->close(cursor));
     testutil_check(session->close(session, NULL));
 
+    /* Remember that this was a full backup. */
+    testutil_snprintf(buf, sizeof(buf), "%s/full", backup_home);
+    testutil_assert_errno((fp = fopen(buf, "w")) != NULL);
+    testutil_assert_errno(fclose(fp) == 0);
+
     /* Remember that the backup finished successfully. */
     testutil_snprintf(buf, sizeof(buf), "%s/done", backup_home);
     testutil_assert_errno((fp = fopen(buf, "w")) != NULL);
@@ -632,16 +635,17 @@ backup_create_incremental(WT_CONNECTION *conn, uint32_t src_index, uint32_t inde
  *     no good reason.
  */
 static void
-backup_delete_old_backups(int retain, int last_full)
+backup_delete_old_backups(int retain)
 {
     struct dirent *dir;
     struct stat sb;
     DIR *d;
     size_t len;
-    int count, i, indexes[256], ndeleted;
+    int count, i, indexes[256], last_full, ndeleted;
     char buf[256];
     bool done;
 
+    last_full = 0;
     len = strlen(BACKUP_BASE);
     ndeleted = 0;
     do {
@@ -651,8 +655,6 @@ backup_delete_old_backups(int retain, int last_full)
         while ((dir = readdir(d)) != NULL) {
             if (strncmp(dir->d_name, BACKUP_BASE, len) == 0) {
                 i = atoi(dir->d_name + len);
-                if (i == last_full)
-                    continue;
                 indexes[count++] = i;
 
                 /* If the backup failed to finish, delete it right away. */
@@ -661,6 +663,11 @@ backup_delete_old_backups(int retain, int last_full)
                     testutil_remove(dir->d_name);
                     ndeleted++;
                 }
+
+                /* Check if this is a full backup - we'd like to keep at least one. */
+                testutil_snprintf(buf, sizeof(buf), "%s/full", dir->d_name);
+                if (stat(buf, &sb) != 0 && errno == ENOENT)
+                    last_full = WT_MAX(last_full, i);
 
                 /* If we have too many backups, finish next time. */
                 if (count >= (int)(sizeof(indexes) / sizeof(*indexes))) {
@@ -675,6 +682,8 @@ backup_delete_old_backups(int retain, int last_full)
 
         __wt_qsort(indexes, (size_t)count, sizeof(*indexes), __int_comparator);
         for (i = 0; i < count - retain; i++) {
+            if (indexes[i] == last_full)
+                continue;
             testutil_snprintf(buf, sizeof(buf), BACKUP_BASE "%d", indexes[i]);
             testutil_remove(buf);
             ndeleted++;
@@ -801,12 +810,17 @@ thread_backup_run(void *arg)
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_SESSION *session;
-    uint32_t i, last_backup, last_full, sleep_time, u;
+    uint32_t force_stop_offset, full_offset, i, last_backup, sleep_time, u;
     char *str;
     char buf[1024];
 
     td = (THREAD_DATA *)arg;
-    last_backup = last_full = 0;
+    last_backup = 0;
+
+    /* Pick random points for starting the full backup and force stop backup cycles. */
+    force_stop_offset =
+      backup_force_stop_interval > 0 ? __wt_random(&td->extra_rnd) % backup_force_stop_interval : 0;
+    full_offset = backup_full_interval > 0 ? __wt_random(&td->extra_rnd) % backup_full_interval : 0;
 
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
 
@@ -838,14 +852,6 @@ thread_backup_run(void *arg)
             printf("Found backup %" PRIu32 "\n", u);
             if (u > last_backup)
                 last_backup = u;
-
-            /* Is it a full backup? */
-            if (u == 1 ||
-              (backup_full_interval > 0 &&
-                BACKUP_INDEX_TO_SEQUENCE(u) % backup_full_interval == 0)) {
-                if (u > last_full)
-                    last_full = u;
-            }
         }
         testutil_assert(ret == WT_NOTFOUND);
         testutil_check(cursor->close(cursor));
@@ -859,24 +865,25 @@ create:
         sleep_time = __wt_random(&td->extra_rnd) % MAX_BACKUP_INVL;
         __wt_sleep(sleep_time, 0);
 
-        if (backup_test_force_stop && i % 2 == 0) {
+        if (backup_force_stop_interval > 0 &&
+          (i + force_stop_offset) % backup_force_stop_interval == 0) {
             backup_force_stop(td->conn);
             last_backup = 0; /* Force creation of a new full backup. */
         }
 
         /* Create a backup. */
         u = BACKUP_INDEX(td, i);
-        if (last_backup == 0 || (backup_full_interval > 0 && i % backup_full_interval == 0)) {
+        if (last_backup == 0 ||
+          (backup_full_interval > 0 && (i + full_offset) % backup_full_interval == 0))
             backup_create_full(td->conn, __wt_random(&td->extra_rnd) % 2, u);
-            last_full = u;
-        } else
+        else
             backup_create_incremental(td->conn, last_backup, u);
 
         last_backup = u;
 
         /* Periodically delete old backups. */
         if (i % 5 == 0 || (td->workload_iteration > 1 && i == 1))
-            backup_delete_old_backups(5, (int)last_full);
+            backup_delete_old_backups(5);
     }
 
     /* NOTREACHED */
@@ -1705,10 +1712,11 @@ main(int argc, char *argv[])
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
 
+    /* FIXME-WT-11297 Enable force_stop testing after this issue is fixed. */
+    backup_force_stop_interval = 0;
     backup_full_interval = 4;
     backup_granularity_kb = 1024;
-    backup_test_force_stop = false;
-    backup_verify_immediately = true;
+    backup_verify_immediately = false;
     backup_verify_quick = false;
     columns = stress = false;
     nth = MIN_TH;
@@ -1723,7 +1731,7 @@ main(int argc, char *argv[])
 
     testutil_parse_begin_opt(argc, argv, SHARED_PARSE_OPTIONS, opts);
 
-    while ((ch = __wt_getopt(progname, argc, argv, "BcF:fI:LlsT:t:vz" SHARED_PARSE_OPTIONS)) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "BcF:I:LlsT:t:vz" SHARED_PARSE_OPTIONS)) != EOF)
         switch (ch) {
         case 'B':
             use_backups = true;
@@ -1734,9 +1742,6 @@ main(int argc, char *argv[])
             break;
         case 'F':
             backup_full_interval = (uint32_t)atoi(__wt_optarg);
-            break;
-        case 'f':
-            backup_test_force_stop = true;
             break;
         case 'I':
             num_iterations = (uint32_t)atoi(__wt_optarg);
@@ -1846,14 +1851,16 @@ main(int argc, char *argv[])
           "use: %s\n",
           opts->compat ? "true" : "false", opts->inmem ? "true" : "false",
           stress ? "true" : "false", use_ts ? "true" : "false");
+        printf("Parent: backups: %s, full backup interval: %" PRIu32
+               ", force stop interval: %" PRIu32 "\n",
+          use_backups ? "true" : "false", backup_full_interval, backup_force_stop_interval);
         printf("Parent: Create %" PRIu32 " threads; sleep %" PRIu32 " seconds\n", nth, timeout);
-        printf("CONFIG: %s%s%s%s%s%s%s%s%s%s -F %" PRIu32 " -h %s -I %" PRIu32 " -T %" PRIu32
+        printf("CONFIG: %s%s%s%s%s%s%s%s%s -F %" PRIu32 " -h %s -I %" PRIu32 " -T %" PRIu32
                " -t %" PRIu32 " " TESTUTIL_SEED_FORMAT "\n",
           progname, use_backups ? " -B" : "", opts->compat ? " -C" : "", columns ? " -c" : "",
-          backup_test_force_stop ? " -f" : "", use_lazyfs ? " -l" : "", opts->inmem ? " -m" : "",
-          opts->tiered_storage ? " -PT" : "", stress ? " -s" : "", !use_ts ? " -z" : "",
-          backup_full_interval, opts->home, num_iterations, nth, timeout, opts->data_seed,
-          opts->extra_seed);
+          use_lazyfs ? " -l" : "", opts->inmem ? " -m" : "", opts->tiered_storage ? " -PT" : "",
+          stress ? " -s" : "", !use_ts ? " -z" : "", backup_full_interval, opts->home,
+          num_iterations, nth, timeout, opts->data_seed, opts->extra_seed);
 
         /*
          * Go inside the home directory (typically WT_TEST), but not all the way into the database's

--- a/test/csuite/timestamp_abort/smoke.sh
+++ b/test/csuite/timestamp_abort/smoke.sh
@@ -28,11 +28,13 @@ $TEST_WRAPPER $test_bin $default_test_args
 $TEST_WRAPPER $test_bin $default_test_args -c
 #$TEST_WRAPPER $test_bin $default_test_args -L
 $TEST_WRAPPER $test_bin $default_test_args -B -I 3
+$TEST_WRAPPER $test_bin $default_test_args -B -I 3 -f
 $TEST_WRAPPER $test_bin -m $default_test_args
 $TEST_WRAPPER $test_bin -m $default_test_args -c
 #$TEST_WRAPPER $test_bin -m $default_test_args -L
 $TEST_WRAPPER $test_bin -C $default_test_args
 $TEST_WRAPPER $test_bin -C $default_test_args -c
 $TEST_WRAPPER $test_bin -C $default_test_args -B -I 3
+$TEST_WRAPPER $test_bin -C $default_test_args -B -I 3 -f
 $TEST_WRAPPER $test_bin -C -m $default_test_args
 $TEST_WRAPPER $test_bin -C -m $default_test_args -c

--- a/test/csuite/timestamp_abort/smoke.sh
+++ b/test/csuite/timestamp_abort/smoke.sh
@@ -28,13 +28,11 @@ $TEST_WRAPPER $test_bin $default_test_args
 $TEST_WRAPPER $test_bin $default_test_args -c
 #$TEST_WRAPPER $test_bin $default_test_args -L
 $TEST_WRAPPER $test_bin $default_test_args -B -I 3
-$TEST_WRAPPER $test_bin $default_test_args -B -I 3 -f
 $TEST_WRAPPER $test_bin -m $default_test_args
 $TEST_WRAPPER $test_bin -m $default_test_args -c
 #$TEST_WRAPPER $test_bin -m $default_test_args -L
 $TEST_WRAPPER $test_bin -C $default_test_args
 $TEST_WRAPPER $test_bin -C $default_test_args -c
 $TEST_WRAPPER $test_bin -C $default_test_args -B -I 3
-$TEST_WRAPPER $test_bin -C $default_test_args -B -I 3 -f
 $TEST_WRAPPER $test_bin -C -m $default_test_args
 $TEST_WRAPPER $test_bin -C -m $default_test_args -c


### PR DESCRIPTION
This PR adds a `-f` flag to `timestamp_abort`, which then performs `force_stop` before every other backup (is this too frequent?) and forces a new full backup to be created.