### PR TITLE
WT-10466 Line up Python source directory in setup script

### DIFF
--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -273,7 +273,7 @@ if pip_command == 'sdist':
     os.chdir(stage_dir)
     sys.argv.append('--dist-dir=' + os.path.join('..', 'dist'))
 else:
-    sources = [ os.path.join(conf_make_dir, python_rel_dir, 'CMakeFiles', '__wiredtiger.dir', 'wiredtigerPYTHON_wrap.c') ]
+    sources = [ os.path.join(conf_make_dir, python_rel_dir, 'CMakeFiles', 'wiredtiger_python.dir', 'wiredtigerPYTHON_wrap.c') ]
 
 wt_ext = Extension('_wiredtiger',
     sources = sources,


### PR DESCRIPTION
WT-8633 introduced a Python source directory name change, and missed changing the corresponding place in the setup script. The mismatch was captured during a Python open-source release while testing "pip install <wiredtiger tarball>". 

The fix in this PR is to make the same directory name change in the setup script so that it's lined up with the CMake file. 