### PR TITLE
POC of removing the WT_PREPARE_LOCKED state and creating a prepare_ts update field.

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1625,9 +1625,6 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
         case WT_PREPARE_INPROGRESS:
             prepare_state = "in-progress";
             break;
-        case WT_PREPARE_LOCKED:
-            prepare_state = "locked";
-            break;
         case WT_PREPARE_RESOLVED:
             prepare_state = "resolved";
             break;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -219,8 +219,7 @@ __curversion_next_int(WT_CURSOR *cursor)
                 version_cursor->next_upd = NULL;
                 F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
             } else {
-                if (upd->prepare_state == WT_PREPARE_INPROGRESS ||
-                  upd->prepare_state == WT_PREPARE_LOCKED)
+                if (upd->prepare_state == WT_PREPARE_INPROGRESS)
                     version_prepare_state = 1;
                 else
                     version_prepare_state = 0;
@@ -333,8 +332,7 @@ __curversion_next_int(WT_CURSOR *cursor)
             }
 
             if (tombstone != NULL &&
-              (tombstone->prepare_state == WT_PREPARE_INPROGRESS ||
-                tombstone->prepare_state == WT_PREPARE_LOCKED))
+              (tombstone->prepare_state == WT_PREPARE_INPROGRESS))
                 version_prepare_state = 1;
             else
                 version_prepare_state = cbt->upd_value->tw.prepare;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -331,8 +331,7 @@ __curversion_next_int(WT_CURSOR *cursor)
                 stop_txn = cbt->upd_value->tw.stop_txn;
             }
 
-            if (tombstone != NULL &&
-              (tombstone->prepare_state == WT_PREPARE_INPROGRESS))
+            if (tombstone != NULL && (tombstone->prepare_state == WT_PREPARE_INPROGRESS))
                 version_prepare_state = 1;
             else
                 version_prepare_state = cbt->upd_value->tw.prepare;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -802,11 +802,6 @@ struct __wt_page {
  * WT_PREPARE_INPROGRESS:
  *	Update is in prepared phase.
  *
- * WT_PREPARE_LOCKED:
- *	State is locked as state transition is in progress from INPROGRESS to
- *	RESOLVED. Any reader of the state needs to wait for state transition to
- *	complete.
- *
  * WT_PREPARE_RESOLVED:
  *	Represents the commit state of the prepared update.
  *
@@ -824,8 +819,7 @@ struct __wt_page {
 /* Must be 0, as structures will be default initialized with 0. */
 #define WT_PREPARE_INIT 0
 #define WT_PREPARE_INPROGRESS 1
-#define WT_PREPARE_LOCKED 2
-#define WT_PREPARE_RESOLVED 3
+#define WT_PREPARE_RESOLVED 2
 
 /*
  * Page state.

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1308,7 +1308,7 @@ struct __wt_update {
      * be necessary.
      */
     wt_timestamp_t prev_durable_ts;
-
+    wt_timestamp_t prepare_ts;
     wt_shared WT_UPDATE *next; /* forward-linked list */
 
     uint32_t size; /* data length */
@@ -1377,7 +1377,7 @@ struct __wt_update {
  * WT_UPDATE_SIZE is the expected structure size excluding the payload data -- we verify the build
  * to ensure the compiler hasn't inserted padding.
  */
-#define WT_UPDATE_SIZE 47
+#define WT_UPDATE_SIZE 55
 
 /*
  * If there is no value, ensure that the memory allocation size matches that returned by sizeof().

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1652,7 +1652,7 @@ __wt_page_del_visible_all(WT_SESSION_IMPL *session, WT_PAGE_DELETED *page_del, b
 
     if (hide_prepared) {
         WT_ORDERED_READ(prepare_state, page_del->prepare_state);
-        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED)
+        if (prepare_state == WT_PREPARE_INPROGRESS)
             return (false);
     }
 
@@ -1678,7 +1678,7 @@ __wt_page_del_visible(WT_SESSION_IMPL *session, WT_PAGE_DELETED *page_del, bool 
 
     if (hide_prepared) {
         WT_ORDERED_READ(prepare_state, page_del->prepare_state);
-        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED)
+        if (prepare_state == WT_PREPARE_INPROGRESS)
             return (false);
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2496,6 +2496,9 @@ static inline uint64_t __wt_txn_id_alloc(WT_SESSION_IMPL *session, bool publish)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline uint64_t __wt_txn_oldest_id(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline uint8_t __wt_read_update_timestamps(
+  WT_SESSION_IMPL *session, WT_UPDATE *upd, wt_timestamp_t *start_tsp, wt_timestamp_t *durable_tsp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline void __wt_btree_disable_bulk(WT_SESSION_IMPL *session);
 static inline void __wt_buf_free(WT_SESSION_IMPL *session, WT_ITEM *buf);
 static inline void __wt_cache_decr_check_size(

--- a/src/include/str_inline.h
+++ b/src/include/str_inline.h
@@ -10,8 +10,6 @@ __wt_prepare_state_str(uint8_t val)
         return ("WT_PREPARE_INIT");
     case WT_PREPARE_INPROGRESS:
         return ("WT_PREPARE_INPROGRESS");
-    case WT_PREPARE_LOCKED:
-        return ("WT_PREPARE_LOCKED");
     case WT_PREPARE_RESOLVED:
         return ("WT_PREPARE_RESOLVED");
     }

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -254,9 +254,9 @@ __wt_read_update_timestamps(
     } else if (prepare_state == WT_PREPARE_RESOLVED) {
         *start_tsp = upd->start_ts;
         *durable_tsp = upd->durable_ts;
-    } else {
+    } else if (prepare_state == WT_PREPARE_INIT) {
         *start_tsp = upd->start_ts;
-        *durable_tsp = WT_TS_NONE;
+        *durable_tsp = upd->durable_ts;
     }
 
     return (prepare_state);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -152,7 +152,7 @@ __txn_apply_prepare_state_update(WT_SESSION_IMPL *session, WT_UPDATE *upd, bool 
         WT_PUBLISH(upd->prepare_state, WT_PREPARE_RESOLVED);
     } else {
         /* Set prepare timestamp. */
-        upd->start_ts = txn->prepare_timestamp;
+        upd->prepare_ts = txn->prepare_timestamp;
 
         /*
          * By default durable timestamp is assigned with 0 which is same as WT_TS_NONE. Assign it

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1784,22 +1784,12 @@ __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
         upd_value->tw.durable_stop_ts = upd->durable_ts;
         upd_value->tw.stop_ts = upd->start_ts;
         upd_value->tw.stop_txn = upd->txnid;
-<<<<<<< HEAD
-        upd_value->tw.prepare = upd->prepare_state == WT_PREPARE_INPROGRESS;
-=======
-        upd_value->tw.prepare =
-          prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
->>>>>>> develop
+        upd_value->tw.prepare = prepare_state == WT_PREPARE_INPROGRESS;
     } else {
         upd_value->tw.durable_start_ts = upd->durable_ts;
         upd_value->tw.start_ts = upd->start_ts;
         upd_value->tw.start_txn = upd->txnid;
-<<<<<<< HEAD
-        upd_value->tw.prepare = upd->prepare_state == WT_PREPARE_INPROGRESS;
-=======
-        upd_value->tw.prepare =
-          prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
->>>>>>> develop
+        upd_value->tw.prepare = prepare_state == WT_PREPARE_INPROGRESS;
     }
     upd_value->type = upd->type;
 }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1784,6 +1784,8 @@ __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
     wt_timestamp_t start_ts;
     wt_timestamp_t durable_ts;
 
+    start_ts = durable_ts = 0;
+
     prepare_state = __wt_read_update_timestamps(NULL, upd, &start_ts, &durable_ts);
 
     if (!upd_value->skip_buf) {

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -700,6 +700,8 @@ __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd)
     wt_timestamp_t start_ts, durable_ts;
     uint8_t prepare_state;
 
+    start_ts = durable_ts = 0;
+
     prepare_state = __wt_read_update_timestamps(NULL, upd, &start_ts, &durable_ts);
 
     if (prepare_state == WT_PREPARE_INPROGRESS)
@@ -934,6 +936,8 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
     wt_timestamp_t start_ts, durable_ts;
     uint8_t prepare_state;
     bool upd_visible;
+
+    durable_ts = start_ts = 0;
 
     /* Entries in the history store are always visible. */
     if ((WT_IS_HS(session->dhandle) && upd->txnid != WT_TXN_ABORTED &&

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -124,7 +124,7 @@ __rec_child_deleted(
      * lost in hard-to-debug ways.
      */
     WT_ORDERED_READ(prepare_state, page_del->prepare_state);
-    if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
+    if (prepare_state == WT_PREPARE_INPROGRESS) {
         WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
           "In progress prepares should never be seen in eviction");
         WT_ASSERT(session, !visible_all);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -583,8 +583,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *first_upd
         }
 
         /* Ignore prepared updates if it is checkpoint. */
-        if (upd->prepare_state == WT_PREPARE_LOCKED ||
-          upd->prepare_state == WT_PREPARE_INPROGRESS) {
+        if (upd->prepare_state == WT_PREPARE_INPROGRESS) {
             WT_ASSERT_ALWAYS(session,
               upd_select->upd == NULL || upd_select->upd->txnid == upd->txnid,
               "Cannot have two different prepared transactions active on the same key");

--- a/src/rollback_to_stable/rts_visibility.c
+++ b/src/rollback_to_stable/rts_visibility.c
@@ -124,8 +124,7 @@ __wt_rts_visibility_page_needs_abort(
       ref->page_del != NULL) {
         tag = "page_del info";
         durable_ts = ref->page_del->durable_timestamp;
-        prepared = ref->page_del->prepare_state == WT_PREPARE_INPROGRESS ||
-          ref->page_del->prepare_state == WT_PREPARE_LOCKED;
+        prepared = ref->page_del->prepare_state == WT_PREPARE_INPROGRESS;
         newest_txn = ref->page_del->txnid;
         result = (durable_ts > rollback_timestamp) || prepared ||
           WT_CHECK_RECOVERY_FLAG_TXNID(session, newest_txn);


### PR DESCRIPTION
This is a POC of a suggested change to our prepared transaction logic, it needs extensive tidying but the gist of it is here. It also would require that the new function __wt_read_update_timestamps is utilized in all places we read update timestamps.