### PR TITLE
WT-11806 Replace shared variables in API macro code with a lock, clean up function arguments

### DIFF
--- a/src/include/api.h
+++ b/src/include/api.h
@@ -18,8 +18,15 @@
         __wt_thread_id(&__tmp_api_tid);                                           \
                                                                                   \
         /*                                                                        \
-         * Don't attempt take the lock if this is the default session             \
-         * (ID == 0), or if we already hold the lock.                             \
+         * Only a single thread should use this session at a time. It's ok        \
+         * (but unexpected) if different threads use the session consecutively,   \
+         * but concurrent access is not allowed. Verify this by having the thread \
+         * a lock on first API access. Failing to take the lock implies another   \
+         * thread holds it and we're attempting concurrent access of the session. \
+         *                                                                        \
+         * The default session (ID == 0) is an exception where concurrent access  \
+         * is allowed. We can also skip taking the lock if we're re-entrant and   \
+         * already hold it.                                                       \
          */                                                                       \
         if ((s)->id != 0 && (s)->thread_check.owning_thread != __tmp_api_tid) {   \
             WT_ASSERT((s), __wt_spin_trylock((s), &(s)->thread_check.lock) == 0); \

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -21,8 +21,9 @@
          * Only a single thread should use this session at a time. It's ok        \
          * (but unexpected) if different threads use the session consecutively,   \
          * but concurrent access is not allowed. Verify this by having the thread \
-         * a lock on first API access. Failing to take the lock implies another   \
-         * thread holds it and we're attempting concurrent access of the session. \
+         * take a lock on first API access. Failing to take the lock implies      \
+         * another thread holds it and we're attempting concurrent access of the  \
+         * session.                                                               \
          *                                                                        \
          * The default session (ID == 0) is an exception where concurrent access  \
          * is allowed. We can also skip taking the lock if we're re-entrant and   \

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -159,12 +159,14 @@ struct __wt_session_impl {
     u_int scratch_alloc;   /* Currently allocated */
     size_t scratch_cached; /* Scratch bytes cached */
 #ifdef HAVE_DIAGNOSTIC
-    /*
-     * Variables used to look for violations of the contract that a session is only used by a single
-     * session at once.
-     */
-    wt_shared volatile uintmax_t api_tid;
-    wt_shared volatile uint32_t api_enter_refcnt;
+
+    /* Enforce the contract that a session is only used by a single thread at a time. */
+    struct __wt_thread_check {
+        WT_SPINLOCK lock;
+        uintmax_t owning_thread;
+        uint32_t entry_count;
+    } thread_check;
+
     /*
      * It's hard to figure out from where a buffer was allocated after it's leaked, so in diagnostic
      * mode we track them; DIAGNOSTIC can't simply add additional fields to WT_ITEM structures

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -375,6 +375,8 @@ struct __wt_table;
 typedef struct __wt_table WT_TABLE;
 struct __wt_thread;
 typedef struct __wt_thread WT_THREAD;
+struct __wt_thread_check;
+typedef struct __wt_thread_check WT_THREAD_CHECK;
 struct __wt_thread_group;
 typedef struct __wt_thread_group WT_THREAD_GROUP;
 struct __wt_tiered;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -396,6 +396,10 @@ __wt_session_close_internal(WT_SESSION_IMPL *session)
     /* Decrement the count of open sessions. */
     WT_STAT_CONN_DECR(session, session_open);
 
+#ifdef HAVE_DIAGNOSTIC
+    __wt_spin_destroy(session, &session->thread_check.lock);
+#endif
+
     /*
      * Sessions are re-used, clear the structure: the clear sets the active field to 0, which will
      * exclude the hazard array from review by the eviction thread. Because some session fields are
@@ -2539,6 +2543,10 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     memset(session->unittest_assert_msg, 0, WT_SESSION_UNITTEST_BUF_LEN);
 #endif
 
+#ifdef HAVE_DIAGNOSTIC
+    WT_ERR(__wt_spin_init(session, &session_ret->thread_check.lock, "thread check lock"));
+#endif
+
     /*
      * Initialize the pseudo random number generator. We're not seeding it, so all of the sessions
      * initialize to the same value and proceed in lock step for the session's life. That's not a
@@ -2628,6 +2636,9 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     WT_STAT_CONN_INCR(session, session_open);
 
 err:
+#ifdef HAVE_DIAGNOSTIC
+    __wt_spin_destroy(session, &session->thread_check.lock);
+#endif
     __wt_spin_unlock(session, &conn->api_lock);
     return (ret);
 }


### PR DESCRIPTION
Code improvements as identified by the PM-3221 code review of the API macros. 
Three changes here:
1. Remove the use of barriers and instead use a lock. This code only runs in diagnostic mode so any possible slowdowns are low impact
2. With the addition of the lock, move the three related variables into a `__wt_thread_check` struct for cleanliness
3. Expand the single letter variables used in our macros to words that describe the fields. The changes were `h -> struct_name` and `n -> func_name`. I've left `s` and `dh` alone as they're commonly used to represent session and dhandle in the codebase.