### PR TITLE
WT-12157 Moving verbose message into backup cursor creation

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -348,8 +348,7 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
     if (othercb != NULL)
         WT_CURSOR_BACKUP_CHECK_STOP(othercb);
 
-    if (cfg != NULL && cfg[1] != NULL &&
-      WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_BACKUP, WT_VERBOSE_LEVEL_DEFAULT))
+    if (cfg != NULL && cfg[1] != NULL)
         __wt_verbose(session, WT_VERB_BACKUP, "Backup cursor config \"%s\"", cfg[1]);
 
     /* Special backup cursor to query incremental IDs. */

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -348,7 +348,8 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
     if (othercb != NULL)
         WT_CURSOR_BACKUP_CHECK_STOP(othercb);
 
-    if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_BACKUP, WT_VERBOSE_LEVEL_DEFAULT) && cfg[1] != NULL)
+    if (cfg != NULL && cfg[1] != NULL &&
+      WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_BACKUP, WT_VERBOSE_LEVEL_DEFAULT))
         __wt_verbose(session, WT_VERB_BACKUP, "Backup cursor config \"%s\"", cfg[1]);
 
     /* Special backup cursor to query incremental IDs. */

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -348,6 +348,9 @@ __wt_curbackup_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *other,
     if (othercb != NULL)
         WT_CURSOR_BACKUP_CHECK_STOP(othercb);
 
+    if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_BACKUP, WT_VERBOSE_LEVEL_DEFAULT) && cfg[1] != NULL)
+        __wt_verbose(session, WT_VERB_BACKUP, "Backup cursor config \"%s\"", cfg[1]);
+
     /* Special backup cursor to query incremental IDs. */
     if (WT_STRING_MATCH("backup:query_id", uri, strlen(uri))) {
         /* Top level cursor code does not allow a URI and cursor. We don't need to check here. */

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -771,9 +771,6 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
         }
     }
 
-    if (config != NULL && (WT_PREFIX_MATCH(uri, "backup:") || to_dup != NULL))
-        __wt_verbose(session, WT_VERB_BACKUP, "Backup cursor config \"%s\"", config);
-
     WT_ERR(__session_open_cursor_int(
       session, uri, NULL, statjoin || dup_backup ? to_dup : NULL, cfg, hash_value, &cursor));
 


### PR DESCRIPTION
The original code was a bit weird. By the point of `__session_open_cursor_int` we know our URI and might have a cursor to dupe, making me think that the `or` logic in the if is redundant. 

I also made a change from what was originally suggested and instead of placing this message in `__session_open_cursor_int` I put it in `__wt_curbackup_open`. That made the most sense to me and also means we really don't need a URI comparison to begin with. I then check the cfg isn't null and forgo checking the `dupe` cursor status for the aforementioned reasons.