### PR TITLE
WT-11873 Add stat if capacity exceeded bitmap

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -416,6 +416,7 @@ conn_stats = [
     ChunkCacheStat('chunkcache_chunks_loaded_from_flushed_tables', 'number of chunks loaded from flushed tables in chunk cache'),
     ChunkCacheStat('chunkcache_chunks_pinned', 'total pinned chunks held by the chunk cache'),
     ChunkCacheStat('chunkcache_created_from_metadata', 'total number of chunks inserted on startup from persisted metadata.'),
+    ChunkCacheStat('chunkcache_exceeded_bitmap_capacity', 'could not allocate due to exceeding bitmap capacity'),
     ChunkCacheStat('chunkcache_exceeded_capacity', 'could not allocate due to exceeding capacity'),
     ChunkCacheStat('chunkcache_io_failed', 'number of times a read from storage failed'),
     ChunkCacheStat('chunkcache_lookups', 'lookups'),

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -288,6 +288,7 @@ static int
 __chunkcache_memory_alloc(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
 {
     WT_CHUNKCACHE *chunkcache;
+    WT_DECL_RET;
     size_t bit_index;
 
     chunkcache = &S2C(session)->chunkcache;
@@ -296,7 +297,15 @@ __chunkcache_memory_alloc(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
     if (chunkcache->type == WT_CHUNKCACHE_IN_VOLATILE_MEMORY)
         WT_RET(__wt_malloc(session, chunk->chunk_size, &chunk->chunk_memory));
     else {
-        WT_RET(__chunkcache_bitmap_alloc(session, &bit_index));
+        if ((ret = __chunkcache_bitmap_alloc(session, &bit_index)) == ENOSPC) {
+            WT_STAT_CONN_INCR(session, chunkcache_exceeded_bitmap_capacity);
+            __wt_verbose(session, WT_VERB_CHUNKCACHE,
+              "chunkcache bitmap exceeded capacity of %" PRIu64
+              " bytes "
+              "with %" PRIu64 " bytes in use and the chunk size of %" PRIu64 " bytes",
+              chunkcache->capacity, chunkcache->bytes_used, (uint64_t)chunk->chunk_size);
+            goto err;
+        }
 
         /* Allocate the free memory in the chunk cache. */
         chunk->chunk_memory = chunkcache->memory + chunkcache->chunk_size * bit_index;
@@ -304,30 +313,31 @@ __chunkcache_memory_alloc(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
 
     __insert_update_stats(session, chunk);
 
-    return (0);
+err:
+    return (ret);
 }
 
 /*
- * __chunkcache_admit_size --
+ * __chunkcache_can_admit_new_chunk --
  *     Decide if we can admit the chunk given the limit on cache capacity.
  */
-static size_t
-__chunkcache_admit_size(WT_SESSION_IMPL *session)
+static bool
+__chunkcache_can_admit_new_chunk(WT_SESSION_IMPL *session, size_t chunk_size)
 {
     WT_CHUNKCACHE *chunkcache;
 
     chunkcache = &S2C(session)->chunkcache;
 
-    if ((chunkcache->bytes_used + chunkcache->chunk_size) < chunkcache->capacity)
-        return (chunkcache->chunk_size);
+    if ((chunkcache->bytes_used + chunk_size) < chunkcache->capacity)
+        return (true);
 
     WT_STAT_CONN_INCR(session, chunkcache_exceeded_capacity);
     __wt_verbose(session, WT_VERB_CHUNKCACHE,
       "chunkcache exceeded capacity of %" PRIu64
       " bytes "
       "with %" PRIu64 " bytes in use and the chunk size of %" PRIu64 " bytes",
-      chunkcache->capacity, chunkcache->bytes_used, (uint64_t)chunkcache->chunk_size);
-    return (0);
+      chunkcache->capacity, chunkcache->bytes_used, (uint64_t)chunk_size);
+    return (false);
 }
 
 /*
@@ -338,9 +348,7 @@ static int
 __create_and_populate_chunk(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK **newchunk,
   wt_off_t chunk_offset, size_t chunk_size, WT_CHUNKCACHE_HASHID *hash_id, uint64_t bucket)
 {
-    size_t admit_size;
-
-    if ((admit_size = __chunkcache_admit_size(session)) == 0)
+    if (!__chunkcache_can_admit_new_chunk(session, chunk_size))
         return (ENOSPC);
     WT_RET(__wt_calloc(session, 1, sizeof(WT_CHUNKCACHE_CHUNK), newchunk));
 

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -304,8 +304,8 @@ __chunkcache_memory_alloc(WT_SESSION_IMPL *session, WT_CHUNKCACHE_CHUNK *chunk)
               " bytes "
               "with %" PRIu64 " bytes in use and the chunk size of %" PRIu64 " bytes",
               chunkcache->capacity, chunkcache->bytes_used, (uint64_t)chunk->chunk_size);
-            goto err;
         }
+        WT_ERR(ret);
 
         /* Allocate the free memory in the chunk cache. */
         chunk->chunk_memory = chunkcache->memory + chunkcache->chunk_size * bit_index;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -613,6 +613,7 @@ struct __wt_connection_stats {
     int64_t checkpoint_wait_reduce_dirty;
     int64_t chunkcache_spans_chunks_read;
     int64_t chunkcache_chunks_evicted;
+    int64_t chunkcache_exceeded_bitmap_capacity;
     int64_t chunkcache_exceeded_capacity;
     int64_t chunkcache_lookups;
     int64_t chunkcache_chunks_loaded_from_flushed_tables;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6028,893 +6028,895 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1271
 /*! chunk-cache: chunks evicted */
 #define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1272
+/*! chunk-cache: could not allocate due to exceeding bitmap capacity */
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1273
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1273
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1274
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1274
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1275
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1275
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1276
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1276
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1277
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1277
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1278
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1278
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1279
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1279
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1280
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1280
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1281
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1281
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1282
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1282
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1283
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1283
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1284
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1284
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1285
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1285
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1286
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1286
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1287
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1287
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1288
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1288
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1289
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1289
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1290
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1290
+#define	WT_STAT_CONN_TIME_TRAVEL			1291
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1291
+#define	WT_STAT_CONN_FILE_OPEN				1292
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1292
+#define	WT_STAT_CONN_BUCKETS_DH				1293
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1293
+#define	WT_STAT_CONN_BUCKETS				1294
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1294
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1295
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1295
+#define	WT_STAT_CONN_MEMORY_FREE			1296
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1296
+#define	WT_STAT_CONN_MEMORY_GROW			1297
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1297
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1298
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1298
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1299
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1299
+#define	WT_STAT_CONN_COND_WAIT				1300
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1300
+#define	WT_STAT_CONN_RWLOCK_READ			1301
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1301
+#define	WT_STAT_CONN_RWLOCK_WRITE			1302
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1302
+#define	WT_STAT_CONN_FSYNC_IO				1303
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1303
+#define	WT_STAT_CONN_READ_IO				1304
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1304
+#define	WT_STAT_CONN_WRITE_IO				1305
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1305
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1306
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1306
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1307
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1307
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1308
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1308
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1309
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1309
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1310
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1310
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1311
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1311
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1312
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1312
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1313
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1313
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1314
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1314
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1315
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1315
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1316
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1316
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1317
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1317
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1318
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1318
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1319
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1319
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1320
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1320
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1321
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1321
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1322
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1322
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1323
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1323
+#define	WT_STAT_CONN_CURSOR_CACHE			1324
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1324
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1325
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1325
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1326
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1326
+#define	WT_STAT_CONN_CURSOR_CREATE			1327
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1327
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1328
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1328
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1329
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1329
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1330
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1330
+#define	WT_STAT_CONN_CURSOR_INSERT			1331
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1331
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1332
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1332
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1333
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1333
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1334
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1334
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1335
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1335
+#define	WT_STAT_CONN_CURSOR_MODIFY			1336
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1336
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1337
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1337
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1338
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1338
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1339
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1339
+#define	WT_STAT_CONN_CURSOR_NEXT			1340
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1340
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1341
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1341
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1342
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1342
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1343
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1343
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1344
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1344
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1345
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1345
+#define	WT_STAT_CONN_CURSOR_RESTART			1346
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1346
+#define	WT_STAT_CONN_CURSOR_PREV			1347
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1347
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1348
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1348
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1349
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1349
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1350
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1350
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1351
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1351
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1352
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1352
+#define	WT_STAT_CONN_CURSOR_REMOVE			1353
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1353
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1354
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1354
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1355
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1355
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1356
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1356
+#define	WT_STAT_CONN_CURSOR_RESERVE			1357
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1357
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1358
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1358
+#define	WT_STAT_CONN_CURSOR_RESET			1359
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1359
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1360
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1360
+#define	WT_STAT_CONN_CURSOR_SEARCH			1361
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1361
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1362
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1362
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1363
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1363
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1364
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1364
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1365
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1365
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1366
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1366
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1367
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1367
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1368
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1368
+#define	WT_STAT_CONN_CURSOR_SWEEP			1369
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1369
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1370
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1370
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1371
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1371
+#define	WT_STAT_CONN_CURSOR_UPDATE			1372
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1372
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1373
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1373
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1374
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1374
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1375
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1375
+#define	WT_STAT_CONN_CURSOR_REOPEN			1376
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1376
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1377
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1377
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1378
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1378
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1379
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1379
+#define	WT_STAT_CONN_DH_SWEEP_REF			1380
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1380
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1381
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1381
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1382
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1382
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1383
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1383
+#define	WT_STAT_CONN_DH_SWEEPS				1384
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1384
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1385
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1385
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1386
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1386
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1387
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1387
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1388
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1388
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1389
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1389
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1390
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1390
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1391
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1391
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1392
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1392
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1393
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1393
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1394
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1394
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1395
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1395
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1396
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1396
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1397
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1397
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1398
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1398
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1399
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1399
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1400
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1400
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1401
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1401
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1402
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1402
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1403
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1403
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1404
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1404
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1405
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1405
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1406
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1406
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1407
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1407
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1408
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1408
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1409
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1409
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1410
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1410
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1411
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1411
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1412
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1412
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1413
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1413
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1414
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1414
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1415
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1415
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1416
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1416
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1417
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1417
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1418
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1418
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1419
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1419
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1420
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1420
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1421
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1421
+#define	WT_STAT_CONN_LOG_FLUSH				1422
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1422
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1423
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1423
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1424
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1424
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1425
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1425
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1426
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1426
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1427
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1427
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1428
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1428
+#define	WT_STAT_CONN_LOG_SCANS				1429
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1429
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1430
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1430
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1431
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1431
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1432
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1432
+#define	WT_STAT_CONN_LOG_SYNC				1433
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1433
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1434
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1434
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1435
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1435
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1436
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1436
+#define	WT_STAT_CONN_LOG_WRITES				1437
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1437
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1438
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1438
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1439
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1439
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1440
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1440
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1441
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1441
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1442
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1442
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1443
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1443
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1444
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1444
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1445
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1445
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1446
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1446
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1447
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1447
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1448
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1448
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1449
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1449
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1450
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1450
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1451
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1451
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1452
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1452
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1453
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1453
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1454
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1454
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1455
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1455
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1456
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1456
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1457
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1457
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1458
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1458
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1459
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1459
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1460
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1460
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1461
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1461
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1462
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1462
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1463
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1463
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1464
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1464
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1465
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1465
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1466
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1466
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1467
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1467
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1468
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1468
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1469
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1469
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1470
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1470
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1471
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1471
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1472
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1472
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1473
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1473
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1474
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1474
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1475
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1475
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1476
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1476
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1477
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1477
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1478
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1478
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1479
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1479
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1480
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1480
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1481
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1481
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1482
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1482
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1483
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1483
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1484
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1484
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1485
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1485
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1486
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1486
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1487
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1487
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1488
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1488
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1489
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1489
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1490
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1490
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1491
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1491
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1492
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1492
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1493
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1493
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1494
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1494
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1495
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1495
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1496
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1496
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1497
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1497
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1498
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1498
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1499
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1499
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1500
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1500
+#define	WT_STAT_CONN_REC_PAGES				1501
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1501
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1502
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1502
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1503
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1503
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1504
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1504
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1505
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1505
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1506
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1506
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1507
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1507
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1508
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1508
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1509
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1509
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1510
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1510
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1511
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1511
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1512
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1512
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1513
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1513
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1514
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1514
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1515
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1515
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1516
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1516
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1517
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1517
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1518
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1518
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1519
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1519
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1520
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1520
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1521
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1521
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1522
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1522
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1523
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1523
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1524
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1524
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1525
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1525
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1526
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1526
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1527
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1527
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1528
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1528
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1529
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1529
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1530
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1530
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1531
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1531
+#define	WT_STAT_CONN_FLUSH_TIER				1532
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1532
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1533
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1533
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1534
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1534
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1535
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1535
+#define	WT_STAT_CONN_SESSION_OPEN			1536
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1536
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1537
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1537
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1538
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1538
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1539
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1539
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1540
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1540
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1541
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1541
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1542
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1542
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1543
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1543
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1544
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1544
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1545
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1545
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1546
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1546
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1547
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1547
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1548
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1548
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1549
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1549
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1550
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1550
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1551
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1551
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1552
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1552
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1553
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1553
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1554
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1554
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1555
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1555
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1556
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1556
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1557
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1557
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1558
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1558
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1559
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1559
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1560
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1560
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1561
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1561
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1562
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1562
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1563
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1563
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1564
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1564
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1565
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1565
+#define	WT_STAT_CONN_TIERED_RETENTION			1566
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1566
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1567
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1567
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1568
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1568
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1569
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1569
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1570
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1570
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1571
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1571
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1572
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1572
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1573
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1573
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1574
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1574
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1575
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1575
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1576
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1576
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1577
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1577
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1578
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1578
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1579
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1579
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1580
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1580
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1581
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1581
+#define	WT_STAT_CONN_PAGE_SLEEP				1582
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1582
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1583
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1583
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1584
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1584
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1585
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1585
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1586
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1586
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1587
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1587
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1588
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1588
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1589
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1589
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1590
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1590
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1591
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1591
+#define	WT_STAT_CONN_TXN_PREPARE			1592
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1592
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1593
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1593
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1594
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1594
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1595
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1595
+#define	WT_STAT_CONN_TXN_QUERY_TS			1596
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1596
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1597
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1597
+#define	WT_STAT_CONN_TXN_RTS				1598
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1598
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1599
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1599
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1600
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1600
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1601
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1601
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1602
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1602
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1603
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1603
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1604
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1604
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1605
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1605
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1606
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1606
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1607
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1607
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1608
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1608
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1609
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1609
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1610
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1610
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1611
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1611
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1612
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1612
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1613
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1613
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1614
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1614
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1615
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1615
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1616
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1616
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1617
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1617
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1618
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1618
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1619
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1619
+#define	WT_STAT_CONN_TXN_SET_TS				1620
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1620
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1621
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1621
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1622
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1622
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1623
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1623
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1624
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1624
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1625
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1625
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1626
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1626
+#define	WT_STAT_CONN_TXN_BEGIN				1627
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1627
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1628
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1628
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1629
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1629
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1630
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1630
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1631
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1631
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1632
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1632
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1633
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1633
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1634
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1634
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1635
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1635
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1636
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1636
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1637
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1637
+#define	WT_STAT_CONN_TXN_COMMIT				1638
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1638
+#define	WT_STAT_CONN_TXN_ROLLBACK			1639
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1639
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1640
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1572,6 +1572,7 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint: wait cycles while cache dirty level is decreasing",
   "chunk-cache: aggregate number of spanned chunks on read",
   "chunk-cache: chunks evicted",
+  "chunk-cache: could not allocate due to exceeding bitmap capacity",
   "chunk-cache: could not allocate due to exceeding capacity",
   "chunk-cache: lookups",
   "chunk-cache: number of chunks loaded from flushed tables in chunk cache",
@@ -2261,6 +2262,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->checkpoint_wait_reduce_dirty = 0;
     stats->chunkcache_spans_chunks_read = 0;
     stats->chunkcache_chunks_evicted = 0;
+    stats->chunkcache_exceeded_bitmap_capacity = 0;
     stats->chunkcache_exceeded_capacity = 0;
     stats->chunkcache_lookups = 0;
     stats->chunkcache_chunks_loaded_from_flushed_tables = 0;
@@ -2961,6 +2963,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->checkpoint_wait_reduce_dirty += WT_STAT_READ(from, checkpoint_wait_reduce_dirty);
     to->chunkcache_spans_chunks_read += WT_STAT_READ(from, chunkcache_spans_chunks_read);
     to->chunkcache_chunks_evicted += WT_STAT_READ(from, chunkcache_chunks_evicted);
+    to->chunkcache_exceeded_bitmap_capacity +=
+      WT_STAT_READ(from, chunkcache_exceeded_bitmap_capacity);
     to->chunkcache_exceeded_capacity += WT_STAT_READ(from, chunkcache_exceeded_capacity);
     to->chunkcache_lookups += WT_STAT_READ(from, chunkcache_lookups);
     to->chunkcache_chunks_loaded_from_flushed_tables +=


### PR DESCRIPTION
This solution differs from what was initially mentioned in the ticket.

My rationale for this is that in the case of DRAM, we should not limit the behavior by requiring chunk sizes to be multiples of the capacity. This also adds extra complexity to the code.

Additionally, for the FILE case, it should be clear that the inability to allocate more chunks is not due to exceeding the capacity in bytes. Instead, it results from using a configuration with a significantly larger chunk size, which reduces the total number of pre-calculated chunks that can fit into the chunkcache's bitmap. 

Therefore, including a stat in the same location could be useful for future diagnosis.