### PR TITLE
WT-11217 POC implementation of session foreach

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -278,16 +278,12 @@ __sweep_check_session_sweep(WT_SESSION_IMPL *session, uint64_t now)
     WT_CONNECTION_IMPL *conn;
     WT_SESSION_IMPL *s;
     uint64_t last, last_cursor_big_sweep, last_sweep;
-    uint32_t i;
 
     conn = S2C(session);
 
-    for (s = conn->sessions, i = 0; i < conn->session_cnt; ++s, ++i) {
-        /*
-         * Ignore inactive and internal sessions.
-         */
-        if (!s->active)
-            continue;
+    WT_SESSION_FOREACH_BEGIN(s, conn)
+    {
+        /* Skip internal sessions. */
         if (F_ISSET(s, WT_SESSION_INTERNAL))
             continue;
 
@@ -325,13 +321,14 @@ __sweep_check_session_sweep(WT_SESSION_IMPL *session, uint64_t now)
                 s->sweep_warning_60min = 1;
                 WT_STAT_CONN_INCR(session, no_session_sweep_60min);
                 __wt_verbose_warning(session, WT_VERB_DEFAULT,
-                  "Session %" PRIu32 " (@: 0x%p name: %s) did not run a sweep for 60 minutes.", i,
-                  (void *)s, s->name == NULL ? "EMPTY" : s->name);
+                  "Session %" PRIu32 " (@: 0x%p name: %s) did not run a sweep for 60 minutes.",
+                  s->id, (void *)s, s->name == NULL ? "EMPTY" : s->name);
             }
         } else {
             s->sweep_warning_60min = 0;
         }
     }
+    WT_SESSION_FOREACH_END;
 }
 
 /*

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -287,6 +287,21 @@ typedef TAILQ_HEAD(__wt_backuphash, __wt_backup_target) WT_BACKUPHASH;
 
 extern const WT_NAME_FLAG __wt_stress_types[];
 
+#define WT_SESSION_FOREACH_BEGIN(session, conn)                                                \
+    do {                                                                                       \
+        uint32_t __i, __session_cnt;                                                           \
+        u_int __active;                                                                        \
+        __session_cnt = *(volatile uint32_t *)&(conn)->session_cnt;                            \
+        for (__i = 0, (session) = (conn)->sessions; __i < __session_cnt; ++__i, ++(session)) { \
+            WT_ORDERED_READ(__active, (session)->active);                                      \
+            if (!__active)                                                                     \
+                continue;
+
+#define WT_SESSION_FOREACH_END \
+    }                          \
+    }                          \
+    while (0)
+
 /*
  * WT_CONNECTION_IMPL --
  *	Implementation of WT_CONNECTION

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -299,7 +299,6 @@ extern const WT_NAME_FLAG __wt_stress_types[];
          * out.                                                                                  \
          */                                                                                      \
         __session_cnt = *(volatile uint32_t *)&(conn)->session_cnt;                              \
-        WT_ORDERED_READ(__session_cnt, (conn)->session_cnt);                                     \
         for (__i = 0, (array_session) = (conn)->sessions; __i < __session_cnt;                   \
              ++__i, ++(array_session)) {                                                         \
             WT_ORDERED_READ(__active, (array_session)->active);                                  \

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -287,22 +287,23 @@ typedef TAILQ_HEAD(__wt_backuphash, __wt_backup_target) WT_BACKUPHASH;
 
 extern const WT_NAME_FLAG __wt_stress_types[];
 
-#define WT_SESSION_FOREACH_BEGIN(array_session, conn)                                           \
-    do {                                                                                        \
-        uint32_t __i, __session_cnt;                                                            \
-        u_int __active;                                                                         \
-                                                                                                \
-        /*                                                                                      \
-         * The session count variable can change concurrently with the reader thread traversing \
-         * the array. It is up to the algorithm doing the traversal, e.g. hazard pointers,      \
-         * generations to handle the consequences of a new session being created or closed out. \
-         */                                                                                     \
-        __session_cnt = *(volatile uint32_t *)&(conn)->session_cnt;                             \
-        WT_ORDERED_READ(__session_cnt, (conn)->session_cnt);                                    \
-        for (__i = 0, (array_session) = (conn)->sessions; __i < __session_cnt;                  \
-             ++__i, ++(array_session)) {                                                        \
-            WT_ORDERED_READ(__active, (array_session)->active);                                 \
-            if (!__active)                                                                      \
+#define WT_SESSION_FOREACH_BEGIN(array_session, conn)                                            \
+    do {                                                                                         \
+        uint32_t __i, __session_cnt;                                                             \
+        u_int __active;                                                                          \
+                                                                                                 \
+        /*                                                                                       \
+         * The session count variable can change concurrently with the reader thread traversing  \
+         * the array. It is up to the algorithm doing the traversal, e.g. hazard pointers,       \
+         * generations, etc, to handle the consequences of a new session being created or closed \
+         * out.                                                                                  \
+         */                                                                                      \
+        __session_cnt = *(volatile uint32_t *)&(conn)->session_cnt;                              \
+        WT_ORDERED_READ(__session_cnt, (conn)->session_cnt);                                     \
+        for (__i = 0, (array_session) = (conn)->sessions; __i < __session_cnt;                   \
+             ++__i, ++(array_session)) {                                                         \
+            WT_ORDERED_READ(__active, (array_session)->active);                                  \
+            if (!__active)                                                                       \
                 continue;
 
 #define WT_SESSION_FOREACH_END \

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -298,7 +298,7 @@ extern const WT_NAME_FLAG __wt_stress_types[];
          * generations, etc, to handle the consequences of a new session being created or closed \
          * out.                                                                                  \
          */                                                                                      \
-        __session_cnt = *(volatile uint32_t *)&(conn)->session_cnt;                              \
+        __session_cnt = *(volatile uint32_t *)&((conn)->session_cnt);                            \
         for (__i = 0, (array_session) = (conn)->sessions; __i < __session_cnt;                   \
              ++__i, ++(array_session)) {                                                         \
             WT_ORDERED_READ(__active, (array_session)->active);                                  \

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -127,7 +127,8 @@ __wt_gen_drain(WT_SESSION_IMPL *session, int which, uint64_t generation)
      */
     minutes = 0;
     pause_cnt = 0;
-    WT_SESSION_FOREACH_BEGIN(s, conn) {
+    WT_SESSION_FOREACH_BEGIN(s, conn)
+    {
         for (;;) {
             /* Ensure we only read the value once. */
             WT_ORDERED_READ(v, s->generations[which]);
@@ -227,7 +228,9 @@ __gen_oldest(WT_SESSION_IMPL *session, int which)
      * it could read an earlier session generation value. This would then violate the acquisition
      * semantics and could result in us reading 0 for the session generation when it is non-zero.
      */
-    WT_SESSION_FOREACH_BEGIN(s, conn) {
+    WT_ORDERED_READ(oldest, conn->generations[which]);
+    WT_SESSION_FOREACH_BEGIN(s, conn)
+    {
         /* Ensure we only read the value once. */
         WT_ORDERED_READ(v, s->generations[which]);
 
@@ -252,7 +255,8 @@ __wt_gen_active(WT_SESSION_IMPL *session, int which, uint64_t generation)
 
     conn = S2C(session);
 
-    WT_SESSION_FOREACH_BEGIN(s, conn) {
+    WT_SESSION_FOREACH_BEGIN(s, conn)
+    {
         /* Ensure we only read the value once. */
         WT_ORDERED_READ(v, s->generations[which]);
 

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -307,7 +307,7 @@ __wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref, WT_SESSION_IMPL **sessi
     WT_SESSION_IMPL *s;
     uint32_t i, hazard_inuse, max, walk_cnt;
 
-    max = 0;
+    max = walk_cnt = 0;
     conn = S2C(session);
 
     /* If a file can never be evicted, hazard pointers aren't required. */


### PR DESCRIPTION
This is a rehash of #9295 but it also handles the active flag and replaces the `ORDERED_READ` on `conn->session_cnt` with a `READ_ONCE` that macro doesn't exist yet so i've just done a volatile cast to demonstrate. This is one of the suggested improvements from the session algo review.

I personally think this a large improvement.

This is a **draft** PR and comments, locations of macros etc are not finalized but I would like a quick (Y/N) in terms of direction.