### PR TITLE
WT-11045 Create the mirror table before its base in Workgen

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -513,9 +513,7 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
             // sequence.
             char rand_chars[DYNAMIC_TABLE_LEN];
             gen_random_table_name(rand_chars, _rand_state);
-            std::string uri("table:");
-            uri += _workload->options.create_prefix;
-            uri += rand_chars;
+            const std::string uri("table:" + _workload->options.create_prefix + rand_chars);
 
             // Create the table and its mirror if enabled.
             int ret = create_table(session, config, uri, _workload->options.mirror_tables);

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -442,11 +442,11 @@ WorkloadRunner::update_dyn_struct(
 {
     ContextInternal *icontext = _workload->_context->_internal;
 
-    tint_t tint = icontext->_dyn_tint_last;
+    // This should be safe as we are supposed to be under a lock.
+    tint_t tint = icontext->_dyn_tint_last++;
     icontext->_dyn_tint[uri] = tint;
     icontext->_dyn_table_names[tint] = uri;
     icontext->_dyn_table_runtime[tint] = TableRuntime(is_base, mirror_uri);
-    (void)workgen_atomic_add32(&icontext->_dyn_tint_last, 1);
     VERBOSE(*_workload, "Created table and added to the dynamic set: " << uri);
 }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -424,9 +424,9 @@ WorkloadRunner::create_table(
     // which are protected by a mutex.
     {
         const std::lock_guard<std::shared_mutex> lock(*icontext->_dyn_mutex);
-        update_dyn_struct(uri, true, mirror_uri);
+        update_dyn_struct_locked(uri, true, mirror_uri);
         if (mirror_enabled)
-            update_dyn_struct(mirror_uri, false, uri);
+            update_dyn_struct_locked(mirror_uri, false, uri);
     }
 
     return 0;
@@ -437,7 +437,7 @@ WorkloadRunner::create_table(
  * caller should hold the mutex that protects those structures.
  */
 void
-WorkloadRunner::update_dyn_struct(
+WorkloadRunner::update_dyn_struct_locked(
   const std::string &uri, bool is_base, const std::string &mirror_uri)
 {
     ContextInternal *icontext = _workload->_context->_internal;

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1620,27 +1620,12 @@ ThreadRunner::op_run_setup(Operation *op)
             std::advance(itr, random_value() % num_tables);
 
             if (_icontext->_dyn_table_runtime[itr->second]._is_base &&
-              !_icontext->_dyn_table_runtime[itr->second]._pending_delete) {
-
-                // In case the selected table has a mirror, we need to check it is ready for use.
-                if (_icontext->_dyn_table_runtime[itr->second].has_mirror()) {
-                    const std::string mirror_op_uri(
-                      _icontext->_dyn_table_runtime[itr->second]._mirror);
-                    // When a table is created, its mirror is fully created when a valid URI and
-                    // unique identifier have been allocated.
-                    if (mirror_op_uri.empty())
-                        continue;
-                    tint_t mirror_op_tint = _icontext->_dyn_tint[mirror_op_uri];
-                    if (mirror_op_tint == 0)
-                        continue;
-                }
+              !_icontext->_dyn_table_runtime[itr->second]._pending_delete)
                 break;
-            }
         }
         // Try again next time.
-        if (num_tables == 0 || retries >= TABLE_MAX_RETRIES) {
+        if (num_tables == 0 || retries >= TABLE_MAX_RETRIES)
             return 0;
-        }
 
         std::string op_uri = itr->first; // Get the table name.
         tint_t op_tint = itr->second;    // Get the tint.

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1623,11 +1623,12 @@ ThreadRunner::op_run_setup(Operation *op)
               !_icontext->_dyn_table_runtime[itr->second]._pending_delete) {
 
                 // In case the selected table has a mirror, we need to check it is ready for use.
-                if(_icontext->_dyn_table_runtime[itr->second].has_mirror()) {
-                    const std::string mirror_op_uri(_icontext->_dyn_table_runtime[itr->second]._mirror);
+                if (_icontext->_dyn_table_runtime[itr->second].has_mirror()) {
+                    const std::string mirror_op_uri(
+                      _icontext->_dyn_table_runtime[itr->second]._mirror);
                     // When a table is created, its mirror is fully created when a valid URI and
                     // unique identifier have been allocated.
-                    if(mirror_op_uri.empty())
+                    if (mirror_op_uri.empty())
                         continue;
                     tint_t mirror_op_tint = _icontext->_dyn_tint[mirror_op_uri];
                     if (mirror_op_tint == 0)

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -388,8 +388,8 @@ WorkloadRunner::create_table(
     else
         base_config += "," + BASE_TABLE_APP_METADATA + "true\"";
 
-    // When mirror is enabled, create the mirror first and the base. If we create the base first,
-    // threads may start working on the base while the mirror is not fully created.
+    // When mirror is enabled, create the mirror first and then the base. If we create the base
+    // first, threads may start working on the base while the mirror is not fully created.
     if (mirror_enabled) {
         const std::string config_tmp(base_config + uri + "," + BASE_TABLE_APP_METADATA + "false\"");
         int ret = session->create(session, mirror_uri.c_str(), config_tmp.c_str());

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -352,7 +352,7 @@ private:
     void report(time_t, time_t, Stats *stats);
     int run_all(WT_CONNECTION *conn);
     int select_table_for_drop(std::vector<std::string> &pending_delete);
-    void update_dyn_struct(const std::string &uri, bool is_base, const std::string &mirror_uri);
+    void update_dyn_struct_locked(const std::string &uri, bool is_base, const std::string &mirror_uri);
 
     WorkloadRunner(const WorkloadRunner &);                 // disallowed
     WorkloadRunner& operator=(const WorkloadRunner &other); // disallowed

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -341,8 +341,8 @@ struct WorkloadRunner {
 private:
     int close_all();
     int create_all(WT_CONNECTION *conn, Context *context);
-    int create_table(WT_SESSION *session, const std::string &config, const std::string &uri,
-      const std::string &mirror_uri, const bool is_base);
+    int create_table(
+      WT_SESSION *session, const std::string &config, const std::string &uri, bool mirror_enabled);
     void final_report(timespec &);
     void schedule_table_for_drop(const std::map<std::string, tint_t>::iterator &itr,
       std::vector<std::string> &pending_delete);

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -352,6 +352,7 @@ private:
     void report(time_t, time_t, Stats *stats);
     int run_all(WT_CONNECTION *conn);
     int select_table_for_drop(std::vector<std::string> &pending_delete);
+    void update_dyn_struct(const std::string &uri, bool is_base, const std::string &mirror_uri);
 
     WorkloadRunner(const WorkloadRunner &);                 // disallowed
     WorkloadRunner& operator=(const WorkloadRunner &other); // disallowed


### PR DESCRIPTION
The following was happening in testy's [workload](https://github.com/wiredtiger/testy/blob/main/workloads/sample/sample_run.py) when mirroring is enabled:

- A table TA is created but not its mirror TB yet
- A thread T1 selects that table to work on and sees that it should have a mirror associated with it.
- T1 starts updating the in-memory data struct of the table and its mirror. **The information about the mirror is wrong as it has not been allocated yet.**
- The mirror TB is finally created
- T1 keeps working on the table and its mirror but now the information related to TB is different since TB has finally been allocated. The inconsistency leads to different assertions to fire.

See the ticket for more information.

I have also added assertions when an exception is caught in the main loops, it could be a different ticket or removed completely.