### PR TITLE
WT-12094 Fix debug log parsing of checkpoints in the model

### DIFF
--- a/test/model/src/core/kv_transaction.cpp
+++ b/test/model/src/core/kv_transaction.cpp
@@ -45,7 +45,7 @@ kv_transaction::add_update(
 {
     std::lock_guard lock_guard(_lock);
 
-    update->set_wt_transaction_metadata(_wt_id, _wt_base_write_gen, _wt_ckpt_seq_number);
+    update->set_wt_transaction_metadata(_wt_id, _wt_base_write_gen);
 
     std::shared_ptr<kv_transaction_update> txn_update =
       std::make_shared<kv_transaction_update>(table.name(), key, update);

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -366,14 +366,13 @@ debug_log_parser::metadata_checkpoint_apply(
         else
             snapshot_ids = std::make_shared<std::vector<uint64_t>>();
         snapshot = std::make_shared<kv_transaction_snapshot_wt>(
-          _ckpt_count, write_gen, snapshot_min, snapshot_max, *snapshot_ids);
+          write_gen, snapshot_min, snapshot_max, *snapshot_ids);
     } else
         snapshot = std::make_shared<kv_transaction_snapshot_wt>(
-          _ckpt_count, write_gen, k_txn_max, k_txn_max, std::vector<uint64_t>());
+          write_gen, k_txn_max, k_txn_max, std::vector<uint64_t>());
 
     /* Create the checkpoint. */
     _database.create_checkpoint(name.c_str(), snapshot, stable_timestamp);
-    _ckpt_count++;
 }
 
 /*
@@ -471,7 +470,7 @@ debug_log_parser::begin_transaction(const debug_log_parser::commit_header &op)
         throw model_exception("The base write generation is not set");
 
     kv_transaction_ptr txn = _database.begin_transaction();
-    txn->set_wt_metadata(op.txnid, _base_write_gen, _ckpt_count);
+    txn->set_wt_metadata(op.txnid, _base_write_gen);
     return txn;
 }
 

--- a/test/model/src/include/model/driver/debug_log_parser.h
+++ b/test/model/src/include/model/driver/debug_log_parser.h
@@ -109,7 +109,7 @@ public:
      *     lifetime of this parser object.
      */
     inline debug_log_parser(kv_database &database)
-        : _database(database), _base_write_gen(k_write_gen_first), _ckpt_count(0)
+        : _database(database), _base_write_gen(k_write_gen_first)
     {
     }
 
@@ -197,9 +197,6 @@ private:
 
     /* The current base write generation. */
     write_gen_t _base_write_gen;
-
-    /* The number of checkpoints so far. */
-    uint64_t _ckpt_count;
 
     /* Place for accumulating checkpoint metadata: TXN ID -> checkpoint name -> config map. */
     std::unordered_map<txn_id_t, std::unordered_map<std::string, std::shared_ptr<config_map>>>

--- a/test/model/src/include/model/kv_transaction.h
+++ b/test/model/src/include/model/kv_transaction.h
@@ -82,7 +82,7 @@ public:
           _durable_timestamp(k_timestamp_none), _prepare_timestamp(k_timestamp_none),
           _failed(false), _read_timestamp(read_timestamp), _snapshot(snapshot),
           _state(kv_transaction_state::in_progress), _wt_id(k_txn_none),
-          _wt_base_write_gen(k_write_gen_none), _wt_ckpt_seq_number(0)
+          _wt_base_write_gen(k_write_gen_none)
     {
         if (!snapshot)
             throw model_exception("The snapshot is NULL.");
@@ -231,14 +231,13 @@ public:
      *     This can be done only before the first update is added to the transaction.
      */
     inline void
-    set_wt_metadata(txn_id_t wt_id, write_gen_t wt_base_write_gen, uint64_t wt_ckpt_seq_number)
+    set_wt_metadata(txn_id_t wt_id, write_gen_t wt_base_write_gen)
     {
         std::lock_guard lock_guard(_lock);
         if (!_updates.empty())
             throw model_exception("There are already updates in the transaction");
         _wt_id = wt_id;
         _wt_base_write_gen = wt_base_write_gen;
-        _wt_ckpt_seq_number = wt_ckpt_seq_number;
     }
 
     /*
@@ -259,16 +258,6 @@ public:
     wt_base_write_gen() const
     {
         return _wt_base_write_gen;
-    }
-
-    /*
-     * kv_transaction::wt_ckpt_seq_number --
-     *     Get the WiredTiger checkpoint's sequence number, if available.
-     */
-    inline uint64_t
-    wt_ckpt_seq_number() const
-    {
-        return _wt_ckpt_seq_number;
     }
 
 protected:
@@ -299,7 +288,6 @@ private:
     /* Transaction information for updates imported from WiredTiger's debug log. */
     txn_id_t _wt_id;
     write_gen_t _wt_base_write_gen;
-    uint64_t _wt_ckpt_seq_number;
 };
 
 /*

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -100,13 +100,12 @@ public:
      * kv_transaction_snapshot_wt::kv_transaction_snapshot_wt --
      *     Create a new instance of the snapshot.
      */
-    inline kv_transaction_snapshot_wt(uint64_t seq_number, write_gen_t write_gen,
-      txn_id_t snapshot_min, txn_id_t snapshot_max, const std::vector<uint64_t> &snapshots)
-        : _seq_number(seq_number), _min_id(snapshot_min), _max_id(snapshot_max),
-          _write_gen(write_gen)
+    inline kv_transaction_snapshot_wt(write_gen_t write_gen, txn_id_t snapshot_min,
+      txn_id_t snapshot_max, const std::vector<uint64_t> &snapshots)
+        : _min_id(snapshot_min), _max_id(snapshot_max), _write_gen(write_gen)
     {
         std::copy(
-          snapshots.begin(), snapshots.end(), std::inserter(_include_ids, _include_ids.begin()));
+          snapshots.begin(), snapshots.end(), std::inserter(_exclude_ids, _exclude_ids.begin()));
     }
 
     /*
@@ -116,11 +115,10 @@ public:
     virtual bool contains(const kv_update &update) const noexcept override;
 
 private:
-    uint64_t _seq_number;
     txn_id_t _min_id, _max_id;
     write_gen_t _write_gen;
 
-    std::unordered_set<txn_id_t> _include_ids;
+    std::unordered_set<txn_id_t> _exclude_ids;
 };
 
 /*

--- a/test/model/src/include/model/kv_update.h
+++ b/test/model/src/include/model/kv_update.h
@@ -125,8 +125,7 @@ public:
      */
     inline kv_update(const data_value &value, timestamp_t timestamp) noexcept
         : _value(value), _commit_timestamp(timestamp), _durable_timestamp(timestamp),
-          _txn_id(k_txn_none), _wt_txn_id(k_txn_none), _wt_base_write_gen(k_write_gen_none),
-          _wt_ckpt_seq_number(0)
+          _txn_id(k_txn_none), _wt_txn_id(k_txn_none), _wt_base_write_gen(k_write_gen_none)
     {
     }
 
@@ -138,7 +137,7 @@ public:
         : _value(value), _commit_timestamp(txn ? txn->commit_timestamp() : k_timestamp_none),
           _durable_timestamp(txn ? txn->durable_timestamp() : k_timestamp_none), _txn(txn),
           _txn_id(txn ? txn->id() : k_txn_none), _wt_txn_id(k_txn_none),
-          _wt_base_write_gen(k_write_gen_none), _wt_ckpt_seq_number(0)
+          _wt_base_write_gen(k_write_gen_none)
     {
     }
 
@@ -337,12 +336,10 @@ public:
      *     metadata.
      */
     inline void
-    set_wt_transaction_metadata(
-      txn_id_t wt_txn_id, write_gen_t wt_base_write_gen, uint64_t wt_ckpt_seq_number)
+    set_wt_transaction_metadata(txn_id_t wt_txn_id, write_gen_t wt_base_write_gen)
     {
         _wt_txn_id = wt_txn_id;
         _wt_base_write_gen = wt_base_write_gen;
-        _wt_ckpt_seq_number = wt_ckpt_seq_number;
     }
 
     /*
@@ -365,16 +362,6 @@ public:
         return _wt_base_write_gen;
     }
 
-    /*
-     * kv_update::wt_ckpt_seq_number --
-     *     Get the checkpoint's sequence number, if available.
-     */
-    inline uint64_t
-    wt_ckpt_seq_number() const
-    {
-        return _wt_ckpt_seq_number;
-    }
-
 private:
     timestamp_t _commit_timestamp;
     timestamp_t _durable_timestamp;
@@ -393,7 +380,6 @@ private:
     /* Transaction information for updates imported from WiredTiger's debug log. */
     txn_id_t _wt_txn_id;
     write_gen_t _wt_base_write_gen;
-    uint64_t _wt_ckpt_seq_number;
 };
 
 } /* namespace model */


### PR DESCRIPTION
It turns out my understanding of WiredTiger's checkpoints was wrong! This PR fixes it in the model, so that I don't embarrass myself by creating tickets that are not really bugs 😆 

The notion of checkpoint numbers becomes obsolete with this change, so I removed them.