### PR TITLE
WT-12018 Fix metadata info comparison in test_import_base

### DIFF
--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -83,7 +83,7 @@ class test_import_base(wttest.WiredTigerTestCase):
         b = re.sub('id=\d+,?', '', bconf)
         b = (re.sub('\w+=\(.*?\)+,?', '', b).strip(',').split(',') +
              re.findall('\w+=\(.*?\)+', b))
-        self.assertTrue(a.sort() == b.sort())
+        self.assertTrue(sorted(a) == sorted(b))
 
     # Populate a database with N tables, each having M rows.
     def populate(self, ntables, nrows):

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -74,16 +74,18 @@ class test_import_base(wttest.WiredTigerTestCase):
             else:
                 self.check_record(uri, keys[i], values[i])
 
-    # We know the ID can be different between configs, so just remove it from comparison.
-    # Everything else should be the same.
+    # The ID and checkpoint information can be different between configs, remove it. Everything else
+    # should be the same.
     def config_compare(self, aconf, bconf):
         a = re.sub('id=\d+,?', '', aconf)
-        a = (re.sub('\w+=\(.*?\)+,?', '', a).strip(',').split(',') +
-             re.findall('\w+=\(.*?\)+', a))
+        a = re.sub('checkpoint=\(.*?\)+,?', '', a)
         b = re.sub('id=\d+,?', '', bconf)
-        b = (re.sub('\w+=\(.*?\)+,?', '', b).strip(',').split(',') +
-             re.findall('\w+=\(.*?\)+', b))
-        self.assertTrue(a.sort() == b.sort())
+        b = re.sub('checkpoint=\(.*?\)+,?', '', b)
+        a = a.split(',')
+        b = b.split(',')
+        a.sort()
+        b.sort()
+        self.assertTrue(a == b)
 
     # Populate a database with N tables, each having M rows.
     def populate(self, ntables, nrows):

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -74,18 +74,16 @@ class test_import_base(wttest.WiredTigerTestCase):
             else:
                 self.check_record(uri, keys[i], values[i])
 
-    # The ID and checkpoint information can be different between configs, remove it. Everything else
-    # should be the same.
+    # We know the ID can be different between configs, so just remove it from comparison.
+    # Everything else should be the same.
     def config_compare(self, aconf, bconf):
         a = re.sub('id=\d+,?', '', aconf)
-        a = re.sub('checkpoint=\(.*?\)+,?', '', a)
+        a = (re.sub('\w+=\(.*?\)+,?', '', a).strip(',').split(',') +
+             re.findall('\w+=\(.*?\)+', a))
         b = re.sub('id=\d+,?', '', bconf)
-        b = re.sub('checkpoint=\(.*?\)+,?', '', b)
-        a = a.split(',')
-        b = b.split(',')
-        a.sort()
-        b.sort()
-        self.assertTrue(a == b)
+        b = (re.sub('\w+=\(.*?\)+,?', '', b).strip(',').split(',') +
+             re.findall('\w+=\(.*?\)+', b))
+        self.assertTrue(a.sort() == b.sort())
 
     # Populate a database with N tables, each having M rows.
     def populate(self, ntables, nrows):

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -74,8 +74,8 @@ class test_import_base(wttest.WiredTigerTestCase):
             else:
                 self.check_record(uri, keys[i], values[i])
 
-    # We know the ID can be different between configs, so just remove it from comparison.
-    # Everything else should be the same.
+    # The ID and checkpoint information can be different between configs, remove it. Everything else
+    # should be the same.
     def config_compare(self, aconf, bconf):
         a = re.sub('id=\d+,?', '', aconf)
         a = (re.sub('\w+=\(.*?\)+,?', '', a).strip(',').split(',') +
@@ -83,6 +83,8 @@ class test_import_base(wttest.WiredTigerTestCase):
         b = re.sub('id=\d+,?', '', bconf)
         b = (re.sub('\w+=\(.*?\)+,?', '', b).strip(',').split(',') +
              re.findall('\w+=\(.*?\)+', b))
+        a = [x for x in a if not x.startswith("checkpoint=")]
+        b = [x for x in b if not x.startswith("checkpoint=")]
         self.assertTrue(sorted(a) == sorted(b))
 
     # Populate a database with N tables, each having M rows.


### PR DESCRIPTION
Before the suggested changed, we would compare `None` with `None` as `sort()` does not return the sorted list. I have also tried to simplify the information that is unique and that cannot be compared: the `id` and `checkpoint`.