### PR TITLE
WT-11529 Disable reconciliation when reading a checkpoint

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -47,6 +47,8 @@ WT_STAT_USECS_HIST_INCR_FUNC(opwrite, perf_hist_opwrite_latency)
                 __saved_txn = NULL;                                                         \
             } else {                                                                        \
                 (session)->txn = (cbt)->checkpoint_txn;                                     \
+                /* Reconciliation is disabled when reading a checkpoint. */                 \
+                F_SET((session), WT_SESSION_NO_RECONCILE);                                  \
                 if ((cbt)->checkpoint_hs_dhandle != NULL) {                                 \
                     WT_ASSERT(session, (session)->hs_checkpoint == NULL);                   \
                     (session)->hs_checkpoint = (cbt)->checkpoint_hs_dhandle->checkpoint;    \
@@ -59,6 +61,7 @@ WT_STAT_USECS_HIST_INCR_FUNC(opwrite, perf_hist_opwrite_latency)
         op;                                                                                 \
         if (__saved_txn != NULL) {                                                          \
             (session)->txn = __saved_txn;                                                   \
+            F_CLR((session), WT_SESSION_NO_RECONCILE);                                      \
             (session)->hs_checkpoint = NULL;                                                \
             (session)->checkpoint_write_gen = __saved_write_gen;                            \
         }                                                                                   \

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -38,8 +38,9 @@ WT_STAT_USECS_HIST_INCR_FUNC(opwrite, perf_hist_opwrite_latency)
     do {                                                                                    \
         WT_TXN *__saved_txn;                                                                \
         uint64_t __saved_write_gen = (session)->checkpoint_write_gen;                       \
-        bool no_reconcil_set;                                                               \
+        bool no_reconcile_set;                                                              \
                                                                                             \
+        no_reconcile_set = F_ISSET((session), WT_SESSION_NO_RECONCILE);                     \
         if ((cbt)->checkpoint_txn != NULL) {                                                \
             __saved_txn = (session)->txn;                                                   \
             if (F_ISSET(__saved_txn, WT_TXN_IS_CHECKPOINT)) {                               \
@@ -49,7 +50,6 @@ WT_STAT_USECS_HIST_INCR_FUNC(opwrite, perf_hist_opwrite_latency)
             } else {                                                                        \
                 (session)->txn = (cbt)->checkpoint_txn;                                     \
                 /* Reconciliation is disabled when reading a checkpoint. */                 \
-                no_reconcile_set = F_ISSET((session), WT_SESSION_NO_RECONCILE);             \
                 F_SET((session), WT_SESSION_NO_RECONCILE);                                  \
                 if ((cbt)->checkpoint_hs_dhandle != NULL) {                                 \
                     WT_ASSERT(session, (session)->hs_checkpoint == NULL);                   \

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -769,7 +769,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
     }
     /*
      * If reconciliation is disabled for this thread (e.g., during an eviction that writes to the
-     * history store), give up.
+     * history store or reading a checkpoint), give up.
      */
     if (F_ISSET(session, WT_SESSION_NO_RECONCILE))
         return (__wt_set_return(session, EBUSY));


### PR DESCRIPTION
I tried to reproduce this issue but it is too specific and hard to trigger.