### PR TITLE
WT-11248 used git ls-files to exclude all files in build directory

### DIFF
--- a/dist/s_python
+++ b/dist/s_python
@@ -8,7 +8,7 @@ cd ..
 
 # Check Python coding standards: check for tab characters.
 # Ignore generated files.
-egrep '	' `find . -name '*.py' -not -path '*.git/*'` |
+egrep '	' `git ls-files -- '*.py'` |
     sed -e 's/:.*//' \
     -e '/swig_wiredtiger.py/d' \
     -e '/\/wiredtiger.py/d' \


### PR DESCRIPTION
git ls-files seems to automatically exclude everything in build directory and also git files. Have not implemented a fallback