### PR TITLE
WT-11986 Fix missing script issue for the doc-update task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -419,6 +419,9 @@ functions:
             mv docs docs-$branch
           done
 
+          # Checkout back to the default ("develop") branch
+          git checkout develop
+
   "update wiredtiger docs":
     - command: shell.exec
       type: setup
@@ -484,7 +487,7 @@ functions:
           export GITHUB_REPO="wiredtiger.github.com"
           export GITHUB_APP_ID="${doc_update_github_app_id}"
           export GITHUB_APP_PRIVATE_KEY="${doc_update_github_app_private_key}"
-          # Make sure the below script is called under the "develop" branch.
+          # Make sure the below script is called under the default ("develop") branch.
           (cd wiredtiger && git checkout develop)
           python wiredtiger/test/evergreen/doc_update.py
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -484,6 +484,8 @@ functions:
           export GITHUB_REPO="wiredtiger.github.com"
           export GITHUB_APP_ID="${doc_update_github_app_id}"
           export GITHUB_APP_PRIVATE_KEY="${doc_update_github_app_private_key}"
+          # Make sure the below script is called under the "develop" branch.
+          (cd wiredtiger && git checkout develop)
           python wiredtiger/test/evergreen/doc_update.py
 
   "make check directory":

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -419,7 +419,7 @@ functions:
             mv docs docs-$branch
           done
 
-          # Checkout back to the default ("develop") branch
+          # Checkout the default ("develop") branch again to leave wiredtiger/ in the same state we started with
           git checkout develop
 
   "update wiredtiger docs":


### PR DESCRIPTION
The `doc-update` Evergreen task failed with a different reason after the merge of WT-11971. 
```
[2023/11/14 12:25:55.911] python: can't open file '/data/mci/5a8f72be949b713593899173fb10809e/wiredtiger/test/evergreen/doc_update.py': [Errno 2] No such file or directory
--
[2023/11/14 12:25:55.913] Command 'shell.exec' in function 'update wiredtiger docs' (step 3.2 of 5) failed: shell script encountered problem: exit code 2.
```
It turns out the "compile wiredtiger docs" func (the one called before the failing "update wiredtiger docs" func) has the logic of checking out each of the configured doc_update_branches, which left a branch without the script for the following "update wiredtiger docs" func to work with (and failed). 

The fix is to checkout "develop" branch before calling the Python script.