### PR TITLE
WT-12246 Check timestamps are in order when taking a checkpoint

### DIFF
--- a/test/suite/test_timestamp02.py
+++ b/test/suite/test_timestamp02.py
@@ -221,6 +221,9 @@ class test_timestamp02(wttest.WiredTigerTestCase, suite_subprocess):
         # Verify the ooo ts has been detected.
         self.assertEqual(self.get_stat(stat.conn.txn_set_ts_force), 1)
 
+        # Restore the system in a correct state.
+        self.conn.set_timestamp('force,oldest_timestamp=' + self.timestamp_str(302))
+
     def test_read_your_writes(self):
         self.session.create(self.uri,
             'key_format=i,value_format=i' + self.extra_config)


### PR DESCRIPTION
This is additional code to ensure applications don't set timestamps in the wrong order before taking a checkpoint:

- Added a check so we never take a checkpoint when the stable timestamp is less than the oldest timestamp, otherwise we could persist invalid data.
- Modified an exiting test as the timestamps were out of order and closing the connection would trigger a checkpoint that would hit the newly added assertion.