### PR TITLE
WT-11609 Verify mirror tables after a mirrored truncate

### DIFF
--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -158,7 +158,7 @@ checkpoint(void *arg)
             lock_writeunlock(session, &g.backup_lock);
 
         /* Verify the checkpoints. */
-        wts_verify_checkpoint(conn, ckpt_vrfy_name);
+        wts_verify_mirrors(conn, ckpt_vrfy_name, NULL);
 
         secs = mmrand(&g.extra_rnd, 5, 40);
     }

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -509,6 +509,7 @@ void wts_reopen(void);
 void wts_salvage(TABLE *, void *);
 void wts_stats(void);
 void wts_verify(WT_CONNECTION *, bool);
+void wts_verify_mirrored_truncate(TINFO *tinfo, TABLE *table);
 void wts_verify_mirrors(WT_CONNECTION *, const char *, TINFO *);
 
 /* Backward compatibility to older versions of the WiredTiger library. */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -509,7 +509,7 @@ void wts_reopen(void);
 void wts_salvage(TABLE *, void *);
 void wts_stats(void);
 void wts_verify(WT_CONNECTION *, bool);
-void wts_verify_checkpoint(WT_CONNECTION *, const char *);
+void wts_verify_mirrors(WT_CONNECTION *, const char *, TINFO *);
 
 /* Backward compatibility to older versions of the WiredTiger library. */
 #if !defined(CUR2S)

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -509,7 +509,7 @@ void wts_reopen(void);
 void wts_salvage(TABLE *, void *);
 void wts_stats(void);
 void wts_verify(WT_CONNECTION *, bool);
-void wts_verify_mirrored_truncate(TINFO *tinfo, TABLE *table);
+void wts_verify_mirrored_truncate(TINFO *tinfo);
 void wts_verify_mirrors(WT_CONNECTION *, const char *, TINFO *);
 
 /* Backward compatibility to older versions of the WiredTiger library. */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1292,7 +1292,7 @@ rollback_retry:
             skip2 = table;
         }
         if (ret == 0 && table->mirror) {
-            if(op == TRUNCATE)
+            if (op == TRUNCATE)
                 mirrored_truncate = true;
             for (i = 1; i <= ntables; ++i)
                 if (tables[i] != skip1 && tables[i] != skip2 && tables[i]->mirror) {

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1400,7 +1400,7 @@ rollback:
             break;
         }
 
-        if (op == TRUNCATE && mirrored_truncate) {
+        if (mirrored_truncate) {
             /*
              * At the end of a mirrored truncate all tables must contain the same keys. It's ok if a
              * parallel insert has added keys back inside the truncated range as long as all mirror

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1401,7 +1401,7 @@ rollback:
         }
 
         if (mirrored_truncate)
-            wts_verify_mirrored_truncate(tinfo, table);
+            wts_verify_mirrored_truncate(tinfo);
 
         intxn = false;
     }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1400,22 +1400,8 @@ rollback:
             break;
         }
 
-        if (mirrored_truncate) {
-            /*
-             * At the end of a mirrored truncate all tables must contain the same keys. It's ok if a
-             * parallel insert has added keys back inside the truncated range as long as all mirror
-             * tables have that same key.
-             *
-             * Verifies can be expensive so we limit them to smaller ranges and only infrequently
-             * check larger ranges.
-             */
-            if (tinfo->last != 0 && tinfo->keyno != 0) {
-                if ((tinfo->last - tinfo->keyno) < 10000)
-                    wts_verify_mirrors(g.wts_conn, NULL, tinfo);
-                else if (mmrand(&tinfo->data_rnd, 0, 10) == 1)
-                    wts_verify_mirrors(g.wts_conn, NULL, tinfo);
-            }
-        }
+        if (mirrored_truncate)
+            wts_verify_mirrored_truncate(tinfo, table);
 
         intxn = false;
     }

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -173,6 +173,7 @@ position_cursor_before(TABLE *table, WT_CURSOR *cursor, uint64_t target_keyno)
             ret = 0;
     }
 
+    key_gen_teardown(&key);
     return ret;
 }
 

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -445,7 +445,7 @@ wts_verify(WT_CONNECTION *conn, bool mirror_check)
 void
 wts_verify_mirrored_truncate(TINFO *tinfo, TABLE *table)
 {
-    int range_begin, range_end;
+    uint64_t range_begin, range_end;
 
     testutil_assert(tinfo != NULL);
 

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -443,14 +443,15 @@ wts_verify(WT_CONNECTION *conn, bool mirror_check)
  *     infrequently check larger ranges.
  */
 void
-wts_verify_mirrored_truncate(TINFO *tinfo, TABLE *table)
+wts_verify_mirrored_truncate(TINFO *tinfo)
 {
     uint64_t range_begin, range_end;
 
     testutil_assert(tinfo != NULL);
+    testutil_assert(g.base_mirror != NULL);
 
     range_begin = tinfo->keyno != 0 ? tinfo->keyno : 1;
-    range_end = tinfo->last != 0 ? tinfo->last : TV(RUNS_ROWS);
+    range_end = tinfo->last != 0 ? tinfo->last : NTV(g.base_mirror, RUNS_ROWS);
 
     if ((range_end - range_begin) < 10000)
         wts_verify_mirrors(g.wts_conn, NULL, tinfo);

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -138,11 +138,53 @@ table_mirror_fail_msg_flcs(WT_SESSION *session, const char *checkpoint, TABLE *b
 }
 
 /*
+ * position_cursor_before --
+ *     Place a cursor on the key directly preceding the target key. It's ok to return WT_NOTFOUND
+ *     from this function as any subsequent cursor next calls will begin at the start of the table.
+ */
+static int
+position_cursor_before(TABLE *table, WT_CURSOR *cursor, uint64_t target_keyno)
+{
+    WT_ITEM key;
+    int exact;
+    int ret;
+
+    key_gen_init(&key);
+    ret = 0;
+
+    switch (table->type) {
+    case FIX:
+    case VAR:
+        cursor->set_key(cursor, target_keyno);
+        break;
+    case ROW:
+        key_gen(table, &key, target_keyno);
+        cursor->set_key(cursor, &key);
+        break;
+    }
+
+    testutil_check(read_op(cursor, SEARCH_NEAR, &exact));
+
+    /* If we're on or past the target key then move backwards one key. */
+    if (exact >= 0) {
+        ret = read_op(cursor, PREV, NULL);
+        testutil_assert(ret == 0 || WT_NOTFOUND);
+        if (ret == WT_NOTFOUND)
+            ret = 0;
+    }
+
+    return ret;
+}
+
+/*
  * table_verify_mirror --
- *     Verify a mirrored pair.
+ *     Verify that a mirrored pair of tables contain the same mirrored entries. If a checkpoint is
+ *     provided compare the tables using checkpoint cursors. If thread info is provided validate
+ *     within its key range (inclusive).
  */
 static void
-table_verify_mirror(WT_CONNECTION *conn, TABLE *base, TABLE *table, const char *checkpoint)
+table_verify_mirror(
+  WT_CONNECTION *conn, TABLE *base, TABLE *table, const char *checkpoint, TINFO *tinfo)
 {
     SAP sap;
     WT_CURSOR *base_cursor, *table_cursor;
@@ -152,6 +194,7 @@ table_verify_mirror(WT_CONNECTION *conn, TABLE *base, TABLE *table, const char *
     uint8_t base_bitv, table_bitv;
     u_int failures, i, last_failures;
     int base_ret, table_ret;
+    uint64_t range_begin, range_end;
     char buf[256], tagbuf[128];
 
     base_keyno = table_keyno = 0;             /* -Wconditional-uninitialized */
@@ -191,7 +234,25 @@ table_verify_mirror(WT_CONNECTION *conn, TABLE *base, TABLE *table, const char *
       table->id, checkpoint == NULL ? "" : checkpoint, checkpoint == NULL ? "" : " checkpoint ");
     trace_msg(session, "%s: start", buf);
 
-    for (failures = 0, rows = 1; rows <= TV(RUNS_ROWS); ++rows) {
+    /*
+     * By default compare the entire range of keys, however if thread info is provided the start/end
+     * key ranges can be used instead. These ranges follow the same rules as truncate; If the
+     * provided value is zero treat that as the start/end of the table.
+     */
+    range_begin = 1;
+    range_end = TV(RUNS_ROWS);
+    if (tinfo != NULL) {
+        if (tinfo->keyno != 0) {
+            range_begin = tinfo->keyno;
+            testutil_check(position_cursor_before(base, base_cursor, range_begin));
+            testutil_check(position_cursor_before(table, table_cursor, range_begin));
+        }
+
+        if (tinfo->last != 0)
+            range_end = tinfo->last;
+    }
+
+    for (failures = 0, rows = range_begin; rows <= range_end; ++rows) {
         last_failures = failures;
         switch (base->type) {
         case FIX:
@@ -371,15 +432,15 @@ wts_verify(WT_CONNECTION *conn, bool mirror_check)
 
     for (i = 1; i <= ntables; ++i)
         if (tables[i]->mirror && tables[i] != g.base_mirror)
-            table_verify_mirror(conn, g.base_mirror, tables[i], NULL);
+            table_verify_mirror(conn, g.base_mirror, tables[i], NULL, NULL);
 }
 
 /*
- * wts_verify_checkpoint --
- *     Verify the database tables at a checkpoint.
+ * wts_verify_mirrors --
+ *     Verify all mirrored tables contain the same mirrored entries.
  */
 void
-wts_verify_checkpoint(WT_CONNECTION *conn, const char *checkpoint)
+wts_verify_mirrors(WT_CONNECTION *conn, const char *checkpoint, TINFO *tinfo)
 {
     u_int i;
 
@@ -391,5 +452,5 @@ wts_verify_checkpoint(WT_CONNECTION *conn, const char *checkpoint)
 
     for (i = 1; i <= ntables; ++i)
         if (tables[i]->mirror && tables[i] != g.base_mirror)
-            table_verify_mirror(conn, g.base_mirror, tables[i], checkpoint);
+            table_verify_mirror(conn, g.base_mirror, tables[i], checkpoint, tinfo);
 }


### PR DESCRIPTION
Inspired by WT-11507.
Perform verification of mirror tables after a mirror truncate. Since this can be expensive we always perform verification for small truncate ranges, and only infrequently for larger truncate ranges.
Previously verification always ran on all keys in the tables. This change updates it to allow for iteration over smaller ranges.
