### PR TITLE
WT-12013 Set the connection with HS open flag if it exists in the database.

### DIFF
--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -142,8 +142,6 @@ __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
 
     WT_RET(__wt_hs_config(session, cfg));
 
-    /* The statistics server is already running, make sure we don't race. */
-    WT_WRITE_BARRIER();
     F_SET(conn, WT_CONN_HS_OPEN);
 
     return (0);

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -92,7 +92,7 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
         WT_ERR_MSG(session, EINVAL, "max history store size %" PRId64 " below minimum %d", cval.val,
           WT_HS_FILE_MIN);
 
-    /* In-memory configuration do not have a history store. */
+    /* The history store is not available for in-memory configurations. */
     if (F_ISSET(conn, WT_CONN_IN_MEMORY))
         return (0);
 
@@ -113,7 +113,10 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
     btree->file_max = (uint64_t)cval.val;
     WT_STAT_CONN_SET(session, cache_hs_ondisk_max, btree->file_max);
 
-    /* To access the history store file later, set up the connection with the HS open flag. */
+    /*
+     * Now that we have the history store's handle, we may set the flag because we know the file is
+     * open.
+     */
     F_SET(conn, WT_CONN_HS_OPEN);
 
 err:

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -92,8 +92,8 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
         WT_ERR_MSG(session, EINVAL, "max history store size %" PRId64 " below minimum %d", cval.val,
           WT_HS_FILE_MIN);
 
-    /* in-memory or readonly configurations do not have a history store. */
-    if (F_ISSET(conn, WT_CONN_IN_MEMORY | WT_CONN_READONLY))
+    /* In-memory configuration do not have a history store. */
+    if (F_ISSET(conn, WT_CONN_IN_MEMORY))
         return (0);
 
     WT_ERR(__hs_start_internal_session(session, &tmp_setup_session));
@@ -112,6 +112,9 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
      */
     btree->file_max = (uint64_t)cval.val;
     WT_STAT_CONN_SET(session, cache_hs_ondisk_max, btree->file_max);
+
+    /* To access the history store file later, set up the connection with the HS open flag. */
+    F_SET(conn, WT_CONN_HS_OPEN);
 
 err:
     if (tmp_setup_session != NULL)
@@ -141,8 +144,6 @@ __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
     WT_RET(__wt_session_create(session, WT_HS_URI, WT_HS_CONFIG));
 
     WT_RET(__wt_hs_config(session, cfg));
-
-    F_SET(conn, WT_CONN_HS_OPEN);
 
     return (0);
 }

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1003,6 +1003,10 @@ done:
     if (hs_exists) {
         WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
         WT_STAT_CONN_SET(session, cache_hs_ondisk, hs_size);
+
+        /* The statistics server is already running, make sure we don't race. */
+        WT_WRITE_BARRIER();
+        F_SET(conn, WT_CONN_HS_OPEN);
     }
 
     /*

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -750,12 +750,6 @@ __hs_exists(WT_SESSION_IMPL *session, WT_CURSOR *metac, const char *cfg[], bool 
                     WT_ERR(wt_session->salvage(wt_session, WT_HS_URI, NULL));
                 } else
                     WT_ERR(ret);
-            } else {
-                /*
-                 * To access the history store file later, set up the connection with the HS open
-                 * flag.
-                 */
-                F_SET(conn, WT_CONN_HS_OPEN);
             }
         } else {
             /*

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -751,9 +751,6 @@ __hs_exists(WT_SESSION_IMPL *session, WT_CURSOR *metac, const char *cfg[], bool 
                 } else
                     WT_ERR(ret);
             } else {
-                /* The statistics server is already running, make sure we don't race. */
-                WT_WRITE_BARRIER();
-
                 /*
                  * To access the history store file later, set up the connection with the HS open
                  * flag.

--- a/test/suite/test_checkpoint31.py
+++ b/test/suite/test_checkpoint31.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+# test_checkpoint31.py
+#
+# Test opening a read-only checkpoint cursor.
+class test_checkpoint(wttest.WiredTigerTestCase):
+
+    def test_checkpoint(self):
+        uri = 'table:checkpoint31'
+
+        # Create a table with some initial data.
+        self.session.create(uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(uri, None, None)
+
+        self.session.begin_transaction()
+        cursor.set_key('1')
+        cursor.set_value('10')
+        cursor.insert()
+        cursor.set_key('2')
+        cursor.set_value('20')
+        cursor.insert()
+        self.session.prepare_transaction('prepare_timestamp=10')
+        self.session.commit_transaction('commit_timestamp=14,durable_timestamp=18')
+
+        self.session.begin_transaction()
+        cursor.set_key('2')
+        cursor.set_value('21')
+        cursor.insert()
+        self.session.prepare_transaction('prepare_timestamp=20')
+        self.session.commit_transaction('commit_timestamp=24,durable_timestamp=28')
+
+        # Create a named checkpoint between the commit and the durable timestamps of the last
+        # transaction.
+        self.conn.set_timestamp('stable_timestamp=26')
+        self.session.checkpoint('name=ckpt1')
+
+        # Now take a nameless checkpoint with the latest stable timestamp.
+        self.conn.set_timestamp('stable_timestamp=40')
+        self.session.checkpoint()
+
+        # Reopen the connection and confirm the value of key 2
+        self.reopen_conn()
+        cursor = self.session.open_cursor(uri, None, 'checkpoint=ckpt1')
+        cursor.set_key('2')
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), '20')
+
+        # Now try with a read-only connection
+        self.reopen_conn(config='readonly=true')
+        cursor = self.session.open_cursor(uri, None, 'checkpoint=ckpt1')
+        cursor.set_key('2')
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), '20')
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_checkpoint31.py
+++ b/test/suite/test_checkpoint31.py
@@ -41,19 +41,13 @@ class test_checkpoint(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri, None, None)
 
         self.session.begin_transaction()
-        cursor.set_key('1')
-        cursor.set_value('10')
-        cursor.insert()
-        cursor.set_key('2')
-        cursor.set_value('20')
-        cursor.insert()
+        cursor['1'] = '10'
+        cursor['2'] = '20'
         self.session.prepare_transaction('prepare_timestamp=10')
         self.session.commit_transaction('commit_timestamp=14,durable_timestamp=18')
 
         self.session.begin_transaction()
-        cursor.set_key('2')
-        cursor.set_value('21')
-        cursor.insert()
+        cursor['2'] = '21'
         self.session.prepare_transaction('prepare_timestamp=20')
         self.session.commit_transaction('commit_timestamp=24,durable_timestamp=28')
 


### PR DESCRIPTION
If the database has a history store file, regardless of whether it is read-only or read-write, mark the connection with HS open. This allows access to the data in the history store even while utilising a read-only connection.