### PR TITLE
WT-11996 Remove long-running label for several C tests

### DIFF
--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -146,7 +146,6 @@ define_c_test(
     DIR_NAME wt2403_lsm_workload
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2403_lsm_workload>/WT_HOME>
     DEPENDS "WT_POSIX"
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -162,7 +161,6 @@ define_c_test(
     DIR_NAME wt2323_join_visibility
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2323_join_visibility>/WT_HOME>
     DEPENDS "WT_POSIX"
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -172,7 +170,6 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2535_insert_race/smoke.sh
     ARGUMENTS $<TARGET_FILE:test_wt2535_insert_race>
     DEPENDS "WT_POSIX"
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -211,7 +208,6 @@ define_c_test(
     SOURCES wt2834_join_bloom_fix/main.c
     DIR_NAME wt2834_join_bloom_fix
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2834_join_bloom_fix>/WT_HOME>
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -394,7 +390,6 @@ define_c_test(
     DIR_NAME wt8963_insert_stress
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8963_insert_stress>/WT_HOME>
     DEPENDS "WT_POSIX"
-    LABEL "long_running"
 )
 
 define_c_test(

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2420,7 +2420,7 @@ tasks:
   # csuite-long-running-bucket1 and csuite-long-running-bucket2 test tasks each run half of the long-running tests
   # so that each test task completes within the 5-hour time limit
 
-  - name: csuite-long-running-bucket1
+  - name: csuite-long-running
     # Set 5 hours timeout (60 * 60 * 5)
     exec_timeout_secs: 18000
     commands:
@@ -2429,18 +2429,7 @@ tasks:
       - func: "make check directory"
         vars:
           # Run the first test, and then every second test
-          extra_args: -L long_running -I 1,,2
-
-  - name: csuite-long-running-bucket2
-    # Set 5 hours timeout (60 * 60 * 5)
-    exec_timeout_secs: 18000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "make check directory"
-        vars:
-          # Run the second test, and then every second test
-          extra_args: -L long_running -I 2,,2
+          extra_args: -L long_running
 
   # Break out Python unit tests into multiple buckets/tasks.  We have a fixed number of buckets,
   # and we use the -b option of the test/suite/run.py script to split up the tests.
@@ -5966,11 +5955,7 @@ buildvariants:
     - name: ".workgen-test"
       batchtime: 1440 # 24 hours
     - name: model-test
-    - name: csuite-long-running-bucket1
-      # Some of the long-running tests require a large instance to run successfully.
-      distros: ubuntu2004-large
-      batchtime: 1440 # once a day
-    - name: csuite-long-running-bucket2
+    - name: csuite-long-running
       # Some of the long-running tests require a large instance to run successfully.
       distros: ubuntu2004-large
       batchtime: 1440 # once a day
@@ -6025,7 +6010,7 @@ buildvariants:
       export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libeatmydata.so:$LD_PRELOAD"
     # We don't run C++ memory sanitized testing as it creates false positives. MSAN also causes
     # some csuite tests to take an extended amount of time. These are excluded from the
-    # make-check-test task and are covered by the csuite-long-running-bucket1 & 2 tasks.
+    # make-check-test task and are covered by the csuite-long-running task.
     extra_args: -LE "cppsuite|long_running"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5956,8 +5956,6 @@ buildvariants:
       batchtime: 1440 # 24 hours
     - name: model-test
     - name: csuite-long-running
-      # Some of the long-running tests require a large instance to run successfully.
-      distros: ubuntu2004-large
       batchtime: 1440 # once a day
 
 - name: ubuntu2004-asan


### PR DESCRIPTION
After [WT-11583](https://jira.mongodb.org/browse/WT-11583):

- Several C tests are not taking that long to run (< 100 seconds)
- Since only a few of them are left, we don't need multiple buckets to run the remaining tests
- A large instance is not necessary either

See the JIRA ticket for the patch build. Please note that these labels might be re-introduced when they will be executed on slower variants, see WT-11989.