### PR TITLE
WT-11823 Fix test_salvage02 for the tiered and timestamp hooks

### DIFF
--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -312,7 +312,7 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
                 "inmem",                # In memory tests don't make sense with tiered storage
                 "lsm",                  # If the test name tells us it uses lsm ignore it
                 "modify_smoke_recover", # Copying WT dir doesn't copy the bucket directory
-                "salvage01",            # Salvage tests directly name files ending in ".wt"
+                "test_salvage",         # Salvage tests directly name files ending in ".wt"
                 "test_config_json",     # create replacement can't handle a json config string
                 "test_cursor_big",      # Cursor caching verified with stats
                 "tiered",               # Tiered tests already do tiering.


### PR DESCRIPTION
Fix two that the python hooks are causing for test_salvage02.

- The tiered hook should skip all salvage logic as salvage is not supported. Update the filter string to catch all salvage tests and not just `test_salvage01`
- The timestamp hook auto-increments timestamps which causes issues with the manually configured `stable_ts`. Use a dedicated `large_updates` function to control this logic.

Co-authored-by: Will Korteland will.korteland@mongodb.com