### PR TITLE
WT-12303 Avoid duplicate code in __wt_block_compact_progress

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -433,10 +433,10 @@ __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block)
          * If we don't have the estimate at this point, it means that we haven't reviewed even
          * enough pages. This should almost never happen.
          */
-        if (block->compact_pages_rewritten_expected == 0) {
-            __wt_verbose_debug1(session, WT_VERB_COMPACT_PROGRESS, "%s", 
+        if (block->compact_pages_rewritten_expected == 0)
+            __wt_verbose_debug1(session, WT_VERB_COMPACT_PROGRESS, "%s",
               "Still collecting information for estimating the progress.");
-        } else {
+        else {
             progress = WT_MIN(
               (int)(100 * block->compact_pages_rewritten / block->compact_pages_rewritten_expected),
               100);

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -424,29 +424,24 @@ __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block)
     if (time_diff_msg > WT_PROGRESS_MSG_PERIOD) {
         session->compact->last_progress = cur_time;
 
+        __wt_verbose_debug1(session, WT_VERB_COMPACT_PROGRESS,
+          "Compacting %s for %" PRIu64 " seconds; reviewed %" PRIu64 " pages, rewritten %" PRIu64
+          " pages (%" PRIu64 "MB)",
+          block->name, time_diff_start, block->compact_pages_reviewed,
+          block->compact_pages_rewritten, block->compact_bytes_rewritten / WT_MEGABYTE);
         /*
          * If we don't have the estimate at this point, it means that we haven't reviewed even
          * enough pages. This should almost never happen.
          */
         if (block->compact_pages_rewritten_expected == 0) {
-            __wt_verbose_debug1(session, WT_VERB_COMPACT_PROGRESS,
-              "compacting %s for %" PRIu64 " seconds; reviewed %" PRIu64
-              " pages, rewritten %" PRIu64 " pages (%" PRIu64 "MB)",
-              block->name, time_diff_start, block->compact_pages_reviewed,
-              block->compact_pages_rewritten, block->compact_bytes_rewritten / WT_MEGABYTE);
-            __wt_verbose_debug1(session, WT_VERB_COMPACT,
-              "%s: still collecting information for estimating the progress", block->name);
+            __wt_verbose_debug1(session, WT_VERB_COMPACT_PROGRESS, "%s", 
+              "Still collecting information for estimating the progress.");
         } else {
             progress = WT_MIN(
               (int)(100 * block->compact_pages_rewritten / block->compact_pages_rewritten_expected),
               100);
             __wt_verbose_debug1(session, WT_VERB_COMPACT_PROGRESS,
-              "compacting %s for %" PRIu64 " seconds; reviewed %" PRIu64
-              " pages, rewritten %" PRIu64 " pages (%" PRIu64
-              "MB). Approx. %d%% of the estimated work done.%s",
-              block->name, time_diff_start, block->compact_pages_reviewed,
-              block->compact_pages_rewritten, block->compact_bytes_rewritten / WT_MEGABYTE,
-              progress,
+              "Approx. %d%% of the estimated work done.%s", progress,
               progress == 100 ? " More work has been discovered since the estimation." : "");
         }
     }


### PR DESCRIPTION
Refactored duplicated code for `__wt_block_compact_progress`

Example outputs:
```
[1708408820:180996][1622023:0xffffb6026020], test_compact04.test_compact04.test_compact04, file:test_compact04-0.wt, WT_SESSION.compact: [WT_VERB_COMPACT_PROGRESS][DEBUG_1]: Compacting test_compact04-0.wt for 0 seconds; reviewed 0 pages, rewritten 0 pages (0MB)
[1708408820:181009][1622023:0xffffb6026020], test_compact04.test_compact04.test_compact04, file:test_compact04-0.wt, WT_SESSION.compact: [WT_VERB_COMPACT_PROGRESS][DEBUG_1]: Still collecting information for estimating the progress.
``` 

```
[1708408820:341298][1622023:0xffffb6026020], test_compact04.test_compact04.test_compact04, file:test_compact04-0.wt, WT_SESSION.compact: [WT_VERB_COMPACT_PROGRESS][DEBUG_1]: Compacting test_compact04-0.wt for 0 seconds; reviewed 2244 pages, rewritten 567 pages (10MB)
[1708408820:341309][1622023:0xffffb6026020], test_compact04.test_compact04.test_compact04, file:test_compact04-0.wt, WT_SESSION.compact: [WT_VERB_COMPACT_PROGRESS][DEBUG_1]: Approx. 53% of the estimated work done.
```

```
[1708407270:190967][1620289:0xffff95300020], test_compact04.test_compact04.test_compact04, file:test_compact04-0.wt, WT_SESSION.compact: [WT_VERB_COMPACT_PROGRESS][DEBUG_1]: Compacting test_compact04-0.wt for 0 seconds; reviewed 2244 pages, rewritten 567 pages (7MB)
[1708407270:190977][1620289:0xffff95300020], test_compact04.test_compact04.test_compact04, file:test_compact04-0.wt, WT_SESSION.compact: [WT_VERB_COMPACT_PROGRESS][DEBUG_1]: Approx. 100% of the estimated work done. More work has been discovered since the estimation.
``` 