### PR TITLE
WT-12029 Initialise chunk cache condition variable earlier

### DIFF
--- a/src/conn/conn_chunkcache.c
+++ b/src/conn/conn_chunkcache.c
@@ -282,9 +282,9 @@ __wt_chunkcache_metadata_create(WT_SESSION_IMPL *session)
       conn, "chunkcache-metadata-server", true, 0, 0, &conn->chunkcache_metadata_session));
     session = conn->chunkcache_metadata_session;
 
-    WT_ERR(__chunkcache_apply_metadata_content(session));
-
     WT_ERR(__wt_cond_alloc(session, "chunkcache metadata", &conn->chunkcache_metadata_cond));
+
+    WT_ERR(__chunkcache_apply_metadata_content(session));
 
     /* Start the thread. */
     WT_ERR(__wt_thread_create(


### PR DESCRIPTION
This was segfaulting:
1. The initialisation code would call `__chunkcache_apply_metadata_content` before initialising the the condition variable.
2. The chunk cache would fill up and call eviction.
3. Eviction would attempt to push the removal to the content management queue
4. It then tried to signal the "there's stuff on the queue" condition variable - but that was still null.