### PR TITLE
WT-12330 Reset testutil tiered storage options when closing connection

### DIFF
--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -420,6 +420,9 @@ wt_shutdown(void)
     if (g.conn == NULL)
         return (0);
 
+    if (g.opts.tiered_storage)
+        testutil_tiered_end(&g.opts);
+
     printf("Closing connection\n");
     fflush(stdout);
     ret = g.conn->close(g.conn, NULL);

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -568,6 +568,7 @@ void testutil_system_internal(const char *function, uint32_t line, const char *f
 void testutil_wiredtiger_open(
   TEST_OPTS *, const char *, const char *, WT_EVENT_HANDLER *, WT_CONNECTION **, bool, bool);
 void testutil_tiered_begin(TEST_OPTS *);
+void testutil_tiered_end(TEST_OPTS *);
 void testutil_tiered_flush_complete(TEST_OPTS *, WT_SESSION *, void *);
 void testutil_tiered_sleep(TEST_OPTS *, WT_SESSION *, uint64_t, bool *);
 void testutil_tiered_storage_configuration(

--- a/test/utility/tiered.c
+++ b/test/utility/tiered.c
@@ -54,6 +54,17 @@ testutil_tiered_begin(TEST_OPTS *opts)
 }
 
 /*
+ * testutil_tiered_end --
+ *     Clear tiered storage test state for a program that supports tiered storage.
+ */
+void
+testutil_tiered_end(TEST_OPTS *opts)
+{
+    testutil_assert(opts->tiered_begun);
+    opts->tiered_begun = false;
+}
+
+/*
  * testutil_tiered_sleep --
  *     Sleep for a number of seconds, or until it is time to flush_tier, or the process wants to
  *     exit.


### PR DESCRIPTION
Second try :-) 

When we run `test_checkpoint` with the `-r` (# of runs) option, it winds up calling `testutil_tiered_begin()` multiple times. But that function checks and asserts that it is only called once. 

This adds a `testutil_tiered_end()` functions to clear the problem flag. It also gives us a matching pair of functions for any future tiered storage state we need to initialize or clear when opening and closing a connection. 