### PR TITLE
WT-11510 Split hazard pointer array fields into their own structure

### DIFF
--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -343,7 +343,8 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
      * reading without locking.
      */
     if (conn->evict_server_running)
-        WT_STAT_SET(session, stats, cache_eviction_walks_active, cache->walk_session->nhazard);
+        WT_STAT_SET(
+          session, stats, cache_eviction_walks_active, cache->walk_session->hazards.active);
 
     WT_STAT_SET(
       session, stats, rec_maximum_hs_wrapup_milliseconds, conn->rec_maximum_hs_wrapup_milliseconds);

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -344,7 +344,7 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
      */
     if (conn->evict_server_running)
         WT_STAT_SET(
-          session, stats, cache_eviction_walks_active, cache->walk_session->hazards.active);
+          session, stats, cache_eviction_walks_active, cache->walk_session->hazards.num_active);
 
     WT_STAT_SET(
       session, stats, rec_maximum_hs_wrapup_milliseconds, conn->rec_maximum_hs_wrapup_milliseconds);

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -181,7 +181,7 @@ __wt_connection_close(WT_CONNECTION_IMPL *conn)
                 __wt_free(session, s->cursor_cache);
                 __wt_free(session, s->dhhash);
                 __wt_stash_discard_all(session, s);
-                __wt_free(session, s->hazard);
+                __wt_free(session, s->hazards.arr);
             }
 
     /* Destroy the file-system configuration. */

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1527,7 +1527,7 @@ retry:
          * Even though that ceiling has been removed, we need to test eviction with huge numbers of
          * active trees before allowing larger numbers of hazard pointers in the walk session.
          */
-        if (btree->evict_ref == NULL && session->nhazard > WT_EVICT_MAX_TREES)
+        if (btree->evict_ref == NULL && session->hazards.active > WT_EVICT_MAX_TREES)
             continue;
 
         /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1527,7 +1527,7 @@ retry:
          * Even though that ceiling has been removed, we need to test eviction with huge numbers of
          * active trees before allowing larger numbers of hazard pointers in the walk session.
          */
-        if (btree->evict_ref == NULL && session->hazards.active > WT_EVICT_MAX_TREES)
+        if (btree->evict_ref == NULL && session->hazards.num_active > WT_EVICT_MAX_TREES)
             continue;
 
         /*

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -468,7 +468,7 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
      */
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
-    busy = busy || txn_shared->id != WT_TXN_NONE || session->nhazard > 0 ||
+    busy = busy || txn_shared->id != WT_TXN_NONE || session->hazards.active > 0 ||
       (txn_shared->pinned_id != WT_TXN_NONE && txn_global->current != txn_global->oldest_id);
 
     /*

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -468,7 +468,7 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
      */
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
-    busy = busy || txn_shared->id != WT_TXN_NONE || session->hazards.active > 0 ||
+    busy = busy || txn_shared->id != WT_TXN_NONE || session->hazards.num_active > 0 ||
       (txn_shared->pinned_id != WT_TXN_NONE && txn_global->current != txn_global->oldest_id);
 
     /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -31,6 +31,23 @@ struct __wt_hazard {
 };
 
 /*
+ * WT_HAZARD_ARRAY --
+ *   An array of all hazard pointers held by the session.
+ *   New hazard pointers are added on a first-fit basis, and on removal their entry
+ *   in the array is set to null. As such this array may contain holes.
+ */
+struct __wt_hazard_array {
+/* The hazard pointer array grows as necessary, initialize with 250 slots. */
+#define WT_SESSION_INITIAL_HAZARD_SLOTS 250
+
+    wt_shared WT_HAZARD *arr;  /* The hazard pointer array */
+    wt_shared uint32_t inuse;  /* Number of array slots potentially in-use. We only need to iterate
+                                  this many slots to find all active pointers */
+    wt_shared uint32_t active; /* Number of array slots containing an active hazard pointer */
+    uint32_t size;             /* Allocated size of the array */
+};
+
+/*
  * WT_PREFETCH --
  *	Pre-fetch structure containing useful information for pre-fetch.
  */
@@ -335,19 +352,11 @@ struct __wt_session_impl {
  * Hazard information persists past session close because it's accessed by threads of control other
  * than the thread owning the session.
  *
- * Use the non-NULL state of the hazard field to know if the session has previously been
+ * Use the non-NULL state of the hazard array to know if the session has previously been
  * initialized.
  */
-#define WT_SESSION_FIRST_USE(s) ((s)->hazard == NULL)
-
-/*
- * The hazard pointer array grows as necessary, initialize with 250 slots.
- */
-#define WT_SESSION_INITIAL_HAZARD_SLOTS 250
-    wt_shared uint32_t hazard_size;  /* Allocated size of the Hazard pointer array */
-    wt_shared uint32_t hazard_inuse; /* Number of hazard pointer array slots potentially in-use */
-    wt_shared uint32_t nhazard;      /* Number of hazard pointer array slots actively in-use */
-    wt_shared WT_HAZARD *hazard;     /* Hazard pointer array */
+#define WT_SESSION_FIRST_USE(s) ((s)->hazards.arr == NULL)
+    WT_HAZARD_ARRAY hazards;
 
     /*
      * Operation tracking.

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -40,11 +40,11 @@ struct __wt_hazard_array {
 /* The hazard pointer array grows as necessary, initialize with 250 slots. */
 #define WT_SESSION_INITIAL_HAZARD_SLOTS 250
 
-    wt_shared WT_HAZARD *arr;  /* The hazard pointer array */
-    wt_shared uint32_t inuse;  /* Number of array slots potentially in-use. We only need to iterate
-                                  this many slots to find all active pointers */
-    wt_shared uint32_t active; /* Number of array slots containing an active hazard pointer */
-    uint32_t size;             /* Allocated size of the array */
+    wt_shared WT_HAZARD *arr; /* The hazard pointer array */
+    wt_shared uint32_t inuse; /* Number of array slots potentially in-use. We only need to iterate
+                                 this many slots to find all active pointers */
+    wt_shared uint32_t num_active; /* Number of array slots containing an active hazard pointer */
+    uint32_t size;                 /* Allocated size of the array */
 };
 
 /*

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -235,6 +235,8 @@ struct __wt_fstream;
 typedef struct __wt_fstream WT_FSTREAM;
 struct __wt_hazard;
 typedef struct __wt_hazard WT_HAZARD;
+struct __wt_hazard_array;
+typedef struct __wt_hazard_array WT_HAZARD_ARRAY;
 struct __wt_ikey;
 typedef struct __wt_ikey WT_IKEY;
 struct __wt_import_entry;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -235,8 +235,8 @@ __session_clear(WT_SESSION_IMPL *session)
      */
     memset(session, 0, WT_SESSION_CLEAR_SIZE);
 
-    session->hazard_inuse = 0;
-    session->nhazard = 0;
+    session->hazards.inuse = 0;
+    session->hazards.active = 0;
 }
 
 /*
@@ -2579,10 +2579,11 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
      * access to it isn't serialized. Allocate the first time we open this session.
      */
     if (WT_SESSION_FIRST_USE(session_ret)) {
-        WT_ERR(__wt_calloc_def(session, WT_SESSION_INITIAL_HAZARD_SLOTS, &session_ret->hazard));
-        session_ret->hazard_size = WT_SESSION_INITIAL_HAZARD_SLOTS;
-        session_ret->hazard_inuse = 0;
-        session_ret->nhazard = 0;
+        WT_ERR(
+          __wt_calloc_def(session, WT_SESSION_INITIAL_HAZARD_SLOTS, &session_ret->hazards.arr));
+        session_ret->hazards.size = WT_SESSION_INITIAL_HAZARD_SLOTS;
+        session_ret->hazards.inuse = 0;
+        session_ret->hazards.active = 0;
     }
 
     /*

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -236,7 +236,7 @@ __session_clear(WT_SESSION_IMPL *session)
     memset(session, 0, WT_SESSION_CLEAR_SIZE);
 
     session->hazards.inuse = 0;
-    session->hazards.active = 0;
+    session->hazards.num_active = 0;
 }
 
 /*
@@ -2583,7 +2583,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
           __wt_calloc_def(session, WT_SESSION_INITIAL_HAZARD_SLOTS, &session_ret->hazards.arr));
         session_ret->hazards.size = WT_SESSION_INITIAL_HAZARD_SLOTS;
         session_ret->hazards.inuse = 0;
-        session_ret->hazards.active = 0;
+        session_ret->hazards.num_active = 0;
     }
 
     /*

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -27,17 +27,17 @@ hazard_grow(WT_SESSION_IMPL *session)
     /*
      * Allocate a new, larger hazard pointer array and copy the contents of the original into place.
      */
-    size = session->hazard_size;
+    size = session->hazards.size;
     WT_RET(__wt_calloc_def(session, size * 2, &new_hazard));
-    memcpy(new_hazard, session->hazard, size * sizeof(WT_HAZARD));
+    memcpy(new_hazard, session->hazards.arr, size * sizeof(WT_HAZARD));
 
     /*
      * Swap the new hazard pointer array into place after initialization is complete (initialization
      * must complete before eviction can see the new hazard pointer array), then schedule the
      * original to be freed.
      */
-    old_hazard = session->hazard;
-    WT_PUBLISH(session->hazard, new_hazard);
+    old_hazard = session->hazards.arr;
+    WT_PUBLISH(session->hazards.arr, new_hazard);
 
     /*
      * Our larger hazard array means we can use larger indices for reading/writing hazard pointers.
@@ -47,7 +47,7 @@ hazard_grow(WT_SESSION_IMPL *session)
      */
     WT_WRITE_BARRIER();
 
-    session->hazard_size = (uint32_t)(size * 2);
+    session->hazards.size = (uint32_t)(size * 2);
 
     /*
      * Threads using the hazard pointer array from now on will use the new one. Increment the hazard
@@ -92,31 +92,31 @@ __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
     }
 
     /* If we have filled the current hazard pointer array, grow it. */
-    if (session->nhazard >= session->hazard_size) {
+    if (session->hazards.active >= session->hazards.size) {
         WT_ASSERT(session,
-          session->nhazard == session->hazard_size &&
-            session->hazard_inuse == session->hazard_size);
+          session->hazards.active == session->hazards.size &&
+            session->hazards.inuse == session->hazards.size);
         WT_RET(hazard_grow(session));
     }
 
     /*
      * If there are no available hazard pointer slots, make another one visible.
      */
-    if (session->nhazard >= session->hazard_inuse) {
+    if (session->hazards.active >= session->hazards.inuse) {
         WT_ASSERT(session,
-          session->nhazard == session->hazard_inuse &&
-            session->hazard_inuse < session->hazard_size);
+          session->hazards.active == session->hazards.inuse &&
+            session->hazards.inuse < session->hazards.size);
         /*
          * If we've grown the hazard array the inuse counter can be incremented beyond the size of
          * the old hazard array. We need to ensure the new hazard array pointer is visible before
          * this increment of the inuse counter and do so with a write barrier in the hazard grow
          * logic.
          */
-        hp = &session->hazard[session->hazard_inuse++];
+        hp = &session->hazards.arr[session->hazards.inuse++];
     } else {
         WT_ASSERT(session,
-          session->nhazard < session->hazard_inuse &&
-            session->hazard_inuse <= session->hazard_size);
+          session->hazards.active < session->hazards.inuse &&
+            session->hazards.inuse <= session->hazards.size);
 
         /*
          * There must be an empty slot in the array, find it. Skip most of the active slots by
@@ -124,9 +124,9 @@ __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
          * is expensive. If we reach the end of the array, continue the search from the beginning of
          * the array.
          */
-        for (hp = session->hazard + session->nhazard;; ++hp) {
-            if (hp >= session->hazard + session->hazard_inuse)
-                hp = session->hazard;
+        for (hp = session->hazards.arr + session->hazards.active;; ++hp) {
+            if (hp >= session->hazards.arr + session->hazards.inuse)
+                hp = session->hazards.arr;
             if (hp->ref == NULL)
                 break;
         }
@@ -158,7 +158,7 @@ __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
      */
     current_state = ref->state;
     if (current_state == WT_REF_MEM) {
-        ++session->nhazard;
+        ++session->hazards.active;
 
         /*
          * Callers require a barrier here so operations holding the hazard pointer see consistent
@@ -198,7 +198,7 @@ __wt_hazard_clear(WT_SESSION_IMPL *session, WT_REF *ref)
     /*
      * Clear the caller's hazard pointer. The common pattern is LIFO, so do a reverse search.
      */
-    for (hp = session->hazard + session->hazard_inuse - 1; hp >= session->hazard; --hp)
+    for (hp = session->hazards.arr + session->hazards.inuse - 1; hp >= session->hazards.arr; --hp)
         if (hp->ref == ref) {
             /*
              * We don't publish the hazard pointer clear in the general case. It's not required for
@@ -214,8 +214,8 @@ __wt_hazard_clear(WT_SESSION_IMPL *session, WT_REF *ref)
              * A write-barrier() is necessary before the change to the in-use value, the number of
              * active references can never be less than the number of in-use slots.
              */
-            if (--session->nhazard == 0)
-                WT_PUBLISH(session->hazard_inuse, 0);
+            if (--session->hazards.active == 0)
+                WT_PUBLISH(session->hazards.inuse, 0);
             return (0);
         }
 
@@ -241,12 +241,13 @@ __wt_hazard_close(WT_SESSION_IMPL *session)
      * Check for a set hazard pointer and complain if we find one. We could just check the session's
      * hazard pointer count, but this is a useful diagnostic.
      */
-    for (found = false, hp = session->hazard; hp < session->hazard + session->hazard_inuse; ++hp)
+    for (found = false, hp = session->hazards.arr;
+         hp < session->hazards.arr + session->hazards.inuse; ++hp)
         if (hp->ref != NULL) {
             found = true;
             break;
         }
-    if (session->nhazard == 0 && !found)
+    if (session->hazards.active == 0 && !found)
         return;
 
     __wt_errx(session, "session %p: close hazard pointer table: table not empty", (void *)session);
@@ -264,13 +265,13 @@ __wt_hazard_close(WT_SESSION_IMPL *session)
      * We don't panic: this shouldn't be a correctness issue (at least, I can't think of a reason it
      * would be).
      */
-    for (hp = session->hazard; hp < session->hazard + session->hazard_inuse; ++hp)
+    for (hp = session->hazards.arr; hp < session->hazards.arr + session->hazards.inuse; ++hp)
         if (hp->ref != NULL) {
             hp->ref = NULL;
-            --session->nhazard;
+            --session->hazards.active;
         }
 
-    if (session->nhazard != 0)
+    if (session->hazards.active != 0)
         __wt_errx(session, "session %p: close hazard pointer table: count didn't match entries",
           (void *)session);
 }
@@ -291,8 +292,8 @@ hazard_get_reference(WT_SESSION_IMPL *session, WT_HAZARD **hazardp, uint32_t *ha
      * Use a barrier instead of marking the fields volatile because we don't want to slow down the
      * rest of the hazard pointer functions that don't need special treatment.
      */
-    WT_ORDERED_READ(*hazard_inusep, session->hazard_inuse);
-    WT_ORDERED_READ(*hazardp, session->hazard);
+    WT_ORDERED_READ(*hazard_inusep, session->hazards.inuse);
+    WT_ORDERED_READ(*hazardp, session->hazards.arr);
 }
 
 /*
@@ -424,7 +425,7 @@ __hazard_dump(WT_SESSION_IMPL *session)
 {
     WT_HAZARD *hp;
 
-    for (hp = session->hazard; hp < session->hazard + session->hazard_inuse; ++hp)
+    for (hp = session->hazards.arr; hp < session->hazards.arr + session->hazards.inuse; ++hp)
         if (hp->ref != NULL)
             __wt_errx(session, "session %p: hazard pointer %p: %s, line %d", (void *)session,
               (void *)hp->ref, hp->func, hp->line);

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -254,6 +254,7 @@ __wt_hazard_close(WT_SESSION_IMPL *session)
 
 #ifdef HAVE_DIAGNOSTIC
     __hazard_dump(session);
+    __wt_abort(session);
 #endif
 
     /*

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -254,7 +254,7 @@ __wt_hazard_close(WT_SESSION_IMPL *session)
 
 #ifdef HAVE_DIAGNOSTIC
     __hazard_dump(session);
-    __wt_abort(session);
+    WT_ASSERT(session, session->hazards.active == 0 && !found);
 #endif
 
     /*


### PR DESCRIPTION
Code style improvements identified during the hazard pointer algo review. I've named this based on the major change, but there are three modifications in total:

1. Take the four hazard pointer fields in session (`hazard_size`, `hazard_inuse`, `nhazard`, `hazard`) and move them into a new `WT_HAZARD_ARRAY` struct. They've also been renamed as follows:
```
hazard_size  -> hazards.size
hazard_inuse -> hazards.inuse
nhazard      -> hazards.active
hazard       -> hazards.arr
```

2. Add an assert in diagnostic mode if a session is closed while still holding hazard pointers. Previously we'd print an error traces and free the pointers. Behaviour is unchanged in release mode.

3. `hazard_size` (now `hazards.size`) is no longer marked as `wt_shared` as this field is only ever accessed by the session that owns the hazard pointer array