### PR TITLE
WT-3515 Abort the child and exit the parent if child never creates

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -1782,6 +1782,8 @@ main(int argc, char *argv[])
                 }
             }
             sleep(timeout);
+            sa.sa_handler = SIG_DFL;
+            testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
 
             /*
              * !!! It should be plenty long enough to make sure more than
@@ -1789,8 +1791,6 @@ main(int argc, char *argv[])
              * here.
              */
             printf("Kill child\n");
-            sa.sa_handler = SIG_DFL;
-            testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
             testutil_assert_errno(kill(pid, SIGKILL) == 0);
             testutil_assert_errno(waitpid(pid, &status, 0) != -1);
 

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -1763,8 +1763,6 @@ main(int argc, char *argv[])
              * correctly on really slow machines.
              */
             wait_time = 0;
-            sa.sa_handler = SIG_DFL;
-            testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
             while (!testutil_exists(NULL, ckpt_file)) {
                 testutil_sleep_wait(1, pid);
                 ++wait_time;
@@ -1775,6 +1773,8 @@ main(int argc, char *argv[])
                  * eventually exit and not have the parent process hang.
                  */
                 if (wait_time > MAX_TIME) {
+                    sa.sa_handler = SIG_DFL;
+                    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
                     testutil_assert_errno(kill(pid, SIGABRT) == 0);
                     testutil_assert_errno(waitpid(pid, &status, 0) != -1);
                     testutil_die(
@@ -1789,6 +1789,8 @@ main(int argc, char *argv[])
              * here.
              */
             printf("Kill child\n");
+            sa.sa_handler = SIG_DFL;
+            testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
             testutil_assert_errno(kill(pid, SIGKILL) == 0);
             testutil_assert_errno(waitpid(pid, &status, 0) != -1);
 

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -1528,7 +1528,7 @@ main(int argc, char *argv[])
     struct sigaction sa;
     pid_t pid;
     uint32_t iteration, num_iterations, rand_value, timeout, tmp;
-    int ch, status, ret;
+    int ch, ret, status, wait_time;
     char buf[PATH_MAX], bucket[512];
     char cwd_start[PATH_MAX]; /* The working directory when we started */
     bool rand_th, rand_time, verify_only;
@@ -1762,11 +1762,26 @@ main(int argc, char *argv[])
              * from the time we notice that the file has been created. That allows the test to run
              * correctly on really slow machines.
              */
-            while (!testutil_exists(NULL, ckpt_file))
-                testutil_sleep_wait(1, pid);
-            sleep(timeout);
+            wait_time = 0;
             sa.sa_handler = SIG_DFL;
             testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
+            while (!testutil_exists(NULL, ckpt_file)) {
+                testutil_sleep_wait(1, pid);
+                ++wait_time;
+                /*
+                 * We want to wait the MAX_TIME not the timeout because the timeout chosen could be
+                 * smaller than the time it takes to start up the child and complete the first
+                 * checkpoint. If there's an issue creating the first checkpoint we just want to
+                 * eventually exit and not have the parent process hang.
+                 */
+                if (wait_time > MAX_TIME) {
+                    testutil_assert_errno(kill(pid, SIGABRT) == 0);
+                    testutil_assert_errno(waitpid(pid, &status, 0) != -1);
+                    testutil_die(
+                      ENOENT, "waited %" PRIu32 " seconds for checkpoint file creation", wait_time);
+                }
+            }
+            sleep(timeout);
 
             /*
              * !!! It should be plenty long enough to make sure more than


### PR DESCRIPTION
checkpoint file.

This takes care of the first item in this old ticket. The second item in the ticket (adding a clean shutdown option) is a lot more involved and I don't plan to do it.