### PR TITLE
WT-9820 Halve concurrency level for long-running MSAN tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5232,7 +5232,7 @@ buildvariants:
     # some csuite tests to take an extended amount of time. These are excluded from the
     # make-check-test task and are covered by the csuite-long-running task.
     extra_args: -LE "cppsuite|long_running"
-    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` / 2" | bc)
   tasks:
     - name: clang-analyzer
     - name: compile


### PR DESCRIPTION
This consistently stopped `test_timestamp_abort` timing out for all of the tests I did.