### PR TITLE
WT-11610 When parse the config of "block_allocation first", "the bool type" directly assigned to "the uint32_t type"

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -210,7 +210,7 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     block->allocsize = allocsize;
 
     WT_ERR(__wt_config_gets(session, cfg, "block_allocation", &cval));
-    block->allocfirst = WT_STRING_MATCH("first", cval.str, cval.len);
+    block->allocfirst = WT_STRING_MATCH("first", cval.str, cval.len) ? 1 : 0;
 
     /* Configuration: optional OS buffer cache maximum size. */
     WT_ERR(__wt_config_gets(session, cfg, "os_cache_max", &cval));


### PR DESCRIPTION
when parse the config of "block_allocation first", "the bool type" assigned to "the uint32_t type".

This coding style is not very friendly.