### PR TITLE
WT-11793 Remove uses of WT_ internal macros in cpp suite: WT_BILLION,…

### DIFF
--- a/test/cppsuite/src/common/logger.cpp
+++ b/test/cppsuite/src/common/logger.cpp
@@ -60,7 +60,7 @@ get_time(char *time_buf, size_t buf_size)
     uint64_t epoch_nanosec = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
     /* Calculate time since epoch in seconds. */
-    time_t time_epoch_sec = epoch_nanosec / 1000000000 /* Billion. */;
+    time_t time_epoch_sec = epoch_nanosec / testutil_billion;
 
     tm = localtime_r(&time_epoch_sec, &_tm);
     testutil_assert(tm != nullptr);
@@ -69,9 +69,8 @@ get_time(char *time_buf, size_t buf_size)
       strftime(time_buf, buf_size, logger::include_date ? "[%Y-%m-%dT%H:%M:%S" : "[%H:%M:%S", tm);
 
     testutil_assert(alloc_size <= buf_size);
-    auto __ignored_ret = (__wt_snprintf(&time_buf[alloc_size], buf_size - alloc_size,
-      ".%" PRIu64 "Z]", (uint64_t)epoch_nanosec % 1000000000 /* Billion. */));
-    (void)__ignored_ret;
+    testutil_ignore_ret(__wt_snprintf(&time_buf[alloc_size], buf_size - alloc_size, ".%" PRIu64 "Z]",
+      (uint64_t)epoch_nanosec % testutil_billion));
 }
 
 /* Used to print out traces for debugging purpose. */

--- a/test/cppsuite/src/common/logger.cpp
+++ b/test/cppsuite/src/common/logger.cpp
@@ -60,7 +60,7 @@ get_time(char *time_buf, size_t buf_size)
     uint64_t epoch_nanosec = std::chrono::high_resolution_clock::now().time_since_epoch().count();
 
     /* Calculate time since epoch in seconds. */
-    time_t time_epoch_sec = epoch_nanosec / WT_BILLION;
+    time_t time_epoch_sec = epoch_nanosec / 1000000000 /* Billion. */;
 
     tm = localtime_r(&time_epoch_sec, &_tm);
     testutil_assert(tm != nullptr);
@@ -69,8 +69,9 @@ get_time(char *time_buf, size_t buf_size)
       strftime(time_buf, buf_size, logger::include_date ? "[%Y-%m-%dT%H:%M:%S" : "[%H:%M:%S", tm);
 
     testutil_assert(alloc_size <= buf_size);
-    WT_IGNORE_RET(__wt_snprintf(&time_buf[alloc_size], buf_size - alloc_size, ".%" PRIu64 "Z]",
-      (uint64_t)epoch_nanosec % WT_BILLION));
+    auto __ignored_ret = (__wt_snprintf(&time_buf[alloc_size], buf_size - alloc_size,
+      ".%" PRIu64 "Z]", (uint64_t)epoch_nanosec % 1000000000 /* Billion. */));
+    (void)__ignored_ret;
 }
 
 /* Used to print out traces for debugging purpose. */

--- a/test/cppsuite/src/common/logger.cpp
+++ b/test/cppsuite/src/common/logger.cpp
@@ -69,8 +69,8 @@ get_time(char *time_buf, size_t buf_size)
       strftime(time_buf, buf_size, logger::include_date ? "[%Y-%m-%dT%H:%M:%S" : "[%H:%M:%S", tm);
 
     testutil_assert(alloc_size <= buf_size);
-    testutil_ignore_ret(__wt_snprintf(&time_buf[alloc_size], buf_size - alloc_size, ".%" PRIu64 "Z]",
-      (uint64_t)epoch_nanosec % testutil_billion));
+    testutil_ignore_ret(__wt_snprintf(&time_buf[alloc_size], buf_size - alloc_size,
+      ".%" PRIu64 "Z]", (uint64_t)epoch_nanosec % testutil_billion));
 }
 
 /* Used to print out traces for debugging purpose. */

--- a/test/cppsuite/src/component/operation_tracker.cpp
+++ b/test/cppsuite/src/component/operation_tracker.cpp
@@ -84,7 +84,7 @@ operation_tracker::load()
 void
 operation_tracker::do_work()
 {
-    WT_DECL_RET;
+    int ret = 0;
     wt_timestamp_t ts, oldest_ts;
     uint64_t collection_id;
     uint64_t sweep_collection_id = 0;

--- a/test/cppsuite/src/main/configuration.cpp
+++ b/test/cppsuite/src/main/configuration.cpp
@@ -168,7 +168,7 @@ T
 configuration::get(
   const std::string &key, bool optional, types type, T def, T (*func)(WT_CONFIG_ITEM item))
 {
-    WT_DECL_RET;
+    int ret = 0;
     WT_CONFIG_ITEM value = {"", 0, 1, WT_CONFIG_ITEM::WT_CONFIG_ITEM_BOOL};
 
     ret = _config_parser->get(_config_parser, key.c_str(), &value);

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -332,7 +332,7 @@ database_operation::remove_operation(thread_worker *tc)
              * one.
              */
             if (ret == WT_NOTFOUND) {
-                (void)(tc->txn.commit());
+                testutil_ignore_ret_bool(tc->txn.commit());
             } else if (ret == WT_ROLLBACK) {
                 tc->txn.rollback();
             } else {
@@ -354,7 +354,7 @@ database_operation::remove_operation(thread_worker *tc)
 
         /* Commit the current transaction if we're able to. */
         if (tc->txn.can_commit())
-            (void)(tc->txn.commit());
+            testutil_ignore_ret_bool(tc->txn.commit());
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */
@@ -413,7 +413,7 @@ database_operation::update_operation(thread_worker *tc)
 
         /* Commit the current transaction if we're able to. */
         if (tc->txn.can_commit())
-            (void)(tc->txn.commit());
+            testutil_ignore_ret_bool(tc->txn.commit());
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -332,7 +332,7 @@ database_operation::remove_operation(thread_worker *tc)
              * one.
              */
             if (ret == WT_NOTFOUND) {
-                WT_IGNORE_RET_BOOL(tc->txn.commit());
+                (void)(tc->txn.commit());
             } else if (ret == WT_ROLLBACK) {
                 tc->txn.rollback();
             } else {
@@ -354,7 +354,7 @@ database_operation::remove_operation(thread_worker *tc)
 
         /* Commit the current transaction if we're able to. */
         if (tc->txn.can_commit())
-            WT_IGNORE_RET_BOOL(tc->txn.commit());
+            (void)(tc->txn.commit());
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */
@@ -413,7 +413,7 @@ database_operation::update_operation(thread_worker *tc)
 
         /* Commit the current transaction if we're able to. */
         if (tc->txn.can_commit())
-            WT_IGNORE_RET_BOOL(tc->txn.commit());
+            (void)(tc->txn.commit());
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -105,7 +105,7 @@ bool
 thread_worker::update(
   scoped_cursor &cursor, uint64_t collection_id, const std::string &key, const std::string &value)
 {
-    WT_DECL_RET;
+    int ret = 0;
 
     testutil_assert(op_tracker != nullptr);
     testutil_assert(cursor.get() != nullptr);
@@ -146,7 +146,7 @@ bool
 thread_worker::insert(
   scoped_cursor &cursor, uint64_t collection_id, const std::string &key, const std::string &value)
 {
-    WT_DECL_RET;
+    int ret = 0;
 
     testutil_assert(op_tracker != nullptr);
     testutil_assert(cursor.get() != nullptr);
@@ -186,7 +186,7 @@ thread_worker::insert(
 bool
 thread_worker::remove(scoped_cursor &cursor, uint64_t collection_id, const std::string &key)
 {
-    WT_DECL_RET;
+    int ret = 0;
     testutil_assert(op_tracker != nullptr);
     testutil_assert(cursor.get() != nullptr);
 
@@ -230,7 +230,7 @@ bool
 thread_worker::truncate(uint64_t collection_id, std::optional<std::string> start_key,
   std::optional<std::string> stop_key, const std::string &config)
 {
-    WT_DECL_RET;
+    int ret = 0;
 
     wt_timestamp_t ts = tsm->get_next_ts();
     ret = txn.set_commit_timestamp(ts);

--- a/test/cppsuite/src/main/transaction.cpp
+++ b/test/cppsuite/src/main/transaction.cpp
@@ -87,7 +87,7 @@ transaction::try_begin(const std::string &config)
 bool
 transaction::commit(const std::string &config)
 {
-    WT_DECL_RET;
+    int ret = 0;
     testutil_assert(_in_txn && !_needs_rollback);
 
     ret = _session->commit_transaction(_session, config.empty() ? nullptr : config.c_str());

--- a/test/cppsuite/src/main/validator.cpp
+++ b/test/cppsuite/src/main/validator.cpp
@@ -38,7 +38,7 @@ void
 validator::validate(
   const std::string &operation_table_name, const std::string &schema_table_name, database &db)
 {
-    WT_DECL_RET;
+    int ret = 0;
     wt_timestamp_t tracked_timestamp;
     std::vector<uint64_t> created_collections, deleted_collections;
     uint64_t tracked_collection_id;
@@ -260,7 +260,7 @@ void
 validator::verify_key_value(scoped_session &session, const uint64_t collection_id,
   const std::string &key, const key_state &key_state)
 {
-    WT_DECL_RET;
+    int ret = 0;
     const char *retrieved_value;
 
     scoped_cursor cursor =

--- a/test/cppsuite/tests/background_compact.cpp
+++ b/test/cppsuite/tests/background_compact.cpp
@@ -150,7 +150,7 @@ public:
                      * starting a new one.
                      */
                     if (ret == WT_NOTFOUND)
-                        (void)(tw->txn.commit());
+                        testutil_ignore_ret_bool(tw->txn.commit());
                     else if (ret == WT_ROLLBACK)
                         tw->txn.rollback();
                     else

--- a/test/cppsuite/tests/background_compact.cpp
+++ b/test/cppsuite/tests/background_compact.cpp
@@ -150,7 +150,7 @@ public:
                      * starting a new one.
                      */
                     if (ret == WT_NOTFOUND)
-                        WT_IGNORE_RET_BOOL(tw->txn.commit());
+                        (void)(tw->txn.commit());
                     else if (ret == WT_ROLLBACK)
                         tw->txn.rollback();
                     else

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -443,7 +443,7 @@ public:
                      * If we cannot find any record, finish the current transaction as we might be
                      * able to see new records after starting a new one.
                      */
-                    WT_IGNORE_RET_BOOL(tc->txn.commit());
+                    (void)(tc->txn.commit());
                     continue;
                 } else if (ret == WT_ROLLBACK)
                     break;

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -443,7 +443,7 @@ public:
                      * If we cannot find any record, finish the current transaction as we might be
                      * able to see new records after starting a new one.
                      */
-                    (void)(tc->txn.commit());
+                    testutil_ignore_ret_bool(tc->txn.commit());
                     continue;
                 } else if (ret == WT_ROLLBACK)
                     break;

--- a/test/cppsuite/tests/csuite_style_example_test.cpp
+++ b/test/cppsuite/tests/csuite_style_example_test.cpp
@@ -79,7 +79,7 @@ read_op(WT_CURSOR *cursor, int key_size)
     while (do_reads) {
         key = random_generator::instance().generate_random_string(key_size);
         cursor->set_key(cursor, key.c_str());
-        WT_IGNORE_RET(cursor->search(cursor));
+        (void)(cursor->search(cursor));
     }
 }
 

--- a/test/cppsuite/tests/csuite_style_example_test.cpp
+++ b/test/cppsuite/tests/csuite_style_example_test.cpp
@@ -79,7 +79,7 @@ read_op(WT_CURSOR *cursor, int key_size)
     while (do_reads) {
         key = random_generator::instance().generate_random_string(key_size);
         cursor->set_key(cursor, key.c_str());
-        (void)(cursor->search(cursor));
+        WT_IGNORE_RET(cursor->search(cursor));
     }
 }
 

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -270,31 +270,31 @@ typedef struct {
 
 /*
  * Quiet compiler warnings about unused function parameters and variables, and unused function
- * return values.  The equivalent of WT_ macros.
+ * return values. The equivalent of WT_ macros.
  */
 #define testutil_unused(var) (void)(var)
 #define testutil_not_read(v, val) \
-    do {                    \
-        (v) = (val);        \
-        (void)(v);          \
+    do {                          \
+        (v) = (val);              \
+        (void)(v);                \
     } while (0);
-#define testutil_ignore_ret(call)                \
+#define testutil_ignore_ret(call)          \
     do {                                   \
         uintmax_t __ignored_ret;           \
         __ignored_ret = (uintmax_t)(call); \
-        testutil_unused(__ignored_ret);          \
+        testutil_unused(__ignored_ret);    \
     } while (0)
 #define testutil_ignore_ret_bool(call)  \
-    do {                          \
-        bool __ignored_ret;       \
-        __ignored_ret = (call);   \
+    do {                                \
+        bool __ignored_ret;             \
+        __ignored_ret = (call);         \
         testutil_unused(__ignored_ret); \
     } while (0)
-#define testutil_ignore_ret_ptr(call)    \
-    do {                           \
-        const void *__ignored_ret; \
-        __ignored_ret = (call);    \
-        testutil_unused(__ignored_ret);  \
+#define testutil_ignore_ret_ptr(call)   \
+    do {                                \
+        const void *__ignored_ret;      \
+        __ignored_ret = (call);         \
+        testutil_unused(__ignored_ret); \
     } while (0)
 
 /* Basic constants. */

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -269,6 +269,38 @@ typedef struct {
     testutil_check(__wt_snprintf_len_set(out, size, retsizep, __VA_ARGS__))
 
 /*
+ * Quiet compiler warnings about unused function parameters and variables, and unused function
+ * return values.  The equivalent of WT_ macros.
+ */
+#define testutil_unused(var) (void)(var)
+#define testutil_not_read(v, val) \
+    do {                    \
+        (v) = (val);        \
+        (void)(v);          \
+    } while (0);
+#define testutil_ignore_ret(call)                \
+    do {                                   \
+        uintmax_t __ignored_ret;           \
+        __ignored_ret = (uintmax_t)(call); \
+        testutil_unused(__ignored_ret);          \
+    } while (0)
+#define testutil_ignore_ret_bool(call)  \
+    do {                          \
+        bool __ignored_ret;       \
+        __ignored_ret = (call);   \
+        testutil_unused(__ignored_ret); \
+    } while (0)
+#define testutil_ignore_ret_ptr(call)    \
+    do {                           \
+        const void *__ignored_ret; \
+        __ignored_ret = (call);    \
+        testutil_unused(__ignored_ret);  \
+    } while (0)
+
+/* Basic constants. */
+#define testutil_billion (1000000000)
+
+/*
  * WT_OP_CHECKPOINT_WAIT --
  *	If an operation returns EBUSY checkpoint and retry.
  */


### PR DESCRIPTION
… WT_DECL_RET, WT_IGNORE_RET(), and WT_IGNORE_RET_BOOL()

The issue specifically requested WT_DECL_RET. It also said to check for other internal macros. That yielded the other macros listed above.