### PR TITLE
WT-11987 Modify the metadata base tracking to detect corruption better.

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -117,14 +117,14 @@ __conn_dhandle_config_set(WT_SESSION_IMPL *session)
     }
     dhandle->cfg[1] = metaconf;
     dhandle->meta_base = base;
-    dhandle->meta_base_length = base == NULL ? 0 : strlen(base);
-#ifdef HAVE_DIAGNOSTIC
     /*  Save the original metadata value for further check to avoid writing corrupted data. */
-    if (base == NULL)
-        dhandle->orig_meta_base = NULL;
-    else
+    if (base != NULL) {
+        dhandle->meta_hash = __wt_hash_city64(base, strlen(base));
+        __wt_epoch(session, &dhandle->base_upd);
         WT_ERR(__wt_strdup(session, base, &dhandle->orig_meta_base));
-#endif
+        dhandle->orig_meta_hash = dhandle->meta_hash;
+        dhandle->orig_upd = dhandle->base_upd;
+    }
     return (0);
 
 err:

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -79,16 +79,17 @@ struct __wt_data_handle {
     TAILQ_ENTRY(__wt_data_handle) q;
     TAILQ_ENTRY(__wt_data_handle) hashq;
 
-    const char *name;         /* Object name as a URI */
-    uint64_t name_hash;       /* Hash of name */
-    const char *checkpoint;   /* Checkpoint name (or NULL) */
-    int64_t checkpoint_order; /* Checkpoint order number, when applicable */
-    const char **cfg;         /* Configuration information */
-    const char *meta_base;    /* Base metadata configuration */
-    size_t meta_base_length;  /* Base metadata length */
-#ifdef HAVE_DIAGNOSTIC
+    const char *name;           /* Object name as a URI */
+    uint64_t name_hash;         /* Hash of name */
+    const char *checkpoint;     /* Checkpoint name (or NULL) */
+    int64_t checkpoint_order;   /* Checkpoint order number, when applicable */
+    const char **cfg;           /* Configuration information */
+    const char *meta_base;      /* Base metadata configuration */
+    uint64_t meta_hash;         /* Base metadata hash */
+    struct timespec base_upd;   /* Time of last metadata update with meta base */
     const char *orig_meta_base; /* Copy of the base metadata configuration */
-#endif
+    uint64_t orig_meta_hash;    /* Copy of base metadata hash */
+    struct timespec orig_upd;   /* Time of original setup of meta base */
     /*
      * Sessions holding a connection's data handle and queued tiered storage work units will hold
      * references; sessions using a connection's data handle will have a non-zero in-use count.


### PR DESCRIPTION
I cannot get more out of the failure since there is no core. I have changed the checking to get rid of the HAVE_DIAGNOSTIC need so that any failure will panic. I went with using a string hash instead of length+strcmp.