### PR TITLE
WT-12409 Add bash common functions. Tidy up dist scripts.

### DIFF
--- a/dist/common_functions.sh
+++ b/dist/common_functions.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+t=__wt.$$
+setup_trap() { trap 'rm -f $t' 0 1 2 3 13 15; }
+
+DIST_DIR="$(realpath "$(dirname -- "${BASH_SOURCE[0]}")")"
+TOP_DIR="$(dirname "$DIST_DIR")"
+
+cd_top() { cd -- "$TOP_DIR" || exit $?; }
+cd_dist() { cd -- "$DIST_DIR" || exit $?; }
+
+check_fast_mode() {
+  if [[ "$(realpath $(git rev-parse --show-toplevel))" != "$TOP_DIR" ]]; then
+      echo "ERROR: Fast mode only works in WT repo. Please run $0 without -F flag."
+      exit 1
+  fi
+}
+
+is_fast_mode() {
+  local arg;
+  for arg in "${BASH_ARGV[*]:-}"; do
+    [[ "$arg" == "-F" ]] && return;
+  done
+}
+
+check_fast_mode_flag() { is_fast_mode && check_fast_mode; }
+
+last_commit_from_dev() { python3 "$DIST_DIR"/common_functions.py last_commit_from_dev; }
+
+use_pygrep() {
+  [[ "$(uname -s)" == Darwin ]] && EGREP="$DIST_DIR/pygrep.py -E" FGREP="$DIST_DIR/pygrep.py -F" || EGREP=egrep FGREP=fgrep
+}
+
+for arg in "$@"; do $arg; done
+

--- a/dist/common_functions.sh
+++ b/dist/common_functions.sh
@@ -30,6 +30,3 @@ last_commit_from_dev() { python3 "$DIST_DIR"/common_functions.py last_commit_fro
 use_pygrep() {
   [[ "$(uname -s)" == Darwin ]] && EGREP="$DIST_DIR/pygrep.py -E" FGREP="$DIST_DIR/pygrep.py -F" || EGREP=egrep FGREP=fgrep
 }
-
-for arg in "$@"; do $arg; done
-

--- a/dist/s_all
+++ b/dist/s_all
@@ -2,7 +2,8 @@
 
 # Run standard scripts.
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
 t_pfx=__s_all_tmp_
 
 allchildpids() { # Recursively get PIDs of all child processes.

--- a/dist/s_all
+++ b/dist/s_all
@@ -2,7 +2,7 @@
 
 # Run standard scripts.
 
-t=__wt.$$
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
 t_pfx=__s_all_tmp_
 
 allchildpids() { # Recursively get PIDs of all child processes.
@@ -87,6 +87,7 @@ while [[ "$#" -gt 0 ]]
         force="-f"
         shift;;
     -F)                # Run fast.
+        check_fast_mode
         echo "dist/s_all running in fast mode..."
         fast="-F"
         shift;;

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -1,9 +1,7 @@
 #! /bin/bash
 
 set -o pipefail
-
-t=__wt.$$
-trap 'rm -rf $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
 download_clang_format() {
     version=$1
@@ -35,17 +33,6 @@ download_clang_format() {
     fi
 }
 
-# Find the top-level WiredTiger directory.
-dest_dir=$(git rev-parse --show-toplevel)
-
-# If this is a MongoDB source tree, move to the WiredTiger subtree.
-git_repo_str=$(git config remote.origin.url)
-is_mongo_repo=$(echo "$git_repo_str" | grep "mongodb/mongo")
-if [ -n "$is_mongo_repo" ] ; then
-       dest_dir="$dest_dir/src/third_party/wiredtiger"
-fi
-cd "$dest_dir" || exit 1
-
 # Override existing Clang-Format versions in the PATH.
 export PATH="${PWD}/dist":$PATH
 
@@ -71,8 +58,8 @@ case $# in
     # If the -F option is not specified then find every source file.
     if [ $1 == "-F" ]; then
         # We are running in fast mode, get all the source files modified according to git.
-        last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
-        search=`git diff --name-only ${last_commit_from_dev} | grep -E '\.(c|h|cpp)$'`
+        check_fast_mode
+        search=`git diff --name-only $(last_commit_from_dev) | grep -E '\.(c|h|cpp)$'`
     else
         search="$1"
         exclude=false

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -1,7 +1,9 @@
 #! /bin/bash
 
 set -o pipefail
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 download_clang_format() {
     version=$1

--- a/dist/s_clang_scan
+++ b/dist/s_clang_scan
@@ -1,13 +1,12 @@
 #!/bin/bash
 
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_top
+
 t_out=__wt.$$.out
 t_out_filtered=__wt.$$.out_filtered
 t_build=__s_clang_scan_tmp_build
 trap 'rm -rf $t_out $t_out_filtered $t_build' 0 1 2 3 13 15
 
-# Find the top-level WiredTiger directory and move to there.
-top=$(git rev-parse --show-toplevel)
-cd $top || exit 1
 echo "$0: running scan-build in $PWD"
 
 compiler=$(which clang)

--- a/dist/s_clang_scan
+++ b/dist/s_clang_scan
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_top
 
 t_out=__wt.$$.out
 t_out_filtered=__wt.$$.out_filtered

--- a/dist/s_clang_tidy
+++ b/dist/s_clang_tidy
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_top
 t_pfx=__s_clang_tidy_tmp_
 trap 'rm -rf $t $t_pfx*' 0 1 2 3 13 15
 

--- a/dist/s_clang_tidy
+++ b/dist/s_clang_tidy
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-t=__wt.$$
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_top
 t_pfx=__s_clang_tidy_tmp_
 trap 'rm -rf $t $t_pfx*' 0 1 2 3 13 15
 
-# Find the top-level WiredTiger directory and move to there.
-top=`git rev-parse --show-toplevel` && cd $top || exit 1
 echo "$0: running clang-tidy in $PWD"
 
 # Clang isn't installed in any standard place, find a binary we can use.

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -2,7 +2,8 @@
 
 # Only run when building a release
 test -z "$WT_RELEASE_BUILD" && exit 0
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
 
 # Check the copyrights.
 

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -2,6 +2,7 @@
 
 # Only run when building a release
 test -z "$WT_RELEASE_BUILD" && exit 0
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
 
 # Check the copyrights.
 

--- a/dist/s_define
+++ b/dist/s_define
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Complain about unused #defines.
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist use_pygrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
+use_pygrep
 
 # List of source files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`

--- a/dist/s_define
+++ b/dist/s_define
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Complain about unused #defines.
-cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
-[[ `uname -s` == Darwin ]] && EGREP="./pygrep.py -E" FGREP="./pygrep.py -F" || EGREP=egrep FGREP=fgrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist use_pygrep
 
 # List of source files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -1,6 +1,7 @@
 #! /bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
 t2=__wt.$$.2
 trap 'rm -f $t $t2' 0 1 2 3 13 15
 

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-t=__wt.$$
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
 t2=__wt.$$.2
 trap 'rm -f $t $t2' 0 1 2 3 13 15
 

--- a/dist/s_evergreen
+++ b/dist/s_evergreen
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
-toplevel_dir=$(git rev-parse --show-toplevel)
-program=${toplevel_dir}/test/evergreen/evg_cfg.py
+program=test/evergreen/evg_cfg.py
 
 # Run checking program to identify missing tests in Evergreen configuration
 ${program} check >$t 2>&1

--- a/dist/s_evergreen
+++ b/dist/s_evergreen
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 program=test/evergreen/evg_cfg.py
 

--- a/dist/s_evergreen_validate
+++ b/dist/s_evergreen_validate
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
 fast=false
 exit1=0
 exit2=0
 case "$1" in
     -F) # Run fast.
+        check_fast_mode
         fast=true
         shift;;
     *)
@@ -21,14 +21,12 @@ esac
 if [ $(command -v evergreen) ] && [ -f ~/.evergreen.yml ]; then
     if $fast ; then
         # Check the evergreen.yml files for modifications.
-        last_commit_from_dev=$(python3 ./common_functions.py last_commit_from_dev)
-        search=`git diff --name-only "${last_commit_from_dev}" | grep -E 'evergreen.*\.yml$'`
+        search=`git diff --name-only "$(last_commit_from_dev)" | grep -E 'evergreen.*\.yml$'`
         # If we didn't find any files then exit.
         if test -z "$search"; then
             exit 0
         fi
     fi
-    cd ..
     echo "Validating evergreen.yml " > dist/$t
     evergreen validate -p wiredtiger test/evergreen.yml >> dist/$t 2>&1
     exit1=$?

--- a/dist/s_evergreen_validate
+++ b/dist/s_evergreen_validate
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 fast=false
 exit1=0

--- a/dist/s_export
+++ b/dist/s_export
@@ -2,7 +2,9 @@
 
 # Check for illegal external symbols.
 #
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_dist
 
 case `uname` in
 Darwin)

--- a/dist/s_export
+++ b/dist/s_export
@@ -2,8 +2,7 @@
 
 # Check for illegal external symbols.
 #
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
 
 case `uname` in
 Darwin)

--- a/dist/s_free
+++ b/dist/s_free
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
 
 # Complain if someone uses free in the library, other than the one call in
 # os_common/os_alloc.c:__wt_free_int. Strip out files in the 'utilities' directory.

--- a/dist/s_free
+++ b/dist/s_free
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_dist
 
 # Complain if someone uses free in the library, other than the one call in
 # os_common/os_alloc.c:__wt_free_int. Strip out files in the 'utilities' directory.

--- a/dist/s_funcs
+++ b/dist/s_funcs
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # Complain about unused functions
-cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
-[[ `uname -s` == Darwin ]] && EGREP="./pygrep.py -E" FGREP="./pygrep.py -F" || EGREP=egrep FGREP=fgrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist use_pygrep
 
 # List of files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`

--- a/dist/s_funcs
+++ b/dist/s_funcs
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Complain about unused functions
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist use_pygrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
+use_pygrep
 
 # List of files to search.
 l=`sed -e '/^[a-z]/!d' -e 's/[	 ].*$//' -e 's,^,../,' filelist`

--- a/dist/s_function
+++ b/dist/s_function
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Check various WiredTiger function behaviors.
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
 fast=1
 case "$1" in
     -F) # Run fast.
+        check_fast_mode
         fast=0
         shift;;
     *)
@@ -16,8 +16,6 @@ case "$1" in
         fi
         ;;
 esac
-
-cd ..
 
 # Turn a C file into a line per function so we can use grep on it.
 file_parse()
@@ -35,8 +33,7 @@ file_parse()
 if test $fast -eq 1 ; then
     files=`find bench examples ext src test -name '*.c' -o -name '*_inline.h'`
 else
-    last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
-    files=`git diff --name-only "${last_commit_from_dev}" bench examples ext src test | grep -E '(.c|_inline.h)$'`
+    files=`git diff --name-only "$(last_commit_from_dev)" bench examples ext src test | grep -E '(.c|_inline.h)$'`
 fi
 
 # Returns in functions after a jump to the error label, or an infinite loop
@@ -131,8 +128,7 @@ done
 if test $fast -eq 1 ; then
     files=`find src -name '*.c' -o -name '*._inline.h'`
 else
-    last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
-    files=`git diff --name-only "${last_commit_from_dev}" src | grep -E '(.c|_inline.h)$'`
+    files=`git diff --name-only "$(last_commit_from_dev)" src | grep -E '(.c|_inline.h)$'`
 fi
 
 # __wt_verbose with a bitwise OR category parameter.

--- a/dist/s_function
+++ b/dist/s_function
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Check various WiredTiger function behaviors.
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 fast=1
 case "$1" in

--- a/dist/s_getopt
+++ b/dist/s_getopt
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
 
 # Complain if someone uses the wrong getopt.
 find ../src ../test ../bench -name '*.c' | xargs egrep '[^a-z_]getopt\(' > $t

--- a/dist/s_getopt
+++ b/dist/s_getopt
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_dist
 
 # Complain if someone uses the wrong getopt.
 find ../src ../test ../bench -name '*.c' | xargs egrep '[^a-z_]getopt\(' > $t

--- a/dist/s_install
+++ b/dist/s_install
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
 f=../INSTALL
 
 . ../RELEASE_INFO

--- a/dist/s_install
+++ b/dist/s_install
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_dist
 f=../INSTALL
 
 . ../RELEASE_INFO

--- a/dist/s_lang
+++ b/dist/s_lang
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Check lang directories for potential name conflicts
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 cd lang
 
 for d in *; do

--- a/dist/s_lang
+++ b/dist/s_lang
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 # Check lang directories for potential name conflicts
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
-
-cd ../lang
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+cd lang
 
 for d in *; do
     f=`find $d -name 'wiredtiger_wrap.c'`

--- a/dist/s_longlines
+++ b/dist/s_longlines
@@ -1,11 +1,9 @@
 #!/bin/bash
 
 # Check for long lines
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
-l=`(cd .. &&
-    find bench/wtperf examples ext src test -name '*.[chsy]' &&
+l=`(find bench/wtperf examples ext src test -name '*.[chsy]' &&
     find dist -name '*.py' &&
     find src -name '*.in') |
     sed -e '/checksum\/power8/d' \
@@ -20,7 +18,7 @@ l=`(cd .. &&
         -e '/support\/stat\.c/d'`
 
 for f in $l ; do
-    expand -t8 < ../$f | awk -- \
+    expand -t8 < $f | awk -- \
         "{if(length(\$0) > 100) printf(\"%s:%d\\n\", \"$f\", NR)}"
 done
 

--- a/dist/s_longlines
+++ b/dist/s_longlines
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Check for long lines
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 l=`(find bench/wtperf examples ext src test -name '*.[chsy]' &&
     find dist -name '*.py' &&

--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -11,7 +11,8 @@
 
 # This script is not supposed to work outside of main WT repo.
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
 
 # Retrieve the current branch name.
 branch_name=$(git rev-parse --abbrev-ref HEAD 2>&1 || echo "BRANCH_NOT_FOUND")

--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -9,6 +9,10 @@
 # build directories, and when the Git repository is checkout out with the Jira ticket in the name
 # of the repo, and the current branch name matches the Jira ticket as well.
 
+# This script is not supposed to work outside of main WT repo.
+
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
+
 # Retrieve the current branch name.
 branch_name=$(git rev-parse --abbrev-ref HEAD 2>&1 || echo "BRANCH_NOT_FOUND")
 

--- a/dist/s_python
+++ b/dist/s_python
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 # Python style checks.
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
-
-cd ..
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
 # Check Python coding standards: check for tab characters.
 # Ignore generated files.

--- a/dist/s_python
+++ b/dist/s_python
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Python style checks.
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 # Check Python coding standards: check for tab characters.
 # Ignore generated files.

--- a/dist/s_readme
+++ b/dist/s_readme
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_dist
 f=../README
 
 . ../RELEASE_INFO

--- a/dist/s_readme
+++ b/dist/s_readme
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
 f=../README
 
 . ../RELEASE_INFO

--- a/dist/s_stat
+++ b/dist/s_stat
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Complain about unused statistics fields.
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist use_pygrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_dist
+use_pygrep
 
 # List of files to search: skip stat.c, it lists all of the fields by
 # definition.

--- a/dist/s_stat
+++ b/dist/s_stat
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 # Complain about unused statistics fields.
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
-cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
-[[ `uname -s` == Darwin ]] && EGREP="./pygrep.py -E" FGREP="./pygrep.py -F" || EGREP=egrep FGREP=fgrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist use_pygrep
 
 # List of files to search: skip stat.c, it lists all of the fields by
 # definition.

--- a/dist/s_string
+++ b/dist/s_string
@@ -2,9 +2,8 @@
 #
 # Check spelling in comments and quoted strings from the source files.
 
-t=__wt.$$
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
 trap 'rm -f $t; exit $exit_val' 0 1 2 3 13 15
-cd -- "$(dirname -- "${BASH_SOURCE[0]}")" || exit $?
 
 # Insulate against locale-specific sort order
 LC_ALL=C
@@ -49,7 +48,7 @@ check() {
 
 # List of files to spellchk.
 if [[ "$1" = "-F" ]]; then
-    last_commit_from_dev=$(python3 common_functions.py last_commit_from_dev)
+    last_commit_from_dev=$(last_commit_from_dev)
     l=$(cd ..
         git diff --name-only "${last_commit_from_dev}" bench examples ext src test | grep -E '\.[chsy]$'
         git diff --name-only "${last_commit_from_dev}" src | grep -E '\.in$'
@@ -96,7 +95,7 @@ while :
             echo "No need to update the $custom_words list."
         fi
         shift;;
-    -F) FAST=1; shift;;
+    -F) check_fast_mode; FAST=1; shift;;
     *)
         test "$#" -eq 0 || usage
         break;;

--- a/dist/s_string
+++ b/dist/s_string
@@ -2,7 +2,8 @@
 #
 # Check spelling in comments and quoted strings from the source files.
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
 trap 'rm -f $t; exit $exit_val' 0 1 2 3 13 15
 
 # Insulate against locale-specific sort order

--- a/dist/s_style
+++ b/dist/s_style
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # General style correction and cleanup.
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
 
 # Parallelize if possible.
 xp=""

--- a/dist/s_style
+++ b/dist/s_style
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # General style correction and cleanup.
-t=__wt.$$
-trap 'rm -f "$t"' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap
 
 # Parallelize if possible.
 xp=""
@@ -18,8 +17,8 @@ search_str="find bench examples ext src test -name '*.[ch]' -o -name '*.in' -o -
 single_file=0
 if [ $# -eq 1 ]; then
     if [ "$1" = "-F" ]; then
-        last_commit_from_dev=$(python3 ./common_functions.py last_commit_from_dev)
-        search_str="git diff --name-only ${last_commit_from_dev} | grep -E '\.(c|h|cpp|cxx|i|py|dox|cmake)$'"
+        check_fast_mode
+        search_str="git diff --name-only $(last_commit_from_dev) | grep -E '\.(c|h|cpp|cxx|i|py|dox|cmake)$'"
     else
         single_file=1
     fi
@@ -28,7 +27,7 @@ fi
 # s_style is re-entrant, when run with no parameters it calls itself
 # again for each file that needs checking.
 if [ "$single_file" -ne 1 ]; then
-    cd ..
+    cd_top
     # Skip auto-generated and third party code, including SWIG generated workgen code.
     eval $search_str |
     sed -e '/Makefile.in/d' \

--- a/dist/s_tags
+++ b/dist/s_tags
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Build tags files.
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_dist
 trap 'rm -f tags' 0 1 2 3 13 15
 
 # Skip this when building release packages

--- a/dist/s_tags
+++ b/dist/s_tags
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Build tags files.
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_dist
 trap 'rm -f tags' 0 1 2 3 13 15
 
 # Skip this when building release packages

--- a/dist/s_test_suite_no_executable
+++ b/dist/s_test_suite_no_executable
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 set -euf -o pipefail
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+cd_top
 
 # All test scripts should be routed through "run.py", running them directly is an anti-pattern.
 # Use the executable bits on the scripts as weak evidence of the anti-pattern.

--- a/dist/s_test_suite_no_executable
+++ b/dist/s_test_suite_no_executable
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 set -euf -o pipefail
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh cd_top
 
 # All test scripts should be routed through "run.py", running them directly is an anti-pattern.
 # Use the executable bits on the scripts as weak evidence of the anti-pattern.
-workspace="$(git rev-parse --show-toplevel)"
-exes=$(find "$workspace"/test/suite -type f \( -perm -u+x -o -perm -g+x -o -perm -o+x \) ! -name 'run.py')
+exes=$(find test/suite -type f \( -perm -u+x -o -perm -g+x -o -perm -o+x \) ! -name 'run.py')
 if [[ -n "$exes" ]]; then
     echo "The following files should not be executable:"
     echo "$exes"

--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
 
 # Insulate against locale-specific sort order and IFS from the user's env
 LC_ALL=C

--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_dist
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_dist
 
 # Insulate against locale-specific sort order and IFS from the user's env
 LC_ALL=C

--- a/dist/s_visibility_checks
+++ b/dist/s_visibility_checks
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
-
-cd ..
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
 # Check to see if a time aggregate is used in a straight visibility check.
 # It should never be - the "snap_min" visibility check should be used instead.

--- a/dist/s_visibility_checks
+++ b/dist/s_visibility_checks
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 # Check to see if a time aggregate is used in a straight visibility check.
 # It should never be - the "snap_min" visibility check should be used instead.

--- a/dist/s_void
+++ b/dist/s_void
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
-cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. || exit $?
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
 
 # Parse a C file, discarding functions that don't return an int, and formatting
 # the remaining functions as a single line.
@@ -190,8 +188,8 @@ func_ok()
 SUBDIRS="bench ext src test"
 
 if [[ "$1" = "-F" ]]; then
-    last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
-    l=`git diff --name-only "${last_commit_from_dev}" $SUBDIRS | grep -E '(_inline\.h|\.c)$' | egrep -Ev '/windows_shim\.c$'`
+    check_fast_mode
+    l=`git diff --name-only "$(last_commit_from_dev)" $SUBDIRS | grep -E '(_inline\.h|\.c)$' | egrep -Ev '/windows_shim\.c$'`
 else
     l=`find $SUBDIRS -name '*.c' -o -name '*_inline.h' | egrep -Ev '/windows_shim\.c$'`
 fi

--- a/dist/s_void
+++ b/dist/s_void
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
 
 # Parse a C file, discarding functions that don't return an int, and formatting
 # the remaining functions as a single line.

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Single space, newline at the end of file, and remove trailing whitespace from source files.
-. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top use_pygrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
+setup_trap
+cd_top
+use_pygrep
 
 # Clear lines that only contain whitespace, compress multiple empty lines
 # into a single line, discard trailing empty lines.

--- a/dist/s_whitespace
+++ b/dist/s_whitespace
@@ -1,10 +1,7 @@
 #!/bin/bash
 
 # Single space, newline at the end of file, and remove trailing whitespace from source files.
-t=__wt.$$
-trap 'rm -f $t' 0 1 2 3 13 15
-cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. || exit $?
-[[ `uname -s` == Darwin ]] && EGREP="dist/pygrep.py -E" FGREP="dist/pygrep.py -F" || EGREP=egrep FGREP=fgrep
+. `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh setup_trap cd_top use_pygrep
 
 # Clear lines that only contain whitespace, compress multiple empty lines
 # into a single line, discard trailing empty lines.
@@ -28,8 +25,8 @@ whitespace()
 SUBDIRS="bench examples ext src test"
 {
     if [[ "$1" = "-F" ]]; then
-        last_commit_from_dev=$(python3 dist/common_functions.py last_commit_from_dev)
-        git diff --name-only "${last_commit_from_dev}" $SUBDIRS | \
+        check_fast_mode
+        git diff --name-only "$(last_commit_from_dev)" $SUBDIRS | \
             $EGREP \
                 -e '\.[ch]$' \
                 -e '\.cpp$' \


### PR DESCRIPTION
Summary of changes:
* Add `common_functions.sh`.
* Use it in every script in `dist/` to locate the repository and sources.
* Since `s_fast` only check files changed since fork, now it checks that it's being run for a proper repo.