### PR TITLE
WT-12105 Re-enable csuite-long-running on the MSan variant

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5429,16 +5429,10 @@ buildvariants:
     - name: format-stress-pull-request-test
     - name: make-check-test
       distros: ubuntu2004-large
-      # FIXME-WT-11989 Long running test may timeout with sanitizers.
-    # - name: csuite-long-running-bucket1
-    #   # Some of the long-running tests require a large instance to run successfully.
-    #   distros: ubuntu2004-large
-    #   batchtime: 1440 # once a day
-      # FIXME-WT-11989 Long running test may timeout with sanitizers.
-    # - name: csuite-long-running-bucket2
-    #   # Some of the long-running tests require a large instance to run successfully.
-    #   distros: ubuntu2004-large
-    #   batchtime: 1440 # once a day
+    - name: csuite-long-running
+      # Some of the long-running tests require a large instance to run successfully.
+      distros: ubuntu2004-large
+      batchtime: 1440 # once a day
 
 - name: ubuntu2004-ubsan
   display_name: "! Ubuntu 20.04 UBSAN"


### PR DESCRIPTION
WT-12050 added a `-j num_jobs` argument to `csuite-long-running` which resolves our timeout issues. Now `csuite-long-running` lasts between 3.5 and 4 hours (less than our 5 hour timeout) so we can re-enable the test.