### PR TITLE
WT-11772 Only rollback txn when the target has been reached in the cppsuite

### DIFF
--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -267,7 +267,8 @@ database_operation::read_operation(thread_worker *tc)
                     testutil_die(ret, "Unexpected error returned from cursor->next()");
             }
             tc->txn.add_op();
-            tc->txn.try_rollback();
+            if (tc->txn.get_op_count() >= tc->txn.get_target_op_count())
+                tc->txn.rollback();
             tc->sleep();
         }
         /* Reset our cursor to avoid pinning content. */

--- a/test/cppsuite/src/main/transaction.cpp
+++ b/test/cppsuite/src/main/transaction.cpp
@@ -127,6 +127,12 @@ transaction::try_rollback(const std::string &config)
 }
 
 int64_t
+transaction::get_op_count() const
+{
+    return _op_count;
+}
+
+int64_t
 transaction::get_target_op_count() const
 {
     return _target_op_count;

--- a/test/cppsuite/src/main/transaction.h
+++ b/test/cppsuite/src/main/transaction.h
@@ -66,6 +66,8 @@ public:
      * the transaction.
      */
     bool can_commit();
+    /* Get the current number of operations executed. */
+    int64_t get_op_count() const;
     /* Get the number of operations this transaction needs before it can commit */
     int64_t get_target_op_count() const;
 

--- a/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
@@ -211,7 +211,8 @@ public:
                   ret, exact_prefix, key_prefix_str, cursor_default, generated_prefix);
 
                 tc->txn.add_op();
-                tc->txn.try_rollback();
+                if (tc->txn.get_op_count() >= tc->txn.get_target_op_count())
+                    tc->txn.rollback();
                 tc->sleep();
             }
             testutil_check(cursor_prefix->reset(cursor_prefix.get()));

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -763,7 +763,8 @@ public:
                     testutil_assert(ret == 0 || ret == WT_ROLLBACK);
                 }
                 tc->txn.add_op();
-                tc->txn.try_rollback();
+                if (tc->txn.get_op_count() >= tc->txn.get_target_op_count())
+                    tc->txn.rollback();
                 tc->sleep();
             }
             normal_cursor->reset(normal_cursor.get());


### PR DESCRIPTION
WT-9466 changed the behaviour of a few cpp tests because the function `try_rollback` was modified. There are two scenarios:

- Rollback if a transaction is active
- Rollback only once the current transaction has reached its target in terms of number of operations

The changes here somehow revert what WT-9466 did to go back to the second scenario wherever expected.

See the JIRA ticket for more details.