### PR TITLE
WT-11469 Missing read barriers when reading the prepared state and durable_ts

### DIFF
--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -699,7 +699,11 @@ __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t times
 static inline bool
 __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 {
-    if (upd->prepare_state == WT_PREPARE_LOCKED || upd->prepare_state == WT_PREPARE_INPROGRESS)
+    uint8_t prepare_state;
+
+    WT_ORDERED_READ(prepare_state, upd->prepare_state);
+
+    if (prepare_state == WT_PREPARE_LOCKED || prepare_state == WT_PREPARE_INPROGRESS)
         return (false);
 
     /*
@@ -1789,6 +1793,9 @@ __wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
 static inline void
 __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
 {
+    WT_ORDERED_READ(prepare_state, upd->prepare_state);
+    uint8_t prepare_state;
+
     if (!upd_value->skip_buf) {
         upd_value->buf.data = upd->data;
         upd_value->buf.size = upd->size;
@@ -1798,13 +1805,13 @@ __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
         upd_value->tw.stop_ts = upd->start_ts;
         upd_value->tw.stop_txn = upd->txnid;
         upd_value->tw.prepare =
-          upd->prepare_state == WT_PREPARE_INPROGRESS || upd->prepare_state == WT_PREPARE_LOCKED;
+          prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
     } else {
         upd_value->tw.durable_start_ts = upd->durable_ts;
         upd_value->tw.start_ts = upd->start_ts;
         upd_value->tw.start_txn = upd->txnid;
         upd_value->tw.prepare =
-          upd->prepare_state == WT_PREPARE_INPROGRESS || upd->prepare_state == WT_PREPARE_LOCKED;
+          prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
     }
     upd_value->type = upd->type;
 }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1793,8 +1793,9 @@ __wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
 static inline void
 __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
 {
-    WT_ORDERED_READ(prepare_state, upd->prepare_state);
     uint8_t prepare_state;
+
+    WT_ORDERED_READ(prepare_state, upd->prepare_state);
 
     if (!upd_value->skip_buf) {
         upd_value->buf.data = upd->data;


### PR DESCRIPTION
The scope of this PR is to implement ordered reads in the two problem areas identified in the ticket. Further work will be made in a following ticket to implement the getter/setter functionality discussed in the ticket.