### PR TITLE
WT-12328 Stop compacting if a file has grown in size between passes

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -25,8 +25,6 @@ __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
     __wt_block_configure_first_fit(block, true);
 
     /* Reset the compaction state information. */
-    block->compact_session_id = session->id;
-    block->compact_pct_tenths = 0;
     block->compact_bytes_reviewed = 0;
     block->compact_bytes_rewritten = 0;
     block->compact_internal_pages_reviewed = 0;
@@ -34,7 +32,9 @@ __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
     block->compact_pages_rewritten = 0;
     block->compact_pages_rewritten_expected = 0;
     block->compact_pages_skipped = 0;
+    block->compact_pct_tenths = 0;
     block->compact_prev_size = block->size;
+    block->compact_session_id = session->id;
 
     if (session == S2C(session)->background_compact.session)
         WT_RET(__wt_background_compact_start(session));

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -491,7 +491,10 @@ __wt_block_compact_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, bool *skipp)
           "%s: skipping because the number of available bytes %" PRIu64
           "B is less than the configured threshold %" PRIu64 "B.",
           block->name, block->live.avail.bytes, session->compact->free_space_target);
-    /* Do not continue compacting if the file size has grown between iterations. */
+    /*
+     * The file can grow due to parallel activity, it is better to stop compacting to avoid
+     * conflicting behavior.
+     */
     else if (block->size > block->compact_prev_size)
         __wt_verbose_debug1(session, WT_VERB_COMPACT,
           "%s: skipping because the file has grown between compact passes.", block->name);

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -34,7 +34,7 @@ __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
     block->compact_pages_rewritten_expected = 0;
     block->compact_pages_skipped = 0;
     block->compact_pct_tenths = 0;
-    block->compact_prev_size = block->size;
+    block->compact_prev_size = 0;
     block->compact_session_id = session->id;
 
     if (session == S2C(session)->background_compact.session)
@@ -494,7 +494,7 @@ __wt_block_compact_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, bool *skipp)
      * The file can grow due to parallel activity, it is better to stop compacting to avoid
      * conflicting behavior.
      */
-    else if (block->size > block->compact_prev_size)
+    else if (block->compact_prev_size > 0 && block->size > block->compact_prev_size)
         __wt_verbose_debug1(session, WT_VERB_COMPACT,
           "%s: skipping because the file has grown between compact passes.", block->name);
     else

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -299,6 +299,7 @@ struct __wt_block {
     uint64_t compact_pages_rewritten_expected; /* The expected number of pages to rewrite */
     uint64_t compact_pages_skipped;            /* Pages skipped */
     uint32_t compact_session_id;               /* Session compacting */
+    wt_off_t compact_prev_size;                /* File size at the start of compact */
 
     /* Salvage support */
     wt_off_t slvg_off; /* Salvage file offset */

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -298,8 +298,8 @@ struct __wt_block {
     uint64_t compact_pages_rewritten;          /* Pages rewritten */
     uint64_t compact_pages_rewritten_expected; /* The expected number of pages to rewrite */
     uint64_t compact_pages_skipped;            /* Pages skipped */
+    wt_off_t compact_prev_size;                /* File size at the start of a compaction pass */
     uint32_t compact_session_id;               /* Session compacting */
-    wt_off_t compact_prev_size;                /* File size at the start of compact */
 
     /* Salvage support */
     wt_off_t slvg_off; /* Salvage file offset */


### PR DESCRIPTION
The compact thread can get 'stuck' on a table for too long passing over it many times but failing to reclaim space due to other concurrent operations.

This adds an exit point to compact to stop iterating over a file when the file size grows between iterations.