### PR TITLE
WT-11621 Implement a workload generator for the model

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1166,6 +1166,7 @@ rotn
 rpc
 rts
 ru
+runnable
 runone
 runtime
 rw

--- a/test/model/CMakeLists.txt
+++ b/test/model/CMakeLists.txt
@@ -9,11 +9,14 @@ add_library(wiredtiger_model SHARED
     src/core/kv_table.cpp
     src/core/kv_transaction.cpp
     src/core/kv_transaction_snapshot.cpp
+    src/core/random.cpp
     src/core/util.cpp
     src/core/verify.cpp
     src/driver/debug_log_parser.cpp
     src/driver/kv_workload.cpp
+    src/driver/kv_workload_generator.cpp
     src/driver/kv_workload_runner_wt.cpp
+    src/driver/kv_workload_sequence.cpp
 )
 
 target_include_directories(

--- a/test/model/src/core/random.cpp
+++ b/test/model/src/core/random.cpp
@@ -1,0 +1,73 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <limits>
+#include "model/random.h"
+
+namespace model {
+
+/*
+ * random::random --
+ *     Create a new instance of the random number generator.
+ */
+random::random(uint64_t seed) noexcept
+{
+    __wt_random_init_custom_seed(&_random_state, seed);
+}
+
+/*
+ * random::next_double --
+ *     Get the next double between 0 and 1.
+ */
+double
+random::next_double() noexcept
+{
+    return __wt_random(&_random_state) / (double)std::numeric_limits<uint32_t>::max();
+}
+
+/*
+ * random::next_float --
+ *     Get the next float between 0 and 1.
+ */
+float
+random::next_float() noexcept
+{
+    return __wt_random(&_random_state) / (float)std::numeric_limits<uint32_t>::max();
+}
+
+/*
+ * random::next_index --
+ *     Get the next index from the list of the given length.
+ */
+size_t
+random::next_index(size_t length)
+{
+    return (size_t)__wt_random(&_random_state) % length;
+}
+
+} /* namespace model */

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -1,0 +1,422 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <algorithm>
+#include "model/driver/kv_workload_generator.h"
+#include "model/util.h"
+
+namespace model {
+
+/*
+ * kv_workload_generator_spec::kv_workload_generator_spec --
+ *     Create the generator specifcation using default probability values.
+ */
+kv_workload_generator_spec::kv_workload_generator_spec()
+{
+    prepared_transaction = 0.25;
+    allow_set_commit_timestamp = 0.25;
+    nonprepared_transaction_rollback = 0.1;
+    prepared_transaction_rollback_after_prepare = 0.1;
+    prepared_transaction_rollback_before_prepare = 0.1;
+
+    insert = 0.7;
+    finish_transaction = 0.05;
+    remove = 0.15;
+    set_commit_timestamp = 0.05;
+    truncate = 0.05;
+
+    checkpoint = 0.1;
+    restart = 0.01;
+    set_stable_timestamp = 0.2;
+
+    max_concurrent_transactions = 3;
+}
+
+/*
+ * kv_workload_generator::kv_workload_generator --
+ *     Create a new workload generator.
+ */
+kv_workload_generator::kv_workload_generator(kv_workload_generator_spec spec, uint64_t seed)
+    : _workload_ptr(std::make_shared<kv_workload>()), _workload(*(_workload_ptr.get())),
+      _last_table_id(0), _last_txn_id(0), _random(seed), _spec(spec)
+{
+}
+
+/*
+ * kv_workload_transaction_ptr --
+ *     Generate a random transaction.
+ */
+kv_workload_transaction_ptr
+kv_workload_generator::generate_transaction()
+{
+    /* Choose the transaction ID and whether this will be a prepared transaction. */
+    txn_id_t txn_id = ++_last_txn_id;
+    bool prepared = _random.next_float() < _spec.prepared_transaction;
+
+    /* Start the new transaction. */
+    kv_workload_transaction_ptr txn_ptr =
+      std::make_shared<kv_workload_transaction>(txn_id, prepared);
+    kv_workload_transaction &txn = *txn_ptr.get();
+    txn << operation::begin_transaction(txn_id);
+
+    bool use_set_commit_timestamp =
+      !prepared && _random.next_float() < _spec.allow_set_commit_timestamp;
+    if (use_set_commit_timestamp)
+        txn << operation::set_commit_timestamp(txn_id, k_timestamp_none /* placeholder */);
+
+    /* Add all operations. But do not actually fill in timestamps; we'll do that later. */
+    bool done = false;
+    while (!done) {
+        probability_switch(_random.next_float())
+        {
+            probability_case(_spec.insert)
+            {
+                table_context_ptr table = choose_table(txn_ptr);
+                data_value key = generate_key(table);
+                data_value value = generate_value(table);
+                txn << operation::insert(table->id(), txn_id, key, value);
+            }
+            probability_case(_spec.finish_transaction)
+            {
+                if (prepared) {
+                    if (_random.next_float() < _spec.prepared_transaction_rollback_before_prepare)
+                        txn << operation::rollback_transaction(txn_id);
+                    else {
+                        txn << operation::prepare_transaction(
+                          txn_id, k_timestamp_none /* placeholder */);
+                        if (_random.next_float() <
+                          _spec.prepared_transaction_rollback_after_prepare)
+                            txn << operation::rollback_transaction(txn_id);
+                        else
+                            txn << operation::commit_transaction(txn_id);
+                    }
+                } else
+                    txn << operation::commit_transaction(txn_id);
+                done = true;
+            }
+            probability_case(_spec.remove)
+            {
+                table_context_ptr table = choose_table(txn_ptr);
+                data_value key = generate_key(table);
+                txn << operation::remove(table->id(), txn_id, key);
+            }
+            probability_case(_spec.set_commit_timestamp)
+            {
+                if (use_set_commit_timestamp)
+                    txn << operation::set_commit_timestamp(
+                      txn_id, k_timestamp_none /* placeholder */);
+            }
+            probability_case(_spec.truncate)
+            {
+                table_context_ptr table = choose_table(txn_ptr);
+                data_value start = generate_key(table);
+                data_value stop = generate_key(table);
+                if (start > stop)
+                    std::swap(start, stop);
+                txn << operation::truncate(table->id(), txn_id, start, stop);
+            }
+        }
+    }
+
+    return txn_ptr;
+}
+
+/*
+ * kv_workload_generator::fill_in_timestamps --
+ *     Fill in the timestamps.
+ */
+void
+kv_workload_generator::fill_in_timestamps(
+  kv_workload_sequence &sequence, timestamp_t first, timestamp_t last)
+{
+    if (first + 10 >= last)
+        throw model_exception("Need a bigger difference between first and last timestamp");
+
+    /* Special operation sequences. */
+    if (!sequence.transaction()) {
+        for (operation::any &op : sequence.operations()) {
+            if (std::holds_alternative<operation::set_stable_timestamp>(op)) {
+                timestamp_t t = first + _random.next_uint64(last - first);
+                std::get<operation::set_stable_timestamp>(op).stable_timestamp = t;
+                /* The "set stable timestamp" sequence has only one operation, so we're done. */
+                break;
+            }
+        }
+        return;
+    }
+
+    /* Transactions. */
+
+    /* Count the number of explicit timestamp sets. Find prepare and commit operations. */
+    size_t num_set_commit_timestamp = 0;
+    operation::prepare_transaction *prepare = nullptr;
+    operation::commit_transaction *commit = nullptr;
+    for (operation::any &op : sequence.operations()) {
+        if (std::holds_alternative<operation::set_commit_timestamp>(op))
+            num_set_commit_timestamp++;
+        if (std::holds_alternative<operation::prepare_transaction>(op))
+            prepare = &std::get<operation::prepare_transaction>(op);
+        if (std::holds_alternative<operation::commit_transaction>(op))
+            commit = &std::get<operation::commit_transaction>(op);
+    }
+
+    /* Non-prepared transactions. */
+    if (prepare == nullptr) {
+
+        /*
+         * Use floating point arithmetic in the unlikely case we'll need too many timestamps to
+         * avoid degenerate cases.
+         */
+        size_t timestamps_needed = num_set_commit_timestamp + 1;
+        double step = (last - first) / (double)timestamps_needed;
+
+        /* Pick timestamps for the "set commit timestamp" operations. */
+        double d = first;
+        size_t count = 1;
+        for (operation::any &op : sequence.operations())
+            if (std::holds_alternative<operation::set_commit_timestamp>(op)) {
+                double l = first + count * step;
+                d = d + _random.next_double() * (l - d);
+                count++;
+                std::get<operation::set_commit_timestamp>(op).commit_timestamp = (timestamp_t)d;
+            }
+
+        /*
+         * Counterintuitively, the commit timestamp applies to operations that come before the
+         * first set commit timestamp operation, but it cannot be less than the first timestamp.
+         */
+        timestamp_t commit_timestamp = (timestamp_t)(d + _random.next_double() * (last - d));
+        if (commit != nullptr)
+            commit->commit_timestamp = commit_timestamp;
+    }
+
+    /* Prepared transactions. */
+    else {
+        timestamp_t prepare_timestamp = first + _random.next_uint64(last - first - 10);
+        timestamp_t commit_timestamp =
+          prepare_timestamp + _random.next_uint64(last - prepare_timestamp - 5);
+        timestamp_t durable_timestamp =
+          commit_timestamp + _random.next_uint64(last - commit_timestamp);
+
+        prepare->prepare_timestamp = prepare_timestamp;
+        if (commit != nullptr) {
+            commit->commit_timestamp = commit_timestamp;
+            commit->durable_timestamp = durable_timestamp;
+        }
+    }
+}
+
+/*
+ * kv_workload_generator::generate --
+ *     Generate the workload.
+ */
+void
+kv_workload_generator::generate()
+{
+    /* Create tables. */
+    /* TODO: Should not be hard-coded. */
+    size_t num_tables = 2 + (size_t)_random.next_uint64(10);
+    for (size_t i = 0; i < num_tables; i++)
+        create_table();
+
+    /* Generate a serialized workload. We'll fill in timestamps and shuffle it later. */
+    /* TODO: Should not be hard-coded. */
+    size_t length = 100 + (size_t)_random.next_uint64(10);
+    for (size_t i = 0; i < length; i++)
+        probability_switch(_random.next_float())
+        {
+            probability_case(_spec.checkpoint)
+            {
+                kv_workload_sequence_ptr p = std::make_shared<kv_workload_sequence>();
+                *p << operation::checkpoint();
+                _sequences.push_back(p);
+            }
+            probability_case(_spec.set_stable_timestamp)
+            {
+                kv_workload_sequence_ptr p = std::make_shared<kv_workload_sequence>();
+                *p << operation::set_stable_timestamp(k_timestamp_none); /* Placeholder. */
+                // XXX _sequences.push_back(p);
+            }
+            probability_case(_spec.restart)
+            {
+                kv_workload_sequence_ptr p = std::make_shared<kv_workload_sequence>();
+                *p << operation::restart();
+                // XXX _sequences.push_back(p);
+            }
+            probability_default
+            {
+                _sequences.push_back(generate_transaction());
+            }
+        }
+
+    /* Position special sequences that are not transactions. */
+    size_t last_special = 0;
+    for (size_t i = 0; i < _sequences.size(); i++) {
+        if (_sequences[i]->transaction())
+            continue;
+
+        /* Position after all sequences since the last special sequence. */
+        for (size_t j = last_special; j < i; j++)
+            _sequences[j]->must_finish_before_starting(*_sequences[i].get());
+
+        last_special = i;
+    }
+
+    /* Add initial partial order, so that we don't have to do full N^2 dependency check. */
+    size_t concurrency_lookahead = 100;
+    for (size_t i = 0; i + concurrency_lookahead < _sequences.size(); i++)
+        _sequences[i]->must_finish_before_starting(*_sequences[i + concurrency_lookahead].get());
+
+    /*
+     * Find dependencies between the workload subsequences: If two sequences operate on the same
+     * keys, they must be run sequentially. If there is any overlap, the transaction in the
+     * second sequence will abort.
+     */
+    for (size_t i = 0; i < _sequences.size(); i++)
+        for (size_t j = i + 1; j < _sequences.size() && j < i + concurrency_lookahead; j++)
+            if (_sequences[i]->overlaps_with(*_sequences[j].get()))
+                _sequences[i]->must_finish_before_starting(*_sequences[j].get());
+
+    /* Fill in the timestamps based on the partial order. */
+    std::deque<kv_workload_sequence *> runnable;
+    for (kv_workload_sequence_ptr &seq : _sequences) {
+        seq->prepare_to_run();
+        if (seq->_unsatisfied_dependencies == 0)
+            runnable.push_front(seq.get());
+    }
+
+    timestamp_t first = 1;
+    timestamp_t step = 1000 - 1;
+    timestamp_t last = first + step;
+    while (!runnable.empty()) {
+        for (kv_workload_sequence *seq : runnable)
+            fill_in_timestamps(*seq, first, last);
+
+        std::deque<kv_workload_sequence *> next;
+        for (kv_workload_sequence *seq : runnable)
+            for (kv_workload_sequence *n : seq->runnable_after_finish())
+                if (n->_unsatisfied_dependencies.fetch_sub(1, std::memory_order_seq_cst) == 1)
+                    next.push_back(n);
+
+        runnable = next;
+        first = last + 1;
+        last = first + step;
+    }
+
+    /* Create an execution schedule, mixing operations from different transactions. */
+
+    // std::deque<kv_workload_sequence *> runnable;
+    runnable.clear();
+    for (kv_workload_sequence_ptr &seq : _sequences) {
+        seq->prepare_to_run();
+        if (seq->_unsatisfied_dependencies == 0)
+            runnable.push_front(seq.get());
+    }
+
+    while (!runnable.empty()) {
+
+        /* Take the next operation from one of the runnable sequences. */
+        size_t next_sequence_index =
+          _random.next_index(std::min(runnable.size(), _spec.max_concurrent_transactions));
+        kv_workload_sequence *next_sequence = runnable[next_sequence_index];
+
+        /* Assert that there is at least one operation left. */
+        const auto &next_sequence_operations = next_sequence->operations();
+        if (next_sequence->_index >= next_sequence_operations.size())
+            throw model_exception("Internal error: No more operations left in a sequence");
+
+        /* Get the next operation. */
+        _workload << next_sequence_operations[next_sequence->_index++];
+
+        /* If this is the last operation, complete the sequence execution. */
+        if (next_sequence->_index >= next_sequence_operations.size()) {
+            next_sequence->_done = true;
+            runnable.erase(runnable.begin() + next_sequence_index);
+            for (kv_workload_sequence *n : next_sequence->runnable_after_finish())
+                if (n->_unsatisfied_dependencies.fetch_sub(1, std::memory_order_seq_cst) == 1)
+                    runnable.push_back(n);
+        }
+    }
+}
+
+/*
+ * kv_workload_generator::choose_table --
+ *     Choose a table for an operation, creating one if necessary.
+ */
+kv_workload_generator::table_context_ptr
+kv_workload_generator::choose_table(kv_workload_transaction_ptr txn)
+{
+    /* TODO: In the future, transaction context will specify its own table distribution. */
+    (void)txn;
+
+    if (_tables.empty())
+        throw model_exception("No tables.");
+
+    return _tables_list[_random.next_index(_tables_list.size())];
+}
+
+/*
+ * kv_workload_generator::create_table --
+ *     Create a table.
+ */
+void
+kv_workload_generator::create_table()
+{
+    table_id_t id = ++_last_table_id;
+    std::string name = "table" + std::to_string(id);
+    std::string key_format = "Q";
+    std::string value_format = "Q";
+
+    table_context_ptr table = std::make_shared<table_context>(id, name, key_format, value_format);
+    _tables_list.push_back(table);
+    _tables[id] = table;
+
+    _workload << operation::create_table(table->id(), table->name().c_str(),
+      table->key_format().c_str(), table->value_format().c_str());
+}
+
+/*
+ * kv_workload_generator::random_data_value --
+ *     Generate a random data value, which can be used either as a key or a value.
+ */
+data_value
+kv_workload_generator::random_data_value(const std::string &format)
+{
+    if (format.length() != 1)
+        throw model_exception("The model does not currently support structs or types with sizes");
+
+    switch (format[0]) {
+    case 'Q':
+        /* TODO: Should not be hard coded. */
+        return data_value(_random.next_uint64(1000000));
+    default:
+        throw model_exception("Unsupported type.");
+    };
+}
+
+} /* namespace model */

--- a/test/model/src/driver/kv_workload_sequence.cpp
+++ b/test/model/src/driver/kv_workload_sequence.cpp
@@ -1,0 +1,130 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+extern "C" {
+#include "wt_internal.h"
+}
+
+#include "model/driver/kv_workload_sequence.h"
+#include "model/util.h"
+
+namespace model {
+
+/*
+ * kv_workload_sequence::overlaps_with --
+ *     Check whether this sequence overlaps in any key ranges with the other sequence.
+ */
+bool
+kv_workload_sequence::overlaps_with(const kv_workload_sequence &other) const
+{
+    for (auto &op : _operations) {
+        if (std::holds_alternative<operation::insert>(op)) {
+            table_id_t t = std::get<operation::insert>(op).table_id;
+            const data_value &k = std::get<operation::insert>(op).key;
+            if (other.contains_key(t, k, k))
+                return true;
+        }
+        if (std::holds_alternative<operation::remove>(op)) {
+            table_id_t t = std::get<operation::remove>(op).table_id;
+            const data_value &k = std::get<operation::remove>(op).key;
+            if (other.contains_key(t, k, k))
+                return true;
+        }
+        if (std::holds_alternative<operation::truncate>(op)) {
+            table_id_t t = std::get<operation::truncate>(op).table_id;
+            const data_value &a = std::get<operation::truncate>(op).start;
+            const data_value &b = std::get<operation::truncate>(op).stop;
+            if (other.contains_key(t, a, b))
+                return true;
+        }
+    }
+    return false;
+}
+
+/*
+ * kv_workload_sequence::contains_key --
+ *     Check whether the sequence contains an operation that touches any key in the range.
+ */
+bool
+kv_workload_sequence::contains_key(
+  table_id_t table_id, const data_value &start, const data_value &stop) const
+{
+    for (auto &op : _operations) {
+        if (std::holds_alternative<operation::insert>(op)) {
+            if (std::get<operation::insert>(op).table_id != table_id)
+                continue;
+            const data_value &k = std::get<operation::insert>(op).key;
+            if (start <= k && k <= stop)
+                return true;
+        }
+        if (std::holds_alternative<operation::remove>(op)) {
+            if (std::get<operation::remove>(op).table_id != table_id)
+                continue;
+            const data_value &k = std::get<operation::remove>(op).key;
+            if (start <= k && k <= stop)
+                return true;
+        }
+        if (std::holds_alternative<operation::truncate>(op)) {
+            if (std::get<operation::truncate>(op).table_id != table_id)
+                continue;
+            const data_value &a = std::get<operation::truncate>(op).start;
+            const data_value &b = std::get<operation::truncate>(op).stop;
+            if (start <= a && a <= stop)
+                return true;
+            if (start <= b && b <= stop)
+                return true;
+            if (a <= start && stop <= b)
+                return true;
+        }
+    }
+    return false;
+}
+
+/*
+ * kv_workload_sequence::must_start_before_starting --
+ *     Declare that the other sequence cannot start until this sequence starts.
+ */
+void
+kv_workload_sequence::must_start_before_starting(kv_workload_sequence &other)
+{
+    other._dependencies_start.push_back(this);
+    _runnable_after_start.push_back(&other);
+}
+
+/*
+ * kv_workload_sequence::must_finish_before_starting --
+ *     Declare that the other sequence cannot start until this sequence finishes.
+ */
+void
+kv_workload_sequence::must_finish_before_starting(kv_workload_sequence &other)
+{
+    other._dependencies_finish.push_back(this);
+    _runnable_after_finish.push_back(&other);
+}
+
+} /* namespace model */

--- a/test/model/src/driver/kv_workload_sequence.cpp
+++ b/test/model/src/driver/kv_workload_sequence.cpp
@@ -106,25 +106,14 @@ kv_workload_sequence::contains_key(
 }
 
 /*
- * kv_workload_sequence::must_start_before_starting --
- *     Declare that the other sequence cannot start until this sequence starts.
- */
-void
-kv_workload_sequence::must_start_before_starting(kv_workload_sequence &other)
-{
-    other._dependencies_start.push_back(this);
-    _runnable_after_start.push_back(&other);
-}
-
-/*
- * kv_workload_sequence::must_finish_before_starting --
+ * kv_workload_sequence::must_finish_before --
  *     Declare that the other sequence cannot start until this sequence finishes.
  */
 void
-kv_workload_sequence::must_finish_before_starting(kv_workload_sequence &other)
+kv_workload_sequence::must_finish_before(kv_workload_sequence *other)
 {
-    other._dependencies_finish.push_back(this);
-    _runnable_after_finish.push_back(&other);
+    other->_dependencies.push_back(this);
+    _unblocks.push_back(other);
 }
 
 } /* namespace model */

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -30,6 +30,7 @@
 #define MODEL_DRIVER_KV_WORKLOAD_H
 
 #include <deque>
+#include <iostream>
 #include <variant>
 #include "model/core.h"
 #include "model/data_value.h"
@@ -60,6 +61,17 @@ struct begin_transaction {
 };
 
 /*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const begin_transaction &op)
+{
+    out << "begin_transaction(" << op.txn_id << ")";
+    return out;
+}
+
+/*
  * checkpoint --
  *     A representation of this workload operation.
  */
@@ -72,6 +84,17 @@ struct checkpoint {
      */
     inline checkpoint(const char *name = nullptr) : name(name == nullptr ? "" : name) {}
 };
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const checkpoint &op)
+{
+    out << "checkpoint(" << op.name << ")";
+    return out;
+}
 
 /*
  * commit_transaction --
@@ -92,6 +115,18 @@ struct commit_transaction {
     {
     }
 };
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const commit_transaction &op)
+{
+    out << "commit_transaction(" << op.txn_id << ", " << op.commit_timestamp << ", "
+        << op.durable_timestamp << ")";
+    return out;
+}
 
 /*
  * create_table --
@@ -115,6 +150,18 @@ struct create_table {
 };
 
 /*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const create_table &op)
+{
+    out << "create_table(" << op.table_id << ", " << op.name << ", " << op.key_format << ", "
+        << op.value_format << ")";
+    return out;
+}
+
+/*
  * insert --
  *     A representation of this workload operation.
  */
@@ -136,6 +183,18 @@ struct insert {
 };
 
 /*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const insert &op)
+{
+    out << "insert(" << op.table_id << ", " << op.txn_id << ", " << op.key << ", " << op.value
+        << ")";
+    return out;
+}
+
+/*
  * prepare_transaction --
  *     A representation of this workload operation.
  */
@@ -152,6 +211,17 @@ struct prepare_transaction {
     {
     }
 };
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const prepare_transaction &op)
+{
+    out << "prepare_transaction(" << op.txn_id << ", " << op.prepare_timestamp << ")";
+    return out;
+}
 
 /*
  * remove --
@@ -173,6 +243,17 @@ struct remove {
 };
 
 /*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const remove &op)
+{
+    out << "remove(" << op.table_id << ", " << op.txn_id << ", " << op.key << ")";
+    return out;
+}
+
+/*
  * restart --
  *     A representation of this workload operation.
  */
@@ -184,6 +265,17 @@ struct restart {
      */
     inline restart() {}
 };
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const restart &op)
+{
+    out << "restart()";
+    return out;
+}
 
 /*
  * rollback_to_stable --
@@ -199,6 +291,17 @@ struct rollback_to_stable {
 };
 
 /*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const rollback_to_stable &op)
+{
+    out << "rollback_to_stable()";
+    return out;
+}
+
+/*
  * rollback_transaction --
  *     A representation of this workload operation.
  */
@@ -211,6 +314,17 @@ struct rollback_transaction {
      */
     inline rollback_transaction(txn_id_t txn_id) : txn_id(txn_id) {}
 };
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const rollback_transaction &op)
+{
+    out << "rollback_transaction(" << op.txn_id << ")";
+    return out;
+}
 
 /*
  * set_commit_timestamp --
@@ -231,6 +345,17 @@ struct set_commit_timestamp {
 };
 
 /*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const set_commit_timestamp &op)
+{
+    out << "set_commit_timestamp(" << op.txn_id << ", " << op.commit_timestamp << ")";
+    return out;
+}
+
+/*
  * set_stable_timestamp --
  *     A representation of this workload operation.
  */
@@ -245,6 +370,17 @@ struct set_stable_timestamp {
     {
     }
 };
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const set_stable_timestamp &op)
+{
+    out << "set_stable_timestamp(" << op.stable_timestamp << ")";
+    return out;
+}
 
 /*
  * truncate --
@@ -268,12 +404,35 @@ struct truncate {
 };
 
 /*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const truncate &op)
+{
+    out << "truncate(" << op.table_id << ", " << op.txn_id << ", " << op.start << ", " << op.stop
+        << ")";
+    return out;
+}
+
+/*
  * any --
  *     Any workload operation.
  */
 using any = std::variant<begin_transaction, checkpoint, commit_transaction, create_table, insert,
   prepare_transaction, remove, restart, rollback_to_stable, rollback_transaction,
   set_commit_timestamp, set_stable_timestamp, truncate>;
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const any &op)
+{
+    std::visit([&out](auto &&x) { out << x; }, op);
+    return out;
+}
 
 } /* namespace operation */
 
@@ -282,6 +441,8 @@ using any = std::variant<begin_transaction, checkpoint, commit_transaction, crea
  *     A workload representation for a key-value database.
  */
 class kv_workload {
+
+    friend std::ostream &operator<<(std::ostream &out, const kv_workload &workload);
 
 public:
     /*
@@ -327,6 +488,29 @@ public:
 private:
     std::deque<operation::any> _operations;
 };
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const kv_workload &workload)
+{
+    for (const operation::any &op : workload._operations)
+        out << op << std::endl;
+    return out;
+}
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const std::shared_ptr<kv_workload> &workload)
+{
+    out << *workload.get();
+    return out;
+}
 
 } /* namespace model */
 #endif

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -64,8 +64,8 @@ struct kv_workload_generator_spec {
     float use_set_commit_timestamp;
 
     /* Probabilities of operations within a transaction. */
-    float insert;
     float finish_transaction; /* Commit, prepare, or rollback. */
+    float insert;
     float remove;
     float set_commit_timestamp; /* If allowed. */
     float truncate;

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -29,7 +29,9 @@
 #ifndef MODEL_DRIVER_KV_WORKLOAD_GENERATOR_H
 #define MODEL_DRIVER_KV_WORKLOAD_GENERATOR_H
 
+#include <atomic>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include "model/driver/kv_workload.h"
@@ -44,16 +46,22 @@ namespace model {
  */
 struct kv_workload_generator_spec {
 
-    /* The probability of starting a prepared transaction. */
-    float prepared_transaction;
+    /* The minimum and maximum number of tables. */
+    size_t min_tables;
+    size_t max_tables;
 
-    /* The probability of allowing "set commit timestamp" in a transaction. */
-    float allow_set_commit_timestamp;
+    /* The minimum and maximum number of operation sequences, e.g., transactions. */
+    size_t min_sequences;
+    size_t max_sequences;
 
-    /* Probabilities of transaction rollback. */
-    float nonprepared_transaction_rollback;
-    float prepared_transaction_rollback_after_prepare;
-    float prepared_transaction_rollback_before_prepare;
+    /* The maximum number of concurrent transactions. */
+    size_t max_concurrent_transactions;
+
+    /* The maximum key/value to use in the generation. */
+    uint64_t max_value_uint64;
+
+    /* The probability of allowing the use of "set commit timestamp" in a transaction. */
+    float use_set_commit_timestamp;
 
     /* Probabilities of operations within a transaction. */
     float insert;
@@ -67,12 +75,17 @@ struct kv_workload_generator_spec {
     float restart;
     float set_stable_timestamp;
 
-    /* The maximum number of concurrent transactions. */
-    size_t max_concurrent_transactions;
+    /* The probability of starting a prepared transaction. */
+    float prepared_transaction;
+
+    /* Probabilities of transaction rollback. */
+    float nonprepared_transaction_rollback;
+    float prepared_transaction_rollback_after_prepare;
+    float prepared_transaction_rollback_before_prepare;
 
     /*
      * kv_workload_generator_spec::kv_workload_generator_spec --
-     *     Create the generator specifcation using default probability values.
+     *     Create the generator specification using default probability values.
      */
     kv_workload_generator_spec();
 };
@@ -156,7 +169,137 @@ protected:
      */
     using table_context_ptr = std::shared_ptr<table_context>;
 
+    /*
+     * sequence_state --
+     *     The traversal state for a sequence.
+     */
+    struct sequence_state {
+
+        /* The actual sequence. An unsafe pointer is okay, as we assume no concurrent uses. */
+        kv_workload_sequence *sequence;
+
+        /* The index of the next operation, if we are also going through their operations. */
+        size_t next_operation_index;
+
+        /* The number of operation sequences that must finish before we can visit this one. */
+        /* Make this atomic in anticipation of a future parallel executor. */
+        std::atomic<size_t> num_unsatisfied_dependencies;
+
+        /*
+         * sequence_state::sequence_state --
+         *     Initialize.
+         */
+        inline sequence_state(kv_workload_sequence *sequence)
+            : sequence(sequence), next_operation_index(0),
+              num_unsatisfied_dependencies(sequence->dependencies().size())
+        {
+        }
+    };
+
+    /*
+     * sequence_traversal --
+     *     The traversal state, when traversing the collection of sequences in order that satisfies
+     *     their dependencies. The traversal can be optionally also constrained by block the
+     *     sequence numbers (we need this when assigning timestamps).
+     */
+    struct sequence_traversal {
+
+    public:
+        /*
+         * sequence_traversal::sequence_traversal --
+         *     Initialize the traversal.
+         */
+        sequence_traversal(
+          std::deque<kv_workload_sequence_ptr> &sequences,
+          std::function<bool(kv_workload_sequence &)> barrier_fn = [](kv_workload_sequence &) {
+              return false;
+          });
+
+        /*
+         * sequence_traversal::~sequence_traversal --
+         *     Clean up after the traversal.
+         */
+        ~sequence_traversal()
+        {
+            for (auto p : _per_sequence_state)
+                delete p.second;
+        }
+
+        /*
+         * sequence_traversal::has_more --
+         *     Check if there are any more sequences left.
+         */
+        inline bool
+        has_more() const noexcept
+        {
+            return !_runnable.empty();
+        }
+
+        /*
+         * sequence_traversal::runnable --
+         *     Get the list of "runnable" operation sequences (which have satisfied dependencies).
+         */
+        inline const std::deque<sequence_state *> &
+        runnable() const
+        {
+            return _runnable;
+        }
+
+        /*
+         * sequence_traversal::complete_all --
+         *     Complete all "runnable" sequences and advance the iterator.
+         */
+        void complete_all();
+
+        /*
+         * sequence_traversal::complete_one --
+         *     Complete one "runnable" sequence and advance the iterator.
+         */
+        void complete_one(sequence_state *s);
+
+    protected:
+        /*
+         * sequence_traversal::advance_barrier --
+         *     Advance the barrier.
+         */
+        void advance_barrier();
+
+        /*
+         * sequence_traversal::find_next_barrier --
+         *     Find the next barrier.
+         */
+        size_t find_next_barrier(size_t start);
+
+    private:
+        std::function<bool(kv_workload_sequence &)> _barrier_fn;
+        std::deque<kv_workload_sequence_ptr> _sequences;
+
+        size_t _barrier_seq_no;
+        std::unordered_map<kv_workload_sequence *, sequence_state *> _per_sequence_state;
+        std::deque<sequence_state *> _runnable;
+        std::deque<sequence_state *> _runnable_after_barrier;
+    };
+
 public:
+    /*
+     * kv_workload_generator::kv_workload_generator --
+     *     Create a new workload generator.
+     */
+    kv_workload_generator() = delete;
+
+    /*
+     * kv_workload_generator::generate --
+     *     Generate the workload.
+     */
+    static inline std::shared_ptr<kv_workload>
+    generate(kv_workload_generator_spec spec = kv_workload_generator_spec{}, uint64_t seed = 0)
+    {
+        kv_workload_generator generator(spec, seed);
+        generator.run();
+        return generator.workload();
+    }
+
+protected:
     /*
      * kv_workload_generator::kv_workload_generator --
      *     Create a new workload generator.
@@ -165,10 +308,10 @@ public:
       kv_workload_generator_spec spec = kv_workload_generator_spec{}, uint64_t seed = 0);
 
     /*
-     * kv_workload_generator::generate --
+     * kv_workload_generator::run --
      *     Generate the workload.
      */
-    void generate();
+    void run();
 
     /*
      * kv_workload_generator::workload --
@@ -182,22 +325,24 @@ public:
 
 protected:
     /*
-     * kv_workload_generator::generate_transaction --
-     *     Generate a random transaction.
+     * kv_workload_generator::assert_timestamps --
+     *     Assert that the timestamps are assigned correctly. Call this function one sequence at a
+     *     time.
      */
-    kv_workload_transaction_ptr generate_transaction();
+    void assert_timestamps(
+      const kv_workload_sequence &sequence, const operation::any &op, timestamp_t &stable);
 
     /*
-     * kv_workload_generator::fill_in_timestamps --
-     *     Fill in the timestamps.
+     * kv_workload_generator::assign_timestamps --
+     *     Assign timestamps to operations in a sequence.
      */
-    void fill_in_timestamps(kv_workload_sequence &sequence, timestamp_t first, timestamp_t last);
+    void assign_timestamps(kv_workload_sequence &sequence, timestamp_t first, timestamp_t last);
 
     /*
      * kv_workload_generator::choose_table --
      *     Choose a table for an operation, creating one if necessary.
      */
-    table_context_ptr choose_table(kv_workload_transaction_ptr txn);
+    table_context_ptr choose_table(kv_workload_sequence_ptr txn);
 
     /*
      * kv_workload_generator::create_table --
@@ -214,6 +359,12 @@ protected:
     {
         return random_data_value(table->key_format());
     }
+
+    /*
+     * kv_workload_generator::generate_transaction --
+     *     Generate a random transaction.
+     */
+    kv_workload_sequence_ptr generate_transaction(size_t seq_no);
 
     /*
      * kv_workload_generator::generate_value --

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -1,0 +1,250 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MODEL_DRIVER_KV_WORKLOAD_GENERATOR_H
+#define MODEL_DRIVER_KV_WORKLOAD_GENERATOR_H
+
+#include <deque>
+#include <memory>
+#include <unordered_map>
+#include "model/driver/kv_workload.h"
+#include "model/driver/kv_workload_sequence.h"
+#include "model/random.h"
+
+namespace model {
+
+/*
+ * kv_workload_generator_spec --
+ *     A high-level workload specification.
+ */
+struct kv_workload_generator_spec {
+
+    /* The probability of starting a prepared transaction. */
+    float prepared_transaction;
+
+    /* The probability of allowing "set commit timestamp" in a transaction. */
+    float allow_set_commit_timestamp;
+
+    /* Probabilities of transaction rollback. */
+    float nonprepared_transaction_rollback;
+    float prepared_transaction_rollback_after_prepare;
+    float prepared_transaction_rollback_before_prepare;
+
+    /* Probabilities of operations within a transaction. */
+    float insert;
+    float finish_transaction; /* Commit, prepare, or rollback. */
+    float remove;
+    float set_commit_timestamp; /* If allowed. */
+    float truncate;
+
+    /* Probabilities of special operations. */
+    float checkpoint;
+    float restart;
+    float set_stable_timestamp;
+
+    /* The maximum number of concurrent transactions. */
+    size_t max_concurrent_transactions;
+
+    /*
+     * kv_workload_generator_spec::kv_workload_generator_spec --
+     *     Create the generator specifcation using default probability values.
+     */
+    kv_workload_generator_spec();
+};
+
+/*
+ * kv_workload_generator --
+ *     A workload generator for a key-value database.
+ */
+class kv_workload_generator {
+
+protected:
+    /*
+     * table_context --
+     *     The context for a table.
+     */
+    class table_context {
+
+    public:
+        /*
+         * table_context::table_context --
+         *     Create a new table context.
+         */
+        inline table_context(table_id_t id, const std::string &name, const std::string &key_format,
+          const std::string &value_format)
+            : _id(id), _name(name), _key_format(key_format), _value_format(value_format)
+        {
+        }
+
+        /*
+         * table_context::id --
+         *     Get the table ID.
+         */
+        inline table_id_t
+        id() const noexcept
+        {
+            return _id;
+        }
+
+        /*
+         * table_context::name --
+         *     Get the table name. Return a reference, which is safe, because its lifetime is tied
+         *     to this object.
+         */
+        inline const std::string &
+        name() const noexcept
+        {
+            return _name;
+        }
+
+        /*
+         * table_context::key_format --
+         *     Get the key format. Return a reference, which is safe, because its lifetime is tied
+         *     to this object.
+         */
+        inline const std::string &
+        key_format() const noexcept
+        {
+            return _key_format;
+        }
+
+        /*
+         * table_context::value_format --
+         *     Get the value format. Return a reference, which is safe, because its lifetime is tied
+         *     to this object.
+         */
+        inline const std::string &
+        value_format() const noexcept
+        {
+            return _value_format;
+        }
+
+    private:
+        table_id_t _id;
+        std::string _name;
+        std::string _key_format, _value_format;
+    };
+
+    /*
+     * table_context_ptr --
+     *     Pointer to a table context.
+     */
+    using table_context_ptr = std::shared_ptr<table_context>;
+
+public:
+    /*
+     * kv_workload_generator::kv_workload_generator --
+     *     Create a new workload generator.
+     */
+    kv_workload_generator(
+      kv_workload_generator_spec spec = kv_workload_generator_spec{}, uint64_t seed = 0);
+
+    /*
+     * kv_workload_generator::generate --
+     *     Generate the workload.
+     */
+    void generate();
+
+    /*
+     * kv_workload_generator::workload --
+     *     Get the generated workload.
+     */
+    inline std::shared_ptr<kv_workload>
+    workload() const
+    {
+        return _workload_ptr;
+    }
+
+protected:
+    /*
+     * kv_workload_generator::generate_transaction --
+     *     Generate a random transaction.
+     */
+    kv_workload_transaction_ptr generate_transaction();
+
+    /*
+     * kv_workload_generator::fill_in_timestamps --
+     *     Fill in the timestamps.
+     */
+    void fill_in_timestamps(kv_workload_sequence &sequence, timestamp_t first, timestamp_t last);
+
+    /*
+     * kv_workload_generator::choose_table --
+     *     Choose a table for an operation, creating one if necessary.
+     */
+    table_context_ptr choose_table(kv_workload_transaction_ptr txn);
+
+    /*
+     * kv_workload_generator::create_table --
+     *     Create a table.
+     */
+    void create_table();
+
+    /*
+     * kv_workload_generator::generate_key --
+     *     Generate a key.
+     */
+    inline data_value
+    generate_key(table_context_ptr table)
+    {
+        return random_data_value(table->key_format());
+    }
+
+    /*
+     * kv_workload_generator::generate_value --
+     *     Generate a value.
+     */
+    inline data_value
+    generate_value(table_context_ptr table)
+    {
+        return random_data_value(table->value_format());
+    }
+
+    /*
+     * kv_workload_generator::random_data_value --
+     *     Generate a random data value, which can be used either as a key or a value.
+     */
+    data_value random_data_value(const std::string &format);
+
+private:
+    std::shared_ptr<kv_workload> _workload_ptr;
+    kv_workload &_workload;
+
+    kv_workload_generator_spec _spec;
+    random _random;
+
+    table_id_t _last_table_id;
+    std::deque<table_context_ptr> _tables_list;
+    std::unordered_map<table_id_t, table_context_ptr> _tables;
+
+    txn_id_t _last_txn_id;
+    std::deque<kv_workload_sequence_ptr> _sequences;
+};
+
+} /* namespace model */
+#endif

--- a/test/model/src/include/model/driver/kv_workload_runner.h
+++ b/test/model/src/include/model/driver/kv_workload_runner.h
@@ -78,7 +78,7 @@ public:
                * point we would record and compare return codes. But we're not there yet, so just
                * fail on error.
                */
-              if (ret != 0)
+              if (ret != 0 && ret != WT_NOTFOUND)
                   throw wiredtiger_exception(ret);
           },
           op);

--- a/test/model/src/include/model/driver/kv_workload_runner_wt.h
+++ b/test/model/src/include/model/driver/kv_workload_runner_wt.h
@@ -145,7 +145,7 @@ public:
                * point we would record and compare return codes. But we're not there yet, so just
                * fail on error.
                */
-              if (ret != 0)
+              if (ret != 0 && ret != WT_NOTFOUND)
                   throw wiredtiger_exception(ret);
           },
           op);

--- a/test/model/src/include/model/driver/kv_workload_sequence.h
+++ b/test/model/src/include/model/driver/kv_workload_sequence.h
@@ -129,12 +129,13 @@ public:
 
     bool _done;
     size_t _index;
+    size_t _next_operation_index;
 
     inline void
     prepare_to_run()
     {
         _done = false;
-        _index = 0;
+        _next_operation_index = 0;
         _unsatisfied_dependencies = _dependencies_start.size() + _dependencies_finish.size();
     }
 

--- a/test/model/src/include/model/driver/kv_workload_sequence.h
+++ b/test/model/src/include/model/driver/kv_workload_sequence.h
@@ -191,19 +191,6 @@ public:
      */
     void must_finish_before(kv_workload_sequence *other);
 
-    // XXX
-    /* The number of unsatisfied dependencies before this sequence can run. */
-    std::atomic<size_t> _unsatisfied_dependencies;
-
-    size_t _next_operation_index;
-
-    inline void
-    prepare_to_run()
-    {
-        _next_operation_index = 0;
-        _unsatisfied_dependencies = _dependencies.size();
-    }
-
 protected:
     /*
      * kv_workload_sequence::contains_key --

--- a/test/model/src/include/model/driver/kv_workload_sequence.h
+++ b/test/model/src/include/model/driver/kv_workload_sequence.h
@@ -1,0 +1,221 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MODEL_DRIVER_KV_WORKLOAD_SEQUENCE_H
+#define MODEL_DRIVER_KV_WORKLOAD_SEQUENCE_H
+
+#include <atomic>
+#include <deque>
+#include <memory>
+#include "model/driver/kv_workload.h"
+#include "model/core.h"
+#include "model/data_value.h"
+
+namespace model {
+
+/*
+ * kv_workload_sequence --
+ *     A sequence of operations in a workload.
+ */
+class kv_workload_sequence {
+
+public:
+    /*
+     * kv_workload_sequence::kv_workload_sequence --
+     *     Create a new sequence of operations.
+     */
+    inline kv_workload_sequence() {}
+
+    /*
+     * kv_workload_sequence::transaction --
+     *     Check if this sequence represents a transaction.
+     */
+    virtual bool
+    transaction() const noexcept
+    {
+        return false;
+    }
+
+    /*
+     * kv_workload_sequence::operator<< --
+     *     Add an operation to the sequence.
+     */
+    inline kv_workload_sequence &
+    operator<<(operation::any &&op)
+    {
+        _operations.push_back(std::move(op));
+        return *this;
+    }
+
+    /*
+     * kv_workload_sequence::overlaps_with --
+     *     Check whether this sequence overlaps in any key ranges with the other sequence.
+     */
+    bool overlaps_with(const kv_workload_sequence &other) const;
+
+    /*
+     * kv_workload_sequence::must_start_before_starting --
+     *     Declare that the other sequence cannot start until this sequence starts.
+     */
+    void must_start_before_starting(kv_workload_sequence &other);
+
+    /*
+     * kv_workload_sequence::must_finish_before_starting --
+     *     Declare that the other sequence cannot start until this sequence finishes.
+     */
+    void must_finish_before_starting(kv_workload_sequence &other);
+
+    /*
+     * kv_workload_sequence::operations --
+     *     Get the list of operations. Note that the lifetime of this reference is constrained to
+     *     the lifetime of this object.
+     */
+    inline std::deque<operation::any> &
+    operations() noexcept
+    {
+        return _operations;
+    }
+
+    /*
+     * kv_workload_sequence::operations --
+     *     Get the list of operations. Note that the lifetime of this reference is constrained to
+     *     the lifetime of this object.
+     */
+    inline const std::deque<operation::any> &
+    operations() const noexcept
+    {
+        return _operations;
+    }
+
+    /*
+     * kv_workload_sequence::runnable_after_finish --
+     *     Get the list of sequences that are unblocked after this sequence completes. Note that the
+     *     lifetime of this reference is constrained to the lifetime of this object.
+     */
+    inline const std::deque<kv_workload_sequence *>
+    runnable_after_finish() const noexcept
+    {
+        return _runnable_after_finish;
+    }
+
+    // XXX
+    /* The number of unsatisfied dependencies before this sequence can run. */
+    std::atomic<size_t> _unsatisfied_dependencies;
+
+    bool _done;
+    size_t _index;
+
+    inline void
+    prepare_to_run()
+    {
+        _done = false;
+        _index = 0;
+        _unsatisfied_dependencies = _dependencies_start.size() + _dependencies_finish.size();
+    }
+
+protected:
+    /*
+     * kv_workload_sequence::contains_key --
+     *     Check whether the sequence contains an operation that touches any key in the range.
+     */
+    bool contains_key(table_id_t table_id, const data_value &start, const data_value &stop) const;
+
+protected:
+    std::deque<operation::any> _operations;
+
+    /* Sequences that must start before this sequence can start, and the inverse. */
+    std::deque<kv_workload_sequence *> _dependencies_start;
+    std::deque<kv_workload_sequence *> _runnable_after_start;
+
+    /* Sequences that must finish before this sequence can start, and the inverse. */
+    std::deque<kv_workload_sequence *> _dependencies_finish;
+    std::deque<kv_workload_sequence *> _runnable_after_finish;
+};
+
+/*
+ * kv_workload_sequence_ptr --
+ *     Pointer to a sequence.
+ */
+using kv_workload_sequence_ptr = std::shared_ptr<kv_workload_sequence>;
+
+/*
+ * kv_workload_transaction --
+ *     A single workload transaction.
+ */
+class kv_workload_transaction : public kv_workload_sequence {
+
+public:
+    /*
+     * kv_workload_transaction::kv_workload_transaction --
+     *     Create a new sequence of operations.
+     */
+    inline kv_workload_transaction(txn_id_t id, bool prepared) : _id(id), _prepared(prepared) {}
+
+    /*
+     * kv_workload_sequence::transaction --
+     *     Check if this sequence represents a transaction.
+     */
+    virtual bool
+    transaction() const noexcept
+    {
+        return true;
+    }
+
+    /*
+     * kv_workload_transaction::id --
+     *     Get the transaction ID.
+     */
+    inline txn_id_t
+    id() const noexcept
+    {
+        return _id;
+    }
+
+    /*
+     * kv_workload_transaction::prepared --
+     *     Check if this is a prepared transaction.
+     */
+    inline bool
+    prepared() const noexcept
+    {
+        return _prepared;
+    }
+
+protected:
+    txn_id_t _id;
+    bool _prepared;
+};
+
+/*
+ * kv_workload_sequence_ptr --
+ *     Pointer to a transaction.
+ */
+using kv_workload_transaction_ptr = std::shared_ptr<kv_workload_transaction>;
+
+} /* namespace model */
+#endif

--- a/test/model/src/include/model/kv_table_item.h
+++ b/test/model/src/include/model/kv_table_item.h
@@ -56,12 +56,6 @@ public:
      * kv_table_item::add_update --
      *     Add an update. Throw exception on error.
      */
-    void add_update(kv_update &&update, bool must_exist, bool must_not_exist);
-
-    /*
-     * kv_table_item::add_update --
-     *     Add an update. Throw exception on error.
-     */
     void add_update(std::shared_ptr<kv_update> update, bool must_exist, bool must_not_exist);
 
     /*

--- a/test/model/src/include/model/random.h
+++ b/test/model/src/include/model/random.h
@@ -1,0 +1,91 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef MODEL_RANDOM_H
+#define MODEL_RANDOM_H
+
+#include <cstddef>
+#include "model/core.h"
+
+extern "C" {
+#include "wt_internal.h"
+}
+
+namespace model {
+
+/*
+ * random --
+ *     A random number generator.
+ */
+class random {
+
+public:
+    /*
+     * random::random --
+     *     Create a new instance of the random number generator.
+     */
+    random(uint64_t seed = 0) noexcept;
+
+    /*
+     * random::next_double --
+     *     Get the next double between 0 and 1.
+     */
+    double next_double() noexcept;
+
+    /*
+     * random::next_float --
+     *     Get the next float between 0 and 1.
+     */
+    float next_float() noexcept;
+
+    /*
+     * random::next_index --
+     *     Get the next index from the list of the given length.
+     */
+    size_t next_index(size_t length);
+
+    /*
+     * random::next_uint64 --
+     *     Get the next integer.
+     */
+    inline uint64_t
+    next_uint64(uint64_t max)
+    {
+        return (uint64_t)(next_double() * max);
+    }
+
+private:
+    WT_RAND_STATE _random_state;
+};
+
+#define probability_switch(p) for (auto __r = (p); __r >= 0; __r = -1)
+#define probability_case(p) if (__r >= 0 && (__r -= (p)) < 0)
+#define probability_default if (__r >= 0)
+
+} /* namespace model */
+#endif

--- a/test/model/src/include/model/random.h
+++ b/test/model/src/include/model/random.h
@@ -79,12 +79,37 @@ public:
         return (uint64_t)(next_double() * max);
     }
 
+    /*
+     * random::next_uint64 --
+     *     Get the next integer.
+     */
+    inline uint64_t
+    next_uint64(uint64_t min, uint64_t max)
+    {
+        return min + next_uint64(max - min);
+    }
+
 private:
     WT_RAND_STATE _random_state;
 };
 
-#define probability_switch(p) for (auto __r = (p); __r >= 0; __r = -1)
+/*
+ * probability_switch --
+ *     A convenience macro for situations where we need to make different decisions with different
+ *     probabilities.
+ */
+#define probability_switch(r) for (auto __r = (r); __r >= 0; __r = -1)
+
+/*
+ * probability_case --
+ *     A case within a probability switch.
+ */
 #define probability_case(p) if (__r >= 0 && (__r -= (p)) < 0)
+
+/*
+ * probability_default --
+ *     The default case within a probability switch.
+ */
 #define probability_default if (__r >= 0)
 
 } /* namespace model */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -321,6 +321,17 @@ private:
 };
 
 /*
+ * one_of --
+ *   Check it the first argument is equal to one or more of the other arguments.
+ */
+template <typename T>
+inline bool
+one_of(T v, T arg1, T arg2)
+{
+    return v == arg1 || v == arg2;
+}
+
+/*
  * starts_with --
  *     Check whether the string has the given prefix. (C++ does not have this until C++20.)
  */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -322,7 +322,7 @@ private:
 
 /*
  * one_of --
- *   Check it the first argument is equal to one or more of the other arguments.
+ *     Check it the first argument is equal to one or more of the other arguments.
  */
 template <typename T>
 inline bool

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -321,17 +321,6 @@ private:
 };
 
 /*
- * one_of --
- *     Check it the first argument is equal to one or more of the other arguments.
- */
-template <typename T>
-inline bool
-one_of(T v, T arg1, T arg2)
-{
-    return v == arg1 || v == arg2;
-}
-
-/*
  * starts_with --
  *     Check whether the string has the given prefix. (C++ does not have this until C++20.)
  */

--- a/test/model/test/common/util.cpp
+++ b/test/model/test/common/util.cpp
@@ -129,6 +129,9 @@ verify_workload(const model::kv_workload &workload, TEST_OPTS *opts, const std::
     model::kv_database database;
     workload.run(database);
 
+    /* When we load the workload from WiredTiger, that would be after running recovery. */
+    database.restart();
+
     /* Run the workload in WiredTiger. */
     testutil_recreate_dir(home.c_str());
     workload.run_in_wiredtiger(home.c_str(), env_config);

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -39,6 +39,7 @@ extern "C" {
 }
 
 #include "model/driver/kv_workload.h"
+#include "model/driver/kv_workload_generator.h"
 #include "model/test/util.h"
 #include "model/test/wiredtiger_util.h"
 #include "model/kv_database.h"
@@ -246,6 +247,28 @@ test_workload_restart(void)
 }
 
 /*
+ * test_workload_generator --
+ *     Test the workload generator.
+ */
+static void
+test_workload_generator(void)
+{
+    model::kv_workload_generator generator;
+    generator.generate();
+
+    std::shared_ptr<model::kv_workload> workload = generator.workload();
+    std::cout << workload;
+
+    /* Run the workload in the model. */
+    model::kv_database database;
+    workload->run(database);
+
+    /* Run the workload in WiredTiger and verify. */
+    std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
+    verify_workload(*workload, opts, test_home, ENV_CONFIG);
+}
+
+/*
  * usage --
  *     Print usage help for the program.
  */
@@ -298,6 +321,7 @@ main(int argc, char *argv[])
         test_workload_txn();
         test_workload_prepared();
         test_workload_restart();
+        test_workload_generator();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;
         ret = EXIT_FAILURE;

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -259,11 +259,7 @@ test_workload_generator(void)
     std::shared_ptr<model::kv_workload> workload = generator.workload();
     std::cout << workload;
 
-    /* Run the workload in the model. */
-    model::kv_database database;
-    workload->run(database);
-
-    /* Run the workload in WiredTiger and verify. */
+    /* Run the workload in the model and in WiredTiger, then verify. */
     std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
     verify_workload(*workload, opts, test_home, ENV_CONFIG);
 }
@@ -317,10 +313,10 @@ main(int argc, char *argv[])
      */
     try {
         ret = EXIT_SUCCESS;
-        test_workload_basic();
+        /*test_workload_basic();
         test_workload_txn();
         test_workload_prepared();
-        test_workload_restart();
+        test_workload_restart();*/
         test_workload_generator();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -253,11 +253,7 @@ test_workload_restart(void)
 static void
 test_workload_generator(void)
 {
-    model::kv_workload_generator generator;
-    generator.generate();
-
-    std::shared_ptr<model::kv_workload> workload = generator.workload();
-    std::cout << workload;
+    std::shared_ptr<model::kv_workload> workload = model::kv_workload_generator::generate();
 
     /* Run the workload in the model and in WiredTiger, then verify. */
     std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
@@ -313,10 +309,10 @@ main(int argc, char *argv[])
      */
     try {
         ret = EXIT_SUCCESS;
-        /*test_workload_basic();
+        test_workload_basic();
         test_workload_txn();
         test_workload_prepared();
-        test_workload_restart();*/
+        test_workload_restart();
         test_workload_generator();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;


### PR DESCRIPTION
This PR implements a workload generator using the primitives built into the model. The PR is fairly long and complicated; I'll be happy to jump on Zoom to go over anything.

I tried to explain the generation process in fairly extensive comments in `kv_workload_generator::run`, but here is the TL;DR: It generates a fully sequential workload, then it finds dependencies between transactions, assigns timestamps, and creates a "concurrent" workload schedule with overlapping transactions (that satisfies the dependencies). The main reason for this is that this allows me to generate much more interesting workloads than the "typical" workload generators, which play tricks such as partitioning key space and timestamps between threads.

The PR also includes fixing a bug where calling `get` without a transaction snapshot would return uncommitted updates, and it also includes `operator<<` for printing workload operations (which I used a lot during debugging).