### PR TITLE
WT-10592 cast 32 bit uint to 64 bit

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -318,7 +318,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
              */
             thread_ops = -1;
             ops_seconds = 0;
-            g.stop_timestamp = (GV(RUNS_OPS) * (uint64_t) run_current) / run_total;
+            g.stop_timestamp = (GV(RUNS_OPS) * (uint64_t)run_current) / run_total;
         } else
             thread_ops = GV(RUNS_OPS) / GV(RUNS_THREADS);
     }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -318,7 +318,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
              */
             thread_ops = -1;
             ops_seconds = 0;
-            g.stop_timestamp = (GV(RUNS_OPS) * run_current) / run_total;
+            g.stop_timestamp = (uint64_t) ((GV(RUNS_OPS) * run_current) / run_total);
         } else
             thread_ops = GV(RUNS_OPS) / GV(RUNS_THREADS);
     }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -318,7 +318,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
              */
             thread_ops = -1;
             ops_seconds = 0;
-            g.stop_timestamp = (uint64_t) ((GV(RUNS_OPS) * run_current) / run_total);
+            g.stop_timestamp = (GV(RUNS_OPS) * (uint64_t) run_current) / run_total;
         } else
             thread_ops = GV(RUNS_OPS) / GV(RUNS_THREADS);
     }


### PR DESCRIPTION
To avoid integer overflow, cast a 32 bit unsigned integer to a 64 bit integer.