### PR TITLE
WT-12206 Add diagnostic output to the Clang analyser task

### DIFF
--- a/dist/s_clang_scan
+++ b/dist/s_clang_scan
@@ -49,4 +49,8 @@ echo 'scan-build output differs from expected:'
 echo '<<<<<<<<<< Expected >>>>>>>>>> Current'
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 diff dist/s_clang_scan.diff $t_out_filtered
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+echo 'scan-build output:'
+echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+cat $t_out
 exit 1


### PR DESCRIPTION
`s_clang_scan` reports any `clang_scan` warnings that aren't present in our whitelist file `s_clang_scan.diff`, but to do so it strips line numbers of where the warnings occur and then diffs against the whitelist. This means when there are new warnings we report their existence, but not their location in the file.

This change also dumps the original output of `clang_scan`, so when `s_clang_scan` detects a difference it reports both the delta and the original `clang_scan` output letting developers know where the introduced issue occurs. The solution provided in the Jira ticket is good, so I've taken that verbatim.
