### PR TITLE
WT-11865 Initialise and teardown chunk cache metadata lock

### DIFF
--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -52,6 +52,7 @@ __wt_connection_init(WT_CONNECTION_IMPL *conn)
     WT_RET(__wt_spin_init(session, &conn->api_lock, "api"));
     WT_SPIN_INIT_TRACKED(session, &conn->checkpoint_lock, checkpoint);
     WT_RET(__wt_spin_init(session, &conn->background_compact.lock, "background compact"));
+    WT_RET(__wt_spin_init(session, &conn->chunkcache_metadata_lock, "chunkcache metadata"));
     WT_RET(__wt_spin_init(session, &conn->encryptor_lock, "encryptor"));
     WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
     WT_RET(__wt_spin_init(session, &conn->flush_tier_lock, "flush tier"));
@@ -120,6 +121,7 @@ __wt_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_spin_destroy(session, &conn->background_compact.lock);
     __wt_spin_destroy(session, &conn->block_lock);
     __wt_spin_destroy(session, &conn->checkpoint_lock);
+    __wt_spin_destroy(session, &conn->chunkcache_metadata_lock);
     __wt_rwlock_destroy(session, &conn->debug_log_retention_lock);
     __wt_rwlock_destroy(session, &conn->dhandle_lock);
     __wt_spin_destroy(session, &conn->encryptor_lock);

--- a/test/suite/test_chunkcache01.py
+++ b/test/suite/test_chunkcache01.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys, platform, wiredtiger, wttest
+import os, sys, wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -67,10 +67,6 @@ class test_chunkcache01(wttest.WiredTigerTestCase):
         extlist.extension('storage_sources', 'dir_store')
 
     def test_chunkcache(self):
-
-        if platform.system() == 'Darwin':
-            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
-
         ds = SimpleDataSet(self, self.uri, 10, key_format=self.key_format, value_format=self.value_format)
         ds.populate()
         ds.check()
@@ -78,7 +74,7 @@ class test_chunkcache01(wttest.WiredTigerTestCase):
         self.session.checkpoint('flush_tier=(enabled)')
         ds.check()
 
-        # Assert the new chunks are ingested. 
+        # Assert the new chunks are ingested.
         self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables), 0)
 
         self.close_conn()

--- a/test/suite/test_chunkcache02.py
+++ b/test/suite/test_chunkcache02.py
@@ -26,8 +26,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys, platform
+import os
 import random
+import sys
 import threading
 import time
 import wiredtiger, wttest
@@ -86,10 +87,6 @@ class test_chunkcache02(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.get_value(), str(key) * self.rows)
 
     def test_chunkcache02(self):
-
-        if platform.system() == 'Darwin':
-            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
-
         ds = SimpleDataSet(
             self, self.uri, 0, key_format=self.key_format, value_format=self.value_format)
         ds.populate()
@@ -102,7 +99,7 @@ class test_chunkcache02(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         self.session.checkpoint('flush_tier=(enabled)')
 
-        # Assert the new chunks are ingested. 
+        # Assert the new chunks are ingested.
         self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables), 0)
 
         # Reopen wiredtiger to migrate all data to disk.

--- a/test/suite/test_chunkcache03.py
+++ b/test/suite/test_chunkcache03.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys, platform
+import os, sys
 import wiredtiger, wttest
 
 from wtdataset import SimpleDataSet
@@ -86,10 +86,6 @@ class test_chunkcache03(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.get_value(), str(i) * 100)
 
     def test_chunkcache03(self):
-
-        if platform.system() == 'Darwin':
-            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
-
         uris = self.pinned_uris + ["table:chunkcache03", "table:chunkcache04"]
         ds = [SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format) for uri in uris]
 
@@ -101,7 +97,7 @@ class test_chunkcache03(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         self.session.checkpoint('flush_tier=(enabled)')
 
-        # Assert the new chunks are ingested. 
+        # Assert the new chunks are ingested.
         self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables), 0)
 
         # Reopen wiredtiger to migrate all data to disk.

--- a/test/suite/test_chunkcache04.py
+++ b/test/suite/test_chunkcache04.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys, platform
+import os, sys
 import wiredtiger, wttest
 
 from wtdataset import SimpleDataSet
@@ -34,7 +34,7 @@ from wtscenario import make_scenarios
 
 '''
 - Functional testing for the ingesting. Verify ingests are taking place with both pinned and unpinned chunks.
-- Verify that when ingesting new chunks with old pinned objects, we are releasing the pin on the old objects. 
+- Verify that when ingesting new chunks with old pinned objects, we are releasing the pin on the old objects.
 '''
 class test_chunkcache4(wttest.WiredTigerTestCase):
     rows = 10000
@@ -48,7 +48,7 @@ class test_chunkcache4(wttest.WiredTigerTestCase):
     if sys.byteorder == 'little':
         # WT's filesystem layer doesn't support mmap on big-endian platforms.
         cache_types.append(('on-disk', dict(chunk_cache_type='FILE')))
-    
+
     pinned_uris = ["table:chunkcache01", "table:chunkcache02"]
 
     scenarios = make_scenarios(format_values, cache_types)
@@ -79,32 +79,28 @@ class test_chunkcache4(wttest.WiredTigerTestCase):
             cursor[ds.key(i)] = str(i) * 100
 
     def test_chunkcache04(self):
-
-        if platform.system() == 'Darwin':
-            self.skipTest("FIXME-WT-11865 - Uninitialised lock on macos")
-
         uris = ["table:chunkcache03", "table:chunkcache04"]
         ds = [SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format) for uri in uris]
 
-        # Insert unpinned data into two tables. 
+        # Insert unpinned data into two tables.
         for i, dataset in enumerate(ds):
             dataset.populate()
             self.insert(uris[i], dataset)
 
-        # As we have not flushed yet, assert we have no newly inserted chunks. 
+        # As we have not flushed yet, assert we have no newly inserted chunks.
         self.assertEqual(self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables), 0)
-        
-        # Flush the unpinned tables into the chunkcache 
+
+        # Flush the unpinned tables into the chunkcache
         self.session.checkpoint()
         self.session.checkpoint('flush_tier=(enabled)')
 
-        # Assert that chunks are not pinned. 
+        # Assert that chunks are not pinned.
         self.assertEqual(self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_pinned), 0)
 
-        # Assert the new chunks are ingested. 
+        # Assert the new chunks are ingested.
         first_ingest = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables)
         self.assertGreater(first_ingest, 0)
-        
+
         ds2 = [SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format) for uri in self.pinned_uris]
 
         # Insert pinned data into two tables.
@@ -112,7 +108,7 @@ class test_chunkcache4(wttest.WiredTigerTestCase):
             dataset.populate()
             self.insert(self.pinned_uris[i], dataset)
 
-        # Flush the pinned tables into the chunkcache 
+        # Flush the pinned tables into the chunkcache
         self.session.checkpoint()
         self.session.checkpoint('flush_tier=(enabled)')
 
@@ -124,17 +120,17 @@ class test_chunkcache4(wttest.WiredTigerTestCase):
         old_pinned = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_pinned)
         self.assertGreater(old_pinned, 0)
 
-        # Modify the tables content so flush has work to do.  
+        # Modify the tables content so flush has work to do.
         cursor = self.session.open_cursor(self.pinned_uris[0])
         cursor[ds2[0].key(1)] = 'foo'
         cursor1 = self.session.open_cursor(self.pinned_uris[1])
         cursor1[ds2[1].key(2)] = 'bar'
 
-        # Flush the pinned tables into the chunkcache 
+        # Flush the pinned tables into the chunkcache
         self.session.checkpoint()
         self.session.checkpoint('flush_tier=(enabled)')
 
-        # Assert another set of ingests took place. 
+        # Assert another set of ingests took place.
         total_ingest = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables)
         self.assertGreater(total_ingest, second_ingest)
 


### PR DESCRIPTION
Not sure how this managed to get as far as it did last time around, but oh well. Did a macOS patch build, it's all green now.