### PR TITLE
WT-11861 Turn off the new test_app_thread_evict01 test

### DIFF
--- a/test/suite/test_app_thread_evict01.py
+++ b/test/suite/test_app_thread_evict01.py
@@ -64,6 +64,7 @@ class test_app_thread_evict01(wttest.WiredTigerTestCase):
             self.session.commit_transaction()
 
     def test_app_thread_evict01(self):
+        self.skipTest("This test fails randomly when it cannot pull application threads to perform eviction.")
         num_app_evict_snapshot_refreshed = 0
 
         format='key_format={},value_format={}'.format(self.key_format, self.value_format)


### PR DESCRIPTION
This new test test_app_thread_evict01 forces the application threads to perform eviction and at the end, it checks for the stats that at least one application thread is triggered to perform eviction. The eviction behavior is not deterministic so the plan is to turn off the test now and create another ticket to modify the test.