### PR TITLE
WT-10691 Reduce delay in stopping the random cursor thread in test format

### DIFF
--- a/test/format/random.c
+++ b/test/format/random.c
@@ -76,7 +76,7 @@ random_kv(void *arg)
         wt_wrap_open_cursor(session, table->uri, config, &cursor);
 
         /* This is just a smoke-test, get some key/value pairs. */
-        for (i = mmrand(&g.extra_rnd, 0, WT_THOUSAND); i > 0; --i) {
+        for (i = mmrand(&g.extra_rnd, 0, WT_THOUSAND); i > 0 && !g.workers_finished; --i) {
             switch (ret = cursor->next(cursor)) {
             case 0:
                 break;


### PR DESCRIPTION
The random cursor would loop calling next and not check that it was requested to stop. Normally that would be fine, but when the stress point for HS search was enabled it became extremely slow and caused task timeouts. I checked the other threads and only the HS thread could have this but it should not have the same stress points.