### PR TITLE
WT-11354 Re-enable test_bug010 on tiered storage

### DIFF
--- a/test/suite/test_bug010.py
+++ b/test/suite/test_bug010.py
@@ -44,10 +44,6 @@ class test_bug010(wttest.WiredTigerTestCase):
     conn_config = 'checkpoint_sync=false'
 
     def test_checkpoint_dirty(self):
-        # FIXME-WT-11354 Too many open files
-        if self.runningHook('tiered'):
-            self.skipTest("this test does not yet work with tiered storage")
-
         # Create a lot of tables
         # insert the same item in each
         # Start a checkpoint with some of the updates


### PR DESCRIPTION
@ddanderson: it look like the file descriptor leak has gone away -- hopefully because the changes to the block manager and file cleanup have addressed it. There's a bit of commentary on the ticket. This PR just re-enables the problematic python test.