### PR TITLE
WT-12135 Don't re-open connections and sessions with pre-fetching enabled after damaging tables

### DIFF
--- a/test/suite/test_salvage01.py
+++ b/test/suite/test_salvage01.py
@@ -317,7 +317,9 @@ class test_salvage01(wttest.WiredTigerTestCase, suite_subprocess):
         self.damage(self.tablename)
 
         # damage() closed the session/connection, reopen them now.
-        self.open_conn()
+        # Disable pre-fetching on the connection and its sessions as it is
+        # not expected to work correctly with damaged contents.
+        self.open_conn(config='prefetch=(available=false,default=false)')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.verify('table:' + self.tablename, None),
             "/read checksum error/")

--- a/test/suite/test_salvage01.py
+++ b/test/suite/test_salvage01.py
@@ -319,6 +319,12 @@ class test_salvage01(wttest.WiredTigerTestCase, suite_subprocess):
         # damage() closed the session/connection, reopen them now.
         # Disable pre-fetching on the connection and its sessions as it is
         # not expected to work correctly with damaged contents.
+        #
+        # FIXME-WT-12143 - It should be the responsibility of the pre-fetching
+        # functionality to stop operating on damaged tables after a restart
+        # rather than relying on the user to explicitly turn prefetching off.
+        # Revert to opening the connection like so once the fix is implemented:
+        # self.open_conn()
         self.open_conn(config='prefetch=(available=false,default=false)')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.verify('table:' + self.tablename, None),


### PR DESCRIPTION
We need to explicitly disable pre-fetching when re-opening the connection because our current logic that skips pre-fetching corrupted contents relies on the `WT_CONN_DATA_CORRUPTION` flag which won't be set anymore because the connection was closed.