### PR TITLE
WT-11778 Restricting dirty eviction to sessions with snapshot isolation and of metadata pages

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -734,10 +734,6 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
     if (F_ISSET(conn, WT_CONN_IN_MEMORY) && !modified && !closing)
         return (__wt_set_return(session, EBUSY));
 
-    /* Check the current session has the correct isolation level for dirty content. */
-    if (modified && session->txn->isolation != WT_ISO_SNAPSHOT)
-        return (__wt_set_return(session, EBUSY));
-
     /* Check if the page can be evicted. */
     if (!closing) {
         /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -734,6 +734,10 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
     if (F_ISSET(conn, WT_CONN_IN_MEMORY) && !modified && !closing)
         return (__wt_set_return(session, EBUSY));
 
+    /* Check the current session has the correct isolation level for dirty content. */
+    if (modified && session->txn->isolation != WT_ISO_SNAPSHOT)
+        return (__wt_set_return(session, EBUSY));
+
     /* Check if the page can be evicted. */
     if (!closing) {
         /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -531,6 +531,10 @@ __rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *first_upd
         if ((txnid = upd->txnid) == WT_TXN_ABORTED)
             continue;
 
+        /* Give up if the update is from this transaction and on the metadata file.*/
+        if (WT_IS_METADATA(session->dhandle) && txnid == session_txnid)
+            return (__wt_set_return(session, EBUSY));
+
         /*
          * Track the first update in the chain that is not aborted and the maximum transaction ID.
          */


### PR DESCRIPTION
WT-11778 Restricting eviction of metadata pages by threads that have active updates on them. Restricting dirty eviction to sessions with snapshot isolation.