### PR TITLE
WT-11491 Log the WiredTiger time spent during startup and shutdown (v6.0 backport)

### DIFF
--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -32,10 +32,11 @@ build() {
 		echo "    typedef $t $n $upper;"
 	done
 
-	# There's one fixed type we use.
-	echo
-	echo 'typedef uint64_t wt_timestamp_t;'
-	echo
+    # Fixed types we use.
+    echo
+    echo 'typedef struct timespec WT_TIMER;'
+    echo 'typedef uint64_t wt_timestamp_t;'
+    echo
 
 	echo '/*'
 	sed -e '/Forward type declarations .*: END/,${' \

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1192,7 +1192,7 @@ err:
         F_SET(conn, WT_CONN_LEAK_MEMORY);
 
     /* Time since the shutdown has started. */
-    __wt_timer_evaluate(session, &timer, &conn->shutdown_timeline.shutdown_ms);
+    __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.shutdown_ms);
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "shutdown was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the rollback to stable, and %" PRIu64 "ms for the checkpoint.",

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1101,12 +1101,15 @@ __conn_close(WT_CONNECTION *wt_conn, const char *config)
     WT_DECL_RET;
     WT_SESSION *wt_session;
     WT_SESSION_IMPL *s, *session;
+    WT_TIMER timer;
     uint32_t i;
 
     conn = (WT_CONNECTION_IMPL *)wt_conn;
 
     CONNECTION_API_CALL(conn, session, close, config, cfg);
 err:
+
+    __wt_timer_start(session, &timer);
 
     /*
      * Ramp the eviction dirty target down to encourage eviction threads to clear dirty content out
@@ -1187,6 +1190,14 @@ err:
     WT_TRET(__wt_config_gets(session, cfg, "leak_memory", &cval));
     if (cval.val != 0)
         F_SET(conn, WT_CONN_LEAK_MEMORY);
+
+    /* Time since the shutdown has started. */
+    __wt_timer_evaluate(session, &timer, &conn->shutdown_timeline.shutdown_ms);
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "shutdown was completed successfully and took %" PRIu64 "ms, including %" PRIu64
+      "ms for the rollback to stable, and %" PRIu64 "ms for the checkpoint.",
+      conn->shutdown_timeline.shutdown_ms, conn->shutdown_timeline.rts_ms,
+      conn->shutdown_timeline.checkpoint_ms);
 
     WT_TRET(__wt_connection_close(conn));
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -385,6 +385,20 @@ struct __wt_connection_impl {
     uint64_t ckpt_write_bytes;
     uint64_t ckpt_write_pages;
 
+    /* Record the important timestamps of each stage in recovery. */
+    struct __wt_recovery_timeline {
+        uint64_t log_replay_ms;
+        uint64_t rts_ms;
+        uint64_t checkpoint_ms;
+        uint64_t recovery_ms;
+    } recovery_timeline;
+
+    /* Record the important timestamps of each stage in shutdown. */
+    struct __wt_shutdown_timeline {
+        uint64_t rts_ms;
+        uint64_t checkpoint_ms;
+        uint64_t shutdown_ms;
+    } shutdown_timeline;
     /* Checkpoint and incremental backup data */
     uint64_t incr_granularity;
     WT_BLKINCR incr_backups[WT_BLKINCR_MAX];

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2344,7 +2344,10 @@ static inline void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_struct_size_adjust(WT_SESSION_IMPL *session, size_t *sizep);
-static inline void __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag);
+static inline void __wt_timer_evaluate(
+  WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff);
+static inline void __wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time);
+static inline void __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session);
 static inline void __wt_tree_modify_set(WT_SESSION_IMPL *session);
 static inline void __wt_txn_cursor_op(WT_SESSION_IMPL *session);
 static inline void __wt_txn_err_set(WT_SESSION_IMPL *session, int ret);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2344,8 +2344,8 @@ static inline void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_struct_size_adjust(WT_SESSION_IMPL *session, size_t *sizep);
-static inline void __wt_timer_evaluate(
-  WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff);
+static inline void __wt_timer_evaluate_ms(
+  WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff_ms);
 static inline void __wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time);
 static inline void __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session);
 static inline void __wt_tree_modify_set(WT_SESSION_IMPL *session);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -44,7 +44,7 @@
 
 #define WT_MINUTE (60)
 
-#define WT_PROGRESS_MSG_PERIOD (20)
+#define WT_PROGRESS_MSG_PERIOD (20) /* Seconds. */
 
 #define WT_KILOBYTE (1024)
 #define WT_MEGABYTE (1048576)

--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -219,14 +219,14 @@ __wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time)
 }
 
 /*
- * __wt_timer_evaluate --
+ * __wt_timer_evaluate_ms --
  *     Evaluate the difference between the current time and start time and output the difference in
  *     milliseconds.
  */
 static inline void
-__wt_timer_evaluate(WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff)
+__wt_timer_evaluate_ms(WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff_ms)
 {
     struct timespec cur_time;
     __wt_epoch(session, &cur_time);
-    *time_diff = WT_TIMEDIFF_MS(cur_time, *start_time);
+    *time_diff_ms = WT_TIMEDIFF_MS(cur_time, *start_time);
 }

--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -207,3 +207,26 @@ __wt_op_timer_fired(WT_SESSION_IMPL *session)
     diff = WT_CLOCKDIFF_US(now, session->operation_start_us);
     return (diff > session->operation_timeout_us);
 }
+
+/*
+ * __wt_timer_start --
+ *     Start the timer.
+ */
+static inline void
+__wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time)
+{
+    __wt_epoch(session, start_time);
+}
+
+/*
+ * __wt_timer_evaluate --
+ *     Evaluate the difference between the current time and start time and output the difference in
+ *     milliseconds.
+ */
+static inline void
+__wt_timer_evaluate(WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff)
+{
+    struct timespec cur_time;
+    __wt_epoch(session, &cur_time);
+    *time_diff = WT_TIMEDIFF_MS(cur_time, *start_time);
+}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -303,6 +303,8 @@ struct __wt_reconcile;
 typedef struct __wt_reconcile WT_RECONCILE;
 struct __wt_reconcile_timeline;
 typedef struct __wt_reconcile_timeline WT_RECONCILE_TIMELINE;
+struct __wt_recovery_timeline;
+typedef struct __wt_recovery_timeline WT_RECOVERY_TIMELINE;
 struct __wt_ref;
 typedef struct __wt_ref WT_REF;
 struct __wt_ref_hist;
@@ -323,6 +325,8 @@ struct __wt_session_stash;
 typedef struct __wt_session_stash WT_SESSION_STASH;
 struct __wt_session_stats;
 typedef struct __wt_session_stats WT_SESSION_STATS;
+struct __wt_shutdown_timeline;
+typedef struct __wt_shutdown_timeline WT_SHUTDOWN_TIMELINE;
 struct __wt_size;
 typedef struct __wt_size WT_SIZE;
 struct __wt_spinlock;
@@ -376,6 +380,7 @@ typedef union __wt_lsn WT_LSN;
 union __wt_rand_state;
 typedef union __wt_rand_state WT_RAND_STATE;
 
+typedef struct timespec WT_TIMER;
 typedef uint64_t wt_timestamp_t;
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2398,7 +2398,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
             WT_TRET(__wt_session_close_internal(s));
 
             /* Time since the shutdown checkpoint has started. */
-            __wt_timer_evaluate(session, &timer, &conn->shutdown_timeline.checkpoint_ms);
+            __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.checkpoint_ms);
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
               "shutdown checkpoint has successfully finished and ran for %" PRIu64 " milliseconds",
               conn->shutdown_timeline.checkpoint_ms);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -844,6 +844,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     WT_DECL_RET;
     WT_RECOVERY r;
     WT_RECOVERY_FILE *metafile;
+    WT_TIMER timer, rts_timer, checkpoint_timer;
     wt_off_t hs_size;
     char *config;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
@@ -860,6 +861,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     rts_executed = false;
     eviction_started = false;
     was_backup = F_ISSET(conn, WT_CONN_WAS_BACKUP);
+
+    __wt_timer_start(session, &timer);
 
     /* We need a real session for recovery. */
     WT_RET(__wt_open_internal_session(conn, "txn-recover", false, 0, 0, &session));
@@ -1047,6 +1050,12 @@ done:
           "Upgrading from a WiredTiger version 10.0.0 database that was not shutdown cleanly is "
           "not allowed. Perform a clean shutdown on version 10.0.0 and then upgrade.");
 #endif
+    /* Time since the Log replay has started. */
+    __wt_timer_evaluate(session, &timer, &conn->recovery_timeline.log_replay_ms);
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "recovery log replay has successfully finished and ran for %" PRIu64 " milliseconds",
+      conn->recovery_timeline.log_replay_ms);
+
     WT_ERR(__recovery_txn_setup_initial_state(session, &r));
 
     /*
@@ -1064,6 +1073,7 @@ done:
      * 2. The history store file was found in the metadata.
      */
     if (hs_exists && !F_ISSET(conn, WT_CONN_READONLY)) {
+        __wt_timer_start(session, &rts_timer);
         /* Start the eviction threads for rollback to stable if not already started. */
         if (!eviction_started) {
             WT_ERR(__wt_evict_create(session));
@@ -1088,12 +1098,20 @@ done:
     if (eviction_started)
         WT_TRET(__wt_evict_destroy(session));
 
-    if (do_checkpoint || rts_executed)
+    if (do_checkpoint || rts_executed) {
+        __wt_timer_start(session, &checkpoint_timer);
         /*
          * Forcibly log a checkpoint so the next open is fast and keep the metadata up to date with
          * the checkpoint LSN and removal.
          */
         WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
+
+        /* Time since the recovery checkpoint has started. */
+        __wt_timer_evaluate(session, &checkpoint_timer, &conn->recovery_timeline.checkpoint_ms);
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "recovery checkpoint has successfully finished and ran for %" PRIu64 " milliseconds",
+          conn->recovery_timeline.checkpoint_ms);
+    }
 
     /* Remove any backup file now that metadata has been synced. */
     WT_ERR(__wt_backup_file_remove(session));
@@ -1114,6 +1132,15 @@ done:
     if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_FORCE_DOWNGRADE))
         WT_ERR(__wt_log_truncate_files(session, NULL, true));
     FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
+
+    /* Time since the recovery has started. */
+    __wt_timer_evaluate(session, &timer, &conn->recovery_timeline.recovery_ms);
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
+      "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64
+      "ms for the checkpoint.",
+      conn->recovery_timeline.recovery_ms, conn->recovery_timeline.log_replay_ms,
+      conn->recovery_timeline.rts_ms, conn->recovery_timeline.checkpoint_ms);
 
 err:
     WT_TRET(__recovery_close_cursors(&r));

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1051,7 +1051,7 @@ done:
           "not allowed. Perform a clean shutdown on version 10.0.0 and then upgrade.");
 #endif
     /* Time since the Log replay has started. */
-    __wt_timer_evaluate(session, &timer, &conn->recovery_timeline.log_replay_ms);
+    __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.log_replay_ms);
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "recovery log replay has successfully finished and ran for %" PRIu64 " milliseconds",
       conn->recovery_timeline.log_replay_ms);
@@ -1107,7 +1107,7 @@ done:
         WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
 
         /* Time since the recovery checkpoint has started. */
-        __wt_timer_evaluate(session, &checkpoint_timer, &conn->recovery_timeline.checkpoint_ms);
+        __wt_timer_evaluate_ms(session, &checkpoint_timer, &conn->recovery_timeline.checkpoint_ms);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
           "recovery checkpoint has successfully finished and ran for %" PRIu64 " milliseconds",
           conn->recovery_timeline.checkpoint_ms);
@@ -1134,7 +1134,7 @@ done:
     FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
 
     /* Time since the recovery has started. */
-    __wt_timer_evaluate(session, &timer, &conn->recovery_timeline.recovery_ms);
+    __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.recovery_ms);
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64

--- a/test/suite/test_recovery01.py
+++ b/test/suite/test_recovery01.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper import simulate_crash_restart
+from wtdataset import SimpleDataSet
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# test_recovery01.py
+# Test WiredTiger logs time spent during recovery and shutdown.
+class test_recovery01(wttest.WiredTigerTestCase):
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        ('column_fix', dict(key_format='r', value_format='8t')),
+        ('row_integer', dict(key_format='i', value_format='S')),
+    ]
+
+    restart_values = [
+        ('crash', dict(crash=True)),
+        ('shutdown', dict(crash=False))
+    ]
+
+    scenarios = make_scenarios(format_values, restart_values)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ignoreStdoutPattern('WT_VERB_RECOVERY_PROGRESS')
+
+    def conn_config(self):
+        config = 'cache_size=50MB,statistics=(all),log=(enabled=true),verbose=(recovery_progress)'
+        return config
+
+    def large_updates(self, uri, value, ds, nrows, commit_ts):
+        # Update a large number of records.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        for i in range(1, nrows+1):
+            session.begin_transaction()
+            cursor[ds.key(i)] = value
+            if commit_ts == 0:
+                session.commit_transaction()
+            else:
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor.close()
+
+    def check(self, check_value, uri, nrows, read_ts):
+        session = self.session
+        if read_ts == 0:
+            session.begin_transaction()
+        else:
+            session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
+        cursor = session.open_cursor(uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, check_value)
+            count += 1
+        session.commit_transaction()
+        self.assertEqual(count, nrows)
+
+    def test_recovery(self):
+        nrows = 1000
+
+        # Create two tables. One logged and another one non-logged.
+        uri_1 = "table:recovery01_1"
+        ds_1 = SimpleDataSet(
+            self, uri_1, 0, key_format=self.key_format, value_format=self.value_format,
+            config='log=(enabled=true)')
+        ds_1.populate()
+
+        uri_2 = "table:recovery01_2"
+        ds_2 = SimpleDataSet(
+            self, uri_2, 0, key_format=self.key_format, value_format=self.value_format,
+            config='log=(enabled=false)')
+        ds_2.populate()
+
+        if self.value_format == '8t':
+            valuea = 97
+            valueb = 98
+        else:
+            valuea = "aaaaa" * 100
+            valueb = "bbbbb" * 100
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        self.large_updates(uri_1, valuea, ds_1, nrows, 0)
+        self.check(valuea, uri_1, nrows, 0)
+
+        self.large_updates(uri_2, valuea, ds_2, nrows, 10)
+        self.check(valuea, uri_2, nrows, 10)
+
+        self.large_updates(uri_1, valueb, ds_1, nrows, 0)
+        self.check(valueb, uri_1, nrows, 0)
+
+        self.large_updates(uri_2, valueb, ds_2, nrows, 20)
+        self.check(valueb, uri_2, nrows, 20)
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        if self.crash:
+            simulate_crash_restart(self, ".", "RESTART")
+        else:
+            self.reopen_conn()
+
+        self.check(valueb, uri_1, nrows, 0)
+        self.check(valuea, uri_2, nrows, 10)
+        self.check(valuea, uri_2, nrows, 20)
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Note that this PR contains the fallout [WT-11777](https://jira.mongodb.org/browse/WT-11777) (Fix units of __wt_timer_evaluate() calls: logging and progress period)