### PR TITLE
WT-12036 Add Windows-specific scheduling workaround when locking dhandles

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -211,7 +211,13 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_dea
 
         /* Give other threads a chance to make progress. */
         WT_STAT_CONN_INCR(session, dhandle_lock_blocked);
+
+        /* FIXME-WT-12037 Use a sleep to work around a Windows-specific scheduling issue. */
+#ifdef _WIN32
+        __wt_sleep(0, 1000);
+#else
         __wt_yield();
+#endif
     }
 }
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -213,11 +213,7 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_dea
         WT_STAT_CONN_INCR(session, dhandle_lock_blocked);
 
         /* FIXME-WT-12037 Use a sleep to work around a Windows-specific scheduling issue. */
-#ifdef _WIN32
-        __wt_sleep(0, 1000);
-#else
-        __wt_yield();
-#endif
+        __wt_sleep(0, 1);
     }
 }
 


### PR DESCRIPTION
See ticket comments for patch build results. Will look at backports once this is in.