### PR TITLE
WT-11239 Add CLANG_C/CXX_VERSION compile flags to the configure wiredtiger task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -181,6 +181,8 @@ functions:
           ${HAVE_DIAGNOSTIC|} \
           ${GNU_C_VERSION|} \
           ${GNU_CXX_VERSION|} \
+          ${CLANG_C_VERSION|} \
+          ${CLANG_CXX_VERSION|} \
           ${ENABLE_AZURE|} \
           ${ENABLE_CPPSUITE|} \
           ${ENABLE_GCP|} \
@@ -1526,10 +1528,6 @@ tasks:
         vars:
           HAVE_DIAGNOSTIC: -DHAVE_DIAGNOSTIC=0
           CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=Debug
-      - func: "compile wiredtiger"
-        vars:
-          CLANG_C_VERSION: -DCLANG_C_VERSION=6.0
-          CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=6.0
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=7


### PR DESCRIPTION
This is a pretty straight forward change. Most of the work took place on the platform config side.

A while back we updated the `configure wiredtiger` task but missed the `CLANG_C_VERSION` and `CLANG_CXX_VERSION` settings. This meant all of our `compile-clang` tasks defaulted to the mongotoolchain instead of using older clang versions as intended.
During this period where the wrong version of clang was used there we installed more recent versions of gcc on the host. Non-mongotoolchain versions of Clang use the latest version of gcc for the C runtime, and assume we can use the same version for the C++ libraries. Since we had gcc11 on the host they also tried to use `/usr/include/c++/11` libraries, but it wasn't installed and gave us `fatal error: 'algorithm' file not found` errors.

Now that g++11 is installed on the host the flags can be added back in and compilation succeeds.

Note I've dropped the clang-6.0 task as WiredTiger's min supported Clang version is 7.0.1