### PR TITLE
WT-12031 Add a new configuration item for background compaction to run once

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1392,7 +1392,7 @@ methods = {
         enable/disabled the background compaction server.''',
         type='boolean'),
     Config('exclude', '', r'''
-        A list of table objects to be excluded from background compaction. The list is immutable and
+        list of table objects to be excluded from background compaction. The list is immutable and
         only applied when the background compaction gets enabled. The list is not saved between the
         calls and needs to be reapplied each time the service is enabled. The individual objects in
         the list can only be of the \c table: URI type''',
@@ -1401,7 +1401,8 @@ methods = {
         minimum amount of space recoverable for compaction to proceed''',
         min='1MB'),
     Config('run_once', 'false', r'''
-        configure background compaction server to run once''',
+        configure background compaction server to run once. In this mode, compaction is always
+        attempted on each table unless explicitly excluded''',
         type='boolean'),
     Config('timeout', '1200', r'''
         maximum amount of time to allow for compact in seconds. The actual amount of time spent

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1400,6 +1400,9 @@ methods = {
     Config('free_space_target', '20MB', r'''
         minimum amount of space recoverable for compaction to proceed''',
         min='1MB'),
+    Config('run_once', 'false', r'''
+        configure background compaction server to run once''',
+        type='boolean'),
     Config('timeout', '1200', r'''
         maximum amount of time to allow for compact in seconds. The actual amount of time spent
         in compact may exceed the configured value. A value of zero disables the timeout''',

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -815,6 +815,8 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_compact[] = {
     NULL},
   {"free_space_target", "int", NULL, "min=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     1LL * WT_MEGABYTE, INT64_MAX, NULL},
+  {"run_once", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, INT64_MIN,
+    INT64_MAX, NULL},
   {"timeout", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, INT64_MIN, INT64_MAX,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, NULL}};
@@ -823,7 +825,7 @@ static const uint8_t confchk_WT_SESSION_compact_jump[WT_CONFIG_JUMP_TABLE_SIZE] 
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 3, 3,
-  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+  3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const char *confchk_access_pattern_hint2_choices[] = {"none", "random", "sequential", NULL};
 
@@ -3361,8 +3363,10 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "commit_timestamp=,durable_timestamp=,operation_timeout_ms=0,"
     "sync=",
     confchk_WT_SESSION_commit_transaction, 4, confchk_WT_SESSION_commit_transaction_jump},
-  {"WT_SESSION.compact", "background=,exclude=,free_space_target=20MB,timeout=1200",
-    confchk_WT_SESSION_compact, 4, confchk_WT_SESSION_compact_jump},
+  {"WT_SESSION.compact",
+    "background=,exclude=,free_space_target=20MB,run_once=false,"
+    "timeout=1200",
+    confchk_WT_SESSION_compact, 5, confchk_WT_SESSION_compact_jump},
   {"WT_SESSION.create",
     "access_pattern_hint=none,allocation_size=4KB,app_metadata=,"
     "assert=(commit_timestamp=none,durable_timestamp=none,"

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -492,6 +492,10 @@ __background_compact_server(void *arg)
         __wt_spin_lock(session, &conn->background_compact.lock);
         running = conn->background_compact.running;
         if (conn->background_compact.signalled) {
+            /* If configured to run once, start from the beginning. */
+            if (running && conn->background_compact.run_once)
+                WT_ERR(__wt_buf_set(session, uri, WT_BACKGROUND_COMPACT_URI_PREFIX,
+                  strlen(WT_BACKGROUND_COMPACT_URI_PREFIX) + 1));
             conn->background_compact.signalled = false;
             WT_STAT_CONN_SET(session, background_compact_running, running);
         }

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -465,6 +465,14 @@ __background_compact_server(void *arg)
              * have been parsed.
              */
             if (uri->size == 0 || full_iteration) {
+                /* If the server was configured to run once, after a full iteration, we are done. */
+                if (full_iteration && conn->background_compact.run_once) {
+                    __wt_spin_lock(session, &conn->background_compact.lock);
+                    conn->background_compact.running = false;
+                    running = false;
+                    WT_STAT_CONN_SET(session, background_compact_running, running);
+                    __wt_spin_unlock(session, &conn->background_compact.lock);
+                }
                 full_iteration = false;
                 WT_ERR(__wt_buf_set(session, uri, WT_BACKGROUND_COMPACT_URI_PREFIX,
                   strlen(WT_BACKGROUND_COMPACT_URI_PREFIX) + 1));

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -698,8 +698,14 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
     if (enable == running)
         goto err;
 
-    /* Update the excluded tables when the server is turned on. */
+    /* Update the background compaction settings when the server is turned on. */
     if (enable) {
+
+        /* The background compaction server can be configured to run once. */
+        WT_ERR(__wt_config_getones(session, stripped_config, "run_once", &cval));
+        conn->background_compact.run_once = cval.val;
+
+        /* Process excluded tables. */
         __background_compact_exclude_list_clear(session, false);
         WT_ERR_NOTFOUND_OK(__wt_config_gets(session, cfg, "exclude", &cval), false);
         if (cval.len != 0) {

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -695,7 +695,7 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
     enable = cval.val;
 
     /* Strip the unused fields from the configuration to check if the configuration has changed. */
-    WT_ERR(__wt_config_merge(session, cfg, "background=,exclude=", &stripped_config));
+    WT_ERR(__wt_config_merge(session, cfg, "background=", &stripped_config));
 
     /* The background compact configuration cannot be changed while it's already running. */
     if (enable && running && strcmp(stripped_config, conn->background_compact.config) != 0)

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -706,7 +706,7 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
     if (enable == running)
         goto err;
 
-    /* Update the background compaction settings when the server is turned on. */
+    /* Update the background compaction settings when the server is enabled. */
     if (enable) {
 
         /* The background compaction server can be configured to run once. */

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -497,9 +497,11 @@ __background_compact_server(void *arg)
         running = conn->background_compact.running;
         if (conn->background_compact.signalled) {
             /* If configured to run once, start from the beginning. */
-            if (running && conn->background_compact.run_once)
+            if (conn->background_compact.run_once) {
+                WT_ASSERT(session, running);
                 WT_ERR(__wt_buf_set(session, uri, WT_BACKGROUND_COMPACT_URI_PREFIX,
                   strlen(WT_BACKGROUND_COMPACT_URI_PREFIX) + 1));
+            }
             conn->background_compact.signalled = false;
             WT_STAT_CONN_SET(session, background_compact_running, running);
         }

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -495,6 +495,8 @@ __background_compact_server(void *arg)
 
         __wt_spin_lock(session, &conn->background_compact.lock);
         running = conn->background_compact.running;
+
+        /* The server has been signalled to change state. */
         if (conn->background_compact.signalled) {
             /* If configured to run once, start from the beginning. */
             if (conn->background_compact.run_once) {
@@ -505,6 +507,7 @@ __background_compact_server(void *arg)
             conn->background_compact.signalled = false;
             WT_STAT_CONN_SET(session, background_compact_running, running);
         }
+
         __wt_spin_unlock(session, &conn->background_compact.lock);
 
         /*

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -213,6 +213,10 @@ __background_compact_should_run(WT_SESSION_IMPL *session, const char *uri, int64
     if (compact_stat == NULL)
         return (true);
 
+    /* If we are running once, force compaction on the file. */
+    if (conn->background_compact.run_once)
+        return (true);
+
     /* Proceed with compaction when the file has not been compacted for some time. */
     cur_time = __wt_clock(session);
     if (WT_CLOCKDIFF_SEC(cur_time, compact_stat->prev_compact_time) >=

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -83,6 +83,7 @@ struct __wt_background_compact_exclude {
  */
 struct __wt_background_compact {
     bool running;             /* Compaction supposed to run */
+    bool run_once;            /* Background compaction is executed once */
     bool signalled;           /* Compact signalled */
     bool tid_set;             /* Thread set */
     wt_thread_t tid;          /* Thread */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1411,6 +1411,8 @@ struct __wt_session {
      * default empty.}
      * @config{free_space_target, minimum amount of space recoverable for compaction to proceed., an
      * integer greater than or equal to \c 1MB; default \c 20MB.}
+     * @config{run_once, configure background compaction server to run once., a boolean flag;
+     * default \c false.}
      * @config{timeout, maximum amount of time to allow for compact in seconds.  The actual amount
      * of time spent in compact may exceed the configured value.  A value of zero disables the
      * timeout., an integer; default \c 1200.}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1404,14 +1404,15 @@ struct __wt_session {
      * @configstart{WT_SESSION.compact, see dist/api_data.py}
      * @config{background, enable/disabled the background compaction server., a boolean flag;
      * default empty.}
-     * @config{exclude, A list of table objects to be excluded from background compaction.  The list
+     * @config{exclude, list of table objects to be excluded from background compaction.  The list
      * is immutable and only applied when the background compaction gets enabled.  The list is not
      * saved between the calls and needs to be reapplied each time the service is enabled.  The
      * individual objects in the list can only be of the \c table: URI type., a list of strings;
      * default empty.}
      * @config{free_space_target, minimum amount of space recoverable for compaction to proceed., an
      * integer greater than or equal to \c 1MB; default \c 20MB.}
-     * @config{run_once, configure background compaction server to run once., a boolean flag;
+     * @config{run_once, configure background compaction server to run once.  In this mode\,
+     * compaction is always attempted on each table unless explicitly excluded., a boolean flag;
      * default \c false.}
      * @config{timeout, maximum amount of time to allow for compact in seconds.  The actual amount
      * of time spent in compact may exceed the configured value.  A value of zero disables the

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -428,6 +428,11 @@ __wt_session_compact(WT_SESSION *wt_session, const char *uri, const char *config
                 WT_ERR_MSG(session, EINVAL,
                   "exclude configuration cannot be set when disabling the background compaction "
                   "server.");
+            WT_ERR_NOTFOUND_OK(__wt_config_getones(session, config, "run_once", &cval), true);
+            if (ret == 0)
+                WT_ERR_MSG(session, EINVAL,
+                  "run_once configuration cannot be set when disabling the background compaction "
+                  "server.");
             WT_ERR_NOTFOUND_OK(__wt_config_getones(session, config, "timeout", &cval), true);
             if (ret == 0)
                 WT_ERR_MSG(session, EINVAL,

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -47,8 +47,8 @@ class test_compact06(wttest.WiredTigerTestCase):
             compact_running = self.get_bg_compaction_running()
         self.assertEqual(compact_running, 0)
 
-    def turn_on_bg_compact(self, config):
-        self.session.compact(None, config)
+    def turn_on_bg_compact(self, config=''):
+        self.session.compact(None, f'background=true,{config}')
         compact_running = self.get_bg_compaction_running()
         while not compact_running:
             time.sleep(1)
@@ -75,7 +75,7 @@ class test_compact06(wttest.WiredTigerTestCase):
             '/can only exclude objects of type "table"/')
 
         # Enable the background compaction server.
-        self.turn_on_bg_compact('background=true')
+        self.turn_on_bg_compact()
 
         # We cannot reconfigure the background server.
         for item in items:
@@ -85,6 +85,15 @@ class test_compact06(wttest.WiredTigerTestCase):
 
         # Disable the background compaction server.
         self.turn_off_bg_compact()
+
+        # Enable background and configure it to run once.
+        self.session.compact(None, 'background=true,run_once=true')
+
+        # Ensure background compaction stops by itself.
+        compact_running = self.get_bg_compaction_running()
+        while compact_running:
+            time.sleep(1)
+            compact_running = self.get_bg_compaction_running()
 
         # Background compaction may have been inspecting a table when disabled, which is considered
         # as an interruption, ignore that message.

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -40,25 +40,25 @@ class test_compact06(wttest.WiredTigerTestCase):
         return compact_running
     
     def test_background_compact_api(self):
-        #   1. We cannot trigger the background compaction on a specific API. Note that the URI is
+        # We cannot trigger the background compaction on a specific API. Note that the URI is
         # not relevant here, the corresponding table does not need to exist for this check.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.compact("file:123", 'background=true'),
             '/Background compaction does not work on specific URIs/')
             
-        #   2. We cannot set other configurations while turning off the background server.
-        items = ['exclude=["table:a.wt"]', 'free_space_target=10MB', 'timeout=60']
+        # We cannot set other configurations while turning off the background server.
+        items = ['exclude=["table:a.wt"]', 'free_space_target=10MB', 'run_once=true', 'timeout=60']
         for item in items:
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
                 self.session.compact(None, f'background=false,{item}'),
                 '/configuration cannot be set when disabling the background compaction server/')
 
-        #   3. We cannot exclude invalid URIs when enabling background compaction.
+        # We cannot exclude invalid URIs when enabling background compaction.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
             self.session.compact(None, 'background=true,exclude=["file:a"]'),
             '/can only exclude objects of type "table"/')
 
-        #   4. Enable the background compaction server.
+        # Enable the background compaction server.
         self.session.compact(None, 'background=true')
 
         # Wait for the background server to wake up.
@@ -68,12 +68,13 @@ class test_compact06(wttest.WiredTigerTestCase):
             compact_running = self.get_bg_compaction_running()
         self.assertEqual(compact_running, 1)
 
-        #   5. We cannot reconfigure the background server.
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-            self.session.compact(None, 'background=true,free_space_target=10MB'),
-            '/Cannot reconfigure background compaction while it\'s already running/')
+        # We cannot reconfigure the background server.
+        for item in items:
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+                self.session.compact(None, f'background=true,{item}'),
+                '/Cannot reconfigure background compaction while it\'s already running/')
 
-        #   6. Disable the background compaction server.
+        # Disable the background compaction server.
         self.session.compact(None, 'background=false')
 
         # Background compaction may have been inspecting a table when disabled, which is considered

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -43,19 +43,13 @@ class test_compact06(wttest.WiredTigerTestCase):
 
     def turn_off_bg_compact(self):
         self.session.compact(None, 'background=false')
-        compact_running = self.get_bg_compaction_running()
-        while compact_running:
+        while self.get_bg_compaction_running():
             time.sleep(1)
-            compact_running = self.get_bg_compaction_running()
-        self.assertEqual(compact_running, 0)
 
     def turn_on_bg_compact(self, config=''):
         self.session.compact(None, f'background=true,{config}')
-        compact_running = self.get_bg_compaction_running()
-        while not compact_running:
+        while not self.get_bg_compaction_running():
             time.sleep(1)
-            compact_running = self.get_bg_compaction_running()
-        self.assertEqual(compact_running, 1)
     
     def test_background_compact_api(self):
         # We cannot trigger the background compaction on a specific API. Note that the URI is
@@ -91,11 +85,8 @@ class test_compact06(wttest.WiredTigerTestCase):
         self.session.compact(None, 'background=true,run_once=true')
 
         # Ensure background compaction stops by itself.
-        compact_running = self.get_bg_compaction_running()
-        while compact_running:
+        while self.get_bg_compaction_running():
             time.sleep(1)
-            compact_running = self.get_bg_compaction_running()
-        self.assertEqual(compact_running, 0)
 
         # Background compaction may have been inspecting a table when disabled, which is considered
         # as an interruption, ignore that message.


### PR DESCRIPTION
- Added a new configuration item `run_once` for the background compaction
- When configured with `run_once`, the background compaction will go to sleep after a full iteration