### PR TITLE
WT-11864 Disable python chunkcache tests on macos

### DIFF
--- a/test/suite/test_chunkcache01.py
+++ b/test/suite/test_chunkcache01.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys, wiredtiger, wttest
+import os, sys, platform, wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -67,6 +67,10 @@ class test_chunkcache01(wttest.WiredTigerTestCase):
         extlist.extension('storage_sources', 'dir_store')
 
     def test_chunkcache(self):
+
+        if platform.system() == 'Darwin':
+            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
+
         ds = SimpleDataSet(self, self.uri, 10, key_format=self.key_format, value_format=self.value_format)
         ds.populate()
         ds.check()

--- a/test/suite/test_chunkcache02.py
+++ b/test/suite/test_chunkcache02.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys
+import os, sys, platform
 import random
 import threading
 import time
@@ -86,6 +86,10 @@ class test_chunkcache02(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.get_value(), str(key) * self.rows)
 
     def test_chunkcache02(self):
+
+        if platform.system() == 'Darwin':
+            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
+
         ds = SimpleDataSet(
             self, self.uri, 0, key_format=self.key_format, value_format=self.value_format)
         ds.populate()

--- a/test/suite/test_chunkcache03.py
+++ b/test/suite/test_chunkcache03.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys
+import os, sys, platform
 import wiredtiger, wttest
 
 from wtdataset import SimpleDataSet
@@ -86,6 +86,10 @@ class test_chunkcache03(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.get_value(), str(i) * 100)
 
     def test_chunkcache03(self):
+
+        if platform.system() == 'Darwin':
+            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
+
         uris = self.pinned_uris + ["table:chunkcache03", "table:chunkcache04"]
         ds = [SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format) for uri in uris]
 

--- a/test/suite/test_chunkcache04.py
+++ b/test/suite/test_chunkcache04.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys
+import os, sys, platform
 import wiredtiger, wttest
 
 from wtdataset import SimpleDataSet
@@ -79,6 +79,10 @@ class test_chunkcache4(wttest.WiredTigerTestCase):
             cursor[ds.key(i)] = str(i) * 100
 
     def test_chunkcache04(self):
+
+        if platform.system() == 'Darwin':
+            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
+
         uris = ["table:chunkcache03", "table:chunkcache04"]
         ds = [SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format) for uri in uris]
 


### PR DESCRIPTION
We have an uninitialised spinlock on macos for the python chunkcache tests. Disable them to be fixed in WT-11865