### PR TITLE
WT-12360 Add model unit testing to PR testing

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5177,7 +5177,7 @@ buildvariants:
     - name: chunkcache-test
     - name: ".workgen-test"
       batchtime: 1440 # 24 hours
-    - name: model-test
+    - name: model-unit-test
     - name: csuite-long-running
       batchtime: 1440 # once a day
 
@@ -5527,7 +5527,7 @@ buildvariants:
       batchtime: 40320 # 28 days
     - name: ".workgen-test"
       batchtime: 1440 # 24 hours
-    - name: model-test
+    - name: model-unit-test
 
 - name: amazon2-arm64
   display_name: "Amazon Linux 2 ARM64"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3606,7 +3606,7 @@ tasks:
       - func: "split stress test"
 
   - name: model-unit-test
-    tags: ["pull_request"]
+    tags: ["pull_request", "model_checking"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -5194,7 +5194,7 @@ buildvariants:
       export LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libeatmydata.so:$LD_PRELOAD"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest"
+    - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest"
     - name: examples-c-test
     - name: format-asan-smoke-test
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3605,7 +3605,8 @@ tasks:
       - func: "compile wiredtiger"
       - func: "split stress test"
 
-  - name: model-test
+  - name: model-unit-test
+    tags: ["pull_request"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"


### PR DESCRIPTION
The PR adds model testing to PR testing. The rationale is explained in the ticket, but TL;DR: If changes to WT result in API-visible changes, e.g., due to a recent change where setting a timestamp can now return EINVAL, it would result in failing this test—which may not be caught until after the PR gets merged.