### PR TITLE
WT-11652 Fix data race when updating btree's last record number

### DIFF
--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -126,11 +126,12 @@ __col_append_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head, WT_
      * Set the calling cursor's record number. If we extended the file, update the last record
      * number.
      */
-    *recnop = recno;
-    if (recno > btree->last_recno)
-        __wt_atomic_cas64(&btree->last_recno, btree->last_recno, recno);
+    do {
+        *recnop = recno;
+    } while (!__wt_atomic_cas64(&btree->last_recno, btree->last_recno, recno) &&
+      (recno > btree->last_recno));
 
-    return (0);
+      return (0);
 }
 
 /*

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -131,7 +131,7 @@ __col_append_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head, WT_
     } while (!__wt_atomic_cas64(&btree->last_recno, btree->last_recno, recno) &&
       (recno > btree->last_recno));
 
-      return (0);
+    return (0);
 }
 
 /*

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -128,7 +128,7 @@ __col_append_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head, WT_
      */
     *recnop = recno;
     if (recno > btree->last_recno)
-        btree->last_recno = recno;
+        __wt_atomic_cas64(&btree->last_recno, btree->last_recno, recno);
 
     return (0);
 }

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -101,7 +101,7 @@ __col_append_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head, WT_
   WT_INSERT *new_ins, uint64_t *recnop, u_int skipdepth)
 {
     WT_BTREE *btree;
-    uint64_t recno, local_recno;
+    uint64_t recno, last_recno;
     u_int i;
 
     btree = S2BT(session);
@@ -128,8 +128,9 @@ __col_append_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head, WT_
      */
     *recnop = recno;
     do {
-        local_recno = *((volatile uint64_t *)(&btree->last_recno));
-    } while ((recno > local_recno) && !__wt_atomic_cas64(&btree->last_recno, local_recno, recno));
+        /* Ensure we only read the value once. */
+        last_recno = *((volatile uint64_t *)(&btree->last_recno));
+    } while ((recno > last_recno) && !__wt_atomic_cas64(&btree->last_recno, last_recno, recno));
 
     return (0);
 }

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -128,7 +128,7 @@ __col_append_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head, WT_
      */
     *recnop = recno;
     do {
-        local_recno = *((volatile uint64_t *)(btree->last_recno));
+        local_recno = *((volatile uint64_t *)(&btree->last_recno));
     } while ((recno > local_recno) && !__wt_atomic_cas64(&btree->last_recno, local_recno, recno));
 
     return (0);


### PR DESCRIPTION
We want to make updating the last recno in the btree to be thread safe. 