### PR TITLE
WT-12073 Disable timestamp_abort and backup until fix is complete

### DIFF
--- a/test/csuite/timestamp_abort/smoke.sh
+++ b/test/csuite/timestamp_abort/smoke.sh
@@ -27,12 +27,14 @@ fi
 $TEST_WRAPPER $test_bin $default_test_args
 $TEST_WRAPPER $test_bin $default_test_args -c
 #$TEST_WRAPPER $test_bin $default_test_args -L
-$TEST_WRAPPER $test_bin $default_test_args -B -I 3
+# FIXME-WT-11669
+# $TEST_WRAPPER $test_bin $default_test_args -B -I 3
 $TEST_WRAPPER $test_bin -m $default_test_args
 $TEST_WRAPPER $test_bin -m $default_test_args -c
 #$TEST_WRAPPER $test_bin -m $default_test_args -L
 $TEST_WRAPPER $test_bin -C $default_test_args
 $TEST_WRAPPER $test_bin -C $default_test_args -c
-$TEST_WRAPPER $test_bin -C $default_test_args -B -I 3
+# FIXME-WT-11669
+#$TEST_WRAPPER $test_bin -C $default_test_args -B -I 3
 $TEST_WRAPPER $test_bin -C -m $default_test_args
 $TEST_WRAPPER $test_bin -C -m $default_test_args -c


### PR DESCRIPTION
to unblock CI testing.

