### PR TITLE
WT-12050 Add long_running label to csuite tests exceeding 20 minutes

### DIFF
--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -28,6 +28,8 @@ define_c_test(
     SOURCES random/main.c
     DIR_NAME random
     DEPENDS "WT_POSIX"
+    # This test takes over 20 minutes under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -261,6 +263,8 @@ define_c_test(
     DIR_NAME wt3338_partial_update
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3338_partial_update>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over an hour under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -357,6 +361,8 @@ define_c_test(
     DIR_NAME wt7989_compact_checkpoint
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt7989_compact_checkpoint>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over 40 minutes under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -382,6 +388,8 @@ define_c_test(
     DIR_NAME wt8659_reconstruct_database_from_logs
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8659_reconstruct_database_from_logs>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over 20 minutes under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -390,6 +398,8 @@ define_c_test(
     DIR_NAME wt8963_insert_stress
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8963_insert_stress>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over an hour under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2221,9 +2221,6 @@ tasks:
               ${python_binary|python3} ../test/suite/run.py -v 4 test_prepare_hs03.py --hook timestamp
             done
 
-  # csuite-long-running-bucket1 and csuite-long-running-bucket2 test tasks each run half of the long-running tests
-  # so that each test task completes within the 5-hour time limit
-
   - name: csuite-long-running
     # Set 5 hours timeout (60 * 60 * 5)
     exec_timeout_secs: 18000
@@ -2232,7 +2229,6 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
-          # Run the first test, and then every second test
           extra_args: -L long_running
 
   # Break out Python unit tests into multiple buckets/tasks.  We have a fixed number of buckets,

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2229,7 +2229,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
-          extra_args: -L long_running
+          extra_args: -L long_running -j ${num_jobs}
 
   # Break out Python unit tests into multiple buckets/tasks.  We have a fixed number of buckets,
   # and we use the -b option of the test/suite/run.py script to split up the tests.


### PR DESCRIPTION
Tag the longer running csuite tests with `long_running` so they'll be excluded from `csuite-tests-pull-request`. This keeps the runtime of `csuite-tests-pull-request` under 20 minutes for fast PR testing turnaround.