### PR TITLE
WT-11309 Updating max size and value to be uint64_t in workgen

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -2356,7 +2356,7 @@ Operation::kv_gen(
     TableOperationInternal *internal = static_cast<TableOperationInternal *>(_internal);
 
     uint_t size = iskey ? internal->_keysize : internal->_valuesize;
-    uint_t max = iskey ? internal->_keymax : internal->_valuemax;
+    uint64_t max = iskey ? internal->_keymax : internal->_valuemax;
     if (n > max)
         THROW((iskey ? "Key" : "Value") << " (" << n << ") too large for size (" << size << ")");
 

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -286,8 +286,8 @@ struct RTSOperationInternal : OperationInternal {
 struct TableOperationInternal : OperationInternal {
     uint_t _keysize;    // derived from Key._size and Table.options.key_size
     uint_t _valuesize;
-    uint_t _keymax;
-    uint_t _valuemax;
+    uint64_t _keymax;
+    uint64_t _valuemax;
 
     TableOperationInternal() : OperationInternal(), _keysize(0), _valuesize(0),
 			       _keymax(0), _valuemax(0) {}


### PR DESCRIPTION
To be merged after WT-11311 as that enables the tests to cover this change.