### PR TITLE
WT-10207 Change log slot flags to flags_atomic and remove debugging (v6.0) (#8578)

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -735,8 +735,8 @@ restart:
                 /*
                  * Copy the flag for later closing.
                  */
-                if (F_ISSET(slot, WT_SLOT_CLOSEFH))
-                    F_SET(coalescing, WT_SLOT_CLOSEFH);
+                if (F_ISSET_ATOMIC_16(slot, WT_SLOT_CLOSEFH))
+                    F_SET_ATOMIC_16(coalescing, WT_SLOT_CLOSEFH);
             } else {
                 /*
                  * If this written slot is not the next LSN, try to start coalescing with later
@@ -766,7 +766,7 @@ restart:
                 /*
                  * Signal the close thread if needed.
                  */
-                if (F_ISSET(slot, WT_SLOT_CLOSEFH))
+                if (F_ISSET_ATOMIC_16(slot, WT_SLOT_CLOSEFH))
                     __wt_cond_signal(session, conn->log_file_cond);
             }
             __wt_log_slot_free(session, slot);

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -205,7 +205,7 @@ struct __wt_logslot {
 #define WT_SLOT_SYNC_DIR 0x08u   /* Directory sync on release */
 #define WT_SLOT_SYNC_DIRTY 0x10u /* Sync system buffers on release */
                                  /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
-    uint32_t flags;
+    uint16_t flags_atomic;       /* Atomic flags, use F_*_ATOMIC_16 */
     WT_CACHE_LINE_PAD_END
 };
 


### PR DESCRIPTION
WT-10207 Changing log slot flags to flags_atomic. Removing debugging added for WT-9796 as the root cause was identified.

(cherry picked from commit 1b6329a945230f76011d0aad7a73b31188104f42)