### PR TITLE
WT-12225 Fix RNG generator weakness around mongodb $sample stage

### DIFF
--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -36,6 +36,8 @@ __wt_rdtsc(void)
         __asm__ volatile("mrs %0,  cntvct_el0" : "=r"(t));
         return (t);
     }
+#elif defined(_M_AMD64)
+    return (__rdtsc());
 #else
     return (0);
 #endif

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -127,7 +127,7 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
  * xor against the machine's timestamp counter.
  */
 #ifdef _WIN32
-    M_Z(rnd) ^= __wt_rdtsc();
+    rnd.v ^= __wt_rdtsc();
 #endif
     rnd.v ^= (uint64_t)threadid;
     rnd.v ^= rnd.v << 13;

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -55,7 +55,7 @@
 
 #define DEFAULT_SEED_W 521288629
 #define DEFAULT_SEED_Z 362436069
-#define WT_LEFT_CIRCULAR_SHIFT32(x, nbits)  (((x) << (nbits)) | ((x) >> (32 - (nbits))))
+#define WT_LEFT_CIRCULAR_SHIFT32(x, nbits) (((x) << (nbits)) | ((x) >> (32 - (nbits))))
 
 /*
  * __wt_random_init --
@@ -118,8 +118,10 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
      * Take the seconds and nanoseconds from the clock together with the thread ID to generate a
      * 64-bit seed, then smear that value using algorithm "xor" from Marsaglia, "Xorshift RNGs".
      */
-    M_W(rnd) = (uint32_t)ts.tv_sec ^ WT_LEFT_CIRCULAR_SHIFT32(ts.tv_nsec, 29) ^ DEFAULT_SEED_W;
-    M_Z(rnd) = (uint32_t)ts.tv_nsec ^ WT_LEFT_CIRCULAR_SHIFT32(ts.tv_sec, 27) ^ DEFAULT_SEED_Z;
+    M_W(rnd) =
+      (uint32_t)ts.tv_sec ^ (uint32_t)WT_LEFT_CIRCULAR_SHIFT32(ts.tv_nsec, 29) ^ DEFAULT_SEED_W;
+    M_Z(rnd) =
+      (uint32_t)ts.tv_nsec ^ (uint32_t)WT_LEFT_CIRCULAR_SHIFT32(ts.tv_sec, 27) ^ DEFAULT_SEED_Z;
     rnd.v ^= (uint64_t)threadid;
     rnd.v ^= rnd.v << 13;
     rnd.v ^= rnd.v >> 7;

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -55,6 +55,7 @@
 
 #define DEFAULT_SEED_W 521288629
 #define DEFAULT_SEED_Z 362436069
+#define WT_LEFT_CIRCULAR_SHIFT32(x, nbits)  (((x) << (nbits)) | ((x) >> (32 - (nbits))))
 
 /*
  * __wt_random_init --
@@ -117,13 +118,12 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
      * Take the seconds and nanoseconds from the clock together with the thread ID to generate a
      * 64-bit seed, then smear that value using algorithm "xor" from Marsaglia, "Xorshift RNGs".
      */
-    M_W(rnd) = (uint32_t)ts.tv_sec ^ DEFAULT_SEED_W;
-    M_Z(rnd) = (uint32_t)ts.tv_nsec ^ DEFAULT_SEED_Z;
+    M_W(rnd) = (uint32_t)ts.tv_sec ^ WT_LEFT_CIRCULAR_SHIFT32(ts.tv_nsec, 29) ^ DEFAULT_SEED_W;
+    M_Z(rnd) = (uint32_t)ts.tv_nsec ^ WT_LEFT_CIRCULAR_SHIFT32(ts.tv_sec, 27) ^ DEFAULT_SEED_Z;
     rnd.v ^= (uint64_t)threadid;
     rnd.v ^= rnd.v << 13;
     rnd.v ^= rnd.v >> 7;
     rnd.v ^= rnd.v << 17;
-
     *rnd_state = rnd;
 }
 

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -123,7 +123,7 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
     M_Z(rnd) =
       (uint32_t)ts.tv_nsec ^ (uint32_t)WT_LEFT_CIRCULAR_SHIFT32(ts.tv_sec, 27) ^ DEFAULT_SEED_Z;
 /*
- * Window's clock does not have a high enough resolution between each tick cycle. Perform an extra
+ * Some system clocks do not have a high enough resolution between each tick cycle. Perform an extra
  * xor against the machine's timestamp counter.
  */
 #ifdef _WIN32

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -122,6 +122,13 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
       (uint32_t)ts.tv_sec ^ (uint32_t)WT_LEFT_CIRCULAR_SHIFT32(ts.tv_nsec, 29) ^ DEFAULT_SEED_W;
     M_Z(rnd) =
       (uint32_t)ts.tv_nsec ^ (uint32_t)WT_LEFT_CIRCULAR_SHIFT32(ts.tv_sec, 27) ^ DEFAULT_SEED_Z;
+/*
+ * Window's clock does not have a high enough resolution between each tick cycle. Perform an extra
+ * xor against the machine's timestamp counter.
+ */
+#ifdef _WIN32
+    M_Z(rnd) ^= __wt_rdtsc();
+#endif
     rnd.v ^= (uint64_t)threadid;
     rnd.v ^= rnd.v << 13;
     rnd.v ^= rnd.v >> 7;

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -124,6 +124,7 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
     rnd.v ^= rnd.v << 13;
     rnd.v ^= rnd.v >> 7;
     rnd.v ^= rnd.v << 17;
+
     *rnd_state = rnd;
 }
 

--- a/test/csuite/wt2719_reconfig/main.c
+++ b/test/csuite/wt2719_reconfig/main.c
@@ -28,213 +28,41 @@
 #include "test_util.h"
 
 #include <signal.h>
-
-/*
- * JIRA ticket reference: WT-2719 Test case description: Fuzz testing for WiredTiger
- * reconfiguration.
- */
-
-static const char *const list[] = {",cache_overhead=13", ",cache_overhead=27", ",cache_overhead=8",
-
-  ",cache_size=75MB", ",cache_size=214MB", ",cache_size=37MB",
-
-  ",checkpoint=(log_size=104857600)",  /* 100MB */
-  ",checkpoint=(log_size=1073741824)", /* 1GB */
-  ",checkpoint=(log_size=2)", ",checkpoint=(log_size=0)", ",checkpoint=(wait=100)",
-  ",checkpoint=(wait=10000)", ",checkpoint=(wait=2)", ",checkpoint=(wait=0)",
-
-  ",compatibility=(release=2.6)", ",compatibility=(release=3.0)",
-
-  ",error_prefix=\"prefix\"",
-
-  ",eviction=(threads_min=7,threads_max=10)", ",eviction=(threads_min=17,threads_max=18)",
-  ",eviction=(threads_min=3,threads_max=7)", ",eviction=(threads_max=12,threads_min=10)",
-  ",eviction=(threads_max=18,threads_min=16)", ",eviction=(threads_max=10,threads_min=9)",
-
-  ",eviction_dirty_target=45", ",eviction_dirty_target=87", ",eviction_dirty_target=8",
-
-  ",eviction_dirty_trigger=37", ",eviction_dirty_trigger=98", ",eviction_dirty_trigger=7",
-
-  ",eviction_target=22", ",eviction_target=84", ",eviction_target=30",
-
-  ",eviction_trigger=75", ",eviction_trigger=95", ",eviction_trigger=66",
-
-  ",file_manager=(close_handle_minimum=200)", ",file_manager=(close_handle_minimum=137)",
-  ",file_manager=(close_handle_minimum=226)", ",file_manager=(close_idle_time=10000)",
-  ",file_manager=(close_idle_time=12000)", ",file_manager=(close_idle_time=7)",
-  ",file_manager=(close_idle_time=0)", ",file_manager=(close_scan_interval=50000)",
-  ",file_manager=(close_scan_interval=59000)", ",file_manager=(close_scan_interval=3)",
-
-  ",log=(prealloc=0)", ",log=(prealloc=1)", ",log=(remove=0)", ",log=(remove=1)",
-  ",log=(zero_fill=0)", ",log=(zero_fill=1)",
-
-  ",lsm_manager=(merge=0)", ",lsm_manager=(merge=1)", ",lsm_manager=(worker_thread_max=5)",
-  ",lsm_manager=(worker_thread_max=18)", ",lsm_manager=(worker_thread_max=3)",
-
-  ",shared_cache=(chunk=20MB)", ",shared_cache=(chunk=30MB)", ",shared_cache=(chunk=5MB)",
-  ",shared_cache=(name=\"shared\")", ",shared_cache=(name=\"none\")", ",shared_cache=(quota=20MB)",
-  ",shared_cache=(quota=30MB)", ",shared_cache=(quota=5MB)", ",shared_cache=(quota=0)",
-  ",shared_cache=(reserve=20MB)", ",shared_cache=(reserve=30MB)", ",shared_cache=(reserve=5MB)",
-  ",shared_cache=(reserve=0)", ",shared_cache=(size=100MB)", ",shared_cache=(size=1GB)",
-  ",shared_cache=(size=75MB)",
-
-  ",statistics=(\"all\")", ",statistics=(\"fast\")", ",statistics=(\"none\")",
-  ",statistics=(\"all\",\"clear\")", ",statistics=(\"fast\",\"clear\")",
-
-  ",statistics_log=(json=0)", ",statistics_log=(json=1)", ",statistics_log=(on_close=0)",
-  ",statistics_log=(on_close=1)", ",statistics_log=(sources=(\"file:\"))",
-  ",statistics_log=(sources=())", ",statistics_log=(timestamp=\"%b:%S\")",
-  ",statistics_log=(timestamp=\"%H:%M\")", ",statistics_log=(wait=60)", ",statistics_log=(wait=76)",
-  ",statistics_log=(wait=37)", ",statistics_log=(wait=0)",
-
-  ",verbose=(\"api\")", ",verbose=(\"block\")", ",verbose=(\"checkpoint\")",
-  ",verbose=(\"compact\")", ",verbose=(\"evict\")", ",verbose=(\"evictserver\")",
-  ",verbose=(\"fileops\")", ",verbose=(\"handleops\")", ",verbose=(\"log\")", ",verbose=(\"lsm\")",
-  ",verbose=(\"lsm_manager\")", ",verbose=(\"metadata\")", ",verbose=(\"mutex\")",
-  ",verbose=(\"overflow\")", ",verbose=(\"read\")", ",verbose=(\"reconcile\")",
-  ",verbose=(\"recovery\")", ",verbose=(\"salvage\")", ",verbose=(\"shared_cache\")",
-  ",verbose=(\"split\")", ",verbose=(\"transaction\")", ",verbose=(\"verify\")",
-  ",verbose=(\"version\")", ",verbose=(\"write\")", ",verbose=()"};
-
-/*
- * handle_message --
- *     TODO: Add a comment describing this function.
- */
-static int
-handle_message(WT_EVENT_HANDLER *handler, WT_SESSION *session, const char *message)
-{
-    (void)(handler);
-    (void)(session);
-    (void)(message);
-
-    /* We configure verbose output, so just ignore. */
-    return (0);
-}
-
-static WT_EVENT_HANDLER event_handler = {NULL, handle_message, NULL, NULL, NULL};
-
-static const char *current; /* Current test configuration */
-
-static void on_alarm(int) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
-
-/*
- * on_alarm --
- *     TODO: Add a comment describing this function.
- */
-static void
-on_alarm(int signo)
-{
-    (void)signo; /* Unused parameter */
-
-    fprintf(stderr, "configuration timed out: %s\n", current);
-    abort();
-
-    /* NOTREACHED */
-}
-
-/*
- * reconfig --
- *     TODO: Add a comment describing this function.
- */
-static void
-reconfig(TEST_OPTS *opts, WT_SESSION *session, const char *config)
-{
-    WT_DECL_RET;
-
-    current = config;
-
-    /*
-     * Reconfiguration starts and stops servers, so hangs are more likely here than in other tests.
-     * Don't let the test run too long and get a core dump when it happens.
-     */
-    (void)alarm(60);
-    if ((ret = opts->conn->reconfigure(opts->conn, config)) != 0) {
-        fprintf(stderr, "%s: %s\n", config, session->strerror(session, ret));
-        exit(EXIT_FAILURE);
-    }
-    (void)alarm(0);
-}
-
 /*
  * main --
  *     TODO: Add a comment describing this function.
  */
 int
-main(int argc, char *argv[])
+main(void)
 {
-    enum { CACHE_SHARED, CACHE_SET, CACHE_NONE } cache;
-    TEST_OPTS *opts, _opts;
     WT_RAND_STATE rnd;
-    WT_SESSION *session;
-    size_t len;
-    u_int i, j;
-    const char *p;
-    char *config;
-
-    opts = &_opts;
-    memset(opts, 0, sizeof(*opts));
-    opts->table_type = TABLE_ROW;
-    testutil_check(testutil_parse_opts(argc, argv, opts));
-    testutil_recreate_dir(opts->home);
-
-    testutil_check(wiredtiger_open(opts->home, &event_handler, "create", &opts->conn));
-
-    /* Open an LSM file so the LSM reconfiguration options make sense. */
-    testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
-    testutil_check(session->create(session, opts->uri, "type=lsm,key_format=S,value_format=S"));
+    uint32_t rnd_num[100] = {0};
+    uint32_t rnd_num2[100] = {0};
+    int count = 0;
 
     /* Initialize the RNG. */
-    __wt_random_init_seed(NULL, &rnd);
-
-    /* Allocate memory for the config. */
-    len = WT_ELEMENTS(list) * 64;
-    config = dmalloc(len);
-
-    /* Set an alarm so we can debug hangs. */
-    (void)signal(SIGALRM, on_alarm);
-
-    /* A linear pass through the list. */
-    for (i = 0; i < WT_ELEMENTS(list); ++i)
-        reconfig(opts, session, list[i]);
-
-    /*
-     * A linear pass through the list, adding random elements.
-     *
-     * WiredTiger configurations are usually "the last one set wins", but "shared_cache" and
-     * "cache_set" options aren't allowed in the same configuration string.
-     */
-    for (i = 0; i < WT_ELEMENTS(list); ++i) {
-        p = list[i];
-        cache = CACHE_NONE;
-        if (WT_PREFIX_MATCH(p, ",shared_cache"))
-            cache = CACHE_SHARED;
-        else if (WT_PREFIX_MATCH(p, ",cache_size"))
-            cache = CACHE_SET;
-        strcpy(config, p);
-
-        for (j = (__wt_random(&rnd) % WT_ELEMENTS(list)) + 1; j > 0; --j) {
-            p = list[__wt_random(&rnd) % WT_ELEMENTS(list)];
-            if (WT_PREFIX_MATCH(p, ",shared_cache")) {
-                if (cache == CACHE_SET)
-                    continue;
-                cache = CACHE_SHARED;
-            } else if (WT_PREFIX_MATCH(p, ",cache_size")) {
-                if (cache == CACHE_SHARED)
-                    continue;
-                cache = CACHE_SET;
-            }
-            strcat(config, p);
+    for (int tries = 0; tries < 1000000000; tries++) {
+        count = 0;
+        __wt_random_init_seed(NULL, &rnd);
+        for (int i = 0; i < 100; i++) {
+            rnd_num[i] = __wt_random(&rnd) % 2048;
         }
-        reconfig(opts, session, config);
+
+        __wt_random_init_seed(NULL, &rnd);
+        for (int i = 0; i < 100; i++) {
+            rnd_num2[i] = __wt_random(&rnd) % 2048;
+        }
+
+        for (int i = 0; i < 100; i++) {
+            if (rnd_num2[i] != rnd_num[i]) {
+                count++;
+            }
+        }
+        
+        if (count == 0) {
+            printf("All results are the same between two rngs\n");
+            break;
+        }
     }
-
-    /*
-     * Turn on-close statistics off, if on-close is on and statistics were randomly turned off
-     * during the run, close would fail.
-     */
-    testutil_check(opts->conn->reconfigure(opts->conn, "statistics_log=(on_close=0)"));
-
-    free(config);
-    testutil_cleanup(opts);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/wt2719_reconfig/main.c
+++ b/test/csuite/wt2719_reconfig/main.c
@@ -28,41 +28,213 @@
 #include "test_util.h"
 
 #include <signal.h>
+
+/*
+ * JIRA ticket reference: WT-2719 Test case description: Fuzz testing for WiredTiger
+ * reconfiguration.
+ */
+
+static const char *const list[] = {",cache_overhead=13", ",cache_overhead=27", ",cache_overhead=8",
+
+  ",cache_size=75MB", ",cache_size=214MB", ",cache_size=37MB",
+
+  ",checkpoint=(log_size=104857600)",  /* 100MB */
+  ",checkpoint=(log_size=1073741824)", /* 1GB */
+  ",checkpoint=(log_size=2)", ",checkpoint=(log_size=0)", ",checkpoint=(wait=100)",
+  ",checkpoint=(wait=10000)", ",checkpoint=(wait=2)", ",checkpoint=(wait=0)",
+
+  ",compatibility=(release=2.6)", ",compatibility=(release=3.0)",
+
+  ",error_prefix=\"prefix\"",
+
+  ",eviction=(threads_min=7,threads_max=10)", ",eviction=(threads_min=17,threads_max=18)",
+  ",eviction=(threads_min=3,threads_max=7)", ",eviction=(threads_max=12,threads_min=10)",
+  ",eviction=(threads_max=18,threads_min=16)", ",eviction=(threads_max=10,threads_min=9)",
+
+  ",eviction_dirty_target=45", ",eviction_dirty_target=87", ",eviction_dirty_target=8",
+
+  ",eviction_dirty_trigger=37", ",eviction_dirty_trigger=98", ",eviction_dirty_trigger=7",
+
+  ",eviction_target=22", ",eviction_target=84", ",eviction_target=30",
+
+  ",eviction_trigger=75", ",eviction_trigger=95", ",eviction_trigger=66",
+
+  ",file_manager=(close_handle_minimum=200)", ",file_manager=(close_handle_minimum=137)",
+  ",file_manager=(close_handle_minimum=226)", ",file_manager=(close_idle_time=10000)",
+  ",file_manager=(close_idle_time=12000)", ",file_manager=(close_idle_time=7)",
+  ",file_manager=(close_idle_time=0)", ",file_manager=(close_scan_interval=50000)",
+  ",file_manager=(close_scan_interval=59000)", ",file_manager=(close_scan_interval=3)",
+
+  ",log=(prealloc=0)", ",log=(prealloc=1)", ",log=(remove=0)", ",log=(remove=1)",
+  ",log=(zero_fill=0)", ",log=(zero_fill=1)",
+
+  ",lsm_manager=(merge=0)", ",lsm_manager=(merge=1)", ",lsm_manager=(worker_thread_max=5)",
+  ",lsm_manager=(worker_thread_max=18)", ",lsm_manager=(worker_thread_max=3)",
+
+  ",shared_cache=(chunk=20MB)", ",shared_cache=(chunk=30MB)", ",shared_cache=(chunk=5MB)",
+  ",shared_cache=(name=\"shared\")", ",shared_cache=(name=\"none\")", ",shared_cache=(quota=20MB)",
+  ",shared_cache=(quota=30MB)", ",shared_cache=(quota=5MB)", ",shared_cache=(quota=0)",
+  ",shared_cache=(reserve=20MB)", ",shared_cache=(reserve=30MB)", ",shared_cache=(reserve=5MB)",
+  ",shared_cache=(reserve=0)", ",shared_cache=(size=100MB)", ",shared_cache=(size=1GB)",
+  ",shared_cache=(size=75MB)",
+
+  ",statistics=(\"all\")", ",statistics=(\"fast\")", ",statistics=(\"none\")",
+  ",statistics=(\"all\",\"clear\")", ",statistics=(\"fast\",\"clear\")",
+
+  ",statistics_log=(json=0)", ",statistics_log=(json=1)", ",statistics_log=(on_close=0)",
+  ",statistics_log=(on_close=1)", ",statistics_log=(sources=(\"file:\"))",
+  ",statistics_log=(sources=())", ",statistics_log=(timestamp=\"%b:%S\")",
+  ",statistics_log=(timestamp=\"%H:%M\")", ",statistics_log=(wait=60)", ",statistics_log=(wait=76)",
+  ",statistics_log=(wait=37)", ",statistics_log=(wait=0)",
+
+  ",verbose=(\"api\")", ",verbose=(\"block\")", ",verbose=(\"checkpoint\")",
+  ",verbose=(\"compact\")", ",verbose=(\"evict\")", ",verbose=(\"evictserver\")",
+  ",verbose=(\"fileops\")", ",verbose=(\"handleops\")", ",verbose=(\"log\")", ",verbose=(\"lsm\")",
+  ",verbose=(\"lsm_manager\")", ",verbose=(\"metadata\")", ",verbose=(\"mutex\")",
+  ",verbose=(\"overflow\")", ",verbose=(\"read\")", ",verbose=(\"reconcile\")",
+  ",verbose=(\"recovery\")", ",verbose=(\"salvage\")", ",verbose=(\"shared_cache\")",
+  ",verbose=(\"split\")", ",verbose=(\"transaction\")", ",verbose=(\"verify\")",
+  ",verbose=(\"version\")", ",verbose=(\"write\")", ",verbose=()"};
+
+/*
+ * handle_message --
+ *     TODO: Add a comment describing this function.
+ */
+static int
+handle_message(WT_EVENT_HANDLER *handler, WT_SESSION *session, const char *message)
+{
+    (void)(handler);
+    (void)(session);
+    (void)(message);
+
+    /* We configure verbose output, so just ignore. */
+    return (0);
+}
+
+static WT_EVENT_HANDLER event_handler = {NULL, handle_message, NULL, NULL, NULL};
+
+static const char *current; /* Current test configuration */
+
+static void on_alarm(int) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
+
+/*
+ * on_alarm --
+ *     TODO: Add a comment describing this function.
+ */
+static void
+on_alarm(int signo)
+{
+    (void)signo; /* Unused parameter */
+
+    fprintf(stderr, "configuration timed out: %s\n", current);
+    abort();
+
+    /* NOTREACHED */
+}
+
+/*
+ * reconfig --
+ *     TODO: Add a comment describing this function.
+ */
+static void
+reconfig(TEST_OPTS *opts, WT_SESSION *session, const char *config)
+{
+    WT_DECL_RET;
+
+    current = config;
+
+    /*
+     * Reconfiguration starts and stops servers, so hangs are more likely here than in other tests.
+     * Don't let the test run too long and get a core dump when it happens.
+     */
+    (void)alarm(60);
+    if ((ret = opts->conn->reconfigure(opts->conn, config)) != 0) {
+        fprintf(stderr, "%s: %s\n", config, session->strerror(session, ret));
+        exit(EXIT_FAILURE);
+    }
+    (void)alarm(0);
+}
+
 /*
  * main --
  *     TODO: Add a comment describing this function.
  */
 int
-main(void)
+main(int argc, char *argv[])
 {
+    enum { CACHE_SHARED, CACHE_SET, CACHE_NONE } cache;
+    TEST_OPTS *opts, _opts;
     WT_RAND_STATE rnd;
-    uint32_t rnd_num[100] = {0};
-    uint32_t rnd_num2[100] = {0};
-    int count = 0;
+    WT_SESSION *session;
+    size_t len;
+    u_int i, j;
+    const char *p;
+    char *config;
+
+    opts = &_opts;
+    memset(opts, 0, sizeof(*opts));
+    opts->table_type = TABLE_ROW;
+    testutil_check(testutil_parse_opts(argc, argv, opts));
+    testutil_recreate_dir(opts->home);
+
+    testutil_check(wiredtiger_open(opts->home, &event_handler, "create", &opts->conn));
+
+    /* Open an LSM file so the LSM reconfiguration options make sense. */
+    testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
+    testutil_check(session->create(session, opts->uri, "type=lsm,key_format=S,value_format=S"));
 
     /* Initialize the RNG. */
-    for (int tries = 0; tries < 1000000000; tries++) {
-        count = 0;
-        __wt_random_init_seed(NULL, &rnd);
-        for (int i = 0; i < 100; i++) {
-            rnd_num[i] = __wt_random(&rnd) % 2048;
-        }
+    __wt_random_init_seed(NULL, &rnd);
 
-        __wt_random_init_seed(NULL, &rnd);
-        for (int i = 0; i < 100; i++) {
-            rnd_num2[i] = __wt_random(&rnd) % 2048;
-        }
+    /* Allocate memory for the config. */
+    len = WT_ELEMENTS(list) * 64;
+    config = dmalloc(len);
 
-        for (int i = 0; i < 100; i++) {
-            if (rnd_num2[i] != rnd_num[i]) {
-                count++;
+    /* Set an alarm so we can debug hangs. */
+    (void)signal(SIGALRM, on_alarm);
+
+    /* A linear pass through the list. */
+    for (i = 0; i < WT_ELEMENTS(list); ++i)
+        reconfig(opts, session, list[i]);
+
+    /*
+     * A linear pass through the list, adding random elements.
+     *
+     * WiredTiger configurations are usually "the last one set wins", but "shared_cache" and
+     * "cache_set" options aren't allowed in the same configuration string.
+     */
+    for (i = 0; i < WT_ELEMENTS(list); ++i) {
+        p = list[i];
+        cache = CACHE_NONE;
+        if (WT_PREFIX_MATCH(p, ",shared_cache"))
+            cache = CACHE_SHARED;
+        else if (WT_PREFIX_MATCH(p, ",cache_size"))
+            cache = CACHE_SET;
+        strcpy(config, p);
+
+        for (j = (__wt_random(&rnd) % WT_ELEMENTS(list)) + 1; j > 0; --j) {
+            p = list[__wt_random(&rnd) % WT_ELEMENTS(list)];
+            if (WT_PREFIX_MATCH(p, ",shared_cache")) {
+                if (cache == CACHE_SET)
+                    continue;
+                cache = CACHE_SHARED;
+            } else if (WT_PREFIX_MATCH(p, ",cache_size")) {
+                if (cache == CACHE_SHARED)
+                    continue;
+                cache = CACHE_SET;
             }
+            strcat(config, p);
         }
-        
-        if (count == 0) {
-            printf("All results are the same between two rngs\n");
-            break;
-        }
+        reconfig(opts, session, config);
     }
+
+    /*
+     * Turn on-close statistics off, if on-close is on and statistics were randomly turned off
+     * during the run, close would fail.
+     */
+    testutil_check(opts->conn->reconfigure(opts->conn, "statistics_log=(on_close=0)"));
+
+    free(config);
+    testutil_cleanup(opts);
     return (EXIT_SUCCESS);
 }

--- a/test/suite/test_cursor_random03.py
+++ b/test/suite/test_cursor_random03.py
@@ -31,8 +31,8 @@ from wtdataset import SimpleDataSet
 
 # test_cursor_random03.py
 #    This python test reproduces the WT-12225 bug where the same stream of numbers are generated
-# from the random cursor. In the presence of where all the values are the insert list, open up 
-# two cursors close to each other in time, and both cursors will return back the exact same 
+# from the random cursor. In the presence of where all the values are the insert list, open up
+# two cursors close to each other in time, and both cursors will return back the exact same
 # records again.
 class test_cursor_random02(wttest.WiredTigerTestCase):
     def test_cursor_random_bug(self):
@@ -65,7 +65,7 @@ class test_cursor_random02(wttest.WiredTigerTestCase):
                     found_different = True
                 break
             cursor.close()
-            
+
             # We expect that the values between two recently opened cursors return different stream
             # of records.
             self.assertTrue(found_different)

--- a/test/suite/test_cursor_random03.py
+++ b/test/suite/test_cursor_random03.py
@@ -32,8 +32,10 @@ from wtdataset import SimpleDataSet
 # test_cursor_random03.py
 #    This python test reproduces the WT-12225 bug where the same stream of numbers are generated
 # from the random cursor. In the presence of where all the values are the insert list, open up
-# two cursors close to each other in time, and both cursors will return back the exact same
-# records again.
+# two cursors close to each other in time, and both cursors will return back the exact same stream
+# of records again. The test makes sure that records returned in both cursors return at least
+# one record that is different, ensuring that the stream of numbers returned from __wt_random
+# are not in the same pattern.
 class test_cursor_random03(wttest.WiredTigerTestCase):
     def test_cursor_random_bug(self):
         uri = 'table:random'
@@ -63,6 +65,7 @@ class test_cursor_random03(wttest.WiredTigerTestCase):
             for i in range(0, 100):
                 self.assertEqual(cursor.next(), 0)
                 current = cursor.get_key()
+                # Exit early once we found a key that is different.
                 if (random_keys[i] != current):
                     found_different = True
                     break

--- a/test/suite/test_cursor_random03.py
+++ b/test/suite/test_cursor_random03.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wtdataset import SimpleDataSet
+
+# test_cursor_random03.py
+#    This python test reproduces the WT-12225 bug where the same stream of numbers are generated
+# from the random cursor. In the presence of where all the values are the insert list, open up 
+# two cursors close to each other in time, and both cursors will return back the exact same 
+# records again.
+class test_cursor_random02(wttest.WiredTigerTestCase):
+    def test_cursor_random_bug(self):
+        uri = 'table:random'
+
+        # Set the leaf-page-max value, otherwise the page might split.
+        ds = SimpleDataSet(self, uri, 3000, config='leaf_page_max=100MB')
+        ds.populate()
+
+        for _ in range(0, 5000):
+            random_keys = []
+
+            cursor = self.session.open_cursor(uri, None, 'next_random=true')
+
+            # Perform 100 nexts and append to our random keys.
+            for _ in range(0, 100):
+                self.assertEqual(cursor.next(), 0)
+                current = cursor.get_key()
+                random_keys.append(current)
+            cursor.close()
+
+            # The random cursor initial seed is time based, reset the initial random seed again
+            # to make sure that we have not generated with the same random numbers
+            cursor = self.session.open_cursor(uri, None, 'next_random=true')
+            found_different = False
+            for i in range(0, 100):
+                self.assertEqual(cursor.next(), 0)
+                current = cursor.get_key()
+                if (random_keys[i] != current):
+                    found_different = True
+                break
+            cursor.close()
+            
+            # We expect that the values between two recently opened cursors return different stream
+            # of records.
+            self.assertTrue(found_different)
+

--- a/test/suite/test_cursor_random03.py
+++ b/test/suite/test_cursor_random03.py
@@ -34,12 +34,14 @@ from wtdataset import SimpleDataSet
 # from the random cursor. In the presence of where all the values are the insert list, open up
 # two cursors close to each other in time, and both cursors will return back the exact same
 # records again.
-class test_cursor_random02(wttest.WiredTigerTestCase):
+class test_cursor_random03(wttest.WiredTigerTestCase):
     def test_cursor_random_bug(self):
         uri = 'table:random'
 
-        # Set the leaf-page-max value, otherwise the page might split.
-        ds = SimpleDataSet(self, uri, 3000, config='leaf_page_max=100MB')
+        # Do not change the chosen number of records. The records is to make sure that
+        # the skip insert list random estimate is a power of 2 to act as a mask.
+        # Also set the leaf-page-max value, otherwise the page might split.
+        ds = SimpleDataSet(self, uri, 2135, config='leaf_page_max=100MB')
         ds.populate()
 
         for _ in range(0, 5000):
@@ -63,7 +65,7 @@ class test_cursor_random02(wttest.WiredTigerTestCase):
                 current = cursor.get_key()
                 if (random_keys[i] != current):
                     found_different = True
-                break
+                    break
             cursor.close()
 
             # We expect that the values between two recently opened cursors return different stream


### PR DESCRIPTION
The error happens where the records are exactly the same because two cursors are opened close together under one thread. In windows machine clock resolution is low, therefore the numbers ts.tv_nsec and ts.tv_sec are the same. If we only changed the rnd.z seed, we get into a problem like the original code, where rnd.w is the same and rnd.z seed is changing. Therefore the solution used all of the 64 bits from RDTSC.