### PR TITLE
WT-12012 Restore original verbose levels if gen_drain becomes unstuck after increasing verbose levels

### DIFF
--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -135,17 +135,16 @@ struct __wt_verbose_multi_category {
     WT_VERBOSE_LEVEL_ISSET(session, category, WT_VERBOSE_LEVEL_DEFAULT)
 
 /* Set the verbose level and save the previous value. */
-#define WT_VERBOSE_SAVE(session, verbose_tmp, category, level)   \
-    do {                                                         \
-        verbose_tmp[category] = S2C(session)->verbose[category]; \
-        WT_SET_VERBOSE_LEVEL(session, category, level);          \
+#define WT_VERBOSE_SET_AND_SAVE(session, verbose_orig_level, category, level) \
+    do {                                                                      \
+        verbose_orig_level[category] = S2C(session)->verbose[category];       \
+        WT_SET_VERBOSE_LEVEL(session, category, level);                       \
     } while (0)
 
 /* Restore the original level  */
-#define WT_VERBOSE_RESTORE(session, verbose_tmp, category)              \
-    do {                                                                \
-        verbose_tmp[category] = S2C(session)->verbose[category];        \
-        WT_SET_VERBOSE_LEVEL(session, category, verbose_tmp[category]); \
+#define WT_VERBOSE_RESTORE(session, verbose_orig_level, category)              \
+    do {                                                                       \
+        WT_SET_VERBOSE_LEVEL(session, category, verbose_orig_level[category]); \
     } while (0)
 
 /*

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -134,26 +134,19 @@ struct __wt_verbose_multi_category {
 #define WT_VERBOSE_ISSET(session, category) \
     WT_VERBOSE_LEVEL_ISSET(session, category, WT_VERBOSE_LEVEL_DEFAULT)
 
-/* get the verbosity level for a given category. */
-#define WT_GET_VERBOSE_LEVEL(session, category, ret)                         \
-    do {                                                                     \
-        ret = S2C(session)->verbose[category];                               \
-    } while (0)
-
-/* Save the original level, and set new level  */
-#define WT_VERBOSE_SAVE(session, verbose_tmp, category, level)                \
-    do {                                                                      \
-        WT_GET_VERBOSE_LEVEL(session, category, ret);                         \
-        verbose_tmp[category] = ret;                                          \
-        WT_SET_VERBOSE_LEVEL(session, category, level);                       \
+/* Set the verbose level and save the previous value. */
+#define WT_VERBOSE_SAVE(session, verbose_tmp, category, level)   \
+    do {                                                         \
+        verbose_tmp[category] = S2C(session)->verbose[category]; \
+        WT_SET_VERBOSE_LEVEL(session, category, level);          \
     } while (0)
 
 /* Restore the original level  */
-#define WT_VERBOSE_RESTORE(session, verbose_tmp, category)                    \
-        do {                                                                  \
-            WT_GET_VERBOSE_LEVEL(session, category, ret);                     \
-            WT_SET_VERBOSE_LEVEL(session, category, verbose_tmp[category]);   \
-        } while (0)
+#define WT_VERBOSE_RESTORE(session, verbose_tmp, category)              \
+    do {                                                                \
+        verbose_tmp[category] = S2C(session)->verbose[category];        \
+        WT_SET_VERBOSE_LEVEL(session, category, verbose_tmp[category]); \
+    } while (0)
 
 /*
  * __wt_verbose_level --

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -134,6 +134,27 @@ struct __wt_verbose_multi_category {
 #define WT_VERBOSE_ISSET(session, category) \
     WT_VERBOSE_LEVEL_ISSET(session, category, WT_VERBOSE_LEVEL_DEFAULT)
 
+/* get the verbosity level for a given category. */
+#define WT_GET_VERBOSE_LEVEL(session, category, ret)                         \
+    do {                                                                     \
+        ret = S2C(session)->verbose[category];                               \
+    } while (0)
+
+/* Save the original level, and set new level  */
+#define WT_VERBOSE_SAVE(session, verbose_tmp, category, level)                \
+    do {                                                                      \
+        WT_GET_VERBOSE_LEVEL(session, category, ret);                         \
+        verbose_tmp[category] = ret;                                          \
+        WT_SET_VERBOSE_LEVEL(session, category, level);                       \
+    } while (0)
+
+/* Restore the original level  */
+#define WT_VERBOSE_RESTORE(session, verbose_tmp, category)                    \
+        do {                                                                  \
+            WT_GET_VERBOSE_LEVEL(session, category, ret);                     \
+            WT_SET_VERBOSE_LEVEL(session, category, verbose_tmp[category]);   \
+        } while (0)
+
 /*
  * __wt_verbose_level --
  *     Display a verbose message considering a category and a verbosity level.

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -192,17 +192,18 @@ __gen_drain_callback(
               (conn->gen_drain_timeout_ms < 20 ||
                 time_diff_ms > (conn->gen_drain_timeout_ms - 20))) {
                 if (cookie->base.which == WT_GEN_EVICT) {
-                    WT_VERBOSE_SAVE(session, verbose_orig_level, WT_VERB_EVICT, WT_VERBOSE_DEBUG_1);
-                    WT_VERBOSE_SAVE(
+                    WT_VERBOSE_SET_AND_SAVE(
+                      session, verbose_orig_level, WT_VERB_EVICT, WT_VERBOSE_DEBUG_1);
+                    WT_VERBOSE_SET_AND_SAVE(
                       session, verbose_orig_level, WT_VERB_EVICTSERVER, WT_VERBOSE_DEBUG_1);
-                    WT_VERBOSE_SAVE(
+                    WT_VERBOSE_SET_AND_SAVE(
                       session, verbose_orig_level, WT_VERB_EVICT_STUCK, WT_VERBOSE_DEBUG_1);
                 } else if (cookie->base.which == WT_GEN_CHECKPOINT) {
-                    WT_VERBOSE_SAVE(
+                    WT_VERBOSE_SET_AND_SAVE(
                       session, verbose_orig_level, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_1);
-                    WT_VERBOSE_SAVE(
+                    WT_VERBOSE_SET_AND_SAVE(
                       session, verbose_orig_level, WT_VERB_CHECKPOINT_CLEANUP, WT_VERBOSE_DEBUG_1);
-                    WT_VERBOSE_SAVE(
+                    WT_VERBOSE_SET_AND_SAVE(
                       session, verbose_orig_level, WT_VERB_CHECKPOINT_PROGRESS, WT_VERBOSE_DEBUG_1);
                 }
                 cookie->verbose_timeout_flags = true;

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -110,7 +110,7 @@ __gen_drain_callback(
     WT_GENERATION_DRAIN_COOKIE *cookie;
     uint64_t time_diff_ms, v;
 #ifdef HAVE_DIAGNOSTIC
-    WT_VERBOSE_LEVEL verbose_tmp[WT_VERB_NUM_CATEGORIES];
+    WT_VERBOSE_LEVEL verbose_orig_level[WT_VERB_NUM_CATEGORIES];
 #endif
 
     cookie = (WT_GENERATION_DRAIN_COOKIE *)cookiep;
@@ -136,13 +136,13 @@ __gen_drain_callback(
              */
             if (cookie->verbose_timeout_flags == true) {
                 if (cookie->base.which == WT_GEN_EVICT) {
-                    WT_VERBOSE_RESTORE(session, verbose_tmp, WT_VERB_EVICT);
-                    WT_VERBOSE_RESTORE(session, verbose_tmp, WT_VERB_EVICTSERVER);
-                    WT_VERBOSE_RESTORE(session, verbose_tmp, WT_VERB_EVICT_STUCK);
+                    WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_EVICT);
+                    WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_EVICTSERVER);
+                    WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_EVICT_STUCK);
                 } else if (cookie->base.which == WT_GEN_CHECKPOINT) {
-                    WT_VERBOSE_RESTORE(session, verbose_tmp, WT_VERB_CHECKPOINT);
-                    WT_VERBOSE_RESTORE(session, verbose_tmp, WT_VERB_CHECKPOINT_CLEANUP);
-                    WT_VERBOSE_RESTORE(session, verbose_tmp, WT_VERB_CHECKPOINT_PROGRESS);
+                    WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_CHECKPOINT);
+                    WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_CHECKPOINT_CLEANUP);
+                    WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_CHECKPOINT_PROGRESS);
                 }
             }
 #endif
@@ -192,15 +192,18 @@ __gen_drain_callback(
               (conn->gen_drain_timeout_ms < 20 ||
                 time_diff_ms > (conn->gen_drain_timeout_ms - 20))) {
                 if (cookie->base.which == WT_GEN_EVICT) {
-                    WT_VERBOSE_SAVE(session, verbose_tmp, WT_VERB_EVICT, WT_VERBOSE_DEBUG_1);
-                    WT_VERBOSE_SAVE(session, verbose_tmp, WT_VERB_EVICTSERVER, WT_VERBOSE_DEBUG_1);
-                    WT_VERBOSE_SAVE(session, verbose_tmp, WT_VERB_EVICT_STUCK, WT_VERBOSE_DEBUG_1);
+                    WT_VERBOSE_SAVE(session, verbose_orig_level, WT_VERB_EVICT, WT_VERBOSE_DEBUG_1);
+                    WT_VERBOSE_SAVE(
+                      session, verbose_orig_level, WT_VERB_EVICTSERVER, WT_VERBOSE_DEBUG_1);
+                    WT_VERBOSE_SAVE(
+                      session, verbose_orig_level, WT_VERB_EVICT_STUCK, WT_VERBOSE_DEBUG_1);
                 } else if (cookie->base.which == WT_GEN_CHECKPOINT) {
-                    WT_VERBOSE_SAVE(session, verbose_tmp, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_1);
                     WT_VERBOSE_SAVE(
-                      session, verbose_tmp, WT_VERB_CHECKPOINT_CLEANUP, WT_VERBOSE_DEBUG_1);
+                      session, verbose_orig_level, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_1);
                     WT_VERBOSE_SAVE(
-                      session, verbose_tmp, WT_VERB_CHECKPOINT_PROGRESS, WT_VERBOSE_DEBUG_1);
+                      session, verbose_orig_level, WT_VERB_CHECKPOINT_CLEANUP, WT_VERBOSE_DEBUG_1);
+                    WT_VERBOSE_SAVE(
+                      session, verbose_orig_level, WT_VERB_CHECKPOINT_PROGRESS, WT_VERBOSE_DEBUG_1);
                 }
                 cookie->verbose_timeout_flags = true;
                 /* Now we have enabled more logs, spin another time to get some information. */


### PR DESCRIPTION
In diagnostic mode WiredTiger will increase the verbosity levels for eviction and checkpoint just before generation drain times out which gives us better insight into what causes the timeout and resulting abort. 
However it's possible that generation drain becomes unstuck after the verbosity levels are increased, but before the timeout occurs. If this happens the original verbosity levels should be restored to prevent noisy traces.