### PR TITLE
WT-12038 Correctly skip chunk cache tests on big-endian platforms

### DIFF
--- a/test/suite/test_chunkcache05.py
+++ b/test/suite/test_chunkcache05.py
@@ -48,6 +48,9 @@ class test_chunkcache05(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(format_values)
 
     def conn_config(self):
+        if sys.byteorder != 'little':
+            return ''
+
         if not os.path.exists('bucket5'):
             os.mkdir('bucket5')
 
@@ -69,7 +72,7 @@ class test_chunkcache05(wttest.WiredTigerTestCase):
     def test_chunkcache05(self):
         # This test only makes sense on-disk, and WT's filesystem layer doesn't support mmap on
         # big-endian platforms.
-        if sys.byteorder == 'little':
+        if sys.byteorder != 'little':
             return
 
         ds = SimpleDataSet(self, self.uri, self.rows, key_format=self.key_format, value_format=self.value_format)

--- a/test/suite/test_chunkcache05.py
+++ b/test/suite/test_chunkcache05.py
@@ -89,8 +89,10 @@ class test_chunkcache05(wttest.WiredTigerTestCase):
         self.close_conn()
         self.reopen_conn()
 
-        # Assert the chunks are read back in on startup.
-        self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_created_from_metadata), 0)
+        # Assert the chunks are read back in on startup. Wait for the stats to indicate
+        # that it's done the work.
+        while self.get_stat(wiredtiger.stat.conn.chunkcache_created_from_metadata) == 0:
+            pass
         self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_bytes_read_persistent), 0)
 
         # Check that our data is all intact.

--- a/test/suite/test_chunkcache06.py
+++ b/test/suite/test_chunkcache06.py
@@ -106,8 +106,10 @@ class test_chunkcache06(wttest.WiredTigerTestCase):
 
         self.reopen_conn()
 
-        # Assert the chunks are read back in on startup.
-        self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_created_from_metadata), 0)
+        # Assert the chunks are read back in on startup. Wait for the stats to indicate
+        # that it's done the work.
+        while self.get_stat(wiredtiger.stat.conn.chunkcache_created_from_metadata) == 0:
+            pass
         self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_bytes_read_persistent), 0)
 
         # Check that our data is all intact, despite having to reload chunks.

--- a/test/suite/test_chunkcache06.py
+++ b/test/suite/test_chunkcache06.py
@@ -48,6 +48,9 @@ class test_chunkcache06(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(format_values)
 
     def conn_config(self):
+        if sys.byteorder != 'little':
+            return ''
+
         if not os.path.exists('bucket6'):
             os.mkdir('bucket6')
 


### PR DESCRIPTION
There were two bugs here:
* `test_chunkcache05` simply had the logic the wrong way around.
* For both of the new tests, we needed to avoid having the chunk cache in the config. It still opens WiredTiger even if we immediately return in the main `test` function, and that's enough to trip the `mmap` sanity check.