### PR TITLE
WT-12275 Disable FLCS scenario from test_prefetch02.py

### DIFF
--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -44,7 +44,7 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
 
     format_values = [
         ('col_var', dict(key_format='r', value_format='i')),
-        #FIXME-WT-12276: Renable FLCS scenario once prefetch bug has been identified and fixed.
+        #FIXME-WT-12276: Re-enable FLCS scenario once prefetch bug has been identified and fixed.
         # ('col_fix', dict(key_format='r', value_format='8t')),
         ('row_int', dict(key_format='i', value_format='i')),
     ]

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -44,7 +44,8 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
 
     format_values = [
         ('col_var', dict(key_format='r', value_format='i')),
-        ('col_fix', dict(key_format='r', value_format='8t')),
+        #FIXME-WT-12276: Renable FLCS scenario once prefetch bug has been identified and fixed.
+        # ('col_fix', dict(key_format='r', value_format='8t')),
         ('row_int', dict(key_format='i', value_format='i')),
     ]
 


### PR DESCRIPTION
As part of bug fixes for WT-12222 and WT-12229, disable the FLCS scenario as it is the suspected failure mode.