### PR TITLE
WT-11584 fix test checkpoint04 test

### DIFF
--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -34,8 +34,7 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
 class test_checkpoint04(wttest.WiredTigerTestCase):
-    # We don't want stats from earlier runs to interfere with later runs.
-    conn_config = 'cache_size=50MB,statistics=(all,clear)'
+    conn_config = 'cache_size=50MB,statistics=(all)'
 
     def create_tables(self, ntables):
         tables = {}
@@ -64,7 +63,7 @@ class test_checkpoint04(wttest.WiredTigerTestCase):
 
     def test_checkpoint_stats(self):
         nrows = 100
-        ntables = 10
+        ntables = 50
         multiplier = 1
 
         # Run the loop and increase the value size with each iteration until
@@ -130,6 +129,9 @@ class test_checkpoint04(wttest.WiredTigerTestCase):
                 break
 
             multiplier += 1
+            # Reopen the connection to reset statistics.
+            # We don't want stats from earlier runs to interfere with later runs.
+            self.reopen_conn()
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -117,7 +117,8 @@ class test_checkpoint04(wttest.WiredTigerTestCase):
             time_total = self.get_stat(stat.conn.checkpoint_time_total)
             self.pr('checkpoint_time_total ' + str(time_total))
 
-            self.assertEqual(num_ckpt, 2)
+            expected_ckpts = 3 if multiplier > 1 else 2
+            self.assertEqual(num_ckpt, expected_ckpts)
             self.assertEqual(running, 0)
             self.assertEqual(prep_running, 0)
             # Assert if this loop continues for more than 100 iterations.

--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -34,7 +34,7 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
 class test_checkpoint04(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=50MB,statistics=(all)'
+    conn_config = 'cache_size=50MB,statistics=(all,clear)'
 
     def create_tables(self, ntables):
         tables = {}
@@ -127,11 +127,8 @@ class test_checkpoint04(wttest.WiredTigerTestCase):
             # Run the loop again if any of the below condition fails and exit if the test passes.
             if prep_min < time_min and prep_max < time_max and prep_recent < time_recent and prep_total < time_total:
                 break
-            else:
-                multiplier += 1
-                # Reopen the connection to reset statistics. 
-                # We don't want stats from earlier runs to interfere with later runs.
-                self.reopen_conn()
+
+            multiplier += 1
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -34,6 +34,7 @@ from wiredtiger import stat
 from wtdataset import SimpleDataSet
 
 class test_checkpoint04(wttest.WiredTigerTestCase):
+    # We don't want stats from earlier runs to interfere with later runs.
     conn_config = 'cache_size=50MB,statistics=(all,clear)'
 
     def create_tables(self, ntables):

--- a/test/suite/test_checkpoint04.py
+++ b/test/suite/test_checkpoint04.py
@@ -117,6 +117,8 @@ class test_checkpoint04(wttest.WiredTigerTestCase):
             time_total = self.get_stat(stat.conn.checkpoint_time_total)
             self.pr('checkpoint_time_total ' + str(time_total))
 
+            # Account for When the connection re-opens on an existing datable as we perform a
+            # checkpoint during the open stage. 
             expected_ckpts = 3 if multiplier > 1 else 2
             self.assertEqual(num_ckpt, expected_ckpts)
             self.assertEqual(running, 0)


### PR DESCRIPTION
The previous PR does not work. The reason why is because the specific statistics in the python test has a **no_clear** option, which means that the statistics do not get re-cleared. We need to perform a re-open and fix the number of expected ckpts. However I still see that the test failing. The test is failing due to eatmydata.so which no-ops any fsync which causes the statistic to not be properly updated. As a safety measure increasing the number of tables helps with solving that problem.