### PR TITLE
BACKPORT-14420 Fix log slot flags and remove debugging

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -730,8 +730,8 @@ restart:
                 /*
                  * Copy the flag for later closing.
                  */
-                if (F_ISSET(slot, WT_SLOT_CLOSEFH))
-                    F_SET(coalescing, WT_SLOT_CLOSEFH);
+                if (F_ISSET_ATOMIC_16(slot, WT_SLOT_CLOSEFH))
+                    F_SET_ATOMIC_16(coalescing, WT_SLOT_CLOSEFH);
             } else {
                 /*
                  * If this written slot is not the next LSN, try to start coalescing with later
@@ -761,7 +761,7 @@ restart:
                 /*
                  * Signal the close thread if needed.
                  */
-                if (F_ISSET(slot, WT_SLOT_CLOSEFH))
+                if (F_ISSET_ATOMIC_16(slot, WT_SLOT_CLOSEFH))
                     __wt_cond_signal(session, conn->log_file_cond);
             }
             __wt_log_slot_free(session, slot);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -205,7 +205,7 @@ struct __wt_logslot {
 #define WT_SLOT_SYNC_DIR 0x08u   /* Directory sync on release */
 #define WT_SLOT_SYNC_DIRTY 0x10u /* Sync system buffers on release */
                                  /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
-    uint32_t flags;
+    uint16_t flags_atomic;       /* Atomic flags, use F_*_ATOMIC_16 */
     WT_CACHE_LINE_PAD_END
 };
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1949,7 +1949,8 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
          * Check if we have to sync the parent directory. Some combinations of sync flags may result
          * in the log file not yet stable in its parent directory. Do that now if needed.
          */
-        if (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC_DIR) && (log->sync_dir_lsn.l.file < sync_lsn.l.file)) {
+        if (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC_DIR) &&
+          (log->sync_dir_lsn.l.file < sync_lsn.l.file)) {
             WT_ASSERT(session, log->log_dir_fh != NULL);
             __wt_verbose(session, WT_VERB_LOG,
               "log_release: sync directory %s to LSN %" PRIu32 "/%" PRIu32, log->log_dir_fh->name,
@@ -1966,7 +1967,8 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
         /*
          * Sync the log file if needed.
          */
-        if (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC) && __wt_log_cmp(&log->sync_lsn, &slot->slot_end_lsn) < 0) {
+        if (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC) &&
+          __wt_log_cmp(&log->sync_lsn, &slot->slot_end_lsn) < 0) {
             __wt_verbose(session, WT_VERB_LOG,
               "log_release: sync log %s to LSN %" PRIu32 "/%" PRIu32, log->log_fh->name,
               sync_lsn.l.file, sync_lsn.l.offset);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1319,7 +1319,7 @@ __wt_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WT_LOGSLOT *slot)
         WT_RET(__log_newfile(session, false, &created_log));
         F_CLR(log, WT_LOG_FORCE_NEWFILE);
         if (log->log_close_fh != NULL)
-            F_SET(slot, WT_SLOT_CLOSEFH);
+            F_SET_ATOMIC_16(slot, WT_SLOT_CLOSEFH);
     }
 
     /*
@@ -1879,7 +1879,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
      * the worker thread. The caller is responsible for freeing the slot in that case. Otherwise the
      * worker thread will free it.
      */
-    if (!F_ISSET(slot, WT_SLOT_FLUSH | WT_SLOT_SYNC_FLAGS)) {
+    if (!F_ISSET_ATOMIC_16(slot, WT_SLOT_FLUSH | WT_SLOT_SYNC_FLAGS)) {
         if (freep != NULL)
             *freep = 0;
         slot->slot_state = WT_LOG_SLOT_WRITTEN;
@@ -1906,15 +1906,15 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
 
     WT_ASSERT(session, slot != log->active_slot);
     __wt_cond_signal(session, log->log_write_cond);
-    F_CLR(slot, WT_SLOT_FLUSH);
+    F_CLR_ATOMIC_16(slot, WT_SLOT_FLUSH);
 
     /*
      * Signal the close thread if needed.
      */
-    if (F_ISSET(slot, WT_SLOT_CLOSEFH))
+    if (F_ISSET_ATOMIC_16(slot, WT_SLOT_CLOSEFH))
         __wt_cond_signal(session, conn->log_file_cond);
 
-    if (F_ISSET(slot, WT_SLOT_SYNC_DIRTY) && !F_ISSET(slot, WT_SLOT_SYNC) &&
+    if (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC_DIRTY) && !F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC) &&
       (ret = __wt_fsync(session, log->log_fh, false)) != 0) {
         /*
          * Ignore ENOTSUP, but don't try again.
@@ -1928,7 +1928,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
      * Try to consolidate calls to fsync to wait less. Acquire a spin lock so that threads finishing
      * writing to the log will wait while the current fsync completes and advance log->sync_lsn.
      */
-    while (F_ISSET(slot, WT_SLOT_SYNC | WT_SLOT_SYNC_DIR)) {
+    while (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC | WT_SLOT_SYNC_DIR)) {
         /*
          * We have to wait until earlier log files have finished their sync operations. The most
          * recent one will set the LSN to the beginning of our file.
@@ -1949,7 +1949,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
          * Check if we have to sync the parent directory. Some combinations of sync flags may result
          * in the log file not yet stable in its parent directory. Do that now if needed.
          */
-        if (F_ISSET(slot, WT_SLOT_SYNC_DIR) && (log->sync_dir_lsn.l.file < sync_lsn.l.file)) {
+        if (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC_DIR) && (log->sync_dir_lsn.l.file < sync_lsn.l.file)) {
             WT_ASSERT(session, log->log_dir_fh != NULL);
             __wt_verbose(session, WT_VERB_LOG,
               "log_release: sync directory %s to LSN %" PRIu32 "/%" PRIu32, log->log_dir_fh->name,
@@ -1966,7 +1966,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
         /*
          * Sync the log file if needed.
          */
-        if (F_ISSET(slot, WT_SLOT_SYNC) && __wt_log_cmp(&log->sync_lsn, &slot->slot_end_lsn) < 0) {
+        if (F_ISSET_ATOMIC_16(slot, WT_SLOT_SYNC) && __wt_log_cmp(&log->sync_lsn, &slot->slot_end_lsn) < 0) {
             __wt_verbose(session, WT_VERB_LOG,
               "log_release: sync log %s to LSN %" PRIu32 "/%" PRIu32, log->log_fh->name,
               sync_lsn.l.file, sync_lsn.l.offset);
@@ -1982,7 +1982,7 @@ __wt_log_release(WT_SESSION_IMPL *session, WT_LOGSLOT *slot, bool *freep)
         /*
          * Clear the flags before leaving the loop.
          */
-        F_CLR(slot, WT_SLOT_SYNC | WT_SLOT_SYNC_DIR);
+        F_CLR_ATOMIC_16(slot, WT_SLOT_SYNC | WT_SLOT_SYNC_DIR);
         locked = false;
         __wt_spin_unlock(session, &log->log_sync_lock);
     }
@@ -2643,6 +2643,7 @@ __log_write_internal(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, ui
      * The only time joining a slot should ever return an error is if it detects a panic.
      */
     __wt_log_slot_join(session, rdup_len, flags, &myslot);
+
     /*
      * If the addition of this record crosses the buffer boundary, switch in a new slot.
      */

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -32,8 +32,8 @@ __log_slot_dump(WT_SESSION_IMPL *session)
         if (__wt_log_cmp(&slot->slot_release_lsn, &log->slot_pool[earliest].slot_release_lsn) < 0)
             earliest = i;
         __wt_errx(session, "Slot %d (0x%p):", i, (void *)slot);
-        __wt_errx(session, "    State: %" PRIx64 " Flags: %" PRIx32, (uint64_t)slot->slot_state,
-          slot->flags);
+        __wt_errx(session, "    State: %" PRIx64 " Flags: %" PRIx16, (uint64_t)slot->slot_state,
+          slot->flags_atomic);
         __wt_errx(session, "    Start LSN: %" PRIu32 "/%" PRIu32, slot->slot_start_lsn.l.file,
           slot->slot_start_lsn.l.offset);
         __wt_errx(session, "    End  LSN: %" PRIu32 "/%" PRIu32, slot->slot_end_lsn.l.file,
@@ -214,7 +214,7 @@ __log_slot_dirty_max_check(WT_SESSION_IMPL *session, WT_LOGSLOT *slot)
     if (current->l.file == last_sync->l.file && current->l.offset > last_sync->l.offset &&
       current->l.offset - last_sync->l.offset > conn->log_dirty_max) {
         /* Schedule the asynchronous sync */
-        F_SET(slot, WT_SLOT_SYNC_DIRTY);
+        F_SET_ATOMIC_16(slot, WT_SLOT_SYNC_DIRTY);
         WT_ASSIGN_LSN(&log->dirty_lsn, &slot->slot_release_lsn);
     }
 }
@@ -448,7 +448,7 @@ __wt_log_slot_init(WT_SESSION_IMPL *session, bool alloc)
           (uint32_t)WT_MIN((size_t)conn->log_file_max / 10, WT_LOG_SLOT_BUF_SIZE);
         for (i = 0; i < WT_SLOT_POOL; i++) {
             WT_ERR(__wt_buf_init(session, &log->slot_pool[i].slot_buf, log->slot_buf_size));
-            F_SET(&log->slot_pool[i], WT_SLOT_INIT_FLAGS);
+            F_SET_ATOMIC_16(&log->slot_pool[i], WT_SLOT_INIT_FLAGS);
         }
         WT_STAT_CONN_SET(session, log_buffer_size, log->slot_buf_size * WT_SLOT_POOL);
     }
@@ -613,11 +613,11 @@ __wt_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WT
             WT_STAT_CONN_INCR(session, log_slot_yield_sleep);
     }
     if (LF_ISSET(WT_LOG_DSYNC | WT_LOG_FSYNC))
-        F_SET(slot, WT_SLOT_SYNC_DIR);
+        F_SET_ATOMIC_16(slot, WT_SLOT_SYNC_DIR);
     if (LF_ISSET(WT_LOG_FLUSH))
-        F_SET(slot, WT_SLOT_FLUSH);
+        F_SET_ATOMIC_16(slot, WT_SLOT_FLUSH);
     if (LF_ISSET(WT_LOG_FSYNC))
-        F_SET(slot, WT_SLOT_SYNC);
+        F_SET_ATOMIC_16(slot, WT_SLOT_SYNC);
     if (F_ISSET(myslot, WT_MYSLOT_UNBUFFERED)) {
         WT_ASSERT(session, slot->slot_unbuffered == 0);
         WT_STAT_CONN_INCR(session, log_slot_unbuffered);
@@ -680,7 +680,7 @@ __wt_log_slot_free(WT_SESSION_IMPL *session, WT_LOGSLOT *slot)
      * initialize the rest of the slot.
      */
     WT_UNUSED(session);
-    slot->flags = WT_SLOT_INIT_FLAGS;
+    slot->flags_atomic = WT_SLOT_INIT_FLAGS;
     slot->slot_error = 0;
     slot->slot_state = WT_LOG_SLOT_FREE;
 }


### PR DESCRIPTION
WT-10207 Changing log slot flags to flags_atomic. Removing debugging added for WT-9796 as the root cause was identified.

(cherry picked from commit 1b6329a945230f76011d0aad7a73b31188104f42)