### PR TITLE
WT-12261 Fix python test suites failing to preserve files

### DIFF
--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -510,7 +510,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                     else:
                         teardown_msg += "; " + str(tmp[1])
 
-        passed = not (self.failed() or teardown_failed)
+        passed = "None" if self.skipped else not (self.failed() or teardown_failed)
 
         try:
             self.platform_api.tearDown()
@@ -579,11 +579,6 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             self.pr('preserving directory ' + self.testdir)
         if WiredTigerTestCase._verbose > 2:
             self.prhead('TEST COMPLETED')
-
-    # Returns None if testcase is running.  If during (or after) tearDown,
-    # will return True or False depending if the test case failed.
-    def failed(self):
-        return self._failed
 
     def backup(self, backup_dir, session=None):
         if session is None:

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -510,7 +510,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                     else:
                         teardown_msg += "; " + str(tmp[1])
 
-        passed = "None" if self.skipped else not (self.failed() or teardown_failed)
+        passed = not (self.failed() or teardown_failed)
 
         try:
             self.platform_api.tearDown()
@@ -552,7 +552,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             # always get back to original directory
             os.chdir(self.origcwd)
 
-        self.pr('passed=' + str(passed))
+        if not self.skipped:
+            self.pr('passed=' + str(passed))
         self.pr('skipped=' + str(self.skipped))
 
         # Clean up unless there's a failure


### PR DESCRIPTION
WT-11101 introduced a new abstract class `AbstractWiredTigerTestCase` which implements a new `failed()` method. This is currently being overridden by the existing `failed` method in the class `WiredTigerTestCase`. This results in the `passed` variable being incorrectly set and therefore failing to preserve database files on failure. I've removed the original `failed` method so that the correct method is used.