### PR TITLE
WT-10861 Annotate shared variables

### DIFF
--- a/dist/primitive_check.py
+++ b/dist/primitive_check.py
@@ -3,8 +3,6 @@ import subprocess, re
 import common_functions
 
 # This is a temporary script to detect code changes to WiredTiger primitives.
-# FIXME-WT-10861 That ticket will introduce a script to replace this one, delete this script when
-# complete.
 primitives = [
     "__wt_atomic_.*",
     "F_CLR_ATOMIC",

--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -111,3 +111,4 @@ __wt_bswap16
 __wt_verbose_error
 __wt_verbose_level
 __wt_verbose_level_multi
+wt_shared

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -260,9 +260,9 @@ struct __wt_block {
     bool readonly;              /* Underlying file was opened only for reading */
 
     /* Configuration information, set when the file is opened. */
-    uint32_t allocfirst; /* Allocation is first-fit */
-    uint32_t allocsize;  /* Allocation size */
-    size_t os_cache;     /* System buffer cache flush max */
+    wt_shared uint32_t allocfirst; /* Allocation is first-fit */
+    uint32_t allocsize;            /* Allocation size */
+    size_t os_cache;               /* System buffer cache flush max */
     size_t os_cache_max;
     size_t os_cache_dirty_max;
 
@@ -309,7 +309,7 @@ struct __wt_block {
     uint8_t *fragckpt;       /* Per-checkpoint frag tracking list */
 
     /* Multi-file support */
-    uint32_t read_count; /* Count of active read requests using this block handle */
+    wt_shared uint32_t read_count; /* Count of active read requests using this block handle */
 };
 
 /*

--- a/src/include/block_cache.h
+++ b/src/include/block_cache.h
@@ -54,9 +54,9 @@ struct __wt_blkcache_item {
      * been reused or for blocks that were reused in the past but lost their appeal. In this sense,
      * this counter is a metric combining frequency and recency, and hence its name.
      */
-    int32_t freq_rec_counter;
+    wt_shared int32_t freq_rec_counter;
 
-    uint32_t ref_count; /* References */
+    wt_shared uint32_t ref_count; /* References */
 
     uint32_t fid;      /* File ID */
     uint8_t addr_size; /* Address cookie */
@@ -74,8 +74,8 @@ struct __wt_blkcache {
     WT_SPINLOCK *hash_locks;
 
     wt_thread_t evict_thread_tid;
-    volatile bool blkcache_exiting; /* If destroying the cache */
-    int32_t evict_aggressive;       /* Seconds an unused block stays in the cache */
+    wt_shared volatile bool blkcache_exiting; /* If destroying the cache */
+    int32_t evict_aggressive;                 /* Seconds an unused block stays in the cache */
 
     bool cache_on_checkpoint; /* Don't cache blocks written by checkpoints */
     bool cache_on_writes;     /* Cache blocks on writes */
@@ -103,11 +103,11 @@ struct __wt_blkcache {
      */
     u_int percent_file_in_os_cache;
 
-    u_int hash_size;     /* Number of block cache hash buckets */
-    u_int type;          /* Type of block cache (NVRAM or DRAM) */
-    uint64_t bytes_used; /* Bytes in the block cache */
-    uint64_t max_bytes;  /* Block cache size */
-    uint64_t system_ram; /* Configured size of system RAM */
+    u_int hash_size;               /* Number of block cache hash buckets */
+    u_int type;                    /* Type of block cache (NVRAM or DRAM) */
+    wt_shared uint64_t bytes_used; /* Bytes in the block cache */
+    uint64_t max_bytes;            /* Block cache size */
+    uint64_t system_ram;           /* Configured size of system RAM */
 
     uint32_t min_num_references; /* The per-block number of references triggering eviction. */
 

--- a/src/include/block_chunkcache.h
+++ b/src/include/block_chunkcache.h
@@ -32,7 +32,7 @@ struct __wt_chunkcache_chunk {
     uint8_t *chunk_memory;
     wt_off_t chunk_offset;
     size_t chunk_size;
-    volatile uint32_t valid;
+    wt_shared volatile uint32_t valid;
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CHUNK_PINNED 0x1u
@@ -66,9 +66,9 @@ struct __wt_chunkcache {
     /* Cache-wide. */
 #define WT_CHUNKCACHE_FILE 1
 #define WT_CHUNKCACHE_IN_VOLATILE_MEMORY 2
-    uint8_t type;        /* Location of the chunk cache (volatile memory or file) */
-    uint64_t bytes_used; /* Amount of data currently in cache */
-    uint64_t capacity;   /* Maximum allowed capacity */
+    uint8_t type;                  /* Location of the chunk cache (volatile memory or file) */
+    wt_shared uint64_t bytes_used; /* Amount of data currently in cache */
+    uint64_t capacity;             /* Maximum allowed capacity */
 
 #define WT_CHUNKCACHE_DEFAULT_CHUNKSIZE 1024 * 1024
     size_t chunk_size;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -324,8 +324,8 @@ struct __wt_page_modify {
     uint64_t update_txn;
 
     /* Dirty bytes added to the cache. */
-    size_t bytes_dirty;
-    size_t bytes_updates;
+    wt_shared size_t bytes_dirty;
+    wt_shared size_t bytes_updates;
 
     /*
      * When pages are reconciled, the result is one or more replacement blocks. A replacement block
@@ -390,7 +390,7 @@ struct __wt_page_modify {
              * page, but gaps created in the namespace by truncate operations can result in the
              * append lists of other pages becoming populated.
              */
-            WT_INSERT_HEAD **append;
+            wt_shared WT_INSERT_HEAD **append;
 
             /*
              * Updated items in column-stores: variable-length RLE entries can expand to multiple
@@ -399,7 +399,7 @@ struct __wt_page_modify {
              * there can be a very large number of bits on a single page, and the cost of the
              * WT_UPDATE array would be huge.
              */
-            WT_INSERT_HEAD **update;
+            wt_shared WT_INSERT_HEAD **update;
 
             /*
              * Split-saved last column-store page record. If a fixed-length column-store page is
@@ -417,10 +417,10 @@ struct __wt_page_modify {
 #define mod_col_split_recno u2.column_leaf.split_recno
         struct {
             /* Inserted items for row-store. */
-            WT_INSERT_HEAD **insert;
+            wt_shared WT_INSERT_HEAD **insert;
 
             /* Updated items for row-stores. */
-            WT_UPDATE **update;
+            wt_shared WT_UPDATE **update;
         } row_leaf;
 #undef mod_row_insert
 #define mod_row_insert u2.row_leaf.insert
@@ -461,7 +461,7 @@ struct __wt_page_modify {
 #define WT_PAGE_CLEAN 0
 #define WT_PAGE_DIRTY_FIRST 1
 #define WT_PAGE_DIRTY 2
-    uint32_t page_state;
+    wt_shared uint32_t page_state;
 
 #define WT_PM_REC_EMPTY 1      /* Reconciliation: no replacement */
 #define WT_PM_REC_MULTIBLOCK 2 /* Reconciliation: multiple blocks */
@@ -499,7 +499,7 @@ WT_PACKED_STRUCT_END
  */
 struct __wt_page_index {
     uint32_t entries;
-    uint32_t deleted_entries;
+    wt_shared uint32_t deleted_entries;
     WT_REF **index;
 };
 
@@ -590,7 +590,7 @@ struct __wt_page {
             WT_REF *parent_ref; /* Parent reference */
             uint64_t split_gen; /* Generation of last split */
 
-            WT_PAGE_INDEX *volatile __index; /* Collated children */
+            wt_shared WT_PAGE_INDEX *volatile __index; /* Collated children */
         } intl;
 #undef pg_intl_parent_ref
 #define pg_intl_parent_ref u.intl.parent_ref
@@ -700,7 +700,7 @@ struct __wt_page {
 #define WT_PAGE_SPLIT_INSERT 0x200u       /* A leaf page was split for append */
 #define WT_PAGE_UPDATE_IGNORE 0x400u      /* Ignore updates on page discard */
                                           /* AUTOMATIC FLAG VALUE GENERATION STOP 16 */
-    uint16_t flags_atomic;                /* Atomic flags, use F_*_ATOMIC_16 */
+    wt_shared uint16_t flags_atomic;      /* Atomic flags, use F_*_ATOMIC_16 */
 
 #define WT_PAGE_IS_INTERNAL(page) \
     ((page)->type == WT_PAGE_COL_INT || (page)->type == WT_PAGE_ROW_INT)
@@ -716,13 +716,13 @@ struct __wt_page {
 
     /* 1 byte hole expected. */
 
-    size_t memory_footprint; /* Memory attached to the page */
+    wt_shared size_t memory_footprint; /* Memory attached to the page */
 
     /* Page's on-disk representation: NULL for pages created in memory. */
     const WT_PAGE_HEADER *dsk;
 
     /* If/when the page is modified, we need lots more information. */
-    WT_PAGE_MODIFY *modify;
+    wt_shared WT_PAGE_MODIFY *modify;
 
     /*
      * !!!
@@ -894,7 +894,7 @@ struct __wt_page_deleted {
      * from memory rather than using the local variable, mark the shared transaction IDs volatile to
      * prevent unexpected repeated/reordered reads.
      */
-    volatile uint64_t txnid; /* Transaction ID */
+    wt_shared volatile uint64_t txnid; /* Transaction ID */
 
     wt_timestamp_t timestamp; /* Timestamps */
     wt_timestamp_t durable_timestamp;
@@ -903,7 +903,7 @@ struct __wt_page_deleted {
      * The prepare state is used for transaction prepare to manage visibility and propagating the
      * prepare state to the updates generated at instantiation time.
      */
-    volatile uint8_t prepare_state;
+    wt_shared volatile uint8_t prepare_state;
 
     /*
      * The previous state of the WT_REF; if the fast-truncate transaction is rolled back without the
@@ -952,14 +952,14 @@ struct __wt_prefetch_queue_entry {
  *	A single in-memory page and state information.
  */
 struct __wt_ref {
-    WT_PAGE *page; /* Page */
+    wt_shared WT_PAGE *page; /* Page */
 
     /*
      * When the tree deepens as a result of a split, the home page value changes. Don't cache it, we
      * need to see that change when looking up our slot in the page's index structure.
      */
-    WT_PAGE *volatile home;        /* Reference page */
-    volatile uint32_t pindex_hint; /* Reference page index hint */
+    wt_shared WT_PAGE *volatile home;        /* Reference page */
+    wt_shared volatile uint32_t pindex_hint; /* Reference page index hint */
 
     uint8_t unused[2]; /* Padding: before the flags field so flags can be easily expanded. */
 
@@ -977,26 +977,26 @@ struct __wt_ref {
                                   /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 
-#define WT_REF_DISK 0       /* Page is on disk */
-#define WT_REF_DELETED 1    /* Page is on disk, but deleted */
-#define WT_REF_LOCKED 2     /* Page locked for exclusive access */
-#define WT_REF_MEM 3        /* Page is in cache and valid */
-#define WT_REF_SPLIT 4      /* Parent page split (WT_REF dead) */
-    volatile uint8_t state; /* Page state */
+#define WT_REF_DISK 0                 /* Page is on disk */
+#define WT_REF_DELETED 1              /* Page is on disk, but deleted */
+#define WT_REF_LOCKED 2               /* Page locked for exclusive access */
+#define WT_REF_MEM 3                  /* Page is in cache and valid */
+#define WT_REF_SPLIT 4                /* Parent page split (WT_REF dead) */
+    wt_shared volatile uint8_t state; /* Page state */
 
     /*
      * Address: on-page cell if read from backing block, off-page WT_ADDR if instantiated in-memory,
      * or NULL if page created in-memory.
      */
-    void *addr;
+    wt_shared void *addr;
 
     /*
      * The child page's key.  Do NOT change this union without reviewing
      * __wt_ref_key.
      */
     union {
-        uint64_t recno; /* Column-store: starting recno */
-        void *ikey;     /* Row-store: key */
+        uint64_t recno;       /* Column-store: starting recno */
+        wt_shared void *ikey; /* Row-store: key */
     } key;
 #undef ref_recno
 #define ref_recno key.recno
@@ -1116,7 +1116,7 @@ struct __wt_ref {
      * disk, a page instantiated after its parent was read from disk will always have inst_updates
      * set to NULL.
      */
-    WT_PAGE_DELETED *page_del; /* Page-delete information for a deleted page. */
+    wt_shared WT_PAGE_DELETED *page_del; /* Page-delete information for a deleted page. */
 
 #ifdef HAVE_REF_TRACK
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1202,7 +1202,7 @@ struct __wt_ref {
  * to make sure we don't introduce this bug (again).
  */
 struct __wt_row { /* On-page key, on-page cell, or off-page WT_IKEY */
-    void *volatile __key;
+    wt_shared void *volatile __key;
 };
 #define WT_ROW_KEY_COPY(rip) ((rip)->__key)
 #define WT_ROW_KEY_SET(rip, v) ((rip)->__key) = (void *)(v)

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1503,7 +1503,7 @@ struct __wt_insert {
 #define WT_INSERT_KEY(ins) ((void *)((uint8_t *)(ins) + ((WT_INSERT *)(ins))->u.key.offset))
 #define WT_INSERT_RECNO(ins) (((WT_INSERT *)(ins))->u.recno)
 
-    WT_INSERT *next[0]; /* forward-linked skip list */
+    wt_shared WT_INSERT *next[0]; /* forward-linked skip list */
 };
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1536,8 +1536,8 @@ struct __wt_insert {
  * 	The head of a skiplist of WT_INSERT items.
  */
 struct __wt_insert_head {
-    WT_INSERT *head[WT_SKIP_MAXDEPTH]; /* first item on skiplists */
-    WT_INSERT *tail[WT_SKIP_MAXDEPTH]; /* last item on skiplists */
+    wt_shared WT_INSERT *head[WT_SKIP_MAXDEPTH]; /* first item on skiplists */
+    wt_shared WT_INSERT *tail[WT_SKIP_MAXDEPTH]; /* last item on skiplists */
 };
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1303,7 +1303,7 @@ struct __wt_update {
      * from memory rather than using the local variable, mark the shared transaction IDs volatile to
      * prevent unexpected repeated/reordered reads.
      */
-    volatile uint64_t txnid; /* transaction ID */
+    wt_shared volatile uint64_t txnid; /* transaction ID */
 
     wt_timestamp_t durable_ts; /* timestamps */
     wt_timestamp_t start_ts;
@@ -1315,7 +1315,7 @@ struct __wt_update {
      */
     wt_timestamp_t prev_durable_ts;
 
-    WT_UPDATE *next; /* forward-linked list */
+    wt_shared WT_UPDATE *next; /* forward-linked list */
 
     uint32_t size; /* data length */
 
@@ -1334,7 +1334,7 @@ struct __wt_update {
      * The update state is used for transaction prepare to manage visibility and transitioning
      * update structure state safely.
      */
-    volatile uint8_t prepare_state; /* prepare state */
+    wt_shared volatile uint8_t prepare_state; /* prepare state */
 
 /* When introducing a new flag, consider adding it to WT_UPDATE_SELECT_FOR_DS. */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
@@ -1489,7 +1489,7 @@ struct __wt_update_vector {
  * to re-implement, IMNSHO.)
  */
 struct __wt_insert {
-    WT_UPDATE *upd; /* value */
+    wt_shared WT_UPDATE *upd; /* value */
 
     union {
         uint64_t recno; /* column-store record number */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -112,14 +112,14 @@ struct __wt_btree {
 
     uint32_t id; /* File ID, for logging */
 
-    uint32_t allocsize;        /* Allocation size */
-    uint32_t maxintlpage;      /* Internal page max size */
-    uint32_t maxleafpage;      /* Leaf page max size */
-    uint32_t maxleafkey;       /* Leaf page max key size */
-    uint32_t maxleafvalue;     /* Leaf page max value size */
-    uint64_t maxmempage;       /* In-memory page max size */
-    uint32_t maxmempage_image; /* In-memory page image max size */
-    uint64_t splitmempage;     /* In-memory split trigger size */
+    uint32_t allocsize;             /* Allocation size */
+    wt_shared uint32_t maxintlpage; /* Internal page max size */
+    uint32_t maxleafpage;           /* Leaf page max size */
+    uint32_t maxleafkey;            /* Leaf page max key size */
+    uint32_t maxleafvalue;          /* Leaf page max value size */
+    uint64_t maxmempage;            /* In-memory page max size */
+    uint32_t maxmempage_image;      /* In-memory page image max size */
+    uint64_t splitmempage;          /* In-memory split trigger size */
 
     void *huffman_value; /* Value huffman encoding */
 
@@ -160,9 +160,9 @@ struct __wt_btree {
 
     uint64_t last_recno; /* Column-store last record number */
 
-    WT_REF root;      /* Root page reference */
-    bool modified;    /* If the tree ever modified */
-    uint8_t original; /* Newly created: bulk-load possible
+    WT_REF root;                /* Root page reference */
+    wt_shared bool modified;    /* If the tree ever modified */
+    wt_shared uint8_t original; /* Newly created: bulk-load possible
                          (want a bool but needs atomic cas) */
 
     bool hs_entries;  /* Has entries in the history store table */
@@ -177,9 +177,9 @@ struct __wt_btree {
     uint64_t rec_max_txn;    /* Maximum txn seen (clean trees) */
     wt_timestamp_t rec_max_timestamp;
 
-    uint64_t checkpoint_gen;       /* Checkpoint generation */
-    WT_SESSION_IMPL *sync_session; /* Syncing session */
-    WT_BTREE_SYNC syncing;         /* Sync status */
+    wt_shared uint64_t checkpoint_gen; /* Checkpoint generation */
+    WT_SESSION_IMPL *sync_session;     /* Syncing session */
+    WT_BTREE_SYNC syncing;             /* Sync status */
 
 /*
  * Helper macros: WT_BTREE_SYNCING indicates if a sync is active (either waiting to start or already
@@ -193,12 +193,12 @@ struct __wt_btree {
 #define WT_SESSION_BTREE_SYNC_SAFE(session, btree) \
     ((btree)->syncing != WT_BTREE_SYNC_RUNNING || (btree)->sync_session == (session))
 
-    uint64_t bytes_dirty_intl;  /* Bytes in dirty internal pages. */
-    uint64_t bytes_dirty_leaf;  /* Bytes in dirty leaf pages. */
-    uint64_t bytes_dirty_total; /* Bytes ever dirtied in cache. */
-    uint64_t bytes_inmem;       /* Cache bytes in memory. */
-    uint64_t bytes_internal;    /* Bytes in internal pages. */
-    uint64_t bytes_updates;     /* Bytes in updates. */
+    wt_shared uint64_t bytes_dirty_intl;  /* Bytes in dirty internal pages. */
+    wt_shared uint64_t bytes_dirty_leaf;  /* Bytes in dirty leaf pages. */
+    wt_shared uint64_t bytes_dirty_total; /* Bytes ever dirtied in cache. */
+    wt_shared uint64_t bytes_inmem;       /* Cache bytes in memory. */
+    wt_shared uint64_t bytes_internal;    /* Bytes in internal pages. */
+    wt_shared uint64_t bytes_updates;     /* Bytes in updates. */
 
     /*
      * The maximum bytes allowed to be used for the table on disk. This is currently only used for
@@ -237,16 +237,16 @@ struct __wt_btree {
      * Eviction information is maintained in the btree handle, but owned by eviction, not the btree
      * code.
      */
-    WT_REF *evict_ref;            /* Eviction thread's location */
-    uint64_t evict_priority;      /* Relative priority of cached pages */
-    uint32_t evict_walk_progress; /* Eviction walk progress */
-    uint32_t evict_walk_target;   /* Eviction walk target */
-    u_int evict_walk_period;      /* Skip this many LRU walks */
-    u_int evict_walk_saved;       /* Saved walk skips for checkpoints */
-    u_int evict_walk_skips;       /* Number of walks skipped */
-    int32_t evict_disabled;       /* Eviction disabled count */
-    bool evict_disabled_open;     /* Eviction disabled on open */
-    volatile uint32_t evict_busy; /* Count of threads in eviction */
+    WT_REF *evict_ref;                      /* Eviction thread's location */
+    uint64_t evict_priority;                /* Relative priority of cached pages */
+    uint32_t evict_walk_progress;           /* Eviction walk progress */
+    uint32_t evict_walk_target;             /* Eviction walk target */
+    u_int evict_walk_period;                /* Skip this many LRU walks */
+    u_int evict_walk_saved;                 /* Saved walk skips for checkpoints */
+    u_int evict_walk_skips;                 /* Number of walks skipped */
+    wt_shared int32_t evict_disabled;       /* Eviction disabled count */
+    bool evict_disabled_open;               /* Eviction disabled on open */
+    wt_shared volatile uint32_t evict_busy; /* Count of threads in eviction */
     WT_EVICT_WALK_TYPE evict_start_type;
 
 /*

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -67,17 +67,17 @@ struct __wt_cache {
      * goes out and calculate the difference as needed.
      */
 
-    uint64_t bytes_dirty_intl; /* Bytes/pages currently dirty */
-    uint64_t bytes_dirty_leaf;
-    uint64_t bytes_dirty_total;
-    uint64_t bytes_evict;      /* Bytes/pages discarded by eviction */
-    uint64_t bytes_image_intl; /* Bytes of disk images (internal) */
-    uint64_t bytes_image_leaf; /* Bytes of disk images (leaf) */
-    uint64_t bytes_inmem;      /* Bytes/pages in memory */
-    uint64_t bytes_internal;   /* Bytes of internal pages */
-    uint64_t bytes_read;       /* Bytes read into memory */
-    uint64_t bytes_updates;    /* Bytes of updates to pages */
-    uint64_t bytes_written;
+    wt_shared uint64_t bytes_dirty_intl; /* Bytes/pages currently dirty */
+    wt_shared uint64_t bytes_dirty_leaf;
+    wt_shared uint64_t bytes_dirty_total;
+    wt_shared uint64_t bytes_evict;      /* Bytes/pages discarded by eviction */
+    wt_shared uint64_t bytes_image_intl; /* Bytes of disk images (internal) */
+    wt_shared uint64_t bytes_image_leaf; /* Bytes of disk images (leaf) */
+    wt_shared uint64_t bytes_inmem;      /* Bytes/pages in memory */
+    wt_shared uint64_t bytes_internal;   /* Bytes of internal pages */
+    wt_shared uint64_t bytes_read;       /* Bytes read into memory */
+    wt_shared uint64_t bytes_updates;    /* Bytes of updates to pages */
+    wt_shared uint64_t bytes_written;
 
     /*
      * History store cache usage. TODO: The values for these variables are cached and potentially
@@ -86,13 +86,13 @@ struct __wt_cache {
     uint64_t bytes_hs;       /* History store bytes inmem */
     uint64_t bytes_hs_dirty; /* History store bytes inmem dirty */
 
-    uint64_t pages_dirty_intl;
-    uint64_t pages_dirty_leaf;
-    uint64_t pages_evicted;
-    uint64_t pages_inmem;
+    wt_shared uint64_t pages_dirty_intl;
+    wt_shared uint64_t pages_dirty_leaf;
+    wt_shared uint64_t pages_evicted;
+    wt_shared uint64_t pages_inmem;
 
-    volatile uint64_t eviction_progress; /* Eviction progress count */
-    uint64_t last_eviction_progress;     /* Tracked eviction progress */
+    wt_shared volatile uint64_t eviction_progress; /* Eviction progress count */
+    uint64_t last_eviction_progress;               /* Tracked eviction progress */
 
     uint64_t app_waits;  /* User threads waited for cache */
     uint64_t app_evicts; /* Pages evicted by user threads */
@@ -151,7 +151,7 @@ struct __wt_cache {
     /*
      * Pass interrupt counter.
      */
-    volatile uint32_t pass_intr; /* Interrupt eviction pass. */
+    wt_shared volatile uint32_t pass_intr; /* Interrupt eviction pass. */
 
     /*
      * LRU eviction list information.
@@ -197,7 +197,7 @@ struct __wt_cache {
      * this we track the checkpoint generation for the most recent read and write verbose messages.
      */
     uint64_t hs_verb_gen_read;
-    uint64_t hs_verb_gen_write;
+    wt_shared uint64_t hs_verb_gen_write;
 
     /*
      * Cache pool information.
@@ -217,10 +217,10 @@ struct __wt_cache {
  * Flags.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_CACHE_POOL_MANAGER 0x1u /* The active cache pool manager */
-#define WT_CACHE_POOL_RUN 0x2u     /* Cache pool thread running */
-                                   /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
-    uint16_t pool_flags_atomic;    /* Cache pool flags */
+#define WT_CACHE_POOL_MANAGER 0x1u        /* The active cache pool manager */
+#define WT_CACHE_POOL_RUN 0x2u            /* Cache pool thread running */
+                                          /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
+    wt_shared uint16_t pool_flags_atomic; /* Cache pool flags */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CACHE_EVICT_CLEAN 0x001u        /* Evict clean pages */
@@ -260,7 +260,7 @@ struct __wt_cache_pool {
     /* Locked: List of connections participating in the cache pool. */
     TAILQ_HEAD(__wt_cache_pool_qh, __wt_connection_impl) cache_pool_qh;
 
-    uint8_t pool_managed; /* Cache pool has a manager thread */
+    wt_shared uint8_t pool_managed; /* Cache pool has a manager thread */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CACHE_POOL_ACTIVE 0x1u /* Cache pool is active */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -38,12 +38,12 @@ struct __wt_evict_entry {
  *	Encapsulation of an eviction candidate queue.
  */
 struct __wt_evict_queue {
-    WT_SPINLOCK evict_lock;        /* Eviction LRU queue */
-    WT_EVICT_ENTRY *evict_queue;   /* LRU pages being tracked */
-    WT_EVICT_ENTRY *evict_current; /* LRU current page to be evicted */
-    uint32_t evict_candidates;     /* LRU list pages to evict */
-    uint32_t evict_entries;        /* LRU entries in the queue */
-    volatile uint32_t evict_max;   /* LRU maximum eviction slot used */
+    WT_SPINLOCK evict_lock;                /* Eviction LRU queue */
+    WT_EVICT_ENTRY *evict_queue;           /* LRU pages being tracked */
+    WT_EVICT_ENTRY *evict_current;         /* LRU current page to be evicted */
+    uint32_t evict_candidates;             /* LRU list pages to evict */
+    uint32_t evict_entries;                /* LRU entries in the queue */
+    wt_shared volatile uint32_t evict_max; /* LRU maximum eviction slot used */
 };
 
 /* Cache operations. */

--- a/src/include/capacity.h
+++ b/src/include/capacity.h
@@ -52,8 +52,8 @@ struct __wt_capacity {
     uint64_t total;     /* Bytes/sec total capacity */
     uint64_t threshold; /* Capacity size period */
 
-    volatile uint64_t written; /* Written this period */
-    volatile bool signalled;   /* Capacity signalled */
+    wt_shared volatile uint64_t written; /* Written this period */
+    wt_shared volatile bool signalled;   /* Capacity signalled */
 
     /*
      * A reservation is a point in time when a read or write for a subsystem can be scheduled, so as
@@ -62,9 +62,9 @@ struct __wt_capacity {
      * that time; getting a reservation with a past time implies that the operation can be done
      * immediately.
      */
-    uint64_t reservation_ckpt;  /* Atomic: next checkpoint write */
-    uint64_t reservation_evict; /* Atomic: next eviction write */
-    uint64_t reservation_log;   /* Atomic: next logging write */
-    uint64_t reservation_read;  /* Atomic: next read */
-    uint64_t reservation_total; /* Atomic: next operation of any kind */
+    wt_shared uint64_t reservation_ckpt;  /* Atomic: next checkpoint write */
+    wt_shared uint64_t reservation_evict; /* Atomic: next eviction write */
+    wt_shared uint64_t reservation_log;   /* Atomic: next logging write */
+    wt_shared uint64_t reservation_read;  /* Atomic: next read */
+    wt_shared uint64_t reservation_total; /* Atomic: next operation of any kind */
 };

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -295,7 +295,7 @@ struct __wt_connection_impl {
     WT_CONNECTION iface;
 
     /* For operations without an application-supplied session */
-    WT_SESSION_IMPL *default_session;
+    wt_shared WT_SESSION_IMPL *default_session;
     WT_SESSION_IMPL dummy_session;
 
     const char *cfg; /* Connection configuration */
@@ -337,7 +337,7 @@ struct __wt_connection_impl {
     WT_EXTENSION_API extension_api; /* Extension API */
 
     /* Configuration */
-    const WT_CONFIG_ENTRY **config_entries;
+    wt_shared const WT_CONFIG_ENTRY **config_entries;
 
     WT_BACKGROUND_COMPACT background_compact; /* Background compaction server */
 
@@ -387,12 +387,12 @@ struct __wt_connection_impl {
 
     /* Locked: handles in each bucket */
     uint64_t *dh_bucket_count;
-    uint64_t dhandle_count;        /* Locked: handles in the queue */
-    u_int open_btree_count;        /* Locked: open writable btree count */
-    uint32_t next_file_id;         /* Locked: file ID counter */
-    uint32_t open_file_count;      /* Atomic: open file handle count */
-    uint32_t open_cursor_count;    /* Atomic: open cursor handle count */
-    uint32_t version_cursor_count; /* Atomic: open version cursor count */
+    uint64_t dhandle_count;                  /* Locked: handles in the queue */
+    u_int open_btree_count;                  /* Locked: open writable btree count */
+    uint32_t next_file_id;                   /* Locked: file ID counter */
+    wt_shared uint32_t open_file_count;      /* Atomic: open file handle count */
+    wt_shared uint32_t open_cursor_count;    /* Atomic: open cursor handle count */
+    wt_shared uint32_t version_cursor_count; /* Atomic: open version cursor count */
 
     /*
      * WiredTiger allocates space for 50 simultaneous sessions (threads of control) by default.
@@ -403,14 +403,14 @@ struct __wt_connection_impl {
      * that way because we want an easy way for the server thread code to avoid walking the entire
      * array when only a few threads are running.
      */
-    WT_SESSION_IMPL *sessions; /* Session reference */
-    uint32_t session_size;     /* Session array size */
-    uint32_t session_cnt;      /* Session count */
+    WT_SESSION_IMPL *sessions;      /* Session reference */
+    uint32_t session_size;          /* Session array size */
+    wt_shared uint32_t session_cnt; /* Session count */
 
     size_t session_scratch_max; /* Max scratch memory per session */
 
-    WT_CACHE *cache;              /* Page cache */
-    volatile uint64_t cache_size; /* Cache size (either statically
+    WT_CACHE *cache;                        /* Page cache */
+    wt_shared volatile uint64_t cache_size; /* Cache size (either statically
                                      configured or the current size
                                      within a cache pool). */
 
@@ -426,11 +426,11 @@ struct __wt_connection_impl {
     char **hot_backup_list;    /* Hot backup file list */
     uint32_t *partial_backup_remove_ids; /* Remove btree id list for partial backup */
 
-    WT_SESSION_IMPL *ckpt_session; /* Checkpoint thread session */
-    wt_thread_t ckpt_tid;          /* Checkpoint thread */
-    bool ckpt_tid_set;             /* Checkpoint thread set */
-    WT_CONDVAR *ckpt_cond;         /* Checkpoint wait mutex */
-    uint64_t ckpt_most_recent;     /* Clock value of most recent checkpoint */
+    WT_SESSION_IMPL *ckpt_session;       /* Checkpoint thread session */
+    wt_thread_t ckpt_tid;                /* Checkpoint thread */
+    bool ckpt_tid_set;                   /* Checkpoint thread set */
+    WT_CONDVAR *ckpt_cond;               /* Checkpoint wait mutex */
+    wt_shared uint64_t ckpt_most_recent; /* Clock value of most recent checkpoint */
 #define WT_CKPT_LOGSIZE(conn) ((conn)->ckpt_logsize != 0)
     wt_off_t ckpt_logsize; /* Checkpoint log size period */
     bool ckpt_signalled;   /* Checkpoint signalled */
@@ -501,7 +501,7 @@ struct __wt_connection_impl {
     bool capacity_tid_set;             /* Capacity thread set */
     WT_CONDVAR *capacity_cond;         /* Capacity wait mutex */
 
-    WT_LSM_MANAGER lsm_manager; /* LSM worker thread information */
+    wt_shared WT_LSM_MANAGER lsm_manager; /* LSM worker thread information */
 
 #define WT_CONN_TIERED_STORAGE_ENABLED(conn) ((conn)->bstorage != NULL)
     WT_BUCKET_STORAGE *bstorage;     /* Bucket storage for the connection */
@@ -578,7 +578,7 @@ struct __wt_connection_impl {
     bool log_wrlsn_tid_set;                /* Log write lsn thread set */
     WT_LOG *log;                           /* Logging structure */
     WT_COMPRESSOR *log_compressor;         /* Logging compressor */
-    uint32_t log_cursors;                  /* Log cursor count */
+    wt_shared uint32_t log_cursors;        /* Log cursor count */
     wt_off_t log_dirty_max;                /* Log dirty system cache max size */
     wt_off_t log_file_max;                 /* Log file max size */
     uint32_t log_force_write_wait;         /* Log force write wait configuration */
@@ -586,7 +586,7 @@ struct __wt_connection_impl {
     uint32_t log_prealloc;                 /* Log file pre-allocation */
     uint16_t log_req_max;                  /* Max required log version */
     uint16_t log_req_min;                  /* Min required log version */
-    uint32_t txn_logsync;                  /* Log sync configuration */
+    wt_shared uint32_t txn_logsync;        /* Log sync configuration */
 
     WT_ROLLBACK_TO_STABLE *rts, _rts;   /* Rollback to stable subsystem */
     WT_SESSION_IMPL *meta_ckpt_session; /* Metadata checkpoint session */
@@ -629,11 +629,11 @@ struct __wt_connection_impl {
     /* If non-zero, all buffers used for I/O will be aligned to this. */
     size_t buffer_alignment;
 
-    uint64_t stashed_bytes; /* Atomic: stashed memory statistics */
-    uint64_t stashed_objects;
+    wt_shared uint64_t stashed_bytes; /* Atomic: stashed memory statistics */
+    wt_shared uint64_t stashed_objects;
 
     /* Generations manager */
-    volatile uint64_t generations[WT_GENERATIONS];
+    wt_shared volatile uint64_t generations[WT_GENERATIONS];
     uint64_t gen_drain_timeout_ms; /* Maximum waiting time for a resource to drain in diagnostic
                                       mode before timing out */
 
@@ -653,10 +653,10 @@ struct __wt_connection_impl {
     int page_size; /* OS page size for mmap alignment */
 
     /* Access to these fields is protected by the debug_log_retention_lock. */
-    WT_LSN *debug_ckpt;      /* Debug mode checkpoint LSNs. */
-    size_t debug_ckpt_alloc; /* Checkpoint retention allocated. */
-    uint32_t debug_ckpt_cnt; /* Checkpoint retention number. */
-    uint32_t debug_log_cnt;  /* Log file retention count */
+    WT_LSN *debug_ckpt;                /* Debug mode checkpoint LSNs. */
+    size_t debug_ckpt_alloc;           /* Checkpoint retention allocated. */
+    wt_shared uint32_t debug_ckpt_cnt; /* Checkpoint retention number. */
+    wt_shared uint32_t debug_log_cnt;  /* Log file retention count */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CONN_DEBUG_CKPT_RETAIN 0x001u
@@ -790,5 +790,5 @@ struct __wt_connection_impl {
 #define WT_CONN_TIERED_FIRST_FLUSH 0x10000000u
 #define WT_CONN_WAS_BACKUP 0x20000000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
-    uint32_t flags;
+    wt_shared uint32_t flags;
 };

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -109,8 +109,8 @@ struct __wt_cursor_btree {
     WT_REF *ref;   /* Current page */
     uint32_t slot; /* WT_COL/WT_ROW 0-based slot */
 
-    wt_shared WT_INSERT_HEAD *ins_head; /* Insert chain head */
-    WT_INSERT *ins;                     /* Current insert node */
+    WT_INSERT_HEAD *ins_head; /* Insert chain head */
+    WT_INSERT *ins;           /* Current insert node */
     /* Search stack */
     WT_INSERT **ins_stack[WT_SKIP_MAXDEPTH];
 

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -109,8 +109,8 @@ struct __wt_cursor_btree {
     WT_REF *ref;   /* Current page */
     uint32_t slot; /* WT_COL/WT_ROW 0-based slot */
 
-    WT_INSERT_HEAD *ins_head; /* Insert chain head */
-    WT_INSERT *ins;           /* Current insert node */
+    wt_shared WT_INSERT_HEAD *ins_head; /* Insert chain head */
+    WT_INSERT *ins;                     /* Current insert node */
     /* Search stack */
     WT_INSERT **ins_stack[WT_SKIP_MAXDEPTH];
 

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -94,11 +94,11 @@ struct __wt_data_handle {
      * references; sessions using a connection's data handle will have a non-zero in-use count.
      * Instances of cached cursors referencing the data handle appear in session_cache_ref.
      */
-    uint32_t references;           /* References to this handle */
-    int32_t session_inuse;         /* Sessions using this handle */
-    uint32_t excl_ref;             /* Refs of handle by excl_session */
-    uint64_t timeofdeath;          /* Use count went to 0 */
-    WT_SESSION_IMPL *excl_session; /* Session with exclusive use, if any */
+    wt_shared uint32_t references;   /* References to this handle */
+    wt_shared int32_t session_inuse; /* Sessions using this handle */
+    uint32_t excl_ref;               /* Refs of handle by excl_session */
+    uint64_t timeofdeath;            /* Use count went to 0 */
+    WT_SESSION_IMPL *excl_session;   /* Session with exclusive use, if any */
 
     WT_DATA_SOURCE *dsrc; /* Data source for this handle */
     void *handle;         /* Generic handle */

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -7,9 +7,10 @@
  */
 
 /*
- * This macro doesn't do anything and is used for annotation only. We use it to highlight to readers
- * that the variable is shared across threads, possibly without locking, and requires caution when
- * handling. It is designed to look like a type qualifier.
+ * This macro doesn't do anything and is used for annotation only. We use it to highlight
+ * the variable is used in lock-less inter-thread communication - using mechanisms like memory
+ * barriers and compare_and_swap - and requires caution when handling. It is designed to look like a
+ * type qualifier.
  *
  * Example usage:
  *     wt_shared volatile bool blkcache_exiting;

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -7,6 +7,16 @@
  */
 
 /*
+ * This macro doesn't do anything and is used for annotation only. We use it to highlight to readers
+ * that the variable is shared across threads, possibly without locking, and requires caution when
+ * handling. It is designed to look like a type qualifier.
+ *
+ * Example usage:
+ *     wt_shared volatile bool blkcache_exiting;
+ */
+#define wt_shared
+
+/*
  * Publish a value to a shared location. All previous stores must complete before the value is made
  * public.
  */

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -199,13 +199,13 @@ struct __wt_logslot {
     WT_ITEM slot_buf;            /* Buffer for grouped writes */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_SLOT_CLOSEFH 0x01u    /* Close old fh on release */
-#define WT_SLOT_FLUSH 0x02u      /* Wait for write */
-#define WT_SLOT_SYNC 0x04u       /* Needs sync on release */
-#define WT_SLOT_SYNC_DIR 0x08u   /* Directory sync on release */
-#define WT_SLOT_SYNC_DIRTY 0x10u /* Sync system buffers on release */
-                                 /* AUTOMATIC FLAG VALUE GENERATION STOP 16 */
-    uint16_t flags_atomic;       /* Atomic flags, use F_*_ATOMIC_16 */
+#define WT_SLOT_CLOSEFH 0x01u        /* Close old fh on release */
+#define WT_SLOT_FLUSH 0x02u          /* Wait for write */
+#define WT_SLOT_SYNC 0x04u           /* Needs sync on release */
+#define WT_SLOT_SYNC_DIR 0x08u       /* Directory sync on release */
+#define WT_SLOT_SYNC_DIRTY 0x10u     /* Sync system buffers on release */
+                                     /* AUTOMATIC FLAG VALUE GENERATION STOP 16 */
+    wt_shared uint16_t flags_atomic; /* Atomic flags, use F_*_ATOMIC_16 */
     WT_CACHE_LINE_PAD_END
 };
 
@@ -235,20 +235,20 @@ struct __wt_myslot {
 #define WT_LOG_END_HEADER log->allocsize
 
 struct __wt_log {
-    uint32_t allocsize;    /* Allocation alignment size */
-    uint32_t first_record; /* Offset of first record in file */
-    wt_off_t log_written;  /* Amount of log written this period */
-                           /*
-                            * Log file information
-                            */
-    uint32_t fileid;       /* Current log file number */
-    uint32_t prep_fileid;  /* Pre-allocated file number */
-    uint32_t tmp_fileid;   /* Temporary file number */
-    uint32_t prep_missed;  /* Pre-allocated file misses */
-    WT_FH *log_fh;         /* Logging file handle */
-    WT_FH *log_dir_fh;     /* Log directory file handle */
-    WT_FH *log_close_fh;   /* Logging file handle to close */
-    WT_LSN log_close_lsn;  /* LSN needed to close */
+    uint32_t allocsize;             /* Allocation alignment size */
+    uint32_t first_record;          /* Offset of first record in file */
+    wt_off_t log_written;           /* Amount of log written this period */
+                                    /*
+                                     * Log file information
+                                     */
+    uint32_t fileid;                /* Current log file number */
+    uint32_t prep_fileid;           /* Pre-allocated file number */
+    wt_shared uint32_t tmp_fileid;  /* Temporary file number */
+    uint32_t prep_missed;           /* Pre-allocated file misses */
+    WT_FH *log_fh;                  /* Logging file handle */
+    WT_FH *log_dir_fh;              /* Log directory file handle */
+    wt_shared WT_FH *log_close_fh;  /* Logging file handle to close */
+    wt_shared WT_LSN log_close_lsn; /* LSN needed to close */
 
     uint16_t log_version; /* Version of log file */
 
@@ -289,10 +289,10 @@ struct __wt_log {
  * arrays.
  */
 #define WT_SLOT_POOL 128
-    WT_LOGSLOT *active_slot;            /* Active slot */
-    WT_LOGSLOT slot_pool[WT_SLOT_POOL]; /* Pool of all slots */
-    int32_t pool_index;                 /* Index into slot pool */
-    size_t slot_buf_size;               /* Buffer size for slots */
+    WT_LOGSLOT *active_slot;                      /* Active slot */
+    wt_shared WT_LOGSLOT slot_pool[WT_SLOT_POOL]; /* Pool of all slots */
+    int32_t pool_index;                           /* Index into slot pool */
+    size_t slot_buf_size;                         /* Buffer size for slots */
 #ifdef HAVE_DIAGNOSTIC
     uint64_t write_calls; /* Calls to log_write */
 #endif

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -38,7 +38,7 @@ union __wt_lsn {
         uint32_t file;
 #endif
     } l;
-    uint64_t file_offset;
+    wt_shared uint64_t file_offset;
 };
 
 #define WT_LOG_FILENAME "WiredTigerLog"     /* Log file name */
@@ -187,16 +187,16 @@ union __wt_lsn {
 
 struct __wt_logslot {
     WT_CACHE_LINE_PAD_BEGIN
-    volatile int64_t slot_state; /* Slot state */
-    int64_t slot_unbuffered;     /* Unbuffered data in this slot */
-    int slot_error;              /* Error value */
-    wt_off_t slot_start_offset;  /* Starting file offset */
-    wt_off_t slot_last_offset;   /* Last record offset */
-    WT_LSN slot_release_lsn;     /* Slot release LSN */
-    WT_LSN slot_start_lsn;       /* Slot starting LSN */
-    WT_LSN slot_end_lsn;         /* Slot ending LSN */
-    WT_FH *slot_fh;              /* File handle for this group */
-    WT_ITEM slot_buf;            /* Buffer for grouped writes */
+    wt_shared volatile int64_t slot_state; /* Slot state */
+    int64_t slot_unbuffered;               /* Unbuffered data in this slot */
+    int slot_error;                        /* Error value */
+    wt_off_t slot_start_offset;            /* Starting file offset */
+    wt_shared wt_off_t slot_last_offset;   /* Last record offset */
+    WT_LSN slot_release_lsn;               /* Slot release LSN */
+    WT_LSN slot_start_lsn;                 /* Slot starting LSN */
+    WT_LSN slot_end_lsn;                   /* Slot ending LSN */
+    WT_FH *slot_fh;                        /* File handle for this group */
+    WT_ITEM slot_buf;                      /* Buffer for grouped writes */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_SLOT_CLOSEFH 0x01u        /* Close old fh on release */

--- a/src/include/lsm.h
+++ b/src/include/lsm.h
@@ -30,7 +30,7 @@ struct __wt_lsm_worker_args {
     u_int id;      /* My manager slot id */
     uint32_t type; /* Types of operations handled */
 
-    volatile bool running; /* Worker is running */
+    wt_shared volatile bool running; /* Worker is running */
 };
 
 /*
@@ -52,7 +52,7 @@ struct __wt_cursor_lsm {
     WT_CURSOR iface;
 
     WT_LSM_TREE *lsm_tree;
-    uint64_t dsk_gen;
+    wt_shared uint64_t dsk_gen;
 
     u_int nchunks;               /* Number of chunks in the cursor */
     u_int nupdates;              /* Updates needed (including
@@ -104,15 +104,15 @@ struct __wt_lsm_chunk {
                                       */
     WT_SPINLOCK timestamp_spinlock;
 
-    uint32_t id;            /* ID used to generate URIs */
-    uint32_t generation;    /* Merge generation */
-    uint32_t refcnt;        /* Number of worker thread references */
-    uint32_t bloom_busy;    /* Currently creating bloom filter */
-    uint32_t evict_enabled; /* Eviction allowed on the chunk */
+    uint32_t id;                      /* ID used to generate URIs */
+    uint32_t generation;              /* Merge generation */
+    wt_shared uint32_t refcnt;        /* Number of worker thread references */
+    wt_shared uint32_t bloom_busy;    /* Currently creating bloom filter */
+    wt_shared uint32_t evict_enabled; /* Eviction allowed on the chunk */
 
-    int8_t empty;     /* 1/0: checkpoint missing */
-    int8_t evicted;   /* 1/0: in-memory chunk was evicted */
-    uint8_t flushing; /* 1/0: chunk flush in progress */
+    int8_t empty;               /* 1/0: checkpoint missing */
+    int8_t evicted;             /* 1/0: in-memory chunk was evicted */
+    wt_shared uint8_t flushing; /* 1/0: chunk flush in progress */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_LSM_CHUNK_BLOOM 0x01u
@@ -175,11 +175,11 @@ struct __wt_lsm_manager {
     TAILQ_HEAD(__wt_lsm_work_switch_qh, __wt_lsm_work_unit) switchqh;
     TAILQ_HEAD(__wt_lsm_work_app_qh, __wt_lsm_work_unit) appqh;
     TAILQ_HEAD(__wt_lsm_work_manager_qh, __wt_lsm_work_unit) managerqh;
-    WT_SPINLOCK switch_lock;  /* Lock for switch queue */
-    WT_SPINLOCK app_lock;     /* Lock for application queue */
-    WT_SPINLOCK manager_lock; /* Lock for manager queue */
-    WT_CONDVAR *work_cond;    /* Used to notify worker of activity */
-    uint32_t lsm_workers;     /* Current number of LSM workers */
+    WT_SPINLOCK switch_lock;        /* Lock for switch queue */
+    WT_SPINLOCK app_lock;           /* Lock for application queue */
+    WT_SPINLOCK manager_lock;       /* Lock for manager queue */
+    WT_CONDVAR *work_cond;          /* Used to notify worker of activity */
+    wt_shared uint32_t lsm_workers; /* Current number of LSM workers */
     uint32_t lsm_workers_max;
 #define WT_LSM_MAX_WORKERS 20
 #define WT_LSM_MIN_WORKERS 3
@@ -188,7 +188,7 @@ struct __wt_lsm_manager {
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_LSM_MANAGER_SHUTDOWN 0x1u /* Manager has shut down */
                                      /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
-    uint32_t flags;
+    wt_shared uint32_t flags;
 };
 
 /*
@@ -222,11 +222,11 @@ struct __wt_lsm_tree {
     const char *collator_name;
     int collator_owned;
 
-    uint32_t refcnt;               /* Number of users of the tree */
-    WT_SESSION_IMPL *excl_session; /* Session has exclusive lock */
+    wt_shared uint32_t refcnt;               /* Number of users of the tree */
+    wt_shared WT_SESSION_IMPL *excl_session; /* Session has exclusive lock */
 
 #define LSM_TREE_MAX_QUEUE 100
-    uint32_t queue_ref;
+    wt_shared uint32_t queue_ref;
     WT_RWLOCK rwlock;
     TAILQ_ENTRY(__wt_lsm_tree) q;
 
@@ -239,10 +239,10 @@ struct __wt_lsm_tree {
     uint64_t chunks_flushed;               /* Count of chunks flushed since open */
     struct timespec merge_aggressive_time; /* Time for merge aggression */
     uint64_t merge_progressing;            /* Bumped when merges are active */
-    uint32_t merge_syncing;                /* Bumped when merges are syncing */
+    wt_shared uint32_t merge_syncing;      /* Bumped when merges are syncing */
     struct timespec last_active;           /* Time last work unit added */
     uint64_t mgr_work_count;               /* Manager work count */
-    uint64_t work_count;                   /* Work units added */
+    wt_shared uint64_t work_count;         /* Work units added */
 
     /* Configuration parameters */
     uint32_t bloom_bit_count;
@@ -259,17 +259,17 @@ struct __wt_lsm_tree {
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t bloom; /* Bloom creation policy */
 
-    WT_LSM_CHUNK **chunk; /* Array of active LSM chunks */
-    size_t chunk_alloc;   /* Space allocated for chunks */
-    uint32_t nchunks;     /* Number of active chunks */
-    uint32_t last;        /* Last allocated ID */
-    bool modified;        /* Have there been updates? */
+    WT_LSM_CHUNK **chunk;    /* Array of active LSM chunks */
+    size_t chunk_alloc;      /* Space allocated for chunks */
+    uint32_t nchunks;        /* Number of active chunks */
+    wt_shared uint32_t last; /* Last allocated ID */
+    bool modified;           /* Have there been updates? */
 
-    WT_LSM_CHUNK **old_chunks;     /* Array of old LSM chunks */
-    size_t old_alloc;              /* Space allocated for old chunks */
-    u_int nold_chunks;             /* Number of old chunks */
-    uint32_t freeing_old_chunks;   /* Whether chunks are being freed */
-    uint32_t merge_aggressiveness; /* Increase amount of work per merge */
+    WT_LSM_CHUNK **old_chunks;             /* Array of old LSM chunks */
+    size_t old_alloc;                      /* Space allocated for old chunks */
+    u_int nold_chunks;                     /* Number of old chunks */
+    wt_shared uint32_t freeing_old_chunks; /* Whether chunks are being freed */
+    uint32_t merge_aggressiveness;         /* Increase amount of work per merge */
 
 /*
  * We maintain a set of statistics outside of the normal statistics area, copying them into place
@@ -295,7 +295,7 @@ struct __wt_lsm_tree {
     /*
      * Following fields used to be flags but are susceptible to races. Don't merge them with flags.
      */
-    bool active;                   /* The tree is open for business */
+    wt_shared bool active;         /* The tree is open for business */
     bool aggressive_timer_enabled; /* Timer for merge aggression enabled */
     bool need_switch;              /* New chunk needs creating */
 

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -18,14 +18,14 @@ struct __wt_condvar {
     wt_mutex_t mtx; /* Mutex */
     wt_cond_t cond; /* Condition variable */
 
-    int waiters; /* Numbers of waiters, or
+    wt_shared int waiters; /* Numbers of waiters, or
                     -1 if signalled with no waiters. */
     /*
      * The following fields are used for automatically adjusting condition variable wait times.
      */
-    uint64_t min_wait;  /* Minimum wait duration */
-    uint64_t max_wait;  /* Maximum wait duration */
-    uint64_t prev_wait; /* Wait duration used last time */
+    uint64_t min_wait;            /* Minimum wait duration */
+    uint64_t max_wait;            /* Maximum wait duration */
+    wt_shared uint64_t prev_wait; /* Wait duration used last time */
 };
 
 /*

--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -37,7 +37,7 @@ struct __wt_condvar {
  * functions.
  */
 struct __wt_rwlock { /* Read/write lock */
-    volatile union {
+    wt_shared volatile union {
         uint64_t v; /* Full 64-bit value */
         struct {
             uint8_t current;         /* Current ticket */
@@ -103,7 +103,7 @@ struct __wt_spinlock {
     uint8_t unused[7];
 #elif SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX || \
   SPINLOCK_TYPE == SPINLOCK_PTHREAD_MUTEX_ADAPTIVE || SPINLOCK_TYPE == SPINLOCK_MSVC
-    wt_mutex_t lock;
+    wt_shared wt_mutex_t lock;
 #else
 #error Unknown spinlock type
 #endif

--- a/src/include/os.h
+++ b/src/include/os.h
@@ -104,13 +104,13 @@ struct __wt_fh {
      */
     const char *name; /* File name */
 
-    uint64_t name_hash;             /* hash of name */
-    uint64_t last_sync;             /* time of background fsync */
-    volatile uint64_t written;      /* written since fsync */
-    TAILQ_ENTRY(__wt_fh) q;         /* internal queue */
-    TAILQ_ENTRY(__wt_fh) hashq;     /* internal hash queue */
-    u_int ref;                      /* reference count */
-    WT_FS_OPEN_FILE_TYPE file_type; /* file type */
+    uint64_t name_hash;                  /* hash of name */
+    uint64_t last_sync;                  /* time of background fsync */
+    wt_shared volatile uint64_t written; /* written since fsync */
+    TAILQ_ENTRY(__wt_fh) q;              /* internal queue */
+    TAILQ_ENTRY(__wt_fh) hashq;          /* internal hash queue */
+    u_int ref;                           /* reference count */
+    WT_FS_OPEN_FILE_TYPE file_type;      /* file type */
 
     WT_FILE_HANDLE *handle;
 };
@@ -146,9 +146,9 @@ struct __wt_file_handle_posix {
     bool mmap_file_mappable;
     int mmap_prot;
     int mmap_flags;
-    volatile uint32_t mmap_resizing;
+    wt_shared volatile uint32_t mmap_resizing;
     wt_off_t mmap_size;
-    volatile uint32_t mmap_usecount;
+    wt_shared volatile uint32_t mmap_usecount;
 };
 #endif
 

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -146,8 +146,8 @@ struct __wt_session_impl {
      * Variables used to look for violations of the contract that a session is only used by a single
      * session at once.
      */
-    volatile uintmax_t api_tid;
-    volatile uint32_t api_enter_refcnt;
+    wt_shared volatile uintmax_t api_tid;
+    wt_shared volatile uint32_t api_enter_refcnt;
     /*
      * It's hard to figure out from where a buffer was allocated after it's leaked, so in diagnostic
      * mode we track them; DIAGNOSTIC can't simply add additional fields to WT_ITEM structures
@@ -292,7 +292,7 @@ struct __wt_session_impl {
      * The random number state persists past session close because we don't want to repeatedly use
      * the same values for skiplist depth when the application isn't caching sessions.
      */
-    WT_RAND_STATE rnd; /* Random number generation state */
+    wt_shared WT_RAND_STATE rnd; /* Random number generation state */
 
     /*
      * Hash tables are allocated lazily as sessions are used to keep the size of this structure from
@@ -310,7 +310,7 @@ struct __wt_session_impl {
 #define WT_GEN_HAZARD 3     /* Hazard pointer */
 #define WT_GEN_SPLIT 4      /* Page splits */
 #define WT_GENERATIONS 5    /* Total generation manager entries */
-    volatile uint64_t generations[WT_GENERATIONS];
+    wt_shared volatile uint64_t generations[WT_GENERATIONS];
 
     /*
      * Session memory persists past session close because it's accessed by threads of control other
@@ -343,10 +343,10 @@ struct __wt_session_impl {
  * The hazard pointer array grows as necessary, initialize with 250 slots.
  */
 #define WT_SESSION_INITIAL_HAZARD_SLOTS 250
-    uint32_t hazard_size;  /* Allocated size of the Hazard pointer array */
-    uint32_t hazard_inuse; /* Number of hazard pointer array slots potentially in-use */
-    uint32_t nhazard;      /* Number of hazard pointer array slots actively in-use */
-    WT_HAZARD *hazard;     /* Hazard pointer array */
+    wt_shared uint32_t hazard_size;  /* Allocated size of the Hazard pointer array */
+    wt_shared uint32_t hazard_inuse; /* Number of hazard pointer array slots potentially in-use */
+    wt_shared uint32_t nhazard;      /* Number of hazard pointer array slots actively in-use */
+    wt_shared WT_HAZARD *hazard;     /* Hazard pointer array */
 
     /*
      * Operation tracking.

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -23,7 +23,7 @@ struct __wt_data_handle_cache {
  *	A hazard pointer.
  */
 struct __wt_hazard {
-    WT_REF *ref; /* Page reference */
+    wt_shared WT_REF *ref; /* Page reference */
 #ifdef HAVE_DIAGNOSTIC
     const char *func; /* Function/line hazard acquired */
     int line;
@@ -93,7 +93,7 @@ struct __wt_session_impl {
     uint64_t operation_timeout_us; /* Maximum operation period before rollback */
     u_int api_call_counter;        /* Depth of api calls */
 
-    WT_DATA_HANDLE *dhandle;           /* Current data handle */
+    wt_shared WT_DATA_HANDLE *dhandle; /* Current data handle */
     WT_BUCKET_STORAGE *bucket_storage; /* Current bucket storage and file system */
 
     /*

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -98,44 +98,44 @@ typedef enum {
 
 struct __wt_txn_shared {
     WT_CACHE_LINE_PAD_BEGIN
-    volatile uint64_t id;
-    volatile uint64_t pinned_id;
-    volatile uint64_t metadata_pinned;
+    wt_shared volatile uint64_t id;
+    wt_shared volatile uint64_t pinned_id;
+    wt_shared volatile uint64_t metadata_pinned;
 
     /*
      * The first commit or durable timestamp used for this transaction. Determines its position in
      * the durable queue and prevents the all_durable timestamp moving past this point.
      */
-    wt_timestamp_t pinned_durable_timestamp;
+    wt_shared wt_timestamp_t pinned_durable_timestamp;
 
     /*
      * The read timestamp used for this transaction. Determines what updates can be read and
      * prevents the oldest timestamp moving past this point.
      */
-    wt_timestamp_t read_timestamp;
+    wt_shared wt_timestamp_t read_timestamp;
 
-    volatile uint8_t is_allocating;
+    wt_shared volatile uint8_t is_allocating;
     WT_CACHE_LINE_PAD_END
 };
 
 struct __wt_txn_global {
-    volatile uint64_t current; /* Current transaction ID. */
+    wt_shared volatile uint64_t current; /* Current transaction ID. */
 
     /* The oldest running transaction ID (may race). */
-    volatile uint64_t last_running;
+    wt_shared volatile uint64_t last_running;
 
     /*
      * The oldest transaction ID that is not yet visible to some transaction in the system.
      */
-    volatile uint64_t oldest_id;
+    wt_shared volatile uint64_t oldest_id;
 
-    wt_timestamp_t durable_timestamp;
-    wt_timestamp_t last_ckpt_timestamp;
+    wt_shared wt_timestamp_t durable_timestamp;
+    wt_shared wt_timestamp_t last_ckpt_timestamp;
     wt_timestamp_t meta_ckpt_timestamp;
-    wt_timestamp_t oldest_timestamp;
-    wt_timestamp_t pinned_timestamp;
+    wt_shared wt_timestamp_t oldest_timestamp;
+    wt_shared wt_timestamp_t pinned_timestamp;
     wt_timestamp_t recovery_timestamp;
-    wt_timestamp_t stable_timestamp;
+    wt_shared wt_timestamp_t stable_timestamp;
     wt_timestamp_t version_cursor_pinned_timestamp;
     bool has_durable_timestamp;
     bool has_oldest_timestamp;
@@ -159,15 +159,16 @@ struct __wt_txn_global {
      * We rely on the fact that (a) the only table a checkpoint updates is the metadata; and (b)
      * once checkpoint has finished reading a table, it won't revisit it.
      */
-    volatile bool checkpoint_running;    /* Checkpoint running */
-    volatile bool checkpoint_running_hs; /* Checkpoint running and processing history store file */
+    wt_shared volatile bool checkpoint_running; /* Checkpoint running */
+    wt_shared volatile bool
+      checkpoint_running_hs;             /* Checkpoint running and processing history store file */
     volatile uint32_t checkpoint_id;     /* Checkpoint's session ID */
     WT_TXN_SHARED checkpoint_txn_shared; /* Checkpoint's txn shared state */
-    wt_timestamp_t checkpoint_timestamp; /* Checkpoint's timestamp */
+    wt_shared wt_timestamp_t checkpoint_timestamp; /* Checkpoint's timestamp */
 
-    volatile uint64_t debug_ops;       /* Debug mode op counter */
-    uint64_t debug_rollback;           /* Debug mode rollback */
-    volatile uint64_t metadata_pinned; /* Oldest ID for metadata */
+    wt_shared volatile uint64_t debug_ops;       /* Debug mode op counter */
+    uint64_t debug_rollback;                     /* Debug mode rollback */
+    wt_shared volatile uint64_t metadata_pinned; /* Oldest ID for metadata */
 
     WT_TXN_SHARED *txn_shared_list; /* Per-session shared transaction states */
 };
@@ -354,7 +355,7 @@ struct __wt_txn {
 #define WT_TXN_TS_ROUND_READ 0x40000u
 #define WT_TXN_UPDATE 0x80000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
-    uint32_t flags;
+    wt_shared uint32_t flags;
 
     /*
      * Zero or more bytes of value (the payload) immediately follows the WT_TXN structure. We use a


### PR DESCRIPTION
This PR adds a `wt_shared` tag to all variables identified in PM-3221 to use concurrency primitives for inter-thread operations. The macro pre-processes away to nothing, and is just used to highlight these variables for future tickets.

I've added a developer link on the Jira ticket to the variable catalog we've built in PM-3221 for reference