### PR TITLE
WT-11607 Add a temporary test/format task using the WT-11507 config in Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4006,6 +4006,16 @@ tasks:
           config: ../../../test/format/CONFIG.mirror
           trace_args: -T all
 
+  # FIXME-WT-11606 Remove this temporary task.
+  - name: format-11507-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "format test script"
+        vars:
+          format_test_script_args: -c ../../../test/format/failure_configs/CONFIG.WT-11507 -t 360 -T all
+
   - name: format-stress-pull-request-test
     tags: ["pull_request"]
     commands:
@@ -6220,6 +6230,8 @@ buildvariants:
     additional_env_vars: export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libeatmydata.so:$LD_PRELOAD"
     CMAKE_PREFIX_PATH: -DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"
   tasks:
+    # FIXME-WT-11606 Remove this temporary task.
+    - name: format-11507-test
     - name: ".stress-test-1"
     - name: ".stress-test-2"
     - name: ".stress-test-3"
@@ -6253,6 +6265,8 @@ buildvariants:
     additional_env_vars: export LD_PRELOAD="/usr/lib/aarch64-linux-gnu/libeatmydata.so:$LD_PRELOAD"
     CMAKE_PREFIX_PATH: -DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"
   tasks:
+    # FIXME-WT-11606 Remove this temporary task.
+    - name: format-11507-test
     - name: ".stress-test-1"
     - name: ".stress-test-2"
     - name: ".stress-test-3"

--- a/test/format/failure_configs/CONFIG.WT-11507
+++ b/test/format/failure_configs/CONFIG.WT-11507
@@ -1,6 +1,7 @@
 ############################################
 #  RUN PARAMETERS: V3
 ############################################
+# FIXME-WT-11606 Remove this temporary config.
 assert.read_timestamp=0
 background_compact=0
 background_compact.free_space_target=2


### PR DESCRIPTION
In order to have more chances to reproduce WT-11507, we are adding a temporary task to Evergreen which runs test/format with the config from WT-11507.