### PR TITLE
WT-12437 Don't dump deleted VLCS cells

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -677,6 +677,10 @@ __debug_cell_kv(
         break;
     }
 
+    /* Early exit for Column store deleted cells. There's nothing further to print. */
+    if (unpack->raw == WT_CELL_DEL)
+        return (0);
+
     /* Overflow addresses. */
     switch (unpack->raw) {
     case WT_CELL_KEY_OVFL:

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -677,7 +677,7 @@ __debug_cell_kv(
         break;
     }
 
-    /* Early exit for Column store deleted cells. There's nothing further to print. */
+    /* Early exit for column store deleted cells. There's nothing further to print. */
     if (unpack->raw == WT_CELL_DEL)
         return (0);
 


### PR DESCRIPTION
We recently merged a ticket that cleans up the output format of our verify `dump_blocks` and `dump_pages` output, and in doing so removed some code that printed [duplicate information](https://github.com/wiredtiger/wiredtiger/commit/d5be6ac2534fa1df4da5721f5434b31dd0b8a024#diff-eec07b0b03dc98e7eba3b478e28ca13a058753c06c4643ee4595f4887b83e609L687). 
However we missed that this function is also early exiting when the cell is deleted (`WT_CELL_DEL`), and the new changes attempted to print content of a deleted cell.
This PR restores the early return logic but still removes the duplicate debug output.