### PR TITLE
WT-10707 Check return values in push_pull.c

### DIFF
--- a/bench/tiered/push_pull.c
+++ b/bench/tiered/push_pull.c
@@ -258,7 +258,7 @@ remove_local_cached_files(const char *home)
         highest = WT_MAX(highest, objnum);
     }
 
-    testutil_check(closedir(dir));
+    testutil_assert_errno(closedir(dir));
 
     testutil_snprintf(file_prefix, sizeof(file_prefix), "%s-000", tablename);
     if (highest > 1 && nmatches > 1) {

--- a/bench/tiered/push_pull.c
+++ b/bench/tiered/push_pull.c
@@ -254,7 +254,7 @@ remove_local_cached_files(const char *home)
 
         ++nmatches;
 
-        testutil_check(sscanf(dir_entry->d_name, "%*[^0-9]%d", &objnum));
+        testutil_assert(sscanf(dir_entry->d_name, "%*[^0-9]%d", &objnum) == 1);
         highest = WT_MAX(highest, objnum);
     }
 

--- a/bench/tiered/push_pull.c
+++ b/bench/tiered/push_pull.c
@@ -258,7 +258,7 @@ remove_local_cached_files(const char *home)
         highest = WT_MAX(highest, objnum);
     }
 
-    testutil_assert_errno(closedir(dir));
+    testutil_assert_errno(closedir(dir) == 0);
 
     testutil_snprintf(file_prefix, sizeof(file_prefix), "%s-000", tablename);
     if (highest > 1 && nmatches > 1) {

--- a/bench/tiered/push_pull.c
+++ b/bench/tiered/push_pull.c
@@ -254,11 +254,11 @@ remove_local_cached_files(const char *home)
 
         ++nmatches;
 
-        sscanf(dir_entry->d_name, "%*[^0-9]%d", &objnum);
+        testutil_check(sscanf(dir_entry->d_name, "%*[^0-9]%d", &objnum));
         highest = WT_MAX(highest, objnum);
     }
 
-    closedir(dir);
+    testutil_check(closedir(dir));
 
     testutil_snprintf(file_prefix, sizeof(file_prefix), "%s-000", tablename);
     if (highest > 1 && nmatches > 1) {


### PR DESCRIPTION
Coverity reporting values for unchecked return values.

Add `testutil` checks to return values.