### PR TITLE
WT-12232 Add check home directory message for incorrect wt tool usage

### DIFF
--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -307,10 +307,10 @@ open:
     config = p;
 
     if ((ret = wiredtiger_open(home, verbose ? verbose_handler : NULL, config, &conn)) != 0) {
+        (void)util_err(NULL, ret, NULL);
         fprintf(stderr,
           "Note: Check if home directory issue (not provided or incorrect) is contributing to this "
           "error.\n");
-        (void)util_err(NULL, ret, NULL);
         goto err;
     }
 

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -309,8 +309,9 @@ open:
     if ((ret = wiredtiger_open(home, verbose ? verbose_handler : NULL, config, &conn)) != 0) {
         (void)util_err(NULL, ret, NULL);
         fprintf(stderr,
-          "Note: Check if home directory issue (not provided or incorrect) is contributing to this "
-          "error.\n");
+          "Note: This issue typically arises from running wt util in an incorrect directory or not "
+          "specifying one. Ensure you execute wt within a WiredTiger directory, or use the -h flag "
+          "to direct it to one.\n");
         goto err;
     }
 

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -309,7 +309,7 @@ open:
     if ((ret = wiredtiger_open(home, verbose ? verbose_handler : NULL, config, &conn)) != 0) {
         (void)util_err(NULL, ret, NULL);
         fprintf(stderr,
-          "Note: This issue typically arises from running wt util in an incorrect directory or not "
+          "Note: this issue typically arises from running wt util in an incorrect directory or not "
           "specifying one. Ensure you execute wt within a WiredTiger directory, or use the -h flag "
           "to direct it to one.\n");
         goto err;

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -307,6 +307,9 @@ open:
     config = p;
 
     if ((ret = wiredtiger_open(home, verbose ? verbose_handler : NULL, config, &conn)) != 0) {
+        fprintf(stderr,
+          "Note: Check if home directory issue (not provided or incorrect) is contributing to this "
+          "error.\n");
         (void)util_err(NULL, ret, NULL);
         goto err;
     }


### PR DESCRIPTION
Add note - provide a home directory or check provided home directory is correct.

[Prior approach](https://github.com/wiredtiger/wiredtiger/pull/10102) provided usage info for the wt tool commands but was not extensible to some edge cases