### PR TITLE
WT-11957 Remove prepare state check from assertion

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2357,8 +2357,6 @@ static inline int __wt_txn_idle_cache_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_txn_modify(WT_SESSION_IMPL *session, WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static inline int __wt_txn_modify_block(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
-  WT_UPDATE *upd, wt_timestamp_t *prev_tsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline int __wt_txn_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_UPDATE *upd, wt_timestamp_t *prev_tsp, u_int modify_type)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1539,11 +1539,11 @@ __wt_txn_search_check(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_txn_modify_block --
+ * __txn_modify_block --
  *     Check if the current transaction can modify an item.
  */
 static inline int
-__wt_txn_modify_block(
+__txn_modify_block(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd, wt_timestamp_t *prev_tsp)
 {
     WT_DECL_ITEM(buf);
@@ -1664,7 +1664,7 @@ __wt_txn_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE 
      * operating on the metadata table.
      */
     if (txn->isolation == WT_ISO_SNAPSHOT && !WT_IS_METADATA(cbt->dhandle))
-        WT_RET(__wt_txn_modify_block(session, cbt, upd, prev_tsp));
+        WT_RET(__txn_modify_block(session, cbt, upd, prev_tsp));
 
     /*
      * Prepending a tombstone to another tombstone indicates remove of a non-existent key and that

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1631,12 +1631,8 @@ __wt_txn_modify_block(
      */
     if (!rollback && prev_tsp != NULL) {
         if (upd != NULL) {
-            /*
-             * The durable timestamp must be greater than or equal to the commit timestamp unless it
-             * is an in-progress prepared update.
-             */
-            WT_ASSERT(session,
-              upd->durable_ts >= upd->start_ts || upd->prepare_state == WT_PREPARE_INPROGRESS);
+            /* The durable timestamp must be greater than or equal to the commit timestamp. */
+            WT_ASSERT(session, upd->durable_ts >= upd->start_ts);
             *prev_tsp = upd->durable_ts;
         } else if (tw_found)
             *prev_tsp = WT_TIME_WINDOW_HAS_STOP(&tw) ? tw.durable_stop_ts : tw.durable_start_ts;


### PR DESCRIPTION
Originally when this assert was created the prepare state check made sense but a few changes over the year have made it redundant.

I noticed while reviewing the code that this function is exported and accessible from anywhere inside WiredTiger when it is only used within the `txn_inline.h` file so I removed the `__wt`.