### PR TITLE
WT-11637 Always increment background compaction failure stat when compaction does not succeed

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -430,32 +430,33 @@ __compact_server(void *arg)
          * - ETIMEDOUT if the configured timer has elapsed.
          * - WT_ERROR if the background compaction has been interrupted.
          */
-        if (ret == EBUSY || ret == ENOENT || ret == ETIMEDOUT || ret == WT_ROLLBACK) {
+        if (ret != 0) {
             WT_STAT_CONN_INCR(session, background_compact_fail);
+            /* The following errors are always silenced. */
+            if (ret == EBUSY || ret == ENOENT || ret == ETIMEDOUT || ret == WT_ROLLBACK) {
 
-            if (ret == EBUSY && __wt_cache_stuck(session))
-                WT_STAT_CONN_INCR(session, background_compact_fail_cache_pressure);
-
-            if (ret == ETIMEDOUT)
-                WT_STAT_CONN_INCR(session, background_compact_timeout);
-
-            ret = 0;
-        }
-
-        /*
-         * WT_ERROR should indicate the server was interrupted, make sure it is no longer running.
-         */
-        if (ret == WT_ERROR) {
-            __wt_spin_lock(session, &conn->background_compact.lock);
-            running = conn->background_compact.running;
-            __wt_spin_unlock(session, &conn->background_compact.lock);
-            if (!running) {
-                WT_STAT_CONN_INCR(session, background_compact_interrupted);
+                if (ret == EBUSY && __wt_cache_stuck(session))
+                    WT_STAT_CONN_INCR(session, background_compact_fail_cache_pressure);
+                else if (ret == ETIMEDOUT)
+                    WT_STAT_CONN_INCR(session, background_compact_timeout);
                 ret = 0;
             }
-        }
 
-        WT_ERR(ret);
+            /*
+             * Verify WT_ERROR comes from an interruption by checking the server is no longer
+             * running.
+             */
+            else if (ret == WT_ERROR) {
+                __wt_spin_lock(session, &conn->background_compact.lock);
+                running = conn->background_compact.running;
+                __wt_spin_unlock(session, &conn->background_compact.lock);
+                if (!running) {
+                    WT_STAT_CONN_INCR(session, background_compact_interrupted);
+                    ret = 0;
+                }
+            }
+            WT_ERR(ret);
+        }
     }
 
     WT_STAT_CONN_SET(session, background_compact_running, 0);

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -343,12 +343,12 @@ __compact_server(void *arg)
     WT_DECL_RET;
     WT_SESSION *wt_session;
     WT_SESSION_IMPL *session;
-    bool full_iteration, running, signalled;
+    bool full_iteration, running;
 
     session = arg;
     conn = S2C(session);
     wt_session = (WT_SESSION *)session;
-    full_iteration = running = signalled = false;
+    full_iteration = running = false;
 
     WT_ERR(__wt_scr_alloc(session, 1024, &config));
     WT_ERR(__wt_scr_alloc(session, 1024, &next_uri));


### PR DESCRIPTION
Previously, `background_compact_fail` was not incremented when `WT_ERROR` was returned from the `compact` call.