### PR TITLE
WT-12070 Extend the model to support tables with logging

### DIFF
--- a/test/model/src/core/kv_database.cpp
+++ b/test/model/src/core/kv_database.cpp
@@ -43,7 +43,7 @@ namespace model {
  *     Create and return a new table. Throw an exception if the name is not unique.
  */
 kv_table_ptr
-kv_database::create_table(const char *name)
+kv_database::create_table(const char *name, const kv_table_config &config)
 {
     std::string s = std::string(name);
     std::lock_guard lock_guard(_tables_lock);
@@ -52,7 +52,7 @@ kv_database::create_table(const char *name)
     if (i != _tables.end())
         throw model_exception("Table already exists: " + s);
 
-    kv_table_ptr table = std::make_shared<kv_table>(name);
+    kv_table_ptr table = std::make_shared<kv_table>(name, config);
     _tables[s] = table;
     return table;
 }

--- a/test/model/src/core/kv_table_item.cpp
+++ b/test/model/src/core/kv_table_item.cpp
@@ -32,6 +32,7 @@
 #include <list>
 #include <sstream>
 
+#include "model/kv_table.h"
 #include "model/kv_table_item.h"
 #include "wiredtiger.h"
 

--- a/test/model/src/core/kv_transaction.cpp
+++ b/test/model/src/core/kv_transaction.cpp
@@ -103,7 +103,7 @@ kv_transaction::commit(timestamp_t commit_timestamp, timestamp_t durable_timesta
     _durable_timestamp = durable_timestamp;
 
     /* Fix commit timestamps. */
-    for (auto &u : _nontimestamped_updates)
+    for (const auto &u : _nontimestamped_updates)
         _database.table(u->table_name())
           ->fix_timestamps(u->key(), _id, commit_timestamp, durable_timestamp);
 
@@ -137,7 +137,7 @@ kv_transaction::prepare(timestamp_t prepare_timestamp)
         throw model_exception("The transaction must be in progress");
 
     /* Ensure that the transaction does not include updates to non-timestamped tables. */
-    for (auto &u : _updates)
+    for (const auto &u : _updates)
         if (!_database.table(u->table_name())->timestamped())
             throw wiredtiger_exception(
               "Transaction prepare is not supported on logged tables or tables without timestamps",

--- a/test/model/src/core/kv_transaction.cpp
+++ b/test/model/src/core/kv_transaction.cpp
@@ -45,7 +45,7 @@ kv_transaction::add_update(
 {
     std::lock_guard lock_guard(_lock);
 
-    update->set_wt_transaction_metadata(_wt_id, _wt_base_write_gen);
+    update->set_wt_transaction_metadata(_wt_id, _wt_base_write_gen, _wt_ckpt_seq_number);
 
     std::shared_ptr<kv_transaction_update> txn_update =
       std::make_shared<kv_transaction_update>(table.name(), key, update);
@@ -135,6 +135,13 @@ kv_transaction::prepare(timestamp_t prepare_timestamp)
 
     if (state() != kv_transaction_state::in_progress)
         throw model_exception("The transaction must be in progress");
+
+    /* Ensure that the transaction does not include updates to non-timestamped tables. */
+    for (auto &u : _updates)
+        if (!_database.table(u->table_name())->timestamped())
+            throw wiredtiger_exception(
+              "Transaction prepare is not supported on logged tables or tables without timestamps",
+              ENOTSUP);
 
     /* Validate the prepare timestamp against the stable timestamp. */
     if (prepare_timestamp <= _database.stable_timestamp())

--- a/test/model/src/include/model/driver/debug_log_parser.h
+++ b/test/model/src/include/model/driver/debug_log_parser.h
@@ -187,7 +187,7 @@ private:
     write_gen_t _base_write_gen;
 
     /* The number of checkpoints so far. */
-    int _ckpt_count;
+    uint64_t _ckpt_count;
 
     /* Place for accumulating checkpoint metadata: TXN ID -> checkpoint name -> config map. */
     std::unordered_map<txn_id_t, std::unordered_map<std::string, std::shared_ptr<config_map>>>

--- a/test/model/src/include/model/driver/debug_log_parser.h
+++ b/test/model/src/include/model/driver/debug_log_parser.h
@@ -97,7 +97,7 @@ public:
      *     lifetime of this parser object.
      */
     inline debug_log_parser(kv_database &database)
-        : _database(database), _base_write_gen(k_write_gen_first)
+        : _database(database), _base_write_gen(k_write_gen_first), _ckpt_count(0)
     {
     }
 
@@ -185,6 +185,9 @@ private:
 
     /* The current base write generation. */
     write_gen_t _base_write_gen;
+
+    /* The number of checkpoints so far. */
+    int _ckpt_count;
 
     /* Place for accumulating checkpoint metadata: TXN ID -> checkpoint name -> config map. */
     std::unordered_map<txn_id_t, std::unordered_map<std::string, std::shared_ptr<config_map>>>

--- a/test/model/src/include/model/kv_database.h
+++ b/test/model/src/include/model/kv_database.h
@@ -71,16 +71,16 @@ public:
      *     Create and return a new table. Throw an exception if the name is not unique.
      */
     inline kv_table_ptr
-    create_table(const std::string &name)
+    create_table(const std::string &name, const kv_table_config &config = kv_table_config{})
     {
-        return create_table(name.c_str());
+        return create_table(name.c_str(), config);
     }
 
     /*
      * kv_database::create_table --
      *     Create and return a new table. Throw an exception if the name is not unique.
      */
-    kv_table_ptr create_table(const char *name);
+    kv_table_ptr create_table(const char *name, const kv_table_config &config = kv_table_config{});
 
     /*
      * kv_database::checkpoint --

--- a/test/model/src/include/model/kv_table_item.h
+++ b/test/model/src/include/model/kv_table_item.h
@@ -39,6 +39,8 @@
 
 namespace model {
 
+class kv_table;
+
 /*
  * kv_table_item --
  *     The value part of a key-value pair, together with its metadata and previous versions.
@@ -155,6 +157,19 @@ public:
         if (!txn)
             throw model_exception("Null transaction");
         return get(txn->snapshot(), txn->id(), txn->read_timestamp());
+    }
+
+    /*
+     * kv_table_item::get_latest --
+     *     Get the corresponding value, but ignore the transaction's read timestamp. Return NONE if
+     *     not found. Throw an exception on error.
+     */
+    inline data_value
+    get_latest(kv_transaction_ptr txn) const
+    {
+        if (!txn)
+            throw model_exception("Null transaction");
+        return get(txn->snapshot(), txn->id(), k_timestamp_latest);
     }
 
     /*

--- a/test/model/src/include/model/kv_table_item.h
+++ b/test/model/src/include/model/kv_table_item.h
@@ -39,8 +39,6 @@
 
 namespace model {
 
-class kv_table;
-
 /*
  * kv_table_item --
  *     The value part of a key-value pair, together with its metadata and previous versions.

--- a/test/model/src/include/model/kv_transaction.h
+++ b/test/model/src/include/model/kv_transaction.h
@@ -82,7 +82,7 @@ public:
           _durable_timestamp(k_timestamp_none), _prepare_timestamp(k_timestamp_none),
           _failed(false), _read_timestamp(read_timestamp), _snapshot(snapshot),
           _state(kv_transaction_state::in_progress), _wt_id(k_txn_none),
-          _wt_base_write_gen(k_write_gen_none)
+          _wt_base_write_gen(k_write_gen_none), _wt_ckpt_seq_number(0)
     {
         if (!snapshot)
             throw model_exception("The snapshot is NULL.");
@@ -231,13 +231,14 @@ public:
      *     This can be done only before the first update is added to the transaction.
      */
     inline void
-    set_wt_metadata(txn_id_t wt_id, write_gen_t wt_base_write_gen)
+    set_wt_metadata(txn_id_t wt_id, write_gen_t wt_base_write_gen, int wt_ckpt_seq_number)
     {
         std::lock_guard lock_guard(_lock);
         if (!_updates.empty())
             throw model_exception("There are already updates in the transaction");
         _wt_id = wt_id;
         _wt_base_write_gen = wt_base_write_gen;
+        _wt_ckpt_seq_number = wt_ckpt_seq_number;
     }
 
     /*
@@ -258,6 +259,16 @@ public:
     wt_base_write_gen() const
     {
         return _wt_base_write_gen;
+    }
+
+    /*
+     * kv_transaction::wt_ckpt_seq_number --
+     *     Get the WiredTiger checkpoint's sequence number, if available.
+     */
+    inline int
+    wt_ckpt_seq_number() const
+    {
+        return _wt_ckpt_seq_number;
     }
 
 protected:
@@ -288,6 +299,7 @@ private:
     /* Transaction information for updates imported from WiredTiger's debug log. */
     txn_id_t _wt_id;
     write_gen_t _wt_base_write_gen;
+    int _wt_ckpt_seq_number;
 };
 
 /*

--- a/test/model/src/include/model/kv_transaction.h
+++ b/test/model/src/include/model/kv_transaction.h
@@ -231,7 +231,7 @@ public:
      *     This can be done only before the first update is added to the transaction.
      */
     inline void
-    set_wt_metadata(txn_id_t wt_id, write_gen_t wt_base_write_gen, int wt_ckpt_seq_number)
+    set_wt_metadata(txn_id_t wt_id, write_gen_t wt_base_write_gen, uint64_t wt_ckpt_seq_number)
     {
         std::lock_guard lock_guard(_lock);
         if (!_updates.empty())
@@ -265,7 +265,7 @@ public:
      * kv_transaction::wt_ckpt_seq_number --
      *     Get the WiredTiger checkpoint's sequence number, if available.
      */
-    inline int
+    inline uint64_t
     wt_ckpt_seq_number() const
     {
         return _wt_ckpt_seq_number;
@@ -299,7 +299,7 @@ private:
     /* Transaction information for updates imported from WiredTiger's debug log. */
     txn_id_t _wt_id;
     write_gen_t _wt_base_write_gen;
-    int _wt_ckpt_seq_number;
+    uint64_t _wt_ckpt_seq_number;
 };
 
 /*

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -100,9 +100,10 @@ public:
      * kv_transaction_snapshot_wt::kv_transaction_snapshot_wt --
      *     Create a new instance of the snapshot.
      */
-    inline kv_transaction_snapshot_wt(write_gen_t write_gen, txn_id_t snapshot_min,
+    inline kv_transaction_snapshot_wt(int seq_number, write_gen_t write_gen, txn_id_t snapshot_min,
       txn_id_t snapshot_max, const std::vector<uint64_t> &snapshots)
-        : _min_id(snapshot_min), _max_id(snapshot_max), _write_gen(write_gen)
+        : _seq_number(seq_number), _min_id(snapshot_min), _max_id(snapshot_max),
+          _write_gen(write_gen)
     {
         std::copy(
           snapshots.begin(), snapshots.end(), std::inserter(_include_ids, _include_ids.begin()));
@@ -115,6 +116,7 @@ public:
     virtual bool contains(const kv_update &update) const noexcept override;
 
 private:
+    int _seq_number;
     txn_id_t _min_id, _max_id;
     write_gen_t _write_gen;
 

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -100,8 +100,8 @@ public:
      * kv_transaction_snapshot_wt::kv_transaction_snapshot_wt --
      *     Create a new instance of the snapshot.
      */
-    inline kv_transaction_snapshot_wt(int seq_number, write_gen_t write_gen, txn_id_t snapshot_min,
-      txn_id_t snapshot_max, const std::vector<uint64_t> &snapshots)
+    inline kv_transaction_snapshot_wt(uint64_t seq_number, write_gen_t write_gen,
+      txn_id_t snapshot_min, txn_id_t snapshot_max, const std::vector<uint64_t> &snapshots)
         : _seq_number(seq_number), _min_id(snapshot_min), _max_id(snapshot_max),
           _write_gen(write_gen)
     {
@@ -116,7 +116,7 @@ public:
     virtual bool contains(const kv_update &update) const noexcept override;
 
 private:
-    int _seq_number;
+    uint64_t _seq_number;
     txn_id_t _min_id, _max_id;
     write_gen_t _write_gen;
 

--- a/test/model/src/include/model/kv_update.h
+++ b/test/model/src/include/model/kv_update.h
@@ -338,7 +338,7 @@ public:
      */
     inline void
     set_wt_transaction_metadata(
-      txn_id_t wt_txn_id, write_gen_t wt_base_write_gen, int wt_ckpt_seq_number)
+      txn_id_t wt_txn_id, write_gen_t wt_base_write_gen, uint64_t wt_ckpt_seq_number)
     {
         _wt_txn_id = wt_txn_id;
         _wt_base_write_gen = wt_base_write_gen;
@@ -369,7 +369,7 @@ public:
      * kv_update::wt_ckpt_seq_number --
      *     Get the checkpoint's sequence number, if available.
      */
-    inline int
+    inline uint64_t
     wt_ckpt_seq_number() const
     {
         return _wt_ckpt_seq_number;
@@ -393,7 +393,7 @@ private:
     /* Transaction information for updates imported from WiredTiger's debug log. */
     txn_id_t _wt_txn_id;
     write_gen_t _wt_base_write_gen;
-    int _wt_ckpt_seq_number;
+    uint64_t _wt_ckpt_seq_number;
 };
 
 } /* namespace model */

--- a/test/model/src/include/model/kv_update.h
+++ b/test/model/src/include/model/kv_update.h
@@ -125,7 +125,8 @@ public:
      */
     inline kv_update(const data_value &value, timestamp_t timestamp) noexcept
         : _value(value), _commit_timestamp(timestamp), _durable_timestamp(timestamp),
-          _txn_id(k_txn_none), _wt_txn_id(k_txn_none), _wt_base_write_gen(k_write_gen_none)
+          _txn_id(k_txn_none), _wt_txn_id(k_txn_none), _wt_base_write_gen(k_write_gen_none),
+          _wt_ckpt_seq_number(0)
     {
     }
 
@@ -137,7 +138,7 @@ public:
         : _value(value), _commit_timestamp(txn ? txn->commit_timestamp() : k_timestamp_none),
           _durable_timestamp(txn ? txn->durable_timestamp() : k_timestamp_none), _txn(txn),
           _txn_id(txn ? txn->id() : k_txn_none), _wt_txn_id(k_txn_none),
-          _wt_base_write_gen(k_write_gen_none)
+          _wt_base_write_gen(k_write_gen_none), _wt_ckpt_seq_number(0)
     {
     }
 
@@ -336,10 +337,12 @@ public:
      *     metadata.
      */
     inline void
-    set_wt_transaction_metadata(txn_id_t wt_txn_id, write_gen_t wt_base_write_gen)
+    set_wt_transaction_metadata(
+      txn_id_t wt_txn_id, write_gen_t wt_base_write_gen, int wt_ckpt_seq_number)
     {
         _wt_txn_id = wt_txn_id;
         _wt_base_write_gen = wt_base_write_gen;
+        _wt_ckpt_seq_number = wt_ckpt_seq_number;
     }
 
     /*
@@ -362,6 +365,16 @@ public:
         return _wt_base_write_gen;
     }
 
+    /*
+     * kv_update::wt_ckpt_seq_number --
+     *     Get the checkpoint's sequence number, if available.
+     */
+    inline int
+    wt_ckpt_seq_number() const
+    {
+        return _wt_ckpt_seq_number;
+    }
+
 private:
     timestamp_t _commit_timestamp;
     timestamp_t _durable_timestamp;
@@ -380,6 +393,7 @@ private:
     /* Transaction information for updates imported from WiredTiger's debug log. */
     txn_id_t _wt_txn_id;
     write_gen_t _wt_base_write_gen;
+    int _wt_ckpt_seq_number;
 };
 
 } /* namespace model */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -229,6 +229,17 @@ public:
     }
 
     /*
+     * config_map::get_bool --
+     *     Get the corresponding bool value. Throw an exception on error.
+     */
+    inline uint64_t
+    get_bool(const char *key) const
+    {
+        std::string v = std::get<std::string>(_map.find(key)->second);
+        return v == "true" || v == "1";
+    }
+
+    /*
      * config_map::get_uint64 --
      *     Get the corresponding integer value. Throw an exception on error.
      */

--- a/test/model/test/model_checkpoint/main.cpp
+++ b/test/model/test/model_checkpoint/main.cpp
@@ -102,7 +102,7 @@ test_checkpoint(void)
     testutil_check(table->insert(txn1, key2, value2));
     txn1->commit(20);
 
-    /* Create a named and an unnamed checkpoint. */
+    /* Create a named checkpoint. */
     model::kv_checkpoint_ptr ckpt1 = database.create_checkpoint("ckpt1");
 
     /* Set the stable timestamp and create an unnamed checkpoint. */
@@ -519,7 +519,7 @@ test_checkpoint_logged(void)
     testutil_check(table->insert(txn1, key2, value2));
     txn1->commit(20);
 
-    /* Create a named and an unnamed checkpoint. */
+    /* Create a named checkpoint. */
     model::kv_checkpoint_ptr ckpt1 = database.create_checkpoint("ckpt1");
 
     /* Set the stable timestamp and create an unnamed checkpoint. */

--- a/test/model/test/model_checkpoint/main.cpp
+++ b/test/model/test/model_checkpoint/main.cpp
@@ -67,6 +67,20 @@ static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
     "log=(enabled,file_max=10M,remove=false),session_max=100," \
     "statistics=(all),statistics_log=(wait=1,json,on_close)"
 
+/* Keys. */
+const model::data_value key1("Key 1");
+const model::data_value key2("Key 2");
+const model::data_value key3("Key 3");
+const model::data_value key4("Key 4");
+const model::data_value key5("Key 5");
+
+/* Values. */
+const model::data_value value1("Value 1");
+const model::data_value value2("Value 2");
+const model::data_value value3("Value 3");
+const model::data_value value4("Value 4");
+const model::data_value value5("Value 5");
+
 /*
  * test_checkpoint --
  *     The basic test of the checkpoint model.
@@ -76,20 +90,6 @@ test_checkpoint(void)
 {
     model::kv_database database;
     model::kv_table_ptr table = database.create_table("table");
-
-    /* Keys. */
-    const model::data_value key1("Key 1");
-    const model::data_value key2("Key 2");
-    const model::data_value key3("Key 3");
-    const model::data_value key4("Key 4");
-    const model::data_value key5("Key 5");
-
-    /* Values. */
-    const model::data_value value1("Value 1");
-    const model::data_value value2("Value 2");
-    const model::data_value value3("Value 3");
-    const model::data_value value4("Value 4");
-    const model::data_value value5("Value 5");
 
     /* Transactions. */
     model::kv_transaction_ptr txn1, txn2;
@@ -200,20 +200,6 @@ test_checkpoint_wt(void)
 {
     model::kv_database database;
     model::kv_table_ptr table = database.create_table("table");
-
-    /* Keys. */
-    const model::data_value key1("Key 1");
-    const model::data_value key2("Key 2");
-    const model::data_value key3("Key 3");
-    const model::data_value key4("Key 4");
-    const model::data_value key5("Key 5");
-
-    /* Values. */
-    const model::data_value value1("Value 1");
-    const model::data_value value2("Value 2");
-    const model::data_value value3("Value 3");
-    const model::data_value value4("Value 4");
-    const model::data_value value5("Value 5");
 
     /* Transactions. */
     model::kv_transaction_ptr txn1, txn2;
@@ -375,19 +361,6 @@ test_checkpoint_restart_wt(void)
     model::kv_database database;
     model::kv_table_ptr table = database.create_table("table");
 
-    /* Keys. */
-    const model::data_value key1("Key 1");
-    const model::data_value key2("Key 2");
-    const model::data_value key3("Key 3");
-    const model::data_value key4("Key 4");
-
-    /* Values. */
-    const model::data_value value1("Value 1");
-    const model::data_value value2("Value 2");
-    const model::data_value value3("Value 3");
-    const model::data_value value4("Value 4");
-    const model::data_value value5("Value 5");
-
     /* Create the test's home directory and database. */
     WT_CONNECTION *conn;
     WT_SESSION *session, *session2;
@@ -523,6 +496,205 @@ test_checkpoint_restart_wt(void)
 }
 
 /*
+ * test_checkpoint_logged --
+ *     The basic test of the checkpoint model with logged tables.
+ */
+static void
+test_checkpoint_logged(void)
+{
+    model::kv_database database;
+
+    model::kv_table_config table_config;
+    table_config.log_enabled = true;
+    model::kv_table_ptr table = database.create_table("table", table_config);
+
+    /* Transactions. */
+    model::kv_transaction_ptr txn1, txn2;
+
+    /* Add some data. */
+    txn1 = database.begin_transaction();
+    testutil_check(table->insert(txn1, key1, value1));
+    txn1->commit(10);
+    txn1 = database.begin_transaction();
+    testutil_check(table->insert(txn1, key2, value2));
+    txn1->commit(20);
+
+    /* Create a named and an unnamed checkpoint. */
+    model::kv_checkpoint_ptr ckpt1 = database.create_checkpoint("ckpt1");
+
+    /* Set the stable timestamp and create an unnamed checkpoint. */
+    database.set_stable_timestamp(15);
+    model::kv_checkpoint_ptr ckpt = database.create_checkpoint();
+
+    /* Add more data. */
+    txn1 = database.begin_transaction();
+    testutil_check(table->insert(txn1, key3, value3));
+    txn1->commit(30);
+
+    /* Verify that we have the data that we expect. */
+    testutil_assert(table->get(ckpt1, key1) == value1);
+    testutil_assert(table->get(ckpt1, key2) == value2); /* The stable timestamp is not yet set. */
+    testutil_assert(table->get(ckpt1, key3) == model::NONE);
+    testutil_assert(table->get(ckpt, key1) == value1);
+    testutil_assert(table->get(ckpt, key2) == value2); /* The stable timestamp is ignored. */
+    testutil_assert(table->get(ckpt, key3) == model::NONE);
+
+    /* Verify that we have the data that we expect - with read timestamps. */
+    testutil_assert(table->get(ckpt1, key1, 15) == value1);
+    testutil_assert(table->get(ckpt1, key2, 15) == value2);
+    testutil_assert(table->get(ckpt1, key3, 15) == model::NONE);
+
+    /* Add two more keys; check that only that the latest committed data are included. */
+    txn1 = database.begin_transaction();
+    txn2 = database.begin_transaction();
+    testutil_check(table->insert(txn1, key4, value3));
+    testutil_check(table->insert(txn1, key4, value4));
+    testutil_check(table->insert(txn2, key5, value5));
+    txn1->commit(40);
+    database.set_stable_timestamp(40);
+    model::kv_checkpoint_ptr ckpt2 = database.create_checkpoint("ckpt2");
+    testutil_assert(table->get(ckpt2, key3) == value3);
+    testutil_assert(table->get(ckpt2, key4) == value4);
+    testutil_assert(table->get(ckpt2, key5) == model::NONE);
+    txn2->commit(50);
+
+    /* Check contains_any. */
+    testutil_assert(!table->contains_any(ckpt2, key4, value1));
+    testutil_assert(!table->contains_any(ckpt2, key4, value2));
+    testutil_assert(table->contains_any(ckpt2, key4, value3));
+    testutil_assert(table->contains_any(ckpt2, key4, value4));
+    testutil_assert(!table->contains_any(ckpt2, key5, value5));
+}
+
+/*
+ * test_checkpoint_logged_wt --
+ *     The basic test of the checkpoint model with logged tables, also in WiredTiger.
+ */
+static void
+test_checkpoint_logged_wt(void)
+{
+    model::kv_database database;
+
+    model::kv_table_config table_config;
+    table_config.log_enabled = true;
+    model::kv_table_ptr table = database.create_table("table", table_config);
+
+    /* Transactions. */
+    model::kv_transaction_ptr txn1, txn2;
+
+    /* Create the test's home directory and database. */
+    WT_CONNECTION *conn;
+    WT_SESSION *session;
+    WT_SESSION *session1;
+    WT_SESSION *session2;
+    const char *uri = "table:table";
+
+    std::string test_home = std::string(home) + DIR_DELIM_STR + "logged";
+    testutil_recreate_dir(test_home.c_str());
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session1));
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session2));
+    testutil_check(session->create(session, uri, "key_format=S,value_format=S,log=(enabled=true)"));
+
+    testutil_assert(database.stable_timestamp() == wt_get_stable_timestamp(conn));
+
+    /* Add some data. */
+    wt_model_txn_begin_both(txn1, session1);
+    wt_model_txn_insert_both(table, uri, txn1, session1, key1, value1);
+    wt_model_txn_commit_both(txn1, session1);
+    wt_model_txn_begin_both(txn1, session1);
+    wt_model_txn_insert_both(table, uri, txn1, session1, key2, value2);
+    wt_model_txn_commit_both(txn1, session1);
+
+    /* Create a named checkpoint. */
+    wt_model_ckpt_create_both("ckpt1");
+
+    /* Set the stable timestamp and create an unnamed checkpoint. */
+    wt_model_set_stable_timestamp_both(15);
+    wt_model_ckpt_create_both(nullptr);
+
+    /* Add more data. */
+    wt_model_txn_begin_both(txn1, session1);
+    wt_model_txn_insert_both(table, uri, txn1, session1, key3, value3);
+    wt_model_txn_commit_both(txn1, session1);
+
+    /* Verify that we have the data that we expect. */
+    wt_model_ckpt_assert(table, uri, "ckpt1", key1);
+    wt_model_ckpt_assert(table, uri, "ckpt1", key2);
+    wt_model_ckpt_assert(table, uri, "ckpt1", key3);
+    wt_model_ckpt_assert(table, uri, nullptr, key1);
+    wt_model_ckpt_assert(table, uri, nullptr, key2);
+    wt_model_ckpt_assert(table, uri, nullptr, key3);
+
+    /* Verify that we have the data that we expect - with read timestamps. */
+    wt_model_ckpt_assert(table, uri, "ckpt1", key1, 15);
+    wt_model_ckpt_assert(table, uri, "ckpt1", key2, 15);
+    wt_model_ckpt_assert(table, uri, "ckpt1", key3, 15);
+
+    /* Add two more keys; check that only that the latest committed data are included. */
+    wt_model_txn_begin_both(txn1, session1);
+    wt_model_txn_begin_both(txn2, session2);
+    wt_model_txn_insert_both(table, uri, txn1, session1, key4, value3);
+    wt_model_txn_insert_both(table, uri, txn1, session1, key4, value4);
+    wt_model_txn_insert_both(table, uri, txn2, session2, key5, value5);
+    wt_model_txn_commit_both(txn1, session1);
+    wt_model_set_stable_timestamp_both(40);
+    wt_model_ckpt_create_both("ckpt2");
+    wt_model_ckpt_assert(table, uri, "ckpt2", key3);
+    wt_model_ckpt_assert(table, uri, "ckpt2", key4);
+    wt_model_ckpt_assert(table, uri, "ckpt2", key5);
+    wt_model_txn_commit_both(txn2, session2);
+
+    /* Verify. */
+    testutil_assert(table->verify_noexcept(conn));
+
+    /* Verify checkpoints. */
+    testutil_assert(table->verify_noexcept(conn, database.checkpoint("ckpt1")));
+    testutil_assert(table->verify_noexcept(conn, database.checkpoint("ckpt2")));
+
+    /* Clean up. */
+    testutil_check(session->close(session, nullptr));
+    testutil_check(session1->close(session1, nullptr));
+    testutil_check(session2->close(session2, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+
+    /* Reopen the database. We must do this for debug log printing to work. */
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+
+    /* Verify using the debug log. */
+    model::kv_database db_from_debug_log;
+    model::debug_log_parser::from_debug_log(db_from_debug_log, conn);
+    testutil_assert(db_from_debug_log.table("table")->verify_noexcept(conn));
+
+    /* Print the debug log to JSON. */
+    std::string tmp_json = create_tmp_file(test_home.c_str(), "debug-log-", ".json");
+    wt_print_debug_log(conn, tmp_json.c_str());
+
+    /* Verify using the debug log JSON. */
+    model::kv_database db_from_debug_log_json;
+    model::debug_log_parser::from_json(db_from_debug_log_json, tmp_json.c_str());
+    testutil_assert(db_from_debug_log_json.table("table")->verify_noexcept(conn));
+
+    /* Verify checkpoints. */
+    testutil_assert(db_from_debug_log.table("table")->verify_noexcept(
+      conn, db_from_debug_log.checkpoint("ckpt1")));
+    testutil_assert(db_from_debug_log.table("table")->verify_noexcept(
+      conn, db_from_debug_log.checkpoint("ckpt2")));
+
+    /* Verify checkpoints - using the debug log JSON. */
+    testutil_assert(db_from_debug_log_json.table("table")->verify_noexcept(
+      conn, db_from_debug_log_json.checkpoint("ckpt1")));
+    testutil_assert(db_from_debug_log_json.table("table")->verify_noexcept(
+      conn, db_from_debug_log_json.checkpoint("ckpt2")));
+
+    /* Clean up. */
+    testutil_check(session->close(session, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+}
+
+/*
  * usage --
  *     Print usage help for the program.
  */
@@ -574,6 +746,8 @@ main(int argc, char *argv[])
         test_checkpoint();
         test_checkpoint_wt();
         test_checkpoint_restart_wt();
+        test_checkpoint_logged();
+        test_checkpoint_logged_wt();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;
         ret = EXIT_FAILURE;


### PR DESCRIPTION
I added support for non-timestamped tables (tables that use logging), as this is a prerequisite for being able to integrate the test with timestamp_abort. The fix mostly boils down to:
* Changing timestamps to 0 at the top-level API (i.e., in `kv_table`) for non-timestamped tables. If you find the fix to be too ugly, I can switch it to a somewhat more verbose solution that uses "if" statements instead of inline functions to fix the timestamp—if that's better :)
* Adding checkpoint sequence numbers for imported checkpoints, which is unfortunately necessary consequences of how WiredTiger's checkpoint get their snapshots. (Explained in more detail in one of the comments.)

As usual, feel free to skip or just skim changes to the tests. Thank you!