### PR TITLE
WT-12308 Generate stats in JSON formats in several tests

### DIFF
--- a/bench/workgen/runner/many-dhandle-stress.py
+++ b/bench/workgen/runner/many-dhandle-stress.py
@@ -66,7 +66,7 @@ sample_rate=1
 
 context = Context()
 conn_config = ""
-conn_config += ",cache_size=10G,eviction=(threads_min=4,threads_max=4),file_manager=(close_idle_time=30),session_max=1000,statistics=[all,clear],statistics_log=(wait=1,json=false,on_close=true)"   # explicitly added
+conn_config += ",cache_size=10G,eviction=(threads_min=4,threads_max=4),file_manager=(close_idle_time=30),session_max=1000,statistics=[all,clear],statistics_log=(wait=1,json=true,on_close=true)"   # explicitly added
 conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 

--- a/bench/workgen/runner/skiplist_stress.py
+++ b/bench/workgen/runner/skiplist_stress.py
@@ -37,7 +37,7 @@ from workgen import *
 
 context = Context()
 # Connection configuration.
-conn_config = "cache_size=100MB,log=(enabled=false),statistics=[fast],statistics_log=(wait=1,json=false),debug_mode=(stress_skiplist=1)"
+conn_config = "cache_size=100MB,log=(enabled=false),statistics=[fast],statistics_log=(wait=1,json=true),debug_mode=(stress_skiplist=1)"
 conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 

--- a/bench/workgen/runner/split_stress.py
+++ b/bench/workgen/runner/split_stress.py
@@ -37,7 +37,7 @@ from workgen import *
 
 context = Context()
 # Connection configuration.
-conn_config = "cache_size=100MB,log=(enabled=false),statistics=[fast],statistics_log=(wait=1,json=false)"
+conn_config = "cache_size=100MB,log=(enabled=false),statistics=[fast],statistics_log=(wait=1,json=true)"
 conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4690,7 +4690,7 @@ tasks:
         vars:
           perf-test-name: evict-fairness.wtperf
           maxruns: 1
-          wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=false,sources=[file:])", "-o reopen_connection=false"'] -ops ['"eviction_page_seen"']
+          wtarg: -args ['"-C statistics_log=(wait=10000,on_close=true,json=true,sources=[file:])", "-o reopen_connection=false"'] -ops ['"eviction_page_seen"']
       - func: "validate-expected-stats"
         vars:
           stat_file: './test_stats/evergreen_out_evict-fairness.wtperf.json'

--- a/test/suite/test_gc03.py
+++ b/test/suite/test_gc03.py
@@ -33,7 +33,7 @@ from wtdataset import SimpleDataSet
 # test_gc03.py
 # Test that checkpoint cleans the obsolete history store pages that are in-memory.
 class test_gc03(test_gc_base):
-    conn_config = 'cache_size=4GB,statistics=(all),statistics_log=(wait=0,on_close=true)'
+    conn_config = 'cache_size=4GB,statistics=(all),statistics_log=(json,wait=0,on_close=true)'
 
     def get_stat(self, stat):
         stat_cursor = self.session.open_cursor('statistics:')


### PR DESCRIPTION
The JSON format is necessary to process generated stats in T2. While most tests generate stats in the JSON format, a few don't. This PR updates a few tests left behind. 