### PR TITLE
WT-12077 Fix zSeries checksum code

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -359,6 +359,7 @@ Spinlock
 Spinlocks
 StoreLoad
 StoreStore
+Strobed
 Su
 Subdirectory
 Subprocess
@@ -976,6 +977,7 @@ metafile
 mfence
 minSnapshotHistoryWindowInSeconds
 minorp
+misalignments
 mkdir
 mmap
 mmrand
@@ -1231,6 +1233,7 @@ strlen
 strncpy
 strndup
 strnlen
+strobed
 strtoll
 strtouq
 struct

--- a/src/checksum/zseries/crc32-s390x.c
+++ b/src/checksum/zseries/crc32-s390x.c
@@ -93,18 +93,6 @@ __wt_checksum_hw(const void *chunk, size_t len)
 }
 #endif
 
-extern uint32_t __wt_checksum_sw(const void *chunk, size_t len);
-extern uint32_t __wt_checksum_with_seed_sw(uint32_t, const void *chunk, size_t len);
-#if defined(__GNUC__)
-extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t)
-  __attribute__((visibility("default")));
-extern uint32_t (*wiredtiger_crc32c_with_seed_func(void))(uint32_t, const void *, size_t)
-  __attribute__((visibility("default")));
-#else
-extern uint32_t (*wiredtiger_crc32c_func(void))(const void *, size_t);
-extern uint32_t (*wiredtiger_crc32c_with_seed_func(void))(uint32_t, const void *, size_t);
-#endif
-
 /*
  * wiredtiger_crc32c_func --
  *     WiredTiger: detect CRC hardware and return the checksum function.

--- a/test/csuite/wt2695_checksum/main.c
+++ b/test/csuite/wt2695_checksum/main.c
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
     uint32_t hw, sw;
     uint8_t *data;
     uint8_t data_ff[32];
-    u_int i, j, k;
+    u_int i, j, k, length, misalignment;
 
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
@@ -327,11 +327,11 @@ main(int argc, char *argv[])
     /*
      * "Strobed" misalignments - test every combo of size/misalignment up to 16B.
      */
-    for (i = 0; i < 16; i++) {     /* Length. */
-        for (j = 0; j < 16; j++) { /* Misalignment. */
-            hw = __wt_checksum(&data_ff[j], i);
-            sw = __wt_checksum_sw(&data_ff[j], i);
-            check(hw, sw, i, "0xff: strobed");
+    for (length = 0; length < 16; length++) {
+        for (misalignment = 0; misalignment < 16; misalignment++) {
+            hw = __wt_checksum(&data_ff[misalignment], length);
+            sw = __wt_checksum_sw(&data_ff[misalignment], length);
+            check(hw, sw, length, "0xff: strobed");
         }
     }
 

--- a/test/csuite/wt2695_checksum/main.c
+++ b/test/csuite/wt2695_checksum/main.c
@@ -80,9 +80,11 @@ main(int argc, char *argv[])
     uint32_t cumulative_hw, cumulative_sw;
     uint32_t hw, sw;
     uint8_t *data;
-    uint8_t data_ff[9] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    uint8_t *data_ff;
+    uint8_t data_ff_buf[9] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
     u_int i, j, k;
 
+    data_ff = data_ff_buf;
     opts = &_opts;
     memset(opts, 0, sizeof(*opts));
     testutil_check(testutil_parse_opts(argc, argv, opts));

--- a/test/csuite/wt2695_checksum/main.c
+++ b/test/csuite/wt2695_checksum/main.c
@@ -294,7 +294,7 @@ main(int argc, char *argv[])
         }
 
         len *= 2;
-        if (len > DATASIZE)
+        if (len > DATASIZE || len == 0)
             len = 512;
     }
 
@@ -302,7 +302,9 @@ main(int argc, char *argv[])
      * Checksums of random data chunks.
      */
     for (i = 0; i < WT_THOUSAND; ++i) {
-        len = __wt_random(&rnd) % DATASIZE;
+        do {
+            len = __wt_random(&rnd) % DATASIZE;
+        } while (len == 0);
         for (j = 0; j < len; ++j)
             data[j] = __wt_random(&rnd) & 0xff;
         hw = __wt_checksum(data, len);
@@ -325,7 +327,7 @@ main(int argc, char *argv[])
     /*
      * "Strobed" misalignments - test every combo of size/misalignment up to 16B.
      */
-    for (i = 0; i < 16; i++) {   /* Length. */
+    for (i = 0; i < 16; i++) {     /* Length. */
         for (j = 0; j < 16; j++) { /* Misalignment. */
             hw = __wt_checksum(&data_ff[j], i);
             sw = __wt_checksum_sw(&data_ff[j], i);


### PR DESCRIPTION
See pinned comment on the ticket for a full description of the bug.

Not sure yet if this needs to go upstream - AFAICT both the "Linux on Z" IBM repo, and Linux itself are broken in the same way. I suspect they aren't checksumming small, misaligned values. And neither were we, until the new tests got merged.

(Adding our interns to the code review since this is kind of an interesting one.)