### PR TITLE
WT-12283 Make s_all and s_fast faster on MacOS

### DIFF
--- a/dist/pygrep.py
+++ b/dist/pygrep.py
@@ -31,22 +31,22 @@ argparser.add_argument('-o', '--only-matching', dest='only_matching', action='st
         help='Prints only the matching part of the lines.')
 argparser.add_argument('pattern', action='append', nargs='?',
         help='Search pattern.')
-#argparser.add_argument('files', action='append', nargs='*',
-#        help='Search pattern.')
 
-#args = argparser.parse_args(sys.argv[1:])
-args = argparser.parse_known_args(sys.argv[1:])[0]  # Ignore unknown options rathern than complain
+# Ignore unknown options rather than complain
+args = argparser.parse_known_args(sys.argv[1:])[0]
 args.pattern = [line
-                for pat in args.pattern if pat is not None
-                for line in pat.splitlines() if line != '']
+                for pat in args.pattern if pat
+                for line in pat.splitlines() if line]
 if not args.pattern:
     argparser.print_help()
     exit()
 
 match = matchSearch if args.only_matching else matchLine
-if not args.is_regex: args.pattern = [re.escape(pat) for pat in args.pattern]
+if not args.is_regex:
+    args.pattern = [re.escape(pat) for pat in args.pattern]
 regex = '|'.join(args.pattern)
-if args.word: regex = '\\b(?:' + regex + ')\\b'
+if args.word:
+    regex = '\\b(?:' + regex + ')\\b'
 
 regex = re.compile(regex)
 

--- a/dist/pygrep.py
+++ b/dist/pygrep.py
@@ -44,7 +44,7 @@ if not args.pattern:
 match = matchSearch if args.only_matching else matchLine
 if not args.is_regex:
     args.pattern = [re.escape(pat) for pat in args.pattern]
-regex = '|'.join(args.pattern)
+regex = '|'.join(['(?:' + pat + ')' for pat in args.pattern])
 if args.word:
     regex = '\\b(?:' + regex + ')\\b'
 

--- a/dist/pygrep.py
+++ b/dist/pygrep.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# This a simple limited replacement for GNU grep
+#  - All options must go in the first arg
+#  - Order of options matters! - see source
+
+import re, sys
+
+def matchLine(regex, line):
+    match = regex.search(line)
+    if bool(match) != bool(inverse): print(line, end="")
+
+def matchSearch(regex, line):
+    for match in regex.finditer(line):
+        print(match if isinstance(match, str) else match[0])
+
+inverse, match, opts, args = False, matchLine, "", sys.argv[1:]
+if args[0][0] == "-": opts, args = args[0], args[1:]
+regex = "|".join(args)
+
+for opt in [c for c in opts]:
+    match opt:
+        case 'e': regex = "|".join(args)
+        case 'f': regex = "|".join([re.escape(arg) for arg in args])
+        case 'w': regex = '\\b(?:' + regex + ')\\b'
+        case 'v': inverse = True; match = matchLine;
+        case 'o': match = matchSearch
+
+regex = re.compile(regex)
+
+for line in sys.stdin:
+    match(regex, line)
+

--- a/dist/pygrep.py
+++ b/dist/pygrep.py
@@ -1,29 +1,52 @@
 #!/usr/bin/env python3
 
 # This a simple limited replacement for GNU grep
-#  - All options must go in the first arg
-#  - Order of options matters! - see source
+# Caveats:
+# * Accepts only stdin
+# * Unknown options must go as a separate arg
 
-import re, sys
+import re, sys, argparse
 
 def matchLine(regex, line):
+    global args
     match = regex.search(line)
-    if bool(match) != bool(inverse): print(line, end="")
+    if bool(match) != bool(args.inverse): print(line, end='')
 
 def matchSearch(regex, line):
     for match in regex.finditer(line):
         print(match if isinstance(match, str) else match[0])
 
-inverse, match, opts, args = False, matchLine, "", sys.argv[1:]
-if args[0][0] == "-": opts, args = args[0], args[1:]
-regex = "|".join(args)
+argparser = argparse.ArgumentParser(description='Simple Grep Replacement.', add_help=False)
+argparser.add_argument('-F', '--fgrep', dest='is_regex', action='store_false', default=True,
+        help='Interpret pattern as a set of fixed strings (behave like fgrep).')
+argparser.add_argument('-E', '--egrep', dest='is_regex', action='store_true',
+        help='Interpret pattern as an extended regular expression (behave like egrep).')
+argparser.add_argument('-e', '--regexp', dest='pattern', action='append',
+        help='Specify multiple patterns on the command line.')
+argparser.add_argument('-w', '--word-regexp', dest='word', action='store_true',
+        help='The expression is searched for as a word.')
+argparser.add_argument('-v', '--invert-match', dest='inverse', action='store_true',
+        help='Selected lines are those not matching any of the specified patterns.')
+argparser.add_argument('-o', '--only-matching', dest='only_matching', action='store_true',
+        help='Prints only the matching part of the lines.')
+argparser.add_argument('pattern', action='append', nargs='?',
+        help='Search pattern.')
+#argparser.add_argument('files', action='append', nargs='*',
+#        help='Search pattern.')
 
-for opt in [c for c in opts]:
-    if opt == 'e': regex = "|".join(args)
-    elif opt == 'f': regex = "|".join([re.escape(arg) for arg in args])
-    elif opt == 'w': regex = '\\b(?:' + regex + ')\\b'
-    elif opt == 'v': inverse = True; match = matchLine;
-    elif opt == 'o': match = matchSearch
+#args = argparser.parse_args(sys.argv[1:])
+args = argparser.parse_known_args(sys.argv[1:])[0]  # Ignore unknown options rathern than complain
+args.pattern = [line
+                for pat in args.pattern if pat is not None
+                for line in pat.splitlines() if line != '']
+if not args.pattern:
+    argparser.print_help()
+    exit()
+
+match = matchSearch if args.only_matching else matchLine
+if not args.is_regex: args.pattern = [re.escape(pat) for pat in args.pattern]
+regex = '|'.join(args.pattern)
+if args.word: regex = '\\b(?:' + regex + ')\\b'
 
 regex = re.compile(regex)
 

--- a/dist/pygrep.py
+++ b/dist/pygrep.py
@@ -19,12 +19,11 @@ if args[0][0] == "-": opts, args = args[0], args[1:]
 regex = "|".join(args)
 
 for opt in [c for c in opts]:
-    match opt:
-        case 'e': regex = "|".join(args)
-        case 'f': regex = "|".join([re.escape(arg) for arg in args])
-        case 'w': regex = '\\b(?:' + regex + ')\\b'
-        case 'v': inverse = True; match = matchLine;
-        case 'o': match = matchSearch
+    if opt == 'e': regex = "|".join(args)
+    elif opt == 'f': regex = "|".join([re.escape(arg) for arg in args])
+    elif opt == 'w': regex = '\\b(?:' + regex + ')\\b'
+    elif opt == 'v': inverse = True; match = matchLine;
+    elif opt == 'o': match = matchSearch
 
 regex = re.compile(regex)
 

--- a/dist/s_all
+++ b/dist/s_all
@@ -173,12 +173,12 @@ run --bg "s_lang" &
 run --bg "s_longlines" &
 run --bg "s_python" &
 run --bg "s_stat" &
-run --bg "s_string" &
+run --bg "s_string $fast" &
 run --bg "s_tags" &
 run --bg "s_typedef -c" &
 run --bg "s_visibility_checks" &
-run --bg "s_void" &
-run --bg "s_whitespace" &
+run --bg "s_void $fast" &
+run --bg "s_whitespace $fast" &
 run --bg "function.py" &
 run --bg "style.py" &
 run --bg "comment_style.py $fast" &

--- a/dist/s_define
+++ b/dist/s_define
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Complain about unused #defines.
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
 
 # List of source files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`
@@ -13,7 +12,7 @@ l="$l `echo ../src/include/*_inline.h ../src/utilities/*.c ../test/*/*.c`"
 dl="../src/include/*.h ../src/include/*.in"
 dl=`echo $dl | sed 's/ [^ ]*queue.h//'`
 
-(
+{
 # Copy out the list of #defines we don't use, but it's OK.
 sed -e '/^$/d' -e '/^#/d' < s_define.list
 
@@ -23,17 +22,15 @@ sed -e '/^$/d' -e '/^#/d' < s_define.list
 search=`cat $dl |
     sed -e '/configuration section: BEGIN/,/configuration section: END/d' \
         -e '/Statistics section: BEGIN/,/Statistics section: END/d' |
-    egrep '^#define' |
+    ./pygrep.py '^#define' |
     sed 's/#define[	 ][	 ]*\([A-Za-z_][A-Za-z0-9_]*\).*/\1/' |
     sort -u`
 
 # Print the list of macros, followed by the occurrences: we're looking for
 # macros that only appear once.
 echo "$search"
-fgrep -who "$search" $l
+cat $l | ./pygrep.py -fwho $search
 
-) | sort | uniq -u > $t
-
-test -s $t && cat $t
+} | sort | uniq -u
 
 exit 0

--- a/dist/s_define
+++ b/dist/s_define
@@ -2,6 +2,7 @@
 
 # Complain about unused #defines.
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
+[[ `uname -s` == Darwin ]] && EGREP="./pygrep.py -E" FGREP="./pygrep.py -F" || EGREP=egrep FGREP=fgrep
 
 # List of source files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`
@@ -22,14 +23,14 @@ sed -e '/^$/d' -e '/^#/d' < s_define.list
 search=`cat $dl |
     sed -e '/configuration section: BEGIN/,/configuration section: END/d' \
         -e '/Statistics section: BEGIN/,/Statistics section: END/d' |
-    ./pygrep.py '^#define' |
+    egrep '^#define' |
     sed 's/#define[	 ][	 ]*\([A-Za-z_][A-Za-z0-9_]*\).*/\1/' |
     sort -u`
 
 # Print the list of macros, followed by the occurrences: we're looking for
 # macros that only appear once.
 echo "$search"
-cat $l | ./pygrep.py -fwho $search
+cat $l | $FGREP -wo -h "$search"
 
 } | sort | uniq -u
 

--- a/dist/s_funcs
+++ b/dist/s_funcs
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Complain about unused functions
-
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
+[[ `uname -s` == Darwin ]] && EGREP="./pygrep.py -E" FGREP="./pygrep.py -F" || EGREP=egrep FGREP=fgrep
 
 # List of files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`
@@ -13,14 +13,14 @@ l="$l `echo ../src/*/*_inline.h ../src/utilities/*.c ../bench/wtperf/*.c ../benc
     sed -e '/^$/d' -e '/^#/d' < s_funcs.list
 
     # Get the list of functions
-    search=`cat $l | ./pygrep.py '^[a-zA-Z0-9_][a-zA-Z0-9_]*\(' | sed -e 's/(.*//' | sort -u`
+    search=`egrep -h '^[a-zA-Z0-9_][a-zA-Z0-9_]*\(' $l | sed -e 's/(.*//' | sort -u`
 
     # Print the list of functions, followed by the occurrences: we're looking for
     # functions that only appear once
     echo "$search"
-    sed -n '/{/,/^}/p' $l | ./pygrep.py -fwo $search
+    sed -n '/{/,/^}/p' $l | $FGREP -wo "$search"
 
-    sed -n '/^#define/,/[^\\]$/p' ../src/include/*.h ../src/include/*.in | ./pygrep.py -fwho $search
-} | ./pygrep.py -v '^__ut_' | sort | uniq -u
+    sed -n '/^#define/,/[^\\]$/p' ../src/include/*.h ../src/include/*.in | $FGREP -wo "$search"
+} | egrep -v '^__ut_' | sort | uniq -u
 
 exit 0

--- a/dist/s_funcs
+++ b/dist/s_funcs
@@ -1,31 +1,26 @@
 #!/bin/bash
 
 # Complain about unused functions
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
 
 # List of files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`
 l="$l `echo ../src/*/*_inline.h ../src/utilities/*.c ../bench/wtperf/*.c ../bench/tiered/*.c`"
 
-(
-# Copy out the functions we don't use, but it's OK.
-sed -e '/^$/d' -e '/^#/d' < s_funcs.list
+{
+    # Copy out the functions we don't use, but it's OK.
+    sed -e '/^$/d' -e '/^#/d' < s_funcs.list
 
-# Get the list of functions
-search=`egrep -h '^[a-zA-Z0-9_][a-zA-Z0-9_]*\(' $l | sed -e 's/(.*//' | sort -u`
+    # Get the list of functions
+    search=`cat $l | ./pygrep.py '^[a-zA-Z0-9_][a-zA-Z0-9_]*\(' | sed -e 's/(.*//' | sort -u`
 
-# Print the list of functions, followed by the occurrences: we're looking for
-# functions that only appear once
-echo "$search"
-sed -n '/{/,/^}/p' $l | fgrep -wo "$search"
+    # Print the list of functions, followed by the occurrences: we're looking for
+    # functions that only appear once
+    echo "$search"
+    sed -n '/{/,/^}/p' $l | ./pygrep.py -fwo $search
 
-sed -n '/^#define/,/[^\\]$/p' ../src/include/*.h ../src/include/*.in |
-    fgrep -who "$search"
-) \
-    | grep -v '^__ut_' \
-    | sort | uniq -u > $t
-
-test -s $t && cat $t
+    sed -n '/^#define/,/[^\\]$/p' ../src/include/*.h ../src/include/*.in | ./pygrep.py -fwho $search
+} | ./pygrep.py -v '^__ut_' | sort | uniq -u
 
 exit 0

--- a/dist/s_stat
+++ b/dist/s_stat
@@ -3,6 +3,7 @@
 # Complain about unused statistics fields.
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
 
 # List of files to search: skip stat.c, it lists all of the fields by
 # definition.
@@ -13,11 +14,11 @@ l=`sed \
     -e 's,^,../,' filelist`
 l="$l `echo ../src/include/*_inline.h ../src/include/os.h`"
 
-(
+{
 # Get the list of statistics fields.
-search=`sed \
-    -e 's/^    int64_t \([a-z_*]*\);$/\1/p' \
-    -e d ../src/include/stat.h |
+search=`sed -n '/^struct/,/^}/p' ../src/include/stat.h | sed \
+    -e 's/^    int64_t \([a-z_]*\);$/\1/p' \
+    -e d |
     sort`
 
 # There are some fields that are used, but we can't detect it.
@@ -58,7 +59,8 @@ txn_rts_upd_aborted_dryrun
 UNUSED_STAT_FIELDS
 
 echo "$search"
-fgrep -who "$search" $l) | sort | uniq -u > $t
+cat $l | ./pygrep.py -fwho $search
+} | sort | uniq -u > $t
 
 test -s $t && {
     echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="

--- a/dist/s_stat
+++ b/dist/s_stat
@@ -4,6 +4,7 @@
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
+[[ `uname -s` == Darwin ]] && EGREP="./pygrep.py -E" FGREP="./pygrep.py -F" || EGREP=egrep FGREP=fgrep
 
 # List of files to search: skip stat.c, it lists all of the fields by
 # definition.
@@ -59,7 +60,7 @@ txn_rts_upd_aborted_dryrun
 UNUSED_STAT_FIELDS
 
 echo "$search"
-cat $l | ./pygrep.py -fwho $search
+cat $l | $FGREP -wo "$search"
 } | sort | uniq -u > $t
 
 test -s $t && {

--- a/dist/s_string
+++ b/dist/s_string
@@ -3,7 +3,8 @@
 # Check spelling in comments and quoted strings from the source files.
 
 t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+trap 'rm -f $t; exit $exit_val' 0 1 2 3 13 15
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
 
 # Insulate against locale-specific sort order
 LC_ALL=C
@@ -47,14 +48,24 @@ check() {
 }
 
 # List of files to spellchk.
-l=$(cd .. &&
-    find bench examples ext src test -name '*.[chsy]' &&
-    find src -name '*.in' &&
-    find test -name '*.cpp')
+if [[ "$1" = "-F" ]]; then
+    last_commit_from_dev=$(python3 common_functions.py last_commit_from_dev)
+    l=$(cd ..
+        git diff --name-only "${last_commit_from_dev}" bench examples ext src test | grep -E '\.[chsy]$'
+        git diff --name-only "${last_commit_from_dev}" src | grep -E '\.in$'
+        git diff --name-only "${last_commit_from_dev}" test | grep -E '\.cpp$'
+    )
+else
+    l=$(cd .. &&
+        find bench examples ext src test -name '*.[chsy]' &&
+        find src -name '*.in' &&
+        find test -name '*.cpp'
+    )
+fi
 
 usage()
 {
-    echo 'usage: s_string [-r]' >&2
+    echo 'usage: s_string [-F] [-r]' >&2
     exit 1
 }
 
@@ -85,6 +96,7 @@ while :
             echo "No need to update the $custom_words list."
         fi
         shift;;
+    -F) FAST=1; shift;;
     *)
         test "$#" -eq 0 || usage
         break;;

--- a/dist/s_void
+++ b/dist/s_void
@@ -2,8 +2,7 @@
 
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15
-
-cd ..
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. || exit $?
 
 # Parse a C file, discarding functions that don't return an int, and formatting
 # the remaining functions as a single line.
@@ -171,11 +170,15 @@ func_ok()
         -e '/int __wt_curhs_search_near_before$/d'
 }
 
-for f in `find bench ext src test -name '*.c' -o -name '*_inline.h'`; do
-    if expr "$f" : '.*/windows_shim.c' > /dev/null; then
-        continue
-    fi
+SUBDIRS="bench ext src test"
 
+if [[ "$1" = "-F" ]]; then
+    last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
+    l=`git diff --name-only "${last_commit_from_dev}" $SUBDIRS | grep -E '(_inline\.h|\.c)$' | egrep -Ev '/windows_shim\.c$'`
+else
+    l=`find $SUBDIRS -name '*.c' -o -name '*_inline.h' | egrep -Ev '/windows_shim\.c$'`
+fi
+for f in $l; do
     # Complain about functions which return an "int" but which don't return
     # except at the end of the function.
     #

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -3,6 +3,7 @@
 # Single space, newline at the end of file, and remove trailing whitespace from source files.
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. || exit $?
 
 # Clear lines that only contain whitespace, compress multiple empty lines
 # into a single line, discard trailing empty lines.
@@ -23,26 +24,53 @@ whitespace()
     cmp $t $1 > /dev/null 2>&1 || (echo "$1" && cp $t $1)
 }
 
-cd ..
+SUBDIRS="bench examples ext src test"
+{
+    if [[ "$1" = "-F" ]]; then
+        last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
+        git diff --name-only "${last_commit_from_dev}" $SUBDIRS | \
+            dist/pygrep.py \
+                '\.[ch]$' \
+                '\.cpp$' \
+                '\.dox$' \
+                '\.in$' \
+                '\.py$' \
+                '\.sh$' \
+                '\.yaml$' \
+                '\.yml$' \
+                '(^|/)s_' \
+                '(^|/)CONFIG\.' \
+                '(^|/)Makefile.am$' | \
+            dist/pygrep.py -fv \
+                'Makefile.in' \
+                'checksum/power8' \
+                '3rdparty' \
+                'docs/tools' \
+                'log/log_auto' \
+                ;
 
-find bench dist examples ext src test \
-    -name '*.[ch]' -o \
-    -name '*.cpp' -o \
-    -name '*.dox' -o \
-    -name '*.in' -o \
-    -name '*.py' -o \
-    -name '*.sh' -o \
-    -name '*.yaml' -o \
-    -name '*.yml' -o \
-    -name 's_*' -o \
-    -name 'CONFIG.*' -o \
-    -name 'Makefile.am' |
-    sed -e '/Makefile.in/d' \
-        -e '/checksum\/power8/d' \
-        -e '/3rdparty/d' \
-        -e '/docs\/tools/d' \
-        -e '/log\/log_auto/d' \
-| while read f ; do
+    else
+        find $SUBDIRS \
+            -name '*.[ch]' -o \
+            -name '*.cpp' -o \
+            -name '*.dox' -o \
+            -name '*.in' -o \
+            -name '*.py' -o \
+            -name '*.sh' -o \
+            -name '*.yaml' -o \
+            -name '*.yml' -o \
+            -name 's_*' -o \
+            -name 'CONFIG.*' -o \
+            -name 'Makefile.am' | \
+            dist/pygrep.py -fv \
+                'Makefile.in' \
+                'checksum/power8' \
+                '3rdparty' \
+                'docs/tools' \
+                'log/log_auto' \
+                ;
+    fi
+} | while read f ; do
     whitespace $f
 done
 

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -4,6 +4,7 @@
 t=__wt.$$
 trap 'rm -f $t' 0 1 2 3 13 15
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. || exit $?
+[[ `uname -s` == Darwin ]] && EGREP="dist/pygrep.py -E" FGREP="dist/pygrep.py -F" || EGREP=egrep FGREP=fgrep
 
 # Clear lines that only contain whitespace, compress multiple empty lines
 # into a single line, discard trailing empty lines.
@@ -29,24 +30,24 @@ SUBDIRS="bench examples ext src test"
     if [[ "$1" = "-F" ]]; then
         last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
         git diff --name-only "${last_commit_from_dev}" $SUBDIRS | \
-            dist/pygrep.py \
-                '\.[ch]$' \
-                '\.cpp$' \
-                '\.dox$' \
-                '\.in$' \
-                '\.py$' \
-                '\.sh$' \
-                '\.yaml$' \
-                '\.yml$' \
-                '(^|/)s_' \
-                '(^|/)CONFIG\.' \
-                '(^|/)Makefile.am$' | \
-            dist/pygrep.py -fv \
-                'Makefile.in' \
-                'checksum/power8' \
-                '3rdparty' \
-                'docs/tools' \
-                'log/log_auto' \
+            $EGREP \
+                -e '\.[ch]$' \
+                -e '\.cpp$' \
+                -e '\.dox$' \
+                -e '\.in$' \
+                -e '\.py$' \
+                -e '\.sh$' \
+                -e '\.yaml$' \
+                -e '\.yml$' \
+                -e '(^|/)s_' \
+                -e '(^|/)CONFIG\.' \
+                -e '(^|/)Makefile.am$' | \
+            $FGREP -v \
+                -e 'Makefile.in' \
+                -e 'checksum/power8' \
+                -e '3rdparty' \
+                -e 'docs/tools' \
+                -e 'log/log_auto' \
                 ;
 
     else
@@ -62,12 +63,12 @@ SUBDIRS="bench examples ext src test"
             -name 's_*' -o \
             -name 'CONFIG.*' -o \
             -name 'Makefile.am' | \
-            dist/pygrep.py -fv \
-                'Makefile.in' \
-                'checksum/power8' \
-                '3rdparty' \
-                'docs/tools' \
-                'log/log_auto' \
+            $FGREP -v \
+                -e 'Makefile.in' \
+                -e 'checksum/power8' \
+                -e '3rdparty' \
+                -e 'docs/tools' \
+                -e 'log/log_auto' \
                 ;
     fi
 } | while read f ; do


### PR DESCRIPTION
This change improves the run time of `s_all` and `s_fast` on MacOS and improves `s_fast` on all platforms.

Summary of changes:
* Use a python implementation of `grep` on MacOS to mitigate the slow (old) version slowness when matching multiple patterns. Use python grep in the slowest scripts on MacOS: `s_define`, `s_funcs`, `s_stat`, `s_whitespace`.
* Implement "fast" mode in: `s_string`, `s_void`, `s_whitespace` and speed up `s_fast`.
* Improve struct fields parsing in `s_stat`.
* Eliminate the use of temp file for output in: `s_define`, `s_funcs`.