### PR TITLE
Revert "WT-12083 Extend conn_api.c to support new get_configuration method"

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1041,12 +1041,8 @@ connection_ops(WT_CONNECTION *conn)
     /*! [Reconfigure a connection] */
 
     /*! [Get the database home directory] */
-    printf("The database home is: %s\n", conn->get_home(conn));
+    printf("The database home is %s\n", conn->get_home(conn));
     /*! [Get the database home directory] */
-
-    /*! [Get the configuration string] */
-    printf("The configuration is: %s\n", conn->get_configuration(conn));
-    /*! [Get the configuration string] */
 
     /*! [Check if the database is newly created] */
     if (conn->is_new(conn)) {

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1339,16 +1339,6 @@ err:
 }
 
 /*
- * __conn_get_configuration --
- *     WT_CONNECTION.get_configuration method.
- */
-static const char *
-__conn_get_configuration(WT_CONNECTION *wt_conn)
-{
-    return (((WT_CONNECTION_IMPL *)wt_conn)->cfg);
-}
-
-/*
  * __conn_open_session --
  *     WT_CONNECTION->open_session method.
  */
@@ -2766,8 +2756,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
   WT_CONNECTION **connectionp)
 {
     static const WT_CONNECTION stdc = {__conn_close, __conn_debug_info, __conn_reconfigure,
-      __conn_get_configuration, __conn_get_home, __conn_configure_method, __conn_is_new,
-      __conn_open_session, __conn_query_timestamp, __conn_set_timestamp, __conn_rollback_to_stable,
+      __conn_get_home, __conn_configure_method, __conn_is_new, __conn_open_session,
+      __conn_query_timestamp, __conn_set_timestamp, __conn_rollback_to_stable,
       __conn_load_extension, __conn_add_data_source, __conn_add_collator, __conn_add_compressor,
       __conn_add_encryptor, __conn_add_extractor, __conn_set_file_system, __conn_add_storage_source,
       __conn_get_storage_source, __conn_get_extension_api};

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2492,16 +2492,6 @@ struct __wt_connection {
     int __F(reconfigure)(WT_CONNECTION *connection, const char *config);
 
     /*!
-     * The configuration string of the connection.
-     *
-     * @snippet ex_all.c Get the configuration string
-     *
-     * @param connection the connection handle
-     * @returns a pointer to a string naming the configuration string
-     */
-    const char * __F(get_configuration)(WT_CONNECTION *connection);
-
-    /*!
      * The home directory of the connection.
      *
      * @snippet ex_all.c Get the database home directory


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#9932

Revert in anticipation of complications with respect to the work on optimizing configuration parsing.