### PR TITLE
session_max reconfig surport, this can helop us to adjust the number of connections dynamically 

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -774,6 +774,9 @@ connection_runtime_config = [
                 directory must already exist. If the value is not an absolute path, the path
                 is relative to the database home (see @ref absolute_path for more information)'''),
         ]),
+    Config('session_max', '100', r'''
+	maximum expected number of sessions (including server threads)''',
+	min='1'),
     Config('shared_cache', '', r'''
         shared cache configuration options. A database should configure either a cache_size
         or a shared_cache not both. Enabling a shared cache uses a session from the configured
@@ -1251,9 +1254,6 @@ wiredtiger_open_common =\
         Salvage rebuilds files in place, overwriting existing files. We recommend making a
         backup copy of all files with the WiredTiger prefix prior to passing this flag.''',
         type='boolean'),
-    Config('session_max', '100', r'''
-        maximum expected number of sessions (including server threads)''',
-        min='1'),
     Config('session_scratch_max', '2MB', r'''
         maximum memory to cache in each session''',
         type='int', undoc=True),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -494,6 +494,8 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
     confchk_wiredtiger_open_operation_tracking_subconfigs, 2,
     confchk_wiredtiger_open_operation_tracking_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     INT64_MIN, INT64_MAX, NULL},
+  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 1, INT64_MAX,
+    NULL},
   {"shared_cache", "category", NULL, NULL, confchk_wiredtiger_open_shared_cache_subconfigs, 5,
     confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     INT64_MIN, INT64_MAX, NULL},
@@ -543,8 +545,8 @@ static const uint8_t confchk_WT_CONNECTION_reconfigure_jump[WT_CONFIG_JUMP_TABLE
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 9,
-  10, 20, 21, 22, 23, 24, 25, 25, 27, 27, 27, 29, 29, 29, 29, 32, 34, 34, 35, 35, 35, 35, 35, 35,
-  35, 35, 35};
+  10, 20, 21, 22, 23, 24, 25, 25, 27, 27, 27, 29, 29, 29, 29, 33, 35, 35, 36, 36, 36, 36, 36, 36,
+  36, 36, 36};
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_rollback_to_stable[] = {
   {"dryrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, INT64_MIN,
@@ -3316,12 +3318,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "os_cache_dirty_pct=0,prealloc=true,remove=true,zero_fill=false),"
     "lsm_manager=(merge=true,worker_thread_max=4),"
     "operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),shared_cache=(chunk=10MB,name=,quota=0,reserve=0,"
-    "size=500MB),statistics=none,statistics_log=(json=false,"
-    "on_close=false,sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+    "path=\".\"),session_max=100,shared_cache=(chunk=10MB,name=,"
+    "quota=0,reserve=0,size=500MB),statistics=none,"
+    "statistics_log=(json=false,on_close=false,sources=,"
+    "timestamp=\"%b %d %H:%M:%S\",wait=0),"
     "tiered_storage=(local_retention=300),timing_stress_for_test=,"
     "verbose=[]",
-    confchk_WT_CONNECTION_reconfigure, 35, confchk_WT_CONNECTION_reconfigure_jump},
+    confchk_WT_CONNECTION_reconfigure, 36, confchk_WT_CONNECTION_reconfigure_jump},
   {"WT_CONNECTION.rollback_to_stable", "dryrun=false", confchk_WT_CONNECTION_rollback_to_stable, 1,
     confchk_WT_CONNECTION_rollback_to_stable_jump},
   {"WT_CONNECTION.set_file_system", "", NULL, 0, NULL},

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2402,6 +2402,8 @@ struct __wt_connection {
      * If the value is not an absolute path\, the path is relative to the database home (see @ref
      * absolute_path for more information)., a string; default \c ".".}
      * @config{ ),,}
+     * @config{session_max, maximum expected number of sessions (including server threads)., an
+     * integer greater than or equal to \c 1; default \c 100.}
      * @config{shared_cache = (, shared cache configuration options.  A database should configure
      * either a cache_size or a shared_cache not both.  Enabling a shared cache uses a session from
      * the configured session_max.  A shared cache can not have absolute values configured for cache

--- a/test/suite/test_reconfig01.py
+++ b/test/suite/test_reconfig01.py
@@ -121,5 +121,13 @@ class test_reconfig01(wttest.WiredTigerTestCase):
         self.conn.reconfigure(
             "file_manager=(close_idle_time=4,close_scan_interval=100)")
 
+    def test_reconfig_verbose(self):
+        self.conn.reconfigure("verbose=[api:1,metadata:2]")
+        self.conn.reconfigure("verbose=[all=0]")
+        self.conn.reconfigure("verbose=[api:2,all=1, metadata:3]")
+
+    def test_reconfig_verbose(self):
+        self.conn.reconfigure("session_max=1000")
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
![企业微信截图_1ec331ba-1642-4f9e-ac0c-aed3fa76dff0](https://github.com/wiredtiger/wiredtiger/assets/14356223/e5160a17-a3df-4d12-a7f5-cf2f89c147fd)


if we surport session_max reconfig, it can help us to djust the number of connections dynamically, especially the thread model is a link a thread model.