### PR TITLE
WT-12147 Temporarily disable clang-analyzer (v6.0 backport)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2035,7 +2035,8 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            sh dist/s_clang-scan 2>&1
+            # FIXME-WT-12144 Turn off noisy test failures until s_clang_scan is fixed.
+            # sh dist/s_clang_scan 2>&1
 
   - name: configure-combinations
     commands:


### PR DESCRIPTION
(cherry picked from commit 54c99901cb9426245361563b4edb61e963c656a4)