### PR TITLE
WT-12445 Show the end of the key in wt_cmp_uri

### DIFF
--- a/tools/wt_cmp_uri.py
+++ b/tools/wt_cmp_uri.py
@@ -103,7 +103,7 @@ def get_compare_cursor(conn, timestamp, uri, arg):
 def show_kv(kv):
     s = str(kv)
     if len(s) > 100:
-        s = s[0:25] + '[...]' + s[-25:]
+        s = s[:25] + '[...]' + s[-25:]
     return s
 
 # Walk through both cursors, comparing them.  Generally, it's very easy, when the

--- a/tools/wt_cmp_uri.py
+++ b/tools/wt_cmp_uri.py
@@ -103,7 +103,7 @@ def get_compare_cursor(conn, timestamp, uri, arg):
 def show_kv(kv):
     s = str(kv)
     if len(s) > 100:
-        s = s[0:100] + '...'
+        s = s[0:25] + '[...]' + s[-25:]
     return s
 
 # Walk through both cursors, comparing them.  Generally, it's very easy, when the


### PR DESCRIPTION
This can be useful when the key contains 100 zeroes and then different numbers.