### PR TITLE
WT-12262 Fix the evict stuck condition 

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -784,7 +784,7 @@ __evict_pass(WT_SESSION_IMPL *session)
          * rolling back transactions and writing updates to the history store table.
          */
         if (eviction_progress == cache->eviction_progress) {
-            if (WT_CLOCKDIFF_MS(time_now, time_prev) >= 20 && F_ISSET(cache, WT_CACHE_EVICT_HARD)) {
+            if (WT_CLOCKDIFF_MS(time_now, time_prev) >= 20 && F_ISSET(cache, WT_CACHE_EVICT_ALL)) {
                 if (cache->evict_aggressive_score < WT_EVICT_SCORE_MAX)
                     ++cache->evict_aggressive_score;
                 oldest_id = txn_global->oldest_id;

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -115,7 +115,7 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
                 c1[i] = 100
             else:
                 c1[i] = i
-	    if i % 101 == 0:
+            if i % 101 == 0:
                 s.commit_transaction()
                 s.begin_transaction()
         c1.close()

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -115,6 +115,9 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
                 c1[i] = 100
             else:
                 c1[i] = i
+	    if i % 101 == 0:
+                s.commit_transaction()
+                s.begin_transaction()
         c1.close()
         s.commit_transaction()
         s.checkpoint()


### PR DESCRIPTION
when cache flag is WT_CACHE_EVICT_ALL, we shold determine if evict is blocked.