### PR TITLE
WT-12255 Fix parsing the --ignore-stdout param of the WT python test suite.

### DIFF
--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -429,7 +429,7 @@ if __name__ == '__main__':
                 if verbose < 0:
                         verbose = 0
                 continue
-            if option == '--ignore-stdout' or option == 'i':
+            if option == '-ignore-stdout' or option == 'i':
                 ignoreStdout = True
                 continue
             if option == '-config' or option == 'c':


### PR DESCRIPTION
wiredtiger/test/suite/run.py parses the --ignore-stdout parameter incorrectly. It should check for -ignore-stdout not --ignore-stdout since one - has been removed already.