### PR TITLE
WT-12330 Reset testutil tiered storage options when closing connection.

### DIFF
--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -420,6 +420,9 @@ wt_shutdown(void)
     if (g.conn == NULL)
         return (0);
 
+    if (g.opts.tiered_storage)
+        testutil_tiered_end(&g.opts);
+
     printf("Closing connection\n");
     fflush(stdout);
     ret = g.conn->close(g.conn, NULL);

--- a/test/csuite/schema_abort/smoke.sh
+++ b/test/csuite/schema_abort/smoke.sh
@@ -39,8 +39,3 @@ $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x
 $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -S
 $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -m
 $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -m -c
-
-$TEST_WRAPPER "$test_bin" -t 10 -T 5 -PT -Po dir_store
-$TEST_WRAPPER "$test_bin" -t 10 -T 5 -c -PT -Po dir_store
-$TEST_WRAPPER "$test_bin" -t 10 -T 5 -z -PT -Po dir_store
-$TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -PT -Po dir_store

--- a/test/csuite/schema_abort/smoke.sh
+++ b/test/csuite/schema_abort/smoke.sh
@@ -39,3 +39,8 @@ $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x
 $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -S
 $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -m
 $TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -m -c
+
+$TEST_WRAPPER "$test_bin" -t 10 -T 5 -PT -Po dir_store
+$TEST_WRAPPER "$test_bin" -t 10 -T 5 -c -PT -Po dir_store
+$TEST_WRAPPER "$test_bin" -t 10 -T 5 -z -PT -Po dir_store
+$TEST_WRAPPER "$test_bin" -t 10 -T 5 -x -PT -Po dir_store

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -557,6 +557,7 @@ void testutil_system(const char *fmt, ...) WT_GCC_FUNC_ATTRIBUTE((format(printf,
 void testutil_wiredtiger_open(
   TEST_OPTS *, const char *, const char *, WT_EVENT_HANDLER *, WT_CONNECTION **, bool, bool);
 void testutil_tiered_begin(TEST_OPTS *);
+void testutil_tiered_end(TEST_OPTS *);
 void testutil_tiered_flush_complete(TEST_OPTS *, WT_SESSION *, void *);
 void testutil_tiered_sleep(TEST_OPTS *, WT_SESSION *, uint64_t, bool *);
 void testutil_tiered_storage_configuration(

--- a/test/utility/tiered.c
+++ b/test/utility/tiered.c
@@ -54,6 +54,17 @@ testutil_tiered_begin(TEST_OPTS *opts)
 }
 
 /*
+ * testutil_tiered_end --
+ *     Clear tiered storage test state for a program that supports tiered storage.
+ */
+void
+testutil_tiered_end(TEST_OPTS *opts)
+{
+    testutil_assert(opts->tiered_begun);
+    opts->tiered_begun = false;
+}
+
+/*
  * testutil_tiered_sleep --
  *     Sleep for a number of seconds, or until it is time to flush_tier, or the process wants to
  *     exit.


### PR DESCRIPTION
`test/checkpoint` will call `testutil_tiered_begin` multiple times when invoked with the `-r` (# of runs) option. That function asserts that it is only called once. This change provides a way to clear the `TEST_OPTS.tiered_begun` flag so this failure doesn't happen.