### PR TITLE
WT-11830 Reduce capacity of chunkcache tests

### DIFF
--- a/test/suite/test_chunkcache01.py
+++ b/test/suite/test_chunkcache01.py
@@ -59,7 +59,7 @@ class test_chunkcache01(wttest.WiredTigerTestCase):
             os.mkdir('bucket1')
 
         return 'tiered_storage=(auth_token=Secret,bucket=bucket1,bucket_prefix=pfx_,name=dir_store),' \
-            'chunk_cache=[enabled=true,chunk_size=10MB,capacity=200MB,type={},storage_path=WiredTigerChunkCache],'.format(self.chunk_cache_type)
+            'chunk_cache=[enabled=true,chunk_size=1MB,capacity=20MB,type={},storage_path=WiredTigerChunkCache],'.format(self.chunk_cache_type)
 
     def conn_extensions(self, extlist):
         if os.name == 'nt':

--- a/test/suite/test_chunkcache01.py
+++ b/test/suite/test_chunkcache01.py
@@ -59,7 +59,7 @@ class test_chunkcache01(wttest.WiredTigerTestCase):
             os.mkdir('bucket1')
 
         return 'tiered_storage=(auth_token=Secret,bucket=bucket1,bucket_prefix=pfx_,name=dir_store),' \
-            'chunk_cache=[enabled=true,chunk_size=100MB,capacity=2GB,type={},storage_path=WiredTigerChunkCache],'.format(self.chunk_cache_type)
+            'chunk_cache=[enabled=true,chunk_size=10MB,capacity=200MB,type={},storage_path=WiredTigerChunkCache],'.format(self.chunk_cache_type)
 
     def conn_extensions(self, extlist):
         if os.name == 'nt':

--- a/test/suite/test_chunkcache03.py
+++ b/test/suite/test_chunkcache03.py
@@ -58,7 +58,7 @@ class test_chunkcache03(wttest.WiredTigerTestCase):
             os.mkdir('bucket2')
 
         return 'tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),' \
-            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=20GB,pinned=' \
+            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=2GB,pinned=' \
                 + '("' + '{}'.format("\",\"".join(self.pinned_uris)) \
                 + '"),type={},storage_path=WiredTigerChunkCache]'.format(self.chunk_cache_type)
 

--- a/test/suite/test_chunkcache03.py
+++ b/test/suite/test_chunkcache03.py
@@ -58,7 +58,7 @@ class test_chunkcache03(wttest.WiredTigerTestCase):
             os.mkdir('bucket2')
 
         return 'tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),' \
-            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=2GB,pinned=' \
+            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=1GB,pinned=' \
                 + '("' + '{}'.format("\",\"".join(self.pinned_uris)) \
                 + '"),type={},storage_path=WiredTigerChunkCache]'.format(self.chunk_cache_type)
 

--- a/test/suite/test_chunkcache04.py
+++ b/test/suite/test_chunkcache04.py
@@ -58,7 +58,7 @@ class test_chunkcache4(wttest.WiredTigerTestCase):
             os.mkdir('bucket2')
 
         return 'tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),' \
-            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=2GB,pinned=' \
+            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=1GB,pinned=' \
                 + '("' + '{}'.format("\",\"".join(self.pinned_uris)) \
                 + '"),type={},storage_path=WiredTigerChunkCache]'.format(self.chunk_cache_type)
 

--- a/test/suite/test_chunkcache04.py
+++ b/test/suite/test_chunkcache04.py
@@ -58,7 +58,7 @@ class test_chunkcache4(wttest.WiredTigerTestCase):
             os.mkdir('bucket2')
 
         return 'tiered_storage=(auth_token=Secret,bucket=bucket2,bucket_prefix=pfx_,name=dir_store),' \
-            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=20GB,pinned=' \
+            'chunk_cache=[enabled=true,chunk_size=512KB,capacity=2GB,pinned=' \
                 + '("' + '{}'.format("\",\"".join(self.pinned_uris)) \
                 + '"),type={},storage_path=WiredTigerChunkCache]'.format(self.chunk_cache_type)
 


### PR DESCRIPTION
Reduce the capacity of chunkcache tests, when they are run in parallel with the original configs they use up all of the RAM available on our ARM macos test hosts and leave the system unresponsive.