### PR TITLE
WT-11588 Remove the table in test_compact06.py

### DIFF
--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -33,8 +33,6 @@ from wiredtiger import stat
 # test_compact06.py
 # Test background compaction API usage.
 class test_compact06(wttest.WiredTigerTestCase):
-    uri = 'file:test_compact06'
-
     def get_bg_compaction_running(self):
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         compact_running = stat_cursor[stat.conn.background_compact_running][2]
@@ -42,12 +40,10 @@ class test_compact06(wttest.WiredTigerTestCase):
         return compact_running
     
     def test_background_compact_api(self):
-        # Create a table.
-        self.session.create(self.uri, 'key_format=i,value_format=S')
-        
-        #   1. We cannot trigger the background compaction on a specific API.
+        #   1. We cannot trigger the background compaction on a specific API. Note that the URI is
+        # not relevant here, the corresponding table does not need to exist for this check.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-            self.session.compact(self.uri, 'background=true'), '/Background compaction does not work on specific URIs/')
+            self.session.compact("file:123", 'background=true'), '/Background compaction does not work on specific URIs/')
             
         #   2. We cannot set other configurations while turning off the background server.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:


### PR DESCRIPTION
We had a failure because the following message was raised:

```
WT_SESSION.compact: [WT_VERB_COMPACT][WARNING]: background compact interrupted by application
```

This happened because we enable/disable the background compaction as part of this test and a table exists. Since we don't need that table for this test, we can simply not create it and avoid that spurious message.