### PR TITLE
WT-9607 Fix timing of compact progress messages

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -421,7 +421,7 @@ __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block)
     /* Log one progress message every twenty seconds. */
     time_diff = WT_TIMEDIFF_SEC(cur_time, session->compact->last_progress);
     if (time_diff > WT_PROGRESS_MSG_PERIOD) {
-        __wt_epoch(session, &session->compact->last_progress);
+        session->compact->last_progress = cur_time;
 
         /*
          * If we don't have the estimate at this point, it means that we haven't reviewed even

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -407,7 +407,7 @@ __block_compact_estimate_remaining_work(WT_SESSION_IMPL *session, WT_BLOCK *bloc
  *     Output compact progress message.
  */
 void
-__wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block, u_int *msg_countp)
+__wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     struct timespec cur_time;
     uint64_t time_diff;
@@ -419,9 +419,9 @@ __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block, u_int *ms
     __wt_epoch(session, &cur_time);
 
     /* Log one progress message every twenty seconds. */
-    time_diff = WT_TIMEDIFF_SEC(cur_time, session->compact->begin);
-    if (time_diff / WT_PROGRESS_MSG_PERIOD > *msg_countp) {
-        ++*msg_countp;
+    time_diff = WT_TIMEDIFF_SEC(cur_time, session->compact->last_progress);
+    if (time_diff > WT_PROGRESS_MSG_PERIOD) {
+        __wt_epoch(session, &session->compact->last_progress);
 
         /*
          * If we don't have the estimate at this point, it means that we haven't reviewed even

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -368,9 +368,9 @@ __bm_compact_page_skip_readonly(
  *     Output compact progress message.
  */
 static void
-__bm_compact_progress(WT_BM *bm, WT_SESSION_IMPL *session, u_int *msg_countp)
+__bm_compact_progress(WT_BM *bm, WT_SESSION_IMPL *session)
 {
-    __wt_block_compact_progress(session, bm->block, msg_countp);
+    __wt_block_compact_progress(session, bm->block);
 }
 
 /*

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -311,7 +311,7 @@ __wt_compact(WT_SESSION_IMPL *session)
     WT_BM *bm;
     WT_DECL_RET;
     WT_REF *ref;
-    u_int i, msg_count;
+    u_int i;
     bool first, skip;
 
     uint64_t stats_pages_reviewed;           /* Pages reviewed */
@@ -320,7 +320,6 @@ __wt_compact(WT_SESSION_IMPL *session)
     uint64_t stats_pages_skipped;            /* Pages skipped */
 
     bm = S2BT(session)->bm;
-    msg_count = 0;
     ref = NULL;
 
     WT_STAT_DATA_INCR(session, session_compact);
@@ -366,7 +365,7 @@ __wt_compact(WT_SESSION_IMPL *session)
          */
         if (first || ++i > 100) {
             if (!first)
-                bm->compact_progress(bm, session, &msg_count);
+                bm->compact_progress(bm, session);
             WT_ERR(__wt_session_compact_check_interrupted(session));
 
             if (__wt_cache_stuck(session))

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -193,7 +193,7 @@ struct __wt_bm {
     int (*compact_page_rewrite)(WT_BM *, WT_SESSION_IMPL *, uint8_t *, size_t *, bool *);
     int (*compact_page_skip)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t, bool *);
     int (*compact_skip)(WT_BM *, WT_SESSION_IMPL *, bool *);
-    void (*compact_progress)(WT_BM *, WT_SESSION_IMPL *, u_int *);
+    void (*compact_progress)(WT_BM *, WT_SESSION_IMPL *);
     int (*compact_start)(WT_BM *, WT_SESSION_IMPL *);
     int (*corrupt)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
     int (*free)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);

--- a/src/include/compact.h
+++ b/src/include/compact.h
@@ -12,5 +12,6 @@ struct __wt_compact_state {
     uint64_t free_space_target; /* Configured minimum space that should be recovered */
     uint64_t max_time;          /* Configured timeout */
 
-    struct timespec begin; /* Starting time */
+    struct timespec begin;         /* Starting time */
+    struct timespec last_progress; /* Last time a progress message was logged. */
 };

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1831,8 +1831,7 @@ extern void __wt_block_ckpt_destroy(WT_SESSION_IMPL *session, WT_BLOCK_CKPT *ci)
 extern void __wt_block_compact_get_progress_stats(WT_SESSION_IMPL *session, WT_BM *bm,
   uint64_t *pages_reviewedp, uint64_t *pages_skippedp, uint64_t *pages_rewrittenp,
   uint64_t *pages_rewritten_expectedp);
-extern void __wt_block_compact_progress(
-  WT_SESSION_IMPL *session, WT_BLOCK *block, u_int *msg_countp);
+extern void __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern void __wt_block_configure_first_fit(WT_BLOCK *block, bool on);
 extern void __wt_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext);
 extern void __wt_block_extlist_free(WT_SESSION_IMPL *session, WT_EXTLIST *el);

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -498,6 +498,7 @@ __wt_session_compact(WT_SESSION *wt_session, const char *uri, const char *config
     WT_ERR(__wt_config_gets(session, cfg, "timeout", &cval));
     session->compact->max_time = (uint64_t)cval.val;
     __wt_epoch(session, &session->compact->begin);
+    __wt_epoch(session, &session->compact->last_progress);
 
     /*
      * Find the types of data sources being compacted. This could involve opening indexes for a

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -498,7 +498,7 @@ __wt_session_compact(WT_SESSION *wt_session, const char *uri, const char *config
     WT_ERR(__wt_config_gets(session, cfg, "timeout", &cval));
     session->compact->max_time = (uint64_t)cval.val;
     __wt_epoch(session, &session->compact->begin);
-    __wt_epoch(session, &session->compact->last_progress);
+    session->compact->last_progress = session->compact->begin;
 
     /*
      * Find the types of data sources being compacted. This could involve opening indexes for a


### PR DESCRIPTION
I've replaced the message counter with a last progress time variable in the `session->compact structure`. Since the `session->compact->begin` was set before the checkpoint, the message counter still had the problem of playing catch up when the first compact checkpoint took a long time.

Alternatively, if we want to keep msg_count, it would have to be initialised in `__session_compact` before the first checkpoint, instead of `__wt_compact` to avoid it being reset to 0 after every iteration. Although this would require passing it into `wt_compact`.