### PR TITLE
WT-11758 Consider prefetching on the session level instead of cursor level

### DIFF
--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -10,54 +10,26 @@
 
 /*
  * __wt_session_prefetch_check --
- *     Check to see whether cursors owned by this session might benefit from doing pre-fetch
- *
- * FIXME-WT-11758 Change this function so that when pre-fetching is enabled on the session level,
- *     all cursors associated with that session with automatically perform pre-fetching. Use the
- *     session-level configuration once it is introduced.
+ *     Turn on prefetching for all cursors within a session if pre-fetching is configured on the
+ *     session.
  */
 bool
 __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
 {
-    /* Internal threads should not be configured to do pre-fetching. */
-    if (!S2C(session)->prefetch_auto_on || F_ISSET(session, WT_SESSION_INTERNAL))
-        return (false);
-
-    if (S2C(session)->prefetch_queue_count > WT_MAX_PREFETCH_QUEUE)
-        return (false);
-
     /*
-     * Don't deal with internal pages at the moment - finding the right content to preload based on
-     * internal pages is hard.
+     * Check if pre-fetching is enabled on the session level. If not, don't perform pre-fetching on
+     * any of the associated cursors. We don't perform pre-fetching on internal threads or internal
+     * pages either (finding the right content to preload based on internal page is hard), so check
+     * for those here too.
      */
-    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+    if (!F_ISSET(session, WT_SESSION_PREFETCH) || F_ISSET(session, WT_SESSION_INTERNAL) ||
+      F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
+        WT_STAT_CONN_INCR(session, block_prefetch_skipped);
         return (false);
+    }
 
     if (session->pf.prefetch_disk_read_count == 1)
         WT_STAT_CONN_INCR(session, block_prefetch_disk_one);
-
-    /* A single read from disk is common - don't use it to guide pre-fetch behavior. */
-    if (session->pf.prefetch_disk_read_count < 2) {
-        WT_STAT_CONN_INCR(session, block_prefetch_skipped);
-        return (false);
-    }
-
-    if (session->pf.prefetch_prev_ref == NULL) {
-        WT_STAT_CONN_INCR(session, block_prefetch_attempts);
-        return (true);
-    }
-
-    /*
-     * If the previous pre-fetch was using the same home ref, pre-fetch for approximately the number
-     * of pages that were added to the queue.
-     */
-    if (session->pf.prefetch_prev_ref->page == ref->home &&
-      session->pf.prefetch_skipped_with_parent < WT_PREFETCH_QUEUE_PER_TRIGGER) {
-        ++session->pf.prefetch_skipped_with_parent;
-        WT_STAT_CONN_INCR(session, block_prefetch_skipped);
-        return (false);
-    }
-    session->pf.prefetch_skipped_with_parent = 0;
 
     WT_STAT_CONN_INCR(session, block_prefetch_attempts);
     return (true);

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -10,7 +10,7 @@
 
 /*
  * __wt_session_prefetch_check --
- *     Check if pre-fetching is configured on the session.
+ *     Check if pre-fetching work should be performed for a given ref.
  */
 bool
 __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
@@ -20,16 +20,40 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
     /*
      * Check if pre-fetching is enabled on the session level. We don't perform pre-fetching on
      * internal threads or internal pages (finding the right content to preload based on internal
-     * pages is hard), so check for that too. The result of this check will be used by cursor logic
-     * to determine if pre-fetching will be performed.
+     * pages is hard), so check for that too. We also want to pre-fetch pages that have had at least
+     * one read. The result of this check will be used by cursor logic to determine if pre-fetching
+     * will be performed.
      */
     if (!F_ISSET(session, WT_SESSION_PREFETCH) || F_ISSET(session, WT_SESSION_INTERNAL) ||
-      F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
+      F_ISSET(ref, WT_REF_FLAG_INTERNAL) || session->pf.prefetch_disk_read_count < 2) {
+        WT_STAT_CONN_INCR(session, block_prefetch_skipped);
+        return (false);
+    }
+
+    /*
+     * We want to avoid the scenario of requesting pre-fetch on one particular ref many times (e.g
+     * when reading along a single page). We can identify this by checking if the previous pre-fetch
+     * was performed using the same home ref.
+     *
+     * In the event that we find this to be true, we perform pre-fetch for approximately the number
+     * of pages that were added to the queue (WT_PREFETCH_QUEUE_PER_TRIGGER). We then want to ensure
+     * that we will not pre-fetch from this ref for a while, and this is done by checking a counter.
+     *
+     * The counter variable prefetch_skipped_with_parent tracks the number of skips we have
+     * performed on a particular ref. If the number of skips surpasses the number of pages that have
+     * been queued for pre-fetch, we are okay to pre-fetch from this ref again. This condition will
+     * evaluate to false and the counter will be reset, effectively marking the ref as available to
+     * pre-fetch from.
+     */
+    if (session->pf.prefetch_prev_ref->page == ref->home &&
+      session->pf.prefetch_skipped_with_parent < WT_PREFETCH_QUEUE_PER_TRIGGER) {
+        ++session->pf.prefetch_skipped_with_parent;
         WT_STAT_CONN_INCR(session, block_prefetch_skipped);
         return (false);
     }
 
     session->pf.prefetch_skipped_with_parent = 0;
+
     if (session->pf.prefetch_disk_read_count == 1)
         WT_STAT_CONN_INCR(session, block_prefetch_disk_one);
 

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -16,6 +16,8 @@
 bool
 __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
 {
+    if (S2C(session)->prefetch_queue_count > WT_MAX_PREFETCH_QUEUE)
+        return (false);
     /*
      * Check if pre-fetching is enabled on the session level. If not, don't perform pre-fetching on
      * any of the associated cursors. We don't perform pre-fetching on internal threads or internal

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -54,7 +54,6 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
      * evaluate to false and the counter will be reset, effectively marking the ref as available to
      * pre-fetch from.
      */
-
     if (session->pf.prefetch_prev_ref->page == ref->home &&
       session->pf.prefetch_skipped_with_parent < WT_PREFETCH_QUEUE_PER_TRIGGER) {
         ++session->pf.prefetch_skipped_with_parent;

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -10,8 +10,7 @@
 
 /*
  * __wt_session_prefetch_check --
- *     Turn on prefetching for all cursors within a session if pre-fetching is configured on the
- *     session.
+ *     Check if pre-fetching is configured on the session.
  */
 bool
 __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
@@ -19,10 +18,10 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
     if (S2C(session)->prefetch_queue_count > WT_MAX_PREFETCH_QUEUE)
         return (false);
     /*
-     * Check if pre-fetching is enabled on the session level. If not, don't perform pre-fetching on
-     * any of the associated cursors. We don't perform pre-fetching on internal threads or internal
-     * pages either (finding the right content to preload based on internal page is hard), so check
-     * for those here too.
+     * Check if pre-fetching is enabled on the session level. We don't perform pre-fetching on
+     * internal threads or internal pages (finding the right content to preload based on internal
+     * pages is hard), so check for that too. The result of this check will be used by cursor logic
+     * to determine if pre-fetching will be performed.
      */
     if (!F_ISSET(session, WT_SESSION_PREFETCH) || F_ISSET(session, WT_SESSION_INTERNAL) ||
       F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
@@ -30,6 +29,7 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
         return (false);
     }
 
+    session->pf.prefetch_skipped_with_parent = 0;
     if (session->pf.prefetch_disk_read_count == 1)
         WT_STAT_CONN_INCR(session, block_prefetch_disk_one);
 

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -34,6 +34,11 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
         return (false);
     }
 
+    if (session->pf.prefetch_prev_ref == NULL) {
+        WT_STAT_CONN_INCR(session, block_prefetch_attempts);
+        return (true);
+    }
+
     /*
      * We want to avoid the scenario of requesting pre-fetch on one particular ref many times (e.g
      * when reading along a single page). We can identify this by checking if the previous pre-fetch
@@ -49,10 +54,6 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
      * evaluate to false and the counter will be reset, effectively marking the ref as available to
      * pre-fetch from.
      */
-    if (session->pf.prefetch_prev_ref == NULL) {
-        WT_STAT_CONN_INCR(session, block_prefetch_attempts);
-        return (true);
-    }
 
     if (session->pf.prefetch_prev_ref->page == ref->home &&
       session->pf.prefetch_skipped_with_parent < WT_PREFETCH_QUEUE_PER_TRIGGER) {

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -18,21 +18,21 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
     if (S2C(session)->prefetch_queue_count > WT_MAX_PREFETCH_QUEUE)
         return (false);
 
-    if (session->pf.prefetch_disk_read_count == 1)
-        WT_STAT_CONN_INCR(session, block_prefetch_disk_one);
-
     /*
      * Check if pre-fetching is enabled for this particular session. We don't perform pre-fetching
      * on internal threads or internal pages (finding the right content to preload based on internal
-     * pages is hard), so check for that too. We also want to pre-fetch pages that have had at least
-     * one read. The result of this check will be used by cursor logic to determine if pre-fetching
-     * will be performed.
+     * pages is hard), so check for that too. We also want to pre-fetch sessions that have read at
+     * least one page from disk. The result of this function will subsequently be checked by cursor
+     * logic to determine if pre-fetching will be performed.
      */
     if (!F_ISSET(session, WT_SESSION_PREFETCH) || F_ISSET(session, WT_SESSION_INTERNAL) ||
       F_ISSET(ref, WT_REF_FLAG_INTERNAL) || session->pf.prefetch_disk_read_count < 2) {
         WT_STAT_CONN_INCR(session, block_prefetch_skipped);
         return (false);
     }
+
+    if (session->pf.prefetch_disk_read_count == 1)
+        WT_STAT_CONN_INCR(session, block_prefetch_disk_one);
 
     if (session->pf.prefetch_prev_ref == NULL) {
         WT_STAT_CONN_INCR(session, block_prefetch_attempts);


### PR DESCRIPTION
The purpose of this PR is to align with the tech design which states that once prefetching is configured on a session, prefetching will automatically be turned on for all cursors with the session regardless of how beneficial it may be for the particular table that the cursor is open on. 

