### PR TITLE
WT-11888 Fix Evergreen Python version detection on macOS

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -195,7 +195,7 @@ functions:
           DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
         fi
 
-        if [ "${build_variant|}" = "macos-1100" -o "${build_variant|}" = "macos-1100-arm64" ]; then
+        if [[ "${build_variant|}" =~ "macos-1100" ]]; then
           # For mac builds, we want explicitly tell cmake which python to use, as
           # well as the matching library directory and header files. The find_libpython
           # module gives us the library.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -214,13 +214,18 @@ functions:
              SYSPYDIR=$(dirname $SYSPYLIB)
              NSYSPYLIB=$(ls $SYSPYDIR/lib/libpython*.dylib 2>/dev/null | head -1)
              if [ -f "$NSYSPYLIB" ]; then
-                 SYSPYLIB=$NSYSPYLIB
+               SYSPYLIB=$NSYSPYLIB
              fi
              if [ -d "$SYSPYDIR/Headers" ]; then
-                 SYSPYINCDEF="-DPython3_INCLUDE_DIR=$SYSPYDIR/Headers"
+               SYSPYINCDEF="$SYSPYDIR/Headers"
              fi
           fi
-          DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPython3_EXECUTABLE=$SYSPY -DPython3_LIBRARY=$SYSPYLIB $SYSPYINCDEF"
+
+          if [ "${build_variant|}" = "macos-1100-arm64" ]; then
+            DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPython3_EXECUTABLE=$SYSPY -DPython3_LIBRARY=$SYSPYLIB -DPython3_INCLUDE_DIR=$SYSPYINCDEF"
+          else
+            DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPYTHON_EXECUTABLE:FILEPATH=$SYSPY -DPYTHON_LIBRARY=$SYSPYLIB -DPYTHON_INCLUDE_DIR=$SYSPYINCDEF"
+          fi
         fi
 
         if [ "$OS" = "Windows_NT" ]; then

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -167,7 +167,7 @@ functions:
           ${CMAKE_INSTALL_PREFIX|-DCMAKE_INSTALL_PREFIX=$(pwd)/cmake_build/LOCAL_INSTALL} \
           ${CMAKE_PREFIX_PATH|-DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"} \
           ${CMAKE_TOOLCHAIN_FILE|-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_gcc.cmake} \
-          ${ENABLE_TCMALLOC|}
+          ${ENABLE_TCMALLOC|} \
           ${NONSTANDALONE|} \
           ${ENABLE_SHARED|} \
           ${ENABLE_STATIC|} \
@@ -195,7 +195,7 @@ functions:
           DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
         fi
 
-        if [ "${build_variant|}" = "macos-1100" ]; then
+        if [ "${build_variant|}" = "macos-1100" -o "${build_variant|}" = "macos-1100-arm64" ]; then
           # For mac builds, we want explicitly tell cmake which python to use, as
           # well as the matching library directory and header files. The find_libpython
           # module gives us the library.
@@ -217,10 +217,10 @@ functions:
                  SYSPYLIB=$NSYSPYLIB
              fi
              if [ -d "$SYSPYDIR/Headers" ]; then
-                 SYSPYINCDEF="-DPYTHON_INCLUDE_DIR=$SYSPYDIR/Headers"
+                 SYSPYINCDEF="-DPython3_INCLUDE_DIR=$SYSPYDIR/Headers"
              fi
           fi
-          DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPYTHON_EXECUTABLE:FILEPATH=$SYSPY -DPYTHON_LIBRARY=$SYSPYLIB $SYSPYINCDEF"
+          DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPython3_EXECUTABLE=$SYSPY -DPython3_LIBRARY=$SYSPYLIB $SYSPYINCDEF"
         fi
 
         if [ "$OS" = "Windows_NT" ]; then
@@ -1309,7 +1309,7 @@ variables:
     ENABLE_CPPSUITE: -DENABLE_CPPSUITE=0
 
 
-# Template for Mac tests
+  # Template for Mac tests
   - &mac_test_template
     expansions: &mac_test_template_expansions
       # The cmake toolchain file is set to the mongodb toolchain gcc by default.

--- a/test/evergreen/python_version_check.py
+++ b/test/evergreen/python_version_check.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import subprocess
 import sys


### PR DESCRIPTION
CMake obsoleted the non-versioned Python executable/library/include strings, plus the code for explicitly setting those wasn't running for the arm64 variant.