### PR TITLE
WT-11938 Allow Evergreen to apply options after ENABLE_TCMALLOC

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -167,7 +167,7 @@ functions:
           ${CMAKE_INSTALL_PREFIX|-DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL} \
           ${CMAKE_PREFIX_PATH|-DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"} \
           ${CMAKE_TOOLCHAIN_FILE|-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_gcc.cmake} \
-          ${ENABLE_TCMALLOC|}
+          ${ENABLE_TCMALLOC|} \
           ${NONSTANDALONE|} \
           ${ENABLE_SHARED|} \
           ${ENABLE_STATIC|} \


### PR DESCRIPTION
This was breaking a lot of stuff - none of the options after this one were getting applied. The shell just took the subsequent lines as a command saying `NONSTANDALONE=1 ...`, with no effect.