### PR TITLE
WT-12100 Fix csuite-long-running timeout with MSan

### DIFF
--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -28,6 +28,8 @@ define_c_test(
     SOURCES random/main.c
     DIR_NAME random
     DEPENDS "WT_POSIX"
+    # This test takes over 20 minutes under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -146,7 +148,6 @@ define_c_test(
     DIR_NAME wt2403_lsm_workload
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2403_lsm_workload>/WT_HOME>
     DEPENDS "WT_POSIX"
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -162,7 +163,6 @@ define_c_test(
     DIR_NAME wt2323_join_visibility
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2323_join_visibility>/WT_HOME>
     DEPENDS "WT_POSIX"
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -172,7 +172,6 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2535_insert_race/smoke.sh
     ARGUMENTS $<TARGET_FILE:test_wt2535_insert_race>
     DEPENDS "WT_POSIX"
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -211,7 +210,6 @@ define_c_test(
     SOURCES wt2834_join_bloom_fix/main.c
     DIR_NAME wt2834_join_bloom_fix
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2834_join_bloom_fix>/WT_HOME>
-    LABEL "long_running"
 )
 
 define_c_test(
@@ -265,6 +263,8 @@ define_c_test(
     DIR_NAME wt3338_partial_update
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3338_partial_update>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over an hour under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -361,6 +361,8 @@ define_c_test(
     DIR_NAME wt7989_compact_checkpoint
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt7989_compact_checkpoint>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over 40 minutes under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -386,6 +388,8 @@ define_c_test(
     DIR_NAME wt8659_reconstruct_database_from_logs
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8659_reconstruct_database_from_logs>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over 20 minutes under ASan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -394,6 +398,7 @@ define_c_test(
     DIR_NAME wt8963_insert_stress
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8963_insert_stress>/WT_HOME>
     DEPENDS "WT_POSIX"
+    # This test takes over an hour under ASan testing
     LABEL "long_running"
 )
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2417,10 +2417,7 @@ tasks:
               ${python_binary|python3} ../test/suite/run.py -v 4 test_prepare_hs03.py --hook timestamp
             done
 
-  # csuite-long-running-bucket1 and csuite-long-running-bucket2 test tasks each run half of the long-running tests
-  # so that each test task completes within the 5-hour time limit
-
-  - name: csuite-long-running-bucket1
+  - name: csuite-long-running
     # Set 5 hours timeout (60 * 60 * 5)
     exec_timeout_secs: 18000
     commands:
@@ -2428,19 +2425,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
-          # Run the first test, and then every second test
-          extra_args: -L long_running -I 1,,2
-
-  - name: csuite-long-running-bucket2
-    # Set 5 hours timeout (60 * 60 * 5)
-    exec_timeout_secs: 18000
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "make check directory"
-        vars:
-          # Run the second test, and then every second test
-          extra_args: -L long_running -I 2,,2
+          extra_args: -L long_running -j ${num_jobs}
 
   # Break out Python unit tests into multiple buckets/tasks.  We have a fixed number of buckets,
   # and we use the -b option of the test/suite/run.py script to split up the tests.
@@ -5966,11 +5951,7 @@ buildvariants:
     - name: ".workgen-test"
       batchtime: 1440 # 24 hours
     - name: model-test
-    - name: csuite-long-running-bucket1
-      # Some of the long-running tests require a large instance to run successfully.
-      distros: ubuntu2004-large
-      batchtime: 1440 # once a day
-    - name: csuite-long-running-bucket2
+    - name: csuite-long-running
       # Some of the long-running tests require a large instance to run successfully.
       distros: ubuntu2004-large
       batchtime: 1440 # once a day
@@ -6025,7 +6006,7 @@ buildvariants:
       export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libeatmydata.so:$LD_PRELOAD"
     # We don't run C++ memory sanitized testing as it creates false positives. MSAN also causes
     # some csuite tests to take an extended amount of time. These are excluded from the
-    # make-check-test task and are covered by the csuite-long-running-bucket1 & 2 tasks.
+    # make-check-test task and are covered by the csuite-long-running task.
     extra_args: -LE "cppsuite|long_running"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
@@ -6038,16 +6019,10 @@ buildvariants:
     - name: format-stress-pull-request-test
     - name: make-check-test
       distros: ubuntu2004-large
-      # FIXME-WT-11989 Long running test may timeout with sanitizers.
-    # - name: csuite-long-running-bucket1
-    #   # Some of the long-running tests require a large instance to run successfully.
-    #   distros: ubuntu2004-large
-    #   batchtime: 1440 # once a day
-      # FIXME-WT-11989 Long running test may timeout with sanitizers.
-    # - name: csuite-long-running-bucket2
-    #   # Some of the long-running tests require a large instance to run successfully.
-    #   distros: ubuntu2004-large
-    #   batchtime: 1440 # once a day
+    - name: csuite-long-running
+      # Some of the long-running tests require a large instance to run successfully.
+      distros: ubuntu2004-large
+      batchtime: 1440 # once a day
 
 - name: ubuntu2004-ubsan
   display_name: "! Ubuntu 20.04 UBSAN"


### PR DESCRIPTION
Note this PR is being delivered to the 7.2 branch.

We've gone through a fair few changes to this test recently. Rather than backport all of those tickets this PR updates the definition of `csuite-long-running` and use of the `long_running` label to be identical with the head of develop. This will also be backported to 7.1.

Similar to the head of develop `csuite-long-running` takes 3.5 hours to execute and is well within the 5 hour timeout.