### PR TITLE
WT-12274 Reduce pre-merge testing turnaround time

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1926,7 +1926,7 @@ tasks:
 
   # End of cppsuite test tasks.
   # Start of csuite test tasks
-  - name: csuite-tests-pull-request
+  - name: csuite-tests-fast
     tags: ["pull_request"]
     commands:
       - func: "get project"
@@ -5336,7 +5336,7 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: compile
-    - name: make-check-test
+    - name: csuite-tests-fast
     - name: fops
     - name: catch2-unittest-test
     - name: examples-c-test


### PR DESCRIPTION
The pre-merge testing (Commit Queue patch builds) takes over 50 mins to finish these days, with the longest-running task `make-check-test` (from the "! Ubuntu 20.04 Minimal" builder) taking over 49 mins.  

The changes in this PR are aimed at bringing down the pre-merge testing turnaround time to under 30 mins, which includes:

- Give the existing `csuite-tests-pull-request` task a more generic name to reflect "running time" instead of "where it's used".
- Use the renamed `csuite-tests-pull-request` task to replace the `make-check-test` task in the "! Ubuntu 20.04 Minimal" builder.

As a tradeoff, this solution reduces the test coverage ("csuite tests" is a major part of "make check tests") for the pre-merge testing to achieve faster turnaround time. The full `make-check-test` has been covered by the PR testing phase (with split tasks to achieve parallelism), making it less critical to be covered again by the later per-merge testing phase. 