### PR TITLE
WT-11755 Add a write once macro to WiredTiger

### DIFF
--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -57,6 +57,23 @@
 #endif
 
 /*
+ * WT_WRITE_ONCE --
+ *
+ * Ensure a single write to memory in the source code produces a single write to memory in the
+ * compiled output.
+ *
+ * See the read once macro description for more details.
+ *
+ * FIXME-WT-11718 - Once Windows build machines that support C11 _Generics are available this macro
+ * will be updated to use _Generic on all platforms.
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define WT_WRITE_ONCE(v, val) ((*(volatile __typeof__(v) *)&(v)) = (val))
+#else
+#define WT_WRITE_ONCE(v, val) WT_PUBLISH(v, val)
+#endif
+
+/*
  * Read a shared location and guarantee that subsequent reads do not see any earlier state.
  */
 #define WT_ACQUIRE_READ_WITH_BARRIER(v, val) \

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2027,7 +2027,7 @@ __rec_compression_adjust(WT_SESSION_IMPL *session, uint32_t max, size_t compress
         else
             return;
     }
-    *adjustp = new;
+    WT_WRITE_ONCE(*adjustp, new);
 }
 
 /*


### PR DESCRIPTION
We have a WT_READ_ONCE but no matching WT_WRITE_ONCE, this PR fixes that and unblocks #10189