### PR TITLE
WT-12080 Disable pre-fetching for special operations apart from verify

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -244,6 +244,7 @@ conn_stats = [
     BlockCacheStat('block_prefetch_pages_queued', 'pre-fetch pages queued'),
     BlockCacheStat('block_prefetch_pages_read', 'pre-fetch pages read in background'),
     BlockCacheStat('block_prefetch_skipped', 'pre-fetch not triggered by page read'),
+    BlockCacheStat('block_prefetch_skipped_special_handle', 'pre-fetch not triggered due to special btree handle'),
     BlockCacheStat('block_prefetch_pages_fail', 'pre-fetch page not on disk when reading'),
 
     ##########################################

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -379,6 +379,7 @@ struct __wt_connection_stats {
     int64_t block_cache_bypass_chkpt;
     int64_t block_prefetch_disk_one;
     int64_t block_prefetch_skipped;
+    int64_t block_prefetch_skipped_special_handle;
     int64_t block_prefetch_pages_fail;
     int64_t block_prefetch_pages_queued;
     int64_t block_prefetch_pages_read;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5452,1497 +5452,1499 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_BLOCK_PREFETCH_DISK_ONE		1037
 /*! block-cache: pre-fetch not triggered by page read */
 #define	WT_STAT_CONN_BLOCK_PREFETCH_SKIPPED		1038
+/*! block-cache: pre-fetch not triggered due to special btree handle */
+#define	WT_STAT_CONN_BLOCK_PREFETCH_SKIPPED_SPECIAL_HANDLE	1039
 /*! block-cache: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_BLOCK_PREFETCH_PAGES_FAIL		1039
+#define	WT_STAT_CONN_BLOCK_PREFETCH_PAGES_FAIL		1040
 /*! block-cache: pre-fetch pages queued */
-#define	WT_STAT_CONN_BLOCK_PREFETCH_PAGES_QUEUED	1040
+#define	WT_STAT_CONN_BLOCK_PREFETCH_PAGES_QUEUED	1041
 /*! block-cache: pre-fetch pages read in background */
-#define	WT_STAT_CONN_BLOCK_PREFETCH_PAGES_READ		1041
+#define	WT_STAT_CONN_BLOCK_PREFETCH_PAGES_READ		1042
 /*! block-cache: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_BLOCK_PREFETCH_ATTEMPTS		1042
+#define	WT_STAT_CONN_BLOCK_PREFETCH_ATTEMPTS		1043
 /*! block-cache: removed blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1043
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1044
 /*! block-cache: time sleeping to remove block (usecs) */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1044
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1045
 /*! block-cache: total blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1045
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1046
 /*! block-cache: total blocks inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1046
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1047
 /*! block-cache: total blocks inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1047
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1048
 /*! block-cache: total bytes */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1048
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1049
 /*! block-cache: total bytes inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1049
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1050
 /*! block-cache: total bytes inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1050
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1051
 /*! block-manager: blocks pre-loaded */
-#define	WT_STAT_CONN_BLOCK_PRELOAD			1051
+#define	WT_STAT_CONN_BLOCK_PRELOAD			1052
 /*! block-manager: blocks read */
-#define	WT_STAT_CONN_BLOCK_READ				1052
+#define	WT_STAT_CONN_BLOCK_READ				1053
 /*! block-manager: blocks written */
-#define	WT_STAT_CONN_BLOCK_WRITE			1053
+#define	WT_STAT_CONN_BLOCK_WRITE			1054
 /*! block-manager: bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ			1054
+#define	WT_STAT_CONN_BLOCK_BYTE_READ			1055
 /*! block-manager: bytes read via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1055
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1056
 /*! block-manager: bytes read via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1056
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1057
 /*! block-manager: bytes written */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1057
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1058
 /*! block-manager: bytes written by compaction */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1058
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1059
 /*! block-manager: bytes written for checkpoint */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1059
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1060
 /*! block-manager: bytes written via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1060
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1061
 /*! block-manager: bytes written via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1061
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1062
 /*! block-manager: mapped blocks read */
-#define	WT_STAT_CONN_BLOCK_MAP_READ			1062
+#define	WT_STAT_CONN_BLOCK_MAP_READ			1063
 /*! block-manager: mapped bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1063
+#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1064
 /*!
  * block-manager: number of times the file was remapped because it
  * changed size via fallocate or truncate
  */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1064
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1065
 /*! block-manager: number of times the region was remapped via write */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1065
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1066
 /*! cache: application threads page read from disk to cache count */
-#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1066
+#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1067
 /*! cache: application threads page read from disk to cache time (usecs) */
-#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1067
+#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1068
 /*! cache: application threads page write from cache to disk count */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1068
+#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1069
 /*! cache: application threads page write from cache to disk time (usecs) */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1069
+#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1070
 /*! cache: bytes allocated for updates */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1070
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1071
 /*! cache: bytes belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1071
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1072
 /*! cache: bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS			1072
+#define	WT_STAT_CONN_CACHE_BYTES_HS			1073
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1073
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1074
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1074
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1075
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1075
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1076
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1076
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1077
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1077
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1078
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1078
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1079
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1079
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1080
 /*! cache: eviction calls to get a page */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1080
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1081
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1081
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1082
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1082
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1083
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1083
+#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1084
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1084
+#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1085
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1085
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1086
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1086
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1087
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1087
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1088
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1088
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1089
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1089
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1090
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1090
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1091
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1091
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1092
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1092
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1093
 /*! cache: eviction server evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1093
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICTING	1094
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1094
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1095
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1095
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1096
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1096
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1097
 /*! cache: eviction state */
-#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1097
+#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1098
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1098
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1099
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1099
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1100
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1100
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1101
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1101
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1102
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1103
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1104
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1104
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1105
 /*! cache: eviction walk target strategy both clean and dirty pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1105
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1106
 /*! cache: eviction walk target strategy only clean pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1106
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1107
 /*! cache: eviction walk target strategy only dirty pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1107
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1108
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1108
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1109
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1109
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1110
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1110
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1111
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1111
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1112
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1112
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1113
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1113
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1114
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1114
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1115
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1115
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1116
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1116
+#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1117
 /*! cache: eviction worker thread created */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1117
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1118
 /*! cache: eviction worker thread evicting pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1118
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICTING	1119
 /*! cache: eviction worker thread removed */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1119
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1120
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1120
+#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1121
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1121
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1122
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1122
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1123
 /*! cache: force re-tuning of eviction workers once in a while */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1123
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1124
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1124
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1125
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1126
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1126
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1127
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1127
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1128
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1128
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1129
 /*! cache: forced eviction - pages evicted that were clean time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1129
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1130
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1130
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1131
 /*! cache: forced eviction - pages evicted that were dirty time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1131
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1132
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1132
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1133
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1133
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1134
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1134
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1135
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1135
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1136
 /*! cache: forced eviction - pages selected unable to be evicted time */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1136
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1137
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1137
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1138
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1138
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1139
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1139
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1140
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1140
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1141
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1141
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1142
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1142
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1143
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1143
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1144
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1144
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1145
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1145
+#define	WT_STAT_CONN_CACHE_HS_READ			1146
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1146
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1147
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1147
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1148
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1148
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1149
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1149
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1150
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1150
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1151
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1151
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1152
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1152
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1153
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1153
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1154
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1154
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1155
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1155
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1156
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1156
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1157
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1157
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1158
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1158
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1159
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1159
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1160
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1160
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1161
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1161
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1162
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1162
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1163
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1163
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1164
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1164
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1165
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1165
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1166
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1166
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1167
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1167
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1168
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1168
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1169
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1169
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1170
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1170
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1171
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1171
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1172
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1172
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1173
 /*! cache: modified pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1173
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY		1174
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1174
+#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1175
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1175
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1176
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1176
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1177
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1177
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1178
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1178
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1179
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1179
+#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1180
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1180
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1181
 /*! cache: pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP			1181
+#define	WT_STAT_CONN_CACHE_EVICTION_APP			1182
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1182
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1183
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1183
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1184
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1184
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1185
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1185
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1186
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1186
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1187
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1187
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1188
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1188
+#define	WT_STAT_CONN_CACHE_READ				1189
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1189
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1190
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1190
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1191
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1191
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1192
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1192
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1193
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1193
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1194
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1194
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1195
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1195
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1196
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1196
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1197
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1197
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1198
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1198
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1199
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1199
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1200
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1200
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1201
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1201
+#define	WT_STAT_CONN_CACHE_WRITE			1202
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1202
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1203
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1203
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1204
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1204
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1205
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1205
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1206
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1206
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1207
 /*! cache: skip dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1207
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1208
 /*!
  * cache: skip pages that are written with transactions greater than the
  * last running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1208
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1209
 /*!
  * cache: skip pages that previously failed eviction and likely will
  * again
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_RETRY	1209
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_RETRY	1210
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1210
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1211
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1211
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1212
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1212
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1213
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1213
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1214
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1214
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1215
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1215
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1216
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1216
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1217
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1217
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1218
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1218
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1219
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1219
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1220
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1220
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1221
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1221
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1222
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1222
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1223
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1223
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1224
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1224
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1225
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1225
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1226
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1226
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1227
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1227
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1228
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1228
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1229
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1229
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1230
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1230
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1231
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1231
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1232
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1232
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1233
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1233
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1234
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1234
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1235
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1235
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1236
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1236
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1237
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1237
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1238
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1238
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1239
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1239
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1240
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1240
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1241
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION_APPLY	1241
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION_APPLY	1242
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION_SKIP	1242
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION_SKIP	1243
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1243
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1244
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1244
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1245
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1245
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1246
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1246
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1247
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1247
+#define	WT_STAT_CONN_CHECKPOINTS_API			1248
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1248
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1249
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1249
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1250
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1250
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1251
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1251
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1252
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1252
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1253
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1253
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1254
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1254
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1255
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1255
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1256
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1256
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1257
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1257
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1258
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1258
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1259
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1259
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1260
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1260
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1261
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1261
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1262
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1262
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1263
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1263
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1264
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1264
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1265
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1265
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1266
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1266
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1267
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1267
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1268
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1268
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1269
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1269
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1270
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1270
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1271
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1271
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1272
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1272
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1273
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1273
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1274
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1274
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1275
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1275
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1276
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1276
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1277
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1277
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1278
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1278
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1279
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1279
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1280
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1280
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1281
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1281
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1282
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1282
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1283
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1283
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1284
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1284
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1285
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1285
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1286
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1286
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1287
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1287
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1288
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1288
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1289
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1289
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1290
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1290
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1291
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1291
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1292
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1292
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1293
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1293
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1294
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1294
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1295
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1295
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1296
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1296
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1297
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1297
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1298
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1298
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1299
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1299
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1300
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1300
+#define	WT_STAT_CONN_TIME_TRAVEL			1301
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1301
+#define	WT_STAT_CONN_FILE_OPEN				1302
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1302
+#define	WT_STAT_CONN_BUCKETS_DH				1303
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1303
+#define	WT_STAT_CONN_BUCKETS				1304
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1304
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1305
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1305
+#define	WT_STAT_CONN_MEMORY_FREE			1306
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1306
+#define	WT_STAT_CONN_MEMORY_GROW			1307
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1307
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1308
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1308
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1309
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1309
+#define	WT_STAT_CONN_COND_WAIT				1310
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1310
+#define	WT_STAT_CONN_RWLOCK_READ			1311
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1311
+#define	WT_STAT_CONN_RWLOCK_WRITE			1312
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1312
+#define	WT_STAT_CONN_FSYNC_IO				1313
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1313
+#define	WT_STAT_CONN_READ_IO				1314
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1314
+#define	WT_STAT_CONN_WRITE_IO				1315
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1315
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1316
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1316
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1317
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1317
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1318
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1318
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1319
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1319
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1320
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1320
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1321
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1321
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1322
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1322
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1323
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1323
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1324
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1324
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1325
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1325
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1326
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1326
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1327
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1327
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1328
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1328
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1329
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1329
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1330
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1330
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1331
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1331
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1332
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1332
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1333
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1333
+#define	WT_STAT_CONN_CURSOR_CACHE			1334
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1334
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1335
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1335
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1336
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1336
+#define	WT_STAT_CONN_CURSOR_CREATE			1337
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1337
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1338
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1338
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1339
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1339
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1340
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1340
+#define	WT_STAT_CONN_CURSOR_INSERT			1341
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1341
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1342
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1342
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1343
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1343
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1344
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1344
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1345
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1345
+#define	WT_STAT_CONN_CURSOR_MODIFY			1346
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1346
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1347
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1347
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1348
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1348
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1349
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1349
+#define	WT_STAT_CONN_CURSOR_NEXT			1350
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1350
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1351
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1351
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1352
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1352
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1353
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1353
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1354
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1354
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1355
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1355
+#define	WT_STAT_CONN_CURSOR_RESTART			1356
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1356
+#define	WT_STAT_CONN_CURSOR_PREV			1357
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1357
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1358
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1358
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1359
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1359
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1360
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1360
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1361
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1361
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1362
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1362
+#define	WT_STAT_CONN_CURSOR_REMOVE			1363
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1363
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1364
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1364
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1365
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1365
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1366
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1366
+#define	WT_STAT_CONN_CURSOR_RESERVE			1367
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1367
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1368
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1368
+#define	WT_STAT_CONN_CURSOR_RESET			1369
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1369
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1370
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1370
+#define	WT_STAT_CONN_CURSOR_SEARCH			1371
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1371
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1372
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1372
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1373
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1373
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1374
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1374
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1375
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1375
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1376
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1376
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1377
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1377
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1378
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1378
+#define	WT_STAT_CONN_CURSOR_SWEEP			1379
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1379
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1380
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1380
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1381
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1381
+#define	WT_STAT_CONN_CURSOR_UPDATE			1382
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1382
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1383
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1383
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1384
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1384
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1385
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1385
+#define	WT_STAT_CONN_CURSOR_REOPEN			1386
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1386
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1387
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1387
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1388
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1388
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1389
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1389
+#define	WT_STAT_CONN_DH_SWEEP_REF			1390
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1390
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1391
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1391
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1392
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1392
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1393
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1393
+#define	WT_STAT_CONN_DH_SWEEPS				1394
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1394
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1395
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1395
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1396
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1396
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1397
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1397
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1398
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1398
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1399
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1399
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1400
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1400
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1401
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1401
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1402
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1402
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1403
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1403
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1404
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1404
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1405
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1405
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1406
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1406
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1407
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1407
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1408
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1408
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1409
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1409
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1410
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1410
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1411
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1411
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1412
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1412
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1413
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1413
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1414
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1414
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1415
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1415
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1416
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1416
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1417
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1417
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1418
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1418
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1419
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1419
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1420
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1420
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1421
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1421
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1422
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1422
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1423
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1423
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1424
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1424
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1425
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1425
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1426
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1426
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1427
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1427
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1428
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1428
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1429
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1429
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1430
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1430
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1431
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1431
+#define	WT_STAT_CONN_LOG_FLUSH				1432
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1432
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1433
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1433
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1434
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1434
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1435
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1435
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1436
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1436
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1437
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1437
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1438
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1438
+#define	WT_STAT_CONN_LOG_SCANS				1439
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1439
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1440
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1440
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1441
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1441
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1442
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1442
+#define	WT_STAT_CONN_LOG_SYNC				1443
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1443
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1444
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1444
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1445
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1445
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1446
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1446
+#define	WT_STAT_CONN_LOG_WRITES				1447
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1447
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1448
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1448
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1449
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1449
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1450
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1450
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1451
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1451
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1452
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1452
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1453
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1453
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1454
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1454
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1455
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1455
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1456
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1456
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1457
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1457
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1458
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1458
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1459
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1459
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1460
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1460
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1461
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1461
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1462
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1462
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1463
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1463
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1464
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1464
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1465
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1465
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1466
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1466
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1467
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1467
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1468
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1468
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1469
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1469
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1470
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1470
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1471
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1471
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1472
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1472
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1473
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1473
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1474
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1474
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1475
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1475
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1476
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1476
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1477
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1477
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1478
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1478
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1479
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1479
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1480
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1480
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1481
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1481
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1482
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1482
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1483
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1483
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1484
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1484
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1485
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1485
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1486
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1486
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1487
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1487
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1488
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1488
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1489
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1489
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1490
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1490
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1491
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1491
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1492
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1492
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1493
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1493
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1494
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1494
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1495
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1495
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1496
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1496
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1497
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1497
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1498
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1498
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1499
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1499
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1500
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1500
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1501
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1501
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1502
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1502
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1503
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1503
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1504
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1504
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1505
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1505
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1506
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1506
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1507
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1507
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1508
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1508
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1509
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1509
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1510
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1510
+#define	WT_STAT_CONN_REC_PAGES				1511
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1511
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1512
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1512
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1513
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1513
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1514
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1514
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1515
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1515
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1516
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1516
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1517
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1517
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1518
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1518
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1519
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1519
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1520
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1520
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1521
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1521
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1522
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1522
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1523
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1523
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1524
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1524
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1525
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1525
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1526
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1526
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1527
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1527
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1528
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1528
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1529
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1529
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1530
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1530
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1531
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1531
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1532
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1532
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1533
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1533
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1534
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1534
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1535
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1535
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1536
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1536
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1537
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1537
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1538
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1538
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1539
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1539
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1540
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1540
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1541
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1541
+#define	WT_STAT_CONN_FLUSH_TIER				1542
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1542
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1543
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1543
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1544
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1544
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1545
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1545
+#define	WT_STAT_CONN_SESSION_OPEN			1546
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1546
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1547
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1547
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1548
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1548
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1549
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1549
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1550
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1550
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1551
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1551
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1552
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1552
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1553
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1553
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1554
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1554
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1555
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1555
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1556
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1556
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1557
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1557
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1558
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1558
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1559
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1559
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1560
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1560
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1561
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1561
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1562
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1562
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1563
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1563
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1564
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1564
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1565
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1565
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1566
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1566
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1567
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1567
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1568
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1568
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1569
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1569
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1570
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1570
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1571
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1571
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1572
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1572
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1573
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1573
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1574
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1574
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1575
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1575
+#define	WT_STAT_CONN_TIERED_RETENTION			1576
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1576
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1577
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1577
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1578
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1578
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1579
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1579
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1580
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1580
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1581
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1581
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1582
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1582
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1583
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1583
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1584
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1584
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1585
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1585
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1586
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1586
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1587
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1587
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1588
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1588
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1589
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1589
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1590
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1590
+#define	WT_STAT_CONN_PAGE_SLEEP				1591
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1591
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1592
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1592
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1593
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1593
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1594
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1594
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1595
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1595
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1596
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1596
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1597
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1597
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1598
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1598
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1599
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1599
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1600
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1600
+#define	WT_STAT_CONN_TXN_PREPARE			1601
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1601
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1602
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1602
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1603
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1603
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1604
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1604
+#define	WT_STAT_CONN_TXN_QUERY_TS			1605
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1605
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1606
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1606
+#define	WT_STAT_CONN_TXN_RTS				1607
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1607
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1608
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1608
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1609
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1609
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1610
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1610
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1611
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1611
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1612
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1612
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1613
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1613
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1614
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1614
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1615
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1615
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1616
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1616
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1617
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1617
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1618
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1618
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1619
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1619
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1620
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1620
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1621
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1621
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1622
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1622
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1623
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1623
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1624
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1624
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1625
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1625
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1626
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1626
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1627
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1627
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1628
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1628
+#define	WT_STAT_CONN_TXN_SET_TS				1629
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1629
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1630
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1630
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1631
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1631
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1632
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1632
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1633
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1633
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1634
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1634
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1635
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1635
+#define	WT_STAT_CONN_TXN_BEGIN				1636
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1636
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1637
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1637
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1638
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1638
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1639
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1639
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1640
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1640
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1641
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1641
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1642
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1642
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1643
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1643
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1644
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1644
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1645
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1645
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1646
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1646
+#define	WT_STAT_CONN_TXN_COMMIT				1647
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1647
+#define	WT_STAT_CONN_TXN_ROLLBACK			1648
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1648
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1649
 
 /*!
  * @}

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -31,6 +31,13 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
         return (false);
     }
 
+    if (F_ISSET(S2BT(session), WT_BTREE_SPECIAL_FLAGS) &&
+      !F_ISSET(S2BT(session), WT_BTREE_VERIFY)) {
+        WT_STAT_CONN_INCR(session, block_prefetch_skipped_special_handle);
+        WT_STAT_CONN_INCR(session, block_prefetch_skipped);
+        return (false);
+    }
+
     if (session->pf.prefetch_disk_read_count == 1)
         WT_STAT_CONN_INCR(session, block_prefetch_disk_one);
 

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1320,6 +1320,7 @@ static const char *const __stats_connection_desc[] = {
   "block-cache: number of put bypasses on checkpoint I/O",
   "block-cache: pre-fetch not triggered after single disk read",
   "block-cache: pre-fetch not triggered by page read",
+  "block-cache: pre-fetch not triggered due to special btree handle",
   "block-cache: pre-fetch page not on disk when reading",
   "block-cache: pre-fetch pages queued",
   "block-cache: pre-fetch pages read in background",
@@ -2036,6 +2037,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->block_cache_bypass_chkpt = 0;
     stats->block_prefetch_disk_one = 0;
     stats->block_prefetch_skipped = 0;
+    stats->block_prefetch_skipped_special_handle = 0;
     stats->block_prefetch_pages_fail = 0;
     stats->block_prefetch_pages_queued = 0;
     stats->block_prefetch_pages_read = 0;
@@ -2703,6 +2705,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->block_cache_bypass_chkpt += WT_STAT_READ(from, block_cache_bypass_chkpt);
     to->block_prefetch_disk_one += WT_STAT_READ(from, block_prefetch_disk_one);
     to->block_prefetch_skipped += WT_STAT_READ(from, block_prefetch_skipped);
+    to->block_prefetch_skipped_special_handle +=
+      WT_STAT_READ(from, block_prefetch_skipped_special_handle);
     to->block_prefetch_pages_fail += WT_STAT_READ(from, block_prefetch_pages_fail);
     to->block_prefetch_pages_queued += WT_STAT_READ(from, block_prefetch_pages_queued);
     to->block_prefetch_pages_read += WT_STAT_READ(from, block_prefetch_pages_read);


### PR DESCRIPTION
I believe we decided to disable pre-fetching for special operations as it was not expected to work for things like salvage, but would there be any other special operations (apart from verify) which should be using prefetching when possible?