### PR TITLE
WT-12061 Skip compact06 with tiered storage

### DIFF
--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -64,6 +64,10 @@ class test_compact06(wttest.WiredTigerTestCase):
             time.sleep(1)
 
     def test_background_compact_api(self):
+        # FIXME-WT-11399
+        if self.runningHook('tiered'):
+            self.skipTest("Compaction isn't supported on tiered tables")
+
         # We cannot trigger the background compaction on a specific API. Note that the URI is
         # not relevant here, the corresponding table does not need to exist for this check.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:


### PR DESCRIPTION
Since this test expects compaction to do work and compaction is not supported with tiered storage, disable that scenario.