### PR TITLE
WT-12053 Resolve a large number of statistics races in chunk cache tests

### DIFF
--- a/test/suite/test_chunkcache01.py
+++ b/test/suite/test_chunkcache01.py
@@ -40,7 +40,7 @@ def get_stat(session, stat):
 
     return val
 
-# These raise an exception since they doesn't have access to assertGreater and friends.
+# These raise an exception since they don't have access to assertGreater and friends.
 def stat_assert_equal(session, stat, expected):
     val = get_stat(session, stat)
     if val != expected:

--- a/test/suite/test_chunkcache01.py
+++ b/test/suite/test_chunkcache01.py
@@ -26,9 +26,30 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, sys, wiredtiger, wttest
+import os, sys, time, wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
+
+def get_stat(session, stat):
+    # This could be made more sophisticated, but there's no need yet.
+    time.sleep(0.5)
+
+    stat_cursor = session.open_cursor('statistics:')
+    val = stat_cursor[stat][2]
+    stat_cursor.close()
+
+    return val
+
+# These raise an exception since they doesn't have access to assertGreater and friends.
+def stat_assert_equal(session, stat, expected):
+    val = get_stat(session, stat)
+    if val != expected:
+        raise Exception("expected {} ({}) to be equal to {}".format(stat, val, expected))
+
+def stat_assert_greater(session, stat, expected):
+    val = get_stat(session, stat)
+    if val <= expected:
+        raise Exception("expected {} ({}) to be greater than {}".format(stat, val, expected))
 
 # Basic functional chunk cache test - put some data in, make sure it
 # comes back out unscathed.
@@ -47,12 +68,6 @@ class test_chunkcache01(wttest.WiredTigerTestCase):
         cache_types.append(('on-disk', dict(chunk_cache_type='FILE')))
 
     scenarios = make_scenarios(format_values, cache_types)
-
-    def get_stat(self, stat):
-        stat_cursor = self.session.open_cursor('statistics:')
-        val = stat_cursor[stat][2]
-        stat_cursor.close()
-        return val
 
     def conn_config(self):
         if not os.path.exists('bucket1'):
@@ -75,9 +90,9 @@ class test_chunkcache01(wttest.WiredTigerTestCase):
         ds.check()
 
         # Assert the new chunks are ingested.
-        self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables), 0)
+        stat_assert_greater(self.session, wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables, 0)
 
         self.close_conn()
         self.reopen_conn()
         ds.check()
-        self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_bytes_inuse), 0)
+        stat_assert_greater(self.session, wiredtiger.stat.conn.chunkcache_bytes_inuse, 0)

--- a/test/suite/test_chunkcache03.py
+++ b/test/suite/test_chunkcache03.py
@@ -69,6 +69,7 @@ class test_chunkcache03(wttest.WiredTigerTestCase):
         extlist.extension('storage_sources', 'dir_store')
 
     def get_stat(self, stat):
+        time.sleep(0.5) # Try to avoid race conditions.
         stat_cursor = self.session.open_cursor('statistics:')
         val = stat_cursor[stat][2]
         stat_cursor.close()
@@ -113,7 +114,6 @@ class test_chunkcache03(wttest.WiredTigerTestCase):
             self.read_and_verify(uris[i], ds[i])
 
         # Assert pinned/unpinned stats.
-        time.sleep(0.5)
         total_chunks = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_inuse)
         pinned_chunks = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_pinned)
         self.assertGreater(total_chunks, 0)

--- a/test/suite/test_chunkcache04.py
+++ b/test/suite/test_chunkcache04.py
@@ -70,6 +70,7 @@ class test_chunkcache04(wttest.WiredTigerTestCase):
         extlist.extension('storage_sources', 'dir_store')
 
     def get_stat(self, stat):
+        time.sleep(0.5) # Try to avoid race conditions.
         stat_cursor = self.session.open_cursor('statistics:')
         val = stat_cursor[stat][2]
         stat_cursor.close()
@@ -100,7 +101,6 @@ class test_chunkcache04(wttest.WiredTigerTestCase):
         stat_assert_equal(self.session, wiredtiger.stat.conn.chunkcache_chunks_pinned, 0)
 
         # Assert the new chunks are ingested.
-        time.sleep(0.5)
         first_ingest = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables)
         self.assertGreater(first_ingest, 0)
 
@@ -116,7 +116,6 @@ class test_chunkcache04(wttest.WiredTigerTestCase):
         self.session.checkpoint('flush_tier=(enabled)')
 
         # Assert the new chunks are ingested.
-        time.sleep(0.5)
         second_ingest = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables)
         self.assertGreater(second_ingest, first_ingest)
 
@@ -135,7 +134,6 @@ class test_chunkcache04(wttest.WiredTigerTestCase):
         self.session.checkpoint('flush_tier=(enabled)')
 
         # Assert another set of ingests took place.
-        time.sleep(0.5)
         total_ingest = self.get_stat(wiredtiger.stat.conn.chunkcache_chunks_loaded_from_flushed_tables)
         self.assertGreater(total_ingest, second_ingest)
 

--- a/test/suite/test_chunkcache05.py
+++ b/test/suite/test_chunkcache05.py
@@ -29,6 +29,7 @@
 import os, sys
 import wiredtiger, wttest
 
+from test_chunkcache01 import stat_assert_equal, stat_assert_greater
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -63,12 +64,6 @@ class test_chunkcache05(wttest.WiredTigerTestCase):
             extlist.skip_if_missing = True
         extlist.extension('storage_sources', 'dir_store')
 
-    def get_stat(self, stat):
-        stat_cursor = self.session.open_cursor('statistics:')
-        val = stat_cursor[stat][2]
-        stat_cursor.close()
-        return val
-
     def test_chunkcache05(self):
         # This test only makes sense on-disk, and WT's filesystem layer doesn't support mmap on
         # big-endian platforms.
@@ -79,8 +74,8 @@ class test_chunkcache05(wttest.WiredTigerTestCase):
         ds.populate()
 
         # Haven't persisted anything yet - check the stats agree.
-        self.assertEqual(self.get_stat(wiredtiger.stat.conn.chunkcache_created_from_metadata), 0)
-        self.assertEqual(self.get_stat(wiredtiger.stat.conn.chunkcache_bytes_read_persistent), 0)
+        stat_assert_equal(self.session, wiredtiger.stat.conn.chunkcache_created_from_metadata, 0)
+        stat_assert_equal(self.session, wiredtiger.stat.conn.chunkcache_bytes_read_persistent, 0)
 
         # Flush the tables into the chunk cache.
         self.session.checkpoint()
@@ -91,9 +86,8 @@ class test_chunkcache05(wttest.WiredTigerTestCase):
 
         # Assert the chunks are read back in on startup. Wait for the stats to indicate
         # that it's done the work.
-        while self.get_stat(wiredtiger.stat.conn.chunkcache_created_from_metadata) == 0:
-            pass
-        self.assertGreater(self.get_stat(wiredtiger.stat.conn.chunkcache_bytes_read_persistent), 0)
+        stat_assert_greater(self.session, wiredtiger.stat.conn.chunkcache_created_from_metadata, 0)
+        stat_assert_greater(self.session, wiredtiger.stat.conn.chunkcache_bytes_read_persistent, 0)
 
         # Check that our data is all intact.
         ds.check()


### PR DESCRIPTION
This introduces some general infrastructure for avoiding races on statistics. It's pretty dumb right now, but it's mostly abstracted away and could easily be made more sophisticated. I've left this running overnight and it definitely fixes `test_chunkcache05` and `06`, and I strongly suspect it'll also fix `02`.