### PR TITLE
WT-11733 Decouple validation from tracking in the cppsuite

### DIFF
--- a/test/cppsuite/how_to_use_cppsuite.md
+++ b/test/cppsuite/how_to_use_cppsuite.md
@@ -109,6 +109,10 @@ validate(bool tracking_enabled, const std::string &operation_table_name, const s
     const int64_t ten_mb = 10 * 1024 * 1024;
     const int64_t one_kb = 1024;
 
+    /*
+     * This validate logic uses data from operation tracking, it must have been enabled during
+     * the test.
+     */
     testutil_assert(tracking_enabled);
     scoped_session session = connection_manager::instance().create_session();
 

--- a/test/cppsuite/how_to_use_cppsuite.md
+++ b/test/cppsuite/how_to_use_cppsuite.md
@@ -103,12 +103,13 @@ In our test `multi_size_inserts` the 10MB updates are too large for cache and no
 
 ```cpp
 void
-validate(const std::string &operation_table_name, const std::string &schema_table_name,
+validate(bool tracking_enabled, const std::string &operation_table_name, const std::string &schema_table_name,
     database &db) override final
 {
     const int64_t ten_mb = 10 * 1024 * 1024;
     const int64_t one_kb = 1024;
 
+    testutil_assert(tracking_enabled);
     scoped_session session = connection_manager::instance().create_session();
 
     // For this test we only need to check the insert operations data saved by the operation tracker.

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -420,9 +420,12 @@ database_operation::update_operation(thread_worker *tc)
 }
 
 void
-database_operation::validate(
-  const std::string &operation_table_name, const std::string &schema_table_name, database &db)
+database_operation::validate(bool tracking_enabled, const std::string &operation_table_name,
+  const std::string &schema_table_name, database &db)
 {
+    // The default implementation requires the tracking component to be enabled.
+    if (!tracking_enabled)
+        return;
     validator wv;
     wv.validate(operation_table_name, schema_table_name, db);
 }

--- a/test/cppsuite/src/main/database_operation.h
+++ b/test/cppsuite/src/main/database_operation.h
@@ -68,8 +68,8 @@ public:
     /* Basic update operation that chooses a random key and updates it. */
     virtual void update_operation(thread_worker *tc);
 
-    virtual void validate(
-      const std::string &operation_table_name, const std::string &schema_table_name, database &db);
+    virtual void validate(bool tracking_enabled, const std::string &operation_table_name,
+      const std::string &schema_table_name, database &db);
 
     virtual ~database_operation() = default;
 };

--- a/test/cppsuite/src/main/test.cpp
+++ b/test/cppsuite/src/main/test.cpp
@@ -168,11 +168,8 @@ test::run()
         it->finish();
 
     /* Validation stage. */
-    if (_operation_tracker->enabled()) {
-        std::unique_ptr<configuration> tracking_config(_config->get_subconfig(OPERATION_TRACKER));
-        this->validate(_operation_tracker->get_operation_table_name(),
-          _operation_tracker->get_schema_table_name(), _workload_manager->get_database());
-    }
+    this->validate(_operation_tracker->enabled(), _operation_tracker->get_operation_table_name(),
+      _operation_tracker->get_schema_table_name(), _workload_manager->get_database());
 
     /* Log perf stats. */
     metrics_writer::instance().output_perf_file(_args.test_name);

--- a/test/cppsuite/tests/cache_resize.cpp
+++ b/test/cppsuite/tests/cache_resize.cpp
@@ -167,8 +167,8 @@ public:
     }
 
     void
-    validate(
-      const std::string &operation_table_name, const std::string &, database &) override final
+    validate(bool tracking_enabled, const std::string &operation_table_name, const std::string &,
+      database &) override final
     {
         bool first_record = true;
         int ret;
@@ -180,6 +180,7 @@ public:
         (void)cache_size_500mb;
 
         /* Open a cursor on the tracking table to read it. */
+        testutil_assert(tracking_enabled);
         scoped_session session = connection_manager::instance().create_session();
         scoped_cursor cursor = session.open_scoped_cursor(operation_table_name);
 

--- a/test/cppsuite/tests/cache_resize.cpp
+++ b/test/cppsuite/tests/cache_resize.cpp
@@ -179,8 +179,13 @@ public:
         (void)cache_size;
         (void)cache_size_500mb;
 
-        /* Open a cursor on the tracking table to read it. */
+        /*
+         * This validate logic uses data from operation tracking, it must have been enabled during
+         * the test.
+         */
         testutil_assert(tracking_enabled);
+
+        /* Open a cursor on the tracking table to read it. */
         scoped_session session = connection_manager::instance().create_session();
         scoped_cursor cursor = session.open_scoped_cursor(operation_table_name);
 

--- a/test/cppsuite/tests/test_template.cpp
+++ b/test/cppsuite/tests/test_template.cpp
@@ -121,7 +121,7 @@ public:
     }
 
     void
-    validate(const std::string &, const std::string &, database &) override final
+    validate(bool, const std::string &, const std::string &, database &) override final
     {
         logger::log_msg(LOG_WARN, "validate: nothing done");
     }


### PR DESCRIPTION
We should be able to validate a workload without the need for the tracking component to be enabled.
The `validate` function has been updated with a new first argument `tracking_enabled`. This one has to be `true` for the default implementation.