### PR TITLE
WT-11747 s_all and other s_ scripts in dist/ should clean up when interrupted

### DIFF
--- a/dist/s_style
+++ b/dist/s_style
@@ -2,7 +2,7 @@
 
 # General style correction and cleanup.
 t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+trap 'rm -f "$t"' 0 1 2 3 13 15
 
 # Parallelize if possible.
 xp=""
@@ -41,6 +41,7 @@ else
     # General style correction and cleanup for a single file
     f=$1
     fname=`basename $f`
+    rm -f "$t"
     t=__wt_s_style.$fname.$$
 
     if [ ! -e $f ]; then

--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -11,15 +11,17 @@ IFS=' ''	''
 export IFS
 
 build() {
+    set -o pipefail
+
     # Build the standard typedefs.
     f=../src/include/wt_internal.h
     (sed -e '/Forward type declarations .*: BEGIN/{' \
         -e 'n' \
         -e 'q' \
-        -e '}' < $f
+        -e '}' < $f || exit $?
 
     l=`ls ../src/include/*.h ../src/include/*.in |
-        sed -e '/wiredtiger.*/d' -e '/queue.h/d'`
+        sed -e '/wiredtiger.*/d' -e '/queue.h/d'` || exit $?
     egrep -h \
         '^[[:space:]]*(((struct|union)[[:space:]].*__wt_.*{)|WT_PACKED_STRUCT_BEGIN)' \
         $l |
@@ -30,7 +32,7 @@ build() {
         upper=`echo $n | sed -e 's/^__//' | tr '[a-z]' '[A-Z]'`
         echo "$t $n;"
         echo "    typedef $t $n $upper;"
-    done
+    done || exit $?
 
     # Fixed types we use.
     echo
@@ -42,10 +44,10 @@ build() {
     sed -e '/Forward type declarations .*: END/,${' \
         -e 'p' \
         -e '}' \
-        -e 'd' < $f) > $t
-    ./s_clang_format "${PWD}/$t"
+        -e 'd' < $f) > $t || exit $?
+    ./s_clang_format "${PWD}/$t" || exit $?
     cmp $t $f > /dev/null 2>&1 ||
-        (echo "Building $f" && rm -f $f && cp $t $f)
+        { echo "Building $f" ; cp -f $t $f; }
 }
 
 check() {


### PR DESCRIPTION
Changes:
* `s_style`: Remove the temporary file as long as it's not needed anymore, before the name is changed.
* `s_typedef`: Don't proceed to overwriting a good file if there were any errors or interruptions.