### PR TITLE
WT-11802 Disable verbose04 for tiered hook tests

### DIFF
--- a/test/suite/test_verbose04.py
+++ b/test/suite/test_verbose04.py
@@ -33,6 +33,12 @@ import wiredtiger, wttest
 
 # test_verbose04.py
 # Verify the use of the `all` field to set verbose categories.
+
+# Enabling tiered alters the logs produced by WiredTiger during this test, 
+# breaking our assumptions about what log output to expect. This doesn't 
+# impact the logic under test (the "all" configuration field) so we'll 
+# disable this test under tiered."
+@wttest.skip_for_hook("tiered", "Enabling tiered alters the logs produced by WiredTiger")
 class test_verbose04(test_verbose_base):
 
     format = [


### PR DESCRIPTION
Adding the tiered hook to verbose04 alters the logs produced by WiredTiger, and since verbose04 is checking logs produced by WiredTiger this can break the test.
The logic under test in verbose04 (the "all" configuration item) is not impacted by tiered storage logic so we'll skip this test when using the tiered hook.