### PR TITLE
WT-12364 Replaced WT_ASSERT() calls in Catch2-based unit test code with REQUIRE()

### DIFF
--- a/test/unittest/tests/test_prepare_mod_sort.cpp
+++ b/test/unittest/tests/test_prepare_mod_sort.cpp
@@ -118,9 +118,9 @@ init_key(WT_SESSION_IMPL *session, WT_ITEM *key, std::string key_str)
     WT_DECL_RET;
 
     ret = __wt_buf_init(session, key, key_str.size());
-    WT_ASSERT(session, ret == 0);
+    REQUIRE(ret == 0);
     ret = __wt_buf_set(session, key, key_str.c_str(), key_str.size());
-    WT_ASSERT(session, ret == 0);
+    REQUIRE(ret == 0);
 }
 
 /* Generate random keys. */


### PR DESCRIPTION
In Catch2-based unit tests, status should be checked using REQUIRE() which is part of the Catch2 framework, rather than using WT_ASSERT as one would within WiredTiger itself.