### PR TITLE
WT-11777 Fix units of __wt_timer_evaluate() calls: logging and progre…

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1215,7 +1215,7 @@ err:
         F_SET(conn, WT_CONN_LEAK_MEMORY);
 
     /* Time since the shutdown has started. */
-    __wt_timer_evaluate(session, &timer, &conn->shutdown_timeline.shutdown_ms);
+    __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.shutdown_ms);
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "shutdown was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the rollback to stable, and %" PRIu64 "ms for the checkpoint.",

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2472,8 +2472,8 @@ static inline void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_struct_size_adjust(WT_SESSION_IMPL *session, size_t *sizep);
-static inline void __wt_timer_evaluate(
-  WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff);
+static inline void __wt_timer_evaluate_ms(
+  WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff_ms);
 static inline void __wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time);
 static inline void __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag, struct timespec *tsp);
 static inline void __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -45,7 +45,7 @@
 
 #define WT_MINUTE (60)
 
-#define WT_PROGRESS_MSG_PERIOD (20)
+#define WT_PROGRESS_MSG_PERIOD (20) /* Seconds. */
 
 #define WT_KILOBYTE (1024)
 #define WT_MEGABYTE (1048576)

--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -219,14 +219,14 @@ __wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time)
 }
 
 /*
- * __wt_timer_evaluate --
+ * __wt_timer_evaluate_ms --
  *     Evaluate the difference between the current time and start time and output the difference in
  *     milliseconds.
  */
 static inline void
-__wt_timer_evaluate(WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff)
+__wt_timer_evaluate_ms(WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff_ms)
 {
     struct timespec cur_time;
     __wt_epoch(session, &cur_time);
-    *time_diff = WT_TIMEDIFF_MS(cur_time, *start_time);
+    *time_diff_ms = WT_TIMEDIFF_MS(cur_time, *start_time);
 }

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -79,24 +79,24 @@ void
 __wt_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t rollback_count,
   uint64_t *rollback_msg_count, bool walk)
 {
-    uint64_t time_diff;
+    uint64_t time_diff_ms;
 
     /* Time since the rollback started. */
-    __wt_timer_evaluate(session, rollback_start, &time_diff);
+    __wt_timer_evaluate_ms(session, rollback_start, &time_diff_ms);
 
-    if ((time_diff / WT_PROGRESS_MSG_PERIOD) > *rollback_msg_count) {
+    if ((time_diff_ms / (1000 * WT_PROGRESS_MSG_PERIOD)) > *rollback_msg_count) {
         if (walk)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
               "Rollback to stable has been performing on %s for %" PRIu64
-              " seconds. For more detailed logging, enable WT_VERB_RTS ",
-              session->dhandle->name, time_diff);
+              " milliseconds. For more detailed logging, enable WT_VERB_RTS ",
+              session->dhandle->name, time_diff_ms);
         else
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
               "Rollback to stable has been running for %" PRIu64
-              " seconds and has inspected %" PRIu64
+              " milliseconds and has inspected %" PRIu64
               " files. For more detailed logging, enable WT_VERB_RTS",
-              time_diff, rollback_count);
-        *rollback_msg_count = time_diff / WT_PROGRESS_MSG_PERIOD;
+              time_diff_ms, rollback_count);
+        *rollback_msg_count = time_diff_ms / (1000 * WT_PROGRESS_MSG_PERIOD);
     }
 }
 

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -119,7 +119,7 @@ __rollback_to_stable_one(WT_SESSION_IMPL *session, const char *uri, bool *skipp)
     WT_DECL_RET;
     WT_TIMER timer;
     wt_timestamp_t pinned_timestamp, rollback_timestamp;
-    uint64_t time_diff;
+    uint64_t time_diff_ms;
     char *config;
 
     conn = S2C(session);
@@ -150,10 +150,10 @@ __rollback_to_stable_one(WT_SESSION_IMPL *session, const char *uri, bool *skipp)
     F_CLR(session, WT_SESSION_QUIET_CORRUPT_FILE);
 
     __rts_assert_timestamps_unchanged(session, pinned_timestamp, rollback_timestamp);
-    __wt_timer_evaluate(session, &timer, &time_diff);
+    __wt_timer_evaluate_ms(session, &timer, &time_diff_ms);
     __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
       "finished rollback to stable on uri %s and has ran for %" PRIu64 " milliseconds", uri,
-      time_diff);
+      time_diff_ms);
 
     __wt_free(session, config);
     return (ret);
@@ -179,7 +179,7 @@ __rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckpt)
     WT_CONFIG_ITEM cval;
     WT_DECL_RET;
     WT_TIMER timer;
-    uint64_t time_diff;
+    uint64_t time_diff_ms;
     bool dryrun;
 
     /*
@@ -212,10 +212,10 @@ __rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckpt)
       session, WT_WITH_SCHEMA_LOCK(session, ret = __rollback_to_stable_int(session, no_ckpt)));
 
     /* Time since the RTS started. */
-    __wt_timer_evaluate(session, &timer, &time_diff);
+    __wt_timer_evaluate_ms(session, &timer, &time_diff_ms);
     __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
       WT_RTS_VERB_TAG_END "finished rollback to stable%s and has ran for %" PRIu64 " milliseconds",
-      dryrun ? " dryrun" : "", time_diff);
+      dryrun ? " dryrun" : "", time_diff_ms);
     WT_STAT_CONN_SET(session, txn_rollback_to_stable_running, 0);
 
     __rollback_to_stable_finalize(S2C(session)->rts);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2501,7 +2501,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
             WT_TRET(conn->rts->rollback_to_stable(session, cfg, true));
 
             /* Time since the shutdown RTS has started. */
-            __wt_timer_evaluate(session, &timer, &conn->shutdown_timeline.rts_ms);
+            __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.rts_ms);
             if (ret != 0)
                 __wt_verbose_notice(session, WT_VERB_RTS,
                   WT_RTS_VERB_TAG_SHUTDOWN_RTS
@@ -2532,7 +2532,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
             WT_TRET(__wt_session_close_internal(s));
 
             /* Time since the shutdown checkpoint has started. */
-            __wt_timer_evaluate(session, &timer, &conn->shutdown_timeline.checkpoint_ms);
+            __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.checkpoint_ms);
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
               "shutdown checkpoint has successfully finished and ran for %" PRIu64 " milliseconds",
               conn->shutdown_timeline.checkpoint_ms);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -988,7 +988,7 @@ done:
           "not allowed. Perform a clean shutdown on version 10.0.0 and then upgrade.");
 #endif
     /* Time since the Log replay has started. */
-    __wt_timer_evaluate(session, &timer, &conn->recovery_timeline.log_replay_ms);
+    __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.log_replay_ms);
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "recovery log replay has successfully finished and ran for %" PRIu64 " milliseconds",
       conn->recovery_timeline.log_replay_ms);
@@ -1027,7 +1027,7 @@ done:
         WT_ERR(conn->rts->rollback_to_stable(session, NULL, true));
 
         /* Time since the rollback to stable has started. */
-        __wt_timer_evaluate(session, &rts_timer, &conn->recovery_timeline.rts_ms);
+        __wt_timer_evaluate_ms(session, &rts_timer, &conn->recovery_timeline.rts_ms);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
           "recovery rollback to stable has successfully finished and ran for %" PRIu64
           " milliseconds",
@@ -1051,7 +1051,7 @@ done:
         WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
 
         /* Time since the recovery checkpoint has started. */
-        __wt_timer_evaluate(session, &checkpoint_timer, &conn->recovery_timeline.checkpoint_ms);
+        __wt_timer_evaluate_ms(session, &checkpoint_timer, &conn->recovery_timeline.checkpoint_ms);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
           "recovery checkpoint has successfully finished and ran for %" PRIu64 " milliseconds",
           conn->recovery_timeline.checkpoint_ms);
@@ -1078,7 +1078,7 @@ done:
     FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 
     /* Time since the recovery has started. */
-    __wt_timer_evaluate(session, &timer, &conn->recovery_timeline.recovery_ms);
+    __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.recovery_ms);
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64


### PR DESCRIPTION
WT-11777 Fix units of __wt_timer_evaluate() calls: logging and progress period (#9824) (#9889)

(cherry picked from commit a9f8d18ee3e65fb53546e63744d9c10d0b919783) in 7.2

Co-authored-by: tod-johnson-mongodb <148508687+tod-johnson-mongodb@users.noreply.github.com>
(cherry picked from commit b3d7955819e257687946c7a168868fc12e07d6eb) in 7.1