### PR TITLE
WT-12382 Fix __pack_encode_WT_ITEM with zero size item

### DIFF
--- a/dist/log.py
+++ b/dist/log.py
@@ -253,7 +253,7 @@ static inline int
 __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
     WT_RET(__wt_vpack_uint(pp, WT_PTRDIFF(end, *pp), item->size));
-    if (item->size) {
+    if (item->size != 0) {
         WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
         memcpy(*pp, item->data, item->size);
         *pp += item->size;
@@ -268,7 +268,7 @@ __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 static inline int
 __pack_encode_WT_ITEM_last(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
-    if (item->size) {
+    if (item->size != 0) {
         WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
         memcpy(*pp, item->data, item->size);
         *pp += item->size;

--- a/dist/log.py
+++ b/dist/log.py
@@ -253,9 +253,11 @@ static inline int
 __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
     WT_RET(__wt_vpack_uint(pp, WT_PTRDIFF(end, *pp), item->size));
-    WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
-    memcpy(*pp, item->data, item->size);
-    *pp += item->size;
+    if (item->size) {
+        WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
+        memcpy(*pp, item->data, item->size);
+        *pp += item->size;
+    }
     return (0);
 }
 
@@ -266,9 +268,11 @@ __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 static inline int
 __pack_encode_WT_ITEM_last(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
-    WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
-    memcpy(*pp, item->data, item->size);
-    *pp += item->size;
+    if (item->size) {
+        WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
+        memcpy(*pp, item->data, item->size);
+        *pp += item->size;
+    }
     return (0);
 }
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -42,9 +42,11 @@ static inline int
 __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
     WT_RET(__wt_vpack_uint(pp, WT_PTRDIFF(end, *pp), item->size));
-    WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
-    memcpy(*pp, item->data, item->size);
-    *pp += item->size;
+    if (item->size) {
+        WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
+        memcpy(*pp, item->data, item->size);
+        *pp += item->size;
+    }
     return (0);
 }
 
@@ -55,9 +57,11 @@ __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 static inline int
 __pack_encode_WT_ITEM_last(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
-    WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
-    memcpy(*pp, item->data, item->size);
-    *pp += item->size;
+    if (item->size) {
+        WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
+        memcpy(*pp, item->data, item->size);
+        *pp += item->size;
+    }
     return (0);
 }
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -42,7 +42,7 @@ static inline int
 __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
     WT_RET(__wt_vpack_uint(pp, WT_PTRDIFF(end, *pp), item->size));
-    if (item->size) {
+    if (item->size != 0) {
         WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
         memcpy(*pp, item->data, item->size);
         *pp += item->size;
@@ -57,7 +57,7 @@ __pack_encode_WT_ITEM(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 static inline int
 __pack_encode_WT_ITEM_last(uint8_t **pp, uint8_t *end, WT_ITEM *item)
 {
-    if (item->size) {
+    if (item->size != 0) {
         WT_SIZE_CHECK_PACK(item->size, WT_PTRDIFF(end, *pp));
         memcpy(*pp, item->data, item->size);
         *pp += item->size;


### PR DESCRIPTION
Summary of the change:
* ASAN was not happy with `memcpy` using NULL pointer with size = 0.