### PR TITLE
Add missing dependent_task arg in code-change-report

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3903,6 +3903,8 @@ tasks:
             echo ". remote path   =  wiredtiger/${build_variant}/${revision}/${dependent_task}_${build_id}-${execution}/full_coverage_report.json"
             mkdir -p coverage_report
       - command: s3.get
+        vars:
+          dependent_task: coverage-report
         params:
           aws_key: ${aws_key}
           aws_secret: ${aws_secret}


### PR DESCRIPTION
With the merge of [EVG-20276](https://jira.mongodb.org/browse/EVG-20276) variables passed into evergreen functions no longer persist across stages. 
The `s3.get` stage of `code-change-report` used to inherit the `dependent_task: coverage-report` field, but now we need to set it explicitly.