### PR TITLE
WT-11885 Apply Github Apps for the doc-update task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -450,7 +450,7 @@ functions:
             if [[ $(git status "$branch" --porcelain) ]]; then
               git add $branch
               git commit -m "Update auto-generated docs for $branch" \
-                        --author="svc-bot-doc-build <svc-wiredtiger-doc-build@10gen.com>"
+                        --author="doc-build-bot <svc-wiredtiger-doc-build@10gen.com>"
             else
               echo "No documentation changes for $branch."
             fi
@@ -470,8 +470,15 @@ functions:
             exit 0
           fi
 
-          cd wiredtiger.github.com
-          git push https://"${doc-update-github-token}"@github.com/wiredtiger/wiredtiger.github.com
+          # Push the above-generated commit
+          virtualenv -p python3 venv
+          source venv/bin/activate
+          python -m pip install PyGithub
+          export GITHUB_OWNER="wiredtiger"
+          export GITHUB_REPO="wiredtiger.github.com"
+          export GITHUB_APP_ID="${doc_update_github_app_id}"
+          export GITHUB_APP_PRIVATE_KEY="${doc_update_github_app_private_key}"
+          python wiredtiger/test/evergreen/doc_update.py
 
   "make check directory":
     command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -471,6 +471,7 @@ functions:
           fi
 
           # Push the above-generated commit
+          ${PREPARE_PATH}
           virtualenv -p python3 venv
           source venv/bin/activate
           python -m pip install PyGithub

--- a/test/evergreen/doc_update.py
+++ b/test/evergreen/doc_update.py
@@ -2,10 +2,10 @@
 #
 # This script attempts to generate Github Apps token and use it to push a local commit to remote.
 # It assumes the local commit is ready and the below set of environment variables are set:
-#	- GITHUB_OWNER
-#	- GITHUB_REPO
-#	- GITHUB_APP_ID
-#	- GITHUB_APP_PRIVATE_KEY
+# - GITHUB_OWNER
+# - GITHUB_REPO
+# - GITHUB_APP_ID
+# - GITHUB_APP_PRIVATE_KEY
 #
 
 import os
@@ -39,19 +39,15 @@ except Exception as e:
 # Get an installation access token
 try:
     installation_auth = app.get_access_token(installation.id)
-    # Print the token to STDOUT and save it in an enviornment variable
-    print(f"token: {installation_auth.token}")
-    print(f"expires at: {installation_auth.expires_at}")
+    # Print the token to STDOUT and save it in an environment variable
     os.environ["GITHUB_APP_INSTALLATION_TOKEN"] = installation_auth.token
 except Exception as e:
     sys.exit(e)
 
 # Use the token to push the commit
 try:
-    os.chdir('wiredtiger.github.com')
-    cmd = f"git push https://'{app_id}:{installation_auth.token}'@github.com/{owner}/{repo}"
-    print(cmd)
-    subprocess.run([cmd], shell=True, check=True)
+    with os.chdir('wiredtiger.github.com'):
+        cmd = f"git push https://'{app_id}:{installation_auth.token}'@github.com/{owner}/{repo}"
+        subprocess.run([cmd], shell=True, check=True)
 except Exception as e:
     sys.exit(e)
-

--- a/test/evergreen/doc_update.py
+++ b/test/evergreen/doc_update.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+#
+# This script attempts to generate Github Apps token and use it to push a local commit to remote.
+# It assumes the local commit is ready and the below set of environment variables are set:
+#	- GITHUB_OWNER
+#	- GITHUB_REPO
+#	- GITHUB_APP_ID
+#	- GITHUB_APP_PRIVATE_KEY
+#
+
+import os
+import subprocess
+import sys
+
+from github.GithubIntegration import GithubIntegration
+
+
+# Get the App
+app_id = os.getenv("GITHUB_APP_ID")
+private_key = os.getenv("GITHUB_APP_PRIVATE_KEY")
+if (not app_id) or (not private_key):
+    sys.exit("Please ensure GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY environment variables are set.")
+try:
+    app = GithubIntegration(int(app_id), private_key)
+except Exception as e:
+    sys.exit(e)
+
+# Get the installation
+owner = os.getenv("GITHUB_OWNER")
+repo = os.getenv("GITHUB_REPO")
+if (not owner) or (not repo):
+    sys.exit("Please ensure GITHUB_OWNER and GITHUB_REPO environment variables are set.")
+try:
+    installation = app.get_repo_installation(owner, repo)
+    print(f"{installation.id=} for {owner}/{repo}")
+except Exception as e:
+    sys.exit(e)
+
+# Get an installation access token
+try:
+    installation_auth = app.get_access_token(installation.id)
+    # Print the token to STDOUT and save it in an enviornment variable
+    print(f"token: {installation_auth.token}")
+    print(f"expires at: {installation_auth.expires_at}")
+    os.environ["GITHUB_APP_INSTALLATION_TOKEN"] = installation_auth.token
+except Exception as e:
+    sys.exit(e)
+
+# Use the token to push the commit
+try:
+    os.chdir('wiredtiger.github.com')
+    cmd = f"git push https://'{app_id}:{installation_auth.token}'@github.com/{owner}/{repo}"
+    print(cmd)
+    subprocess.run([cmd], shell=True, check=True)
+except Exception as e:
+    sys.exit(e)
+


### PR DESCRIPTION
In the past, we used a bot account "svc-bot-doc-build" (and a static token) to push document updates to the "wiredtiger.github.com" repo. Now that the bot account needs to be moved out (see WTBUILD-100 for context), we had to switch to using Github App.

A new Github App "doc-build-bot" was created (with credentials provisioned in the Evergreen project). The changes in this PR are to leverage the new Github App token for "git push".