### PR TITLE
WT-12042 Adding read ordering when reading log_close_fh

### DIFF
--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -604,7 +604,7 @@ __log_file_server(void *arg)
          *
          * The read from log close file handle is ordered with respect to the log close lsn. We
          * write to it in the order log close lsn, then log close file handle. As such we need to
-         * read from it in that order. We are not protected by an address dependency in this
+         * read from it the reverse order. We are not protected by an address dependency in this
          * context.
          */
         WT_ORDERED_READ(close_fh, log->log_close_fh);

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -602,10 +602,9 @@ __log_file_server(void *arg)
          * If there is a log file to close, make sure any outstanding write operations have
          * completed, then fsync and close it.
          *
-         * The read from log close file handle is ordered with respect to the log close lsn. We
-         * write to it in the order log close lsn, then log close file handle. As such we need to
-         * read from it the reverse order. We are not protected by an address dependency in this
-         * context.
+         * The read from the log close file handle is ordered with the read from the log close lsn.
+         * Writers will set the log close lsn first and then the log close file handle, so we need
+         * to read them in the reverse order to see a consistent state.
          */
         WT_ORDERED_READ(close_fh, log->log_close_fh);
         if (close_fh != NULL) {

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1175,6 +1175,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
         log->log_close_fh = NULL;
     else {
         WT_ASSIGN_LSN(&log->log_close_lsn, &log->alloc_lsn);
+        /* Paired with an ordered read in the log file server path. */
         WT_PUBLISH(log->log_close_fh, log->log_fh);
     }
     log->fileid++;


### PR DESCRIPTION
I wanted to get this in before waiting for Acq/rel semantics. Then we can simply rename this barrier.