### PR TITLE
WT-12417 Increase performance testing cadence to 4 times daily

### DIFF
--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -6,7 +6,7 @@ include:
 variables:
 # Template for perf-tasks
 - &perf-tasks-template
-  batchtime: 1440 # 1 day
+  batchtime: 360 # 6 hours
   expansions: &ubuntu2004-perf-tests-expansions-template
     additional_env_vars: export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$WT_BUILDDIR/test/utility/"
     CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O3


### PR DESCRIPTION
Per the Jira description increase testing frequency to 4 times daily so we can detect true changepoints - and rule out false changepoints - faster.