### PR TITLE
WT-8570 WT-8702 WT-8709 WT-8825 WT-11492 WT-9248 (v4.4 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -896,6 +896,7 @@ conn_dsrc_stats = [
     # Transaction statistics
     ##########################################
     TxnStat('txn_checkpoint_obsolete_applied', 'transaction checkpoints due to obsolete pages'),
+    TxnStat('txn_checkpoint_snapshot_acquired', 'checkpoint has acquired a snapshot for its transaction'),
     TxnStat('txn_read_race_prepare_update', 'race to read prepared update retry'),
     TxnStat('txn_rts_delete_rle_skipped', 'rollback to stable skipping delete rle'),
     TxnStat('txn_rts_hs_removed', 'rollback to stable updates removed from history store'),

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -743,6 +743,7 @@ struct __wt_connection_stats {
     int64_t txn_prepared_updates_committed;
     int64_t txn_prepared_updates_key_repeated;
     int64_t txn_prepared_updates_rolledback;
+    int64_t txn_checkpoint_snapshot_acquired;
     int64_t txn_rollback_oldest_pinned;
     int64_t txn_prepare;
     int64_t txn_prepare_commit;
@@ -1033,6 +1034,7 @@ struct __wt_dsrc_stats {
     int64_t tiered_work_units_dequeued;
     int64_t tiered_work_units_created;
     int64_t tiered_retention;
+    int64_t txn_checkpoint_snapshot_acquired;
     int64_t txn_read_race_prepare_update;
     int64_t txn_rts_hs_stop_older_than_newer_start;
     int64_t txn_rts_inconsistent_ckpt;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -451,10 +451,12 @@ err:
 static inline uint64_t
 __wt_txn_oldest_id(WT_SESSION_IMPL *session)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_TXN_GLOBAL *txn_global;
-    uint64_t checkpoint_pinned, oldest_id;
+    uint64_t checkpoint_pinned, oldest_id, recovery_ckpt_snap_min;
 
-    txn_global = &S2C(session)->txn_global;
+    conn = S2C(session);
+    txn_global = &conn->txn_global;
 
     /*
      * The metadata is tracked specially because of optimizations for checkpoints.
@@ -474,19 +476,25 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
      */
     WT_READ_BARRIER();
 
-    /*
-     * Checkpoint transactions often fall behind ordinary application threads. Take special effort
-     * to not keep changes pinned in cache if they are only required for the checkpoint and it has
-     * already seen them.
-     *
-     * If there is no active checkpoint or this handle is up to date with the active checkpoint then
-     * it's safe to ignore the checkpoint ID in the visibility check.
-     */
-    checkpoint_pinned = txn_global->checkpoint_txn_shared.pinned_id;
-    if (checkpoint_pinned == WT_TXN_NONE || WT_TXNID_LT(oldest_id, checkpoint_pinned))
-        return (oldest_id);
-
-    return (checkpoint_pinned);
+    if (!F_ISSET(conn, WT_CONN_RECOVERING)) {
+        /*
+         * Checkpoint transactions often fall behind ordinary application threads. If there is an
+         * active checkpoint, keep changes until checkpoint is finished.
+         */
+        checkpoint_pinned = txn_global->checkpoint_txn_shared.pinned_id;
+        if (checkpoint_pinned == WT_TXN_NONE || WT_TXNID_LT(oldest_id, checkpoint_pinned))
+            return (oldest_id);
+        return (checkpoint_pinned);
+    } else {
+        /*
+         * Recovered checkpoint snapshot rarely fall behind ordinary application threads. Keep the
+         * changes until the recovery is finished.
+         */
+        recovery_ckpt_snap_min = conn->recovery_ckpt_snap_min;
+        if (recovery_ckpt_snap_min == WT_TXN_NONE || WT_TXNID_LT(oldest_id, recovery_ckpt_snap_min))
+            return (oldest_id);
+        return (recovery_ckpt_snap_min);
+    }
 }
 
 /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -472,11 +472,13 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
     /*
      * The read of the transaction ID pinned by a checkpoint needs to be carefully ordered: if a
      * checkpoint is starting and we have to start checking the pinned ID, we take the minimum of it
-     * with the oldest ID, which is what we want.
+     * with the oldest ID, which is what we want. The logged tables are excluded as part of RTS, so
+     * there is no need of holding their oldest_id
      */
     WT_READ_BARRIER();
 
-    if (!F_ISSET(conn, WT_CONN_RECOVERING)) {
+    if (!F_ISSET(conn, WT_CONN_RECOVERING) || session->dhandle == NULL ||
+      __wt_btree_immediately_durable(session)) {
         /*
          * Checkpoint transactions often fall behind ordinary application threads. If there is an
          * active checkpoint, keep changes until checkpoint is finished.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6075,187 +6075,189 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1428
 /*! transaction: Number of prepared updates rolled back */
 #define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1429
+/*! transaction: checkpoint has acquired a snapshot for its transaction */
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1430
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1430
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1431
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1431
+#define	WT_STAT_CONN_TXN_PREPARE			1432
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1432
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1433
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1433
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1434
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1434
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1435
 /*!
  * transaction: prepared transactions rolled back and do not remove the
  * history store entry
  */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_DO_NOT_REMOVE_HS_UPDATE	1435
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_DO_NOT_REMOVE_HS_UPDATE	1436
 /*!
  * transaction: prepared transactions rolled back and fix the history
  * store entry with checkpoint reserved transaction id
  */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_FIX_HS_UPDATE_WITH_CKPT_RESERVED_TXNID	1436
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_FIX_HS_UPDATE_WITH_CKPT_RESERVED_TXNID	1437
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1437
+#define	WT_STAT_CONN_TXN_QUERY_TS			1438
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1438
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1439
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1439
+#define	WT_STAT_CONN_TXN_RTS				1440
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1440
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1441
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1441
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1442
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1442
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1443
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1443
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1444
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1444
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1445
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1445
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1446
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1446
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1447
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1447
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1448
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1448
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1449
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1449
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1450
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1450
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1451
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1451
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1452
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1452
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1453
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1453
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1454
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1454
+#define	WT_STAT_CONN_TXN_SET_TS				1455
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1455
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1456
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1456
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1457
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1457
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1458
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1458
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1459
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1459
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1460
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1460
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1461
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1461
+#define	WT_STAT_CONN_TXN_BEGIN				1462
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1462
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1463
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1463
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1464
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1464
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1465
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1465
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1466
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1466
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1467
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1467
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1468
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1468
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1469
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1469
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1470
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1470
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1471
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1471
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1472
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1472
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1473
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1473
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1474
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1474
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1475
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1475
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1476
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1476
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1477
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1477
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1478
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1478
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1479
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1479
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1480
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1480
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1481
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1481
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1482
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1482
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1483
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1483
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1484
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1484
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1485
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1485
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1486
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1486
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1487
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1487
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1488
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1488
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1489
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1489
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1490
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1490
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1491
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1491
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1492
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1492
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1493
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1493
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1494
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1494
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1495
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1495
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1496
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1496
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1497
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1497
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1498
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1498
+#define	WT_STAT_CONN_TXN_COMMIT				1499
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1499
+#define	WT_STAT_CONN_TXN_ROLLBACK			1500
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1500
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1501
 
 /*!
  * @}
@@ -6889,35 +6891,37 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2210
 /*! session: tiered storage local retention time (secs) */
 #define	WT_STAT_DSRC_TIERED_RETENTION			2211
+/*! transaction: checkpoint has acquired a snapshot for its transaction */
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2212
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2212
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2213
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2213
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2214
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2214
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2215
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2215
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2216
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2216
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2217
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2217
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2218
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2218
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2219
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2219
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2220
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2220
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2221
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2221
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2222
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2222
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2223
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2223
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2224
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2224
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2225
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -224,6 +224,7 @@ static const char *const __stats_dsrc_desc[] = {
   "session: tiered operations dequeued and processed",
   "session: tiered operations scheduled",
   "session: tiered storage local retention time (secs)",
+  "transaction: checkpoint has acquired a snapshot for its transaction",
   "transaction: race to read prepared update retry",
   "transaction: rollback to stable history store records with stop timestamps older than newer "
   "records",
@@ -490,6 +491,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->tiered_work_units_dequeued = 0;
     stats->tiered_work_units_created = 0;
     /* not clearing tiered_retention */
+    stats->txn_checkpoint_snapshot_acquired = 0;
     stats->txn_read_race_prepare_update = 0;
     stats->txn_rts_hs_stop_older_than_newer_start = 0;
     stats->txn_rts_inconsistent_ckpt = 0;
@@ -746,6 +748,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->tiered_work_units_dequeued += from->tiered_work_units_dequeued;
     to->tiered_work_units_created += from->tiered_work_units_created;
     to->tiered_retention += from->tiered_retention;
+    to->txn_checkpoint_snapshot_acquired += from->txn_checkpoint_snapshot_acquired;
     to->txn_read_race_prepare_update += from->txn_read_race_prepare_update;
     to->txn_rts_hs_stop_older_than_newer_start += from->txn_rts_hs_stop_older_than_newer_start;
     to->txn_rts_inconsistent_ckpt += from->txn_rts_inconsistent_ckpt;
@@ -1010,6 +1013,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->tiered_work_units_dequeued += WT_STAT_READ(from, tiered_work_units_dequeued);
     to->tiered_work_units_created += WT_STAT_READ(from, tiered_work_units_created);
     to->tiered_retention += WT_STAT_READ(from, tiered_retention);
+    to->txn_checkpoint_snapshot_acquired += WT_STAT_READ(from, txn_checkpoint_snapshot_acquired);
     to->txn_read_race_prepare_update += WT_STAT_READ(from, txn_read_race_prepare_update);
     to->txn_rts_hs_stop_older_than_newer_start +=
       WT_STAT_READ(from, txn_rts_hs_stop_older_than_newer_start);
@@ -1472,6 +1476,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: Number of prepared updates committed",
   "transaction: Number of prepared updates repeated on the same key",
   "transaction: Number of prepared updates rolled back",
+  "transaction: checkpoint has acquired a snapshot for its transaction",
   "transaction: oldest pinned transaction ID rolled back for eviction",
   "transaction: prepared transactions",
   "transaction: prepared transactions committed",
@@ -2016,6 +2021,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->txn_prepared_updates_committed = 0;
     stats->txn_prepared_updates_key_repeated = 0;
     stats->txn_prepared_updates_rolledback = 0;
+    stats->txn_checkpoint_snapshot_acquired = 0;
     stats->txn_rollback_oldest_pinned = 0;
     stats->txn_prepare = 0;
     stats->txn_prepare_commit = 0;
@@ -2578,6 +2584,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_prepared_updates_committed += WT_STAT_READ(from, txn_prepared_updates_committed);
     to->txn_prepared_updates_key_repeated += WT_STAT_READ(from, txn_prepared_updates_key_repeated);
     to->txn_prepared_updates_rolledback += WT_STAT_READ(from, txn_prepared_updates_rolledback);
+    to->txn_checkpoint_snapshot_acquired += WT_STAT_READ(from, txn_checkpoint_snapshot_acquired);
     to->txn_rollback_oldest_pinned += WT_STAT_READ(from, txn_rollback_oldest_pinned);
     to->txn_prepare += WT_STAT_READ(from, txn_prepare);
     to->txn_prepare_commit += WT_STAT_READ(from, txn_prepare_commit);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -469,6 +469,14 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
     prev_metadata_pinned = txn_global->metadata_pinned;
     prev_oldest_id = txn_global->oldest_id;
 
+    /*
+     * Do not modify the oldest ID during recovery. Modifying the oldest ID during recovery can lead
+     * to a scenario where the current generation oldest ID leads to wrong global visibility of the
+     * data whereas it doesn't according to the recovered checkpoint snapshot.
+     */
+    if (F_ISSET(conn, WT_CONN_RECOVERING))
+        return (0);
+
     /* Try to move the pinned timestamp forward. */
     if (strict)
         WT_RET(__wt_txn_update_pinned_timestamp(session, false));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -469,14 +469,6 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
     prev_metadata_pinned = txn_global->metadata_pinned;
     prev_oldest_id = txn_global->oldest_id;
 
-    /*
-     * Do not modify the oldest ID during recovery. Modifying the oldest ID during recovery can lead
-     * to a scenario where the current generation oldest ID leads to wrong global visibility of the
-     * data whereas it doesn't according to the recovered checkpoint snapshot.
-     */
-    if (F_ISSET(conn, WT_CONN_RECOVERING))
-        return (0);
-
     /* Try to move the pinned timestamp forward. */
     if (strict)
         WT_RET(__wt_txn_update_pinned_timestamp(session, false));

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -679,6 +679,8 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
         __wt_verbose_timestamp(
           session, txn_global->checkpoint_timestamp, "Checkpoint requested at stable timestamp");
 
+    WT_STAT_CONN_SET(session, txn_checkpoint_snapshot_acquired, 1);
+
     /*
      * Get a list of handles we want to flush; for named checkpoints this may pull closed objects
      * into the session cache.
@@ -984,6 +986,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Release the snapshot so we aren't pinning updates in cache. */
     __wt_txn_release_snapshot(session);
+
+    WT_STAT_CONN_SET(session, txn_checkpoint_snapshot_acquired, 0);
 
     /* Mark all trees as open for business (particularly eviction). */
     WT_ERR(__checkpoint_apply_to_dhandles(session, cfg, __checkpoint_presync));

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -380,7 +380,7 @@ __rollback_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
      * outside the constraints of transactions. Therefore, there is no need for snapshot based
      * visibility checks.
      */
-    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
+    F_SET(hs_cursor, WT_CURSTD_HS_READ_ALL);
 
     /*
      * Scan the history store for the given btree and key with maximum start timestamp to let the

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -138,8 +138,15 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         try:
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts before committing last transaction.
-            time.sleep(2)
+
+            # Wait for checkpoint to start and acquire its snapshot before committing.
+            ckpt_snapshot = 0
+            while not ckpt_snapshot:
+                time.sleep(1)
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_snapshot = stat_cursor[stat.conn.txn_checkpoint_snapshot_acquired][2]
+                stat_cursor.close()
+
             session1.commit_transaction()
 
         finally:
@@ -190,8 +197,15 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         try:
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts before committing last transaction.
-            time.sleep(2)
+
+            # Wait for checkpoint to start and acquire its snapshot before committing.
+            ckpt_snapshot = 0
+            while not ckpt_snapshot:
+                time.sleep(1)
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_snapshot = stat_cursor[stat.conn.txn_checkpoint_snapshot_acquired][2]
+                stat_cursor.close()
+
             session1.commit_transaction()
 
         finally:
@@ -246,8 +260,15 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         try:
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts before committing last transaction.
-            time.sleep(2)
+
+            # Wait for checkpoint to start and acquire its snapshot before committing.
+            ckpt_snapshot = 0
+            while not ckpt_snapshot:
+                time.sleep(1)
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_snapshot = stat_cursor[stat.conn.txn_checkpoint_snapshot_acquired][2]
+                stat_cursor.close()
+
             session2.commit_transaction()
 
         finally:

--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, shutil, threading, time
+from wtthread import checkpoint_thread
+import wiredtiger, wttest
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+# test_checkpoint_snapshot05.py
+#   This test is to run checkpoint and eviction in parallel with timing
+#   stress for checkpoint and let eviction write more data than checkpoint
+#   after a bulk load on a table to check the backup recovery.
+class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
+    # Create a table.
+    uri = "table:test_checkpoint_snapshot05"
+    backup_dir = "BACKUP"
+
+    format_values = [
+        ('column_fix', dict(key_format='r', value_format='8t')),
+        ('column', dict(key_format='r', value_format='S')),
+        ('row_integer', dict(key_format='i', value_format='S')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def conn_config(self):
+        config = 'cache_size=10MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true),timing_stress_for_test=[checkpoint_slow]'
+        return config
+
+    def moresetup(self):
+        if self.value_format == '8t':
+            # Rig to use more than one page; otherwise the inconsistent checkpoint assertions fail.
+            self.extraconfig = ',leaf_page_max=4096'
+            self.nrows = 5000
+            self.valuea = 97
+            self.valueb = 98
+        else:
+            self.extraconfig = ''
+            self.nrows = 1000
+            self.valuea = "aaaaa" * 100
+            self.valueb = "bbbbb" * 100
+
+    def take_full_backup(self, fromdir, todir):
+        # Open up the backup cursor, and copy the files.  Do a full backup.
+        cursor = self.session.open_cursor('backup:', None, None)
+        self.pr('Full backup from '+ fromdir + ' to ' + todir + ': ')
+        os.mkdir(todir)
+        while True:
+            ret = cursor.next()
+            if ret != 0:
+                break
+            bkup_file = cursor.get_key()
+            copy_file = os.path.join(fromdir, bkup_file)
+            sz = os.path.getsize(copy_file)
+            self.pr('Copy from: ' + bkup_file + ' (' + str(sz) + ') to ' + todir)
+            shutil.copy(copy_file, todir)
+        self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+        cursor.close()
+
+    def check(self, check_value, uri, nrows):
+        session = self.session
+        session.begin_transaction()
+        cursor = session.open_cursor(uri)
+        count = 0
+        for k, v in cursor:
+            if self.value_format == '8t':
+                self.assertEqual(v, check_value)
+            else:
+                self.assertEqual(v, check_value + str(count + 1))
+            count += 1
+        session.commit_transaction()
+        self.assertEqual(count, nrows)
+
+    def evict(self, uri, ds, nrows):
+        s = self.conn.open_session()
+        s.begin_transaction()
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = s.open_cursor(uri, None, "debug=(release_evict)")
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(ds.key(i))
+            self.assertEquals(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        s.rollback_transaction()
+        evict_cursor.close()
+        s.close()
+
+    def test_checkpoint_snapshot(self):
+        self.moresetup()
+
+        ds = SimpleDataSet(self, self.uri, 0, \
+                key_format=self.key_format, value_format=self.value_format, \
+                config='log=(enabled=false)'+self.extraconfig)
+        ds.populate()
+
+        cursor = self.session.open_cursor(self.uri, None, "bulk")
+        for i in range(1, self.nrows + 1):
+            if self.value_format == '8t':
+                cursor[i] = self.valuea
+            else:
+                cursor[i] = self.valuea + str(i)
+        cursor.close()
+
+        self.check(self.valuea, self.uri, self.nrows)
+
+        session1 = self.conn.open_session()
+        session1.begin_transaction()
+        cursor1 = session1.open_cursor(self.uri)
+
+        for i in range(1, self.nrows + 1):
+            cursor1.set_key(ds.key(i))
+            if self.value_format == '8t':
+                cursor1.set_value(self.valueb)
+            else:
+                cursor1.set_value(self.valueb + str(i))
+            cursor1.set_value(self.valueb)
+            self.assertEqual(cursor1.update(), 0)
+
+        # Create a checkpoint thread
+        done = threading.Event()
+        ckpt = checkpoint_thread(self.conn, done)
+        try:
+            ckpt.start()
+            # Sleep for sometime so that checkpoint starts before committing last transaction.
+            time.sleep(2)
+            session1.commit_transaction()
+            self.evict(self.uri, ds, self.nrows)
+        finally:
+            done.set()
+            ckpt.join()
+
+        #Take a backup and restore it.
+        self.take_full_backup(".", self.backup_dir)
+        self.reopen_conn(self.backup_dir)
+
+        # Check the table contains the last checkpointed value.
+        self.check(self.valuea, self.uri, self.nrows)
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
+        keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
+        stat_cursor.close()
+
+        self.assertGreater(inconsistent_ckpt, 0)
+        self.assertEqual(keys_removed, 0)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -43,8 +43,8 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
     backup_dir = "BACKUP"
 
     format_values = [
-        ('column_fix', dict(key_format='r', value_format='8t')),
-        ('column', dict(key_format='r', value_format='S')),
+        # ('column_fix', dict(key_format='r', value_format='8t')),
+        # ('column', dict(key_format='r', value_format='S')),
         ('row_integer', dict(key_format='i', value_format='S')),
     ]
 
@@ -139,7 +139,6 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
                 cursor1.set_value(self.valueb)
             else:
                 cursor1.set_value(self.valueb + str(i))
-            cursor1.set_value(self.valueb)
             self.assertEqual(cursor1.update(), 0)
 
         # Create a checkpoint thread

--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -147,8 +147,15 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
         ckpt = checkpoint_thread(self.conn, done)
         try:
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts before committing last transaction.
-            time.sleep(2)
+
+            # Wait for checkpoint to start and acquire its snapshot before committing.
+            ckpt_snapshot = 0
+            while not ckpt_snapshot:
+                time.sleep(1)
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_snapshot = stat_cursor[stat.conn.txn_checkpoint_snapshot_acquired][2]
+                stat_cursor.close()
+
             session1.commit_transaction()
             self.evict(self.uri, ds, self.nrows)
         finally:

--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -144,7 +144,7 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
 
         # Create a checkpoint thread
         done = threading.Event()
-        ckpt = checkpoint_thread(self.conn, done)
+        ckpt = checkpoint_thread(self.conn, done, checkpoint_count_max=1)
         try:
             ckpt.start()
 

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -249,8 +249,14 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         try:
             self.pr("start checkpoint")
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts.
-            time.sleep(2)
+
+            # Wait for checkpoint to start before committing.
+            ckpt_started = 0
+            while not ckpt_started:
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_started = stat_cursor[stat.conn.txn_checkpoint_running][2]
+                stat_cursor.close()
+                time.sleep(1)
 
             # Perform several updates in parallel with checkpoint.
             session_p1 = self.conn.open_session()

--- a/test/suite/test_rollback_to_stable14.py
+++ b/test/suite/test_rollback_to_stable14.py
@@ -113,8 +113,14 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         try:
             self.pr("start checkpoint")
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts.
-            time.sleep(2)
+
+            # Wait for checkpoint to start before committing.
+            ckpt_started = 0
+            while not ckpt_started:
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_started = stat_cursor[stat.conn.txn_checkpoint_running][2]
+                stat_cursor.close()
+                time.sleep(1)
 
             # Perform several modifies in parallel with checkpoint.
             # Rollbacks may occur when checkpoint is running, so retry as needed.
@@ -224,8 +230,14 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         try:
             self.pr("start checkpoint")
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts.
-            time.sleep(2)
+
+            # Wait for checkpoint to start before committing.
+            ckpt_started = 0
+            while not ckpt_started:
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_started = stat_cursor[stat.conn.txn_checkpoint_running][2]
+                stat_cursor.close()
+                time.sleep(1)
 
             # Perform several modifies in parallel with checkpoint.
             # Rollbacks may occur when checkpoint is running, so retry as needed.
@@ -333,8 +345,14 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         try:
             self.pr("start checkpoint")
             ckpt.start()
-            # Sleep for sometime so that checkpoint starts.
-            time.sleep(2)
+
+            # Wait for checkpoint to start before committing.
+            ckpt_started = 0
+            while not ckpt_started:
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_started = stat_cursor[stat.conn.txn_checkpoint_running][2]
+                stat_cursor.close()
+                time.sleep(1)
 
             # Perform several modifies in parallel with checkpoint.
             # Rollbacks may occur when checkpoint is running, so retry as needed.

--- a/test/suite/wtthread.py
+++ b/test/suite/wtthread.py
@@ -30,17 +30,38 @@ import os, queue, shutil, sys, threading, time, wiredtiger, wttest
 from helper import compare_tables
 
 class checkpoint_thread(threading.Thread):
-    def __init__(self, conn, done):
+    def __init__(self, conn, done, **kwargs):
+        """
+        Keyword Args:
+            checkpoint_count_max (int): Maximum number of checkpoints to initiate. Must be greater
+                than zero. Thread will exit if done is signalled, or maximum number of checkpoints
+                is reached.
+        """
         self.conn = conn
         self.done = done
+        self.checkpoint_count = 0
+        
+        if "checkpoint_count_max" in kwargs:
+            count_max = int(kwargs["checkpoint_count_max"])
+            if count_max <= 0:
+                raise ValueError("checkpoint_count_max must be a positive integer")
+            self._max_count = count_max
+        else:
+            # Infinite checkpoints: run until signalled.
+            self._max_count = 0
+
         threading.Thread.__init__(self)
+
+    def reached_max_count(self):
+        return self._max_count > 0 and self.checkpoint_count >= self._max_count
 
     def run(self):
         sess = self.conn.open_session()
-        while not self.done.isSet():
+        while not self.done.isSet() and not self.reached_max_count():
             # Sleep for 10 milliseconds.
             time.sleep(0.001)
             sess.checkpoint()
+            self.checkpoint_count += 1
         sess.close()
 
 class flush_tier_thread(threading.Thread):


### PR DESCRIPTION
The backports are done together due to their dependency:
[WT-8570](https://jira.mongodb.org/browse/WT-8570)
[WT-8702](https://jira.mongodb.org/browse/WT-8702) (caused by [WT-8570](https://jira.mongodb.org/browse/WT-8570))
[WT-8709](https://jira.mongodb.org/browse/WT-8709) (caused by [WT-8702](https://jira.mongodb.org/browse/WT-8702))

WT-8825, WT-9248 and WT-11492 have also been included as they create/modify/fix the new test `test_checkpoint_snapshot05.py`.