### PR TITLE
WT-11913 Include write generation information wt verify dump

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -385,9 +385,9 @@ __verify_addr_string(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *buf)
     WT_ERR(__wt_scr_alloc(session, 0, &tmp));
 
     if (__wt_ref_addr_copy(session, ref, &addr)) {
-        WT_ERR(__wt_buf_fmt(session, buf, "%-43s %s",
-          __wt_addr_string(session, addr.addr, addr.size, tmp),
-          __wt_time_aggregate_to_string(&addr.ta, time_string)));
+        WT_ERR(
+          __wt_buf_fmt(session, buf, "%s %s", __wt_addr_string(session, addr.addr, addr.size, tmp),
+            __wt_time_aggregate_to_string(&addr.ta, time_string)));
     } else
         WT_ERR(__wt_buf_fmt(session, buf, "%s -/-,-/-", __wt_addr_string(session, NULL, 0, tmp)));
 
@@ -456,7 +456,7 @@ __verify_tree(
 
     /* Optionally dump address information. */
     if (vs->dump_address)
-        WT_RET(__wt_msg(session, "%s %-18s write gen: %" PRIu64,
+        WT_RET(__wt_msg(session, "%s %s write gen: %" PRIu64,
           __verify_addr_string(session, ref, vs->tmp1), __wt_page_type_string(page->type),
           page->dsk->write_gen));
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -456,8 +456,9 @@ __verify_tree(
 
     /* Optionally dump address information. */
     if (vs->dump_address)
-        WT_RET(__wt_msg(session, "%s %s", __verify_addr_string(session, ref, vs->tmp1),
-          __wt_page_type_string(page->type)));
+        WT_RET(__wt_msg(session, "%s %s write gen: %" PRIu64,
+          __verify_addr_string(session, ref, vs->tmp1), __wt_page_type_string(page->type),
+          page->dsk->write_gen));
 
     /* Track the shape of the tree. */
     if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -385,9 +385,9 @@ __verify_addr_string(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *buf)
     WT_ERR(__wt_scr_alloc(session, 0, &tmp));
 
     if (__wt_ref_addr_copy(session, ref, &addr)) {
-        WT_ERR(
-          __wt_buf_fmt(session, buf, "%s %s", __wt_addr_string(session, addr.addr, addr.size, tmp),
-            __wt_time_aggregate_to_string(&addr.ta, time_string)));
+        WT_ERR(__wt_buf_fmt(session, buf, "%-43s %s",
+          __wt_addr_string(session, addr.addr, addr.size, tmp),
+          __wt_time_aggregate_to_string(&addr.ta, time_string)));
     } else
         WT_ERR(__wt_buf_fmt(session, buf, "%s -/-,-/-", __wt_addr_string(session, NULL, 0, tmp)));
 
@@ -456,7 +456,7 @@ __verify_tree(
 
     /* Optionally dump address information. */
     if (vs->dump_address)
-        WT_RET(__wt_msg(session, "%s %s write gen: %" PRIu64,
+        WT_RET(__wt_msg(session, "%s %-18s write gen: %" PRIu64,
           __verify_addr_string(session, ref, vs->tmp1), __wt_page_type_string(page->type),
           page->dsk->write_gen));
 

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -65,7 +65,7 @@ __wt_time_aggregate_to_string(WT_TIME_AGGREGATE *ta, char *ta_string)
     char ts_string[4][WT_TS_INT_STRING_SIZE];
 
     WT_IGNORE_RET(__wt_snprintf(ta_string, WT_TIME_STRING_SIZE,
-      "newest durable: %s/%s oldest start: %s/%" PRIu64 " newest stop %s/%" PRIu64 "%s",
+      "newest durable: %s/%s oldest start: %s/%" PRIu64 " newest stop: %s/%" PRIu64 "%s",
       __wt_timestamp_to_string(ta->newest_start_durable_ts, ts_string[0]),
       __wt_timestamp_to_string(ta->newest_stop_durable_ts, ts_string[1]),
       __wt_timestamp_to_string(ta->oldest_start_ts, ts_string[2]), ta->newest_txn,


### PR DESCRIPTION
Have added workgen info to wt-verify dump output.

We have attempted to align the columns for easier reading, it is currently hard coded just as a demonstration to see if this is something that is even wanted (this is not in the ticket scope). Downsides of aligning the columns is mostly that we will be adding unnecessary white space in most columns, which causes the output to wrap on the cmd line (which makes it more difficult to read anyways).