### PR TITLE
WT-11767 Use bash in dist/s_* scripts

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This file is a python script that describes the WiredTiger API.
 
 class Method:

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Output C #defines for errors into wiredtiger.in and the associated error
 # message code in strerror.c.
 

--- a/dist/db.py
+++ b/dist/db.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # A simple python script to build a file that can be bulk-loaded into a
 # WiredTiger database for smoke-testing.
 

--- a/dist/dist.py
+++ b/dist/dist.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import filecmp, fnmatch, glob, os, re, shutil, subprocess
 from contextlib import contextmanager
 

--- a/dist/docs.py
+++ b/dist/docs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Read and verify the documentation data to make sure path names are valid.
 
 import os, sys

--- a/dist/docs_data.py
+++ b/dist/docs_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Create entries used by our doxygen filter to expand the arch_page
 # macros in the documentation.
 

--- a/dist/log_data.py
+++ b/dist/log_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Data for log.py, describes the format of log records
 
 # There are a small number of main log record types.

--- a/dist/s_all
+++ b/dist/s_all
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Run standard scripts.
 t=__wt.$$
@@ -40,7 +40,7 @@ while :
 done
 
 echo "Updating files that include the package version" &&
-    sh ./s_version $force
+    bash ./s_version $force
 
 errchk()
 {
@@ -69,19 +69,19 @@ run()
 
 # Non parallelizable scripts. The following scripts either modify files or
 # already parallelize internally.
-run "sh ./s_readme $force"
-run "sh ./s_install $force"
+run "bash ./s_readme $force"
+run "bash ./s_install $force"
 run "python3 api_config_gen.py"
 run "python3 api_err.py"
 run "python3 flags.py"
 run "python3 log.py"
 run "python3 stat.py"
 run "python3 verbose.py"
-run "sh ./s_copyright"
-run "sh ./s_style ${fast}"
+run "bash ./s_copyright"
+run "bash ./s_style ${fast}"
 run "./s_clang_format ${fast}"
 run "python3 prototypes.py"
-run "sh ./s_typedef -b"
+run "bash ./s_typedef -b"
 run "python3 test_tag.py"
 # The s_mentions script requires bash.
 run "./s_mentions" "--warning-only"
@@ -118,7 +118,7 @@ echo date | xargs -P 20 >/dev/null 2>&1
 if test $? -eq 0; then
     xp="-P 20"
 fi
-echo "$COMMANDS" | xargs $xp -I{} /bin/sh -c {}
+echo "$COMMANDS" | xargs $xp -I{} /bin/bash -c {}
 
 # For each command check if an output file has been generated. If it has, report the contents and
 # the command used to populate it.

--- a/dist/s_c_test_create
+++ b/dist/s_c_test_create
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Usage: s_c_test_create test_name

--- a/dist/s_clang_scan
+++ b/dist/s_clang_scan
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t_out=__wt.$$.out
 t_err=__wt.$$.err

--- a/dist/s_clang_tidy
+++ b/dist/s_clang_tidy
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 t_pfx=__s_clang_tidy_tmp_

--- a/dist/s_comment.py
+++ b/dist/s_comment.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Fill out block comments to the full line length (currently 100).
 #
 # We're defining a "block comment" to be a multiline comment where each line

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Only run when building a release
 test -z "$WT_RELEASE_BUILD" && exit 0
@@ -119,10 +119,10 @@ fi
     -e '/\/node_modules\//d' \
     -e '/dist\/__/d' \
     -e 's/^\.\///' |
-    xargs $xp -n 1 -I{} sh dist/s_copyright {})
+    xargs $xp -n 1 -I{} bash dist/s_copyright {})
 
 # One-offs.
-(cd .. && sh dist/s_copyright test/syscall/wt2336_base/base.run)
+(cd .. && bash dist/s_copyright test/syscall/wt2336_base/base.run)
 
 # A few special cases: LICENSE, documentation, wt utility, some of which have
 # more than one copyright notice in the file. For files that have only a single

--- a/dist/s_define
+++ b/dist/s_define
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Complain about unused #defines.
 t=__wt.$$

--- a/dist/s_docs_plantuml
+++ b/dist/s_docs_plantuml
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 # Usage: ./s_docs_plantuml [-d|Auto download plantuml if doesn't exist in dist/]
 # This script checks for the existence of plantuml jar file (optionally
 # downloading it from sourceforge) and then generates uml images from the

--- a/dist/s_errno
+++ b/dist/s_errno
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Complain about code that returns a system error value without an associated
 # verbose message.

--- a/dist/s_evergreen
+++ b/dist/s_evergreen
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_evergreen_validate
+++ b/dist/s_evergreen_validate
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_evergreen_validate
+++ b/dist/s_evergreen_validate
@@ -15,7 +15,7 @@ case "$1" in
             echo "Usage: $0 [-F]"
             echo "-F only run validation commands if evergreen yml files have been modified"
         fi
-        break;;
+        ;;
 esac
 
 if [ $(command -v evergreen) ] && [ -f ~/.evergreen.yml ]; then

--- a/dist/s_export
+++ b/dist/s_export
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Check for illegal external symbols.
 #

--- a/dist/s_fast
+++ b/dist/s_fast
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/bin/bash
 ./s_all -F

--- a/dist/s_free
+++ b/dist/s_free
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_funcs
+++ b/dist/s_funcs
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Complain about unused functions
 t=__wt.$$

--- a/dist/s_function
+++ b/dist/s_function
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Check various WiredTiger function behaviors.
 t=__wt.$$

--- a/dist/s_function
+++ b/dist/s_function
@@ -14,7 +14,7 @@ case "$1" in
             echo "Usage: $0 [-F]"
             echo "-F only run function validation on modified soure files."
         fi
-        break;;
+        ;;
 esac
 
 cd ..

--- a/dist/s_function_loop.py
+++ b/dist/s_function_loop.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Mark outer loop boundaries with {@ and }@ .  Nested loops are not marked.
 # Each input line is the content of a C function.
 import re, sys

--- a/dist/s_function_verbose.py
+++ b/dist/s_function_verbose.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # When calling '__wt_verbose', the second parameter can only be a single verbose
 # category definition i.e. can't treat the parameter as a flag/mask value.
 # Iterate over uses of '__wt_verbose' and detect any invalid uses where multiple

--- a/dist/s_function_with.py
+++ b/dist/s_function_with.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Examine WT_WITH_* macros and complain if an early exit out of the
 # macro is done.  These macros potentially restore state after they execute
 # an expression, and an early exit, like a return/goto means the state

--- a/dist/s_getopt
+++ b/dist/s_getopt
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_install
+++ b/dist/s_install
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_lang
+++ b/dist/s_lang
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Check lang directories for potential name conflicts
 t=__wt.$$

--- a/dist/s_longlines
+++ b/dist/s_longlines
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Check for long lines
 t=__wt.$$

--- a/dist/s_python
+++ b/dist/s_python
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Python style checks.
 t=__wt.$$

--- a/dist/s_readme
+++ b/dist/s_readme
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_release
+++ b/dist/s_release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Build a WiredTiger release package.
 
 set -e
@@ -26,10 +26,10 @@ else
 fi
 
 echo "Running 'dist/s_all' in the release tree"
-(cd "$DEST/dist" && env WT_RELEASE_BUILD=yes sh s_all -A > /dev/null)
+(cd "$DEST/dist" && env WT_RELEASE_BUILD=yes bash s_all -A > /dev/null)
 
 echo "Building documentation"
-(cd "$DEST/dist" && sh s_docs > /dev/null)
+(cd "$DEST/dist" && bash s_docs > /dev/null)
 
 echo "Packing release into $RELEASE_DIR/$PKG.tar.bz2"
 (cd "$RELEASE_DIR" && tar cf - $PKG | bzip2 -9 > $PKG.tar.bz2)

--- a/dist/s_release_docs
+++ b/dist/s_release_docs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Build a WiredTiger release package.
 
 set -e
@@ -60,7 +60,7 @@ if [ $OLD_VERSION_MINOR != $WIREDTIGER_VERSION_MINOR ]; then
 fi
 
 echo "Rebuild documentation root"
-(cd "$TOPDIR/dist" && sh s_docs -l > /dev/null)
+(cd "$TOPDIR/dist" && bash s_docs -l > /dev/null)
 
 # Copy the new files into the documentation repository
 (cd $TOPDIR && cp -r docs/top/* $DOC_DIR/)

--- a/dist/s_stat
+++ b/dist/s_stat
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Complain about unused statistics fields.
 t=__wt.$$

--- a/dist/s_string
+++ b/dist/s_string
@@ -1,4 +1,4 @@
-#!/bin/sh -
+#!/bin/bash -
 #
 # Check spelling in comments and quoted strings from the source files.
 

--- a/dist/s_style
+++ b/dist/s_style
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # General style correction and cleanup.
 t=__wt.$$
@@ -36,7 +36,7 @@ if [ "$single_file" -ne 1 ]; then
         -e '/test\/checksum\/power8/d' \
         -e '/bench\/workgen\/workgen_wrap.cxx/d' \
         -e '/checksum\/zseries/d' |
-    xargs $xp -I{} sh ./dist/s_style {}
+    xargs $xp -I{} bash ./dist/s_style {}
 else
     # General style correction and cleanup for a single file
     f=$1

--- a/dist/s_tags
+++ b/dist/s_tags
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Build tags files.
 trap 'rm -f tags' 0 1 2 3 13 15

--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_version
+++ b/dist/s_version
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Propagate version changes to the necessary files.
 . ../RELEASE_INFO

--- a/dist/s_void
+++ b/dist/s_void
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 # Single space, newline at the end of file, and remove trailing whitespace from source files.
 t=__wt.$$

--- a/dist/stat.py
+++ b/dist/stat.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Read the source files and output the statistics #defines plus the
 # initialize and refresh code.
 

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Auto-generate statistics #defines, with initialization, clear and aggregate
 # functions.
 #

--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This file is a python script that describes the cpp test framework test configuration options.
 
 class Method:

--- a/dist/test_tag.py
+++ b/dist/test_tag.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 from dist import compare_srcfile

--- a/dist/wtperf_config.py
+++ b/dist/wtperf_config.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 ''' Output a doxgen version of the wtperf configuration options. '''
 import sys
 


### PR DESCRIPTION
Summary of changes in `dist/` directory:

* Upgrade `s_*` scripts from `sh` to `bash`.
* Add missing hashband `#!` to all scripts as a manifest of language used.
* Fix invalid use of `break` in shell's `case` clause (probably was copy-pasted).