### PR TITLE
WT-12169 Check ret value when parsing configuration

### DIFF
--- a/src/config/config_api.c
+++ b/src/config/config_api.c
@@ -273,6 +273,7 @@ __config_add_checks(WT_SESSION_IMPL *session, WT_CONFIG_ENTRY *entry, WT_CONFIG_
                 __conn_foc_add(session, cp->choices);
             }
         }
+        WT_RET_NOTFOUND_OK(ret);
     }
     return (0);
 }

--- a/src/config/config_check.c
+++ b/src/config/config_check.c
@@ -213,13 +213,12 @@ __config_check(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *checks, u_int ch
             if (v.len == 0)
                 WT_RET_MSG(session, EINVAL, "Key '%.*s' requires a value", (int)k.len, k.str);
             if (v.type == WT_CONFIG_ITEM_STRUCT) {
-                /*
-                 * Handle the 'verbose' case of a list containing restricted choices.
-                 */
+                /* Handle the 'verbose' case of a list containing restricted choices. */
                 __wt_config_subinit(session, &sparser, &v);
                 found = true;
                 while (found && (ret = __wt_config_next(&sparser, &v, &dummy)) == 0)
                     found = __config_get_choice(choices, &v);
+                WT_RET_NOTFOUND_OK(ret);
             } else
                 found = __config_get_choice(choices, &v);
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -473,6 +473,7 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
             WT_ERR(__session_close_cached_cursors(session));
         }
     }
+    WT_ERR_NOTFOUND_OK(ret, false);
 
     /*
      * FIXME-WT-12021 Replace this debug option with the corresponding failpoint once this project
@@ -485,6 +486,7 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
         else
             F_CLR(session, WT_SESSION_DEBUG_CHECKPOINT_FAIL_BEFORE_TURTLE_UPDATE);
     }
+    WT_ERR_NOTFOUND_OK(ret, false);
 
     /*
      * There is a session debug configuration which can be set to evict pages as they are released


### PR DESCRIPTION
Ensure `ret` is either `0` or `WT_NOTFOUND` when parsing configuration items.

Note: those warnings were detected after enabling `scan-build` again in WT-12144.