### PR TITLE
WT-10754 replacing certain system() calls with testutil_system() 

### DIFF
--- a/test/csuite/wt8659_reconstruct_database_from_logs/main.c
+++ b/test/csuite/wt8659_reconstruct_database_from_logs/main.c
@@ -72,7 +72,7 @@ dump_table(const char *home, const char *table, const char *out_file)
 }
 
 /*
- * reset_dir --a
+ * reset_dir --
  *     Recreate the directory.
  */
 static void

--- a/test/csuite/wt8659_reconstruct_database_from_logs/main.c
+++ b/test/csuite/wt8659_reconstruct_database_from_logs/main.c
@@ -71,7 +71,7 @@ dump_table(const char *home, const char *table, const char *out_file)
       "%s -R -h %s/%s dump %s > %s/%s", wt_tool_path, test_root, home, table, test_root, out_file);
 }
 
-/*s
+/*
  * reset_dir --
  *     Recreate the directory.
  */

--- a/test/csuite/wt8659_reconstruct_database_from_logs/main.c
+++ b/test/csuite/wt8659_reconstruct_database_from_logs/main.c
@@ -67,11 +67,8 @@ static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 static void
 dump_table(const char *home, const char *table, const char *out_file)
 {
-    char buf[1024];
-
-    testutil_snprintf(buf, sizeof(buf), "%s -R -h %s/%s dump %s > %s/%s", wt_tool_path, test_root,
+    testutil_system("%s -R -h %s/%s dump %s > %s/%s", wt_tool_path, test_root,
       home, table, test_root, out_file);
-    testutil_check(system(buf));
 }
 
 /*

--- a/test/csuite/wt8659_reconstruct_database_from_logs/main.c
+++ b/test/csuite/wt8659_reconstruct_database_from_logs/main.c
@@ -72,7 +72,7 @@ dump_table(const char *home, const char *table, const char *out_file)
 }
 
 /*
- * reset_dir --
+ * reset_dir --a
  *     Recreate the directory.
  */
 static void

--- a/test/csuite/wt8659_reconstruct_database_from_logs/main.c
+++ b/test/csuite/wt8659_reconstruct_database_from_logs/main.c
@@ -71,7 +71,7 @@ dump_table(const char *home, const char *table, const char *out_file)
       "%s -R -h %s/%s dump %s > %s/%s", wt_tool_path, test_root, home, table, test_root, out_file);
 }
 
-/*
+/*s
  * reset_dir --
  *     Recreate the directory.
  */

--- a/test/csuite/wt8659_reconstruct_database_from_logs/main.c
+++ b/test/csuite/wt8659_reconstruct_database_from_logs/main.c
@@ -67,8 +67,8 @@ static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 static void
 dump_table(const char *home, const char *table, const char *out_file)
 {
-    testutil_system("%s -R -h %s/%s dump %s > %s/%s", wt_tool_path, test_root,
-      home, table, test_root, out_file);
+    testutil_system(
+      "%s -R -h %s/%s dump %s > %s/%s", wt_tool_path, test_root, home, table, test_root, out_file);
 }
 
 /*

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -168,8 +168,6 @@ usage(void)
 void
 run(int r)
 {
-    char buf[128];
-
     printf("\t%s: run %d\n", __wt_page_type_string(page_type), r);
 
     testutil_recreate_dir(HOME);

--- a/test/salvage/salvage.c
+++ b/test/salvage/salvage.c
@@ -481,11 +481,7 @@ run(int r)
 
     process();
 
-    testutil_snprintf(buf, sizeof(buf), "cmp %s %s > /dev/null", DUMP, RSLT);
-    if (system(buf)) {
-        fprintf(stderr, "check failed, salvage results were incorrect\n");
-        exit(EXIT_FAILURE);
-    }
+    testutil_system("cmp %s %s > /dev/null", DUMP, RSLT);
 
     testutil_remove(HOME);
 }

--- a/test/utility/lazyfs.c
+++ b/test/utility/lazyfs.c
@@ -223,7 +223,6 @@ lazyfs_unmount(const char *mount_dir, pid_t lazyfs_pid)
 #else
     struct stat sb;
     int status;
-    char buf[PATH_MAX];
 
     /* Check whether the file system is mounted. */
     if (stat(mount_dir, &sb) != 0) {
@@ -236,7 +235,7 @@ lazyfs_unmount(const char *mount_dir, pid_t lazyfs_pid)
 
     /* Unmount. */
     testutil_system("cd '%s' && ./scripts/umount-lazyfs.sh -m \"%s\"", lazyfs_home, mount_dir);
-    
+
     if (lazyfs_pid > 0)
         testutil_assert_errno(waitpid(lazyfs_pid, &status, 0) >= 0);
 #endif

--- a/test/utility/lazyfs.c
+++ b/test/utility/lazyfs.c
@@ -235,9 +235,8 @@ lazyfs_unmount(const char *mount_dir, pid_t lazyfs_pid)
         return;
 
     /* Unmount. */
-    testutil_snprintf(
-      buf, sizeof(buf), "cd '%s' && ./scripts/umount-lazyfs.sh -m \"%s\"", lazyfs_home, mount_dir);
-    testutil_check(system(buf));
+    testutil_system("cd '%s' && ./scripts/umount-lazyfs.sh -m \"%s\"", lazyfs_home, mount_dir);
+    
     if (lazyfs_pid > 0)
         testutil_assert_errno(waitpid(lazyfs_pid, &status, 0) >= 0);
 #endif

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -720,7 +720,8 @@ is_mounted(const char *mount_dir)
  *     A convenience function that combines snprintf, system, and testutil_check.
  */
 void
-testutil_system(const char *fmt, ...) WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2)))
+testutil_system_internal(uint32_t line, const char *fmt, ...)
+  WT_GCC_FUNC_ATTRIBUTE((format(printf, 2, 3)))
 {
     WT_DECL_RET;
     size_t len;
@@ -732,9 +733,9 @@ testutil_system(const char *fmt, ...) WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2
     va_start(ap, fmt);
     ret = __wt_vsnprintf_len_incr(buf, sizeof(buf), &len, fmt, ap);
     va_end(ap);
-    testutil_check(ret);
+    testutil_check_line(line, ret);
     if (len >= sizeof(buf))
         testutil_die(ERANGE, "The command is too long.");
 
-    testutil_check(system(buf));
+    testutil_check_line(line, system(buf));
 }

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -729,8 +729,7 @@ testutil_system_internal(const char *function, uint32_t line, const char *fmt, .
     ret = __wt_vsnprintf_len_incr(buf, sizeof(buf), &len, fmt, ap);
     va_end(ap);
 
-    if ((ret = (system(buf))) != 0)
-        testutil_die(ret, "%s/%d: system(%s)", function, line, buf);
+    testutil_check(ret);
 
     if (len >= sizeof(buf))
         testutil_die(ERANGE, "The command is too long.");

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -715,7 +715,7 @@ is_mounted(const char *mount_dir)
  *     A convenience function that combines snprintf, system, and testutil_check.
  */
 void
-testutil_system_internal(uint32_t line, const char *fmt, ...)
+testutil_system_internal(const char *function, uint32_t line, const char *fmt, ...)
   WT_GCC_FUNC_ATTRIBUTE((format(printf, 2, 3)))
 {
     WT_DECL_RET;
@@ -728,9 +728,13 @@ testutil_system_internal(uint32_t line, const char *fmt, ...)
     va_start(ap, fmt);
     ret = __wt_vsnprintf_len_incr(buf, sizeof(buf), &len, fmt, ap);
     va_end(ap);
-    testutil_check_line(line, ret);
+
+    if ((ret = (system(buf))) != 0)
+        testutil_die(ret, "%s/%d: system(%s)", function, line, buf);
+
     if (len >= sizeof(buf))
         testutil_die(ERANGE, "The command is too long.");
 
-    testutil_check_line(line, system(buf));
+    if ((ret = (system(buf))) != 0)
+        testutil_die(ret, "%s/%d: system(%s)", function, line, buf);
 }

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -382,13 +382,8 @@ testutil_verify_src_backup(WT_CONNECTION *conn, const char *backup, const char *
                 if (offset > prev_offset) {
                     /* Compare the unchanged chunk. */
                     cmp_size = offset - prev_offset;
-                    testutil_snprintf(buf, sizeof(buf),
-                      "cmp -n %" PRIu64 " %s/%s %s/%s %" PRIu64 " %" PRIu64, cmp_size, home,
+                    testutil_system("cmp -n %" PRIu64 " %s/%s %s/%s %" PRIu64 " %" PRIu64, cmp_size, home,
                       filename, backup, filename, prev_offset, prev_offset);
-                    status = system(buf);
-                    if (status != 0)
-                        fprintf(stderr, "FAIL: status %d ID %s from cmd: %s\n", status, id[j], buf);
-                    testutil_assert(status == 0);
                 }
                 prev_offset = offset + size;
             }
@@ -716,7 +711,7 @@ is_mounted(const char *mount_dir)
 }
 
 /*
- * testutil_system --
+ * testutil_system_internal --
  *     A convenience function that combines snprintf, system, and testutil_check.
  */
 void

--- a/test/utility/misc.c
+++ b/test/utility/misc.c
@@ -315,7 +315,7 @@ testutil_verify_src_backup(WT_CONNECTION *conn, const char *backup, const char *
     WT_DECL_RET;
     WT_SESSION *session;
     uint64_t cmp_size, offset, prev_offset, size, type;
-    int i, j, status;
+    int i, j;
     char buf[1024], *filename, *id[WT_BLKINCR_MAX];
     const char *idstr;
 
@@ -382,8 +382,8 @@ testutil_verify_src_backup(WT_CONNECTION *conn, const char *backup, const char *
                 if (offset > prev_offset) {
                     /* Compare the unchanged chunk. */
                     cmp_size = offset - prev_offset;
-                    testutil_system("cmp -n %" PRIu64 " %s/%s %s/%s %" PRIu64 " %" PRIu64, cmp_size, home,
-                      filename, backup, filename, prev_offset, prev_offset);
+                    testutil_system("cmp -n %" PRIu64 " %s/%s %s/%s %" PRIu64 " %" PRIu64, cmp_size,
+                      home, filename, backup, filename, prev_offset, prev_offset);
                 }
                 prev_offset = offset + size;
             }

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -227,17 +227,6 @@ typedef struct {
     } while (0)
 
 /*
- * testutil_check --
- *     Complain and quit if a function call fails.
- */
-#define testutil_check_line(line, call)                                       \
-    do {                                                                      \
-        int __r;                                                              \
-        if ((__r = (call)) != 0)                                              \
-            testutil_die(__r, "%s/%d: %s", __PRETTY_FUNCTION__, line, #call); \
-    } while (0)
-
-/*
  * testutil_check_error_ok --
  *     Complain and quit if a function call fails, with specified error ok.
  */
@@ -346,10 +335,10 @@ typedef struct {
  * testutil_system --
  *     A convenience macro for testutil_system_internal. Accepts line number as an argument
  */
-#define testutil_system(fmt, ...)                             \
-    WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2)))             \
-    do {                                                      \
-        testutil_system_internal(__LINE__, fmt, __VA_ARGS__); \
+#define testutil_system(fmt, ...)                                                  \
+    WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2)))                                  \
+    do {                                                                           \
+        testutil_system_internal(__PRETTY_FUNCTION__, __LINE__, fmt, __VA_ARGS__); \
     } while (0)
 
 /*
@@ -574,7 +563,7 @@ void testutil_sentinel(const char *, const char *);
 #ifndef _WIN32
 void testutil_sleep_wait(uint32_t, pid_t);
 #endif
-void testutil_system_internal(uint32_t line, const char *fmt, ...)
+void testutil_system_internal(const char *function, uint32_t line, const char *fmt, ...)
   WT_GCC_FUNC_ATTRIBUTE((format(printf, 2, 3)));
 void testutil_wiredtiger_open(
   TEST_OPTS *, const char *, const char *, WT_EVENT_HANDLER *, WT_CONNECTION **, bool, bool);

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -333,7 +333,7 @@ typedef struct {
 
 /*
  * testutil_system --
- *     A convenience macro for testutil_system_internal. Accepts line number as an argument
+ *     A convenience macro for testutil_system_internal. Accepts line number as an argument.
  */
 #define testutil_system(fmt, ...)                                                  \
     WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2)))                                  \

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -227,6 +227,17 @@ typedef struct {
     } while (0)
 
 /*
+ * testutil_check --
+ *     Complain and quit if a function call fails.
+ */
+#define testutil_check_line(line, call)                                       \
+    do {                                                                      \
+        int __r;                                                              \
+        if ((__r = (call)) != 0)                                              \
+            testutil_die(__r, "%s/%d: %s", __PRETTY_FUNCTION__, line, #call); \
+    } while (0)
+
+/*
  * testutil_check_error_ok --
  *     Complain and quit if a function call fails, with specified error ok.
  */
@@ -329,6 +340,16 @@ typedef struct {
         while ((__ret = session->drop(session, uri, config)) == EBUSY) \
             testutil_check(session->checkpoint(session, NULL));        \
         testutil_check(__ret);                                         \
+    } while (0)
+
+/*
+ * testutil_system --
+ *     blah
+ */
+#define testutil_system(fmt, ...)                             \
+    WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2)))             \
+    do {                                                      \
+        testutil_system_internal(__LINE__, fmt, __VA_ARGS__); \
     } while (0)
 
 /*
@@ -553,7 +574,8 @@ void testutil_sentinel(const char *, const char *);
 #ifndef _WIN32
 void testutil_sleep_wait(uint32_t, pid_t);
 #endif
-void testutil_system(const char *fmt, ...) WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2)));
+void testutil_system_internal(uint32_t line, const char *fmt, ...)
+  WT_GCC_FUNC_ATTRIBUTE((format(printf, 2, 3)));
 void testutil_wiredtiger_open(
   TEST_OPTS *, const char *, const char *, WT_EVENT_HANDLER *, WT_CONNECTION **, bool, bool);
 void testutil_tiered_begin(TEST_OPTS *);

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -344,7 +344,7 @@ typedef struct {
 
 /*
  * testutil_system --
- *     blah
+ *     A convenience macro for testutil_system_internal. Accepts line number as an argument
  */
 #define testutil_system(fmt, ...)                             \
     WT_GCC_FUNC_ATTRIBUTE((format(printf, 1, 2)))             \


### PR DESCRIPTION
WT-10754 replace all instances of ...... testutil_check(system(buf)); with the new testutil_system() function. Unsure about the comment on macros and how I should go about doing it.