### PR TITLE
WT-12211 Fix PATH env variable in hang analyzer to generate python core dump (#10078) (v6.0)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -564,7 +564,7 @@ functions:
         wt_hang_analyzer_option="-c -o file -o stdout"
 
         echo "Calling the wt hang analyzer ..."
-        PATH="/opt/mongodbtoolchain/gdb/bin:$PATH" ${python_binary|python3} ../test/wt_hang_analyzer/wt_hang_analyzer.py $wt_hang_analyzer_option
+        PATH="/opt/mongodbtoolchain/v4/bin:$PATH" ${python_binary|python3} ../test/wt_hang_analyzer/wt_hang_analyzer.py $wt_hang_analyzer_option
 
   "save wt hang analyzer core/debugger files":
     - command: archive.targz_pack


### PR DESCRIPTION
Fix PATH env variable in hang analyzer to generate python core dump

(cherry picked from commit 6182fab3e84fb35ab918463c5a4dd1770d6b9978)