### PR TITLE
WT-12258 Remove use of deprecated -A flag in s_release

### DIFF
--- a/dist/s_release
+++ b/dist/s_release
@@ -26,7 +26,7 @@ else
 fi
 
 echo "Running 'dist/s_all' in the release tree"
-(cd "$DEST/dist" && env WT_RELEASE_BUILD=yes bash s_all -A > /dev/null)
+(cd "$DEST/dist" && env WT_RELEASE_BUILD=yes bash s_all > /dev/null)
 
 echo "Building documentation"
 (cd "$DEST/dist" && bash s_docs > /dev/null)


### PR DESCRIPTION
We removed the dead `-A` flag from `s_all` in WT-12198, but missed one usage in `s_release`. This failure was silently ignored until we fixed up `s_all`'s error reporting in WT-12247, and now this is causing the `package` task to fail on each run.

This PR removes the deprecated use of the `-A` flag in `s_release`