### PR TITLE
WT-12279 Fix evict_candidates can not exceed 50% of the entries

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1336,6 +1336,9 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
              * don't exclude it.
              */
             queue->evict_candidates = 1 + candidates + ((entries - candidates) - 1) / 3;
+            if (queue->evict_candidates > entries / 2)
+                queue->evict_candidates = entries / 2;
+
             cache->read_gen_oldest = read_gen_oldest;
         }
     }


### PR DESCRIPTION
evict lru walk perfect, evict_candidates can not excced 50% of the entries