### PR TITLE
block_off_remove optimize, Adjust deletion order.

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -335,14 +335,6 @@ __block_off_remove(
     WT_SIZE *szp, **sstack[WT_SKIP_MAXDEPTH];
     u_int i;
 
-    /* Find and remove the record from the by-offset skiplist. */
-    __block_off_srch(el->off, off, astack, false);
-    ext = *astack[0];
-    if (ext == NULL || ext->off != off)
-        goto corrupt;
-    for (i = 0; i < ext->depth; ++i)
-        *astack[i] = ext->next[i];
-
     /*
      * Find and remove the record from the size's offset skiplist; if that empties the by-size
      * skiplist entry, remove it as well.
@@ -373,6 +365,14 @@ __block_off_remove(
         WT_ASSERT(session, not_null == false);
     }
 #endif
+
+    /* Find and remove the record from the by-offset skiplist. */
+    __block_off_srch(el->off, off, astack, false);
+    ext = *astack[0];
+    if (ext == NULL || ext->off != off)
+        goto corrupt;
+    for (i = 0; i < ext->depth; ++i)
+        *astack[i] = ext->next[i];
 
     --el->entries;
     el->bytes -= (uint64_t)ext->size;


### PR DESCRIPTION
The purpose is as follows:
1.   keep the order of remove consistent with insert (__ block ext insert)
2.  Priority should be given to deleting the size skiplist, which will be faster in the corrupt scene.