### PR TITLE
WT-12030 Fortify config_compare in test import base and add named checkpoint test

### DIFF
--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -85,7 +85,7 @@ class test_import_base(wttest.WiredTigerTestCase):
     # Remove information related to the ID and checkpoints from a config.
     def strip_subconfig(self, conf):
         subconfigs = []
-        curr_subconfig = []
+        curr_subconfig = ''
         depth = 0
 
         for char in conf:
@@ -95,19 +95,19 @@ class test_import_base(wttest.WiredTigerTestCase):
                 depth -= 1
            # If end of one subconfig, append it to subconfigs list.
             if char == ',' and depth == 0:
-                subconfigs.append(''.join(curr_subconfig))
-                curr_subconfig = []
+                subconfigs.append(curr_subconfig)
+                curr_subconfig = ''
             else:
                 # Append char to curr subconfig
-                curr_subconfig.append(char)
+                curr_subconfig += char
         # Append any subconfig left.
         if curr_subconfig:
-            subconfigs.append(''.join(curr_subconfig))
+            subconfigs.append(curr_subconfig)
 
         # The ID and checkpoint information can be different between configs, remove it.
-        sliced_subconfigs = [con for con in subconfigs if not con.startswith("id=") and not con.startswith("checkpoint")]
+        stripped_subconfigs = [con for con in subconfigs if not con.startswith("id=") and not con.startswith("checkpoint")]
 
-        return sliced_subconfigs
+        return stripped_subconfigs
 
     # Populate a database with N tables, each having M rows.
     def populate(self, ntables, nrows):

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -117,8 +117,8 @@ class test_import_base(wttest.WiredTigerTestCase):
         # If curr not empty append to subconfigs.
         if curr_subconfig:
             subconfigs.append(''.join(curr_subconfig))
-    
-        sliced_subconfigs = [con for con in subconfigs if not con.startswith("id=") and "checkpoint" not in con]
+  
+        sliced_subconfigs = [con for con in subconfigs if not con.startswith("id=") and not con.startswith("checkpoint")]
         # final_subconfigs = ','.join(map(str, sliced_subconfigs))
         # return final_subconfigs
 
@@ -206,7 +206,7 @@ class test_import01(test_import_base):
 
         # Import the file.
         self.session.create(self.uri, import_config)
-        self.session.checkpoint("name=1")
+        self.session.checkpoint("name=abc")
 
         # Verify object.
         self.verifyUntilSuccess(self.session, self.uri, None)
@@ -229,8 +229,6 @@ class test_import01(test_import_base):
 
         # Perform a checkpoint.
         self.session.checkpoint()
-        self.session.checkpoint("name=abc1")
-
 
     def test_file_import_dropped_file(self):
         self.session.create(self.uri, self.create_config)

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -77,21 +77,8 @@ class test_import_base(wttest.WiredTigerTestCase):
     # The ID and checkpoint information can be different between configs, remove it. Everything else
     # should be the same.
     def config_compare(self, aconf, bconf):
-
         stripped_aconf = self.strip_subconfigs(aconf)
         stripped_bconf = self.strip_subconfigs(bconf)
-
-        # a = re.sub('id=\d+,?', '', aconf)
-        # a = (re.sub('\w+=\(.*?\)+,?', '', a).strip(',').split(',') +
-        #      re.findall('\w+=\(.*?\)+', a))
-        # b = re.sub('id=\d+,?', '', bconf)
-        # b = (re.sub('\w+=\(.*?\)+,?', '', b).strip(',').split(',') +
-        #      re.findall('\w+=\(.*?\)+', b))
-        
-        # a = [x for x in a if not x.startswith("checkpoint")]
-        # b = [x for x in b if not x.startswith("checkpoint")]
-
-        # self.assertTrue(sorted(a) == sorted(b))
 
         self.assertTrue(sorted(stripped_aconf) == sorted(stripped_bconf))
 
@@ -102,7 +89,6 @@ class test_import_base(wttest.WiredTigerTestCase):
         depth = 0
 
         for char in conf:
-
             if char == '(':
                 depth += 1
             elif char == ')':
@@ -119,8 +105,6 @@ class test_import_base(wttest.WiredTigerTestCase):
             subconfigs.append(''.join(curr_subconfig))
   
         sliced_subconfigs = [con for con in subconfigs if not con.startswith("id=") and not con.startswith("checkpoint")]
-        # final_subconfigs = ','.join(map(str, sliced_subconfigs))
-        # return final_subconfigs
 
         return sliced_subconfigs
 

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -99,7 +99,7 @@ class test_import_base(wttest.WiredTigerTestCase):
                 subconfigs.append(curr_subconfig)
                 curr_subconfig = ''
             else:
-                # Append char to curr subconfig
+                # Append the character to the current subconfiguration.
                 curr_subconfig += char
 
         # Append any subconfig left.

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -93,6 +93,7 @@ class test_import_base(wttest.WiredTigerTestCase):
                 depth += 1
             elif char == ')':
                 depth -= 1
+
            # If end of one subconfig, append it to subconfigs list.
             if char == ',' and depth == 0:
                 subconfigs.append(curr_subconfig)
@@ -100,6 +101,7 @@ class test_import_base(wttest.WiredTigerTestCase):
             else:
                 # Append char to curr subconfig
                 curr_subconfig += char
+
         # Append any subconfig left.
         if curr_subconfig:
             subconfigs.append(curr_subconfig)

--- a/test/suite/test_import01.py
+++ b/test/suite/test_import01.py
@@ -103,7 +103,7 @@ class test_import_base(wttest.WiredTigerTestCase):
         # If curr not empty append to subconfigs.
         if curr_subconfig:
             subconfigs.append(''.join(curr_subconfig))
-  
+
         sliced_subconfigs = [con for con in subconfigs if not con.startswith("id=") and not con.startswith("checkpoint")]
 
         return sliced_subconfigs


### PR DESCRIPTION
- Made changes to config_compare
  - replaced regex functionality with list comprehension
  - created strip_subconfigs helper function to remove the fields that we wont be comparing (id, checkpoints)
- Added named checkpoint test.