### PR TITLE
WT-10601 Fix wt verify -c failure when first block on page is corrupt (v5.0 backport) (#9209) (#9294)

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -611,22 +611,24 @@ __verify_row_int_key_order(
 
     btree = S2BT(session);
 
-    /* The maximum key is set, we updated it from a leaf page first. */
-    WT_ASSERT(session, vs->max_addr->size != 0);
-
     /* Get the parent page's internal key. */
     __wt_ref_key(parent, ref, &item.data, &item.size);
 
-    /* Compare the key against the largest key we've seen so far. */
-    WT_RET(__wt_compare(session, btree->collator, &item, vs->max_key, &cmp));
-    if (cmp <= 0)
-        WT_RET_MSG(session, WT_ERROR,
-          "the internal key in entry %" PRIu32
-          " on the page at %s sorts before the last key appearing on page %s, earlier in the tree: "
-          "%s, %s",
-          entry, __verify_addr_string(session, ref, vs->tmp1), (char *)vs->max_addr->data,
-          __wt_buf_set_printable(session, item.data, item.size, false, vs->tmp2),
-          __wt_buf_set_printable(session, vs->max_key->data, vs->max_key->size, false, vs->tmp3));
+    /* There is an edge case where the maximum key is not set due the first leaf being corrupted. */
+    if (vs->max_addr->size != 0) {
+        /* Compare the key against the largest key we've seen so far. */
+        WT_RET(__wt_compare(session, btree->collator, &item, vs->max_key, &cmp));
+        if (cmp <= 0)
+            WT_RET_MSG(session, WT_ERROR,
+              "the internal key in entry %" PRIu32
+              " on the page at %s sorts before the last key appearing on page %s, earlier in the "
+              "tree: "
+              "%s, %s",
+              entry, __verify_addr_string(session, ref, vs->tmp1), (char *)vs->max_addr->data,
+              __wt_buf_set_printable(session, item.data, item.size, false, vs->tmp2),
+              __wt_buf_set_printable(
+                session, vs->max_key->data, vs->max_key->size, false, vs->tmp3));
+    }
 
     /* Update the largest key we've seen to the key just checked. */
     WT_RET(__wt_buf_set(session, vs->max_key, item.data, item.size));

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, struct
+import os, re, struct
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
 
@@ -77,11 +77,28 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         filename = tablename + ".wt"
 
         filesize = os.path.getsize(filename)
-        position = (filesize * pct) // 100
+        position = int((filesize * pct) // 100)
 
         self.pr('damaging file at: ' + str(position))
         fp = open(filename, "r+b")
         fp.seek(position)
+        return fp
+
+    def open_and_offset(self, tablename, offset):
+        """
+        Open the file for the table, position it at the given offset.
+        As a side effect, the connection is closed.
+        """
+        # we close the connection to guarantee everything is
+        # flushed and closed from the WT point of view.
+        if self.conn != None:
+            self.conn.close()
+            self.conn = None
+        filename = tablename + ".wt"
+
+        self.pr('damaging file at: ' + str(offset))
+        fp = open(filename, "r+b")
+        fp.seek(offset)
         return fp
 
     def test_verify_process_empty(self):
@@ -138,6 +155,60 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         self.session = self.setUpSessionOpen(self.conn)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.verify('table:' + self.tablename, None),
+            "/WT_SESSION.verify/")
+
+    def test_verify_api_read_corrupt_pages(self):
+        """
+        Test verify via API, on a table that is purposely corrupted in
+        multiple places. A verify operation with read_corrupt on should
+        result in multiple checksum errors being logged.
+        """
+        params = 'key_format=S,value_format=S'
+        self.session.create('table:' + self.tablename, params)
+        self.populate(self.tablename)
+        with self.open_and_position(self.tablename, 25) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+        with self.open_and_position(self.tablename, 50) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+        with self.open_and_position(self.tablename, 75) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+
+    def test_verify_api_corrupt_first_page(self):
+        """
+        Test that verify works when the first child of an internal node is corrupted. A verify
+        operation with read_corrupt on should result in a checksum errors being logged.
+        """
+        params = 'key_format=S,value_format=S'
+        self.session.create('table:' + self.tablename, params)
+        self.populate(self.tablename)
+
+        # wt verify -d dump_address performs a depth-first traversal of the BTree. So the first
+        # leaf page it prints is the first child of its parent. Grab the offset of this one so we
+        # can corrupt it.
+        self.runWt(['verify', '-d', 'dump_address', 'table:' + self.tablename], outfilename='dump.out')
+
+        # Grab the offset position of the first page.
+        offset = 0
+        lines = open('dump.out').readlines()
+        for line in lines:
+            m = re.search('(\d+)-(\d+).*row-store leaf', line)
+            if m:
+                offset = int((int(m.group(2)) - int(m.group(1)))/2)
+                break
+
+        # Open the file and corrupt the first page.
+        with self.open_and_offset(self.tablename, offset) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+
+        # open_and_position closed the session/connection, reopen them now.
+        self.conn = self.setUpConnectionOpen(".")
+        self.session = self.setUpSessionOpen(self.conn)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.verify('table:' + self.tablename, "read_corrupt"),
             "/WT_SESSION.verify/")
 
     def test_verify_process_75pct_null(self):


### PR DESCRIPTION
    (cherry picked from commit 28f2aea2b5a703aac9247e136ed32c677336c4a0)

    Co-authored-by: jchen <29520270+jiechenbo@users.noreply.github.com>
    (cherry picked from commit b5af7beeac8f79612f6302128e03d87a83901b77)
    (cherry picked from commit 9f9de2bfd4c447a1a177eb38edd6f8ae687b2c20)