### PR TITLE
WT-12128 Make checksum logging more consistent

### DIFF
--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -354,28 +354,28 @@ __wt_ckpt_verbose(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *tag, co
         WT_ERR(__wt_buf_catfmt(session, tmp, ", root=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", root=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
+          ", root=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%" PRIx32 "]",
           (uintmax_t)ci->root_offset, (uintmax_t)(ci->root_offset + ci->root_size), ci->root_size,
           ci->root_checksum));
     if (ci->alloc.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", alloc=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", alloc=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
+          ", alloc=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%" PRIx32 "]",
           (uintmax_t)ci->alloc.offset, (uintmax_t)(ci->alloc.offset + ci->alloc.size),
           ci->alloc.size, ci->alloc.checksum));
     if (ci->avail.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", avail=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", avail=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
+          ", avail=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%" PRIx32 "]",
           (uintmax_t)ci->avail.offset, (uintmax_t)(ci->avail.offset + ci->avail.size),
           ci->avail.size, ci->avail.checksum));
     if (ci->discard.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", discard=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", discard=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
+          ", discard=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%" PRIx32 "]",
           (uintmax_t)ci->discard.offset, (uintmax_t)(ci->discard.offset + ci->discard.size),
           ci->discard.size, ci->discard.checksum));
     WT_ERR(__wt_buf_catfmt(session, tmp, ", file size=%" PRIuMAX, (uintmax_t)ci->file_size));

--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -354,28 +354,28 @@ __wt_ckpt_verbose(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *tag, co
         WT_ERR(__wt_buf_catfmt(session, tmp, ", root=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", root=[%" PRIuMAX "-%" PRIuMAX ", %" PRIu32 ", %" PRIu32 "]",
+          ", root=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
           (uintmax_t)ci->root_offset, (uintmax_t)(ci->root_offset + ci->root_size), ci->root_size,
           ci->root_checksum));
     if (ci->alloc.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", alloc=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", alloc=[%" PRIuMAX "-%" PRIuMAX ", %" PRIu32 ", %" PRIu32 "]",
+          ", alloc=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
           (uintmax_t)ci->alloc.offset, (uintmax_t)(ci->alloc.offset + ci->alloc.size),
           ci->alloc.size, ci->alloc.checksum));
     if (ci->avail.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", avail=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", avail=[%" PRIuMAX "-%" PRIuMAX ", %" PRIu32 ", %" PRIu32 "]",
+          ", avail=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
           (uintmax_t)ci->avail.offset, (uintmax_t)(ci->avail.offset + ci->avail.size),
           ci->avail.size, ci->avail.checksum));
     if (ci->discard.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", discard=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", discard=[%" PRIuMAX "-%" PRIuMAX ", %" PRIu32 ", %" PRIu32 "]",
+          ", discard=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
           (uintmax_t)ci->discard.offset, (uintmax_t)(ci->discard.offset + ci->discard.size),
           ci->discard.size, ci->discard.checksum));
     WT_ERR(__wt_buf_catfmt(session, tmp, ", file size=%" PRIuMAX, (uintmax_t)ci->file_size));

--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -354,28 +354,28 @@ __wt_ckpt_verbose(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *tag, co
         WT_ERR(__wt_buf_catfmt(session, tmp, ", root=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", root=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
+          ", root=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
           (uintmax_t)ci->root_offset, (uintmax_t)(ci->root_offset + ci->root_size), ci->root_size,
           ci->root_checksum));
     if (ci->alloc.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", alloc=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", alloc=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
+          ", alloc=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
           (uintmax_t)ci->alloc.offset, (uintmax_t)(ci->alloc.offset + ci->alloc.size),
           ci->alloc.size, ci->alloc.checksum));
     if (ci->avail.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", avail=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", avail=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
+          ", avail=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
           (uintmax_t)ci->avail.offset, (uintmax_t)(ci->avail.offset + ci->avail.size),
           ci->avail.size, ci->avail.checksum));
     if (ci->discard.offset == WT_BLOCK_INVALID_OFFSET)
         WT_ERR(__wt_buf_catfmt(session, tmp, ", discard=[Empty]"));
     else
         WT_ERR(__wt_buf_catfmt(session, tmp,
-          ", discard=[off:%" PRIuMAX "-%" PRIuMAX ", size:%" PRIu32 ", checksum:%08x]",
+          ", discard=[off: %" PRIuMAX "-%" PRIuMAX ", size: %" PRIu32 ", checksum: 0x%08x]",
           (uintmax_t)ci->discard.offset, (uintmax_t)(ci->discard.offset + ci->discard.size),
           ci->discard.size, ci->discard.checksum));
     WT_ERR(__wt_buf_catfmt(session, tmp, ", file size=%" PRIuMAX, (uintmax_t)ci->file_size));

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -20,7 +20,8 @@ __wt_block_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t len)
 
     conn = S2C(session);
 
-    __wt_verbose(session, WT_VERB_BLOCK, "truncate file %s to %" PRIuMAX, block->name, (uintmax_t)len);
+    __wt_verbose(
+      session, WT_VERB_BLOCK, "truncate file %s to %" PRIuMAX, block->name, (uintmax_t)len);
 
     /*
      * Truncate requires serialization, we depend on our caller for that.

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -20,7 +20,7 @@ __wt_block_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t len)
 
     conn = S2C(session);
 
-    __wt_verbose(session, WT_VERB_BLOCK, "truncate file to %" PRIuMAX, (uintmax_t)len);
+    __wt_verbose(session, WT_VERB_BLOCK, "truncate file %s to %" PRIuMAX, block->name, (uintmax_t)len);
 
     /*
      * Truncate requires serialization, we depend on our caller for that.

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -20,7 +20,7 @@ __wt_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
     WT_CONNECTION_IMPL *conn;
     uint64_t bucket, hash;
 
-    __wt_verbose(session, WT_VERB_BLKCACHE, "close: %s", block->name);
+    __wt_verbose(session, WT_VERB_BLKCACHE, "block close: %s", block->name);
 
     conn = S2C(session);
     __wt_spin_lock(session, &conn->block_lock);


### PR DESCRIPTION
![image](https://github.com/wiredtiger/wiredtiger/assets/14356223/2c4a9cc1-77e8-4280-8802-271bd85edade)
One output in decimal and one in hexadecimal, keeping the output format consistent and helping us to understand the code.