### PR TITLE
WT-9821 Add option to verify to report all data corruption in a file (v5.0 backport)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1681,6 +1681,10 @@ methods = {
         Display the contents of in-memory pages as they are verified,
         using the application's message handler, intended for debugging''',
         type='boolean'),
+    Config('read_corrupt', 'false', r'''
+        A mode that allows verify to continue reading after encountering a checksum error. It
+        will skip past the corrupt block and continue with the verification process''',
+        type='boolean'),
     Config('stable_timestamp', 'false', r'''
         Ensure that no data has a start timestamp after the stable timestamp,
         to be run after rollback_to_stable.''',

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -29,11 +29,14 @@ typedef struct {
     bool dump_blocks;
     bool dump_layout;
     bool dump_pages;
+    bool read_corrupt;
 
     /* Page layout information. */
     uint64_t depth, depth_internal[100], depth_leaf[100];
 
     WT_ITEM *tmp1, *tmp2, *tmp3, *tmp4; /* Temporary buffers */
+
+    int verify_err;
 } WT_VSTUFF;
 
 static void __verify_checkpoint_reset(WT_VSTUFF *);
@@ -69,6 +72,10 @@ __verify_config(WT_SESSION_IMPL *session, const char *cfg[], WT_VSTUFF *vs)
 
     WT_RET(__wt_config_gets(session, cfg, "dump_pages", &cval));
     vs->dump_pages = cval.val != 0;
+
+    WT_RET(__wt_config_gets(session, cfg, "read_corrupt", &cval));
+    vs->read_corrupt = cval.val != 0;
+    vs->verify_err = 0;
 
     WT_RET(__wt_config_gets(session, cfg, "stable_timestamp", &cval));
     vs->stable_timestamp = WT_TS_NONE; /* Ignored unless a value has been set */
@@ -286,6 +293,13 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
                  */
             }
 #endif
+
+            /*
+             * If the read_corrupt mode was turned on, we may have continued traversing and
+             * verifying the pages of the tree despite encountering an error. Set the error.
+             */
+            if (vs->verify_err != 0)
+                ret = vs->verify_err;
 
             /*
              * We have an exclusive lock on the handle, but we're swapping root pages in-and-out of
@@ -552,7 +566,18 @@ celltype_err:
 
             /* Verify the subtree. */
             ++vs->depth;
-            WT_RET(__wt_page_in(session, child_ref, 0));
+            ret = __wt_page_in(session, child_ref, 0);
+
+            /*
+             * If configured, continue traversing through the pages of the tree even after
+             * encountering errors reading in the page.
+             */
+            if (vs->read_corrupt && ret != 0) {
+                if (vs->verify_err == 0)
+                    vs->verify_err = ret;
+                continue;
+            } else
+                WT_RET(ret);
             ret = __verify_tree(session, child_ref, unpack, vs);
             WT_TRET(__wt_page_release(session, child_ref, 0));
             --vs->depth;
@@ -582,7 +607,18 @@ celltype_err:
 
             /* Verify the subtree. */
             ++vs->depth;
-            WT_RET(__wt_page_in(session, child_ref, 0));
+            ret = __wt_page_in(session, child_ref, 0);
+
+            /*
+             * If configured, continue traversing through the pages of the tree even after
+             * encountering errors reading in the page.
+             */
+            if (vs->read_corrupt && ret != 0) {
+                if (vs->verify_err == 0)
+                    vs->verify_err = ret;
+                continue;
+            } else
+                WT_RET(ret);
             ret = __verify_tree(session, child_ref, unpack, vs);
             WT_TRET(__wt_page_release(session, child_ref, 0));
             --vs->depth;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -647,22 +647,31 @@ __verify_row_int_key_order(
 
     btree = S2BT(session);
 
-    /* The maximum key is set, we updated it from a leaf page first. */
-    WT_ASSERT(session, vs->max_addr->size != 0);
+    /*
+     * The maximum key is usually set from the leaf page first. If the first leaf page is corrupted,
+     * it is possible that the key is not set. In that case skip this check.
+     */
+    if (!vs->verify_err)
+        WT_ASSERT(session, vs->max_addr->size != 0);
 
     /* Get the parent page's internal key. */
     __wt_ref_key(parent, ref, &item.data, &item.size);
 
-    /* Compare the key against the largest key we've seen so far. */
-    WT_RET(__wt_compare(session, btree->collator, &item, vs->max_key, &cmp));
-    if (cmp <= 0)
-        WT_RET_MSG(session, WT_ERROR,
-          "the internal key in entry %" PRIu32
-          " on the page at %s sorts before the last key appearing on page %s, earlier in the tree: "
-          "%s, %s",
-          entry, __verify_addr_string(session, ref, vs->tmp1), (char *)vs->max_addr->data,
-          __wt_buf_set_printable(session, item.data, item.size, false, vs->tmp2),
-          __wt_buf_set_printable(session, vs->max_key->data, vs->max_key->size, false, vs->tmp3));
+    /* There is an edge case where the maximum key is not set due the first leaf being corrupted. */
+    if (vs->max_addr->size != 0) {
+        /* Compare the key against the largest key we've seen so far. */
+        WT_RET(__wt_compare(session, btree->collator, &item, vs->max_key, &cmp));
+        if (cmp <= 0)
+            WT_RET_MSG(session, WT_ERROR,
+              "the internal key in entry %" PRIu32
+              " on the page at %s sorts before the last key appearing on page %s, earlier in the "
+              "tree: "
+              "%s, %s",
+              entry, __verify_addr_string(session, ref, vs->tmp1), (char *)vs->max_addr->data,
+              __wt_buf_set_printable(session, item.data, item.size, false, vs->tmp2),
+              __wt_buf_set_printable(
+                session, vs->max_key->data, vs->max_key->size, false, vs->tmp3));
+    }
 
     /* Update the largest key we've seen to the key just checked. */
     WT_RET(__wt_buf_set(session, vs->max_key, item.data, item.size));

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -428,7 +428,7 @@ static const WT_CONFIG_CHECK confchk_WT_SESSION_timestamp_transaction[] = {
 static const WT_CONFIG_CHECK confchk_WT_SESSION_verify[] = {
   {"dump_address", "boolean", NULL, NULL, NULL, 0}, {"dump_blocks", "boolean", NULL, NULL, NULL, 0},
   {"dump_layout", "boolean", NULL, NULL, NULL, 0}, {"dump_offsets", "list", NULL, NULL, NULL, 0},
-  {"dump_pages", "boolean", NULL, NULL, NULL, 0},
+  {"dump_pages", "boolean", NULL, NULL, NULL, 0}, {"read_corrupt", "boolean", NULL, NULL, NULL, 0},
   {"stable_timestamp", "boolean", NULL, NULL, NULL, 0}, {"strict", "boolean", NULL, NULL, NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -1294,9 +1294,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
   {"WT_SESSION.truncate", "", NULL, 0}, {"WT_SESSION.upgrade", "", NULL, 0},
   {"WT_SESSION.verify",
     "dump_address=false,dump_blocks=false,dump_layout=false,"
-    "dump_offsets=,dump_pages=false,stable_timestamp=false,"
-    "strict=false",
-    confchk_WT_SESSION_verify, 7},
+    "dump_offsets=,dump_pages=false,read_corrupt=false,"
+    "stable_timestamp=false,strict=false",
+    confchk_WT_SESSION_verify, 8},
   {"colgroup.meta",
     "app_metadata=,assert=(commit_timestamp=none,"
     "durable_timestamp=none,read_timestamp=none,write_timestamp=off),"

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1642,6 +1642,9 @@ struct __wt_session {
 	 * @config{dump_pages, Display the contents of in-memory pages as they are verified\, using
 	 * the application's message handler\, intended for debugging., a boolean flag; default \c
 	 * false.}
+	 * @config{read_corrupt, A mode that allows verify to continue reading after encountering a
+	 * checksum error.  It will skip past the corrupt block and continue with the verification
+	 * process., a boolean flag; default \c false.}
 	 * @config{stable_timestamp, Ensure that no data has a start timestamp after the stable
 	 * timestamp\, to be run after rollback_to_stable., a boolean flag; default \c false.}
 	 * @config{strict, Treat any verification problem as an error; by default\, verify will

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -12,11 +12,13 @@ static int
 usage(void)
 {
     static const char *options[] = {"-d config",
-      "display underlying information during verification", "-s",
+      "display underlying information during verification", "-c",
+      "continue to the next page after encountering error during verification", "-s",
       "verify against the specified timestamp", NULL, NULL};
 
     util_usage(
-      "verify [-s] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | dump_pages] "
+      "verify [-s] [-c] [-d dump_address | dump_blocks | dump_layout | dump_offsets=#,# | "
+      "dump_pages] "
       "[uri]",
       "options:", options);
 
@@ -30,12 +32,15 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
     size_t size;
     int ch;
     char *config, *dump_offsets, *uri;
-    bool dump_address, dump_blocks, dump_layout, dump_pages, stable_timestamp;
+    bool dump_address, dump_blocks, dump_layout, dump_pages, read_corrupt, stable_timestamp;
 
-    dump_address = dump_blocks = dump_layout = dump_pages = stable_timestamp = false;
+    dump_address = dump_blocks = dump_layout = dump_pages = read_corrupt = stable_timestamp = false;
     config = dump_offsets = uri = NULL;
-    while ((ch = __wt_getopt(progname, argc, argv, "d:s")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "cd:s")) != EOF)
         switch (ch) {
+        case 'c':
+            read_corrupt = true;
+            break;
         case 'd':
             if (strcmp(__wt_optarg, "dump_address") == 0)
                 dump_address = true;
@@ -74,19 +79,20 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
     if ((uri = util_uri(session, *argv, "table")) == NULL)
         return (1);
 
-    if (dump_address || dump_blocks || dump_layout || dump_offsets != NULL || dump_pages ||
-      stable_timestamp) {
-        size = strlen("dump_address,") + strlen("dump_blocks,") + strlen("dump_layout,") +
-          strlen("dump_pages,") + strlen("dump_offsets[],") +
+    if (read_corrupt || dump_address || dump_blocks || dump_layout || dump_offsets != NULL ||
+      dump_pages || stable_timestamp) {
+        size = strlen("read_corrupt,") + strlen("dump_address,") + strlen("dump_blocks,") +
+          strlen("dump_layout,") + strlen("dump_pages,") + strlen("dump_offsets[],") +
           (dump_offsets == NULL ? 0 : strlen(dump_offsets)) + strlen("history_store") +
           strlen("stable_timestamp,") + 20;
         if ((config = malloc(size)) == NULL) {
             ret = util_err(session, errno, NULL);
             goto err;
         }
-        if ((ret = __wt_snprintf(config, size, "%s%s%s%s%s%s%s%s",
-               dump_address ? "dump_address," : "", dump_blocks ? "dump_blocks," : "",
-               dump_layout ? "dump_layout," : "", dump_offsets != NULL ? "dump_offsets=[" : "",
+        if ((ret = __wt_snprintf(config, size, "%s%s%s%s%s%s%s%s%s",
+               read_corrupt ? "read_corrupt," : "", dump_address ? "dump_address," : "",
+               dump_blocks ? "dump_blocks," : "", dump_layout ? "dump_layout," : "",
+               dump_offsets != NULL ? "dump_offsets=[" : "",
                dump_offsets != NULL ? dump_offsets : "", dump_offsets != NULL ? "]," : "",
                dump_pages ? "dump_pages," : "", stable_timestamp ? "stable_timestamp," : "")) !=
           0) {

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -63,6 +63,15 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(i, self.nentries)
         cursor.close()
 
+    def count_file_contains(self, filename, content):
+        count = 0
+        with open(filename) as f:
+            for line in f:
+                if content in line:
+                    count += 1
+            f.close()
+        return count
+
     def open_and_position(self, tablename, pct):
         """
         Open the file for the table, position it at a 4K page
@@ -137,8 +146,44 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         self.conn = self.setUpConnectionOpen(".")
         self.session = self.setUpSessionOpen(self.conn)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.session.verify('table:' + self.tablename, None),
+            lambda: self.session.verify('table:' + self.tablename, "read_corrupt"),
             "/WT_SESSION.verify/")
+        self.assertEqual(self.count_file_contains("stderr.txt",
+            "calculated block checksum doesn't match expected checksum"), 1)
+
+    def test_verify_api_read_corrupt_pages(self):
+        """
+        Test verify via API, on a table that is purposely corrupted in
+        multiple places. A verify operation with read_corrupt on should
+        result in multiple checksum errors being logged.
+        """
+        params = 'key_format=S,value_format=S'
+        self.session.create('table:' + self.tablename, params)
+        self.populate(self.tablename)
+        with self.open_and_position(self.tablename, 25) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+        with self.open_and_position(self.tablename, 50) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+        with self.open_and_position(self.tablename, 75) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+
+        # open_and_position closed the session/connection, reopen them now.
+        self.conn = self.setUpConnectionOpen(".")
+        self.session = self.setUpSessionOpen(self.conn)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.verify('table:' + self.tablename, "read_corrupt"),
+            "/WT_SESSION.verify/")
+
+        # It is expected that more than one checksum error is logged given
+        # that we have corrupted the table in multiple locations, but we may
+        # not necessarily detect all three corruptions - e.g. we won't detect
+        # a corruption if we overwrite free space or overwrite a page that is
+        # a child of another page that we overwrite.
+        self.assertGreater(self.count_file_contains("stderr.txt",
+            "calculated block checksum doesn't match expected checksum"), 1)
 
     def test_verify_process_75pct_null(self):
         """
@@ -151,9 +196,11 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         with self.open_and_position(self.tablename, 75) as f:
             for i in range(0, 4096):
                 f.write(struct.pack('B', 0))
-        self.runWt(["verify", "table:" + self.tablename],
+        self.runWt(["verify", "-c", "table:" + self.tablename],
             errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
+        self.assertEqual(self.count_file_contains("verifyerr.out",
+            "calculated block checksum doesn't match expected checksum"), 1)
 
     def test_verify_process_25pct_junk(self):
         """
@@ -166,9 +213,42 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         with self.open_and_position(self.tablename, 25) as f:
             for i in range(0, 100):
                 f.write(b'\x01\xff\x80')
-        self.runWt(["verify", "table:" + self.tablename],
+        self.runWt(["verify", "-c", "table:" + self.tablename],
             errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
+        self.assertEqual(self.count_file_contains("verifyerr.out",
+            "calculated block checksum doesn't match expected checksum"), 1)
+
+    def test_verify_process_read_corrupt_pages(self):
+        """
+        Test verify in a 'wt' process on a table that is purposely corrupted
+        in multiple places. A verify operation with read_corrupt on should
+        result in multiple checksum errors being logged.
+        """
+        params = 'key_format=S,value_format=S'
+        self.session.create('table:' + self.tablename, params)
+        self.populate(self.tablename)
+        with self.open_and_position(self.tablename, 25) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+        with self.open_and_position(self.tablename, 75) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+        with self.open_and_position(self.tablename, 80) as f:
+            for i in range(0, 100):
+                f.write(b'\x01\xff\x80')
+        self.runWt(["verify", "-c", "table:" + self.tablename],
+            errfilename="verifyerr.out", failure=True)
+
+        self.check_non_empty_file("verifyerr.out")
+
+        # It is expected that more than one checksum error is logged given
+        # that we have corrupted the table in multiple locations, but we may
+        # not necessarily detect all three corruptions - e.g. we won't detect
+        # a corruption if we overwrite free space or overwrite a page that is
+        # a child of another page that we overwrite.
+        self.assertGreater(self.count_file_contains("verifyerr.out",
+            "calculated block checksum doesn't match expected checksum"), 1)
 
     def test_verify_process_truncated(self):
         """


### PR DESCRIPTION
Note that this PR contains the fallout WT-10601 (Fix wt verify -c failure when first block on page is corrupt)