### PR TITLE
WT-12048 Update architecture guide timestamp documentation

### DIFF
--- a/src/docs/arch-timestamp.dox
+++ b/src/docs/arch-timestamp.dox
@@ -120,13 +120,13 @@ execution time) replacing the entire prior value sequence once committed.
 predate the non-timestamped write will continue to see the prior
 database state until they commit or get a new snapshot.)
 
-Applications are expected to write the value sequence in order; that
-is, for each key in the database, every write should commit with a
+Applications are required to write the value sequence in order; that
+is, for each key in the database, every write must commit with a
 timestamp later than the latest existing timestamp for that key.
-This is currently not enforced; because MongoDB sometimes issues out
-of order updates, they must for the time being be handled.
-<!-- XXX and it would probably be good to document what the resolution
-rules/semantics are, except I haven't any idea... -->
+By default, WiredTiger will enforce that once timestamps are used for
+a key, they must always be used, and that the timestamps never
+decrease. This may be altered by using the \c write_timestamp_usage
+configuration for WT_SESSION::create.
 
 @section arch-timestamp-representation Representation of timestamps and time windows
 


### PR DESCRIPTION
Here's how it looks rendered:

![Screenshot 2023-12-07 at 2 15 47 pm](https://github.com/wiredtiger/wiredtiger/assets/1955860/7797b3e6-9224-4deb-b8ba-dd4f55519172)
