### PR TITLE
WT-11804 Improve hook filtering in python tests

### DIFF
--- a/test/suite/hook_demo.py
+++ b/test/suite/hook_demo.py
@@ -111,8 +111,8 @@ class DemoHookCreator(wthooks.WiredTigerHookCreator):
 
     # We have an opportunity to filter the list of tests to be run.
     # For this demo, we don't filter.
-    def filter_tests(self, tests):
-        print('Filtering: ' + str(tests))
+    def register_skipped_tests(self, tests):
+        print('Registering skipped tests: ' + str(tests))
         return tests
 
     # If the hook wants to override some implementation of the test framework,

--- a/test/suite/hook_demo.py
+++ b/test/suite/hook_demo.py
@@ -112,8 +112,7 @@ class DemoHookCreator(wthooks.WiredTigerHookCreator):
     # We have an opportunity to filter the list of tests to be run.
     # For this demo, we don't filter.
     def register_skipped_tests(self, tests):
-        print('Registering skipped tests: ' + str(tests))
-        return tests
+        pass
 
     # If the hook wants to override some implementation of the test framework,
     # it would need to subclass wthooks.WiredTigerHookPlatformAPI and return

--- a/test/suite/hook_nonstandalone.py
+++ b/test/suite/hook_nonstandalone.py
@@ -50,19 +50,11 @@ class NonStandAloneHookCreator(wthooks.WiredTigerHookCreator):
     def get_platform_api(self):
         return self.platform_api
 
-    # Is this test one we should skip?
-    def skip_reason(self, test):
-        # There are no general categories of tests to skip. 
-        # Individual tests are skipped via the skip_for_hook decorator
-        return None
-
     # Skip tests that won't work on non-standalone build
     def register_skipped_test(self, tests):
-        for t in tests:
-            skip_reason = self.skip_reason(t)
-            if skip_reason is not None:
-                wttest.register_skipped_test(t, "nonstandalone", skip_reason)
-        return tests
+        # There are no general categories of tests to skip for non-standalone. 
+        # Individual tests are skipped via the skip_for_hook decorator
+        pass
 
     def setup_hooks(self):
         pass

--- a/test/suite/hook_nonstandalone.py
+++ b/test/suite/hook_nonstandalone.py
@@ -38,7 +38,7 @@
 
 from __future__ import print_function
 
-import unittest, wthooks
+import unittest, wthooks, wttest
 from urllib.parse import parse_qsl
 
 # Every hook file must have one or more classes descended from WiredTigerHook
@@ -51,30 +51,19 @@ class NonStandAloneHookCreator(wthooks.WiredTigerHookCreator):
         return self.platform_api
 
     # Is this test one we should skip?
-    def skip_test(self, test):
-        # Skip any test that contains one of these strings as a substring
-        skip = [
-                # Skip all tests that do timestamped truncate operations.
-                "test_checkpoint25.test_checkpoint",
-                "test_rollback_to_stable34.test_rollback_to_stable",
-                "test_rollback_to_stable36.test_rollback_to_stable36",
-                "test_truncate09.test_truncate09",
-                "test_truncate15.test_truncate15",
-
-                # This group fail within Python for various, sometimes unknown, reasons.
-                "test_bug018.test_bug018"
-                ]
-
-        for item in skip:
-            if item in str(test):
-                return True
-        return False
+    def skip_reason(self, test):
+        # There are no general categories of tests to skip. 
+        # Individual tests are skipped via the skip_for_hook decorator
+        return None
 
     # Remove tests that won't work on non-standalone build
+    # FIXME-WT-11804 - Common pattern?
     def filter_tests(self, tests):
-        new_tests = unittest.TestSuite()
-        new_tests.addTests([t for t in tests if not self.skip_test(t)])
-        return new_tests
+        for t in tests:
+            skip_reason = self.skip_reason(t)
+            if skip_reason is not None:
+                wttest.register_skipped_test(t, "nonstandalone", skip_reason)
+        return tests
 
     def setup_hooks(self):
         pass

--- a/test/suite/hook_nonstandalone.py
+++ b/test/suite/hook_nonstandalone.py
@@ -56,9 +56,8 @@ class NonStandAloneHookCreator(wthooks.WiredTigerHookCreator):
         # Individual tests are skipped via the skip_for_hook decorator
         return None
 
-    # Remove tests that won't work on non-standalone build
-    # FIXME-WT-11804 - Common pattern?
-    def filter_tests(self, tests):
+    # Skip tests that won't work on non-standalone build
+    def register_skipped_test(self, tests):
         for t in tests:
             skip_reason = self.skip_reason(t)
             if skip_reason is not None:

--- a/test/suite/hook_rollback.py
+++ b/test/suite/hook_rollback.py
@@ -111,9 +111,8 @@ class RollbackHookCreator(wthooks.WiredTigerHookCreator):
     def do_retry(self):
         return self.rand.randint(1, 1000000) % self.mod == 0
 
-    # No filtering needed
-    def filter_tests(self, tests):
-        #print('Filtering: ' + str(tests))
+    # No skipping needed
+    def register_skipped_tests(self, tests):
         return tests
 
     def setup_hooks(self):

--- a/test/suite/hook_rollback.py
+++ b/test/suite/hook_rollback.py
@@ -113,7 +113,7 @@ class RollbackHookCreator(wthooks.WiredTigerHookCreator):
 
     # No skipping needed
     def register_skipped_tests(self, tests):
-        return tests
+        pass
 
     def setup_hooks(self):
         self.Session['begin_transaction'] = (wthooks.HOOK_NOTIFY, session_begin_transaction_notify)

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -307,10 +307,10 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
         skip_categories = [
             ("backup",               "Can't backup a tiered table"),
             ("inmem",                "In memory tests don't make sense with tiered storage"),
-            ("lsm",                  "If the test name tells us it uses lsm ignore it"),
+            ("lsm",                  "LSM is not supported with tiering"),
             ("modify_smoke_recover", "Copying WT dir doesn't copy the bucket directory"),
             ("test_salvage",         "Salvage tests directly name files ending in '.wt'"),
-            ("test_config_json",     "create replacement can't handle a json config string"),
+            ("test_config_json",     "Tiered hook's create function can't handle a json config string"),
             ("test_cursor_big",      "Cursor caching verified with stats"),
             ("tiered",               "Tiered tests already do tiering."),
             ("test_verify",          "Verify not supported on tiered tables (yet)")

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -329,7 +329,6 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
             skip_reason = self.skip_reason(t)
             if skip_reason is not None:
                 wttest.register_skipped_test(t, "tiered", skip_reason)
-        return tests
 
     def get_platform_api(self):
         return self.platform_api

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -323,8 +323,8 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
 
         return None
 
-    # Remove tests that won't work on tiered cursors
-    def filter_tests(self, tests):
+    # Skip tests that won't work on tiered cursors
+    def register_skipped_tests(self, tests):
         for t in tests:
             skip_reason = self.skip_reason(t)
             if skip_reason is not None:

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -300,11 +300,10 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
             return True
         return False
 
-    # Determine if a test should be skipped. 
-    # If it should skip, return the reason as a string. If it shouldn't, return None
+    # Determine whether a test should be skipped, if it should also return the reason for skipping.
     # Some features aren't supported with tiered storage currently. If they exist in 
     # the test name (or scenario name) skip the test.
-    def skip_reason(self, test):
+    def should_skip(self, test) -> (bool, str):
         skip_categories = [
             ("backup",               "Can't backup a tiered table"),
             ("inmem",                "In memory tests don't make sense with tiered storage"),
@@ -319,15 +318,15 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
 
         for (skip_string, skip_reason) in skip_categories:
             if skip_string in str(test):
-                return skip_reason
+                return (True, skip_reason)
 
-        return None
+        return (False, None)
 
     # Skip tests that won't work on tiered cursors
     def register_skipped_tests(self, tests):
         for t in tests:
-            skip_reason = self.skip_reason(t)
-            if skip_reason is not None:
+            (should_skip, skip_reason) = self.should_skip(t)
+            if should_skip:
                 wttest.register_skipped_test(t, "tiered", skip_reason)
 
     def get_platform_api(self):

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -304,11 +304,6 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
     def skip_test(self, test):
         # Skip any test that contains one of these strings as a substring
         skip = ["backup",               # Can't backup a tiered table
-                "env01",                # Using environment variable to set WT home
-                "config02",             # Using environment variable to set WT home
-                "cursor13_ckpt",        # Checkpoint tests with cached cursors
-                "cursor13_dup",         # More cursor cache tests
-                "cursor13_reopens",     # More cursor cache tests
                 "inmem",                # In memory tests don't make sense with tiered storage
                 "lsm",                  # If the test name tells us it uses lsm ignore it
                 "modify_smoke_recover", # Copying WT dir doesn't copy the bucket directory
@@ -317,60 +312,6 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
                 "test_cursor_big",      # Cursor caching verified with stats
                 "tiered",               # Tiered tests already do tiering.
                 "test_verify",          # Verify not supported on tiered tables (yet)
-
-                # FIXME-WT-9809 The following failures should be triaged and potentially
-                # individually reticketed.
-
-                # This first group currently cause severe errors, where Python crashes,
-                # whether from internal assertion or other causes.
-                "test_bug003.test_bug003",   # Triggers WT-9954
-                "test_bug024.test_bug024",
-                "test_bulk01.test_bulk_load",   # Triggers WT-9954
-                "test_durable_ts03.test_durable_ts03",
-                "test_rollback_to_stable20.test_rollback_to_stable",
-                "test_stat_log01_readonly.test_stat_log01_readonly",
-                "test_stat_log02.test_stats_log_on_json_with_tables",
-                "test_txn02.test_ops",
-
-                # This group fail within Python for various, sometimes unknown, reasons.
-                "test_bug018.test_bug018",
-                "test_checkpoint.test_checkpoint",
-                "test_checkpoint_snapshot02.test_checkpoint_snapshot_with_txnid_and_timestamp",
-                "test_compat05.test_compat05",
-                "test_config05.test_too_many_sessions",
-                "test_config09.test_config09",
-                "test_drop.test_drop",
-                "test_empty.test_empty",     # looks at wt file names and uses column store
-                "test_encrypt06.test_encrypt",
-                "test_encrypt07.test_salvage_api",
-                "test_encrypt07.test_salvage_api_damaged",
-                "test_encrypt07.test_salvage_process_damaged",
-                "test_export01.test_export_restart",
-                "test_hs21.test_hs",
-                "test_import04.test_table_import",
-                "test_import09.test_import_table_repair",
-                "test_import09.test_import_table_repair",
-                "test_import11.test_file_import",
-                "test_import11.test_file_import",
-                "test_join03.test_join",
-                "test_join07.test_join_string",
-                "test_jsondump02.test_json_all_bytes",
-                "test_metadata_cursor02.test_missing",
-                "test_prepare02.test_prepare_session_operations",
-                "test_prepare_hs03.test_prepare_hs",
-                "test_prepare_hs03.test_prepare_hs",
-                "test_rename.test_rename",
-                "test_rollback_to_stable09.test_rollback_to_stable",
-                "test_rollback_to_stable28.test_update_restore_evict_recovery",
-                "test_rollback_to_stable34.test_rollback_to_stable",
-                "test_rollback_to_stable35.test_rollback_to_stable",
-                "test_rollback_to_stable36.test_rollback_to_stable",
-                "test_sweep03.test_disable_idle_timeout_drop",
-                "test_sweep03.test_disable_idle_timeout_drop_force",
-                "test_txn22.test_corrupt_meta",
-                "test_verbose01.test_verbose_single",
-                "test_verbose02.test_verbose_single",
-                "test_verify2.test_verify_ckpt",
                 ]
 
         for item in skip:

--- a/test/suite/hook_timestamp.py
+++ b/test/suite/hook_timestamp.py
@@ -120,9 +120,8 @@ class TimestampHookCreator(wthooks.WiredTigerHookCreator):
         else:
             return None
 
-    # FIXME-WT-11804 - Update name of filter_tests
     # Remove tests that won't work on timestamp cursors
-    def filter_tests(self, tests):
+    def register_skipped_tests(self, tests):
         for t in tests:
             skip_reason = self.skip_reason(t)
             if skip_reason is not None:

--- a/test/suite/hook_timestamp.py
+++ b/test/suite/hook_timestamp.py
@@ -126,7 +126,7 @@ class TimestampHookCreator(wthooks.WiredTigerHookCreator):
         for t in tests:
             skip_reason = self.skip_reason(t)
             if skip_reason is not None:
-                wttest.register_skipped_test(t, skip_reason)
+                wttest.register_skipped_test(t, "timestamp", skip_reason)
         return tests
 
     def get_platform_api(self):

--- a/test/suite/hook_timestamp.py
+++ b/test/suite/hook_timestamp.py
@@ -120,13 +120,12 @@ class TimestampHookCreator(wthooks.WiredTigerHookCreator):
         else:
             return None
 
-    # Remove tests that won't work on timestamp cursors
+    # Skip tests that won't work on timestamp cursors
     def register_skipped_tests(self, tests):
         for t in tests:
             skip_reason = self.skip_reason(t)
             if skip_reason is not None:
                 wttest.register_skipped_test(t, "timestamp", skip_reason)
-        return tests
 
     def get_platform_api(self):
         return self.platform_api

--- a/test/suite/hook_timestamp.py
+++ b/test/suite/hook_timestamp.py
@@ -101,10 +101,9 @@ class TimestampHookCreator(wthooks.WiredTigerHookCreator):
 
     dataset_names = make_dataset_names()
 
-    # Determine if a test should be skipped. 
-    # If it should skip, return the reason as a string. If it shouldn't, return None
+    # Determine whether a test should be skipped, if it should also return the reason for skipping.
     # The timestamp hook skips tests that don't use datasets.
-    def skip_reason(self, test):
+    def should_skip(self, test) -> (bool, str):
         testname = str(test)
         modname = testname.split('.')[0]
         g = sys.modules[modname].__dict__
@@ -116,15 +115,15 @@ class TimestampHookCreator(wthooks.WiredTigerHookCreator):
                 break
 
         if not uses_dataset:
-            return "Doesn't use dataset"
+            return (True, "Doesn't use dataset")
         else:
-            return None
+            return (False, None)
 
     # Skip tests that won't work on timestamp cursors
     def register_skipped_tests(self, tests):
         for t in tests:
-            skip_reason = self.skip_reason(t)
-            if skip_reason is not None:
+            (should_skip, skip_reason) = self.should_skip(t)
+            if should_skip:
                 wttest.register_skipped_test(t, "timestamp", skip_reason)
 
     def get_platform_api(self):

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -576,7 +576,7 @@ if __name__ == '__main__':
         for arg in testargs:
             testsFromArg(tests, loader, arg, scenario)
 
-    tests = hookmgr.register_skipped_tests(tests)
+    hookmgr.register_skipped_tests(tests)
 
     # Shuffle the tests and create a new suite containing every Nth test from
     # the original suite

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -576,7 +576,7 @@ if __name__ == '__main__':
         for arg in testargs:
             testsFromArg(tests, loader, arg, scenario)
 
-    tests = hookmgr.filter_tests(tests)
+    tests = hookmgr.register_skipped_tests(tests)
 
     # Shuffle the tests and create a new suite containing every Nth test from
     # the original suite

--- a/test/suite/test_bug003.py
+++ b/test/suite/test_bug003.py
@@ -33,6 +33,7 @@ import wttest
 from wtscenario import make_scenarios
 
 # Regression tests.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9954")
 class test_bug003(wttest.WiredTigerTestCase):
     types = [
         ('file', dict(uri='file:data')),

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -35,7 +35,8 @@ import wiredtiger, wttest
 #   JIRA WT-3590: if writing table data fails during close then tables
 # that were updated within the same transaction could get out of sync with
 # each other.
-@wttest.skip_for_hook("nonstandalone", "fails for standalone")
+@wttest.skip_for_hook("nonstandalone", "fails for nonstandalone")
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - fails on tiered")
 class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
     '''Test closing/reopening/recovering tables when writes fail'''
 

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -35,6 +35,7 @@ import wiredtiger, wttest
 #   JIRA WT-3590: if writing table data fails during close then tables
 # that were updated within the same transaction could get out of sync with
 # each other.
+@wttest.skip_for_hook("nonstandalone", "fails for standalone")
 class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
     '''Test closing/reopening/recovering tables when writes fail'''
 

--- a/test/suite/test_bug024.py
+++ b/test/suite/test_bug024.py
@@ -38,6 +38,7 @@ import os, shutil
 # WT-6526: test that we can successfully open a readonly connection after it was stopped while
 # the temporary turtle file existed. We simulate that by copying the turtle file to its temporary name
 # and then opening the connection readonly.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Causes python crash")
 class test_bug024(wttest.WiredTigerTestCase):
     conn_config = ('cache_size=50MB')
 

--- a/test/suite/test_bulk01.py
+++ b/test/suite/test_bulk01.py
@@ -35,6 +35,7 @@ from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
 
 # Smoke test bulk-load.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Triggers WT-9954")
 class test_bulk_load(wttest.WiredTigerTestCase):
     name = 'test_bulk'
 

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 # General checkpoint test: create an object containing sets of data associated
 # with a set of checkpoints, then confirm the checkpoint's values are correct,
 # including after other checkpoints are dropped.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     scenarios = make_scenarios([
         ('file', dict(uri='file:checkpoint',fmt='S')),

--- a/test/suite/test_checkpoint10.py
+++ b/test/suite/test_checkpoint10.py
@@ -38,6 +38,7 @@ from wtscenario import make_scenarios
 # Test what happens if we create an inconsistent checkpoint and then try to
 # open it for read. No timestamps in this version.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
 

--- a/test/suite/test_checkpoint11.py
+++ b/test/suite/test_checkpoint11.py
@@ -38,6 +38,7 @@ from wtscenario import make_scenarios
 # Test what happens if we create an inconsistent checkpoint and then try to
 # open it for read. This version uses timestamps.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all),timing_stress_for_test=[checkpoint_slow]'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint12.py
+++ b/test/suite/test_checkpoint12.py
@@ -36,6 +36,7 @@ from wtscenario import make_scenarios
 # checkpoints don't interfere with the blanket ban on doing other operations after
 # preparing.)
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = ''
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint13.py
+++ b/test/suite/test_checkpoint13.py
@@ -39,6 +39,7 @@ from wtscenario import make_scenarios
 #
 # - You may not regen or drop a named checkpoint with a cursor open.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = ''
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint14.py
+++ b/test/suite/test_checkpoint14.py
@@ -39,6 +39,7 @@ from wtscenario import make_scenarios
 # Make sure each checkpoint has its own snapshot by creating two successive
 # inconsistent checkpoints and reading both of them.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all),timing_stress_for_test=[checkpoint_slow]'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint15.py
+++ b/test/suite/test_checkpoint15.py
@@ -37,6 +37,7 @@ from wtscenario import make_scenarios
 # Make sure each checkpoint has its own timestamp info by writing out
 # multiple checkpoints with different times and reading all of them.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
 

--- a/test/suite/test_checkpoint16.py
+++ b/test/suite/test_checkpoint16.py
@@ -37,6 +37,7 @@ from wtscenario import make_scenarios
 # Make sure a table that's clean when a checkpointed can still be read in
 # that checkpoint.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
 

--- a/test/suite/test_checkpoint17.py
+++ b/test/suite/test_checkpoint17.py
@@ -37,6 +37,7 @@ from wtscenario import make_scenarios
 # Make sure that if the history store is clean when a checkpoint is taken
 # that we can still access it via the checkpoint.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
 

--- a/test/suite/test_checkpoint18.py
+++ b/test/suite/test_checkpoint18.py
@@ -46,6 +46,7 @@ from wtscenario import make_scenarios
 # an interesting scenario. The concern is getting the matching version
 # of WiredTigerCheckpoint and hanging onto it.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all),timing_stress_for_test=[checkpoint_slow]'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint19.py
+++ b/test/suite/test_checkpoint19.py
@@ -44,6 +44,7 @@ from wtscenario import make_scenarios
 # an interesting scenario. The concern is getting the matching version
 # of WiredTigerCheckpoint and hanging onto it.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
 

--- a/test/suite/test_checkpoint20.py
+++ b/test/suite/test_checkpoint20.py
@@ -36,6 +36,7 @@ from wtscenario import make_scenarios
 #
 # Test reading a checkpoint that contains prepared data.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
 
     format_values = [

--- a/test/suite/test_checkpoint21.py
+++ b/test/suite/test_checkpoint21.py
@@ -56,6 +56,7 @@ from wtscenario import make_scenarios
 # This test sets up such a transaction, evicts half of it, then checkpoints the
 # rest, and checks that it is all visible by reading the checkpoint.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
 
     format_values = [

--- a/test/suite/test_checkpoint22.py
+++ b/test/suite/test_checkpoint22.py
@@ -72,6 +72,7 @@ from wtscenario import make_scenarios
 # This test doesn't use timestamps; it is about transaction-level visibility.
 # There doesn't seem any immediate reason to think timestamps would add anything.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
 
     format_values = [

--- a/test/suite/test_checkpoint24.py
+++ b/test/suite/test_checkpoint24.py
@@ -38,6 +38,7 @@ from wtscenario import make_scenarios
 # Test reading a checkpoint that contains fast-delete pages.
 # This version does not use timestamps.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
 

--- a/test/suite/test_checkpoint25.py
+++ b/test/suite/test_checkpoint25.py
@@ -38,6 +38,7 @@ from wtscenario import make_scenarios
 # Test reading a checkpoint that contains fast-delete pages.
 # This version uses timestamps.
 
+@wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
 

--- a/test/suite/test_checkpoint25.py
+++ b/test/suite/test_checkpoint25.py
@@ -39,6 +39,7 @@ from wtscenario import make_scenarios
 # This version uses timestamps.
 
 @wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
 

--- a/test/suite/test_checkpoint27.py
+++ b/test/suite/test_checkpoint27.py
@@ -37,6 +37,7 @@ from wtscenario import make_scenarios
 # Check that nothing bad happens if we read in metadata pages while in the
 # middle of reading a checkpoint.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
 
     format_values = [

--- a/test/suite/test_checkpoint28.py
+++ b/test/suite/test_checkpoint28.py
@@ -46,6 +46,7 @@ from wtscenario import make_scenarios
 # an interesting scenario. The concern is getting the matching version
 # of WiredTigerCheckpoint and hanging onto it.
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all),timing_stress_for_test=[checkpoint_handle]'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_checkpoint29.py
+++ b/test/suite/test_checkpoint29.py
@@ -31,6 +31,7 @@ import wiredtiger, wttest
 # test_checkpoint29.py
 #
 # Test opening a checkpoint cursor after bulk operations.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
 
     def test_checkpoint(self):

--- a/test/suite/test_checkpoint30.py
+++ b/test/suite/test_checkpoint30.py
@@ -36,6 +36,7 @@ from wtscenario import make_scenarios
 #
 # Test reading a cursor when the aggregate time window is visible to the snapshot
 # but not all deleted keys on-disk version are not visible.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,statistics=(all)'
 

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -250,6 +250,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         self.assertGreater(inconsistent_ckpt, 0)
         self.assertGreaterEqual(keys_removed, 0)
 
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
     def test_checkpoint_snapshot_with_txnid_and_timestamp(self):
         self.moresetup()
 

--- a/test/suite/test_compat05.py
+++ b/test/suite/test_compat05.py
@@ -35,6 +35,7 @@ from suite_subprocess import suite_subprocess
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_compat05(wttest.WiredTigerTestCase, suite_subprocess):
     remove_values = [
         ('archive-false', dict(remove_arg = 'archive=false', removed = False)),

--- a/test/suite/test_config02.py
+++ b/test/suite/test_config02.py
@@ -36,6 +36,7 @@ import wiredtiger, wttest
 
 # test_config02.py
 #    The home directory for wiredtiger_open
+@wttest.skip_for_hook("tiered", "using environment variable to set WT home")
 class test_config02(wttest.WiredTigerTestCase):
     table_name1 = 'test_config02'
     nentries = 100

--- a/test/suite/test_config05.py
+++ b/test/suite/test_config05.py
@@ -86,6 +86,7 @@ class test_config05(wttest.WiredTigerTestCase):
         self.populate(self.session)
         self.verify_entries(self.session)
 
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
     def test_too_many_sessions(self):
         self.conn = self.wiredtiger_open('.', 'create,session_max=1')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,

--- a/test/suite/test_config09.py
+++ b/test/suite/test_config09.py
@@ -33,6 +33,7 @@
 import wiredtiger, wttest
 from wiredtiger import stat
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_config09(wttest.WiredTigerTestCase):
     ntables = 50
     nentries = 5

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -123,34 +123,42 @@ class test_cursor13_02(test_cursor02.test_cursor02, test_cursor13_base):
 class test_cursor13_03(test_cursor03.test_cursor03, test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_ckpt01(test_checkpoint01.test_checkpoint,
                            test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_ckpt02(test_checkpoint01.test_checkpoint_cursor,
                            test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_ckpt03(test_checkpoint01.test_checkpoint_target,
                            test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_ckpt04(test_checkpoint01.test_checkpoint_cursor_update,
                            test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_ckpt05(test_checkpoint01.test_checkpoint_last,
                            test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_ckpt06(test_checkpoint01.test_checkpoint_empty,
                            test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_ckpt2(test_checkpoint02.test_checkpoint02,
                           test_cursor13_base):
     pass
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_reopens(test_cursor13_base):
     # The SimpleDataSet uses simple tables, that have no column groups or
     # indices. Thus, these tables will be cached. The more complex data sets
@@ -563,6 +571,7 @@ class test_cursor13_sweep(test_cursor13_big_base):
         # predictable.
         self.assertGreater(end_stats[1] - begin_stats[1], 0)
 
+@wttest.skip_for_hook("tiered", "uses cached cursors")
 class test_cursor13_dup(test_cursor13_base):
     def test_dup(self):
         self.cursor_stats_init()

--- a/test/suite/test_drop.py
+++ b/test/suite/test_drop.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 
 # test_drop.py
 #    session level drop operation
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_drop(wttest.WiredTigerTestCase):
     name = 'test_drop'
     extra_config = ''

--- a/test/suite/test_durable_ts03.py
+++ b/test/suite/test_durable_ts03.py
@@ -31,6 +31,7 @@ from wtscenario import make_scenarios
 
 # test_durable_ts03.py
 #    Check that the checkpoint honors the durable timestamp of updates.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Causes python crash")
 class test_durable_ts03(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=10MB'
 

--- a/test/suite/test_empty.py
+++ b/test/suite/test_empty.py
@@ -32,6 +32,7 @@ from wtscenario import make_scenarios
 
 # test_empty.py
 #       Test that empty objects don't write anything other than a single sector.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Looks at wt file names and uses column store")
 class test_empty(wttest.WiredTigerTestCase):
     name = 'test_empty'
 

--- a/test/suite/test_encrypt06.py
+++ b/test/suite/test_encrypt06.py
@@ -35,6 +35,7 @@ import wttest
 from wtscenario import make_scenarios
 
 # Test encryption, when on, does not leak any information
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_encrypt06(wttest.WiredTigerTestCase):
     # To test the sodium encryptor, we use secretkey= rather than
     # setting a keyid, because for a "real" (vs. test-only) encryptor,

--- a/test/suite/test_encrypt07.py
+++ b/test/suite/test_encrypt07.py
@@ -37,6 +37,7 @@ import wttest
 import test_salvage01
 
 # Run the regular salvage test, but with encryption on
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_encrypt07(test_salvage01.test_salvage01):
 
     uri='table:test_encrypt07'
@@ -69,6 +70,19 @@ class test_encrypt07(test_salvage01.test_salvage01):
     # overrides test_salvage.damage.
     #def damage(self, tablename):
     #    self.damage_inner(tablename, self.rot13(self.unique).encode())
+
+    # To apply decorators to parent methods we need to define them in the child class
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
+    def test_salvage_api(self):
+        return super(test_encrypt07, self).test_salvage_api()
+
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
+    def test_salvage_api_damaged(self):
+        return super(test_encrypt07, self).test_salvage_api_damaged()
+
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
+    def test_salvage_process_damaged(self):
+        return super(test_encrypt07, self).test_salvage_process_damaged()
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_env01.py
+++ b/test/suite/test_env01.py
@@ -33,6 +33,7 @@ import wiredtiger, wttest
 #    Test privileged operations.
 #    This is a variant of test_config02.py.  This test should be run as both
 # normal and privileged (e.g. root) user, and should pass in both cases.
+@wttest.skip_for_hook("tiered", "using environment variable to set WT home")
 class test_priv01(wttest.WiredTigerTestCase):
     """
     This tests privileged operations.

--- a/test/suite/test_export01.py
+++ b/test/suite/test_export01.py
@@ -91,6 +91,7 @@ class test_export01(TieredConfigMixin, wttest.WiredTigerTestCase):
         # The export file should exist in the backup directory.
         self.assertTrue(os.path.isfile(os.path.join(self.dir, "WiredTiger.export")))
 
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
     def test_export_restart(self):
         uri_a = self.type + "exporta"
         uri_b = self.type + "exportb"

--- a/test/suite/test_hs21.py
+++ b/test/suite/test_hs21.py
@@ -38,6 +38,7 @@ from wtscenario import make_scenarios
 # We want to ensure that when an active history file is idle closed we can continue reading the
 # correct version of data and their base write generation hasn't changed (since we haven't
 # restarted the system).
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_hs21(wttest.WiredTigerTestCase):
     # Configure handle sweeping to occur within a specific amount of time.
     conn_config = 'file_manager=(close_handle_minimum=0,close_idle_time=2,close_scan_interval=1),' + \

--- a/test/suite/test_import04.py
+++ b/test/suite/test_import04.py
@@ -53,6 +53,7 @@ import wiredtiger, wttest
 from wtscenario import make_scenarios
 from test_import01 import test_import_base
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_import04(test_import_base):
     conn_config = 'cache_size=50MB'
 

--- a/test/suite/test_import09.py
+++ b/test/suite/test_import09.py
@@ -32,6 +32,7 @@
 import os, random, shutil
 from test_import01 import test_import_base
 from wtscenario import make_scenarios
+import wttest
 
 @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_import09(test_import_base):

--- a/test/suite/test_import09.py
+++ b/test/suite/test_import09.py
@@ -33,6 +33,7 @@ import os, random, shutil
 from test_import01 import test_import_base
 from wtscenario import make_scenarios
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_import09(test_import_base):
     nrows = 100
     ntables = 1

--- a/test/suite/test_import11.py
+++ b/test/suite/test_import11.py
@@ -97,6 +97,7 @@ class test_import_base(TieredConfigMixin, wttest.WiredTigerTestCase):
             self.session.checkpoint()
 
 # test_import11
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_import11(test_import_base):
     uri_a = 'table:test_a'
     uri_b = 'table:test_b'

--- a/test/suite/test_join03.py
+++ b/test/suite/test_join03.py
@@ -31,6 +31,7 @@ import wttest
 # test_join03.py
 #    Join operations
 # Joins with a custom extractor
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_join03(wttest.WiredTigerTestCase):
     table_name1 = 'test_join03'
     nentries = 100

--- a/test/suite/test_join07.py
+++ b/test/suite/test_join07.py
@@ -186,6 +186,7 @@ class Tokenizer:
 
 # test_join07.py
 #    Join interpreter
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_join07(wttest.WiredTigerTestCase):
     reverseop = { '==' : '==', '<=' : '>=', '<' : '>', '>=' : '<=', '>' : '<' }
     compareop = { '==' : 'eq', '<=' : 'le', '<' : 'lt', '>=' : 'ge',

--- a/test/suite/test_jsondump02.py
+++ b/test/suite/test_jsondump02.py
@@ -31,6 +31,7 @@ from suite_subprocess import suite_subprocess
 
 # test_jsondump.py
 # Test dump output from json cursors.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_jsondump02(wttest.WiredTigerTestCase, suite_subprocess):
 
     table_uri1 = 'table:jsondump02a.wt'

--- a/test/suite/test_metadata_cursor02.py
+++ b/test/suite/test_metadata_cursor02.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 # Test metadata cursor semantics when the underlying metadata is invalid.
 # This can happen after a crash, or if part of a table is dropped separate
 # from dropping the whole table.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_metadata_cursor02(wttest.WiredTigerTestCase):
     """
     Test metadata cursor operations with invalid metadata

--- a/test/suite/test_prepare02.py
+++ b/test/suite/test_prepare02.py
@@ -33,6 +33,7 @@
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_prepare_session_operations(self):

--- a/test/suite/test_prepare28.py
+++ b/test/suite/test_prepare28.py
@@ -31,6 +31,7 @@ import wttest, threading
 
 # Prior to a bugfix in WiredTiger it was possible to read a partial transaction if the config
 # ignore prepare was provided. This test demonstrates that case.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_prepare28(wttest.WiredTigerTestCase):
     conn_config= 'timing_stress_for_test=[prepare_resolution_2]'
     uri = 'table:test_prepare28'

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -40,6 +40,7 @@ from wiredtiger import stat
 
 # test_prepare_hs03.py
 # test to ensure salvage, verify & simulating crash are working for prepared transactions.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_prepare_hs03(wttest.WiredTigerTestCase):
     # Force a small cache.
     conn_config = ('cache_size=50MB,statistics=(fast),'

--- a/test/suite/test_rename.py
+++ b/test/suite/test_rename.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 
 # test_rename.py
 #    session level rename operation
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_rename(wttest.WiredTigerTestCase):
     name1 = 'test_rename1'
     name2 = 'test_rename2'

--- a/test/suite/test_rollback_to_stable09.py
+++ b/test/suite/test_rollback_to_stable09.py
@@ -34,6 +34,7 @@ from rollback_to_stable_util import test_rollback_to_stable_base
 # test_rollback_to_stable09.py
 # Test that rollback to stable does not abort schema operations that are done
 # as they don't have transaction support
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_rollback_to_stable09(test_rollback_to_stable_base):
 
     # Don't bother testing FLCS tables as well as they're highly unlikely to

--- a/test/suite/test_rollback_to_stable09.py
+++ b/test/suite/test_rollback_to_stable09.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os
-import wiredtiger
+import wiredtiger, wttest
 from wtscenario import make_scenarios
 from rollback_to_stable_util import test_rollback_to_stable_base
 

--- a/test/suite/test_rollback_to_stable28.py
+++ b/test/suite/test_rollback_to_stable28.py
@@ -32,6 +32,7 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 from helper import simulate_crash_restart
 from rollback_to_stable_util import test_rollback_to_stable_base
+import wttest
 
 # test_rollback_to_stable28.py
 # Test the debug mode setting for update_restore_evict during recovery.

--- a/test/suite/test_rollback_to_stable28.py
+++ b/test/suite/test_rollback_to_stable28.py
@@ -39,6 +39,7 @@ from rollback_to_stable_util import test_rollback_to_stable_base
 # perform this in recovery to ensure that all the in-memory images have
 # the proper write generation number and we don't end up reading stale
 # transaction ID's stored on the page.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Causes python crash")
 class test_rollback_to_stable28(test_rollback_to_stable_base):
     conn_config = 'statistics=(all),verbose=(rts:5)'
     # Recovery connection config: The debug mode is only effective on high cache pressure as WiredTiger can potentially decide

--- a/test/suite/test_rollback_to_stable34.py
+++ b/test/suite/test_rollback_to_stable34.py
@@ -36,6 +36,7 @@ import wttest
 # test_rollback_to_stable34.py
 # Test interaction between fast-delete and RTS.
 @wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_rollback_to_stable34(test_rollback_to_stable_base):
     session_config = 'isolation=snapshot'
     conn_config = 'cache_size=50MB,statistics=(all),log=(enabled=false),verbose=(rts:5)'

--- a/test/suite/test_rollback_to_stable34.py
+++ b/test/suite/test_rollback_to_stable34.py
@@ -31,9 +31,11 @@ from rollback_to_stable_util import test_rollback_to_stable_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
+import wttest
 
 # test_rollback_to_stable34.py
 # Test interaction between fast-delete and RTS.
+@wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
 class test_rollback_to_stable34(test_rollback_to_stable_base):
     session_config = 'isolation=snapshot'
     conn_config = 'cache_size=50MB,statistics=(all),log=(enabled=false),verbose=(rts:5)'

--- a/test/suite/test_rollback_to_stable35.py
+++ b/test/suite/test_rollback_to_stable35.py
@@ -36,6 +36,7 @@ from rollback_to_stable_util import test_rollback_to_stable_base
 
 # test_rollback_to_stable35.py
 # Test that log is flushed for all writes that occurred in the checkpoint.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_rollback_to_stable35(test_rollback_to_stable_base):
 
     format_values = [

--- a/test/suite/test_rollback_to_stable36.py
+++ b/test/suite/test_rollback_to_stable36.py
@@ -38,6 +38,7 @@ from wtscenario import make_scenarios
 # Check the behavior of a fast-truncated page where the truncation is not stable but
 # everything else on the page is.
 
+@wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
 class test_rollback_to_stable36(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all),verbose=(rts:5)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_rollback_to_stable36.py
+++ b/test/suite/test_rollback_to_stable36.py
@@ -39,6 +39,7 @@ from wtscenario import make_scenarios
 # everything else on the page is.
 
 @wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_rollback_to_stable36(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all),verbose=(rts:5)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_stat_log01.py
+++ b/test/suite/test_stat_log01.py
@@ -76,6 +76,7 @@ class test_stat_log01(wttest.WiredTigerTestCase):
         self.check_stats_file(".")
 
 # Statistics log, test subsequent readonly open works.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Causes python crash")
 class test_stat_log01_readonly(wttest.WiredTigerTestCase):
     # Configure statistics logging so it gets written into the base configuration file.
     conn_config = 'log=(enabled),statistics=(all),statistics_log=(on_close=true)'

--- a/test/suite/test_stat_log02.py
+++ b/test/suite/test_stat_log02.py
@@ -73,6 +73,7 @@ class test_stat_log02(wttest.WiredTigerTestCase):
 
         self.check_stats_file(".")
 
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Causes python crash")
     def test_stats_log_on_json_with_tables(self):
         self.conn = self.wiredtiger_open(None,
             "create,statistics=(fast)," +\

--- a/test/suite/test_sweep03.py
+++ b/test/suite/test_sweep03.py
@@ -103,6 +103,7 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
         # We expect nothing to have been closed.
         self.assertEqual(close1, 0)
 
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
     def test_disable_idle_timeout_drop_force(self):
         # Create a table to drop. A drop should close its associated handle
         drop_uri = '%s.%s' % (self.uri, "force_drop_test")
@@ -137,6 +138,7 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
         # Ensure that any space was reclaimed from cache.
         self.assertLess(cache2, cache1)
 
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
     def test_disable_idle_timeout_drop(self):
         # Create a table to drop. A drop should close its associated handles
         drop_uri = '%s.%s' % (self.uri, "drop_test")

--- a/test/suite/test_truncate09.py
+++ b/test/suite/test_truncate09.py
@@ -34,6 +34,7 @@ from helper import simulate_crash_restart
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
 
+@wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
 class test_truncate09(wttest.WiredTigerTestCase):
     # We don't test FLCS, missing records return as 0 values.
     format_values = [

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 #
 # Check that readonly database reading fast truncated pages doesn't lead to cache stuck.
 
+@wttest.skip_for_hook("nonstandalone", "timestamped truncate not supported for nonstandalone")
 class test_truncate15(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_txn02.py
+++ b/test/suite/test_txn02.py
@@ -35,6 +35,7 @@ from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 import wttest
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Causes python crash")
 class test_txn02(wttest.WiredTigerTestCase, suite_subprocess):
     logmax = "100K"
     tablename = 'test_txn02'

--- a/test/suite/test_txn22.py
+++ b/test/suite/test_txn22.py
@@ -34,6 +34,7 @@ from wtscenario import make_scenarios
 from suite_subprocess import suite_subprocess
 import helper, wiredtiger, wttest
 
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
 class test_txn22(wttest.WiredTigerTestCase, suite_subprocess):
     base_config = 'cache_size=1GB'
     conn_config = base_config

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -157,6 +157,7 @@ class test_verbose01(test_verbose_base):
     collection_cfg = 'key_format=S,value_format=S'
 
     # Test use cases passing single verbose categories, ensuring we only produce verbose output for the single category.
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
     def test_verbose_single(self):
         # Close the initial connection. We will be opening new connections with different verbosity settings throughout
         # this test.

--- a/test/suite/test_verbose02.py
+++ b/test/suite/test_verbose02.py
@@ -46,6 +46,7 @@ class test_verbose02(test_verbose_base):
 
     # Test use cases passing single verbose categories, ensuring we only produce verbose output for
     # the single category.
+    @wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Fails for tiered")
     def test_verbose_single(self):
         # Close the initial connection. We will be opening new connections with different verbosity
         # settings throughout this test.

--- a/test/suite/wthooks.py
+++ b/test/suite/wthooks.py
@@ -230,7 +230,6 @@ class WiredTigerHookManager(object):
     def register_skipped_tests(self, tests):
         for hook in self.hooks:
             tests = hook.register_skipped_tests(tests)
-        return tests
 
     def get_hook_names(self):
         return self.hook_names
@@ -275,9 +274,10 @@ class WiredTigerHookCreator(ABC):
         self.Session = HookCreatorProxy(self.hookmgr, wiredtiger.Session)
         self.Cursor = HookCreatorProxy(self.hookmgr, wiredtiger.Cursor)
 
-    # default version of register_skipped_tests, can be overridden
+    # Default version of register_skipped_tests, can be overridden.
+    # Walks the lists of tests in-place, modifying the tests that should be skipped
     def register_skipped_tests(self, tests):
-        return tests
+        pass
 
     @abstractmethod
     def setup_hooks(self):

--- a/test/suite/wthooks.py
+++ b/test/suite/wthooks.py
@@ -229,7 +229,7 @@ class WiredTigerHookManager(object):
 
     def register_skipped_tests(self, tests):
         for hook in self.hooks:
-            tests = hook.register_skipped_tests(tests)
+            hook.register_skipped_tests(tests)
 
     def get_hook_names(self):
         return self.hook_names

--- a/test/suite/wthooks.py
+++ b/test/suite/wthooks.py
@@ -227,9 +227,9 @@ class WiredTigerHookManager(object):
             orig_func = getattr(clazz, method_name)
         return orig_func
 
-    def filter_tests(self, tests):
+    def register_skipped_tests(self, tests):
         for hook in self.hooks:
-            tests = hook.filter_tests(tests)
+            tests = hook.register_skipped_tests(tests)
         return tests
 
     def get_hook_names(self):
@@ -275,8 +275,8 @@ class WiredTigerHookCreator(ABC):
         self.Session = HookCreatorProxy(self.hookmgr, wiredtiger.Session)
         self.Cursor = HookCreatorProxy(self.hookmgr, wiredtiger.Cursor)
 
-    # default version of filter_tests, can be overridden
-    def filter_tests(self, tests):
+    # default version of register_skipped_tests, can be overridden
+    def register_skipped_tests(self, tests):
         return tests
 
     @abstractmethod

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -923,6 +923,14 @@ def skip_for_hook(hookname, description):
     else:
         return runit_decorator
 
+# Override a test's setUp function to instead skip and report the reason for skipping
+def register_skipped_test(test, hook, skip_reason):
+
+    def _skip_test(self):
+        raise unittest.SkipTest(f"{test} for hook {hook}: {skip_reason}")
+
+    setattr(test, "setUp", lambda: _skip_test(test))
+
 def islongtest():
     return WiredTigerTestCase._longtest
 


### PR DESCRIPTION
Starting this off in draft mode. This is just one proposal and I'm happy to change it up as needed.

Previously each hook had a `filter_tests` function that would determine if a test wasn't relevant for the hook. If this returned true then the test was removed from the list of tests to run. This could result in users running commands like `pyt test_salvage01 --hook timestamp` and seeing `Ran 0 tests in 0.000s` with no explanation for the why the tests were skipped. Additionally if the hook filtered out an individual test like `test_salvage01` and developers created a new test `test_salvage02` based on it the filter would not expand to the new test, causing unexpected failures.

This PR makes the following changes:
- Where an individual test was being filtered the new code instead uses the `wttest.skip_for_hook` decorator in the test file. This makes it easier for developers to see the test is being skipped
- Where a group of tests don't make sense to run for the hook (for example in-memory tests when running with `--hook tiered`) they are still managed by the `hook_*.py` logic, however instead of removing the tests they are modified to skip and report the reason for skipping.

One tradeoff from this approach is additional verbosity. For example `--hook timestamp` used to print 
`Ran 3104 tests in 2644.837s ... OK (skipped=307)` 
and now prints 
`Ran 13532 tests in 2487.218s ... OK (skipped=10734)`
with all the additional lines reported why each test was skipped. 

There's a large number of decorators added in this PR. I've broken the changes down into individual commits to hopefully help with review.
