### PR TITLE
WT-10593 Add assert in replay_committed to avoid out-of-bounds access

### DIFF
--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -450,6 +450,7 @@ replay_committed(TINFO *tinfo)
         return;
 
     testutil_assert(tinfo->replay_ts != 0);
+    testutil_assert(tinfo->lane != LANE_NONE);
 
     lane = tinfo->lane;
     testutil_assert(!tinfo->replay_again);


### PR DESCRIPTION
Coverity defect analysis: Out-of-bounds access detected.

In `replay.c`, `replay_committed` function - added `testutil_assert` to avoid out-of-bounds access.

Tracing the error:
1. `tinfo->lane` is initialized to LANE_NONE (i.e. u32_max)
2. `tinfo` passed into `commit_transaction`
3. `tinfo` passed into `replay_committed` where `lane` is assigned to `tinfo->lane` and then an out-of-bounds access attempt occurs at `WT_PUBLISH(g.lanes[lane].in_use, false)`