### PR TITLE
WT-11311 Address workgen issues and enable in evergreen

### DIFF
--- a/bench/workgen/runner/evict-btree-hs.py
+++ b/bench/workgen/runner/evict-btree-hs.py
@@ -157,7 +157,8 @@ logging_thread = Thread(ops)
 workload = Workload(context, 400 * thread0 + 100 * thread1 +\
                     10 * thread2 + 100 * thread3 + logging_thread)
 workload.options.report_interval=5
-workload.options.run_time=500
+# Run for 400 seconds due to the disk space requirements
+workload.options.run_time=400
 workload.options.max_latency=50000
 ret = workload.run(conn)
 assert ret == 0, ret

--- a/bench/workgen/runner/prepare_stress.py
+++ b/bench/workgen/runner/prepare_stress.py
@@ -192,7 +192,7 @@ workload.options.max_latency=50000
 # oldest_timestamp_lag - Number of seconds lag to the oldest_timestamp from current time.
 workload.options.oldest_timestamp_lag=60
 # stable_timestamp_lag - Number of seconds lag to the stable_timestamp from current time.
-workload.options.stable_timestamp_lag=20
+workload.options.stable_timestamp_lag=30
 # timestamp_advance is the number of seconds to wait before moving oldest and stable timestamp.
 workload.options.timestamp_advance=1
 ret = workload.run(conn)

--- a/bench/workgen/runner/prepare_stress.py
+++ b/bench/workgen/runner/prepare_stress.py
@@ -78,8 +78,7 @@ from workgen import *
 import time
 
 context = Context()
-#FIXME - WT-10494 Update the cache_size to 1GB after fixing this ticket.
-conn_config =   "cache_size=2G,checkpoint=(wait=60,log_size=2GB),\
+conn_config =   "cache_size=1G,checkpoint=(wait=60,log_size=2GB),\
                 eviction=(threads_min=12,threads_max=12),log=(enabled=true),session_max=800,\
                 debug_mode=(table_logging=true),\
                 eviction_target=60,statistics=(fast),statistics_log=(wait=1,json)"# explicitly added
@@ -98,8 +97,7 @@ for i in range(0, table_count):
     table = Table(tname)
     s.create(tname, wtperf_table_config +\
              compress_table_config + table_config + ",log=(enabled=false)")
-    #FIXME - WT-10494 Update the key_size to 200 after fixing this ticket.
-    table.options.key_size = 2000
+    table.options.key_size = 200
     table.options.value_size = 5000
     tables.append(table)
 
@@ -189,13 +187,12 @@ logging_thread.options.session_config="isolation=snapshot"
 workload = Workload(context, 50 * thread0 + 50 * thread1 +\
                     10 * thread2 + 100 * thread3 + logging_thread)
 workload.options.report_interval=5
-#FIXME - WT-10494 Update the run_time to 500 after fixing this ticket.
-workload.options.run_time=400
+workload.options.run_time=500
 workload.options.max_latency=50000
 # oldest_timestamp_lag - Number of seconds lag to the oldest_timestamp from current time.
-workload.options.oldest_timestamp_lag=30
+workload.options.oldest_timestamp_lag=60
 # stable_timestamp_lag - Number of seconds lag to the stable_timestamp from current time.
-workload.options.stable_timestamp_lag=10
+workload.options.stable_timestamp_lag=20
 # timestamp_advance is the number of seconds to wait before moving oldest and stable timestamp.
 workload.options.timestamp_advance=1
 ret = workload.run(conn)

--- a/bench/workgen/runner/prepare_stress.py
+++ b/bench/workgen/runner/prepare_stress.py
@@ -187,12 +187,12 @@ logging_thread.options.session_config="isolation=snapshot"
 workload = Workload(context, 50 * thread0 + 50 * thread1 +\
                     10 * thread2 + 100 * thread3 + logging_thread)
 workload.options.report_interval=5
-workload.options.run_time=500
+workload.options.run_time=400
 workload.options.max_latency=50000
 # oldest_timestamp_lag - Number of seconds lag to the oldest_timestamp from current time.
-workload.options.oldest_timestamp_lag=60
+workload.options.oldest_timestamp_lag=40
 # stable_timestamp_lag - Number of seconds lag to the stable_timestamp from current time.
-workload.options.stable_timestamp_lag=30
+workload.options.stable_timestamp_lag=20
 # timestamp_advance is the number of seconds to wait before moving oldest and stable timestamp.
 workload.options.timestamp_advance=1
 ret = workload.run(conn)

--- a/bench/workgen/runner/runner/core.py
+++ b/bench/workgen/runner/runner/core.py
@@ -290,8 +290,8 @@ def op_multi_table(ops_arg, tables, range_partition = False):
         ops = op_append(ops, op)
     return ops
 
-# should be 8 bytes format 'Q'
-_logkey = Key(Key.KEYGEN_APPEND, 8)
+# should be 8 bytes format 'Q', but for 'S' it needs to be larger for workgen tests
+_logkey = Key(Key.KEYGEN_APPEND, 12)
 def _op_log_op(op, log_table):
     keysize = op._key._size
     if keysize == 0:

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1275,15 +1275,15 @@ ThreadRunner::free_all()
         _rand_state = nullptr;
     }
     if (_cursors != nullptr) {
-        delete [] _cursors;
+        delete[] _cursors;
         _cursors = nullptr;
     }
     if (_keybuf != nullptr) {
-        delete [] _keybuf;
+        delete[] _keybuf;
         _keybuf = nullptr;
     }
     if (_valuebuf != nullptr) {
-        delete [] _valuebuf;
+        delete[] _valuebuf;
         _valuebuf = nullptr;
     }
 }
@@ -2533,9 +2533,9 @@ Track::Track(const Track &other)
 Track::~Track()
 {
     if (us != nullptr) {
-        delete [] us;
-        delete [] ms;
-        delete [] sec;
+        delete[] us;
+        delete[] ms;
+        delete[] sec;
     }
 }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -686,13 +686,13 @@ WorkloadRunner::increment_timestamp(WT_CONNECTION *conn)
     while (!stopping) {
         if (_workload->options.oldest_timestamp_lag > 0) {
             time_us = WorkgenTimeStamp::get_timestamp_lag(_workload->options.oldest_timestamp_lag);
-            snprintf(buf, BUF_SIZE, "oldest_timestamp=%" PRIu64, time_us);
+            snprintf(buf, BUF_SIZE, "oldest_timestamp=%" PRIx64, time_us);
             conn->set_timestamp(conn, buf);
         }
 
         if (_workload->options.stable_timestamp_lag > 0) {
             time_us = WorkgenTimeStamp::get_timestamp_lag(_workload->options.stable_timestamp_lag);
-            snprintf(buf, BUF_SIZE, "stable_timestamp=%" PRIu64, time_us);
+            snprintf(buf, BUF_SIZE, "stable_timestamp=%" PRIx64, time_us);
             conn->set_timestamp(conn, buf);
         }
 
@@ -1768,7 +1768,7 @@ ThreadRunner::op_run(Operation *op)
                 uint64_t read =
                   WorkgenTimeStamp::get_timestamp_lag(op->transaction->read_timestamp_lag);
                 snprintf(
-                  buf, BUF_SIZE, "%s=%" PRIu64, op->transaction->_begin_config.c_str(), read);
+                  buf, BUF_SIZE, "%s=%" PRIx64, op->transaction->_begin_config.c_str(), read);
             } else {
                 snprintf(buf, BUF_SIZE, "%s", op->transaction->_begin_config.c_str());
             }
@@ -1864,14 +1864,14 @@ err:
             // Set prepare, commit and durable timestamp if prepare is set.
             if (op->transaction->use_prepare_timestamp) {
                 time_us = WorkgenTimeStamp::get_timestamp();
-                snprintf(buf, BUF_SIZE, "prepare_timestamp=%" PRIu64, time_us);
+                snprintf(buf, BUF_SIZE, "prepare_timestamp=%" PRIx64, time_us);
                 ret = _session->prepare_transaction(_session, buf);
-                snprintf(buf, BUF_SIZE, "commit_timestamp=%" PRIu64 ",durable_timestamp=%" PRIu64,
+                snprintf(buf, BUF_SIZE, "commit_timestamp=%" PRIx64 ",durable_timestamp=%" PRIx64,
                   time_us, time_us);
                 ret = _session->commit_transaction(_session, buf);
             } else if (op->transaction->use_commit_timestamp) {
                 uint64_t commit_time_us = WorkgenTimeStamp::get_timestamp();
-                snprintf(buf, BUF_SIZE, "commit_timestamp=%" PRIu64, commit_time_us);
+                snprintf(buf, BUF_SIZE, "commit_timestamp=%" PRIx64, commit_time_us);
                 ret = _session->commit_transaction(_session, buf);
             } else {
                 ret =

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -46,6 +46,7 @@ struct Transaction;
 struct OptionsList {
     OptionsList() = default;
     OptionsList(const OptionsList &other);
+    ~OptionsList() = default;
 
     void add_int(const std::string& name, int default_value, const std::string& desc);
     void add_bool(const std::string& name, bool default_value, const std::string& desc);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -55,10 +55,7 @@ struct WorkgenTimeStamp {
     WorkgenTimeStamp() {}
 
     static uint64_t get_timestamp_lag(double seconds) {
-        uint64_t start_time;
-        workgen_clock(&start_time);
-
-        return (ns_to_us(start_time) - secs_us(seconds));
+        return (get_timestamp() - secs_us(seconds));
     }
 
     static void sleep(double seconds) {
@@ -66,9 +63,16 @@ struct WorkgenTimeStamp {
     }
 
     static uint64_t get_timestamp() {
-        uint64_t start_time;
-        workgen_clock(&start_time);
-        return (ns_to_us(start_time));
+        thread_local uint64_t last_ts = 0;
+        uint64_t ts;
+        struct timespec t;
+
+        workgen_epoch(&t);
+        ts = ns_to_us((uint64_t)(sec_to_ns(t.tv_sec) + t.tv_nsec));
+        if (ts <= last_ts)
+            ts = last_ts + 1;
+        last_ts = ts;
+        return ts;
     }
 };
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1191,7 +1191,9 @@ functions:
         set -o verbose
         ${PREPARE_TEST_ENV}
         # The task name gives us the test name to run (workgen-test-<filename>)
-        ${python_binary|python3} $(echo ${task_name}| cut -d'-' -f 3-).py
+        FILENAME=`echo ${task_name}| cut -d'-' -f 3-`
+        echo "Running $FILENAME.py"
+        ${python_binary|python3} $FILENAME.py
 
 #######################################
 #               Variables             #
@@ -1364,6 +1366,7 @@ variables:
           times: 25
 
   - &workgen-test
+    tags: ["workgen-test"]
     exec_timeout_secs: 21600
     commands:
       - func: "get project"
@@ -6040,83 +6043,63 @@ tasks:
 
   - <<: *workgen-test
     name: "workgen-test-compress_ratio"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-evict-btree-hs"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-example_dynamic_tables"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-example_prepare"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-example_prepare_evict_reconcile"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-example_simple"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-example_txn"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-insert_stress"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-insert_test"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-maintain_low_dirty_cache"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-many-dhandle-stress"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-multi_btree_heavy_stress"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-multiversion"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-prepare_stress"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-read_write_storms"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-read_write_sync_long"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-read_write_sync_short"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-skiplist_stress"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-small_btree"
-    tags: ["workgen-test"]
 
   - <<: *workgen-test
     name: "workgen-test-small_btree_reopen"
-    tags: ["workgen-test"]
 
 #######################################
 #     Antithesis Integration          #

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1179,16 +1179,19 @@ functions:
       args:
       - "./build_and_push_containers.sh"
 
-  "workgen test":
+  "run workgen test":
     command: shell.exec
     params:
       working_dir: "wiredtiger/bench/workgen/runner"
+      include_expansions_in_env:
+        - task_name
       shell: bash
       script: |
         set -o errexit
         set -o verbose
         ${PREPARE_TEST_ENV}
-        ${python_binary|python3} ${workgen_test_name}
+        # The task name gives us the test name to run (workgen-test-<filename>)
+        ${python_binary|python3} $(echo ${task_name}| cut -d'-' -f 3-).py
 
 #######################################
 #               Variables             #
@@ -1359,6 +1362,15 @@ variables:
       - func: "recovery stress test script"
         vars:
           times: 25
+
+  - &workgen-test
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "run workgen test"
 
 #######################################
 #               Tasks                 #
@@ -6026,245 +6038,85 @@ tasks:
         vars:
           test_path: bench/wt2853_perf/wt2853_perf
 
-  - name: "workgen-test-compress_ratio"
+  - <<: *workgen-test
+    name: "workgen-test-compress_ratio"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "compress_ratio.py"
 
-  - name: "workgen-test-evict-btree-hs"
+  - <<: *workgen-test
+    name: "workgen-test-evict-btree-hs"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "evict-btree-hs.py"
 
-  - name: "workgen-test-example_dynamic_tables"
+  - <<: *workgen-test
+    name: "workgen-test-example_dynamic_tables"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "example_dynamic_tables.py"
 
-  - name: "workgen-test-example_prepare"
+  - <<: *workgen-test
+    name: "workgen-test-example_prepare"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "example_prepare.py"
 
-  - name: "workgen-test-example_prepare_evict_reconcile"
+  - <<: *workgen-test
+    name: "workgen-test-example_prepare_evict_reconcile"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "example_prepare_evict_reconcile.py"
 
-  - name: "workgen-test-example_simple"
+  - <<: *workgen-test
+    name: "workgen-test-example_simple"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "example_simple.py"
 
-  - name: "workgen-test-example_txn"
+  - <<: *workgen-test
+    name: "workgen-test-example_txn"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "example_txn.py"
 
-  - name: "workgen-test-insert_stress"
+  - <<: *workgen-test
+    name: "workgen-test-insert_stress"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "insert_stress.py"
 
-  - name: "workgen-test-insert_test"
+  - <<: *workgen-test
+    name: "workgen-test-insert_test"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "insert_test.py"
 
-  - name: "workgen-test-maintain_low_dirty_cache"
+  - <<: *workgen-test
+    name: "workgen-test-maintain_low_dirty_cache"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "maintain_low_dirty_cache.py"
 
-  - name: "workgen-test-many-dhandle-stress"
+  - <<: *workgen-test
+    name: "workgen-test-many-dhandle-stress"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "many-dhandle-stress.py"
 
-  - name: "workgen-test-multi_btree_heavy_stress"
+  - <<: *workgen-test
+    name: "workgen-test-multi_btree_heavy_stress"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "multi_btree_heavy_stress.py"
 
-  - name: "workgen-test-multiversion"
+  - <<: *workgen-test
+    name: "workgen-test-multiversion"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "multiversion.py"
 
-  - name: "workgen-test-prepare_stress"
+  - <<: *workgen-test
+    name: "workgen-test-prepare_stress"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "prepare_stress.py"
 
-  - name: "workgen-test-read_write_storms"
+  - <<: *workgen-test
+    name: "workgen-test-read_write_storms"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "read_write_storms.py"
 
-  - name: "workgen-test-read_write_sync_long"
+  - <<: *workgen-test
+    name: "workgen-test-read_write_sync_long"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "read_write_sync_long.py"
 
-  - name: "workgen-test-read_write_sync_short"
+  - <<: *workgen-test
+    name: "workgen-test-read_write_sync_short"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "read_write_sync_short.py"
 
-  - name: "workgen-test-skiplist_stress"
+  - <<: *workgen-test
+    name: "workgen-test-skiplist_stress"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "skiplist_stress.py"
 
-  - name: "workgen-test-small_btree"
+  - <<: *workgen-test
+    name: "workgen-test-small_btree"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "small_btree.py"
 
-  - name: "workgen-test-small_btree_reopen"
+  - <<: *workgen-test
+    name: "workgen-test-small_btree_reopen"
     tags: ["workgen-test"]
-    exec_timeout_secs: 21600
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-      - func: "workgen test"
-        vars:
-          workgen_test_name: "small_btree_reopen.py"
 
 #######################################
 #     Antithesis Integration          #

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1179,6 +1179,17 @@ functions:
       args:
       - "./build_and_push_containers.sh"
 
+  "workgen test":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/bench/workgen/runner"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        ${PREPARE_TEST_ENV}
+        ${python_binary|python3} ${workgen_test_name}
+
 #######################################
 #               Variables             #
 #######################################
@@ -6015,6 +6026,246 @@ tasks:
         vars:
           test_path: bench/wt2853_perf/wt2853_perf
 
+  - name: "workgen-test-compress_ratio"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "compress_ratio.py"
+
+  - name: "workgen-test-evict-btree-hs"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "evict-btree-hs.py"
+
+  - name: "workgen-test-example_dynamic_tables"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "example_dynamic_tables.py"
+
+  - name: "workgen-test-example_prepare"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "example_prepare.py"
+
+  - name: "workgen-test-example_prepare_evict_reconcile"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "example_prepare_evict_reconcile.py"
+
+  - name: "workgen-test-example_simple"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "example_simple.py"
+
+  - name: "workgen-test-example_txn"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "example_txn.py"
+
+  - name: "workgen-test-insert_stress"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "insert_stress.py"
+
+  - name: "workgen-test-insert_test"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "insert_test.py"
+
+  - name: "workgen-test-maintain_low_dirty_cache"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "maintain_low_dirty_cache.py"
+
+  - name: "workgen-test-many-dhandle-stress"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "many-dhandle-stress.py"
+
+  - name: "workgen-test-multi_btree_heavy_stress"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "multi_btree_heavy_stress.py"
+
+  - name: "workgen-test-multiversion"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "multiversion.py"
+
+  - name: "workgen-test-prepare_stress"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "prepare_stress.py"
+
+  - name: "workgen-test-read_write_storms"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "read_write_storms.py"
+
+  - name: "workgen-test-read_write_sync_long"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "read_write_sync_long.py"
+
+  - name: "workgen-test-read_write_sync_short"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "read_write_sync_short.py"
+
+  - name: "workgen-test-skiplist_stress"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "skiplist_stress.py"
+
+  - name: "workgen-test-small_btree"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "small_btree.py"
+
+  - name: "workgen-test-small_btree_reopen"
+    tags: ["workgen-test"]
+    exec_timeout_secs: 21600
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_with_builtins
+      - func: "workgen test"
+        vars:
+          workgen_test_name: "small_btree_reopen.py"
+
 #######################################
 #     Antithesis Integration          #
 #######################################
@@ -6095,6 +6346,8 @@ buildvariants:
     - name: csuite-timestamp-abort-test-s3
     - name: unit-test-hook-tiered-s3
     - name: chunkcache-test
+    - name: ".workgen-test"
+      batchtime: 1440 # 24 hours
 
 - name: ubuntu2004-asan
   display_name: "! Ubuntu 20.04 ASAN"
@@ -6478,6 +6731,8 @@ buildvariants:
       distros: ubuntu2004-arm64-large
     - name: memory-model-test
       batchtime: 40320 # 28 days
+    - name: ".workgen-test"
+      batchtime: 1440 # 24 hours
 
 - name: amazon2-arm64
   display_name: "Amazon Linux 2 ARM64"


### PR DESCRIPTION
Addressed a number of issues found under ASAN. Also updated some of the tests in order for them to pass consistently (e.g. with core.py increasing the key size to 12 for log keys as they are S and not Q).  Fixed overflow memory issue and fixed stopping issue when dropping tables. Enabled for evergreen once per day.