### PR TITLE
WT-11616 Extend the debug log parser to support checkpoints

### DIFF
--- a/test/model/CMakeLists.txt
+++ b/test/model/CMakeLists.txt
@@ -2,11 +2,13 @@ project(wiredtiger_model CXX)
 
 # Create a model library.
 add_library(wiredtiger_model SHARED
+    src/core/core.cpp
     src/core/data_value.cpp
     src/core/kv_database.cpp
     src/core/kv_table_item.cpp
     src/core/kv_table.cpp
     src/core/kv_transaction.cpp
+    src/core/kv_transaction_snapshot.cpp
     src/core/util.cpp
     src/core/verify.cpp
     src/driver/debug_log_parser.cpp

--- a/test/model/src/core/core.cpp
+++ b/test/model/src/core/core.cpp
@@ -1,0 +1,40 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "model/core.h"
+
+extern "C" {
+#include "wt_internal.h"
+}
+
+namespace model {
+
+/* Finish checking WiredTiger's constants. */
+static_assert(k_txn_max == WT_TXN_MAX);
+
+} /* namespace model */

--- a/test/model/src/core/kv_table.cpp
+++ b/test/model/src/core/kv_table.cpp
@@ -49,6 +49,20 @@ kv_table::contains_any(const data_value &key, const data_value &value, timestamp
 }
 
 /*
+ * kv_table::contains_any --
+ *     Check whether the table contains the given key-value pair. If there are multiple values
+ *     associated with the given timestamp, return true if any of them match.
+ */
+bool
+kv_table::contains_any(kv_checkpoint_ptr ckpt, const data_value &key, const data_value &value) const
+{
+    const kv_table_item *item = item_if_exists(key);
+    if (item == nullptr)
+        return false;
+    return item->contains_any(ckpt, value);
+}
+
+/*
  * kv_table::get --
  *     Get the value. Return a copy of the value if is found, or NONE if not found. Throw an
  *     exception on error.
@@ -73,9 +87,6 @@ kv_table::get(kv_checkpoint_ptr ckpt, const data_value &key, timestamp_t timesta
     const kv_table_item *item = item_if_exists(key);
     if (item == nullptr)
         return NONE;
-    if (timestamp == k_timestamp_latest)
-        timestamp = ckpt->stable_timestamp() != k_timestamp_none ? ckpt->stable_timestamp() :
-                                                                   k_timestamp_latest;
     return item->get(ckpt, timestamp);
 }
 

--- a/test/model/src/core/kv_table_item.cpp
+++ b/test/model/src/core/kv_table_item.cpp
@@ -100,7 +100,7 @@ kv_table_item::add_update_nolock(
                 fail_with_rollback(update);
             case kv_transaction_state::committed:
             case kv_transaction_state::prepared:
-                if (!txn->visible_txn(u->txn_id()))
+                if (!txn->visible_update(*u))
                     fail_with_rollback(update);
                 break;
             case kv_transaction_state::rolled_back:
@@ -153,13 +153,14 @@ kv_table_item::fail_with_rollback(std::shared_ptr<kv_update> update)
  *     the given timestamp, return true if any of them match.
  */
 bool
-kv_table_item::contains_any(const data_value &value, timestamp_t timestamp) const
+kv_table_item::contains_any(const data_value &value, kv_transaction_snapshot_ptr txn_snapshot,
+  timestamp_t read_timestamp, timestamp_t stable_timestamp) const
 {
     std::lock_guard lock_guard(_lock);
     kv_update::timestamp_comparator cmp;
 
     /* Position the cursor on the update that is right after the provided timestamp. */
-    auto i = std::upper_bound(_updates.begin(), _updates.end(), timestamp, cmp);
+    auto i = std::upper_bound(_updates.begin(), _updates.end(), read_timestamp, cmp);
 
     /*
      * If we are positioned at the beginning of the list, there are no visible updates given the
@@ -169,16 +170,45 @@ kv_table_item::contains_any(const data_value &value, timestamp_t timestamp) cons
     if (i == _updates.begin())
         return false;
 
-    /* Read the timestamp of the latest visible update. */
-    timestamp_t t = (*(--i))->commit_timestamp();
+    /*
+     * Position the iterator to the latest visible update, if we consider only on the read
+     * timestamp.
+     */
+    i--;
 
-    /* Check all updates with that timestamp. */
-    for (; (*i)->commit_timestamp() == t; i--) {
-        if ((*i)->value() == value)
+    /* Skip any updates that are not visible due to the stable timestamp or the snapshot. */
+    auto visible = [&](const std::shared_ptr<kv_update> &u) -> bool {
+        return (!txn_snapshot || txn_snapshot->contains(*u)) &&
+          u->durable_timestamp() <= stable_timestamp;
+    };
+    for (;;) {
+        const std::shared_ptr<kv_update> &u = *i;
+
+        /* Check the snapshot and the timestamp. */
+        if (visible(u))
+            break;
+
+        /* Otherwise go to the previous update (unless we are already at the beginning). */
+        if (i == _updates.begin())
+            return false; /* No more updates - we are done. */
+        i--;
+    }
+
+    /* Now check all updates with the same commit timestamp. */
+    timestamp_t t = (*i)->commit_timestamp();
+    while ((*i)->commit_timestamp() == t) {
+        const std::shared_ptr<kv_update> &u = *i;
+
+        /* Found one! */
+        if (visible(u) && u->value() == value)
             return true;
+
+        /* Otherwise go to the previous update (unless we are already at the beginning). */
         if (i == _updates.begin())
             break;
+        i--;
     }
+
     return false;
 }
 
@@ -190,6 +220,16 @@ bool
 kv_table_item::exists() const
 {
     return get(k_timestamp_latest) != NONE;
+}
+
+/*
+ * kv_table_item::exists --
+ *     Check whether the latest value exists in the given checkpoint.
+ */
+bool
+kv_table_item::exists(kv_checkpoint_ptr checkpoint) const
+{
+    return get(checkpoint) != NONE;
 }
 
 /*
@@ -236,7 +276,7 @@ kv_table_item::get(kv_transaction_snapshot_ptr txn_snapshot, txn_id_t txn_id,
              * The transaction snapshot includes only committed transactions, so no need to check
              * whether the update is actually committed.
              */
-            if (txn_snapshot->contains(u->txn_id()) && u->durable_timestamp() <= stable_timestamp) {
+            if (txn_snapshot->contains(*u) && u->durable_timestamp() <= stable_timestamp) {
                 assert(u->committed());
                 return u->value();
             }

--- a/test/model/src/core/kv_table_item.cpp
+++ b/test/model/src/core/kv_table_item.cpp
@@ -177,15 +177,15 @@ kv_table_item::contains_any(const data_value &value, kv_transaction_snapshot_ptr
     i--;
 
     /* Skip any updates that are not visible due to the stable timestamp or the snapshot. */
-    auto visible = [&](const std::shared_ptr<kv_update> &u) -> bool {
+    auto update_visible = [&](const std::shared_ptr<kv_update> &u) -> bool {
         return (!txn_snapshot || txn_snapshot->contains(*u)) &&
           u->durable_timestamp() <= stable_timestamp;
     };
     for (;;) {
         const std::shared_ptr<kv_update> &u = *i;
 
-        /* Check the snapshot and the timestamp. */
-        if (visible(u))
+        /* Check the update's visibility. */
+        if (update_visible(u))
             break;
 
         /* Otherwise go to the previous update (unless we are already at the beginning). */
@@ -200,7 +200,7 @@ kv_table_item::contains_any(const data_value &value, kv_transaction_snapshot_ptr
         const std::shared_ptr<kv_update> &u = *i;
 
         /* Found one! */
-        if (visible(u) && u->value() == value)
+        if (update_visible(u) && u->value() == value)
             return true;
 
         /* Otherwise go to the previous update (unless we are already at the beginning). */

--- a/test/model/src/core/kv_transaction.cpp
+++ b/test/model/src/core/kv_transaction.cpp
@@ -44,6 +44,9 @@ kv_transaction::add_update(
   kv_table &table, const data_value &key, std::shared_ptr<kv_update> update)
 {
     std::lock_guard lock_guard(_lock);
+
+    update->set_wt_transaction_metadata(_wt_id, _wt_base_write_gen);
+
     std::shared_ptr<kv_transaction_update> txn_update =
       std::make_shared<kv_transaction_update>(table.name(), key, update);
 

--- a/test/model/src/core/kv_transaction_snapshot.cpp
+++ b/test/model/src/core/kv_transaction_snapshot.cpp
@@ -1,0 +1,69 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "model/kv_transaction_snapshot.h"
+#include "model/kv_update.h"
+
+namespace model {
+
+/*
+ * kv_transaction_snapshot_by_exclusion::contains --
+ *     Check whether the given update belongs to the snapshot.
+ */
+bool
+kv_transaction_snapshot_by_exclusion::contains(const kv_update &update) const noexcept
+{
+    if (update.txn_id() > _exclude_after)
+        return false;
+    return _exclude_ids.find(update.txn_id()) == _exclude_ids.end();
+}
+
+/*
+ * kv_transaction_snapshot_wt::contains --
+ *     Check whether the given update belongs to the snapshot.
+ */
+bool
+kv_transaction_snapshot_wt::contains(const kv_update &update) const noexcept
+{
+    /* First, compare the base generation numbers to see if we are in the right restart cycle. */
+    write_gen_t update_write_gen = update.wt_base_write_gen();
+    if (update_write_gen < _write_gen)
+        return true;
+    if (update_write_gen > _write_gen)
+        return false;
+
+    /* ...because only then the transaction IDs are meaningful. */
+    txn_id_t txn_id = update.wt_txn_id();
+    if (txn_id >= _max_id) /* Max is exclusive. */
+        return false;
+    if (txn_id < _min_id)
+        return true;
+    return _include_ids.find(txn_id) != _include_ids.end();
+}
+
+} /* namespace model */

--- a/test/model/src/core/verify.cpp
+++ b/test/model/src/core/verify.cpp
@@ -102,11 +102,6 @@ kv_table_verifier::verify(WT_CONNECTION *connection, kv_checkpoint_ptr ckpt)
     kv_table_verify_cursor model_cursor = _table.verify_cursor();
     model_cursor.set_checkpoint(ckpt);
 
-    /* Create the WiredTiger cursor config. */
-    std::string cursor_config;
-    if (ckpt)
-        cursor_config += std::string("checkpoint=") + ckpt->name();
-
     try {
         /* Get the database cursor. */
         ret = connection->open_session(connection, nullptr, nullptr, &session);
@@ -116,6 +111,10 @@ kv_table_verifier::verify(WT_CONNECTION *connection, kv_checkpoint_ptr ckpt)
         /* Automatically close the session at the end of the block. */
         wiredtiger_session_guard session_guard(session);
 
+        /* Create the WiredTiger cursor config and open the cursor. */
+        std::string cursor_config;
+        if (ckpt)
+            cursor_config += std::string("checkpoint=") + ckpt->name();
         std::string uri = std::string("table:") + _table.name();
         ret =
           session->open_cursor(session, uri.c_str(), nullptr, cursor_config.c_str(), &wt_cursor);

--- a/test/model/src/core/verify.cpp
+++ b/test/model/src/core/verify.cpp
@@ -47,7 +47,7 @@ kv_table_verify_cursor::has_next()
     auto i = _iterator;
 
     /* Skip over any deleted items. */
-    while (i != _data.end() && !i->second.exists())
+    while (i != _data.end() && !i->second.exists_opt(_ckpt))
         i++;
 
     return i != _data.end();
@@ -65,7 +65,7 @@ kv_table_verify_cursor::verify_next(const data_value &key, const data_value &val
         return false;
 
     /* Skip over any deleted items. */
-    while (_iterator != _data.end() && !_iterator->second.exists())
+    while (_iterator != _data.end() && !_iterator->second.exists_opt(_ckpt))
         _iterator++;
     if (_iterator == _data.end())
         return false;
@@ -79,16 +79,16 @@ kv_table_verify_cursor::verify_next(const data_value &key, const data_value &val
         return false;
 
     /* Check the value. */
-    return i->second.contains_any(value);
+    return _ckpt ? i->second.contains_any(_ckpt, value) : i->second.contains_any(value);
 }
 
 /*
  * kv_table_verifier::verify --
- *     Verify the table by comparing a WiredTiger table against the model. Throw an exception on
- *     error.
+ *     Verify the table by comparing a WiredTiger table against the model, with or without using a
+ *     checkpoint. Throw an exception on error.
  */
 void
-kv_table_verifier::verify(WT_CONNECTION *connection)
+kv_table_verifier::verify(WT_CONNECTION *connection, kv_checkpoint_ptr ckpt)
 {
     WT_SESSION *session = nullptr;
     WT_CURSOR *wt_cursor = nullptr;
@@ -100,6 +100,12 @@ kv_table_verifier::verify(WT_CONNECTION *connection)
 
     /* Get the model cursor. */
     kv_table_verify_cursor model_cursor = _table.verify_cursor();
+    model_cursor.set_checkpoint(ckpt);
+
+    /* Create the WiredTiger cursor config. */
+    std::string cursor_config;
+    if (ckpt)
+        cursor_config += std::string("checkpoint=") + ckpt->name();
 
     try {
         /* Get the database cursor. */
@@ -111,7 +117,8 @@ kv_table_verifier::verify(WT_CONNECTION *connection)
         wiredtiger_session_guard session_guard(session);
 
         std::string uri = std::string("table:") + _table.name();
-        ret = session->open_cursor(session, uri.c_str(), nullptr, nullptr, &wt_cursor);
+        ret =
+          session->open_cursor(session, uri.c_str(), nullptr, cursor_config.c_str(), &wt_cursor);
         if (ret != 0)
             throw wiredtiger_exception(session, ret);
 
@@ -127,7 +134,7 @@ kv_table_verifier::verify(WT_CONNECTION *connection)
             if (!model_cursor.verify_next(key, value)) {
                 std::ostringstream ss;
                 ss << "\"" << key << "=" << value
-                   << "\" is not the next key-value pair in the model.";
+                   << "\" is not the next key-value pair in the model";
                 throw verify_exception(ss.str());
             }
         }

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -266,6 +266,19 @@ debug_log_parser::metadata_apply(kv_transaction_ptr txn, const row_put &op)
 
         /* Handle checkpoints. */
         else if (starts_with(key, "system:checkpoint") || starts_with(key, "system:oldest")) {
+            /*
+             * WiredTiger uses the following naming conventions:
+             *     - system:checkpoint, system:checkpoint_snapshot, system:oldest, etc., for
+             *       nameless checkpoints
+             *     - system:checkpoint.NAME, system:checkpoint_snapshot.NAME, etc., for named
+             *       checkpoints
+             *
+             * We don't need to handle these kinds of metadata differently as the config strings
+             * within them have different names, so we just build one unified configuration map from
+             * all of them.
+             */
+
+            /* If this is a named checkpoint, the name follows the '.' character. */
             size_t p = key.find('.');
             std::string ckpt_name = p == std::string::npos ? WT_CHECKPOINT : key.substr(p + 1);
 

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -46,6 +46,16 @@ namespace model {
  *     Parse the given log entry.
  */
 static void
+from_json(const json &j, debug_log_parser::commit_header &out)
+{
+    j.at("txnid").get_to(out.txnid);
+}
+
+/*
+ * from_json --
+ *     Parse the given log entry.
+ */
+static void
 from_json(const json &j, debug_log_parser::row_put &out)
 {
     j.at("fileid").get_to(out.fileid);
@@ -74,6 +84,25 @@ from_json(const json &j, debug_log_parser::txn_timestamp &out)
     j.at("commit_ts").get_to(out.commit_ts);
     j.at("durable_ts").get_to(out.durable_ts);
     j.at("prepare_ts").get_to(out.prepare_ts);
+}
+
+/*
+ * from_debug_log --
+ *     Parse the given debug log entry.
+ */
+static int
+from_debug_log(WT_SESSION_IMPL *session, const uint8_t **pp, const uint8_t *end,
+  debug_log_parser::commit_header &out)
+{
+    int ret;
+    uint64_t txnid;
+    WT_UNUSED(session);
+
+    if ((ret = __wt_vunpack_uint(pp, WT_PTRDIFF(end, *pp), &txnid)) != 0)
+        return ret;
+
+    out.txnid = txnid;
+    return 0;
 }
 
 /*
@@ -165,7 +194,7 @@ debug_log_parser::table_by_fileid(uint64_t fileid)
  *     Apply the given operation to the model.
  */
 void
-debug_log_parser::metadata_apply(const row_put &op)
+debug_log_parser::metadata_apply(kv_transaction_ptr txn, const row_put &op)
 {
     std::string key =
       std::get<std::string>(data_value::unpack(op.key.c_str(), op.key.length(), "S"));
@@ -229,12 +258,72 @@ debug_log_parser::metadata_apply(const row_put &op)
 
     /* Special handling for the system prefix. */
     else if (starts_with(key, "system:")) {
-        /* We don't currently need to handle this. */
+
+        /* Set the base write generation. */
+        if (key == "system:checkpoint_base_write_gen") {
+            _base_write_gen = m->get_uint64("base_write_gen");
+        }
+
+        /* Handle checkpoints. */
+        else if (starts_with(key, "system:checkpoint") || starts_with(key, "system:oldest")) {
+            size_t p = key.find('.');
+            std::string ckpt_name = p == std::string::npos ? WT_CHECKPOINT : key.substr(p + 1);
+
+            /* Accumulate checkpoint metadata for future handling. */
+            auto &ckpt_metadata_map = _txn_ckpt_metadata[txn->id()];
+            auto i = ckpt_metadata_map.find(ckpt_name);
+            if (i == ckpt_metadata_map.end())
+                ckpt_metadata_map[ckpt_name] = m;
+            else
+                ckpt_metadata_map[ckpt_name] = config_map::merge(ckpt_metadata_map[ckpt_name], m);
+        }
+
+        /* Unsupported system URI. */
+        else
+            throw model_exception("Unsupported metadata system URI: " + key);
     }
 
     /* Otherwise this is an unsupported URI type. */
     else
         throw model_exception("Unsupported metadata URI: " + key);
+}
+
+/*
+ * debug_log_parser::metadata_checkpoint_apply --
+ *     Handle the given checkpoint metadata operation.
+ */
+void
+debug_log_parser::metadata_checkpoint_apply(
+  const std::string &name, std::shared_ptr<config_map> config)
+{
+    /* Get the stable timestamp. */
+    timestamp_t stable_timestamp = config->contains("checkpoint_timestamp") ?
+      config->get_uint64_hex("checkpoint_timestamp") :
+      k_timestamp_none;
+
+    /* Get the write generation number. */
+    write_gen_t write_gen = config->get_uint64("write_gen");
+
+    /* Get the transaction snapshot. */
+    kv_transaction_snapshot_ptr snapshot;
+    if (config->contains("snapshot_min")) {
+        txn_id_t snapshot_min = config->get_uint64("snapshot_min");
+        txn_id_t snapshot_max = config->get_uint64("snapshot_max");
+        std::shared_ptr<std::vector<uint64_t>> snapshot_ids;
+        if (config->contains("snapshots"))
+            snapshot_ids = config->get_array_uint64("snapshots");
+        else
+            snapshot_ids = std::make_shared<std::vector<uint64_t>>();
+        snapshot = std::make_shared<kv_transaction_snapshot_wt>(
+          write_gen, snapshot_min, snapshot_max, *snapshot_ids);
+    } else {
+        std::vector<uint64_t> snapshot_ids;
+        snapshot = std::make_shared<kv_transaction_snapshot_wt>(
+          write_gen, k_txn_max, k_txn_max, snapshot_ids);
+    }
+
+    /* Create the checkpoint. */
+    _database.create_checkpoint(name.c_str(), snapshot, stable_timestamp);
 }
 
 /*
@@ -246,7 +335,7 @@ debug_log_parser::apply(kv_transaction_ptr txn, const row_put &op)
 {
     /* Handle metadata operations. */
     if (op.fileid == 0) {
-        metadata_apply(op);
+        metadata_apply(txn, op);
         return;
     }
 
@@ -310,6 +399,39 @@ debug_log_parser::apply(kv_transaction_ptr txn, const txn_timestamp &op)
 }
 
 /*
+ * debug_log_parser::begin_transaction --
+ *     Begin a transaction.
+ */
+kv_transaction_ptr
+debug_log_parser::begin_transaction(const debug_log_parser::commit_header &op)
+{
+    if (_base_write_gen == k_write_gen_none)
+        throw model_exception("The base write generation is not set");
+
+    kv_transaction_ptr txn = _database.begin_transaction();
+    txn->set_wt_metadata(op.txnid, _base_write_gen);
+    return txn;
+}
+
+/*
+ * debug_log_parser::commit_transaction --
+ *     Commit/finalize a transaction.
+ */
+void
+debug_log_parser::commit_transaction(kv_transaction_ptr txn)
+{
+    /* Commit the transaction if has not yet been committed. */
+    if (txn->state() != kv_transaction_state::committed)
+        txn->commit();
+
+    /* Process the checkpoint metadata, if there are any associated with the transaction. */
+    auto i = _txn_ckpt_metadata.find(txn->id());
+    if (i != _txn_ckpt_metadata.end())
+        for (auto p : i->second)
+            metadata_checkpoint_apply(p.first, p.second);
+}
+
+/*
  * from_debug_log_helper_args --
  *     Arguments for the helper function.
  */
@@ -341,16 +463,17 @@ from_debug_log_helper(WT_SESSION_IMPL *session, WT_ITEM *rawrec, WT_LSN *lsnp, W
     /* Process supported record types. */
     switch (rec_type) {
     case WT_LOGREC_COMMIT: {
+        const uint8_t **pp = &p;
+
         /* The commit entry, which contains the list of operations in the transaction. */
-        uint64_t txnid;
-        if ((ret = __wt_vunpack_uint(&p, WT_PTRDIFF(rec_end, p), &txnid)) != 0)
+        debug_log_parser::commit_header commit;
+        if ((ret = from_debug_log(session, pp, rec_end, commit)) != 0)
             return ret;
 
         /* Start the transaction. */
-        kv_transaction_ptr txn = args.database.begin_transaction();
+        kv_transaction_ptr txn = args.parser.begin_transaction(commit);
 
         /* Iterate over the list of operations. */
-        const uint8_t **pp = &p;
         while (*pp < rec_end && **pp) {
             uint32_t op_type, op_size;
 
@@ -388,8 +511,7 @@ from_debug_log_helper(WT_SESSION_IMPL *session, WT_ITEM *rawrec, WT_LSN *lsnp, W
             }
         }
 
-        if (txn->state() != kv_transaction_state::committed)
-            txn->commit();
+        args.parser.commit_transaction(txn);
         break;
     }
 
@@ -458,7 +580,8 @@ debug_log_parser::from_json(kv_database &database, const char *path)
         /* The commit entry contains full description of a transaction, including all
          * operations. */
         if (log_entry_type == "commit") {
-            kv_transaction_ptr txn = database.begin_transaction();
+            /* Begin the transaction. */
+            kv_transaction_ptr txn = parser.begin_transaction(log_entry.get<commit_header>());
 
             /* Replay all operations. */
             for (auto &op_entry : log_entry.at("ops")) {
@@ -495,8 +618,8 @@ debug_log_parser::from_json(kv_database &database, const char *path)
                 throw model_exception("Unsupported operation \"" + op_type + "\"");
             }
 
-            if (txn->state() != kv_transaction_state::committed)
-                txn->commit();
+            /* Commit/finalize the transaction. */
+            parser.commit_transaction(txn);
             continue;
         }
 

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -426,9 +426,11 @@ debug_log_parser::commit_transaction(kv_transaction_ptr txn)
 
     /* Process the checkpoint metadata, if there are any associated with the transaction. */
     auto i = _txn_ckpt_metadata.find(txn->id());
-    if (i != _txn_ckpt_metadata.end())
+    if (i != _txn_ckpt_metadata.end()) {
         for (auto p : i->second)
             metadata_checkpoint_apply(p.first, p.second);
+        _txn_ckpt_metadata.erase(i);
+    }
 }
 
 /*

--- a/test/model/src/include/model/core.h
+++ b/test/model/src/include/model/core.h
@@ -30,6 +30,7 @@
 #define MODEL_CORE_H
 
 #include <limits>
+#include <stdexcept>
 #include "wiredtiger.h"
 
 /* Redefine important WiredTiger internal constants, if they are not already available. */
@@ -101,8 +102,37 @@ using txn_id_t = uint64_t;
  */
 constexpr txn_id_t k_txn_none = std::numeric_limits<txn_id_t>::min();
 
+/*
+ * k_txn_max --
+ *     The maximum ID.
+ */
+constexpr txn_id_t k_txn_max = std::numeric_limits<txn_id_t>::max() - 10;
+
 /* Verify that model's constants are numerically equal to WiredTiger's constants. */
 static_assert(k_txn_none == WT_TXN_NONE);
+/* We will check k_txn_max in the .cpp file, as we don't have the right imports. */
+
+/*
+ * write_gen_t --
+ *     The write generation number.
+ */
+using write_gen_t = uint64_t;
+
+/*
+ * k_write_gen_none --
+ *     No write generation.
+ */
+constexpr write_gen_t k_write_gen_none = std::numeric_limits<write_gen_t>::min();
+
+/*
+ * k_write_gen_first --
+ *     The first (initial) write generation.
+ */
+constexpr write_gen_t k_write_gen_first = k_write_gen_none + 1;
+
+/* Verify that model's constants are numerically equal to WiredTiger's constants. */
+static_assert(k_write_gen_none == 0);
+static_assert(k_write_gen_first == 1);
 
 /*
  * model_exception --

--- a/test/model/src/include/model/core.h
+++ b/test/model/src/include/model/core.h
@@ -31,6 +31,7 @@
 
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include "wiredtiger.h"
 
 /* Redefine important WiredTiger internal constants, if they are not already available. */
@@ -110,7 +111,8 @@ constexpr txn_id_t k_txn_max = std::numeric_limits<txn_id_t>::max() - 10;
 
 /* Verify that model's constants are numerically equal to WiredTiger's constants. */
 static_assert(k_txn_none == WT_TXN_NONE);
-/* We will check k_txn_max in the .cpp file, as we don't have the right imports. */
+static_assert(k_txn_max == UINT64_MAX - 10);
+/* We will check k_txn_max again in the .cpp file, as we don't have the right imports. */
 
 /*
  * write_gen_t --

--- a/test/model/src/include/model/kv_database.h
+++ b/test/model/src/include/model/kv_database.h
@@ -60,6 +60,13 @@ public:
     kv_checkpoint_ptr create_checkpoint(const char *name = nullptr);
 
     /*
+     * kv_database::create_checkpoint --
+     *     Create a checkpoint from custom metadata. Throw an exception if the name is not unique.
+     */
+    kv_checkpoint_ptr create_checkpoint(
+      const char *name, kv_transaction_snapshot_ptr snapshot, timestamp_t stable_timestamp);
+
+    /*
      * kv_database::create_table --
      *     Create and return a new table. Throw an exception if the name is not unique.
      */

--- a/test/model/src/include/model/kv_table.h
+++ b/test/model/src/include/model/kv_table.h
@@ -126,6 +126,13 @@ public:
       timestamp_t timestamp = k_timestamp_latest) const;
 
     /*
+     * kv_table::contains_any --
+     *     Check whether the table contains the given key-value pair. If there are multiple values
+     *     associated with the given timestamp, return true if any of them match.
+     */
+    bool contains_any(kv_checkpoint_ptr ckpt, const data_value &key, const data_value &value) const;
+
+    /*
      * kv_table::get --
      *     Get the value. Return a copy of the value if is found, or NONE if not found. Throw an
      *     exception on error.
@@ -225,22 +232,24 @@ public:
     /*
      * kv_table::verify --
      *     Verify the table by comparing a WiredTiger table against the model. Throw an exception on
-     *     verification error.
+     *     verification error. If the checkpoint is specified, verify just that checkpoint.
      */
     inline void
-    verify(WT_CONNECTION *connection)
+    verify(WT_CONNECTION *connection, kv_checkpoint_ptr ckpt = kv_checkpoint_ptr(nullptr))
     {
-        kv_table_verifier(*this).verify(connection);
+        kv_table_verifier(*this).verify(connection, ckpt);
     }
 
     /*
      * kv_table::verify_noexcept --
-     *     Verify the table by comparing a WiredTiger table against the model.
+     *     Verify the table by comparing a WiredTiger table against the model. If the checkpoint is
+     *     specified, verify just that checkpoint.
      */
     inline bool
-    verify_noexcept(WT_CONNECTION *connection) noexcept
+    verify_noexcept(
+      WT_CONNECTION *connection, kv_checkpoint_ptr ckpt = kv_checkpoint_ptr(nullptr)) noexcept
     {
-        return kv_table_verifier(*this).verify_noexcept(connection);
+        return kv_table_verifier(*this).verify_noexcept(connection, ckpt);
     }
 
     /*

--- a/test/model/src/include/model/kv_table_item.h
+++ b/test/model/src/include/model/kv_table_item.h
@@ -69,13 +69,49 @@ public:
      *     Check whether the table contains the given value. If there are multiple values associated
      *     with the given timestamp, return true if any of them match.
      */
-    bool contains_any(const data_value &value, timestamp_t timestamp = k_timestamp_latest) const;
+    inline bool
+    contains_any(const data_value &value, timestamp_t timestamp = k_timestamp_latest) const
+    {
+        return contains_any(value, kv_transaction_snapshot_ptr(nullptr), timestamp);
+    }
+
+    /*
+     * kv_table_item::contains_any --
+     *     Check whether the table contains the given value. If there are multiple values associated
+     *     with the given timestamp, return true if any of them match.
+     */
+    inline bool
+    contains_any(kv_checkpoint_ptr ckpt, const data_value &value) const
+    {
+        if (!ckpt)
+            throw model_exception("Null checkpoint");
+        timestamp_t timestamp = ckpt->stable_timestamp() != k_timestamp_none ?
+          ckpt->stable_timestamp() :
+          k_timestamp_latest;
+        return contains_any(value, ckpt->snapshot(), timestamp, timestamp);
+    }
 
     /*
      * kv_table_item::exists --
      *     Check whether the latest value exists.
      */
     bool exists() const;
+
+    /*
+     * kv_table_item::exists --
+     *     Check whether the latest value exists in the given checkpoint.
+     */
+    bool exists(kv_checkpoint_ptr checkpoint) const;
+
+    /*
+     * kv_table_item::exists_opt --
+     *     Check whether the latest value exists, using the checkpoint if provided.
+     */
+    inline bool
+    exists_opt(kv_checkpoint_ptr checkpoint) const
+    {
+        return checkpoint ? exists(checkpoint) : exists();
+    }
 
     /*
      * kv_table_item::get --
@@ -92,10 +128,16 @@ public:
      *     Get the corresponding value. Return NONE if not found. Throw an exception on error.
      */
     inline data_value
-    get(kv_checkpoint_ptr ckpt, timestamp_t timestamp) const
+    get(kv_checkpoint_ptr ckpt, timestamp_t timestamp = k_timestamp_latest) const
     {
         if (!ckpt)
             throw model_exception("Null checkpoint");
+
+        /* Get the stable (checkpoint) timestamp, if not overridden by the caller. */
+        if (timestamp == k_timestamp_latest)
+            timestamp = ckpt->stable_timestamp() != k_timestamp_none ? ckpt->stable_timestamp() :
+                                                                       k_timestamp_latest;
+
         /*
          * When using checkpoint cursors, we need to compare the stable timestamp against the
          * durable timestamp, not the commit timestamp.
@@ -149,6 +191,14 @@ protected:
      *     Fail the given update and throw an exception indicating rollback.
      */
     void fail_with_rollback(std::shared_ptr<kv_update> update);
+
+    /*
+     * kv_table_item::contains_any --
+     *     Check whether the table contains the given value. If there are multiple values associated
+     *     with the given timestamp, return true if any of them match.
+     */
+    bool contains_any(const data_value &value, kv_transaction_snapshot_ptr txn_snapshot,
+      timestamp_t read_timestamp, timestamp_t stable_timestamp = k_timestamp_latest) const;
 
     /*
      * kv_table_item::get --

--- a/test/model/src/include/model/kv_transaction.h
+++ b/test/model/src/include/model/kv_transaction.h
@@ -77,12 +77,15 @@ public:
      *     Create a new instance of the transaction.
      */
     inline kv_transaction(kv_database &database, txn_id_t id, kv_transaction_snapshot_ptr snapshot,
-      timestamp_t read_timestamp = k_timestamp_latest) noexcept
+      timestamp_t read_timestamp = k_timestamp_latest)
         : _database(database), _id(id), _commit_timestamp(k_initial_commit_timestamp),
           _durable_timestamp(k_timestamp_none), _prepare_timestamp(k_timestamp_none),
           _failed(false), _read_timestamp(read_timestamp), _snapshot(snapshot),
-          _state(kv_transaction_state::in_progress)
+          _state(kv_transaction_state::in_progress), _wt_id(k_txn_none),
+          _wt_base_write_gen(k_write_gen_none)
     {
+        if (!snapshot)
+            throw model_exception("The snapshot is NULL.");
     }
 
     /*
@@ -166,13 +169,13 @@ public:
     }
 
     /*
-     * kv_transaction::visible_txn --
-     *     Check whether the given transaction ID is visible for this transaction.
+     * kv_transaction::visible_update --
+     *     Check whether the given update is visible for this transaction.
      */
     inline bool
-    visible_txn(txn_id_t id) const noexcept
+    visible_update(const kv_update &update) const noexcept
     {
-        return _snapshot->contains(id);
+        return _snapshot->contains(update);
     }
 
     /*
@@ -222,6 +225,41 @@ public:
      */
     void set_commit_timestamp(timestamp_t commit_timestamp);
 
+    /*
+     * kv_transaction::set_wt_metadata --
+     *     If this transaction was imported from WiredTiger, remember the corresponding metadata.
+     *     This can be done only before the first update is added to the transaction.
+     */
+    inline void
+    set_wt_metadata(txn_id_t wt_id, write_gen_t wt_base_write_gen)
+    {
+        std::lock_guard lock_guard(_lock);
+        if (!_updates.empty())
+            throw model_exception("There are already updates in the transaction");
+        _wt_id = wt_id;
+        _wt_base_write_gen = wt_base_write_gen;
+    }
+
+    /*
+     * kv_transaction::wt_id --
+     *     Get the WiredTiger ID, if available.
+     */
+    inline txn_id_t
+    wt_id() const
+    {
+        return _wt_id;
+    }
+
+    /*
+     * kv_transaction::wt_base_write_gen --
+     *     Get the WiredTiger base write generation number, if available.
+     */
+    inline write_gen_t
+    wt_base_write_gen() const
+    {
+        return _wt_base_write_gen;
+    }
+
 protected:
     /*
      * kv_transaction::assert_in_progress_or_prepared --
@@ -246,6 +284,10 @@ private:
     mutable std::mutex _lock;
     std::list<std::shared_ptr<kv_transaction_update>> _updates;
     std::list<std::shared_ptr<kv_transaction_update>> _nontimestamped_updates;
+
+    /* Transaction information for updates imported from WiredTiger's debug log. */
+    txn_id_t _wt_id;
+    write_gen_t _wt_base_write_gen;
 };
 
 /*

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -47,16 +47,17 @@ class kv_transaction_snapshot {
 
 public:
     /*
-     * kv_transaction_snapshot::kv_transaction_snapshot --
-     *     Create a new instance of the snapshot based on what to exclude.
-     */
-    inline kv_transaction_snapshot() {}
-
-    /*
      * kv_transaction_snapshot::contains --
      *     Check whether the given update belongs to the snapshot.
      */
     virtual bool contains(const kv_update &update) const noexcept = 0;
+
+protected:
+    /*
+     * kv_transaction_snapshot::kv_transaction_snapshot --
+     *     Create a new instance of the snapshot.
+     */
+    inline kv_transaction_snapshot(){};
 };
 
 /*
@@ -80,7 +81,7 @@ public:
      * kv_transaction_snapshot_by_exclusion::contains --
      *     Check whether the given update belongs to the snapshot.
      */
-    virtual bool contains(const kv_update &update) const noexcept;
+    virtual bool contains(const kv_update &update) const noexcept override;
 
 private:
     txn_id_t _exclude_after;
@@ -110,7 +111,7 @@ public:
      * kv_transaction_snapshot_wt::contains --
      *     Check whether the given update belongs to the snapshot.
      */
-    virtual bool contains(const kv_update &update) const noexcept;
+    virtual bool contains(const kv_update &update) const noexcept override;
 
 private:
     txn_id_t _min_id, _max_id;

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -29,6 +29,7 @@
 #ifndef MODEL_KV_TRANSACTION_SNAPSHOT_H
 #define MODEL_KV_TRANSACTION_SNAPSHOT_H
 
+#include <algorithm>
 #include <memory>
 #include <unordered_set>
 #include <vector>
@@ -103,8 +104,8 @@ public:
       txn_id_t snapshot_max, const std::vector<uint64_t> &snapshots)
         : _min_id(snapshot_min), _max_id(snapshot_max), _write_gen(write_gen)
     {
-        for (uint64_t t : snapshots)
-            _include_ids.insert(t);
+        std::copy(
+          snapshots.begin(), snapshots.end(), std::inserter(_include_ids, _include_ids.begin()));
     }
 
     /*

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -31,10 +31,13 @@
 
 #include <memory>
 #include <unordered_set>
+#include <vector>
 
 #include "model/core.h"
 
 namespace model {
+
+class kv_update;
 
 /*
  * kv_transaction_snapshot --
@@ -47,27 +50,73 @@ public:
      * kv_transaction_snapshot::kv_transaction_snapshot --
      *     Create a new instance of the snapshot based on what to exclude.
      */
-    inline kv_transaction_snapshot(
+    inline kv_transaction_snapshot() {}
+
+    /*
+     * kv_transaction_snapshot::contains --
+     *     Check whether the given update belongs to the snapshot.
+     */
+    virtual bool contains(const kv_update &update) const noexcept = 0;
+};
+
+/*
+ * kv_transaction_snapshot_by_exclusion --
+ *     A transaction snapshot based on which transactions to exclude.
+ */
+class kv_transaction_snapshot_by_exclusion : public kv_transaction_snapshot {
+
+public:
+    /*
+     * kv_transaction_snapshot_by_exclusion::kv_transaction_snapshot_by_exclusion --
+     *     Create a new instance of the snapshot based on what to exclude.
+     */
+    inline kv_transaction_snapshot_by_exclusion(
       txn_id_t exclude_after, std::unordered_set<txn_id_t> &&exclude_ids)
         : _exclude_after(exclude_after), _exclude_ids(exclude_ids)
     {
     }
 
     /*
-     * kv_transaction_snapshot::contains --
-     *     Check whether the given transaction ID belongs to the snapshot.
+     * kv_transaction_snapshot_by_exclusion::contains --
+     *     Check whether the given update belongs to the snapshot.
      */
-    inline bool
-    contains(txn_id_t id) const noexcept
-    {
-        if (id > _exclude_after)
-            return false;
-        return _exclude_ids.find(id) == _exclude_ids.end();
-    }
+    virtual bool contains(const kv_update &update) const noexcept;
 
 private:
     txn_id_t _exclude_after;
     std::unordered_set<txn_id_t> _exclude_ids;
+};
+
+/*
+ * kv_transaction_snapshot_wt --
+ *     A transaction snapshot that emulates WiredTiger's behavior.
+ */
+class kv_transaction_snapshot_wt : public kv_transaction_snapshot {
+
+public:
+    /*
+     * kv_transaction_snapshot_wt::kv_transaction_snapshot_wt --
+     *     Create a new instance of the snapshot.
+     */
+    inline kv_transaction_snapshot_wt(write_gen_t write_gen, txn_id_t snapshot_min,
+      txn_id_t snapshot_max, const std::vector<uint64_t> &snapshots)
+        : _min_id(snapshot_min), _max_id(snapshot_max), _write_gen(write_gen)
+    {
+        for (uint64_t t : snapshots)
+            _include_ids.insert(t);
+    }
+
+    /*
+     * kv_transaction_snapshot_wt::contains --
+     *     Check whether the given update belongs to the snapshot.
+     */
+    virtual bool contains(const kv_update &update) const noexcept;
+
+private:
+    txn_id_t _min_id, _max_id;
+    write_gen_t _write_gen;
+
+    std::unordered_set<txn_id_t> _include_ids;
 };
 
 /*

--- a/test/model/src/include/model/verify.h
+++ b/test/model/src/include/model/verify.h
@@ -76,6 +76,18 @@ public:
     bool has_next();
 
     /*
+     * kv_table_verify_cursor::set_checkpoint --
+     *     Set the checkpoint for verifying the table. This can be called only at the beginning.
+     */
+    inline void
+    set_checkpoint(kv_checkpoint_ptr ckpt)
+    {
+        if (_iterator != _data.begin())
+            throw model_exception("The cursor is not at the beginning");
+        _ckpt = ckpt;
+    }
+
+    /*
      * kv_table_verify_cursor::verify_next --
      *     Verify the next key-value pair. This method is not thread-safe.
      */
@@ -84,6 +96,7 @@ public:
 private:
     std::map<data_value, kv_table_item> &_data;
     std::map<data_value, kv_table_item>::iterator _iterator;
+    kv_checkpoint_ptr _ckpt;
 };
 
 /*
@@ -101,10 +114,10 @@ public:
 
     /*
      * kv_table_verifier::verify --
-     *     Verify the table by comparing a WiredTiger table against the model. Throw an exception on
-     *     error.
+     *     Verify the table by comparing a WiredTiger table against the model, with or without using
+     *     a checkpoint. Throw an exception on error.
      */
-    void verify(WT_CONNECTION *connection);
+    void verify(WT_CONNECTION *connection, kv_checkpoint_ptr ckpt = kv_checkpoint_ptr(nullptr));
 
     /*
      * kv_table_verifier::verify --
@@ -112,10 +125,11 @@ public:
      *     exceptions, but simply returns a boolean. This is useful for model's own unit testing.
      */
     inline bool
-    verify_noexcept(WT_CONNECTION *connection) noexcept
+    verify_noexcept(
+      WT_CONNECTION *connection, kv_checkpoint_ptr ckpt = kv_checkpoint_ptr(nullptr)) noexcept
     {
         try {
-            verify(connection);
+            verify(connection, ckpt);
         } catch (...) {
             return false;
         }

--- a/test/model/test/model_checkpoint/main.cpp
+++ b/test/model/test/model_checkpoint/main.cpp
@@ -225,8 +225,9 @@ test_checkpoint_wt(void)
     WT_SESSION *session2;
     const char *uri = "table:table";
 
-    testutil_recreate_dir(home);
-    testutil_wiredtiger_open(opts, home, ENV_CONFIG, nullptr, &conn, false, false);
+    std::string test_home = std::string(home) + DIR_DELIM_STR + "checkpoint";
+    testutil_recreate_dir(test_home.c_str());
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
     testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
     testutil_check(conn->open_session(conn, nullptr, nullptr, &session1));
     testutil_check(conn->open_session(conn, nullptr, nullptr, &session2));
@@ -322,7 +323,7 @@ test_checkpoint_wt(void)
     testutil_check(conn->close(conn, nullptr));
 
     /* Reopen the database. We must do this for debug log printing to work. */
-    testutil_wiredtiger_open(opts, home, ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
     testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
 
     /* Verify using the debug log. */
@@ -331,7 +332,7 @@ test_checkpoint_wt(void)
     testutil_assert(db_from_debug_log.table("table")->verify_noexcept(conn));
 
     /* Print the debug log to JSON. */
-    std::string tmp_json = create_tmp_file(home, "debug-log-", ".json");
+    std::string tmp_json = create_tmp_file(test_home.c_str(), "debug-log-", ".json");
     wt_print_debug_log(conn, tmp_json.c_str());
 
     /* Verify using the debug log JSON. */
@@ -358,6 +359,163 @@ test_checkpoint_wt(void)
       conn, db_from_debug_log_json.checkpoint("ckpt3")));
     testutil_assert(db_from_debug_log_json.table("table")->verify_noexcept(
       conn, db_from_debug_log_json.checkpoint("ckpt4")));
+
+    /* Clean up. */
+    testutil_check(session->close(session, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+}
+
+/*
+ * test_checkpoint_restart_wt --
+ *     Check loading checkpoints with database restarts.
+ */
+static void
+test_checkpoint_restart_wt(void)
+{
+    model::kv_database database;
+    model::kv_table_ptr table = database.create_table("table");
+
+    /* Keys. */
+    const model::data_value key1("Key 1");
+    const model::data_value key2("Key 2");
+    const model::data_value key3("Key 3");
+    const model::data_value key4("Key 4");
+
+    /* Values. */
+    const model::data_value value1("Value 1");
+    const model::data_value value2("Value 2");
+    const model::data_value value3("Value 3");
+    const model::data_value value4("Value 4");
+    const model::data_value value5("Value 5");
+
+    /* Create the test's home directory and database. */
+    WT_CONNECTION *conn;
+    WT_SESSION *session, *session2;
+    const char *uri = "table:table";
+
+    std::string test_home = std::string(home) + DIR_DELIM_STR + "checkpoint-restart";
+    testutil_recreate_dir(test_home.c_str());
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+    testutil_check(
+      session->create(session, uri, "key_format=S,value_format=S,log=(enabled=false)"));
+
+    /* Transaction. */
+    model::kv_transaction_ptr txn;
+
+    /* Add some data. */
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key1, value1);
+    wt_model_txn_commit_both(txn, session, 10);
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key2, value2);
+    wt_model_txn_commit_both(txn, session, 20);
+
+    /* Create a named checkpoint. */
+    wt_model_set_stable_timestamp_both(15);
+    wt_model_ckpt_create_both("ckpt1");
+
+    /* Add some data. */
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key3, value3);
+    wt_model_txn_commit_both(txn, session, 30);
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key4, value4);
+    wt_model_txn_commit_both(txn, session, 40);
+
+    /* Create a named checkpoint. */
+    wt_model_set_stable_timestamp_both(35);
+    wt_model_ckpt_create_both("ckpt2");
+
+    /* Create a nameless checkpoint and restart. */
+    wt_model_set_stable_timestamp_both(40);
+    wt_model_ckpt_create_both(nullptr);
+    testutil_check(session->close(session, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+
+    /* Add some data. */
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key1, value2);
+    wt_model_txn_commit_both(txn, session, 50);
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key2, value3);
+    wt_model_txn_commit_both(txn, session, 60);
+
+    /* Create a named checkpoint. */
+    wt_model_set_stable_timestamp_both(55);
+    wt_model_ckpt_create_both("ckpt3");
+
+    /* Add some data. */
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key3, value4);
+    wt_model_txn_commit_both(txn, session, 70);
+
+    /* Add some data. Take a checkpoint while a transaction is still running. */
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session2));
+    wt_model_txn_begin_both(txn, session2);
+    wt_model_txn_insert_both(table, uri, txn, session2, key4, value5);
+    wt_model_set_stable_timestamp_both(75);
+    wt_model_ckpt_create_both("ckpt4");
+    wt_model_txn_commit_both(txn, session2, 80);
+    testutil_check(session2->close(session2, nullptr));
+
+    /* Create a nameless checkpoint and restart. */
+    wt_model_set_stable_timestamp_both(80);
+    wt_model_ckpt_create_both(nullptr);
+    testutil_check(session->close(session, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+
+    /* Add some data - use prepared transactions. */
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key1, value3);
+    wt_model_txn_prepare_both(txn, session, 90);
+    wt_model_txn_commit_both(txn, session, 94, 98);
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key2, value4);
+    wt_model_txn_prepare_both(txn, session, 100);
+    wt_model_txn_commit_both(txn, session, 104, 108);
+
+    /* Create a named checkpoint. */
+    wt_model_set_stable_timestamp_both(95);
+    wt_model_ckpt_create_both("ckpt5");
+
+    /* Add some data - use prepared transactions. */
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key3, value5);
+    wt_model_txn_prepare_both(txn, session, 110);
+    wt_model_txn_commit_both(txn, session, 114, 118);
+    wt_model_txn_begin_both(txn, session);
+    wt_model_txn_insert_both(table, uri, txn, session, key4, value1);
+    wt_model_txn_prepare_both(txn, session, 120);
+    wt_model_txn_commit_both(txn, session, 124, 128);
+
+    /* Create a named checkpoint. */
+    wt_model_set_stable_timestamp_both(115);
+    wt_model_ckpt_create_both("ckpt6");
+
+    /* Create a nameless checkpoint and restart. */
+    wt_model_set_stable_timestamp_both(129);
+    wt_model_ckpt_create_both(nullptr);
+    testutil_check(session->close(session, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+
+    /* Verify using the debug log. */
+    model::kv_database db_from_debug_log;
+    model::debug_log_parser::from_debug_log(db_from_debug_log, conn);
+    model::kv_table_ptr t = db_from_debug_log.table("table");
+    testutil_assert(t->verify_noexcept(conn));
+    testutil_assert(t->verify_noexcept(conn, db_from_debug_log.checkpoint("ckpt1")));
+    testutil_assert(t->verify_noexcept(conn, db_from_debug_log.checkpoint("ckpt2")));
+    testutil_assert(t->verify_noexcept(conn, db_from_debug_log.checkpoint("ckpt3")));
+    testutil_assert(t->verify_noexcept(conn, db_from_debug_log.checkpoint("ckpt4")));
+    testutil_assert(t->verify_noexcept(conn, db_from_debug_log.checkpoint("ckpt5")));
+    testutil_assert(t->verify_noexcept(conn, db_from_debug_log.checkpoint("ckpt6")));
 
     /* Clean up. */
     testutil_check(session->close(session, nullptr));
@@ -406,6 +564,7 @@ main(int argc, char *argv[])
 
     testutil_parse_end_opt(opts);
     testutil_work_dir_from_path(home, sizeof(home), opts->home);
+    testutil_recreate_dir(home);
 
     /*
      * Tests.
@@ -414,6 +573,7 @@ main(int argc, char *argv[])
         ret = EXIT_SUCCESS;
         test_checkpoint();
         test_checkpoint_wt();
+        test_checkpoint_restart_wt();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;
         ret = EXIT_FAILURE;


### PR DESCRIPTION
This PR extends WT-11615 by adding debug log parsing for checkpoints. It is surprisingly long for what it does to support WiredTiger's transaction IDs, and also because WiredTiger's transaction IDs are not unique across restarts.

Feel free to not scrutinize changes to the model's test code, as this is again just a test for a test.

Thank you!