### PR TITLE
WT-11755 Update READ_ONCE and add a WRITE_ONCE macro to WiredTiger.

### DIFF
--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -51,10 +51,11 @@
  * Ensure a single write to memory in the source code produces a single write to memory in the
  * compiled output.
  *
- * We can describe a scenario with a memory location 'a' which is read from into a local variable
- * 'b', 'b' is then updated repeatedly within the function and written back out to 'a'. Without a
- * WT_WRITE_ONCE wrapping the final write to 'a' the compiler could convert every update to 'b' into
- * a separate store to 'a'. This is defined as 'invented stores' in WiredTiger.
+ * We can describe a scenario where a variable in memory is read to a local register, and then the
+ * register value is repeatedly updated before the final value is written back to memory. Without a
+ * WT_WRITE_ONCE wrapping the final write back to memory, the compiler is allowed to convert these
+ * register writes into writes to memory (see "register spilling") which can leak interim, invalid,
+ * state to other threads. We call these 'invented stores' in WiredTiger.
  *
  * See the read once macro description for more details.
  *

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -46,6 +46,23 @@
 #endif
 
 /*
+ * WT_WRITE_ONCE --
+ *
+ * Ensure a single write to memory in the source code produces a single write to memory in the
+ * compiled output.
+ *
+ * See the read once macro description for more details.
+ *
+ * FIXME-WT-11718 - Once Windows build machines that support C11 _Generics are available this macro
+ * will be updated to use _Generic on all platforms.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define WT_WRITE_ONCE(v, val) ((*(volatile __typeof__(v) *)&(v)) = (val))
+#else
+#define WT_WRITE_ONCE(v, val) WT_PUBLISH(v, val)
+#endif
+
+/*
  * Read a shared location and guarantee that subsequent reads do not see any earlier state.
  */
 #define WT_ORDERED_READ(v, val) \

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -51,6 +51,11 @@
  * Ensure a single write to memory in the source code produces a single write to memory in the
  * compiled output.
  *
+ * We can describe a scenario with a memory location 'a' which is read from into a local variable
+ * 'b', 'b' is then updated repeatedly within the function and written back out to 'a'. Without a
+ * WT_WRITE_ONCE wrapping the final write to 'a' the compiler could convert every update to 'b' into
+ * a separate store to 'a'. This is defined as 'invented stores' in WiredTiger.
+ *
  * See the read once macro description for more details.
  *
  * FIXME-WT-11718 - Once Windows build machines that support C11 _Generics are available this macro

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2009,7 +2009,7 @@ __rec_compression_adjust(WT_SESSION_IMPL *session, uint32_t max, size_t compress
         else
             return;
     }
-    *adjustp = new;
+    WT_WRITE_ONCE(*adjustp, new);
 }
 
 /*

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -145,7 +145,7 @@ __wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility
      * of the random state so we can ensure that the calculation operates on the state consistently
      * regardless of concurrent calls with the same random state.
      */
-    WT_ORDERED_READ(rnd, *rnd_state);
+    WT_READ_ONCE(rnd, *rnd_state);
     w = M_W(rnd);
     z = M_Z(rnd);
 

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -68,7 +68,7 @@ __wt_random_init(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visib
     M_W(rnd) = DEFAULT_SEED_W;
     M_Z(rnd) = DEFAULT_SEED_Z;
 
-    *rnd_state = rnd;
+    WT_WRITE_ONCE(rnd_state, rnd);
 }
 
 /*

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -68,7 +68,7 @@ __wt_random_init(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visib
     M_W(rnd) = DEFAULT_SEED_W;
     M_Z(rnd) = DEFAULT_SEED_Z;
 
-    WT_WRITE_ONCE(rnd_state, rnd);
+    WT_WRITE_ONCE(*rnd_state, rnd);
 }
 
 /*

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -68,7 +68,7 @@ __wt_random_init(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visib
     M_W(rnd) = DEFAULT_SEED_W;
     M_Z(rnd) = DEFAULT_SEED_Z;
 
-    WT_WRITE_ONCE(*rnd_state, rnd);
+    *rnd_state = rnd;
 }
 
 /*
@@ -91,7 +91,7 @@ __wt_random_init_custom_seed(WT_RAND_STATE volatile *rnd_state, uint64_t v)
     M_W(rnd) ^= DEFAULT_SEED_W;
     M_Z(rnd) ^= DEFAULT_SEED_Z;
 
-    WT_WRITE_ONCE(*rnd_state, rnd);
+    *rnd_state = rnd;
 }
 
 /*
@@ -124,7 +124,7 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
     rnd.v ^= rnd.v >> 7;
     rnd.v ^= rnd.v << 17;
 
-    WT_WRITE_ONCE(*rnd_state, rnd);
+    *rnd_state = rnd;
 }
 
 /*

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -91,7 +91,7 @@ __wt_random_init_custom_seed(WT_RAND_STATE volatile *rnd_state, uint64_t v)
     M_W(rnd) ^= DEFAULT_SEED_W;
     M_Z(rnd) ^= DEFAULT_SEED_Z;
 
-    *rnd_state = rnd;
+    WT_WRITE_ONCE(*rnd_state, rnd);
 }
 
 /*
@@ -124,7 +124,7 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
     rnd.v ^= rnd.v >> 7;
     rnd.v ^= rnd.v << 17;
 
-    *rnd_state = rnd;
+    WT_WRITE_ONCE(*rnd_state, rnd);
 }
 
 /*
@@ -169,7 +169,7 @@ __wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility
 
     M_W(rnd) = w = 18000 * (w & 65535) + (w >> 16);
     M_Z(rnd) = z = 36969 * (z & 65535) + (z >> 16);
-    *rnd_state = rnd;
+    WT_WRITE_ONCE(*rnd_state, rnd);
 
     return ((z << 16) + (w & 65535));
 #endif


### PR DESCRIPTION
Write once semantics are utilized in a couple code paths in wiredtiger, given we added WT_READ_ONCE, we should add its counterpart WT_WRITE_ONCE.