### PR TITLE
WT-11709 API to retrieve timestamp of a checkpoint cursor

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -658,6 +658,7 @@ designator
 dest
 destSize
 destructor
+detailsp
 dev
 dh
 dhandle

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -467,6 +467,7 @@ ap
 api
 arg
 argc
+argout
 args
 argv
 asdf
@@ -1293,6 +1294,7 @@ txnid
 txp
 txt
 typedef
+typemap
 typeof
 uS
 ui

--- a/dist/s_void
+++ b/dist/s_void
@@ -164,7 +164,8 @@ func_ok()
         -e '/int zstd_pre_size$/d' \
         -e '/int zstd_terminate$/d' \
         -e '/int __wt_curhs_search_near_after$/d' \
-        -e '/int __wt_curhs_search_near_before$/d'
+        -e '/int __wt_curhs_search_near_before$/d' \
+	-e '/__curfile_cursor_get_details$/d'
 }
 
 for f in `find bench ext src test -name '*.c' -o -name '*_inline.h'`; do

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -64,7 +64,7 @@ from packing import pack, unpack
     typedef unsigned int uint32_t;
 %}
 
-/* Set the input argument to point to a temporary variable */ 
+/* Set the input argument to point to a temporary variable */
 %typemap(in, numinputs=0) WT_CONNECTION ** (WT_CONNECTION *temp = NULL) {
 	$1 = &temp;
 }
@@ -314,10 +314,11 @@ from packing import pack, unpack
 	freeModifyArray($1);
 }
 
-/* 64 bit typemaps. */
+  /* 64 bit typemaps. */
 %typemap(in) uint64_t {
-	$1 = PyLong_AsUnsignedLongLong($input);
+        $1 = PyLong_AsUnsignedLongLong($input);
 }
+
 %typemap(out) uint64_t {
 	$result = PyLong_FromUnsignedLongLong($1);
 }
@@ -330,7 +331,7 @@ from packing import pack, unpack
 %feature("shadow") class::method %{
 	def method(self, *args):
 		'''method(self, config) -> int
-		
+
 		@copydoc class::method'''
 		try:
 			self._freecb()
@@ -370,7 +371,7 @@ DESTRUCTOR(__wt_file_system, fs_terminate)
 %typemap(default) const char *config { $1 = NULL; }
 %typemap(default) WT_CURSOR *to_dup { $1 = NULL; }
 
-/* 
+/*
  * Error returns other than WT_NOTFOUND generate an exception.
  * Use our own exception type, in future tailored to the kind
  * of error.
@@ -907,7 +908,7 @@ typedef int int_void;
 %pythoncode %{
 	def get_key(self):
 		'''get_key(self) -> object
-		
+
 		@copydoc WT_CURSOR::get_key
 		Returns only the first column.'''
 		k = self.get_keys()
@@ -917,7 +918,7 @@ typedef int int_void;
 
 	def get_keys(self):
 		'''get_keys(self) -> (object, ...)
-		
+
 		@copydoc WT_CURSOR::get_key'''
 		if self.is_json:
 			return [self._get_json_key()]
@@ -928,7 +929,7 @@ typedef int int_void;
 
 	def get_value(self):
 		'''get_value(self) -> object
-		
+
 		@copydoc WT_CURSOR::get_value
 		Returns only the first column.'''
 		v = self.get_values()
@@ -938,7 +939,7 @@ typedef int int_void;
 
 	def get_values(self):
 		'''get_values(self) -> (object, ...)
-		
+
 		@copydoc WT_CURSOR::get_value'''
 		if self.is_json:
 			return [self._get_json_value()]
@@ -963,7 +964,7 @@ typedef int int_void;
 
 	def set_key(self, *args):
 		'''set_key(self) -> None
-		
+
 		@copydoc WT_CURSOR::set_key'''
 		if len(args) == 1 and type(args[0]) == tuple:
 			args = args[0]
@@ -978,7 +979,7 @@ typedef int int_void;
 
 	def set_value(self, *args):
 		'''set_value(self) -> None
-		
+
 		@copydoc WT_CURSOR::set_value'''
 		if self.is_json:
 			self._set_value_str(args[0])
@@ -1358,7 +1359,7 @@ writeToPythonStream(const char *streamname, const char *message)
 	strcpy(&msg[msglen], "\n");
 
 	/* Acquire python Global Interpreter Lock. Otherwise can segfault. */
-	SWIG_PYTHON_THREAD_BEGIN_BLOCK; 
+	SWIG_PYTHON_THREAD_BEGIN_BLOCK;
 
 	ret = 1;
 	if ((sys = PyImport_ImportModule("sys")) == NULL)

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -362,7 +362,7 @@ from packing import pack, unpack
 %}
 };
 
-  /* 64 bit typemaps. */
+/* 64 bit typemaps. */
 %typemap(in) uint64_t {
         $1 = PyLong_AsUnsignedLongLong($input);
 }
@@ -677,6 +677,9 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 
 /* Replace get_raw_key_value method with a Python equivalent */
 %ignore __wt_cursor::get_raw_key_value;
+
+%ignore __wt_cursor::get_details(WT_CURSOR *, WT_CURSOR_DETAILS *, const char *);
+%rename(_get_details) __wt_cursor::get_details;
 
 /* Next, override methods that return integers via arguments. */
 %ignore __wt_cursor::compare(WT_CURSOR *, WT_CURSOR *, int *);
@@ -1045,6 +1048,18 @@ typedef int int_void;
 			# Keep the Python string pinned
 			self._value = pack(self.value_format, *args)
 			self._set_value(self._value)
+
+	def get_details(self, config = None):
+		'''get_details(self, config) -> CursorDetails
+
+		@copydoc WT_CURSOR::get_details
+		'''
+		# Configuration is currently not required, nor supported.
+		assert config == None
+		result = self._get_details(None)
+		if len(result) == 1:
+			raise NotImplementedError
+		return result[1]
 
 	def __iter__(self):
 		'''Cursor objects support iteration, equivalent to calling

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -170,6 +170,38 @@ from packing import pack, unpack
 	}
 }
 
+%rename (CursorDetails) __wt_cursor_details;
+%ignore __wt_cursor_details::checkpoint;
+
+%typemap(in, numimputs=0) WT_CURSOR_DETAILS * %{
+	$1 = malloc(sizeof(WT_CURSOR_DETAILS));
+%}
+
+%typemap(freearg) WT_CURSOR_DETAILS * {
+	free($1);
+}
+
+%typemap(argout) WT_CURSOR_DETAILS *output {
+	%append_output(SWIG_NewPointerObj($1, $1_descriptor, SWIG_POINTER_OWN));
+}
+
+%rename (CursorDetailsCheckpoint) __wt_cursor_details_checkpoint;
+%ignore __wt_cursor_details_checkpoint::oldest_timestamp;
+%ignore __wt_cursor_details_checkpoint::read_timestamp;
+%ignore __wt_cursor_details_checkpoint::stable_timestamp;
+
+%extend __wt_cursor_details_checkpoint {
+%pythoncode %{
+	def __init__(self):
+		self.oldest_timestmap = 0
+		self.read_timestamp = 0
+		self.stable_timestamp = 0
+
+	def __repr__(self):
+		return f'CursorDetailsCheckpoint(oldest={self.oldest_timestamp}, read={self.read_timestamp}, stable={self.stable_timestamp})'
+%}
+};
+
 %typemap(argout) (WT_MODIFY *entries_string, int *nentriesp) {
 	int i;
 
@@ -184,7 +216,7 @@ from packing import pack, unpack
 		    PyInt_FromLong($1[i].size));
 		PyList_SetItem($result, i, o);
 	}
- }
+}
 
 %typemap(in) const WT_ITEM * (WT_ITEM val) {
 	if (unpackBytesOrString($input, &val.data, &val.size) != 0)

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -170,12 +170,29 @@ from packing import pack, unpack
 	}
 }
 
+%rename (CursorDetailsCheckpoint) __wt_cursor_details_checkpoint;
+%ignore __wt_cursor_details_checkpoint::oldest_timestamp;
+%ignore __wt_cursor_details_checkpoint::read_timestamp;
+%ignore __wt_cursor_details_checkpoint::stable_timestamp;
+
+%extend __wt_cursor_details_checkpoint {
+%pythoncode %{
+	def __init__(self):
+		self.oldest_timestamp = 0
+		self.read_timestamp = 0
+		self.stable_timestamp = 0
+
+	def __repr__(self):
+		return f'CursorDetailsCheckpoint(oldest={self.oldest_timestamp}, read={self.read_timestamp}, stable={self.stable_timestamp})'
+%}
+};
+
 %rename (CursorDetails) __wt_cursor_details;
 %ignore __wt_cursor_details::checkpoint;
 
-%typemap(in, numimputs=0) WT_CURSOR_DETAILS * %{
+%typemap(in, numimputs=0) WT_CURSOR_DETAILS * {
 	$1 = malloc(sizeof(WT_CURSOR_DETAILS));
-%}
+}
 
 %typemap(freearg) WT_CURSOR_DETAILS * {
 	free($1);
@@ -185,22 +202,16 @@ from packing import pack, unpack
 	%append_output(SWIG_NewPointerObj($1, $1_descriptor, SWIG_POINTER_OWN));
 }
 
-%rename (CursorDetailsCheckpoint) __wt_cursor_details_checkpoint;
-%ignore __wt_cursor_details_checkpoint::oldest_timestamp;
-%ignore __wt_cursor_details_checkpoint::read_timestamp;
-%ignore __wt_cursor_details_checkpoint::stable_timestamp;
-
-%extend __wt_cursor_details_checkpoint {
+%extend __wt_cursor_details {
 %pythoncode %{
-	def __init__(self):
-		self.oldest_timestmap = 0
-		self.read_timestamp = 0
-		self.stable_timestamp = 0
+         def __init__(self):
+         	self.checkpoint = CursorDetailsCheckpoint()
 
-	def __repr__(self):
-		return f'CursorDetailsCheckpoint(oldest={self.oldest_timestamp}, read={self.read_timestamp}, stable={self.stable_timestamp})'
+         def __repr__(self):
+         	return 'CursorDetails'
 %}
 };
+
 
 %typemap(argout) (WT_MODIFY *entries_string, int *nentriesp) {
 	int i;

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -325,10 +325,9 @@ from packing import pack, unpack
 		self.checkpoint_id = 0
 
 	def __repr__(self):
-		return f'CursorDetailsCheckpoint(checkpoint_id={self.checkpoint_id}, stable_timestamp={self.stable_timestamp})'
+		return 'CursorDetailsCheckpoint(ckpt_id={self.checkpoint_id}, stable={self.stable_timestamp})'
 %}
 };
-
 
 %rename (CursorDetails) __wt_cursor_details;
 %ignore __wt_cursor_details::checkpoint;
@@ -678,8 +677,8 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 /* Replace get_raw_key_value method with a Python equivalent */
 %ignore __wt_cursor::get_raw_key_value;
 
+/* Suppress as we will define a custom Pythonic wrapper. */
 %ignore __wt_cursor::get_details(WT_CURSOR *, WT_CURSOR_DETAILS *, const char *);
-%rename(_get_details) __wt_cursor::get_details;
 
 /* Next, override methods that return integers via arguments. */
 %ignore __wt_cursor::compare(WT_CURSOR *, WT_CURSOR *, int *);
@@ -896,6 +895,10 @@ typedef int int_void;
 		return (ret);
 	}
 
+	int_void _get_details(WT_CURSOR_DETAILS *detailsp, const char *config) {
+		return $self->get_details($self, detailsp, config);
+	}
+
 	/* compare: special handling. */
 	int _compare(WT_CURSOR *other) {
 		int cmp = 0;
@@ -1056,10 +1059,7 @@ typedef int int_void;
 		'''
 		# Configuration is currently not required, nor supported.
 		assert config == None
-		result = self._get_details(None)
-		if len(result) == 1:
-			raise NotImplementedError
-		return result[1]
+		return self._get_details(config)
 
 	def __iter__(self):
 		'''Cursor objects support iteration, equivalent to calling

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1046,8 +1046,8 @@ __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
      * name in the session, substitute the one from this cursor. This allows the dump to print from
      * the history store, which otherwise will get skipped.
      */
-    if (cbt->checkpoint_hs_dhandle != NULL && session->hs_checkpoint == NULL) {
-        session->hs_checkpoint = cbt->checkpoint_hs_dhandle->checkpoint;
+    if (cbt->checkpoint.hs_dhandle != NULL && session->hs_checkpoint == NULL) {
+        session->hs_checkpoint = cbt->checkpoint.hs_dhandle->checkpoint;
         did_hs_checkpoint = true;
     }
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -275,7 +275,7 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curbackup_close,                              /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_BACKUP *cb, *othercb;

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -275,7 +275,7 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curbackup_close,                              /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_BACKUP *cb, *othercb;

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -274,7 +274,9 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curbackup_close);                             /* close */
+      __curbackup_close,                              /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR *cursor;
     WT_CURSOR_BACKUP *cb, *othercb;
     WT_DECL_RET;

--- a/src/cursor/cur_config.c
+++ b/src/cursor/cur_config.c
@@ -58,7 +58,7 @@ __wt_curconfig_open(
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curconfig_close,                              /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR_CONFIG *cconfig;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_config.c
+++ b/src/cursor/cur_config.c
@@ -58,7 +58,7 @@ __wt_curconfig_open(
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curconfig_close,                              /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR_CONFIG *cconfig;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_config.c
+++ b/src/cursor/cur_config.c
@@ -57,7 +57,9 @@ __wt_curconfig_open(
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curconfig_close);
+      __curconfig_close,                              /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR_CONFIG *cconfig;
     WT_CURSOR *cursor;
     WT_DECL_RET;

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -454,7 +454,7 @@ __wt_curds_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, con
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curds_close,                                  /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CONFIG_ITEM cval, metadata;
     WT_CURSOR *cursor, *source;

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -453,7 +453,9 @@ __wt_curds_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, con
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curds_close);                                 /* close */
+      __curds_close,                                  /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CONFIG_ITEM cval, metadata;
     WT_CURSOR *cursor, *source;
     WT_CURSOR_DATA_SOURCE *data_source;

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -454,7 +454,7 @@ __wt_curds_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, con
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curds_close,                                  /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CONFIG_ITEM cval, metadata;
     WT_CURSOR *cursor, *source;

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -415,7 +415,9 @@ __wt_curdump_create(WT_CURSOR *child, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_notsup,                           /* cache */
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
-      __curdump_close);                             /* close */
+      __curdump_close,                              /* close */
+      __wt_cursor_get_details                       /* get_details */
+    );
     WT_CURSOR *cursor;
     WT_CURSOR_DUMP *cdump;
     WT_CURSOR_JSON *json;

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -416,7 +416,7 @@ __wt_curdump_create(WT_CURSOR *child, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curdump_close,                              /* close */
-      __wt_cursor_get_details                       /* get_details */
+      __wt_cursor_get_details_notsup                       /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_DUMP *cdump;

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -416,7 +416,7 @@ __wt_curdump_create(WT_CURSOR *child, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curdump_close,                              /* close */
-      __wt_cursor_get_details_notsup                       /* get_details */
+      __wt_cursor_get_details_notsup                /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_DUMP *cdump;

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -113,17 +113,17 @@ __wt_cursor_checkpoint_id(WT_CURSOR *cursor)
 int
 __wt_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
 {
-    WT_CURSOR_BTREE *cbt;    
+    WT_CURSOR_BTREE *cbt;
     WT_ASSERT(CUR2S(cursor), detailsp != NULL);
     WT_ASSERT(CUR2S(cursor), config == NULL);
-    cbt = (WT_CURSOR_BTREE*)cursor;
+    cbt = (WT_CURSOR_BTREE *)cursor;
     if (cbt->checkpoint_txn) {
         detailsp->checkpoint.oldest_timestamp = cbt->checkpoint_txn->checkpoint_oldest_timestamp;
         detailsp->checkpoint.read_timestamp = cbt->checkpoint_txn->checkpoint_read_timestamp;
         detailsp->checkpoint.stable_timestamp = cbt->checkpoint_txn->checkpoint_stable_timestamp;
-        return 0;
+        return (0);
     }
-    return ENODATA;
+    return (ENODATA);
 }
 
 /*

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -113,19 +113,14 @@ __wt_cursor_checkpoint_id(WT_CURSOR *cursor)
 static int
 __curfile_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
 {
-    WT_CURSOR_BTREE *cbt;
+    /* WT_CURSOR_BTREE *cbt; */
 
     WT_UNUSED(config);
     WT_ASSERT(CUR2S(cursor), detailsp != NULL);
 
-    cbt = (WT_CURSOR_BTREE *)cursor;
-    if (cbt != NULL && cbt->checkpoint_txn != NULL) {
-        detailsp->checkpoint.oldest_timestamp = cbt->checkpoint_txn->checkpoint_oldest_timestamp;
-        detailsp->checkpoint.read_timestamp = cbt->checkpoint_txn->checkpoint_read_timestamp;
-        detailsp->checkpoint.stable_timestamp = cbt->checkpoint_txn->checkpoint_stable_timestamp;
-        return (0);
-    }
-    return (ENODATA);
+    /* cbt = (WT_CURSOR_BTREE *)cursor; */
+    detailsp->checkpoint.stable_timestamp = 12345;
+    return (0);
 }
 
 /*

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -119,7 +119,7 @@ __curfile_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, con
     WT_ASSERT(CUR2S(cursor), detailsp != NULL);
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    if (cbt->checkpoint_txn) {
+    if (cbt != NULL && cbt->checkpoint_txn != NULL) {
         detailsp->checkpoint.oldest_timestamp = cbt->checkpoint_txn->checkpoint_oldest_timestamp;
         detailsp->checkpoint.read_timestamp = cbt->checkpoint_txn->checkpoint_read_timestamp;
         detailsp->checkpoint.stable_timestamp = cbt->checkpoint_txn->checkpoint_stable_timestamp;

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -107,15 +107,17 @@ __wt_cursor_checkpoint_id(WT_CURSOR *cursor)
 }
 
 /*
- * __wt_cursor_get_details --
+ * __curfile_cursor_get_details --
  *     Query detailed information using this cursor instance.
  */
-int
-__wt_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
+static int
+__curfile_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
 {
     WT_CURSOR_BTREE *cbt;
+
+    WT_UNUSED(config);
     WT_ASSERT(CUR2S(cursor), detailsp != NULL);
-    WT_ASSERT(CUR2S(cursor), config == NULL);
+
     cbt = (WT_CURSOR_BTREE *)cursor;
     if (cbt->checkpoint_txn) {
         detailsp->checkpoint.oldest_timestamp = cbt->checkpoint_txn->checkpoint_oldest_timestamp;
@@ -985,7 +987,7 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
       __curfile_reopen,                               /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curfile_close,                                /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __curfile_cursor_get_details                    /* get_details */
     );
     WT_BTREE *btree;
     WT_CONFIG_ITEM cval;

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -107,6 +107,26 @@ __wt_cursor_checkpoint_id(WT_CURSOR *cursor)
 }
 
 /*
+ * __wt_cursor_get_details --
+ *     Query detailed information using this cursor instance.
+ */
+int
+__wt_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
+{
+    WT_CURSOR_BTREE *cbt;    
+    WT_ASSERT(CUR2S(cursor), detailsp != NULL);
+    WT_ASSERT(CUR2S(cursor), config == NULL);
+    cbt = (WT_CURSOR_BTREE*)cursor;
+    if (cbt->checkpoint_txn) {
+        detailsp->checkpoint.oldest_timestamp = cbt->checkpoint_txn->checkpoint_oldest_timestamp;
+        detailsp->checkpoint.read_timestamp = cbt->checkpoint_txn->checkpoint_read_timestamp;
+        detailsp->checkpoint.stable_timestamp = cbt->checkpoint_txn->checkpoint_stable_timestamp;
+        return 0;
+    }
+    return ENODATA;
+}
+
+/*
  * __curfile_compare --
  *     WT_CURSOR->compare method for the btree cursor type.
  */
@@ -964,7 +984,9 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
       __curfile_cache,                                /* cache */
       __curfile_reopen,                               /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curfile_close);                               /* close */
+      __curfile_close,                                /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_BTREE *btree;
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1255,7 +1255,7 @@ __wt_curhs_open(WT_SESSION_IMPL *session, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curhs_close,                                  /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_HS *hs_cursor;

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1254,7 +1254,9 @@ __wt_curhs_open(WT_SESSION_IMPL *session, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curhs_close);                                 /* close */
+      __curhs_close,                                  /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR *cursor;
     WT_CURSOR_HS *hs_cursor;
     WT_DECL_RET;

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1255,7 +1255,7 @@ __wt_curhs_open(WT_SESSION_IMPL *session, WT_CURSOR *owner, WT_CURSOR **cursorp)
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curhs_close,                                  /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_HS *hs_cursor;

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -584,7 +584,7 @@ __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curindex_close,                               /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR_INDEX *cindex;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -583,7 +583,9 @@ __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curindex_close);                              /* close */
+      __curindex_close,                               /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR_INDEX *cindex;
     WT_CURSOR *cursor;
     WT_DECL_ITEM(tmp);

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -584,7 +584,7 @@ __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curindex_close,                               /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR_INDEX *cindex;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -583,7 +583,7 @@ __curjoin_entry_member(
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_cursor_notsup,                             /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_DECL_RET;
     WT_INDEX *idx;
@@ -1235,7 +1235,7 @@ __wt_curjoin_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, c
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curjoin_close,                              /* close */
-      __wt_cursor_get_details_notsup                       /* get_details */
+      __wt_cursor_get_details_notsup                /* get_details */
     );
 
     WT_CURSOR *cursor;

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -583,7 +583,7 @@ __curjoin_entry_member(
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_cursor_notsup,                             /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_DECL_RET;
     WT_INDEX *idx;
@@ -1235,7 +1235,7 @@ __wt_curjoin_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, c
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curjoin_close,                              /* close */
-      __wt_cursor_get_details                       /* get_details */
+      __wt_cursor_get_details_notsup                       /* get_details */
     );
 
     WT_CURSOR *cursor;

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -582,7 +582,9 @@ __curjoin_entry_member(
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __wt_cursor_notsup);                            /* close */
+      __wt_cursor_notsup,                             /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_DECL_RET;
     WT_INDEX *idx;
     WT_ITEM v;
@@ -1232,7 +1234,10 @@ __wt_curjoin_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, c
       __wt_cursor_notsup,                           /* cache */
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
-      __curjoin_close);                             /* close */
+      __curjoin_close,                              /* close */
+      __wt_cursor_get_details                       /* get_details */
+    );
+
     WT_CURSOR *cursor;
     WT_CURSOR_JOIN *cjoin;
     WT_DECL_ITEM(tmp);

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -349,7 +349,7 @@ __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], W
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curlog_close,                                 /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_LOG *cl;

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -348,7 +348,9 @@ __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], W
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curlog_close);                                /* close */
+      __curlog_close,                                 /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR *cursor;
     WT_CURSOR_LOG *cl;
     WT_DECL_RET;

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -349,7 +349,7 @@ __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], W
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curlog_close,                                 /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_LOG *cl;

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -601,7 +601,7 @@ __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owne
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curmetadata_close,                            /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_METADATA *mdc;

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -601,7 +601,7 @@ __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owne
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __curmetadata_close,                            /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_METADATA *mdc;

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -600,7 +600,9 @@ __wt_curmetadata_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owne
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __curmetadata_close);                           /* close */
+      __curmetadata_close,                            /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR *cursor;
     WT_CURSOR_METADATA *mdc;
     WT_DECL_RET;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -640,7 +640,9 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
       __wt_cursor_notsup,                           /* cache */
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
-      __curstat_close);                             /* close */
+      __curstat_close,                              /* close */
+      __wt_cursor_get_details                       /* get_details */
+    );
     WT_CONFIG_ITEM cval, sval;
     WT_CURSOR *cursor;
     WT_CURSOR_STAT *cst;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -641,7 +641,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curstat_close,                              /* close */
-      __wt_cursor_get_details                       /* get_details */
+      __wt_cursor_get_details_notsup                       /* get_details */
     );
     WT_CONFIG_ITEM cval, sval;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -641,7 +641,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other, c
       __wt_cursor_reopen_notsup,                    /* reopen */
       __wt_cursor_checkpoint_id,                    /* checkpoint ID */
       __curstat_close,                              /* close */
-      __wt_cursor_get_details_notsup                       /* get_details */
+      __wt_cursor_get_details_notsup                /* get_details */
     );
     WT_CONFIG_ITEM cval, sval;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1534,3 +1534,15 @@ __wt_cursor_init(
     *cursorp = (cdump != NULL) ? cdump : cursor;
     return (0);
 }
+
+/*
+ * __wt_cursor_get_details --
+ *     Vast majority of cursor types do not support retrieving contextual details.
+ */
+int
+__wt_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
+{
+    WT_UNUSED(detailsp);
+    WT_UNUSED(config);
+    return (__wt_cursor_notsup(cursor));
+}

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1540,7 +1540,7 @@ __wt_cursor_init(
  *     Vast majority of cursor types do not support retrieving contextual details.
  */
 int
-__wt_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
+__wt_cursor_get_details_notsup(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)
 {
     WT_UNUSED(detailsp);
     WT_UNUSED(config);

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1536,8 +1536,8 @@ __wt_cursor_init(
 }
 
 /*
- * __wt_cursor_get_details --
- *     Vast majority of cursor types do not support retrieving contextual details.
+ * __wt_cursor_get_details_notsup --
+ *     The majority of cursor types do not support retrieving contextual details.
  */
 int
 __wt_cursor_get_details_notsup(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config)

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -108,7 +108,9 @@ __wt_apply_single_idx(WT_SESSION_IMPL *session, WT_INDEX *idx, WT_CURSOR *cur,
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __wt_cursor_notsup);                            /* close */
+      __wt_cursor_notsup,                             /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR_EXTRACTOR extract_cursor;
     WT_DECL_RET;
     WT_ITEM key, value;
@@ -1070,7 +1072,9 @@ __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wt_cursor_notsup,                               /* cache */
       __wt_cursor_reopen_notsup,                        /* reopen */
       __wt_cursor_checkpoint_id,                        /* checkpoint ID */
-      __curtable_close);                                /* close */
+      __curtable_close,                                 /* close */
+      __wt_cursor_get_details                           /* get_details */
+    );
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cursor;
     WT_CURSOR_TABLE *ctable;

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -109,7 +109,7 @@ __wt_apply_single_idx(WT_SESSION_IMPL *session, WT_INDEX *idx, WT_CURSOR *cur,
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_cursor_notsup,                             /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR_EXTRACTOR extract_cursor;
     WT_DECL_RET;
@@ -1073,7 +1073,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wt_cursor_reopen_notsup,                        /* reopen */
       __wt_cursor_checkpoint_id,                        /* checkpoint ID */
       __curtable_close,                                 /* close */
-      __wt_cursor_get_details_notsup                           /* get_details */
+      __wt_cursor_get_details_notsup                    /* get_details */
     );
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -109,7 +109,7 @@ __wt_apply_single_idx(WT_SESSION_IMPL *session, WT_INDEX *idx, WT_CURSOR *cur,
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_cursor_notsup,                             /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR_EXTRACTOR extract_cursor;
     WT_DECL_RET;
@@ -1073,7 +1073,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wt_cursor_reopen_notsup,                        /* reopen */
       __wt_cursor_checkpoint_id,                        /* checkpoint ID */
       __curtable_close,                                 /* close */
-      __wt_cursor_get_details                           /* get_details */
+      __wt_cursor_get_details_notsup                           /* get_details */
     );
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cursor;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -623,7 +623,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
       __wt_cursor_reopen_notsup,                       /* reopen */
       __wt_cursor_checkpoint_id,                       /* checkpoint ID */
       __curversion_close,                              /* close */
-      __wt_cursor_get_details_notsup                          /* get_details */
+      __wt_cursor_get_details_notsup                   /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_VERSION *version_cursor;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -622,8 +622,9 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
       __wt_cursor_notsup,                              /* cache */
       __wt_cursor_reopen_notsup,                       /* reopen */
       __wt_cursor_checkpoint_id,                       /* checkpoint ID */
-      __curversion_close);                             /* close */
-
+      __curversion_close,                              /* close */
+      __wt_cursor_get_details                          /* get_details */
+    );
     WT_CURSOR *cursor;
     WT_CURSOR_VERSION *version_cursor;
     WT_DECL_RET;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -623,7 +623,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
       __wt_cursor_reopen_notsup,                       /* reopen */
       __wt_cursor_checkpoint_id,                       /* checkpoint ID */
       __curversion_close,                              /* close */
-      __wt_cursor_get_details                          /* get_details */
+      __wt_cursor_get_details_notsup                          /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_VERSION *version_cursor;

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -14,7 +14,7 @@
  */
 #define WT_CURSOR_STATIC_INIT(n, get_key, get_value, get_raw_key_value, set_key, set_value,      \
   compare, equals, next, prev, reset, search, search_near, insert, modify, update, remove,       \
-  reserve, reconfigure, largest_key, bound, cache, reopen, checkpoint_id, close)                 \
+  reserve, reconfigure, largest_key, bound, cache, reopen, checkpoint_id, close, get_details)    \
     static const WT_CURSOR n = {                                                                 \
       NULL, /* session */                                                                        \
       NULL, /* uri */                                                                            \
@@ -22,19 +22,19 @@
       NULL, /* value_format */                                                                   \
       get_key, get_value, get_raw_key_value, set_key, set_value, compare, equals, next, prev,    \
       reset, search, search_near, insert, modify, update, remove, reserve, checkpoint_id, close, \
-      largest_key, reconfigure, bound, cache, reopen, 0, /* uri_hash */                          \
-      {NULL, NULL},                                      /* TAILQ_ENTRY q */                     \
-      0,                                                 /* recno key */                         \
-      {0},                                               /* recno raw buffer */                  \
-      NULL,                                              /* json_private */                      \
-      NULL,                                              /* lang_private */                      \
-      {NULL, 0, NULL, 0, 0},                             /* WT_ITEM key */                       \
-      {NULL, 0, NULL, 0, 0},                             /* WT_ITEM value */                     \
-      0,                                                 /* int saved_err */                     \
-      NULL,                                              /* internal_uri */                      \
-      {NULL, 0, NULL, 0, 0},                             /* WT_ITEM lower bound */               \
-      {NULL, 0, NULL, 0, 0},                             /* WT_ITEM upper bound */               \
-      0                                                  /* uint32_t flags */                    \
+      largest_key, reconfigure, bound, get_details, cache, reopen, 0, /* uri_hash */             \
+      {NULL, NULL},                                                   /* TAILQ_ENTRY q */        \
+      0,                                                              /* recno key */            \
+      {0},                                                            /* recno raw buffer */     \
+      NULL,                                                           /* json_private */         \
+      NULL,                                                           /* lang_private */         \
+      {NULL, 0, NULL, 0, 0},                                          /* WT_ITEM key */          \
+      {NULL, 0, NULL, 0, 0},                                          /* WT_ITEM value */        \
+      0,                                                              /* int saved_err */        \
+      NULL,                                                           /* internal_uri */         \
+      {NULL, 0, NULL, 0, 0},                                          /* WT_ITEM lower bound */  \
+      {NULL, 0, NULL, 0, 0},                                          /* WT_ITEM upper bound */  \
+      0                                                               /* uint32_t flags */       \
     }
 
 /* Call a function without the evict reposition cursor flag, restore afterwards. */

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -221,8 +221,10 @@ struct __wt_cursor_btree {
          */
         WT_DATA_HANDLE *hs_dhandle;
 
-        /* Write generation, used to override the tree's base write generation in the unpacking
-         * cleanup code. */
+        /*
+         * Write generation, used to override the tree's base write generation in the unpacking
+         * cleanup code.
+         */
         uint64_t write_gen;
 
         /* Available to the application via cursor::get_details() API call. */

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -209,18 +209,26 @@ struct __wt_cursor_btree {
     WT_UPDATE_VALUE *upd_value, _upd_value;
 
     /*
-     * Bits used by checkpoint cursor: a private transaction, used to provide the proper read
-     * snapshot; a reference to the corresponding history store checkpoint, which keeps it from
-     * disappearing under us if it's unnamed and also tracks its identity for use in history store
-     * accesses; a write generation, used to override the tree's base write generation in the
-     * unpacking cleanup code; and a checkpoint ID, which is available to applications through an
-     * undocumented interface to allow them to open cursors on multiple files and check if they got
-     * the same checkpoint in all of them.
+     * Data used by checkpoint cursor.
      */
-    WT_TXN *checkpoint_txn;
-    WT_DATA_HANDLE *checkpoint_hs_dhandle;
-    uint64_t checkpoint_write_gen;
-    uint64_t checkpoint_id;
+    struct {
+        /* Private transaction, used to provide the proper read snapshot. */
+        WT_TXN *txn;
+
+        /*
+         * Reference to the corresponding history store checkpoint, which keeps it from disappearing
+         * under us if it's unnamed and also tracks its identity for use in history store accesses.
+         */
+        WT_DATA_HANDLE *hs_dhandle;
+
+        /* Write generation, used to override the tree's base write generation in the unpacking
+         * cleanup code. */
+        uint64_t write_gen;
+
+        /* Available to the application via cursor::get_details() API call. */
+        uint64_t checkpoint_id;
+        wt_timestamp_t stable_timestamp;
+    } checkpoint;
 
     /*
      * Fixed-length column-store items are a single byte, and it's simpler and cheaper to allocate

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -629,6 +629,8 @@ extern int __wt_cursor_equals(WT_CURSOR *cursor, WT_CURSOR *other, int *equalp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_equals_notsup(WT_CURSOR *cursor, WT_CURSOR *other, int *equalp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp,
+  const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_get_key(WT_CURSOR *cursor, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_get_keyv(WT_CURSOR *cursor, uint64_t flags, va_list ap)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -629,7 +629,7 @@ extern int __wt_cursor_equals(WT_CURSOR *cursor, WT_CURSOR *other, int *equalp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_equals_notsup(WT_CURSOR *cursor, WT_CURSOR *other, int *equalp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_cursor_get_details(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp,
+extern int __wt_cursor_get_details_notsup(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp,
   const char *config) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_cursor_get_key(WT_CURSOR *cursor, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -69,7 +69,7 @@ struct __wt_config_parser;
 struct __wt_connection;     typedef struct __wt_connection WT_CONNECTION;
 struct __wt_cursor;     typedef struct __wt_cursor WT_CURSOR;
 struct __wt_cursor_details_checkpoint; typedef struct __wt_cursor_details_checkpoint WT_CURSOR_DETAILS_CHECKPOINT;
-struct __wt_cursor_details; typedef struct __wt_cursor_details WT_CURSOR_DETAILS;
+union __wt_cursor_details; typedef union __wt_cursor_details WT_CURSOR_DETAILS;
 struct __wt_data_source;    typedef struct __wt_data_source WT_DATA_SOURCE;
 struct __wt_encryptor;      typedef struct __wt_encryptor WT_ENCRYPTOR;
 struct __wt_event_handler;  typedef struct __wt_event_handler WT_EVENT_HANDLER;
@@ -178,12 +178,10 @@ struct __wt_modify {
 #define WT_INTPACK32_MAXSIZE    ((int)sizeof(int32_t) + 1)
 
 struct __wt_cursor_details_checkpoint {
-    uint64_t oldest_timestamp; 
-    uint64_t read_timestamp; 
-    uint64_t stable_timestamp; 
+    uint64_t stable_timestamp;
 };
 
-struct __wt_cursor_details { 
+union __wt_cursor_details {
     struct __wt_cursor_details_checkpoint checkpoint;
 };
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -816,10 +816,11 @@ struct __wt_cursor {
 };
 
 /*!
- * Checkpoint details that may be retrieved from a cursor. Only available
- * through __wt_cursor_details.
+ * Checkpoint details. Only accessible through __wt_cursor_details, so
+ * there is no corresponding WT_ typedef.
  *
- * Not declared as a nested structure as that interferes with SWIG parsing.
+ * Not declared as a nested structure in __wt_cursor_details as it is
+ * too difficult to support in SWIG.
  */
 struct __wt_cursor_details_checkpoint {
     uint64_t checkpoint_id;
@@ -827,7 +828,10 @@ struct __wt_cursor_details_checkpoint {
 };
 
 /*!
- * Details specific to the given cursor type.
+ * Details specific to the given cursor type filled in by WT_CURSOR::get_details().
+ *
+ * This is logically a union, but making it one would the create unacceptable
+ * ambiguity in the SWIG argout typemap.
  */
 struct __wt_cursor_details {
     struct __wt_cursor_details_checkpoint checkpoint;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -180,7 +180,11 @@ struct __wt_modify {
  * The WT_CURSOR_DETAILS is used to report contextual information from a cursor handle.
  */
 struct __wt_cursor_details {
-    int unused;                 /* Ensure structure is not empty during prototyping. */
+    struct {
+        wt_timestamp_t oldest_timestamp;
+        wt_timestamp_t read_timestamp;
+        wt_timestamp_t stable_timestamp;
+    } checkpoint;
 };
 
 /*!

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -68,7 +68,8 @@ struct __wt_config_parser;
     typedef struct __wt_config_parser WT_CONFIG_PARSER;
 struct __wt_connection;     typedef struct __wt_connection WT_CONNECTION;
 struct __wt_cursor;     typedef struct __wt_cursor WT_CURSOR;
-struct __wt_cursor_details; typedef struct __wt_cursor_details WT_CURSOR_DETAILS;
+struct __wt_cursor_checkpoint_details; typedef struct __wt_cursor_checkpoint_details WT_CURSOR_CHECKPOINT_DETAILS;
+union __wt_cursor_details; typedef union __wt_cursor_details WT_CURSOR_DETAILS;
 struct __wt_data_source;    typedef struct __wt_data_source WT_DATA_SOURCE;
 struct __wt_encryptor;      typedef struct __wt_encryptor WT_ENCRYPTOR;
 struct __wt_event_handler;  typedef struct __wt_event_handler WT_EVENT_HANDLER;
@@ -179,12 +180,14 @@ struct __wt_modify {
 /*!
  * The WT_CURSOR_DETAILS is used to report contextual information from a cursor handle.
  */
-struct __wt_cursor_details {
-    struct {
-        uint64_t oldest_timestamp;
-        uint64_t read_timestamp;
-        uint64_t stable_timestamp;
-    } checkpoint;
+struct __wt_cursor_checkpoint_details {
+    uint64_t oldest_timestamp;
+    uint64_t read_timestamp;
+    uint64_t stable_timestamp;
+};
+
+union __wt_cursor_details {
+    struct __wt_cursor_checkpoint_details checkpoint;
 };
 
 /*!

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -68,8 +68,8 @@ struct __wt_config_parser;
     typedef struct __wt_config_parser WT_CONFIG_PARSER;
 struct __wt_connection;     typedef struct __wt_connection WT_CONNECTION;
 struct __wt_cursor;     typedef struct __wt_cursor WT_CURSOR;
-struct __wt_cursor_checkpoint_details; typedef struct __wt_cursor_checkpoint_details WT_CURSOR_CHECKPOINT_DETAILS;
-union __wt_cursor_details; typedef union __wt_cursor_details WT_CURSOR_DETAILS;
+struct __wt_cursor_details_checkpoint; typedef struct __wt_cursor_details_checkpoint WT_CURSOR_DETAILS_CHECKPOINT;
+struct __wt_cursor_details; typedef struct __wt_cursor_details WT_CURSOR_DETAILS;
 struct __wt_data_source;    typedef struct __wt_data_source WT_DATA_SOURCE;
 struct __wt_encryptor;      typedef struct __wt_encryptor WT_ENCRYPTOR;
 struct __wt_event_handler;  typedef struct __wt_event_handler WT_EVENT_HANDLER;
@@ -177,17 +177,14 @@ struct __wt_modify {
  */
 #define WT_INTPACK32_MAXSIZE    ((int)sizeof(int32_t) + 1)
 
-/*!
- * The WT_CURSOR_DETAILS is used to report contextual information from a cursor handle.
- */
-struct __wt_cursor_checkpoint_details {
-    uint64_t oldest_timestamp;
-    uint64_t read_timestamp;
-    uint64_t stable_timestamp;
+struct __wt_cursor_details_checkpoint {
+    uint64_t oldest_timestamp; 
+    uint64_t read_timestamp; 
+    uint64_t stable_timestamp; 
 };
 
-union __wt_cursor_details {
-    struct __wt_cursor_checkpoint_details checkpoint;
+struct __wt_cursor_details { 
+    struct __wt_cursor_details_checkpoint checkpoint;
 };
 
 /*!

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -68,6 +68,7 @@ struct __wt_config_parser;
     typedef struct __wt_config_parser WT_CONFIG_PARSER;
 struct __wt_connection;     typedef struct __wt_connection WT_CONNECTION;
 struct __wt_cursor;     typedef struct __wt_cursor WT_CURSOR;
+struct __wt_cursor_details; typedef struct __wt_cursor_details WT_CURSOR_DETAILS;
 struct __wt_data_source;    typedef struct __wt_data_source WT_DATA_SOURCE;
 struct __wt_encryptor;      typedef struct __wt_encryptor WT_ENCRYPTOR;
 struct __wt_event_handler;  typedef struct __wt_event_handler WT_EVENT_HANDLER;
@@ -176,6 +177,13 @@ struct __wt_modify {
 #define WT_INTPACK32_MAXSIZE    ((int)sizeof(int32_t) + 1)
 
 /*!
+ * The WT_CURSOR_DETAILS is used to report contextual information from a cursor handle.
+ */
+struct __wt_cursor_details {
+    int unused;                 /* Ensure structure is not empty during prototyping. */
+};
+
+/*!
  * A WT_CURSOR handle is the interface to a cursor.
  *
  * Cursors allow data to be searched, iterated and modified, implementing the
@@ -225,6 +233,7 @@ struct __wt_cursor {
      * @name Data access
      * @{
      */
+
     /*!
      * Get the key for the current record.
      *
@@ -717,6 +726,16 @@ struct __wt_cursor {
      * @errors
      */
     int __F(bound)(WT_CURSOR *cursor, const char *config);
+
+    /*!
+     * Query a cursor for additional contextual information.
+     *
+     * @param cursor  Cursor handle. Must not be \c NULL.
+     * @param[out] detailsp  Used to return any information to caller. Must not be \c NULL.
+     * @param config  Reserved for future use. Must be \c NULL.
+     * @errors
+     */
+    int __F(get_details)(WT_CURSOR *cursor, WT_CURSOR_DETAILS *detailsp, const char *config);
 
     /*
      * Protected fields, only to be used by cursor implementations.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -181,9 +181,9 @@ struct __wt_modify {
  */
 struct __wt_cursor_details {
     struct {
-        wt_timestamp_t oldest_timestamp;
-        wt_timestamp_t read_timestamp;
-        wt_timestamp_t stable_timestamp;
+        uint64_t oldest_timestamp;
+        uint64_t read_timestamp;
+        uint64_t stable_timestamp;
     } checkpoint;
 };
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -68,8 +68,7 @@ struct __wt_config_parser;
     typedef struct __wt_config_parser WT_CONFIG_PARSER;
 struct __wt_connection;     typedef struct __wt_connection WT_CONNECTION;
 struct __wt_cursor;     typedef struct __wt_cursor WT_CURSOR;
-struct __wt_cursor_details_checkpoint; typedef struct __wt_cursor_details_checkpoint WT_CURSOR_DETAILS_CHECKPOINT;
-union __wt_cursor_details; typedef union __wt_cursor_details WT_CURSOR_DETAILS;
+struct __wt_cursor_details; typedef struct __wt_cursor_details WT_CURSOR_DETAILS;
 struct __wt_data_source;    typedef struct __wt_data_source WT_DATA_SOURCE;
 struct __wt_encryptor;      typedef struct __wt_encryptor WT_ENCRYPTOR;
 struct __wt_event_handler;  typedef struct __wt_event_handler WT_EVENT_HANDLER;
@@ -176,14 +175,6 @@ struct __wt_modify {
  * function will pack single integers into at most this many bytes.
  */
 #define WT_INTPACK32_MAXSIZE    ((int)sizeof(int32_t) + 1)
-
-struct __wt_cursor_details_checkpoint {
-    uint64_t stable_timestamp;
-};
-
-union __wt_cursor_details {
-    struct __wt_cursor_details_checkpoint checkpoint;
-};
 
 /*!
  * A WT_CURSOR handle is the interface to a cursor.
@@ -822,6 +813,24 @@ struct __wt_cursor {
 | WT_CURSTD_BOUND_LOWER | WT_CURSTD_BOUND_LOWER_INCLUSIVE)
     uint64_t flags;
 #endif
+};
+
+/*!
+ * Checkpoint details that may be retrieved from a cursor. Only available
+ * through __wt_cursor_details.
+ *
+ * Not declared as a nested structure as that interferes with SWIG parsing.
+ */
+struct __wt_cursor_details_checkpoint {
+    uint64_t checkpoint_id;
+    uint64_t stable_timestamp;
+};
+
+/*!
+ * Details specific to the given cursor type.
+ */
+struct __wt_cursor_details {
+    struct __wt_cursor_details_checkpoint checkpoint;
 };
 
 /*! WT_SESSION::timestamp_transaction_uint timestamp types */

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1706,7 +1706,7 @@ __wt_clsm_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, cons
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_clsm_close,                                /* close */
-      __wt_cursor_get_details_notsup                         /* get_details */
+      __wt_cursor_get_details_notsup                  /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_LSM *clsm;

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1706,7 +1706,7 @@ __wt_clsm_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, cons
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __wt_clsm_close,                                /* close */
-      __wt_cursor_get_details                         /* get_details */
+      __wt_cursor_get_details_notsup                         /* get_details */
     );
     WT_CURSOR *cursor;
     WT_CURSOR_LSM *clsm;

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -1705,7 +1705,9 @@ __wt_clsm_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, cons
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
-      __wt_clsm_close);                               /* close */
+      __wt_clsm_close,                                /* close */
+      __wt_cursor_get_details                         /* get_details */
+    );
     WT_CURSOR *cursor;
     WT_CURSOR_LSM *clsm;
     WT_DECL_RET;

--- a/test/cppsuite/tests/csuite_style_example_test.cpp
+++ b/test/cppsuite/tests/csuite_style_example_test.cpp
@@ -123,7 +123,6 @@ main(int argc, char *argv[])
     WT_CURSOR_DETAILS details;
     testutil_check(ckpt_cursor->get_details(ckpt_cursor, &details, nullptr));
 
-
     /* Open different cursors. */
     WT_CURSOR *insert_cursor, *read_cursor;
     testutil_check(insert_session->open_cursor(

--- a/test/cppsuite/tests/csuite_style_example_test.cpp
+++ b/test/cppsuite/tests/csuite_style_example_test.cpp
@@ -114,9 +114,18 @@ main(int argc, char *argv[])
     testutil_check(insert_session->create(
       insert_session, collection_name.c_str(), DEFAULT_FRAMEWORK_SCHEMA.c_str()));
 
+    testutil_check(insert_session->checkpoint(insert_session, nullptr));
+
+    const std::string cursor_config = "";
+    WT_CURSOR *ckpt_cursor;
+    testutil_check(insert_session->open_cursor(
+      insert_session, collection_name.c_str(), nullptr, cursor_config.c_str(), &ckpt_cursor));
+    WT_CURSOR_DETAILS details;
+    testutil_check(ckpt_cursor->get_details(ckpt_cursor, &details, nullptr));
+
+
     /* Open different cursors. */
     WT_CURSOR *insert_cursor, *read_cursor;
-    const std::string cursor_config = "";
     testutil_check(insert_session->open_cursor(
       insert_session, collection_name.c_str(), nullptr, cursor_config.c_str(), &insert_cursor));
     testutil_check(read_session->open_cursor(

--- a/test/suite/test_cursor_details01.py
+++ b/test/suite/test_cursor_details01.py
@@ -1,0 +1,21 @@
+
+import wiredtiger, wttest
+
+class test_cursor_details(wttest.WiredTigerTestCase):
+
+    def test_cursor_details(self):
+        uri = 'table:cursor_details_checkpoint'
+        internal_checkpoint_name = 'WiredTigerCheckpoint'
+        self.session.create(uri, "key_format=S,value_format=S")
+        # Need to insert data?
+        self.session.checkpoint()
+        cursor = self.session.open_cursor(uri, None, f"checkpoint={internal_checkpoint_name}")
+        # Is this the wrong cursor type?
+        details = wiredtiger.CursorDetails()
+        self.assertEqual(details.checkpoint.stable_timestamp, 0)
+        cursor.get_details(details, None)
+        self.assertNotEqual(details.checkpoint.stable_timestamp, 0)
+        cursor.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_cursor_details01.py
+++ b/test/suite/test_cursor_details01.py
@@ -1,33 +1,88 @@
 
-import time, wttest
+import time, wiredtiger, wttest
+from wtdataset import SimpleDataSet
 
 class test_cursor_details(wttest.WiredTigerTestCase):
     """
-    Check that the cursor get_details API works with a checkpoint cursor.
+    Validate basic cursor::get_details support.
     """
+
+    uri = 'table:cursor_details'
+    checkpoint_name = 'WiredTigerCheckpoint'
+    key_format = 'S'
+    value_format = 'S'
 
     def test_cursor_details(self):
 
         # Create a checkpoint.
-        uri = 'table:cursor_details_checkpoint'
-        internal_checkpoint_name = 'WiredTigerCheckpoint'
-        self.session.create(uri, "key_format=S,value_format=S")
+        self.session.create(self.uri,
+                            f'key_format={self.key_format},value_format={self.value_format}')
+
+        # Statistics cursors don't support get_details() make invoking results in
+        # ENOTSUP.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                                     lambda: self.session.open_cursor('statistics:cursor_details'),
+                                     '/unsupported object operation/')
+
+        # There is no data in the database hence the stable timestamp will not have advanced,
+        # verify it is zero.
+        self._create_checkpoint_and_check_details(0)
+
+        # Set oldest and stable timestamps to 10.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
+
+        # The stable timestamp has been forcibly advanced, and this should be
+        # reflected in the checkpoint.
+        self._create_checkpoint_and_check_details(10)
+
+        # Insert at timestamp 20.
+        ds = SimpleDataSet(
+            self, self.uri, 0, key_format=self.key_format, value_format=self.value_format)
+        ds.populate()
+        self._insert_updates(ds, 10, 'aaaaa' * 10, 20)
+
+        # Stable timestamp should be unchanged.
+        self._create_checkpoint_and_check_details(10)
+
+        # Advanced the stable timestamp again and check.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        self._create_checkpoint_and_check_details(20)
+
+    def _create_checkpoint_and_check_details(self, expected_stable_ts):
+        '''
+        Create a checkpoint with the current table and verify that the
+        stable timestamp reported by get_details() is as expected.
+        '''
+
+        wall_time_pre_checkpoint = time.time()
         self.session.checkpoint()
+        wall_time_post_checkpoint = time.time()
 
-        # Query checkpoint cursor details. This is the first and currently
-        # only cursor to support this API all other should return ENOTSUP.
-        cursor = self.session.open_cursor(uri, None, f"checkpoint={internal_checkpoint_name}")
-        ret, details = cursor.get_details(None)
-        
-        # Checkpoint cursor support this interface and there are no runtime errors.
-        self.assertEqual(ret, 0)
-        
-        # The checkpoint is the wall time the snapshot was taken.
-        self.assertGreaterEqual(details.checkpoint.checkpoint_id, time.time())
+        cursor = self.session.open_cursor(self.uri, None, f"checkpoint={self.checkpoint_name}")
+        details = cursor.get_details(None)
 
-        # There is no data in the database hence the stable timestamp will not have advanced.
-        self.assertEqual(details.checkpoint.stable_timestamp, 0)
+        # The checkpoint id happens to correspond to the wall time at some point in checkpoint
+        # creation. Use this "insider" knowledge to sythesize a test for an otherwise opaque value.
+        self.assertLessEqual(wall_time_pre_checkpoint, details.checkpoint.checkpoint_id)
+        self.assertGreaterEqual(details.checkpoint.checkpoint_id, wall_time_post_checkpoint)
 
+        self.assertEqual(details.checkpoint.stable_timestamp, expected_stable_ts)
+
+        cursor.close()
+
+    def _insert_updates(self, ds, nrows, value, ts):
+        '''
+        Insert data from specified datastore in table.
+        '''
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, nrows + 1):
+            cursor[ds.key(i)] = value
+            if i % 101 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
         cursor.close()
 
 if __name__ == '__main__':

--- a/test/suite/test_cursor_details01.py
+++ b/test/suite/test_cursor_details01.py
@@ -1,20 +1,33 @@
 
-import wiredtiger, wttest
+import time, wttest
 
 class test_cursor_details(wttest.WiredTigerTestCase):
+    """
+    Check that the cursor get_details API works with a checkpoint cursor.
+    """
 
     def test_cursor_details(self):
+
+        # Create a checkpoint.
         uri = 'table:cursor_details_checkpoint'
         internal_checkpoint_name = 'WiredTigerCheckpoint'
         self.session.create(uri, "key_format=S,value_format=S")
-        # Need to insert data?
         self.session.checkpoint()
+
+        # Query checkpoint cursor details. This is the first and currently
+        # only cursor to support this API all other should return ENOTSUP.
         cursor = self.session.open_cursor(uri, None, f"checkpoint={internal_checkpoint_name}")
-        # Is this the wrong cursor type?
-        details = wiredtiger.CursorDetails()
+        ret, details = cursor.get_details(None)
+        
+        # Checkpoint cursor support this interface and there are no runtime errors.
+        self.assertEqual(ret, 0)
+        
+        # The checkpoint is the wall time the snapshot was taken.
+        self.assertGreaterEqual(details.checkpoint.checkpoint_id, time.time())
+
+        # There is no data in the database hence the stable timestamp will not have advanced.
         self.assertEqual(details.checkpoint.stable_timestamp, 0)
-        cursor.get_details(details, None)
-        self.assertNotEqual(details.checkpoint.stable_timestamp, 0)
+
         cursor.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
This also encompasses creating a more general interface for querying cursors for detailed information.