### PR TITLE
WT-11827 Explicitly set locale for s_docs

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -4,6 +4,10 @@ t=__wt.$$
 t2=__wt.$$.2
 trap 'rm -f $t $t2' 0 1 2 3 13 15
 
+# Insulate against locale-specific sort order
+LC_ALL=C
+export LC_ALL
+
 # Skip this when building release packages: docs are built separately
 test -n "$WT_RELEASE_BUILD" && exit 0
 


### PR DESCRIPTION
Explicitly set locale in `dist/s_docs` so that we get consistent output when running the script across different testing/development environments. 