### PR TITLE
WT-11691 Convert prefetch worker threads to wait on condition variable

### DIFF
--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -11,11 +11,6 @@
 /*
  * __wt_prefetch_create --
  *     Start the pre-fetch server.
- *
- * FIXME-WT-11691 The pre-fetch server currently starts up when pre-fetch is enabled on the
- *     connection level but this needs to be modified when we add the session level configuration.
- *     Perhaps we could delay starting the utility threads until the first session enables
- *     pre-fetching.
  */
 int
 __wt_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])


### PR DESCRIPTION
Passed all tests on my machine. The only way I can see this not working is if the thread group doesn't automatically restart threads (since the worker loop can now exit).