### PR TITLE
WT-11614 Parse the debug log into a set of corresponding functional model operations

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -440,6 +440,7 @@ Wundef
 Wuninitialized
 Wunused
 XP
+XXXXXX
 Xorshift
 YCSB
 ZSTD

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -440,7 +440,6 @@ Wundef
 Wuninitialized
 Wunused
 XP
-XXXXXX
 Xorshift
 YCSB
 ZSTD
@@ -1167,6 +1166,7 @@ rw
 rwlock
 sH
 sHQ
+sXXXXXX
 sanitizer
 sanitizers
 scalable

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -202,6 +202,7 @@ Kounavis
 LANGID
 LF
 LLVMFuzzerTestOneInput
+LOGOP
 LOGREC
 LOGSCAN
 LRU

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -131,7 +131,7 @@ extern char *__wt_optarg;
     "M,create,"                                               \
     "debug_mode=(table_logging=true,checkpoint_retention=5)," \
     "eviction_updates_target=20,eviction_updates_trigger=90," \
-    "log=(enabled,file_max=10M,remove=false),session_max=%d," \
+    "log=(enabled,file_max=10M,remove=true),session_max=%d,"  \
     "statistics=(all),statistics_log=(wait=%d,json,on_close)"
 #define ENV_CONFIG_TXNSYNC \
     ENV_CONFIG_DEF         \

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -131,7 +131,7 @@ extern char *__wt_optarg;
     "M,create,"                                               \
     "debug_mode=(table_logging=true,checkpoint_retention=5)," \
     "eviction_updates_target=20,eviction_updates_trigger=90," \
-    "log=(enabled,file_max=10M,remove=true),session_max=%d,"  \
+    "log=(enabled,file_max=10M,remove=false),session_max=%d," \
     "statistics=(all),statistics_log=(wait=%d,json,on_close)"
 #define ENV_CONFIG_TXNSYNC \
     ENV_CONFIG_DEF         \

--- a/test/model/CMakeLists.txt
+++ b/test/model/CMakeLists.txt
@@ -7,9 +7,19 @@ add_library(wiredtiger_model SHARED
     src/core/kv_table_item.cpp
     src/core/kv_table.cpp
     src/core/kv_transaction.cpp
+    src/core/util.cpp
     src/core/verify.cpp
+    src/driver/debug_log_parser.cpp
 )
-target_include_directories(wiredtiger_model PUBLIC src/include)
+
+target_include_directories(
+    wiredtiger_model
+    PUBLIC src/include
+    PRIVATE
+        ${CMAKE_BINARY_DIR}/config
+        ${CMAKE_SOURCE_DIR}/src/include
+        ${CMAKE_SOURCE_DIR}/test/3rdparty
+)
 
 target_compile_options(
     wiredtiger_model
@@ -19,5 +29,6 @@ target_compile_options(
 
 target_link_libraries(wiredtiger_model wt::wiredtiger)
 
-# Build tests.
+# Build the tests and the tools.
 add_subdirectory(test)
+add_subdirectory(tools)

--- a/test/model/src/core/data_value.cpp
+++ b/test/model/src/core/data_value.cpp
@@ -155,23 +155,145 @@ operator<<(std::ostream &out, const data_value &value)
 }
 
 /*
+ * get_wt_cursor_key_or_value --
+ *     Get the key or value from a WiredTiger cursor.
+ */
+inline static data_value
+get_wt_cursor_key_or_value(
+  WT_CURSOR *cursor, int get_fn(WT_CURSOR *cursor, ...), const char *format)
+{
+    if (format == NULL)
+        format = "u";
+    if (strlen(format) != 1)
+        throw model_exception("The model does not currently support structs or types with sizes");
+
+    int ret = 0;
+
+    /*
+     * GET_DATA_VALUE --
+     *     Read the given key or value into a data_value.
+     */
+#define GET_DATA_VALUE(wt_type, c_type, cast) \
+    case wt_type[0]: {                        \
+        c_type v;                             \
+        ret = get_fn(cursor, &v);             \
+        if (ret == 0)                         \
+            return data_value(cast(v));       \
+    }
+
+    switch (format[0]) {
+        GET_DATA_VALUE("b", int8_t, static_cast<int64_t>);
+        GET_DATA_VALUE("B", uint8_t, static_cast<uint64_t>);
+        GET_DATA_VALUE("h", int16_t, static_cast<int64_t>);
+        GET_DATA_VALUE("H", uint16_t, static_cast<uint64_t>);
+        GET_DATA_VALUE("i", int32_t, static_cast<int64_t>);
+        GET_DATA_VALUE("I", uint32_t, static_cast<uint64_t>);
+        GET_DATA_VALUE("l", int32_t, static_cast<int64_t>);
+        GET_DATA_VALUE("L", uint32_t, static_cast<uint64_t>);
+        GET_DATA_VALUE("q", int64_t, static_cast<int64_t>);
+        GET_DATA_VALUE("Q", uint64_t, static_cast<uint64_t>);
+        GET_DATA_VALUE("r", uint64_t, static_cast<uint64_t>);
+        GET_DATA_VALUE("s", const char *, std::string);
+        GET_DATA_VALUE("S", const char *, std::string);
+        GET_DATA_VALUE("t", uint8_t, static_cast<uint64_t>);
+        GET_DATA_VALUE("u", WT_ITEM, item_to_string);
+    case 'x':
+        throw model_exception("Type \"x\" is not implemented.");
+    default:
+        throw model_exception("Unknown type.");
+    };
+
+    throw wiredtiger_exception(cursor->session, "Cannot read value: ", ret);
+#undef GET_DATA_VALUE
+}
+
+/*
+ * get_wt_cursor_key --
+ *     Get the key from a WiredTiger cursor.
+ */
+data_value
+get_wt_cursor_key(WT_CURSOR *cursor)
+{
+    return get_wt_cursor_key_or_value(cursor, cursor->get_key, cursor->key_format);
+}
+
+/*
+ * get_wt_cursor_value --
+ *     Get the value from a WiredTiger cursor.
+ */
+data_value
+get_wt_cursor_value(WT_CURSOR *cursor)
+{
+    return get_wt_cursor_key_or_value(cursor, cursor->get_value, cursor->value_format);
+}
+
+/*
  * set_wt_cursor_key_or_value --
  *     Set the value as WiredTiger cursor key or value.
  */
 inline static void
-set_wt_cursor_key_or_value(
-  WT_CURSOR *cursor, void set_fn(WT_CURSOR *cursor, ...), const data_value &value)
+set_wt_cursor_key_or_value(WT_CURSOR *cursor, void set_fn(WT_CURSOR *cursor, ...),
+  const char *format, const data_value &value)
 {
+    if (format == NULL)
+        format = "u";
+    if (strlen(format) != 1)
+        throw model_exception("The model does not currently support structs or types with sizes");
     if (std::holds_alternative<std::monostate>(value) || value.valueless_by_exception())
-        set_fn(cursor);
-    else if (std::holds_alternative<int64_t>(value))
-        set_fn(cursor, std::get<int64_t>(value));
-    else if (std::holds_alternative<uint64_t>(value))
-        set_fn(cursor, std::get<uint64_t>(value));
-    else if (std::holds_alternative<std::string>(value))
+        throw model_exception("Cannot use the NONE value in a WiredTiger cursor");
+
+        /*
+         * SET_DATA_VALUE --
+         *     Read the given key or value into a data_value.
+         */
+#define SET_DATA_VALUE(wt_type, c_type, variant_type)              \
+    case wt_type[0]: {                                             \
+        if (!std::holds_alternative<variant_type>(value))          \
+            throw model_exception("Incompatible data_value type"); \
+        variant_type v = std::get<variant_type>(value);            \
+        set_fn(cursor, static_cast<c_type>(v));                    \
+        break;                                                     \
+    }
+
+    switch (format[0]) {
+        SET_DATA_VALUE("b", int8_t, int64_t);
+        SET_DATA_VALUE("B", uint8_t, uint64_t);
+        SET_DATA_VALUE("h", int16_t, int64_t);
+        SET_DATA_VALUE("H", uint16_t, uint64_t);
+        SET_DATA_VALUE("i", int32_t, int64_t);
+        SET_DATA_VALUE("I", uint32_t, uint64_t);
+        SET_DATA_VALUE("l", int32_t, int64_t);
+        SET_DATA_VALUE("L", uint32_t, uint64_t);
+        SET_DATA_VALUE("q", int64_t, int64_t);
+        SET_DATA_VALUE("Q", uint64_t, uint64_t);
+        SET_DATA_VALUE("r", uint64_t, uint64_t);
+    case 's':
+    case 'S': {
+        if (!std::holds_alternative<std::string>(value))
+            throw model_exception("Incompatible data_value type");
         set_fn(cursor, std::get<std::string>(value).c_str());
-    else
-        assert(!"Invalid code path unexpected data_value type");
+        break;
+    }
+    case 'u': {
+        if (!std::holds_alternative<std::string>(value))
+            throw model_exception("Incompatible data_value type");
+        WT_ITEM item;
+        memset(&item, 0, sizeof(item));
+        item.data = std::get<std::string>(value).c_str();
+        item.size = std::get<std::string>(value).length();
+        /*
+         * It is safe to pass the pointer to WT_ITEM, because the implementation will only use its
+         * data and size fields, without keeping a reference to the actual WT_ITEM.
+         */
+        set_fn(cursor, &item);
+        break;
+    }
+    case 'x':
+        throw model_exception("Type \"x\" is not implemented.");
+    default:
+        throw model_exception("Unknown type.");
+    };
+#undef SET_DATA_VALUE
 }
 
 /*
@@ -181,7 +303,7 @@ set_wt_cursor_key_or_value(
 void
 set_wt_cursor_key(WT_CURSOR *cursor, const data_value &value)
 {
-    set_wt_cursor_key_or_value(cursor, cursor->set_key, value);
+    set_wt_cursor_key_or_value(cursor, cursor->set_key, cursor->key_format, value);
 }
 
 /*
@@ -191,7 +313,7 @@ set_wt_cursor_key(WT_CURSOR *cursor, const data_value &value)
 void
 set_wt_cursor_value(WT_CURSOR *cursor, const data_value &value)
 {
-    set_wt_cursor_key_or_value(cursor, cursor->set_value, value);
+    set_wt_cursor_key_or_value(cursor, cursor->set_value, cursor->value_format, value);
 }
 
 } /* namespace model */

--- a/test/model/src/core/data_value.cpp
+++ b/test/model/src/core/data_value.cpp
@@ -78,31 +78,30 @@ data_value::unpack(const void *buffer, size_t length, const char *format)
      *     Unpack the given raw buffer value into a data_value.
      */
 #define UNPACK_TO_DATA_VALUE(wt_type, c_type, cast)                               \
-    case wt_type: {                                                               \
+    case wt_type[0]: {                                                            \
         c_type v;                                                                 \
-        std::string f(1, wt_type);                                                \
         /* It is okay to use NULL session, as this is just for error handling. */ \
-        ret = __wt_struct_unpack(NULL, buffer, length, f.c_str(), &v);            \
+        ret = __wt_struct_unpack(nullptr, buffer, length, wt_type, &v);           \
         if (ret == 0)                                                             \
             return data_value(cast(v));                                           \
     }
 
     switch (format[0]) {
-        UNPACK_TO_DATA_VALUE('b', int8_t, static_cast<int64_t>);
-        UNPACK_TO_DATA_VALUE('B', uint8_t, static_cast<uint64_t>);
-        UNPACK_TO_DATA_VALUE('h', int16_t, static_cast<int64_t>);
-        UNPACK_TO_DATA_VALUE('H', uint16_t, static_cast<uint64_t>);
-        UNPACK_TO_DATA_VALUE('i', int32_t, static_cast<int64_t>);
-        UNPACK_TO_DATA_VALUE('I', uint32_t, static_cast<uint64_t>);
-        UNPACK_TO_DATA_VALUE('l', int32_t, static_cast<int64_t>);
-        UNPACK_TO_DATA_VALUE('L', uint32_t, static_cast<uint64_t>);
-        UNPACK_TO_DATA_VALUE('q', int64_t, static_cast<int64_t>);
-        UNPACK_TO_DATA_VALUE('Q', uint64_t, static_cast<uint64_t>);
-        UNPACK_TO_DATA_VALUE('r', uint64_t, static_cast<uint64_t>);
-        UNPACK_TO_DATA_VALUE('s', const char *, std::string);
-        UNPACK_TO_DATA_VALUE('S', const char *, std::string);
-        UNPACK_TO_DATA_VALUE('t', uint8_t, static_cast<uint64_t>);
-        UNPACK_TO_DATA_VALUE('u', WT_ITEM, item_to_string);
+        UNPACK_TO_DATA_VALUE("b", int8_t, static_cast<int64_t>);
+        UNPACK_TO_DATA_VALUE("B", uint8_t, static_cast<uint64_t>);
+        UNPACK_TO_DATA_VALUE("h", int16_t, static_cast<int64_t>);
+        UNPACK_TO_DATA_VALUE("H", uint16_t, static_cast<uint64_t>);
+        UNPACK_TO_DATA_VALUE("i", int32_t, static_cast<int64_t>);
+        UNPACK_TO_DATA_VALUE("I", uint32_t, static_cast<uint64_t>);
+        UNPACK_TO_DATA_VALUE("l", int32_t, static_cast<int64_t>);
+        UNPACK_TO_DATA_VALUE("L", uint32_t, static_cast<uint64_t>);
+        UNPACK_TO_DATA_VALUE("q", int64_t, static_cast<int64_t>);
+        UNPACK_TO_DATA_VALUE("Q", uint64_t, static_cast<uint64_t>);
+        UNPACK_TO_DATA_VALUE("r", uint64_t, static_cast<uint64_t>);
+        UNPACK_TO_DATA_VALUE("s", const char *, std::string);
+        UNPACK_TO_DATA_VALUE("S", const char *, std::string);
+        UNPACK_TO_DATA_VALUE("t", uint8_t, static_cast<uint64_t>);
+        UNPACK_TO_DATA_VALUE("u", WT_ITEM, item_to_string);
     case 'x':
         throw model_exception("Type \"x\" is not implemented.");
     default:

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -1,0 +1,112 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "model/util.h"
+
+namespace model {
+
+/*
+ * config_map::from_string --
+ *     Parse config map from a string.
+ */
+config_map
+config_map::from_string(const char *str, const char **end)
+{
+    std::ostringstream key_buf, value_buf;
+    bool in_key, in_quotes;
+    config_map m;
+    const char *p;
+
+    in_key = true;
+    in_quotes = false;
+
+    for (p = str; *p != '\0' && (in_quotes || *p != ')'); p++) {
+        char c = *p;
+
+        /* Handle quotes. */
+        if (in_quotes) {
+            if (c == '\"') {
+                in_quotes = false;
+                continue;
+            }
+        } else if (c == '\"') {
+            in_quotes = true;
+            continue;
+        }
+
+        if (in_key) {
+            /* Handle keys. */
+            if (!in_quotes && c == '=')
+                in_key = false;
+            else
+                key_buf << c;
+        } else {
+            /* Handle nested config maps. */
+            if (!in_quotes && c == '(') {
+                if (value_buf.str() != "")
+                    throw model_exception("Invalid nested configuration string");
+                m._map[key_buf.str()] = std::make_shared<config_map>(from_string(p + 1, &p));
+                if (*p != ')')
+                    throw model_exception("Invalid nesting within a configuration string");
+                key_buf.str("");
+                in_key = true;
+            }
+            /* Handle regular values. */
+            else if (!in_quotes && c == ',') {
+                m._map[key_buf.str()] = value_buf.str();
+                key_buf.str("");
+                value_buf.str("");
+                in_key = true;
+            }
+            /* Else we just get the next character. */
+            else
+                value_buf << c;
+        }
+    }
+
+    /* Handle the last value. */
+    if (in_quotes)
+        throw model_exception("Unmatched quotes within a configuration string");
+    if (!in_key)
+        m._map[key_buf.str()] = value_buf.str();
+
+    /* Handle the end of a nested map. */
+    if (end == NULL) {
+        if (*p != '\0')
+            throw model_exception("Invalid configuration string");
+    } else
+        *end = p;
+
+    return m;
+}
+
+} /* namespace model */

--- a/test/model/src/core/verify.cpp
+++ b/test/model/src/core/verify.cpp
@@ -93,7 +93,7 @@ kv_table_verifier::verify(WT_CONNECTION *connection)
     WT_SESSION *session = nullptr;
     WT_CURSOR *wt_cursor = nullptr;
     int ret;
-    const char *key, *value;
+    data_value key, value;
 
     if (_verbose)
         std::cout << "Verification: Verify " << _table.name() << std::endl;
@@ -120,15 +120,11 @@ kv_table_verifier::verify(WT_CONNECTION *connection)
 
         /* Verify each key-value pair. */
         while ((ret = wt_cursor->next(wt_cursor)) == 0) {
-            ret = wt_cursor->get_key(wt_cursor, &key);
-            if (ret != 0)
-                throw wiredtiger_exception(session, ret);
-            ret = wt_cursor->get_value(wt_cursor, &value);
-            if (ret != 0)
-                throw wiredtiger_exception(session, ret);
+            key = get_wt_cursor_key(wt_cursor);
+            value = get_wt_cursor_value(wt_cursor);
             if (_verbose)
                 std::cout << "Verification: key = " << key << ", value = " << value << std::endl;
-            if (!model_cursor.verify_next(data_value(key), data_value(value))) {
+            if (!model_cursor.verify_next(key, value)) {
                 std::ostringstream ss;
                 ss << "\"" << key << "=" << value
                    << "\" is not the next key-value pair in the model.";

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -199,7 +199,7 @@ debug_log_parser::metadata_apply(const row_put &op)
     }
 
     /* Special handling for files. */
-    if (starts_with(key, "file:")) {
+    else if (starts_with(key, "file:")) {
         uint64_t id = m->get_uint64("id");
         _fileid_to_file[id] = key;
         _file_to_fileid[key] = id;
@@ -215,17 +215,26 @@ debug_log_parser::metadata_apply(const row_put &op)
     }
 
     /* Special handling for LSM. */
-    if (starts_with(key, "lsm:"))
+    else if (starts_with(key, "lsm:"))
         throw model_exception("The model does not currently support LSM");
 
     /* Special handling for tables. */
-    if (starts_with(key, "table:")) {
+    else if (starts_with(key, "table:")) {
         std::string name = key.substr(std::strlen("table:"));
         if (!_database.contains_table(name)) {
             kv_table_ptr table = _database.create_table(name);
             table->set_key_value_format(m->get_string("key_format"), m->get_string("value_format"));
         }
     }
+
+    /* Special handling for the system prefix. */
+    else if (starts_with(key, "system:")) {
+        /* We don't currently need to handle this. */
+    }
+
+    /* Otherwise this is an unsupported URI type. */
+    else
+        throw model_exception("Unsupported metadata URI: " + key);
 }
 
 /*

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -1,0 +1,262 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <iostream>
+
+using json = nlohmann::json;
+
+extern "C" {
+#include "wt_internal.h"
+}
+
+#include "model/driver/debug_log_parser.h"
+#include "model/util.h"
+
+namespace model {
+
+/*
+ * from_json --
+ *     Parse the given log entry.
+ */
+void
+from_json(const json &j, debug_log_parser::row_put &out)
+{
+    j.at("fileid").get_to(out.fileid);
+    j.at("key").get_to(out.key);
+    j.at("value").get_to(out.value);
+}
+
+/*
+ * from_json --
+ *     Parse the given log entry.
+ */
+void
+from_json(const json &j, debug_log_parser::txn_timestamp &out)
+{
+    j.at("commit_ts").get_to(out.commit_ts);
+    j.at("durable_ts").get_to(out.durable_ts);
+    j.at("prepare_ts").get_to(out.prepare_ts);
+}
+
+/*
+ * debug_log_parser::metadata_apply --
+ *     Apply the given operation to the model.
+ */
+void
+debug_log_parser::metadata_apply(const row_put &op)
+{
+    std::string key =
+      std::get<std::string>(data_value::unpack(op.key.c_str(), op.key.length(), "S"));
+    std::string value =
+      std::get<std::string>(data_value::unpack(op.value.c_str(), op.value.length(), "S"));
+
+    /* Parse the configuration string. */
+    std::shared_ptr<config_map> m =
+      std::make_shared<config_map>(config_map::from_string(value.c_str()));
+
+    /* Remember the metadata. */
+    _metadata[key] = m;
+
+    /* Special handling for column groups. */
+    if (key.substr(0, 9) == "colgroup:") {
+        std::string name = key.substr(9);
+        if (name.find(':') != std::string::npos)
+            throw model_exception("The model does not currently support column groups");
+
+        std::string source = m->get_string("source");
+        _file_to_colgroup[source] = name;
+
+        /* Establish mapping from the file ID to the table name, if possible. */
+        auto i = _file_to_fileid.find(source);
+        if (i != _file_to_fileid.end())
+            _fileid_to_table[i->second] = name;
+    }
+
+    /* Special handling for files. */
+    if (key.substr(0, 5) == "file:") {
+        uint64_t id = m->get_uint64("id");
+        _fileid_to_file[id] = key;
+        _file_to_fileid[key] = id;
+
+        /* Establish mapping from the file ID to the table name, if possible. */
+        auto i = _file_to_colgroup.find(key);
+        if (i != _file_to_colgroup.end())
+            _fileid_to_table[id] = i->second;
+    }
+
+    /* Special handling for LSM. */
+    if (key.substr(0, 4) == "lsm:")
+        throw model_exception("The model does not currently support LSM");
+
+    /* Special handling for tables. */
+    if (key.substr(0, 6) == "table:") {
+        std::string name = key.substr(6);
+        if (!_database.contains_table(name))
+            _database.create_table(name);
+    }
+}
+
+/*
+ * debug_log_parser::apply --
+ *     Apply the given operation to the model.
+ */
+void
+debug_log_parser::apply(kv_transaction_ptr txn, const row_put &op)
+{
+    /* Handle metadata operations. */
+    if (op.fileid == 0) {
+        metadata_apply(op);
+        return;
+    }
+
+    /* Find the table name from the file ID. */
+    uint64_t fileid = op.fileid & (WT_LOGOP_IGNORE - 1);
+    auto table_itr = _fileid_to_table.find(fileid);
+    if (table_itr == _fileid_to_table.end())
+        throw model_exception("Unknown file ID: " + std::to_string(fileid));
+    std::string table = table_itr->second;
+
+    /* Find the table's metadata. */
+    auto metadata_itr = _metadata.find("table:" + table);
+    if (metadata_itr == _metadata.end())
+        throw model_exception("No metadata for table: " + table);
+    std::shared_ptr<config_map> table_metadata = metadata_itr->second;
+
+    /* Parse the key and the value. */
+    data_value key = data_value::unpack(
+      op.key.c_str(), op.key.length(), table_metadata->get_string("key_format").c_str());
+    data_value value = data_value::unpack(
+      op.value.c_str(), op.value.length(), table_metadata->get_string("value_format").c_str());
+
+    /* Perform the operation. */
+    _database.table(table)->insert(txn, key, value);
+}
+
+/*
+ * debug_log_parser::apply --
+ *     Apply the given operation to the model.
+ */
+void
+debug_log_parser::apply(kv_transaction_ptr txn, const txn_timestamp &op)
+{
+    /* Handle the prepare operation. */
+    if (op.commit_ts == k_timestamp_none && op.prepare_ts != k_timestamp_none) {
+        txn->prepare(op.prepare_ts);
+        return;
+    }
+
+    /* Handle the commit of a prepared transaction. */
+    if (op.commit_ts != k_timestamp_none && op.prepare_ts != k_timestamp_none) {
+        if (txn->state() != kv_transaction_state::prepared)
+            throw model_exception("The transaction must be in a prepared state before commit");
+        txn->commit(op.commit_ts, op.durable_ts);
+        return;
+    }
+
+    /* Otherwise it is just an operation to set the commit timestamp. */
+    txn->set_commit_timestamp(op.commit_ts);
+}
+
+/*
+ * debug_log_parser::parse_json --
+ *     Parse the debug log JSON file into the model.
+ */
+void
+debug_log_parser::parse_json(kv_database &database, const char *path)
+{
+    debug_log_parser parser(database);
+
+    /* Load the JSON from the provided file. */
+    std::ifstream f(path);
+    json data = json::parse(f);
+
+    /* The debug log JSON file is structured as an array of log entries. */
+    if (!data.is_array())
+        throw model_exception("The top-level element in the JSON file is not an array");
+
+    /* Now parse each individual entry. */
+    for (auto &log_entry : data) {
+        if (!log_entry.is_object())
+            throw model_exception("The second-level element in the JSON file is not an object");
+
+        std::string log_entry_type = log_entry.at("type").get<std::string>();
+
+        /* The commit entry contains full description of a transaction, including all operations. */
+        if (log_entry_type == "commit") {
+            kv_transaction_ptr txn = database.begin_transaction();
+
+            /* Replay all operations. */
+            for (auto &op_entry : log_entry.at("ops")) {
+                std::string op_type = op_entry.at("optype").get<std::string>();
+
+                /* Row-store operations. */
+                if (op_type == "row_modify")
+                    throw model_exception("Unsupported operation.");
+                if (op_type == "row_put") {
+                    parser.apply(txn, op_entry.get<row_put>());
+                    continue;
+                }
+                if (op_type == "row_remove")
+                    throw model_exception("Unsupported operation.");
+                if (op_type == "row_truncate")
+                    throw model_exception("Unsupported operation.");
+
+                /* Transaction operations. */
+                if (op_type == "txn_timestamp") {
+                    parser.apply(txn, op_entry.get<txn_timestamp>());
+                    continue;
+                }
+
+                /* Operations that we can skip... for now. */
+                if (op_type == "prev_lsn" || op_type == "checkpoint_start")
+                    continue;
+
+                /* Column-store operations (unsupported). */
+                if (op_type.substr(0, 4) == "col_")
+                    throw model_exception("The parser does not currently support column stores.");
+
+                throw model_exception("Unsupported operation \"" + op_type + "\"");
+            }
+
+            if (txn->state() != kv_transaction_state::committed)
+                txn->commit();
+            continue;
+        }
+
+        /* Ignore these fields. */
+        if (log_entry_type == "checkpoint" || log_entry_type == "file_sync" ||
+          log_entry_type == "message" || log_entry_type == "system")
+            continue;
+
+        throw model_exception("Unsupported log entry type \"" + log_entry_type + "\"");
+    }
+}
+
+} /* namespace model */

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -45,7 +45,7 @@ namespace model {
  * from_json --
  *     Parse the given log entry.
  */
-void
+static void
 from_json(const json &j, debug_log_parser::row_put &out)
 {
     j.at("fileid").get_to(out.fileid);
@@ -57,7 +57,7 @@ from_json(const json &j, debug_log_parser::row_put &out)
  * from_json --
  *     Parse the given log entry.
  */
-void
+static void
 from_json(const json &j, debug_log_parser::row_remove &out)
 {
     j.at("fileid").get_to(out.fileid);
@@ -68,7 +68,7 @@ from_json(const json &j, debug_log_parser::row_remove &out)
  * from_json --
  *     Parse the given log entry.
  */
-void
+static void
 from_json(const json &j, debug_log_parser::txn_timestamp &out)
 {
     j.at("commit_ts").get_to(out.commit_ts);
@@ -80,7 +80,7 @@ from_json(const json &j, debug_log_parser::txn_timestamp &out)
  * from_debug_log --
  *     Parse the given debug log entry.
  */
-int
+static int
 from_debug_log(
   WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end, debug_log_parser::row_put &out)
 {
@@ -102,7 +102,7 @@ from_debug_log(
  * from_debug_log --
  *     Parse the given debug log entry.
  */
-int
+static int
 from_debug_log(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   debug_log_parser::row_remove &out)
 {
@@ -122,7 +122,7 @@ from_debug_log(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
  * from_debug_log --
  *     Parse the given debug log entry.
  */
-int
+static int
 from_debug_log(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
   debug_log_parser::txn_timestamp &out)
 {

--- a/test/model/src/include/model/core.h
+++ b/test/model/src/include/model/core.h
@@ -157,6 +157,15 @@ public:
      * wiredtiger_exception::wiredtiger_exception --
      *     Create a new instance of the exception. This constructor is not thread-safe.
      */
+    inline wiredtiger_exception(const char *message, int error) noexcept
+        : std::runtime_error(std::string(message) + wiredtiger_strerror(error)), _error(error)
+    {
+    }
+
+    /*
+     * wiredtiger_exception::wiredtiger_exception --
+     *     Create a new instance of the exception. This constructor is not thread-safe.
+     */
     inline wiredtiger_exception(int error) noexcept
         : std::runtime_error(wiredtiger_strerror(error)), _error(error)
     {

--- a/test/model/src/include/model/data_value.h
+++ b/test/model/src/include/model/data_value.h
@@ -32,6 +32,7 @@
 #include <ostream>
 #include <string>
 #include <variant>
+#include <vector>
 
 #include "model/core.h"
 #include "wiredtiger.h"
@@ -39,11 +40,17 @@
 namespace model {
 
 /*
+ * byte_vector --
+ *     A vector of arbitrary bytes, used to represent a WT_ITEM.
+ */
+using byte_vector = std::vector<uint8_t>;
+
+/*
  * base_data_value --
  *     The base type for data values, which is an std::variant of all the relevant types that we
  *     support.
  */
-using base_data_value = std::variant<std::monostate, int64_t, uint64_t, std::string>;
+using base_data_value = std::variant<std::monostate, int64_t, uint64_t, std::string, byte_vector>;
 
 /*
  * data_value --
@@ -89,6 +96,16 @@ public:
      *     Unpack a WiredTiger buffer into a data value.
      */
     inline static data_value
+    unpack(const byte_vector &data, const char *format)
+    {
+        return unpack(data.data(), data.size(), format);
+    }
+
+    /*
+     * data_value::unpack --
+     *     Unpack a WiredTiger buffer into a data value.
+     */
+    inline static data_value
     unpack(const std::string &str, const char *format)
     {
         return unpack(str.c_str(), str.length(), format);
@@ -126,6 +143,12 @@ public:
  *     The "None" value.
  */
 extern const data_value NONE;
+
+/*
+ * operator<< --
+ *     Add human-readable output to the stream for a byte vector.
+ */
+std::ostream &operator<<(std::ostream &out, const byte_vector &data);
 
 /*
  * operator<< --

--- a/test/model/src/include/model/data_value.h
+++ b/test/model/src/include/model/data_value.h
@@ -79,6 +79,12 @@ public:
     }
 
     /*
+     * data_value::unpack --
+     *     Unpack a WiredTiger buffer into a data value.
+     */
+    static data_value unpack(const void *buffer, size_t length, const char *format);
+
+    /*
      * data_value::none --
      *     Check if this is a None value.
      */

--- a/test/model/src/include/model/data_value.h
+++ b/test/model/src/include/model/data_value.h
@@ -124,6 +124,18 @@ extern const data_value NONE;
 std::ostream &operator<<(std::ostream &out, const data_value &value);
 
 /*
+ * get_wt_cursor_key --
+ *     Get the key from a WiredTiger cursor.
+ */
+data_value get_wt_cursor_key(WT_CURSOR *cursor);
+
+/*
+ * get_wt_cursor_value --
+ *     Get the value from a WiredTiger cursor.
+ */
+data_value get_wt_cursor_value(WT_CURSOR *cursor);
+
+/*
  * set_wt_cursor_key --
  *     Set the value as WiredTiger cursor key.
  */

--- a/test/model/src/include/model/data_value.h
+++ b/test/model/src/include/model/data_value.h
@@ -95,6 +95,16 @@ public:
     }
 
     /*
+     * data_value::unpack --
+     *     Unpack a WiredTiger buffer into a data value.
+     */
+    inline static data_value
+    unpack(const WT_ITEM &item, const char *format)
+    {
+        return unpack(item.data, item.size, format);
+    }
+
+    /*
      * data_value::none --
      *     Check if this is a None value.
      */

--- a/test/model/src/include/model/data_value.h
+++ b/test/model/src/include/model/data_value.h
@@ -85,6 +85,16 @@ public:
     static data_value unpack(const void *buffer, size_t length, const char *format);
 
     /*
+     * data_value::unpack --
+     *     Unpack a WiredTiger buffer into a data value.
+     */
+    inline static data_value
+    unpack(const std::string &str, const char *format)
+    {
+        return unpack(str.c_str(), str.length(), format);
+    }
+
+    /*
      * data_value::none --
      *     Check if this is a None value.
      */

--- a/test/model/src/include/model/driver/debug_log_parser.h
+++ b/test/model/src/include/model/driver/debug_log_parser.h
@@ -33,6 +33,7 @@
 #include <unordered_map>
 #include "model/kv_database.h"
 #include "model/util.h"
+#include "wiredtiger.h"
 
 namespace model {
 
@@ -81,10 +82,16 @@ public:
     inline debug_log_parser(kv_database &database) : _database(database) {}
 
     /*
-     * debug_log_parser::parse_json --
+     * debug_log_parser::from_debug_log --
+     *     Parse the debug log into the model.
+     */
+    static void from_debug_log(kv_database &database, WT_CONNECTION *conn);
+
+    /*
+     * debug_log_parser::from_json --
      *     Parse the debug log JSON file into the model.
      */
-    static void parse_json(kv_database &database, const char *path);
+    static void from_json(kv_database &database, const char *path);
 
     /*
      * debug_log_parser::apply --

--- a/test/model/src/include/model/driver/debug_log_parser.h
+++ b/test/model/src/include/model/driver/debug_log_parser.h
@@ -54,6 +54,15 @@ public:
     };
 
     /*
+     * debug_log_parser::row_remove --
+     *     The row_put log entry.
+     */
+    struct row_remove {
+        uint64_t fileid;
+        std::string key;
+    };
+
+    /*
      * debug_log_parser::txn_timestamp --
      *     The txn_timestamp log entry.
      */
@@ -87,6 +96,12 @@ public:
      * debug_log_parser::apply --
      *     Apply the given operation to the model.
      */
+    void apply(kv_transaction_ptr txn, const row_remove &op);
+
+    /*
+     * debug_log_parser::apply --
+     *     Apply the given operation to the model.
+     */
     void apply(kv_transaction_ptr txn, const txn_timestamp &op);
 
 protected:
@@ -96,14 +111,21 @@ protected:
      */
     void metadata_apply(const row_put &op);
 
+    /*
+     * debug_log_parser::table_by_fileid --
+     *     Find a table by the file ID.
+     */
+    kv_table_ptr table_by_fileid(uint64_t fileid);
+
 private:
     kv_database &_database;
 
     std::unordered_map<std::string, std::shared_ptr<config_map>> _metadata;
-    std::unordered_map<std::string, std::string> _file_to_colgroup;
+    std::unordered_map<std::string, std::string> _file_to_colgroup_name;
     std::unordered_map<std::string, uint64_t> _file_to_fileid;
     std::unordered_map<uint64_t, std::string> _fileid_to_file;
-    std::unordered_map<uint64_t, std::string> _fileid_to_table;
+    std::unordered_map<uint64_t, std::string> _fileid_to_table_name;
+    std::unordered_map<uint64_t, kv_table_ptr> _fileid_to_table;
 };
 
 } /* namespace model */

--- a/test/model/src/include/model/driver/debug_log_parser.h
+++ b/test/model/src/include/model/driver/debug_log_parser.h
@@ -1,0 +1,110 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MODEL_DRIVER_DEBUG_LOG_PARSER_H
+#define MODEL_DRIVER_DEBUG_LOG_PARSER_H
+
+#include <memory>
+#include <unordered_map>
+#include "model/kv_database.h"
+#include "model/util.h"
+
+namespace model {
+
+/*
+ * debug_log_parser --
+ *     A parser that feeds the model from the database's debug log.
+ */
+class debug_log_parser {
+
+public:
+    /*
+     * debug_log_parser::row_put --
+     *     The row_put log entry.
+     */
+    struct row_put {
+        uint64_t fileid;
+        std::string key;
+        std::string value;
+    };
+
+    /*
+     * debug_log_parser::txn_timestamp --
+     *     The txn_timestamp log entry.
+     */
+    struct txn_timestamp {
+        timestamp_t commit_ts;
+        timestamp_t durable_ts;
+        timestamp_t prepare_ts;
+    };
+
+public:
+    /*
+     * debug_log_parser::debug_log_parser --
+     *     Create a new instance of the parser. Make sure that the database instance outlives the
+     *     lifetime of this parser object.
+     */
+    inline debug_log_parser(kv_database &database) : _database(database) {}
+
+    /*
+     * debug_log_parser::parse_json --
+     *     Parse the debug log JSON file into the model.
+     */
+    static void parse_json(kv_database &database, const char *path);
+
+    /*
+     * debug_log_parser::apply --
+     *     Apply the given operation to the model.
+     */
+    void apply(kv_transaction_ptr txn, const row_put &op);
+
+    /*
+     * debug_log_parser::apply --
+     *     Apply the given operation to the model.
+     */
+    void apply(kv_transaction_ptr txn, const txn_timestamp &op);
+
+protected:
+    /*
+     * debug_log_parser::metadata_apply --
+     *     Handle the given metadata operation.
+     */
+    void metadata_apply(const row_put &op);
+
+private:
+    kv_database &_database;
+
+    std::unordered_map<std::string, std::shared_ptr<config_map>> _metadata;
+    std::unordered_map<std::string, std::string> _file_to_colgroup;
+    std::unordered_map<std::string, uint64_t> _file_to_fileid;
+    std::unordered_map<uint64_t, std::string> _fileid_to_file;
+    std::unordered_map<uint64_t, std::string> _fileid_to_table;
+};
+
+} /* namespace model */
+#endif

--- a/test/model/src/include/model/kv_database.h
+++ b/test/model/src/include/model/kv_database.h
@@ -56,7 +56,29 @@ public:
      * kv_database::create_table --
      *     Create and return a new table. Throw an exception if the name is not unique.
      */
+    inline kv_table_ptr
+    create_table(const std::string &name)
+    {
+        return create_table(name.c_str());
+    }
+
+    /*
+     * kv_database::create_table --
+     *     Create and return a new table. Throw an exception if the name is not unique.
+     */
     kv_table_ptr create_table(const char *name);
+
+    /*
+     * kv_database::contains_table --
+     *     Check whether the database contains the given table.
+     */
+    inline bool
+    contains_table(const std::string &name) const
+    {
+        std::lock_guard lock_guard(_tables_lock);
+        auto i = _tables.find(name);
+        return i != _tables.end();
+    }
 
     /*
      * kv_database::table --
@@ -110,10 +132,10 @@ protected:
     kv_transaction_snapshot txn_snapshot_nolock(txn_id_t do_not_exclude = k_txn_none);
 
 private:
-    std::mutex _tables_lock;
+    mutable std::mutex _tables_lock;
     std::unordered_map<std::string, kv_table_ptr> _tables;
 
-    std::mutex _transactions_lock;
+    mutable std::mutex _transactions_lock;
     txn_id_t _last_transaction_id;
     std::unordered_map<txn_id_t, kv_transaction_ptr> _active_transactions;
 };

--- a/test/model/src/include/model/kv_table.h
+++ b/test/model/src/include/model/kv_table.h
@@ -68,6 +68,56 @@ public:
     }
 
     /*
+     * kv_table::set_key_value_format --
+     *     Set the key and value format of the table. This is not actually used by the model itself,
+     *     but it is useful when interacting with WiredTiger.
+     */
+    inline void
+    set_key_value_format(const char *key_format, const char *value_format) noexcept
+    {
+        _key_format = key_format;
+        _value_format = value_format;
+    }
+
+    /*
+     * kv_table::set_key_value_format --
+     *     Set the key and value format of the table. This is not actually used by the model itself,
+     *     but it is useful when interacting with WiredTiger.
+     */
+    inline void
+    set_key_value_format(const std::string &key_format, const std::string &value_format) noexcept
+    {
+        _key_format = key_format;
+        _value_format = value_format;
+    }
+
+    /*
+     * kv_table::key_format --
+     *     Return the key format of the table. This is returned as a C pointer, which has lifetime
+     *     that ends when the key format changes, or when this object is destroyed.
+     */
+    inline const char *
+    key_format() const
+    {
+        if (_key_format.empty())
+            throw model_exception("The key format was not set");
+        return _key_format.c_str();
+    }
+
+    /*
+     * kv_table::value_format --
+     *     Return the value format of the table. This is returned as a C pointer, which has lifetime
+     *     that ends when the key format changes, or when this object is destroyed.
+     */
+    inline const char *
+    value_format() const
+    {
+        if (_value_format.empty())
+            throw model_exception("The value format was not set");
+        return _value_format.c_str();
+    }
+
+    /*
      * kv_table::contains_any --
      *     Check whether the table contains the given key-value pair. If there are multiple values
      *     associated with the given timestamp, return true if any of them match.
@@ -226,6 +276,11 @@ protected:
     }
 
 private:
+    std::string _name;
+
+    std::string _key_format;
+    std::string _value_format;
+
     /*
      * This data structure is designed so that the global lock is only necessary for the map
      * operations; it is okay to release the lock while the caller is still operating on the data
@@ -235,7 +290,6 @@ private:
      */
     std::map<data_value, kv_table_item> _data;
     mutable std::mutex _lock;
-    std::string _name;
 };
 
 /*

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -42,6 +42,37 @@
 namespace model {
 
 /*
+ * wiredtiger_connection_guard --
+ *     Automatically close the connection on delete.
+ */
+class wiredtiger_connection_guard {
+
+public:
+    /*
+     * wiredtiger_connection_guard::wiredtiger_connection_guard --
+     *     Create a new instance of the guard.
+     */
+    inline wiredtiger_connection_guard(
+      WT_CONNECTION *connection, const char *close_config = nullptr) noexcept
+        : _connection(connection), _close_config(close_config == nullptr ? "" : close_config){};
+
+    /*
+     * wiredtiger_connection_guard::~wiredtiger_connection_guard --
+     *     Destroy the guard.
+     */
+    inline ~wiredtiger_connection_guard()
+    {
+        if (_connection != nullptr)
+            (void)_connection->close(
+              _connection, _close_config.empty() ? nullptr : _close_config.c_str());
+    }
+
+private:
+    WT_CONNECTION *_connection;
+    std::string _close_config;
+};
+
+/*
  * wiredtiger_cursor_guard --
  *     Automatically close the cursor on delete.
  */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -66,8 +66,7 @@ public:
     inline ~wiredtiger_connection_guard()
     {
         if (_connection != nullptr)
-            (void)_connection->close(
-              _connection, _close_config.empty() ? nullptr : _close_config.c_str());
+            (void)_connection->close(_connection, _close_config.c_str());
     }
 
 private:

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <vector>
 #include "model/core.h"
 #include "model/data_value.h"
 #include "wiredtiger.h"
@@ -205,31 +206,6 @@ private:
 };
 
 /*
- * wt_cursor_get_string --
- *     Search in WiredTiger using the provided cursor. Return a string result, or NONE if not found.
- *     Throw an exception on error.
- */
-inline data_value
-wt_cursor_get_string(WT_CURSOR *cursor, const data_value &key)
-{
-    const char *s;
-    int ret;
-
-    set_wt_cursor_key(cursor, key);
-    ret = cursor->search(cursor);
-    if (ret != 0) {
-        if (ret == WT_NOTFOUND)
-            return NONE;
-        throw wiredtiger_exception(cursor->session, ret);
-    }
-
-    ret = cursor->get_value(cursor, &s);
-    if (ret != 0)
-        throw wiredtiger_exception(cursor->session, ret);
-    return data_value(s);
-}
-
-/*
  * wt_cursor_insert --
  *     Insert into WiredTiger using the provided cursor.
  */
@@ -274,6 +250,12 @@ wt_cursor_update(WT_CURSOR *cursor, const data_value &key, const data_value &val
     set_wt_cursor_value(cursor, value);
     return cursor->update(cursor);
 }
+
+/*
+ * wt_list_tables --
+ *     Get the list of WiredTiger tables.
+ */
+std::vector<std::string> wt_list_tables(WT_CONNECTION *conn);
 
 } /* namespace model */
 #endif

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -29,10 +29,12 @@
 #ifndef MODEL_UTIL_H
 #define MODEL_UTIL_H
 
+#include <cstring>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -204,6 +206,16 @@ private:
 private:
     std::unordered_map<std::string, value_t> _map;
 };
+
+/*
+ * starts_with --
+ *     Check whether the string has the given prefix. (C++ does not have this until C++20.)
+ */
+inline bool
+starts_with(std::string_view str, const char *prefix)
+{
+    return str.compare(0, std::strlen(prefix), prefix) == 0;
+}
 
 /*
  * wt_cursor_insert --

--- a/test/model/src/include/model/verify.h
+++ b/test/model/src/include/model/verify.h
@@ -43,7 +43,7 @@ class kv_table;
  * verify_exception --
  *     The verification exception.
  */
-class verify_exception : std::runtime_error {
+class verify_exception : public std::runtime_error {
 
 public:
     /*

--- a/test/model/test/CMakeLists.txt
+++ b/test/model/test/CMakeLists.txt
@@ -4,6 +4,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
 
 # Create the common test utility library for the model.
 add_library(wiredtiger_model_test_common SHARED
+   common/util.cpp
    common/wiredtiger_util.cpp
 )
 target_include_directories(wiredtiger_model_test_common PUBLIC common/include)

--- a/test/model/test/common/include/model/test/wiredtiger_util.h
+++ b/test/model/test/common/include/model/test/wiredtiger_util.h
@@ -233,4 +233,10 @@ int wt_txn_insert(WT_SESSION *session, const char *uri, const model::data_value 
     testutil_assert(table->insert(txn, key, value, ##__VA_ARGS__) ==        \
       wt_txn_insert(session, uri, key, value, ##__VA_ARGS__));
 
+/*
+ * wt_print_debug_log --
+ *     Print the contents of a debug log to a file.
+ */
+void wt_print_debug_log(WT_CONNECTION *conn, const char *file);
+
 #endif

--- a/test/model/test/common/util.cpp
+++ b/test/model/test/common/util.cpp
@@ -26,32 +26,43 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef MODEL_TEST_UTIL_H
-#define MODEL_TEST_UTIL_H
-
-#include <string>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <errno.h>
+#include <iostream>
+#include <stdexcept>
+#include <unistd.h>
 
 extern "C" {
 #include "test_util.h"
 }
 
-/*
- * model_testutil_assert_exception --
- *     Assert that the given exception is thrown.
- */
-#define model_testutil_assert_exception(call, exception)                                        \
-    try {                                                                                       \
-        call;                                                                                   \
-        testutil_die(0, #call " did not throw " #exception);                                    \
-    } catch (exception &) {                                                                     \
-    } catch (...) {                                                                             \
-        testutil_die(0, #call " did not throw " #exception "; it threw a different exception"); \
-    }
+#include "model/test/util.h"
 
 /*
  * create_tmp_file --
  *     Create an empty temporary file and return its name.
  */
-std::string create_tmp_file(const char *dir, const char *prefix, const char *suffix = nullptr);
+std::string
+create_tmp_file(const char *dir, const char *prefix, const char *suffix)
+{
+    size_t dir_len = dir ? strlen(dir) + strlen(DIR_DELIM_STR) : 0;
+    size_t prefix_len = strlen(prefix);
+    size_t suffix_len = suffix ? strlen(suffix) : 0;
+    size_t buf_len = dir_len + prefix_len + 6 + suffix_len + 4;
 
-#endif
+    char *buf = (char *)alloca(buf_len);
+    testutil_snprintf(buf, buf_len,
+      "%s%s%s"
+      "XXXXXX"
+      "%s",
+      dir ? dir : "", dir ? DIR_DELIM_STR : "", suffix ? suffix : "");
+
+    /* This will also create the file - we only care about a name, but this is ok. */
+    int fd = mkstemps(buf, suffix_len);
+    testutil_assert_errno(fd > 0);
+    testutil_check(close(fd));
+
+    return std::string(buf);
+}

--- a/test/model/test/common/util.cpp
+++ b/test/model/test/common/util.cpp
@@ -53,11 +53,8 @@ create_tmp_file(const char *dir, const char *prefix, const char *suffix)
     size_t buf_len = dir_len + prefix_len + 6 + suffix_len + 4;
 
     char *buf = (char *)alloca(buf_len);
-    testutil_snprintf(buf, buf_len,
-      "%s%s%s"
-      "XXXXXX"
-      "%s",
-      dir ? dir : "", dir ? DIR_DELIM_STR : "", suffix ? suffix : "");
+    testutil_snprintf(buf, buf_len, "%s%s%sXXXXXX%s", dir ? dir : "", dir ? DIR_DELIM_STR : "",
+      prefix, suffix ? suffix : "");
 
     /* This will also create the file - we only care about a name, but this is ok. */
     int fd = mkstemps(buf, suffix_len);

--- a/test/model/test/model_basic/main.cpp
+++ b/test/model/test/model_basic/main.cpp
@@ -38,6 +38,8 @@ extern "C" {
 #include "test_util.h"
 }
 
+#include "model/driver/debug_log_parser.h"
+#include "model/test/util.h"
 #include "model/test/wiredtiger_util.h"
 #include "model/kv_database.h"
 
@@ -57,11 +59,11 @@ static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 /*
  * Configuration.
  */
-#define ENV_CONFIG                                            \
-    "cache_size=20M,create,"                                  \
-    "debug_mode=(table_logging=true,checkpoint_retention=5)," \
-    "eviction_updates_target=20,eviction_updates_trigger=90," \
-    "log=(enabled,file_max=10M,remove=true),session_max=100," \
+#define ENV_CONFIG                                             \
+    "cache_size=20M,create,"                                   \
+    "debug_mode=(table_logging=true,checkpoint_retention=5),"  \
+    "eviction_updates_target=20,eviction_updates_trigger=90,"  \
+    "log=(enabled,file_max=10M,remove=false),session_max=100," \
     "statistics=(all),statistics_log=(wait=1,json,on_close)"
 
 /*
@@ -342,11 +344,31 @@ test_model_basic_wt(void)
     wt_model_update_both(table, uri, key1, value1, 80, false);
     wt_model_update_both(table, uri, key1, value1, 85, false);
 
+    /* Verify. */
     testutil_assert(table->verify_noexcept(conn));
 
     /* Now try to get the verification to fail. */
     testutil_check(table->remove(key2, 1000));
     testutil_assert(!table->verify_noexcept(conn));
+
+    /* Close and reopen the database. We must do this for debug log printing to work. */
+    testutil_check(session->close(session, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+    testutil_wiredtiger_open(opts, home, ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+
+    /* Print the debug log. */
+    std::string tmp_json = create_tmp_file(home, "debug-log-", ".json");
+    wt_print_debug_log(conn, tmp_json.c_str());
+
+    /* Verify using debug log. */
+    model::kv_database from_debug_log;
+    model::debug_log_parser::parse_json(from_debug_log, tmp_json.c_str());
+    testutil_assert(from_debug_log.table("table")->verify_noexcept(conn));
+
+    /* Now try to get the verification to fail. */
+    wt_remove(session, uri, key2, 1000);
+    testutil_assert(!from_debug_log.table("table")->verify_noexcept(conn));
 
     /* Clean up. */
     testutil_check(session->close(session, nullptr));

--- a/test/model/test/model_transaction/main.cpp
+++ b/test/model/test/model_transaction/main.cpp
@@ -38,6 +38,7 @@ extern "C" {
 #include "test_util.h"
 }
 
+#include "model/driver/debug_log_parser.h"
 #include "model/test/util.h"
 #include "model/test/wiredtiger_util.h"
 #include "model/kv_database.h"
@@ -59,11 +60,11 @@ static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 /*
  * Configuration.
  */
-#define ENV_CONFIG                                            \
-    "cache_size=20M,create,"                                  \
-    "debug_mode=(table_logging=true,checkpoint_retention=5)," \
-    "eviction_updates_target=20,eviction_updates_trigger=90," \
-    "log=(enabled,file_max=10M,remove=true),session_max=100," \
+#define ENV_CONFIG                                             \
+    "cache_size=20M,create,"                                   \
+    "debug_mode=(table_logging=true,checkpoint_retention=5),"  \
+    "eviction_updates_target=20,eviction_updates_trigger=90,"  \
+    "log=(enabled,file_max=10M,remove=false),session_max=100," \
     "statistics=(all),statistics_log=(wait=1,json,on_close)"
 
 /*
@@ -558,6 +559,27 @@ test_transaction_prepared_wt(void)
     testutil_check(session->close(session, nullptr));
     testutil_check(session1->close(session1, nullptr));
     testutil_check(session2->close(session2, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+
+    /* Reopen the database. We must do this for debug log printing to work. */
+    testutil_wiredtiger_open(opts, home, ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+
+    /* Print the debug log. */
+    std::string tmp_json = create_tmp_file(home, "debug-log-", ".json");
+    wt_print_debug_log(conn, tmp_json.c_str());
+
+    /* Verify using debug log. */
+    model::kv_database from_debug_log;
+    model::debug_log_parser::parse_json(from_debug_log, tmp_json.c_str());
+    testutil_assert(from_debug_log.table("table")->verify_noexcept(conn));
+
+    /* Now try to get the verification to fail. */
+    wt_remove(session, uri, key2, 1000);
+    testutil_assert(!from_debug_log.table("table")->verify_noexcept(conn));
+
+    /* Clean up. */
+    testutil_check(session->close(session, nullptr));
     testutil_check(conn->close(conn, nullptr));
 }
 

--- a/test/model/test/model_transaction/main.cpp
+++ b/test/model/test/model_transaction/main.cpp
@@ -565,18 +565,23 @@ test_transaction_prepared_wt(void)
     testutil_wiredtiger_open(opts, home, ENV_CONFIG, nullptr, &conn, false, false);
     testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
 
-    /* Print the debug log. */
+    /* Verify using the debug log. */
+    model::kv_database db_from_debug_log;
+    model::debug_log_parser::from_debug_log(db_from_debug_log, conn);
+    testutil_assert(db_from_debug_log.table("table")->verify_noexcept(conn));
+
+    /* Print the debug log to JSON. */
     std::string tmp_json = create_tmp_file(home, "debug-log-", ".json");
     wt_print_debug_log(conn, tmp_json.c_str());
 
-    /* Verify using debug log. */
-    model::kv_database from_debug_log;
-    model::debug_log_parser::parse_json(from_debug_log, tmp_json.c_str());
-    testutil_assert(from_debug_log.table("table")->verify_noexcept(conn));
+    /* Verify using the debug log JSON. */
+    model::kv_database db_from_debug_log_json;
+    model::debug_log_parser::from_json(db_from_debug_log_json, tmp_json.c_str());
+    testutil_assert(db_from_debug_log_json.table("table")->verify_noexcept(conn));
 
     /* Now try to get the verification to fail. */
     wt_remove(session, uri, key2, 1000);
-    testutil_assert(!from_debug_log.table("table")->verify_noexcept(conn));
+    testutil_assert(!db_from_debug_log.table("table")->verify_noexcept(conn));
 
     /* Clean up. */
     testutil_check(session->close(session, nullptr));

--- a/test/model/tools/CMakeLists.txt
+++ b/test/model/tools/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(model_tools)
+
+include(${CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
+
+# Build the tools.
+create_test_executable(model_verify_debug_log
+    SOURCES model_verify_debug_log/main.cpp
+    LIBS wiredtiger_model wiredtiger_model_test_common
+    CXX
+)

--- a/test/model/tools/model_verify_debug_log/main.cpp
+++ b/test/model/tools/model_verify_debug_log/main.cpp
@@ -120,27 +120,7 @@ main(int argc, char *argv[])
      */
     std::vector<std::string> tables;
     try {
-        WT_SESSION *session;
-        ret = conn->open_session(conn, nullptr, nullptr, &session);
-        if (ret != 0)
-            throw model::wiredtiger_exception("Cannot open a session: ", ret);
-        model::wiredtiger_session_guard session_guard(session);
-
-        WT_CURSOR *cursor;
-        ret = session->open_cursor(session, WT_METADATA_URI, NULL, NULL, &cursor);
-        if (ret != 0)
-            throw model::wiredtiger_exception("Cannot open a metadata cursor: ", ret);
-        model::wiredtiger_cursor_guard cursor_guard(cursor);
-
-        const char *key;
-        while ((ret = cursor->next(cursor)) == 0) {
-            /* Get the key. */
-            if ((ret = cursor->get_key(cursor, &key)) != 0)
-                throw model::wiredtiger_exception("Cannot get key: ", ret);
-
-            if (strncmp(key, "table:", 6) == 0)
-                tables.push_back(key + 6);
-        }
+        tables = model::wt_list_tables(conn);
     } catch (std::exception &e) {
         std::cerr << "Failed to list the tables: " << e.what() << std::endl;
         return EXIT_FAILURE;

--- a/test/model/tools/model_verify_debug_log/main.cpp
+++ b/test/model/tools/model_verify_debug_log/main.cpp
@@ -1,0 +1,118 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+#include "wiredtiger.h"
+extern "C" {
+#include "wt_internal.h"
+}
+
+#include "model/driver/debug_log_parser.h"
+#include "model/kv_database.h"
+
+/*
+ * Command-line arguments.
+ */
+extern int __wt_optind, __wt_optwt;
+extern char *__wt_optarg;
+
+/*
+ * Configuration.
+ */
+/*#define ENV_CONFIG                                            \
+    "cache_size=20M,create,"                                  \
+    "debug_mode=(table_logging=true,checkpoint_retention=5)," \
+    "eviction_updates_target=20,eviction_updates_trigger=90," \
+    "log=(enabled,file_max=10M,remove=true),session_max=100," \
+    "statistics=(all),statistics_log=(wait=1,json,on_close)"*/
+
+/*
+ * usage --
+ *     Print usage help for the program. (Don't exit.)
+ */
+static void
+usage(const char *progname)
+{
+    fprintf(stderr, "usage: %s DEBUG_LOG_JSON\n", progname);
+}
+
+/*
+ * main --
+ *     The main entry point for the test.
+ */
+int
+main(int argc, char *argv[])
+{
+    const char *progname;
+    int ch, ret;
+
+    progname = argv[0];
+
+    /*
+     * Parse the command-line arguments.
+     */
+    __wt_optwt = 1;
+    while ((ch = __wt_getopt(progname, argc, argv, "?")) != EOF)
+        switch (ch) {
+        case '?':
+            usage(progname);
+            return EXIT_SUCCESS;
+        default:
+            usage(progname);
+            return EXIT_FAILURE;
+        }
+    argc -= __wt_optind;
+    if (argc != 1) {
+        usage(progname);
+        return EXIT_FAILURE;
+    }
+
+    const char *debug_log_json = argv[__wt_optind];
+
+    /*
+     * Verify.
+     */
+    try {
+        ret = EXIT_SUCCESS;
+
+        std::cout << "Loading " << debug_log_json << std::endl;
+        model::kv_database db;
+        model::debug_log_parser::parse_json(db, debug_log_json);
+    } catch (std::exception &e) {
+        std::cerr << "Verification failed: " << e.what() << std::endl;
+        ret = EXIT_FAILURE;
+    }
+
+    return ret;
+}


### PR DESCRIPTION
This PR adds support and tooling for parsing the debug log into the model operations, both directly (for efficiency) and via JSON export (for easier debugging).

Don, Will: Let me know if you'd like me to go over these changes with you, as this is also a fairly substantial PR.