### PR TITLE
WT-11626 Add failure injection to the workload generator

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -395,6 +395,7 @@ Unbuffered
 Unencrypted
 Unhandled
 UnixLib
+Unlink
 UnlockFile
 Unmap
 UnmapViewOfFile

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -277,7 +277,7 @@ shared_memory::~shared_memory()
     if (munmap(_data, _size) < 0)
         /* Cannot throw an exception from out of a destructor, so just complain. */
         std::cerr << "WARNING: Failed to unmap shared memory object \"" << _name
-                  << "\": " << strerror(errno) << " (" << errno << ")";
+                  << "\": " << strerror(errno) << " (" << errno << ")" << std::endl;
 }
 
 /*

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -233,7 +233,7 @@ shared_memory::shared_memory(size_t size) : _data(nullptr), _size(size)
     }
 
     /* Set the initial size. */
-    ret = ftruncate64(fd, (loff_t)size);
+    ret = ftruncate(fd, (off_t)size);
     if (ret < 0) {
         (void)close(fd);
         throw std::runtime_error("Setting shared memory size failed");

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -29,6 +29,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
 #include <iostream>
@@ -274,10 +275,12 @@ shared_memory::~shared_memory()
     if (_data == nullptr)
         return;
 
-    if (munmap(_data, _size) < 0)
-        /* Cannot throw an exception from out of a destructor, so just complain. */
-        std::cerr << "WARNING: Failed to unmap shared memory object \"" << _name
+    if (munmap(_data, _size) < 0) {
+        /* Cannot throw an exception from out of a destructor, so just fail. */
+        std::cerr << "PANIC: Failed to unmap shared memory object \"" << _name
                   << "\": " << strerror(errno) << " (" << errno << ")" << std::endl;
+        abort();
+    }
 }
 
 /*

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -233,7 +233,7 @@ shared_memory::shared_memory(size_t size) : _data(nullptr), _size(size)
     }
 
     /* Set the initial size. */
-    ret = ftruncate(fd, (off_t)size);
+    ret = ftruncate(fd, (wt_off_t)size);
     if (ret < 0) {
         (void)close(fd);
         throw std::runtime_error("Setting shared memory size failed");

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -26,8 +26,11 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <algorithm>
 #include <cstring>
+#include <fcntl.h>
 #include <iostream>
 #include <sstream>
 #include <vector>
@@ -196,6 +199,85 @@ config_map::merge(const config_map &a, const config_map &b)
     std::merge(a._map.begin(), a._map.end(), b._map.begin(), b._map.end(),
       std::inserter(m._map, m._map.begin()));
     return m;
+}
+
+/*
+ * shared_memory::shared_memory --
+ *     Create a shared memory object of the given size.
+ */
+shared_memory::shared_memory(size_t size) : _data(nullptr), _size(size)
+{
+    /* Create a unique name using the PID and the memory offset of this object. */
+    std::ostringstream name_stream;
+    name_stream << "/shm-" << getpid() << "-" << this;
+    _name = name_stream.str();
+
+    /* Create the shared memory object. */
+    int fd = shm_open(_name.c_str(), O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+        std::ostringstream err;
+        err << "Failed to open shared memory object \"" << _name << "\": " << strerror(errno)
+            << " (" << errno << ")";
+        throw std::runtime_error(err.str());
+    }
+
+    /* Unlink the object from the namespace, as it is no longer needed. */
+    int ret = shm_unlink(_name.c_str());
+    if (ret < 0) {
+        (void)close(fd);
+        std::ostringstream err;
+        err << "Failed to unlink shared memory object \"" << _name << "\": " << strerror(errno)
+            << " (" << errno << ")";
+        _data = nullptr;
+        throw std::runtime_error(err.str());
+    }
+
+    /* Set the initial size. */
+    ret = ftruncate64(fd, (loff_t)size);
+    if (ret < 0) {
+        (void)close(fd);
+        throw std::runtime_error("Setting shared memory size failed");
+    }
+
+    /* Map the shared memory. */
+    _data = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (_data == MAP_FAILED) {
+        (void)close(fd);
+        std::ostringstream err;
+        err << "Failed to map shared memory object \"" << _name << "\": " << strerror(errno) << " ("
+            << errno << ")";
+        _data = nullptr;
+        throw std::runtime_error(err.str());
+    }
+
+    /* Close the handle. */
+    ret = close(fd);
+    if (ret < 0) {
+        (void)munmap(_data, _size);
+        std::ostringstream err;
+        err << "Failed to close shared memory object \"" << _name << "\": " << strerror(errno)
+            << " (" << errno << ")";
+        _data = nullptr;
+        throw std::runtime_error(err.str());
+    }
+
+    /* Zero the object. */
+    memset(_data, 0, _size);
+}
+
+/*
+ * shared_memory::~shared_memory --
+ *     Free the memory object.
+ */
+shared_memory::~shared_memory()
+{
+    if (_data == nullptr)
+        return;
+
+    if (munmap(_data, _size) < 0)
+        /* Cannot throw an exception from out of a destructor, so just complain. */
+        std::cerr << "WARNING: Failed to unmap shared memory object \"" << _name
+                  << "\": " << strerror(errno) << " (" << errno << ")";
 }
 
 /*

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -209,7 +209,7 @@ shared_memory::shared_memory(size_t size) : _data(nullptr), _size(size)
 {
     /* Create a unique name using the PID and the memory offset of this object. */
     std::ostringstream name_stream;
-    name_stream << "/shm-" << getpid() << "-" << this;
+    name_stream << "/wt-" << getpid() << "-" << this;
     _name = name_stream.str();
 
     /* Create the shared memory object. */

--- a/test/model/src/driver/kv_workload.cpp
+++ b/test/model/src/driver/kv_workload.cpp
@@ -45,8 +45,7 @@ void
 kv_workload::run(kv_database &database) const
 {
     kv_workload_runner runner{database};
-    for (const operation::any &op : _operations)
-        runner.run_operation(op);
+    runner.run(*this);
 }
 
 /*
@@ -57,12 +56,7 @@ void
 kv_workload::run_in_wiredtiger(const char *home, const char *connection_config) const
 {
     kv_workload_runner_wt runner{home, connection_config};
-    runner.wiredtiger_open();
-
-    for (const operation::any &op : _operations)
-        runner.run_operation(op);
-
-    runner.wiredtiger_close();
+    runner.run(*this);
 }
 
 } /* namespace model */

--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -118,7 +118,7 @@ kv_workload_runner_wt::run(const kv_workload &workload)
      * process crashes intentionally, we'll learn about it through the shared state.
      */
     size_t p = 0; /* Position in the workload. */
-    while (p < workload.size()) {
+    for (;;) {
         bool crashed = _state->expect_crash;
         _state->expect_crash = false;
 

--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -31,7 +31,9 @@
 #include <cassert>
 #include <iomanip>
 #include <iostream>
+#include <signal.h>
 #include <sstream>
+#include <unistd.h>
 #include "model/driver/kv_workload_runner_wt.h"
 #include "model/util.h"
 

--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -265,8 +265,8 @@ kv_workload_runner_wt::do_operation(const operation::checkpoint &op)
     std::ostringstream config;
     if (!op.name.empty())
         config << "name=" << op.name;
-
     std::string config_str = config.str();
+
     return session->checkpoint(session, config_str.c_str());
 }
 
@@ -277,16 +277,16 @@ kv_workload_runner_wt::do_operation(const operation::checkpoint &op)
 int
 kv_workload_runner_wt::do_operation(const operation::commit_transaction &op)
 {
-    std::shared_lock lock(_connection_lock);
-    session_context_ptr session = remove_txn_session(op.txn_id);
-
     std::ostringstream config;
     if (op.commit_timestamp != k_timestamp_none)
         config << ",commit_timestamp=" << std::hex << op.commit_timestamp;
     if (op.durable_timestamp != k_timestamp_none)
         config << ",durable_timestamp=" << std::hex << op.durable_timestamp;
-
     std::string config_str = config.str();
+
+    std::shared_lock lock(_connection_lock);
+    session_context_ptr session = remove_txn_session(op.txn_id);
+
     return session->session()->commit_transaction(session->session(), config_str.c_str());
 }
 
@@ -340,8 +340,8 @@ kv_workload_runner_wt::do_operation(const operation::create_table &op)
      */
     config << "log=(enabled=false)";
     config << ",key_format=" << op.key_format << ",value_format=" << op.value_format;
-
     std::string config_str = config.str();
+
     std::string uri = std::string("table:") + op.name;
     ret = session->create(session, uri.c_str(), config_str.c_str());
     if (ret == 0)
@@ -369,14 +369,14 @@ kv_workload_runner_wt::do_operation(const operation::insert &op)
 int
 kv_workload_runner_wt::do_operation(const operation::prepare_transaction &op)
 {
-    std::shared_lock lock(_connection_lock);
-    session_context_ptr session = txn_session(op.txn_id);
-
     std::ostringstream config;
     if (op.prepare_timestamp != k_timestamp_none)
         config << ",prepare_timestamp=" << std::hex << op.prepare_timestamp;
-
     std::string config_str = config.str();
+
+    std::shared_lock lock(_connection_lock);
+    session_context_ptr session = txn_session(op.txn_id);
+
     return session->session()->prepare_transaction(session->session(), config_str.c_str());
 }
 
@@ -416,8 +416,9 @@ kv_workload_runner_wt::do_operation(const operation::restart &op)
 int
 kv_workload_runner_wt::do_operation(const operation::rollback_to_stable &op)
 {
-    std::unique_lock lock(_connection_lock);
     (void)op;
+
+    std::unique_lock lock(_connection_lock);
     return _connection->rollback_to_stable(_connection, nullptr);
 }
 
@@ -440,14 +441,14 @@ kv_workload_runner_wt::do_operation(const operation::rollback_transaction &op)
 int
 kv_workload_runner_wt::do_operation(const operation::set_commit_timestamp &op)
 {
-    std::shared_lock lock(_connection_lock);
-    session_context_ptr session = txn_session(op.txn_id);
-
     std::ostringstream config;
     if (op.commit_timestamp != k_timestamp_none)
         config << ",commit_timestamp=" << std::hex << op.commit_timestamp;
-
     std::string config_str = config.str();
+
+    std::shared_lock lock(_connection_lock);
+    session_context_ptr session = txn_session(op.txn_id);
+
     return session->session()->timestamp_transaction(session->session(), config_str.c_str());
 }
 
@@ -458,11 +459,11 @@ kv_workload_runner_wt::do_operation(const operation::set_commit_timestamp &op)
 int
 kv_workload_runner_wt::do_operation(const operation::set_stable_timestamp &op)
 {
-    std::shared_lock lock(_connection_lock);
     std::ostringstream config;
     config << "stable_timestamp=" << std::hex << op.stable_timestamp;
-
     std::string config_str = config.str();
+
+    std::shared_lock lock(_connection_lock);
     return _connection->set_timestamp(_connection, config_str.c_str());
 }
 

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -30,6 +30,7 @@
 #define MODEL_DRIVER_KV_WORKLOAD_H
 
 #include <deque>
+#include <iostream>
 #include <variant>
 #include "model/core.h"
 #include "model/data_value.h"
@@ -92,6 +93,30 @@ struct commit_transaction {
     {
     }
 };
+
+/*
+ * crash --
+ *     A representation of this workload operation.
+ */
+struct crash {
+
+    /*
+     * crash::crash --
+     *     Create the operation.
+     */
+    inline crash() {}
+};
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const crash &op)
+{
+    out << "crash()";
+    return out;
+}
 
 /*
  * create_table --
@@ -271,8 +296,8 @@ struct truncate {
  * any --
  *     Any workload operation.
  */
-using any = std::variant<begin_transaction, checkpoint, commit_transaction, create_table, insert,
-  prepare_transaction, remove, restart, rollback_to_stable, rollback_transaction,
+using any = std::variant<begin_transaction, checkpoint, commit_transaction, crash, create_table,
+  insert, prepare_transaction, remove, restart, rollback_to_stable, rollback_transaction,
   set_commit_timestamp, set_stable_timestamp, truncate>;
 
 } /* namespace operation */
@@ -310,6 +335,36 @@ public:
     {
         _operations.push_back(std::move(op));
         return *this;
+    }
+
+    /*
+     * kv_workload_sequence::size --
+     *     Get the length of the sequence.
+     */
+    inline size_t
+    size() const noexcept
+    {
+        return _operations.size();
+    }
+
+    /*
+     * kv_workload_sequence::operator[] --
+     *     Get an operation in the sequence.
+     */
+    inline operation::any &
+    operator[](size_t index)
+    {
+        return _operations[index];
+    }
+
+    /*
+     * kv_workload_sequence::operator[] --
+     *     Get an operation in the sequence.
+     */
+    inline const operation::any &
+    operator[](size_t index) const
+    {
+        return _operations[index];
     }
 
     /*

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -72,6 +72,7 @@ struct kv_workload_generator_spec {
 
     /* Probabilities of special operations. */
     float checkpoint;
+    float crash;
     float restart;
     float set_stable_timestamp;
 

--- a/test/model/src/include/model/driver/kv_workload_runner.h
+++ b/test/model/src/include/model/driver/kv_workload_runner.h
@@ -64,6 +64,17 @@ public:
     }
 
     /*
+     * kv_workload_runner::run --
+     *     Run the workload in the model.
+     */
+    inline void
+    run(const kv_workload &workload)
+    {
+        for (size_t i = 0; i < workload.size(); i++)
+            run_operation(workload[i]);
+    }
+
+    /*
      * kv_workload_runner::run_operation --
      *     Run the given operation.
      */
@@ -116,6 +127,18 @@ protected:
     {
         /* Remove the transaction first, so that the map has only uncommitted transactions. */
         remove_transaction(op.txn_id)->commit(op.commit_timestamp, op.durable_timestamp);
+        return 0;
+    }
+
+    /*
+     * kv_workload_runner::do_operation --
+     *     Execute the given workload operation in the model.
+     */
+    int
+    do_operation(const operation::crash &op)
+    {
+        (void)op;
+        restart(true /* crash */);
         return 0;
     }
 
@@ -235,11 +258,11 @@ protected:
      *     Simulate database restart.
      */
     inline void
-    restart()
+    restart(bool crash = false)
     {
         std::unique_lock lock(_transactions_lock);
         _transactions.clear();
-        _database.restart();
+        _database.restart(crash);
     }
 
     /*

--- a/test/model/src/include/model/driver/kv_workload_runner_wt.h
+++ b/test/model/src/include/model/driver/kv_workload_runner_wt.h
@@ -114,13 +114,43 @@ protected:
      */
     using session_context_ptr = std::shared_ptr<session_context>;
 
+    /*
+     * shared_state --
+     *     The shared state of the child executor process, which is shared with the parent. Because
+     *     of the way this struct is used, only C types are allowed.
+     */
+    struct shared_state {
+
+        /*
+         * shared_state::table_state --
+         *     Shared table state.
+         */
+        struct table_state {
+            table_id_t id;
+            char uri[256];
+        };
+
+        /* Crash handling. */
+        size_t crash_index; /* The crash operation that resulted, well, in the crash. */
+        bool expect_crash;  /* True when the child process is expected to crash. */
+
+        /* Execution failure handling. */
+        bool exception;              /* If there was an exception. */
+        size_t failed_operation;     /* The operation that caused an exception. */
+        char exception_message[256]; /* The exception message. */
+
+        /* The map of table IDs to to URIs, needed to resume the workload from a crash. */
+        size_t num_tables;
+        table_state tables[256]; /* The table states; protected by the same lock as the URI map. */
+    };
+
 public:
     /*
      * kv_workload_runner_wt::kv_workload_runner_wt --
      *     Create a new workload
      */
     inline kv_workload_runner_wt(const char *home, const char *connection_config)
-        : _connection(nullptr), _connection_config(connection_config), _home(home)
+        : _connection(nullptr), _connection_config(connection_config), _home(home), _state(nullptr)
     {
     }
 
@@ -130,6 +160,13 @@ public:
      */
     ~kv_workload_runner_wt();
 
+    /*
+     * kv_workload::run --
+     *     Run the workload in WiredTiger.
+     */
+    void run(const kv_workload &workload);
+
+protected:
     /*
      * kv_workload_runner::run_operation --
      *     Run the given operation.
@@ -173,7 +210,6 @@ public:
         wiredtiger_close_nolock();
     }
 
-protected:
     /*
      * kv_workload_runner_wt::do_operation --
      *     Execute the given workload operation in WiredTiger.
@@ -191,6 +227,12 @@ protected:
      *     Execute the given workload operation in WiredTiger.
      */
     int do_operation(const operation::commit_transaction &op);
+
+    /*
+     * kv_workload_runner_wt::crash --
+     *     Execute the given workload operation in WiredTiger.
+     */
+    int do_operation(const operation::crash &op);
 
     /*
      * kv_workload_runner_wt::do_operation --
@@ -268,15 +310,7 @@ protected:
      * kv_workload_runner_wt::add_table_uri --
      *     Add a table URI.
      */
-    inline void
-    add_table_uri(table_id_t id, std::string uri)
-    {
-        std::unique_lock lock(_table_uris_lock);
-        auto i = _table_uris.find(id);
-        if (i != _table_uris.end())
-            throw model_exception("A table with the given ID already exists");
-        _table_uris.insert_or_assign(i, id, uri);
-    }
+    void add_table_uri(table_id_t id, std::string uri, bool recovery = false);
 
     /*
      * kv_workload_runner_wt::table_uri --
@@ -332,6 +366,8 @@ protected:
 private:
     std::string _connection_config;
     std::string _home;
+
+    shared_state *_state; /* The shared state between the executor and the parent process. */
 
     mutable std::shared_mutex _connection_lock; /* Should be held for all operations. */
     WT_CONNECTION *_connection;

--- a/test/model/src/include/model/driver/kv_workload_runner_wt.h
+++ b/test/model/src/include/model/driver/kv_workload_runner_wt.h
@@ -139,7 +139,7 @@ protected:
         size_t failed_operation;     /* The operation that caused an exception. */
         char exception_message[256]; /* The exception message. */
 
-        /* The map of table IDs to to URIs, needed to resume the workload from a crash. */
+        /* The map of table IDs to URIs, needed to resume the workload from a crash. */
         size_t num_tables;
         table_state tables[256]; /* The table states; protected by the same lock as the URI map. */
     };

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -321,6 +321,59 @@ private:
 };
 
 /*
+ * shared_memory --
+ *     Shared memory with a child process. After creating this object, the shared memory would be
+ *     available in both the parent and the child process. The memory object will be automatically
+ *     cleaned up when it falls out of scope.
+ */
+class shared_memory {
+
+public:
+    /*
+     * shared_memory::shared_memory --
+     *     Create a shared memory object of the given size.
+     */
+    shared_memory(size_t size);
+
+    /* Delete the copy constructor. */
+    shared_memory(const shared_memory &) = delete;
+
+    /* Delete the copy operator. */
+    shared_memory &operator=(const shared_memory &) = delete;
+
+    /*
+     * shared_memory::~shared_memory --
+     *     Free the memory object.
+     */
+    ~shared_memory();
+
+    /*
+     * shared_memory::data --
+     *     Get the data pointer.
+     */
+    inline void *
+    data() noexcept
+    {
+        return _data;
+    }
+
+    /*
+     * shared_memory::size --
+     *     Get the data size.
+     */
+    inline size_t
+    size() noexcept
+    {
+        return _size;
+    }
+
+private:
+    void *_data;
+    size_t _size;
+    std::string _name;
+};
+
+/*
  * starts_with --
  *     Check whether the string has the given prefix. (C++ does not have this until C++20.)
  */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -374,6 +374,38 @@ private:
 };
 
 /*
+ * at_cleanup --
+ *     Run an action at the time this object falls out of scope.
+ */
+class at_cleanup {
+
+public:
+    /*
+     * at_cleanup::at_cleanup --
+     *     Create the cleanup object.
+     */
+    inline at_cleanup(std::function<void()> fn) : _fn(fn){};
+
+    /* Delete the copy constructor. */
+    at_cleanup(const at_cleanup &) = delete;
+
+    /* Delete the copy operator. */
+    at_cleanup &operator=(const at_cleanup &) = delete;
+
+    /*
+     * at_cleanup::~at_cleanup --
+     *     Free the object and run the clean up function.
+     */
+    inline ~at_cleanup()
+    {
+        _fn();
+    }
+
+private:
+    std::function<void()> _fn;
+};
+
+/*
  * starts_with --
  *     Check whether the string has the given prefix. (C++ does not have this until C++20.)
  */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -30,6 +30,7 @@
 #define MODEL_UTIL_H
 
 #include <cstring>
+#include <functional>
 #include <iomanip>
 #include <memory>
 #include <sstream>

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -246,6 +246,46 @@ test_workload_restart(void)
 }
 
 /*
+ * test_workload_crash --
+ *     Test the workload executor with database crash.
+ */
+static void
+test_workload_crash(void)
+{
+    model::kv_workload workload;
+    workload << model::operation::create_table(k_table1_id, "table1", "S", "S")
+             << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
+             << model::operation::insert(k_table1_id, 1, key1, value1)
+             << model::operation::insert(k_table1_id, 2, key2, value2)
+             << model::operation::prepare_transaction(1, 10)
+             << model::operation::prepare_transaction(2, 15)
+             << model::operation::commit_transaction(1, 20, 21)
+             << model::operation::commit_transaction(2, 25, 26)
+             << model::operation::set_stable_timestamp(22) << model::operation::begin_transaction(1)
+             << model::operation::remove(k_table1_id, 1, key1) << model::operation::checkpoint()
+             << model::operation::crash() << model::operation::begin_transaction(1)
+             << model::operation::insert(k_table1_id, 1, key3, value3)
+             << model::operation::prepare_transaction(1, 23)
+             << model::operation::commit_transaction(1, 24, 25)
+             << model::operation::set_stable_timestamp(25);
+
+    /* Run the workload in the model. */
+    model::kv_database database;
+    workload.run(database);
+
+    /* Verify the contents of the model. */
+    model::kv_table_ptr table = database.table("table1");
+    testutil_assert(table->get(key1) == value1);
+    testutil_assert(table->get(key2) == model::NONE);
+    testutil_assert(table->get(key3) == value3);
+
+    /* Run the workload in WiredTiger and verify. */
+    std::string test_home = std::string(home) + DIR_DELIM_STR + "crash";
+    verify_workload(workload, opts, test_home, ENV_CONFIG);
+    verify_using_debug_log(opts, test_home.c_str()); /* May as well test this. */
+}
+
+/*
  * usage --
  *     Print usage help for the program.
  */
@@ -298,6 +338,7 @@ main(int argc, char *argv[])
         test_workload_txn();
         test_workload_prepared();
         test_workload_restart();
+        test_workload_crash();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;
         ret = EXIT_FAILURE;


### PR DESCRIPTION
This PR introduces the "crash" operation to the workload generator, which intentionally crashes WiredTiger to force it to do recovery—and thus to run RTS, as the main goal of this project is to add more RTS testing.

The trick to getting this working with WiredTiger was to run the workload in a child process, so that we can easily crash and restart it. The child process saves its state between crashes using shared memory, and it also uses it to return information back to the controller parent process, e.g., whether the crash was intentional.

Feel free to let me know if you have any questions, or if you'd like me to go over anything via Zoom.