### PR TITLE
WT-12504 Ensure mirrored operations in Workgen are done within the same transaction

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -1924,9 +1924,9 @@ ThreadRunner::op_run(Operation *op)
                      * means it has been interrupted, quit.
                      */
                     if ((*i)._random_table && has_mirror && (i != op->_group->begin()) &&
-                      !_in_transaction) {
+                      !_in_transaction)
                         goto err;
-                    } else
+                    else
                         WT_ERR(op_run_setup(&*i));
                 }
             }

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -167,6 +167,7 @@ struct ThreadRunner {
     uint64_t op_get_key_recno(Operation *, uint64_t range, tint_t tint);
     void op_get_static_counts(Operation *, Stats &, int);
     std::tuple<std::string, tint_t> op_get_table(Operation *op) const;
+    bool op_has_mirror(tint_t tint) const;
     bool op_has_table(Operation *op) const;
     void op_kv_gen(Operation *op, const tint_t tint);
     int op_run(Operation *);


### PR DESCRIPTION
- Ensure we are performing mirrored operations within a transaction
- Cancel a mirrored operation after facing a `WT_ROLLBACK`