### PR TITLE
WT-11959 Don't increment cache_inmem_split statistic when split fails

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1983,6 +1983,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
         WT_STAT_CONN_DATA_INCR(session, cache_inmem_split);
         return (0);
     }
+    
     /*
      * Failure.
      *

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1767,8 +1767,6 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     int i;
     void *key;
 
-    WT_STAT_CONN_DATA_INCR(session, cache_inmem_split);
-
     page = ref->page;
     right = NULL;
     page_decr = parent_incr = right_incr = 0;
@@ -1981,9 +1979,10 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     /*
      * Split into the parent.
      */
-    if ((ret = __split_parent(session, ref, split_ref, 2, parent_incr, false, true)) == 0)
+    if ((ret = __split_parent(session, ref, split_ref, 2, parent_incr, false, true)) == 0) {
+        WT_STAT_CONN_DATA_INCR(session, cache_inmem_split);
         return (0);
-
+    }
     /*
      * Failure.
      *

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1983,7 +1983,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
         WT_STAT_CONN_DATA_INCR(session, cache_inmem_split);
         return (0);
     }
-    
+
     /*
      * Failure.
      *


### PR DESCRIPTION
cache_inmem_split Statistics perfect,  it should be after "split_parent" sunccess, So we can increase the count