### PR TITLE
WT-11491 WT-11777 v5.0 group backport

### DIFF
--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -32,10 +32,11 @@ build() {
 		echo "    typedef $t $n $upper;"
 	done
 
-	# There's one fixed type we use.
-	echo
-	echo 'typedef uint64_t wt_timestamp_t;'
-	echo
+    # Fixed types we use.
+    echo
+    echo 'typedef struct timespec WT_TIMER;'
+    echo 'typedef uint64_t wt_timestamp_t;'
+    echo
 
 	echo '/*'
 	sed -e '/Forward type declarations .*: END/,${' \

--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -32,11 +32,11 @@ build() {
 		echo "    typedef $t $n $upper;"
 	done
 
-    # Fixed types we use.
-    echo
-    echo 'typedef struct timespec WT_TIMER;'
-    echo 'typedef uint64_t wt_timestamp_t;'
-    echo
+	# Fixed types we use.
+	echo
+	echo 'typedef struct timespec WT_TIMER;'
+	echo 'typedef uint64_t wt_timestamp_t;'
+	echo
 
 	echo '/*'
 	sed -e '/Forward type declarations .*: END/,${' \

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -377,6 +377,20 @@ struct __wt_connection_impl {
     uint64_t ckpt_write_bytes;
     uint64_t ckpt_write_pages;
 
+    /* Record the important timestamps of each stage in recovery. */
+    struct __wt_recovery_timeline {
+        uint64_t log_replay_ms;
+        uint64_t rts_ms;
+        uint64_t checkpoint_ms;
+        uint64_t recovery_ms;
+    } recovery_timeline;
+
+    /* Record the important timestamps of each stage in shutdown. */
+    struct __wt_shutdown_timeline {
+        uint64_t rts_ms;
+        uint64_t checkpoint_ms;
+        uint64_t shutdown_ms;
+    } shutdown_timeline;
     /* Checkpoint and incremental backup data */
     uint64_t incr_granularity;
     WT_BLKINCR incr_backups[WT_BLKINCR_MAX];

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2358,6 +2358,9 @@ static inline void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_lock_track(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_spin_unlock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static inline void __wt_struct_size_adjust(WT_SESSION_IMPL *session, size_t *sizep);
+static inline void __wt_timer_evaluate_ms(
+  WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff_ms);
+static inline void __wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time);
 static inline void __wt_timing_stress(WT_SESSION_IMPL *session, u_int flag);
 static inline void __wt_tree_modify_set(WT_SESSION_IMPL *session);
 static inline void __wt_txn_cursor_op(WT_SESSION_IMPL *session);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -44,7 +44,7 @@
 
 #define WT_MINUTE (60)
 
-#define WT_PROGRESS_MSG_PERIOD (20)
+#define WT_PROGRESS_MSG_PERIOD (20) /* Seconds. */
 
 #define WT_KILOBYTE (1024)
 #define WT_MEGABYTE (1048576)

--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -206,3 +206,26 @@ __wt_op_timer_fired(WT_SESSION_IMPL *session)
     diff = WT_CLOCKDIFF_US(now, session->operation_start_us);
     return (diff > session->operation_timeout_us);
 }
+
+/*
+ * __wt_timer_start --
+ *     Start the timer.
+ */
+static inline void
+__wt_timer_start(WT_SESSION_IMPL *session, WT_TIMER *start_time)
+{
+    __wt_epoch(session, start_time);
+}
+
+/*
+ * __wt_timer_evaluate_ms --
+ *     Evaluate the difference between the current time and start time and output the difference in
+ *     milliseconds.
+ */
+static inline void
+__wt_timer_evaluate_ms(WT_SESSION_IMPL *session, WT_TIMER *start_time, uint64_t *time_diff_ms)
+{
+    struct timespec cur_time;
+    __wt_epoch(session, &cur_time);
+    *time_diff_ms = WT_TIMEDIFF_MS(cur_time, *start_time);
+}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -301,6 +301,8 @@ struct __wt_reconcile;
 typedef struct __wt_reconcile WT_RECONCILE;
 struct __wt_reconcile_timeline;
 typedef struct __wt_reconcile_timeline WT_RECONCILE_TIMELINE;
+struct __wt_recovery_timeline;
+typedef struct __wt_recovery_timeline WT_RECOVERY_TIMELINE;
 struct __wt_ref;
 typedef struct __wt_ref WT_REF;
 struct __wt_ref_hist;
@@ -321,6 +323,8 @@ struct __wt_session_stash;
 typedef struct __wt_session_stash WT_SESSION_STASH;
 struct __wt_session_stats;
 typedef struct __wt_session_stats WT_SESSION_STATS;
+struct __wt_shutdown_timeline;
+typedef struct __wt_shutdown_timeline WT_SHUTDOWN_TIMELINE;
 struct __wt_size;
 typedef struct __wt_size WT_SIZE;
 struct __wt_spinlock;
@@ -372,6 +376,7 @@ typedef union __wt_lsn WT_LSN;
 union __wt_rand_state;
 typedef union __wt_rand_state WT_RAND_STATE;
 
+typedef struct timespec WT_TIMER;
 typedef uint64_t wt_timestamp_t;
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2543,7 +2543,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
             /* Time since the shutdown RTS has started. */
             __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.rts_ms);
             if (ret != 0)
-                __wt_verbose_notice(session, WT_VERB_RTS,
+                __wt_verbose(session, WT_VERB_RTS,
                   "performing shutdown rollback to stable failed with code %s",
                   __wt_strerror(session, ret, NULL, 0));
             else

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2506,6 +2506,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_SESSION_IMPL *s;
+    WT_TIMER timer;
     char ts_string[WT_TS_INT_STRING_SIZE];
     const char *ckpt_cfg;
     bool use_timestamp;
@@ -2533,10 +2534,23 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
          * clean shutdown.
          */
         if (use_timestamp) {
+            __wt_timer_start(session, &timer);
             __wt_verbose(session, WT_VERB_RTS,
               "performing shutdown rollback to stable with stable timestamp: %s",
               __wt_timestamp_to_string(conn->txn_global.stable_timestamp, ts_string));
             WT_TRET(__wt_rollback_to_stable(session, cfg, true));
+
+            /* Time since the shutdown RTS has started. */
+            __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.rts_ms);
+            if (ret != 0)
+                __wt_verbose_notice(session, WT_VERB_RTS,
+                  "performing shutdown rollback to stable failed with code %s",
+                  __wt_strerror(session, ret, NULL, 0));
+            else
+                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+                  "shutdown rollback to stable has successfully finished and ran for %" PRIu64
+                  " milliseconds",
+                  conn->shutdown_timeline.rts_ms);
         }
 
         s = NULL;
@@ -2544,6 +2558,9 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
         if (s != NULL) {
             const char *checkpoint_cfg[] = {
               WT_CONFIG_BASE(session, WT_SESSION_checkpoint), ckpt_cfg, NULL};
+
+            __wt_timer_start(session, &timer);
+
             WT_TRET(__wt_txn_checkpoint(s, checkpoint_cfg, true));
 
             /*
@@ -2552,6 +2569,12 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
             WT_WITH_DHANDLE(s, WT_SESSION_META_DHANDLE(s), __wt_tree_modify_set(s));
 
             WT_TRET(__wt_session_close_internal(s));
+
+            /* Time since the shutdown checkpoint has started. */
+            __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.checkpoint_ms);
+            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+              "shutdown checkpoint has successfully finished and ran for %" PRIu64 " milliseconds",
+              conn->shutdown_timeline.checkpoint_ms);
         }
     }
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -834,6 +834,7 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     WT_DECL_RET;
     WT_RECOVERY r;
     WT_RECOVERY_FILE *metafile;
+    WT_TIMER timer, rts_timer, checkpoint_timer;
     wt_off_t hs_size;
     char *config;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
@@ -848,6 +849,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     rts_executed = false;
     eviction_started = false;
     was_backup = F_ISSET(conn, WT_CONN_WAS_BACKUP);
+
+    __wt_timer_start(session, &timer);
 
     /* We need a real session for recovery. */
     WT_RET(
@@ -1038,6 +1041,12 @@ done:
           "Upgrading from a WiredTiger version 10.0.0 database that was not shutdown cleanly is "
           "not allowed. Perform a clean shutdown on version 10.0.0 and then upgrade.");
 #endif
+    /* Time since the Log replay has started. */
+    __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.log_replay_ms);
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "recovery log replay has successfully finished and ran for %" PRIu64 " milliseconds",
+      conn->recovery_timeline.log_replay_ms);
+
     WT_ERR(__recovery_txn_setup_initial_state(session, &r));
 
     /*
@@ -1055,6 +1064,7 @@ done:
      * 2. The history store file was found in the metadata.
      */
     if (hs_exists && !F_ISSET(conn, WT_CONN_READONLY)) {
+        __wt_timer_start(session, &rts_timer);
         /* Start the eviction threads for rollback to stable if not already started. */
         if (!eviction_started) {
             WT_ERR(__wt_evict_create(session));
@@ -1069,6 +1079,13 @@ done:
           __wt_timestamp_to_string(conn->txn_global.oldest_timestamp, ts_string[1]));
         rts_executed = true;
         WT_ERR(__wt_rollback_to_stable(session, NULL, true));
+
+        /* Time since the rollback to stable has started. */
+        __wt_timer_evaluate_ms(session, &rts_timer, &conn->recovery_timeline.rts_ms);
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "recovery rollback to stable has successfully finished and ran for %" PRIu64
+          " milliseconds",
+          conn->recovery_timeline.rts_ms);
     }
 
     /*
@@ -1079,12 +1096,20 @@ done:
     if (eviction_started)
         WT_TRET(__wt_evict_destroy(session));
 
-    if (do_checkpoint || rts_executed)
+    if (do_checkpoint || rts_executed) {
+        __wt_timer_start(session, &checkpoint_timer);
         /*
          * Forcibly log a checkpoint so the next open is fast and keep the metadata up to date with
          * the checkpoint LSN and archiving.
          */
         WT_ERR(session->iface.checkpoint(&session->iface, "force=1"));
+
+        /* Time since the recovery checkpoint has started. */
+        __wt_timer_evaluate_ms(session, &checkpoint_timer, &conn->recovery_timeline.checkpoint_ms);
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "recovery checkpoint has successfully finished and ran for %" PRIu64 " milliseconds",
+          conn->recovery_timeline.checkpoint_ms);
+    }
 
     /* Remove any backup file now that metadata has been synced. */
     WT_ERR(__wt_backup_file_remove(session));
@@ -1105,6 +1130,15 @@ done:
     if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_FORCE_DOWNGRADE))
         WT_ERR(__wt_log_truncate_files(session, NULL, true));
     FLD_SET(conn->log_flags, WT_CONN_LOG_RECOVER_DONE);
+
+    /* Time since the recovery has started. */
+    __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.recovery_ms);
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
+      "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64
+      "ms for the checkpoint.",
+      conn->recovery_timeline.recovery_ms, conn->recovery_timeline.log_replay_ms,
+      conn->recovery_timeline.rts_ms, conn->recovery_timeline.checkpoint_ms);
 
 err:
     WT_TRET(__recovery_close_cursors(&r));

--- a/test/suite/test_recovery01.py
+++ b/test/suite/test_recovery01.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper import simulate_crash_restart
+from wtdataset import SimpleDataSet
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# test_recovery01.py
+# Test WiredTiger logs time spent during recovery and shutdown.
+class test_recovery01(wttest.WiredTigerTestCase):
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        ('column_fix', dict(key_format='r', value_format='8t')),
+        ('row_integer', dict(key_format='i', value_format='S')),
+    ]
+
+    restart_values = [
+        ('crash', dict(crash=True)),
+        ('shutdown', dict(crash=False))
+    ]
+
+    scenarios = make_scenarios(format_values, restart_values)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # BACKPORT remove for CI
+        #self.ignoreStdoutPattern('WT_VERB_RECOVERY_PROGRESS')
+
+    def conn_config(self):
+        # BACKPORT modify for CI
+        #config = 'cache_size=50MB,statistics=(all),log=(enabled=true),verbose=(recovery_progress)'
+        config = 'cache_size=50MB,statistics=(all),log=(enabled=true)'
+        return config
+
+    def large_updates(self, uri, value, ds, nrows, commit_ts):
+        # Update a large number of records.
+        session = self.session
+        cursor = session.open_cursor(uri)
+        for i in range(1, nrows+1):
+            session.begin_transaction()
+            cursor[ds.key(i)] = value
+            if commit_ts == 0:
+                session.commit_transaction()
+            else:
+                session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor.close()
+
+    def check(self, check_value, uri, nrows, read_ts):
+        session = self.session
+        if read_ts == 0:
+            session.begin_transaction()
+        else:
+            session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
+        cursor = session.open_cursor(uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, check_value)
+            count += 1
+        session.commit_transaction()
+        self.assertEqual(count, nrows)
+
+    def test_recovery(self):
+        nrows = 1000
+
+        # Create two tables. One logged and another one non-logged.
+        uri_1 = "table:recovery01_1"
+        ds_1 = SimpleDataSet(
+            self, uri_1, 0, key_format=self.key_format, value_format=self.value_format,
+            config='log=(enabled=true)')
+        ds_1.populate()
+
+        uri_2 = "table:recovery01_2"
+        ds_2 = SimpleDataSet(
+            self, uri_2, 0, key_format=self.key_format, value_format=self.value_format,
+            config='log=(enabled=false)')
+        ds_2.populate()
+
+        if self.value_format == '8t':
+            valuea = 97
+            valueb = 98
+        else:
+            valuea = "aaaaa" * 100
+            valueb = "bbbbb" * 100
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        self.large_updates(uri_1, valuea, ds_1, nrows, 0)
+        self.check(valuea, uri_1, nrows, 0)
+
+        self.large_updates(uri_2, valuea, ds_2, nrows, 10)
+        self.check(valuea, uri_2, nrows, 10)
+
+        self.large_updates(uri_1, valueb, ds_1, nrows, 0)
+        self.check(valueb, uri_1, nrows, 0)
+
+        self.large_updates(uri_2, valueb, ds_2, nrows, 20)
+        self.check(valueb, uri_2, nrows, 20)
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        if self.crash:
+            simulate_crash_restart(self, ".", "RESTART")
+        else:
+            self.reopen_conn()
+
+        self.check(valueb, uri_1, nrows, 0)
+        self.check(valuea, uri_2, nrows, 10)
+        self.check(valuea, uri_2, nrows, 20)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_recovery01.py
+++ b/test/suite/test_recovery01.py
@@ -38,7 +38,7 @@ class test_recovery01(wttest.WiredTigerTestCase):
 
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
-        ('column_fix', dict(key_format='r', value_format='8t')),
+        # ('column_fix', dict(key_format='r', value_format='8t')),
         ('row_integer', dict(key_format='i', value_format='S')),
     ]
 


### PR DESCRIPTION
In this backport test/suite/test_recovery01.py has been made a no-op as the test infrastructure required to make it work is not available in v6.0.

* WT-11491 Log the WiredTiger time spent during startup and shutdown (v7.0 backport) (#9710)

* WT-11491 Log the WiredTiger time spent during startup and shutdown (#9524)

(cherry picked from commit 542d756f1d33d9eb1b6f8aaa5ec04a37633e64c6)

---------

Co-authored-by: Hari Babu Kommi <haribabu.kommi@mongodb.com>
Co-authored-by: Jie Chen <jie.chen@mongodb.com>
(cherry picked from commit c77753914ff6da624081436939d27ccfe911cafd)

* WT-11777 Fix units of __wt_timer_evaluate() calls: logging and progress period (#9824) (#9889) (#10016)

(cherry picked from commit a9f8d18ee3e65fb53546e63744d9c10d0b919783) in 7.2

Co-authored-by: tod-johnson-mongodb <148508687+tod-johnson-mongodb@users.noreply.github.com>
(cherry picked from commit b3d7955819e257687946c7a168868fc12e07d6eb) in 7.1

Co-authored-by: jchen <29520270+jiechenbo@users.noreply.github.com>
(cherry picked from commit 961cd71de93c8bda033da4c2ad3ba66062b02cff)

---------

Co-authored-by: svc-bot-sebb <82952146+svc-bot-sebb@users.noreply.github.com>
Co-authored-by: tod-johnson-mongodb <148508687+tod-johnson-mongodb@users.noreply.github.com>
Co-authored-by: Ubuntu <ubuntu@ip-10-0-5-23.ec2.internal>
(cherry picked from commit 6c9177d816fff1211be78861e7fc1f09e0b32571)