### PR TITLE
WT-11826 Always check if background compaction is being interrupted

### DIFF
--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -215,8 +215,8 @@ __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    bool background_compaction;
     char interrupt_msg[128];
+    bool background_compaction;
 
     background_compaction = false;
     conn = S2C(session);

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -223,13 +223,10 @@ __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
     /* If compaction has been interrupted, we return WT_ERROR to the caller. */
     if (session == conn->background_compact.session) {
         background_compaction = true;
-        /* Only check for interruption when the connection is not being opened/closed. */
-        if (!F_ISSET(conn, WT_CONN_CLOSING | WT_CONN_MINIMAL)) {
-            __wt_spin_lock(session, &conn->background_compact.lock);
-            if (!conn->background_compact.running)
-                ret = WT_ERROR;
-            __wt_spin_unlock(session, &conn->background_compact.lock);
-        }
+        __wt_spin_lock(session, &conn->background_compact.lock);
+        if (!conn->background_compact.running)
+            ret = WT_ERROR;
+        __wt_spin_unlock(session, &conn->background_compact.lock);
     } else if (session->event_handler->handle_general != NULL) {
         ret = session->event_handler->handle_general(
           session->event_handler, &conn->iface, &session->iface, WT_EVENT_COMPACT_CHECK, NULL);


### PR DESCRIPTION
Currently, we are not checking if background compaction should be interrupted when the connection closes. This has the consequence of increasing the shutdown time when background compaction is still working since we are not trying to interrupt it.