### PR TITLE
WT-11670 verify test_checkpoint_snapshot05 expectations

### DIFF
--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -164,10 +164,8 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
         # Verify exactly one checkpoint is present: as required by the test assertions.
         # Assertion is NOT about the code under test, so use 'assert'.
         with open_cursor(self.session, 'statistics:') as stat_cursor:
-            started = stat_cursor[stat.conn.checkpoints][2]
-            skipped = stat_cursor[stat.conn.checkpoint_skipped][2]
-        assert stat_cursor[stat.conn.checkpoints][2] == 1
-        assert stat_cursor[stat.conn.checkpoint_skipped][2] == 0
+            assert stat_cursor[stat.conn.checkpoints][2] == 1
+            assert stat_cursor[stat.conn.checkpoint_skipped][2] == 0
 
         # Take a backup and restore it.
         self.take_full_backup(".", self.backup_dir)

--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -166,7 +166,8 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
         with open_cursor(self.session, 'statistics:') as stat_cursor:
             started = stat_cursor[stat.conn.checkpoints][2]
             skipped = stat_cursor[stat.conn.checkpoint_skipped][2]
-        assert (started - skipped) == 1
+        assert stat_cursor[stat.conn.checkpoints][2] == 1
+        assert stat_cursor[stat.conn.checkpoint_skipped][2] == 0
 
         # Take a backup and restore it.
         self.take_full_backup(".", self.backup_dir)

--- a/test/suite/test_checkpoint_snapshot05.py
+++ b/test/suite/test_checkpoint_snapshot05.py
@@ -28,6 +28,7 @@
 
 import os, shutil, threading, time
 from wtthread import checkpoint_thread
+from wttest import open_cursor
 import wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
@@ -140,20 +141,19 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
             else:
                 cursor1.set_value(self.valueb + str(i))
             self.assertEqual(cursor1.update(), 0)
-
-        # Create a checkpoint thread
+        
+        # Commit the transaction during a checkpoint.
         done = threading.Event()
         ckpt = checkpoint_thread(self.conn, done, checkpoint_count_max=1)
         try:
             ckpt.start()
             
-            # Wait for checkpoint to start and acquire its snapshot before committing.
+            # Wait for checkpoint to acquire its snapshot executing the commit.
             ckpt_snapshot = 0
             while not ckpt_snapshot:
-                time.sleep(1)
-                stat_cursor = self.session.open_cursor('statistics:', None, None)
-                ckpt_snapshot = stat_cursor[stat.conn.checkpoint_snapshot_acquired][2]
-                stat_cursor.close()
+                with open_cursor(self.session, 'statistics:') as stat_cursor:
+                    ckpt_snapshot = stat_cursor[stat.conn.checkpoint_snapshot_acquired][2]
+                time.sleep(0.5)
 
             session1.commit_transaction()
             self.evict(self.uri, ds, self.nrows)
@@ -161,17 +161,23 @@ class test_checkpoint_snapshot05(wttest.WiredTigerTestCase):
             done.set()
             ckpt.join()
 
-        #Take a backup and restore it.
+        # Verify exactly one checkpoint is present: as required by the test assertions.
+        # Assertion is NOT about the code under test, so use 'assert'.
+        with open_cursor(self.session, 'statistics:') as stat_cursor:
+            started = stat_cursor[stat.conn.checkpoints][2]
+            skipped = stat_cursor[stat.conn.checkpoint_skipped][2]
+        assert (started - skipped) == 1
+
+        # Take a backup and restore it.
         self.take_full_backup(".", self.backup_dir)
         self.reopen_conn(self.backup_dir)
 
         # Check the table contains the last checkpointed value.
         self.check(self.valuea, self.uri, self.nrows)
 
-        stat_cursor = self.session.open_cursor('statistics:', None, None)
-        inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
-        keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
-        stat_cursor.close()
+        with open_cursor(self.session, 'statistics:') as stat_cursor:
+            inconsistent_ckpt = stat_cursor[stat.conn.txn_rts_inconsistent_ckpt][2]
+            keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
 
         self.assertGreater(inconsistent_ckpt, 0)
         self.assertEqual(keys_removed, 0)

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -830,6 +830,21 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         """
         return i
 
+@contextmanager
+def open_cursor(session, uri: str):
+    """
+    Open a cursor instance that supports 'with' statements.
+    """
+    assert session is not None
+    assert uri is not None
+
+    cursor = session.open_cursor(uri, None, None)
+    try:
+        yield cursor
+    finally:
+        cursor.close()
+
+
 def zstdtest(description):
     """
     Used as a function decorator, for example, @wttest.zstdtest("description").

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -843,8 +843,6 @@ def open_cursor(session, uri: str, **kwargs):
     Keyword Args:
         config (str): Configuration.
     """
-    assert session is not None
-    assert uri is not None
 
     config = None if "config" not in kwargs else str(kwargs["config"])
 

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -831,14 +831,24 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         return i
 
 @contextmanager
-def open_cursor(session, uri: str):
+def open_cursor(session, uri: str, **kwargs):
     """
-    Open a cursor instance that supports 'with' statements.
+    Open a cursor instance on a session.
+
+    Supports 'with' statements.
+
+    Args:
+        uri (str): URI.
+
+    Keyword Args:
+        config (str): Configuration.
     """
     assert session is not None
     assert uri is not None
 
-    cursor = session.open_cursor(uri, None, None)
+    config = None if "config" not in kwargs else str(kwargs["config"])
+
+    cursor = session.open_cursor(uri, None, config)
     try:
         yield cursor
     finally:


### PR DESCRIPTION
This test uses synchronous API calls and threads to coordinate concurrent activity, and sensitive to changes in timing.

Add assertion to verify test environment expectations. Both Improving documentation and simplyfing failure identification.

Add free function to wttest to allow cursor instances to be used in `with` statements.