### PR TITLE
WT-11584 Fix test_checkpoint_stats test

### DIFF
--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -34,7 +34,7 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
 class test_checkpoint04(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB,statistics=(all)'
+    conn_config = 'cache_size=50MB,statistics=(all,clear)'
 
     def create_tables(self, ntables):
         tables = {}
@@ -127,11 +127,8 @@ class test_checkpoint04(wttest.WiredTigerTestCase):
             # Run the loop again if any of the below condition fails and exit if the test passes.
             if prep_min < time_min and prep_max < time_max and prep_recent < time_recent and prep_total < time_total:
                 break
-            else:
-                multiplier += 1
-                # Reopen the connection to reset statistics. 
-                # We don't want stats from earlier runs to interfere with later runs.
-                self.reopen_conn()
+
+            multiplier += 1
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -34,6 +34,7 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
 class test_checkpoint04(wttest.WiredTigerTestCase):
+    # We don't want stats from earlier runs to interfere with later runs.
     conn_config = 'cache_size=50MB,statistics=(all,clear)'
 
     def create_tables(self, ntables):


### PR DESCRIPTION
The changes made in WT-10671 has a slight bug, where when we perform a retry of the loop we don't account for the extra checkpoint performed by the connection reopen.