### PR TITLE
WT-11954 Account for the case where the max in-memory page size is smaller than the max on-disk page size

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1789,7 +1789,8 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
  * are 5 items on the page.
  */
 #define WT_MAX_SPLIT_COUNT 5
-    if (page->memory_footprint > (size_t)btree->maxleafpage * 2) {
+    mem_split_threshold = (size_t)WT_MIN(btree->maxleafpage * 2, btree->splitmempage);
+    if (page->memory_footprint > mem_split_threshold) {
         for (count = 0, ins = ins_head->head[0]; ins != NULL; ins = ins->next[0]) {
             if (++count < WT_MAX_SPLIT_COUNT)
                 continue;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1789,7 +1789,7 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
  * are 5 items on the page.
  */
 #define WT_MAX_SPLIT_COUNT 5
-    if (page->memory_footprint > btree->maxleafpage * 2) {
+    if (page->memory_footprint > (size_t)btree->maxleafpage * 2) {
         for (count = 0, ins = ins_head->head[0]; ins != NULL; ins = ins->next[0]) {
             if (++count < WT_MAX_SPLIT_COUNT)
                 continue;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1814,6 +1814,12 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
          ins = ins->next[WT_MIN_SPLIT_DEPTH]) {
         count += WT_MIN_SPLIT_MULTIPLIER;
         size += WT_MIN_SPLIT_MULTIPLIER * (WT_INSERT_KEY_SIZE(ins) + WT_UPDATE_MEMSIZE(ins->upd));
+
+        /*
+         * Account for the case where the maximum in-memory page size is configured to be smaller than the
+         * maximum on-disk page size. Even with that configuration it is beneficial to be able to in-memory split
+         * for append workloads, and allow the reconciliation to happen in a background thread.
+         */        
         mem_split_threshold = (size_t)WT_MIN(btree->maxleafpage, btree->splitmempage);
         if (count > WT_MIN_SPLIT_COUNT && size > mem_split_threshold) {
             WT_STAT_CONN_DATA_INCR(session, cache_inmem_splittable);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1789,8 +1789,7 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
  * are 5 items on the page.
  */
 #define WT_MAX_SPLIT_COUNT 5
-    mem_split_threshold = WT_MIN(btree->maxleafpage * 2, btree->splitmempage);
-    if (page->memory_footprint > mem_split_threshold) {
+    if (page->memory_footprint > btree->maxleafpage * 2) {
         for (count = 0, ins = ins_head->head[0]; ins != NULL; ins = ins->next[0]) {
             if (++count < WT_MAX_SPLIT_COUNT)
                 continue;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1789,8 +1789,7 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
  * are 5 items on the page.
  */
 #define WT_MAX_SPLIT_COUNT 5
-    mem_split_threshold = (size_t)WT_MIN(btree->maxleafpage * 2, btree->splitmempage);
-    if (page->memory_footprint > mem_split_threshold) {
+    if (page->memory_footprint > (size_t)btree->maxleafpage * 2) {
         for (count = 0, ins = ins_head->head[0]; ins != NULL; ins = ins->next[0]) {
             if (++count < WT_MAX_SPLIT_COUNT)
                 continue;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1735,9 +1735,8 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
     WT_BTREE *btree;
     WT_INSERT *ins;
     WT_INSERT_HEAD *ins_head;
-    size_t size;
+    size_t size, mem_split_threshold;
     int count;
-    size_t mem_split_threshold = 0;
 
     btree = S2BT(session);
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1816,10 +1816,11 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
         size += WT_MIN_SPLIT_MULTIPLIER * (WT_INSERT_KEY_SIZE(ins) + WT_UPDATE_MEMSIZE(ins->upd));
 
         /*
-         * Account for the case where the maximum in-memory page size is configured to be smaller than the
-         * maximum on-disk page size. Even with that configuration it is beneficial to be able to in-memory split
-         * for append workloads, and allow the reconciliation to happen in a background thread.
-         */        
+         * Account for the case where the maximum in-memory page size is configured to be smaller
+         * than the maximum on-disk page size. Even with that configuration it is beneficial to be
+         * able to in-memory split for append workloads, and allow the reconciliation to happen in a
+         * background thread.
+         */
         mem_split_threshold = (size_t)WT_MIN(btree->maxleafpage, btree->splitmempage);
         if (count > WT_MIN_SPLIT_COUNT && size > mem_split_threshold) {
             WT_STAT_CONN_DATA_INCR(session, cache_inmem_splittable);


### PR DESCRIPTION
For example, if cache_size is set to a small value,  btree->maxleafpage may be greater than btree->splitmempage.