### PR TITLE
WT-12063 Don't permit on-disk chunk cache combined with a read-only connection

### DIFF
--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -1237,6 +1237,9 @@ __wt_chunkcache_setup(WT_SESSION_IMPL *session, const char *cfg[])
         if (cval.len == 0)
             WT_RET_MSG(session, EINVAL, "chunk cache storage path not provided in the config.");
 
+        if (F_ISSET(S2C(session), WT_CONN_READONLY))
+            WT_RET_MSG(session, EINVAL, "on-disk chunk cache incompatible with read-only connection");
+
         WT_RET(__wt_strndup(session, cval.str, cval.len, &chunkcache->storage_path));
         WT_RET(__wt_open(session, chunkcache->storage_path, WT_FS_OPEN_FILE_TYPE_DATA,
           WT_FS_OPEN_CREATE | WT_FS_OPEN_FORCE_MMAP, &chunkcache->fh));

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -1238,7 +1238,8 @@ __wt_chunkcache_setup(WT_SESSION_IMPL *session, const char *cfg[])
             WT_RET_MSG(session, EINVAL, "chunk cache storage path not provided in the config.");
 
         if (F_ISSET(S2C(session), WT_CONN_READONLY))
-            WT_RET_MSG(session, EINVAL, "on-disk chunk cache incompatible with read-only connection");
+            WT_RET_MSG(
+              session, EINVAL, "on-disk chunk cache incompatible with read-only connection");
 
         WT_RET(__wt_strndup(session, cval.str, cval.len, &chunkcache->storage_path));
         WT_RET(__wt_open(session, chunkcache->storage_path, WT_FS_OPEN_FILE_TYPE_DATA,


### PR DESCRIPTION
This would previously crash with an assertion in the filesystem layer that the read-only flag must be set on a file handle if the connection is read-only. Having a read-only connection with an on-disk chunk cache doesn't make sense (to me), so it now fails like this:

```
[1701986486:771353][1716541:0x7f2ba8cb0000], connection: [WT_VERB_DEFAULT][ERROR]: __wt_chunkcache_setup, 1241: on-disk chunk cache incompatible with read-only connection: Invalid argument
Re-opening the connection failed Error: Invalid argument
```