### PR TITLE
WT-11564 Fix RTS to read the newest_txn value only when it exists in the checkpoint (6.0 backport)

### DIFF
--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1626,7 +1626,7 @@ __rollback_to_stable_btree_apply(
         }
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "newest_txn", &value);
-        if (value.len != 0)
+        if (ret == 0)
             rollback_txnid = (uint64_t)value.val;
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "addr", &value);


### PR DESCRIPTION
(cherry picked from commit 5af8d7ffe439462df9c8c67992a1688e90995e40)

Co-authored-by: Hari Babu Kommi <haribabu.kommi@mongodb.com>
(cherry picked from commit d7de14f738f12cd95365e211e3840be046237a48)