### PR TITLE
WT-12095 Wait for background compaction to process the HS

### DIFF
--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -90,10 +90,14 @@ class test_compact06(wttest.WiredTigerTestCase):
                 self.session.compact(None, f'background=true,{item}'),
                 '/Cannot reconfigure background compaction while it\'s already running/')
 
+        # Wait for background compaction to process the HS.
+        while self.get_bg_compaction_success() == 0:
+            time.sleep(1)
+
         # Disable the background compaction server.
         self.turn_off_bg_compact()
 
-        # The background compaction should have tried to compact the HS.
+        # Background compaction should have tried to compact the HS hence skipped no files.
         assert self.get_bg_compaction_files_skipped() == 0
         assert self.get_bg_compaction_success() == 1
 


### PR DESCRIPTION
The assertions verify background compaction has done some work, make sure it is the case before turning off background compaction. Once background compaction has processed a file, we can proceed with the remaining part of the test.