### PR TITLE
WT-11832 Add the strict option to the wt tool verify command

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -450,7 +450,7 @@ aa
 aaa
 abcdef
 abcdefghijklmnopqrstuvwxyz
-acstu
+acestu
 addl
 addr
 addrs

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -450,7 +450,7 @@ aa
 aaa
 abcdef
 abcdefghijklmnopqrstuvwxyz
-acestu
+acSstu
 addl
 addr
 addrs

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -498,7 +498,7 @@ process if one of the tables is damaged. Currently, the verify operation is not 
 tiered tables and the history store file.
 
 @subsection util_verify_synopsis Synopsis
-`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] verify [-acestu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | dump_pages ] [uri]`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] verify [-acSstu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | dump_pages ] [uri]`
 
 @subsection util_verify_options Options
 The following are command-specific options for the \c verify command:
@@ -514,8 +514,8 @@ Continue to the next page after encountering error during verification.
 This option allows you to specify values which you want to be displayed
 when verification is run. See the WT_SESSION::verify configuration options.
 
-\c -e
-Treat any verification problem as an error.
+\c -S
+This option enables strict mode and treats any verification problem as an error.
 
 \c -s
 This option allows you to verify against the stable timestamp, valid only after a

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -498,7 +498,7 @@ process if one of the tables is damaged. Currently, the verify operation is not 
 tiered tables and the history store file.
 
 @subsection util_verify_synopsis Synopsis
-`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] verify [-acstu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | dump_pages ] [uri]`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] verify [-acestu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | dump_pages ] [uri]`
 
 @subsection util_verify_options Options
 The following are command-specific options for the \c verify command:
@@ -513,6 +513,9 @@ Continue to the next page after encountering error during verification.
 \c -d [config]
 This option allows you to specify values which you want to be displayed
 when verification is run. See the WT_SESSION::verify configuration options.
+
+\c -e
+Treat any verification problem as an error.
 
 \c -s
 This option allows you to verify against the stable timestamp, valid only after a

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -172,7 +172,7 @@ aarch
 abc
 abstime
 ack'ed
-acestu
+acSstu
 addr
 ajn
 alloc

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -172,7 +172,7 @@ aarch
 abc
 abstime
 ack'ed
-acstu
+acestu
 addr
 ajn
 alloc

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -171,8 +171,8 @@ aR
 aarch
 abc
 abstime
-ack'ed
 acSstu
+ack'ed
 addr
 ajn
 alloc

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -24,7 +24,7 @@ usage(void)
       "-?", "show this message", NULL, NULL};
 
     util_usage(
-      "verify [-acstu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# "
+      "verify [-acestu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# "
       "| dump_pages] [uri]",
       "options:", options);
 
@@ -62,12 +62,12 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
     int ch;
     char *config, *dump_offsets, *key, *uri;
     bool abort_on_error, do_not_clear_txn_id, dump_address, dump_app_data, dump_blocks, dump_layout,
-      dump_pages, read_corrupt, stable_timestamp;
+      dump_pages, read_corrupt, stable_timestamp, strict;
 
     abort_on_error = do_not_clear_txn_id = dump_address = dump_app_data = dump_blocks =
-      dump_layout = dump_pages = read_corrupt = stable_timestamp = false;
+      dump_layout = dump_pages = read_corrupt = stable_timestamp = strict = false;
     config = dump_offsets = uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "acd:stu?")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "acd:estu?")) != EOF)
         switch (ch) {
         case 'a':
             abort_on_error = true;
@@ -94,6 +94,9 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
             else
                 return (usage());
             break;
+        case 'e':
+            strict = true;
+            break;
         case 's':
             stable_timestamp = true;
             break;
@@ -109,28 +112,29 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
         default:
             return (usage());
         }
+
     argc -= __wt_optind;
     argv += __wt_optind;
 
     if (do_not_clear_txn_id || dump_address || dump_app_data || dump_blocks || dump_layout ||
-      dump_offsets != NULL || dump_pages || read_corrupt || stable_timestamp) {
-        size = strlen("do_not_clear_txn_id,") + strlen("dump_address,") +
-          +strlen("dump_app_data,") + strlen("dump_blocks,") + strlen("dump_layout,") +
-          strlen("dump_pages,") + strlen("dump_offsets[],") +
-          (dump_offsets == NULL ? 0 : strlen(dump_offsets)) + strlen("history_store") +
-          +strlen("read_corrupt,") + strlen("stable_timestamp,") + 20;
+      dump_offsets != NULL || dump_pages || read_corrupt || stable_timestamp || strict) {
+        size = strlen("do_not_clear_txn_id,") + strlen("dump_address,") + strlen("dump_app_data,") +
+          strlen("dump_blocks,") + strlen("dump_layout,") + strlen("dump_pages,") +
+          strlen("dump_offsets[],") + (dump_offsets == NULL ? 0 : strlen(dump_offsets)) +
+          strlen("history_store") + strlen("read_corrupt,") + strlen("stable_timestamp,") +
+          strlen("strict") + 20;
         if ((config = util_malloc(size)) == NULL) {
             ret = util_err(session, errno, NULL);
             goto err;
         }
-        if ((ret = __wt_snprintf(config, size, "%s%s%s%s%s%s%s%s%s%s%s",
+        if ((ret = __wt_snprintf(config, size, "%s%s%s%s%s%s%s%s%s%s%s%s",
                do_not_clear_txn_id ? "do_not_clear_txn_id," : "",
                dump_address ? "dump_address," : "", dump_app_data ? "dump_app_data," : "",
                dump_blocks ? "dump_blocks," : "", dump_layout ? "dump_layout," : "",
                dump_offsets != NULL ? "dump_offsets=[" : "",
                dump_offsets != NULL ? dump_offsets : "", dump_offsets != NULL ? "]," : "",
                dump_pages ? "dump_pages," : "", read_corrupt ? "read_corrupt," : "",
-               stable_timestamp ? "stable_timestamp," : "")) != 0) {
+               stable_timestamp ? "stable_timestamp," : "", strict ? "strict," : "")) != 0) {
             (void)util_err(session, ret, NULL);
             goto err;
         }

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -67,7 +67,7 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
     abort_on_error = do_not_clear_txn_id = dump_address = dump_app_data = dump_blocks =
       dump_layout = dump_pages = read_corrupt = stable_timestamp = strict = false;
     config = dump_offsets = uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "acd:eStu?")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "acd:Sstu?")) != EOF)
         switch (ch) {
         case 'a':
             abort_on_error = true;

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -100,11 +100,11 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
         case 's':
             stable_timestamp = true;
             break;
-        case 'u':
-            dump_app_data = true;
-            break;
         case 't':
             do_not_clear_txn_id = true;
+            break;
+        case 'u':
+            dump_app_data = true;
             break;
         case '?':
             usage();

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -24,7 +24,7 @@ usage(void)
       "-?", "show this message", NULL, NULL};
 
     util_usage(
-      "verify [-acestu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# "
+      "verify [-acSstu] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# "
       "| dump_pages] [uri]",
       "options:", options);
 
@@ -67,7 +67,7 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
     abort_on_error = do_not_clear_txn_id = dump_address = dump_app_data = dump_blocks =
       dump_layout = dump_pages = read_corrupt = stable_timestamp = strict = false;
     config = dump_offsets = uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "acd:estu?")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "acd:eStu?")) != EOF)
         switch (ch) {
         case 'a':
             abort_on_error = true;
@@ -94,7 +94,7 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
             else
                 return (usage());
             break;
-        case 'e':
+        case 'S':
             strict = true;
             break;
         case 's':


### PR DESCRIPTION
The `strict` command can be enabled with the `-S` option when using the `verify` command:
```
./wt -h <db_path> -r verify -S
```