### PR TITLE
WT-12059 Keep the exclude list in the background compaction configuration string

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -698,7 +698,7 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
     if (enable == running)
         goto err;
 
-    /* Update the excluded tables when the server is turned on. */
+    /* Update the excluded tables when the server is enabled. */
     if (enable) {
         __background_compact_exclude_list_clear(session, false);
         WT_ERR_NOTFOUND_OK(__wt_config_gets(session, cfg, "exclude", &cval), false);

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -721,10 +721,6 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
             }
             WT_ERR_NOTFOUND_OK(ret, false);
         }
-
-        /* We can now strip the exclude list from the configuration as it is no longer relevant. */
-        __wt_free(session, stripped_config);
-        WT_ERR(__wt_config_merge(session, cfg, "background=,exclude=", &stripped_config));
     }
 
     /* The background compaction has been signalled successfully, update its state. */

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -686,8 +686,8 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
     WT_ERR(__wt_config_getones(session, config, "background", &cval));
     enable = cval.val;
 
-    /* Strip the unused fields from the configuration to check if the configuration has changed. */
-    WT_ERR(__wt_config_merge(session, cfg, "background=,exclude=", &stripped_config));
+    /* Strip the toggle field from the configuration to check if the configuration has changed. */
+    WT_ERR(__wt_config_merge(session, cfg, "background=", &stripped_config));
 
     /* The background compact configuration cannot be changed while it's already running. */
     if (enable && running && strcmp(stripped_config, conn->background_compact.config) != 0)
@@ -721,6 +721,10 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
             }
             WT_ERR_NOTFOUND_OK(ret, false);
         }
+
+        /* We can now strip the exclude list from the configuration as it is no longer relevant. */
+        __wt_free(session, stripped_config);
+        WT_ERR(__wt_config_merge(session, cfg, "background=,exclude=", &stripped_config));
     }
 
     /* The background compaction has been signalled successfully, update its state. */

--- a/test/suite/test_compact05.py
+++ b/test/suite/test_compact05.py
@@ -27,15 +27,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # test_compact05.py
-#   Test compaction through the background compaction server.
+#   Test if foreground compaction proceeds depending on the free_space_target field.
 #
 
 import wttest
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-# Test if compaction proceeds depending on the free_space_target field used by the background
-# compaction server.
 class test_compact05(wttest.WiredTigerTestCase):
 
     free_space_target = [

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -69,9 +69,10 @@ class test_compact06(wttest.WiredTigerTestCase):
         self.assertEqual(compact_running, 1)
 
         #   5. We cannot reconfigure the background server.
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-            self.session.compact(None, 'background=true,free_space_target=10MB'),
-            '/Cannot reconfigure background compaction while it\'s already running/')
+        for item in items:
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+                self.session.compact(None, f'background=true,{item}'),
+                '/Cannot reconfigure background compaction while it\'s already running/')
 
         #   6. Disable the background compaction server.
         self.session.compact(None, 'background=false')

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -33,6 +33,8 @@ from wiredtiger import stat
 # test_compact06.py
 # Test background compaction API usage.
 class test_compact06(wttest.WiredTigerTestCase):
+    configuration_items = ['exclude=["table:a.wt"]', 'free_space_target=10MB', 'timeout=60']
+
     def get_bg_compaction_running(self):
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         compact_running = stat_cursor[stat.conn.background_compact_running][2]
@@ -47,8 +49,7 @@ class test_compact06(wttest.WiredTigerTestCase):
             '/Background compaction does not work on specific URIs/')
             
         # We cannot set other configurations while turning off the background server.
-        items = ['exclude=["table:a.wt"]', 'free_space_target=10MB', 'timeout=60']
-        for item in items:
+        for item in self.configuration_items:
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
                 self.session.compact(None, f'background=false,{item}'),
                 '/configuration cannot be set when disabling the background compaction server/')
@@ -69,7 +70,7 @@ class test_compact06(wttest.WiredTigerTestCase):
         self.assertEqual(compact_running, 1)
 
         # We cannot reconfigure the background server.
-        for item in items:
+        for item in self.configuration_items:
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
                 self.session.compact(None, f'background=true,{item}'),
                 '/Cannot reconfigure background compaction while it\'s already running/')

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -40,25 +40,25 @@ class test_compact06(wttest.WiredTigerTestCase):
         return compact_running
     
     def test_background_compact_api(self):
-        #   1. We cannot trigger the background compaction on a specific API. Note that the URI is
-        # not relevant here, the corresponding table does not need to exist for this check.
+        # We cannot trigger the background compaction on a specific API. Note that the URI is not
+        # relevant here, the corresponding table does not need to exist for this check.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.compact("file:123", 'background=true'),
             '/Background compaction does not work on specific URIs/')
             
-        #   2. We cannot set other configurations while turning off the background server.
+        # We cannot set other configurations while turning off the background server.
         items = ['exclude=["table:a.wt"]', 'free_space_target=10MB', 'timeout=60']
         for item in items:
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
                 self.session.compact(None, f'background=false,{item}'),
                 '/configuration cannot be set when disabling the background compaction server/')
 
-        #   3. We cannot exclude invalid URIs when enabling background compaction.
+        # We cannot exclude invalid URIs when enabling background compaction.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.compact(None, 'background=true,exclude=["file:a"]'),
             '/can only exclude objects of type "table"/')
 
-        #   4. Enable the background compaction server.
+        # Enable the background compaction server.
         self.session.compact(None, 'background=true')
 
         # Wait for the background server to wake up.
@@ -68,13 +68,13 @@ class test_compact06(wttest.WiredTigerTestCase):
             compact_running = self.get_bg_compaction_running()
         self.assertEqual(compact_running, 1)
 
-        #   5. We cannot reconfigure the background server.
+        # We cannot reconfigure the background server.
         for item in items:
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
                 self.session.compact(None, f'background=true,{item}'),
                 '/Cannot reconfigure background compaction while it\'s already running/')
 
-        #   6. Disable the background compaction server.
+        # Disable the background compaction server.
         self.session.compact(None, 'background=false')
 
         # Background compaction may have been inspecting a table when disabled, which is considered


### PR DESCRIPTION
If one tries to reconfigure the background compaction server while it is running with a different exclude list, an error is returned.