### PR TITLE
WT-11671 Compact short csuite tests into one task variant

### DIFF
--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -107,7 +107,7 @@ define_c_test(
     SOURCES timestamp_abort/main.c
     DIR_NAME timestamp_abort
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/timestamp_abort/smoke.sh
-    ARGUMENTS -s -b $<TARGET_FILE:test_timestamp_abort>
+    ARGUMENTS -s -b $<TARGET_FILE:test_timestamp_abort>_stress
     DEPENDS "WT_POSIX"
 )
 

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -223,6 +223,7 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2909_checkpoint_integrity/smoke.sh
     ARGUMENTS -b ${CMAKE_BINARY_DIR} $<TARGET_FILE:test_wt2909_checkpoint_integrity>
     DEPENDS "WT_POSIX"
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -375,6 +376,7 @@ define_c_test(
     DIR_NAME wt8246_compact_rts_data_correctness
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8246_compact_rts_data_correctness>/WT_HOME>
     DEPENDS "WT_POSIX"
+    LABEL "long_running"
 )
 
 define_c_test(

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -100,6 +100,7 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/timestamp_abort/smoke.sh
     ARGUMENTS -b $<TARGET_FILE:test_timestamp_abort>
     DEPENDS "WT_POSIX"
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -109,6 +110,7 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/timestamp_abort/smoke.sh
     ARGUMENTS -s -b $<TARGET_FILE:test_timestamp_abort>_stress
     DEPENDS "WT_POSIX"
+    LABEL "long_running"
 )
 
 define_c_test(

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -103,6 +103,15 @@ define_c_test(
 )
 
 define_c_test(
+    TARGET test_timestamp_abort_stress
+    SOURCES timestamp_abort/main.c
+    DIR_NAME timestamp_abort
+    EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/timestamp_abort/smoke.sh
+    ARGUMENTS -s -b $<TARGET_FILE:test_timestamp_abort>
+    DEPENDS "WT_POSIX"
+)
+
+define_c_test(
     TARGET test_timestamp_abort_lazyfs
     SOURCES timestamp_abort/main.c
     DIR_NAME timestamp_abort

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -11,6 +11,7 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt10461_skip_list_stress/smoke.sh
     ARGUMENTS $<TARGET_FILE:test_wt10461_skip_list_stress>
     DEPENDS "WT_POSIX"
+    LABEL "long_running"
 )
 
 define_c_test(

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2174,48 +2174,34 @@ tasks:
 
   # End of cppsuite test tasks.
   # Start of csuite test tasks
-
-  - name: csuite-incr-backup-test
+  - name: csuite-all-tests
     tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
       - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: incr_backup
+      command: shell.exec
+      params:
+        working_dir: "wiredtiger/cmake_build"
+        shell: bash
+        script: |
+          set -o errexit
+          set -o verbose
+          ${PREPARE_TEST_ENV}
 
-  - name: csuite-random-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: random
+          csuite_tests=`find $(pwd)/test/csuite -not -path "$(pwd)/test/csuite/CMakeFiles/*" -name "test_*"`
+          smoke_tests=('test_schema_abort', 'test_timestamp_abort')
+          special_tests=('wt2909_checkpoint_integrity', 'csuite-wt3120-filesys-test')
+          for test in $csuite_tests
+          do
+            test_binary=`echo $test | sed "s/.*\///"`
+            if [[ "$smoke_tests[*]" =~ "$test_binary" ]] || [[ "$special_tests[*]" =~ "$test_binary" ]]; then
+                continue
+            fi
+            echo "Running $test"
+            $test 2>&1
+          done
 
-  - name: csuite-random-abort-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite smoke test"
-        vars:
-          test_args: cmake_build/test/csuite/random_abort/test_random_abort
-          test_binary: random_abort
-
-  - name: csuite-random-directio-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite smoke test"
-        vars:
-          test_args: cmake_build/test/csuite/random_directio/test_random_directio
-          test_binary: random_directio
 
   - name: csuite-schema-abort-test
     tags: ["pull_request"]
@@ -2269,96 +2255,6 @@ tasks:
           test_args: -s -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
           test_binary: timestamp_abort
 
-  - name: csuite-scope-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: scope
-
-  - name: csuite-truncated-log-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: truncated_log
-
-  - name: csuite-wt1965-col-efficiency-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt1965_col_efficiency
-
-  - name: csuite-wt2403-lsm-workload-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2403_lsm_workload
-
-  - name: csuite-wt2447-join-main-table-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2447_join_main_table
-
-  - name: csuite-wt2695-checksum-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2695_checksum
-
-  - name: csuite-wt2592-join-schema-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2592_join_schema
-
-  - name: csuite-wt2719-reconfig-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2719_reconfig
-
-  - name: csuite-wt2999-join-extractor-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2999_join_extractor
-
   - name: csuite-wt3120-filesys-test
     tags: ["pull_request"]
     depends_on:
@@ -2369,166 +2265,6 @@ tasks:
         vars:
           test_args: -b $(pwd)
           test_name: wt3120_filesys
-
-  - name: csuite-wt3135-search-near-collator-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt3135_search_near_collator
-
-  - name: csuite-wt3184-dup-index-collator-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt3184_dup_index_collator
-
-  - name: csuite-wt3363-checkpoint-op-races-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt3363_checkpoint_op_races
-
-  - name: csuite-wt3874-pad-byte-collator-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt3874_pad_byte_collator
-
-  - name: csuite-wt4105-large-doc-small-upd-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt4105_large_doc_small_upd
-
-  - name: csuite-wt4117-checksum-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt4117_checksum
-
-  - name: csuite-wt4156-metadata-salvage-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt4156_metadata_salvage
-
-  - name: csuite-wt4699-json-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt4699_json
-
-  - name: csuite-wt4803-history-store-abort-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt4803_history_store_abort
-
-  - name: csuite-wt4891-meta-ckptlist-get-alloc-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt4891_meta_ckptlist_get_alloc
-
-  - name: csuite-wt6185-modify-ts-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt6185_modify_ts
-
-  - name: csuite-rwlock-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: rwlock
-
-  - name: csuite-wt2246-col-append-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2246_col_append
-
-  - name: csuite-wt2323-join-visibility-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2323_join_visibility
-
-  - name: csuite-wt2535-insert-race-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2535_insert_race
-
-  - name: csuite-wt2834-join-bloom-fix-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt2834_join_bloom_fix
 
   - name: csuite-wt2909-checkpoint-integrity-test
     tags: ["pull_request"]
@@ -2541,85 +2277,6 @@ tasks:
           test_args: -b $(pwd)
           test_name: wt2909_checkpoint_integrity
 
-  - name: csuite-wt3338-partial-update-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt3338_partial_update
-
-  - name: csuite-wt4333-handle-locks-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt4333_handle_locks
-
-  - name: csuite-wt6616-checkpoint-oldest-ts-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt6616_checkpoint_oldest_ts
-
-  - name: csuite-wt7989-compact-checkpoint-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt7989_compact_checkpoint
-
-  - name: csuite-wt8057-compact-stress-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt8057_compact_stress
-
-  - name: csuite-wt8246-compact-rts-data-correctness-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt8246_compact_rts_data_correctness
-
-  - name: csuite-wt8659-reconstruct-database-from-logs-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt8659_reconstruct_database_from_logs
-
-  - name: csuite-wt8963-insert-stress-test
-    tags: ["stress-test-1"]
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "csuite test"
-        vars:
-          test_name: wt8963_insert_stress
-
   - name: csuite-wt8963-insert-stress-test-nonstandalone
     tags: ["stress-test-1-nonstandalone"]
     commands:
@@ -2631,25 +2288,6 @@ tasks:
         vars:
           test_name: wt8963_insert_stress
 
-  - name: csuite-wt9937-parse-opts-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt9937_parse_opts
-
-  - name: csuite-wt10461-skip-list-stress-test
-    tags: ["stress-test-1"]
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "csuite test"
-        vars:
-          test_name: wt10461_skip_list_stress
-
   - name: csuite-wt10461-skip-list-stress-test-nonstandalone
     tags: ["stress-test-1"]
     commands:
@@ -2660,27 +2298,6 @@ tasks:
       - func: "csuite test"
         vars:
           test_name: wt10461_skip_list_stress
-
-  - name: csuite-wt10897-compact-quick-interrupt-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt10897_compact_quick_interrupt
-
-  - name: csuite-wt11440-config-check-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_name: wt11440_config_check
-
   # End of csuite test tasks
 
   # Start of Python unit test tasks

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2202,7 +2202,6 @@ tasks:
             $test 2>&1
           done
 
-
   - name: csuite-schema-abort-test
     tags: ["pull_request"]
     depends_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2194,17 +2194,6 @@ tasks:
       - func: "compile wiredtiger"
       - func: "csuite tests all"
 
-  - name: csuite-timestamp-abort-stress-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite smoke test"
-        vars:
-          test_args: -s -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
-          test_binary: timestamp_abort
-
   - name: csuite-timestamp-abort-test-s3
     commands:
       - func: "get project"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -627,6 +627,19 @@ functions:
         ${PREPARE_TEST_ENV}
         $(pwd)/test/csuite/${test_name}/test_${test_name} ${test_args|} 2>&1
 
+  "csuite tests all":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/cmake_build"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        ${PREPARE_TEST_ENV}
+        . test/evergreen/find_cmake.sh
+        cd cmake_build
+        ${test_env_vars|} $CTEST -L csuite --output-on-failure 2>&1
+
   "unit test":
     command: shell.exec
     params:
@@ -2174,38 +2187,13 @@ tasks:
 
   # End of cppsuite test tasks.
   # Start of csuite test tasks
-  - name: csuite-all-tests
+  - name: csuite-tests-all
     tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
       - func: "fetch artifacts"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-
-            csuite_tests=`find $(pwd)/test/csuite -not -path "$(pwd)/test/csuite/CMakeFiles/*" -name "test_*"`
-            smoke_tests=('test_schema_abort', 'test_timestamp_abort')
-            special_tests=('wt2909_checkpoint_integrity', 'csuite-wt3120-filesys-test')
-            for test in $csuite_tests
-            do
-              test_binary=`echo $test | sed "s/.*\///"`
-              if [[ "$smoke_tests[*]" =~ "$test_binary" ]]; then
-                  continue
-              fi
-
-              echo "Running $test"
-              if [[ "$special_tests[*]" =~ "$test_binary" ]]; then
-                $test -b $(pwd) 2>&1
-              else
-                $test 2>&1 
-              fi
-            done
+      - func: "csuite tests all"
 
   - name: csuite-smoke-tests
     tags: ["pull_request"]
@@ -2213,14 +2201,6 @@ tasks:
       - name: compile
     commands:
       - func: "fetch artifacts"
-      - func: "csuite smoke test"
-        vars:
-          test_args: cmake_build/test/csuite/schema_abort/test_schema_abort
-          test_binary: schema_abort
-      - func: "csuite smoke test"
-        vars:
-          test_args: -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
-          test_binary: timestamp_abort
       - func: "csuite smoke test"
         vars:
           test_args: -s -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2180,27 +2180,27 @@ tasks:
       - name: compile
     commands:
       - func: "fetch artifacts"
-      command: shell.exec
-      params:
-        working_dir: "wiredtiger/cmake_build"
-        shell: bash
-        script: |
-          set -o errexit
-          set -o verbose
-          ${PREPARE_TEST_ENV}
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
 
-          csuite_tests=`find $(pwd)/test/csuite -not -path "$(pwd)/test/csuite/CMakeFiles/*" -name "test_*"`
-          smoke_tests=('test_schema_abort', 'test_timestamp_abort')
-          special_tests=('wt2909_checkpoint_integrity', 'csuite-wt3120-filesys-test')
-          for test in $csuite_tests
-          do
-            test_binary=`echo $test | sed "s/.*\///"`
-            if [[ "$smoke_tests[*]" =~ "$test_binary" ]] || [[ "$special_tests[*]" =~ "$test_binary" ]]; then
-                continue
-            fi
-            echo "Running $test"
-            $test 2>&1
-          done
+            csuite_tests=`find $(pwd)/test/csuite -not -path "$(pwd)/test/csuite/CMakeFiles/*" -name "test_*"`
+            smoke_tests=('test_schema_abort', 'test_timestamp_abort')
+            special_tests=('wt2909_checkpoint_integrity', 'csuite-wt3120-filesys-test')
+            for test in $csuite_tests
+            do
+              test_binary=`echo $test | sed "s/.*\///"`
+              if [[ "$smoke_tests[*]" =~ "$test_binary" ]] || [[ "$special_tests[*]" =~ "$test_binary" ]]; then
+                  continue
+              fi
+              echo "Running $test"
+              $test 2>&1
+            done
 
   - name: csuite-schema-abort-test
     tags: ["pull_request"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -638,7 +638,7 @@ functions:
         ${PREPARE_TEST_ENV}
         . test/evergreen/find_cmake.sh
         cd cmake_build
-        $CTEST -L csuite -j ${num_jobs} --output-on-failure 2>&1
+        $CTEST -L csuite ${check_args} -j ${num_jobs} --output-on-failure 2>&1
 
   "unit test":
     command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2194,7 +2194,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "csuite tests all"
 
-  - name: csuite-smoke-tests
+  - name: csuite-timestamp-abort-stress-test
     tags: ["pull_request"]
     depends_on:
       - name: compile

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2259,7 +2259,6 @@ tasks:
           test_args: -s -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
           test_binary: timestamp_abort
 
-
   - name: csuite-wt8963-insert-stress-test-nonstandalone
     tags: ["stress-test-1-nonstandalone"]
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2207,7 +2207,7 @@ tasks:
               fi
             done
 
-  - name: csuite-schema-abort-test
+  - name: csuite-smoke-tests
     tags: ["pull_request"]
     depends_on:
       - name: compile
@@ -2217,16 +2217,13 @@ tasks:
         vars:
           test_args: cmake_build/test/csuite/schema_abort/test_schema_abort
           test_binary: schema_abort
-
-  - name: csuite-timestamp-abort-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
       - func: "csuite smoke test"
         vars:
           test_args: -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
+          test_binary: timestamp_abort
+      - func: "csuite smoke test"
+        vars:
+          test_args: -s -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
           test_binary: timestamp_abort
 
   - name: csuite-timestamp-abort-test-s3
@@ -2247,17 +2244,6 @@ tasks:
             set -o verbose
 
             ./test_timestamp_abort -PT -Po s3_store
-
-  - name: csuite-timestamp-abort-stress-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite smoke test"
-        vars:
-          test_args: -s -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
-          test_binary: timestamp_abort
 
   - name: csuite-wt8963-insert-stress-test-nonstandalone
     tags: ["stress-test-1-nonstandalone"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -630,7 +630,7 @@ functions:
   "csuite tests all":
     command: shell.exec
     params:
-      working_dir: "wiredtiger/cmake_build"
+      working_dir: "wiredtiger"
       shell: bash
       script: |
         set -o errexit
@@ -638,7 +638,7 @@ functions:
         ${PREPARE_TEST_ENV}
         . test/evergreen/find_cmake.sh
         cd cmake_build
-        ${test_env_vars|} $CTEST -L csuite --output-on-failure 2>&1
+        $CTEST -L csuite -j ${num_jobs} --output-on-failure 2>&1
 
   "unit test":
     command: shell.exec
@@ -2189,10 +2189,9 @@ tasks:
   # Start of csuite test tasks
   - name: csuite-tests-all
     tags: ["pull_request"]
-    depends_on:
-      - name: compile
     commands:
-      - func: "fetch artifacts"
+      - func: "get project"
+      - func: "compile wiredtiger"
       - func: "csuite tests all"
 
   - name: csuite-smoke-tests

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2195,11 +2195,16 @@ tasks:
             for test in $csuite_tests
             do
               test_binary=`echo $test | sed "s/.*\///"`
-              if [[ "$smoke_tests[*]" =~ "$test_binary" ]] || [[ "$special_tests[*]" =~ "$test_binary" ]]; then
+              if [[ "$smoke_tests[*]" =~ "$test_binary" ]]; then
                   continue
               fi
+
               echo "Running $test"
-              $test 2>&1
+              if [[ "$special_tests[*]" =~ "$test_binary" ]]; then
+                $test -b $(pwd) 2>&1
+              else
+                $test 2>&1 
+              fi
             done
 
   - name: csuite-schema-abort-test
@@ -2254,27 +2259,6 @@ tasks:
           test_args: -s -b cmake_build/test/csuite/timestamp_abort/test_timestamp_abort
           test_binary: timestamp_abort
 
-  - name: csuite-wt3120-filesys-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_args: -b $(pwd)
-          test_name: wt3120_filesys
-
-  - name: csuite-wt2909-checkpoint-integrity-test
-    tags: ["pull_request"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "csuite test"
-        vars:
-          test_args: -b $(pwd)
-          test_name: wt2909_checkpoint_integrity
 
   - name: csuite-wt8963-insert-stress-test-nonstandalone
     tags: ["stress-test-1-nonstandalone"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -485,6 +485,7 @@ functions:
         . test/evergreen/find_cmake.sh
         cd cmake_build/${directory}
         $CTEST ${extra_args} --output-on-failure 2>&1
+
   "make check all":
     command: shell.exec
     params:
@@ -497,7 +498,7 @@ functions:
         . test/evergreen/find_cmake.sh
         cd cmake_build
         echo "Using number of parallel processes '-j ${num_jobs}' for 'make check all'"
-        $CTEST -L check -j ${num_jobs} --output-on-failure ${check_args|} 2>&1
+        $CTEST -L check -j ${num_jobs} --output-on-failure ${extra_args|} 2>&1
 
   # The following cppsuite tasks define a greater overall task.
   "cppsuite test run": &cppsuite_test_run
@@ -626,19 +627,6 @@ functions:
         set -o verbose
         ${PREPARE_TEST_ENV}
         $(pwd)/test/csuite/${test_name}/test_${test_name} ${test_args|} 2>&1
-
-  "csuite tests all":
-    command: shell.exec
-    params:
-      working_dir: "wiredtiger"
-      shell: bash
-      script: |
-        set -o errexit
-        set -o verbose
-        ${PREPARE_TEST_ENV}
-        . test/evergreen/find_cmake.sh
-        cd cmake_build
-        $CTEST -L csuite ${check_args} -j ${num_jobs} --output-on-failure 2>&1
 
   "unit test":
     command: shell.exec
@@ -2187,12 +2175,15 @@ tasks:
 
   # End of cppsuite test tasks.
   # Start of csuite test tasks
-  - name: csuite-tests-all
+  - name: csuite-tests-pull-request
     tags: ["pull_request"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
-      - func: "csuite tests all"
+      - func: "make check directory"
+        vars:
+          directory: test/csuite
+          extra_args: -LE "long_running"
 
   - name: csuite-timestamp-abort-test-s3
     commands:
@@ -5929,7 +5920,6 @@ buildvariants:
       export LSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/asan_leaks.supp"
       export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libeatmydata.so:$LD_PRELOAD"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
-    check_args: -LE "long_running"
   tasks:
     - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest"
     - name: examples-c-test
@@ -5969,7 +5959,7 @@ buildvariants:
     # We don't run C++ memory sanitized testing as it creates false positives. MSAN also causes
     # some csuite tests to take an extended amount of time. These are excluded from the
     # make-check-test task and are covered by the csuite-long-running task.
-    check_args: -LE "cppsuite|long_running"
+    extra_args: -LE "cppsuite|long_running"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: clang-analyzer

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5929,6 +5929,7 @@ buildvariants:
       export LSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/asan_leaks.supp"
       export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libeatmydata.so:$LD_PRELOAD"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+    check_args: -LE "long_running"
   tasks:
     - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest"
     - name: examples-c-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2183,7 +2183,7 @@ tasks:
       - func: "make check directory"
         vars:
           directory: test/csuite
-          extra_args: -LE "long_running"
+          extra_args: -LE "long_running" -j ${num_jobs}
 
   - name: csuite-timestamp-abort-test-s3
     commands:

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -90,8 +90,11 @@ def find_tests_missing_evg_cfg(test_type, dirs, evg_cfg_file):
     debug('\n')
     missing_tests = {}
     for d in dirs:
-        # Figure out the Evergreen task name from the directory name
+        # Skip csuite tests as we run all of them using ctest.
+        if test_type == 'csuite':
+            continue
 
+        # Figure out the Evergreen task name from the directory name
         if test_type == 'make_check':
             # The Evergreen task name for each 'make check' test is worked out from directory name
             # E.g. for 'make check' directory 'test/cursor_order', the corresponding Evergreen

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -103,8 +103,7 @@ def find_tests_missing_evg_cfg(test_type, dirs, evg_cfg_file):
         else:
             sys.exit("Unsupported test_type '%s'" % test_type)
 
-        # Check if the Evergreen task name exists in current Evergreen configuration or in the
-        # csuite CMakeLists file.
+        # Check if the Evergreen task name exists in current Evergreen configuration
         if evg_task_name in str(evg_cfg):
             # Match found
             continue

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -87,9 +87,6 @@ def find_tests_missing_evg_cfg(test_type, dirs, evg_cfg_file):
     with open(evg_cfg_file, 'r') as f:
         evg_cfg = f.readlines()
 
-    with open(CSUITE_TEST_DIR + "/CMakeLists.txt", 'r') as f:
-        cmake_cfg = f.readlines()
-
     debug('\n')
     missing_tests = {}
     for d in dirs:
@@ -103,28 +100,19 @@ def find_tests_missing_evg_cfg(test_type, dirs, evg_cfg_file):
             dir_wo_test_prefix = d[len("test/"):] if d.startswith("test/") else d
             evg_task_name = dir_wo_test_prefix.replace('/', '-').replace('_', '-') + '-test'
             debug("Evergreen task name for make check directory '%s' is: %s" % (d, evg_task_name))
-
-        elif test_type == 'csuite':
-            # The Evergreen task name for each 'csuite' test is worked out from sub directory name
-            # E.g. for 'test/csuite' sub directory 'wt3184_dup_index_collator', the corresponding
-            # Evergreen task name will be 'csuite-wt3184-dup-index-collator-test'.
-
-            evg_task_name = 'csuite-' + d.replace('_', '-') + '-test'
-            debug("Evergreen task name for csuite sub directory '%s' is: %s" % (d, evg_task_name))
-
         else:
             sys.exit("Unsupported test_type '%s'" % test_type)
 
         # Check if the Evergreen task name exists in current Evergreen configuration or in the
         # csuite CMakeLists file.
-        if evg_task_name in str(evg_cfg) or d in str(cmake_cfg):
+        if evg_task_name in str(evg_cfg):
             # Match found
             continue
         else:
             # Missing task/test found
             missing_tests.update({evg_task_name: d})
-            print("Task '%s' (for directory '%s') is missing in %s or CMakeLists.txt file!" %
-                  (evg_task_name, d, evg_cfg_file))
+            print("Task '%s' (for directory '%s') is missing in %s!" %
+                (evg_task_name, d, evg_cfg_file))
 
     return missing_tests
 

--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -87,6 +87,9 @@ def find_tests_missing_evg_cfg(test_type, dirs, evg_cfg_file):
     with open(evg_cfg_file, 'r') as f:
         evg_cfg = f.readlines()
 
+    with open(CSUITE_TEST_DIR + "/CMakeLists.txt", 'r') as f:
+        cmake_cfg = f.readlines()
+
     debug('\n')
     missing_tests = {}
     for d in dirs:
@@ -112,14 +115,15 @@ def find_tests_missing_evg_cfg(test_type, dirs, evg_cfg_file):
         else:
             sys.exit("Unsupported test_type '%s'" % test_type)
 
-        # Check if the Evergreen task name exists in current Evergreen configuration
-        if evg_task_name in str(evg_cfg):
+        # Check if the Evergreen task name exists in current Evergreen configuration or in the
+        # csuite CMakeLists file.
+        if evg_task_name in str(evg_cfg) or d in str(cmake_cfg):
             # Match found
             continue
         else:
             # Missing task/test found
             missing_tests.update({evg_task_name: d})
-            print("Task '%s' (for directory '%s') is missing in %s!" %
+            print("Task '%s' (for directory '%s') is missing in %s or CMakeLists.txt file!" %
                   (evg_task_name, d, evg_cfg_file))
 
     return missing_tests


### PR DESCRIPTION
The changes done in this pull request aims to clean up the csuite tasks and run them in one task under parallel jobs. I measured the time for the csuite task in the normal and ASAN variant. In the normal variant, the task roughly takes ~30 minutes and for ASAN it takes 90 minutes, to remedy this problem I have made the ASAN variant not running the long running tests and i have updated the long running labels as well, with both the additions i have gotten it down to 24 minutes. 30 minutes is a good target and acceptable for pull request testing.