### PR TITLE
WT-11322 Copy blocks smaller than the chunk size to properly sized buffer

### DIFF
--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -83,10 +83,10 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
     WT_RET(__wt_blkcache_map_read(session, ip, addr, addr_size, &found));
     if (found) {
         skip_cache_put = true;
-        dsk = ip->data;
         if (!expect_conversion) {
             /* Initialize the buffer to the correct size, and copy to the caller's buffer before
              * releasing our reference. */
+            dsk = ip->data;
             WT_ERR(__wt_buf_initsize(session, buf, dsk->mem_size));
             WT_ERR(__wt_buf_set(session, buf, ip->data, dsk->mem_size));
             goto verify;
@@ -100,10 +100,10 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
             blkcache_found = true;
             ip->data = blkcache_item->data;
             ip->size = blkcache_item->data_size;
-            dsk = ip->data;
             if (!expect_conversion) {
                 /* Initialize the buffer to the correct size, and copy to the caller's buffer before
                  * releasing our reference. */
+                dsk = ip->data;
                 WT_ERR(__wt_buf_initsize(session, buf, dsk->mem_size));
                 WT_ERR(__wt_buf_set(session, buf, ip->data, dsk->mem_size));
                 goto verify;

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -212,8 +212,6 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
 verify:
     /* If the handle is a verify handle, verify the physical page. */
     if (F_ISSET(btree, WT_BTREE_VERIFY)) {
-        if (tmp == NULL)
-            WT_ERR(__wt_scr_alloc(session, 4 * 1024, &tmp));
         WT_ERR(bm->addr_string(bm, session, tmp, addr, addr_size));
         WT_ERR(__wt_verify_dsk(session, tmp->data, buf));
     }


### PR DESCRIPTION
Instead of using the caller's buffer to start, we will start with a scratch buffer like compressed or encrypted blocks, and set the size of the buffer to the actual  chunk size (dsk->memsize) and copying over the data to the correctly sized caller's buffer. 

**The design can be improved but I wanted to first check if the direction of the PR is correct before continuing to the second part of this ticket.**

The second part will cover changes for WT-10831, since that ticket was reverted we will need to add some relevant stats and ensure accurate tracking of memory allocated to the cache. 

Also, I will add a threshold to improve the design as suggested here: (As part of the second part of the ticket changes)
> I would suggest adding a threshold so that we only copy if we save more than X bytes of cache space (or Y%?), relying on [WT-10831](https://jira.mongodb.org/browse/WT-10831) to keep the accounting accurate for other cases.

Will also improve the design with some function calls instead of repeat code - once the first part is approved!