### PR TITLE
WT-12515 Enable Bazel Remote Execution in evergreen scons.py invocation

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -96,12 +96,32 @@ functions:
       remote_file: engflow/engflow.cert
       bucket: serverengflow
       local_file: "mongo/engflow.cert"
-  - command: subprocess.exec
+  - command: shell.exec
     params:
       display_name: "generate evergreen engflow bazelrc"
-      binary: bash
-      args:
-      - "mongo/evergreen/generate_evergreen_engflow_bazelrc.sh"
+      shell: bash
+      working_dir: mongo
+      script: |
+        set -o errexit
+        set -o verbose
+
+        # Pulled from evergreen/generate_evergreen_engflow_bazelrc.sh consider
+        # consolidating once prelude.sh is runnable in the perf project.
+
+        source ./evergreen/bazel_RBE_supported.sh
+
+        if bazel_rbe_supported; then
+
+          uri="https://spruce.mongodb.com/task/${task_id}?execution=${execution}"
+
+          echo "build --tls_client_certificate=./engflow.cert" > .bazelrc.evergreen_engflow_creds
+          echo "build --tls_client_key=./engflow.key" >> .bazelrc.evergreen_engflow_creds
+          echo "build --bes_keywords=engflow:CiCdPipelineName=${build_variant}" >> .bazelrc.evergreen_engflow_creds
+          echo "build --bes_keywords=engflow:CiCdJobName=${task_name}" >> .bazelrc.evergreen_engflow_creds
+          echo "build --bes_keywords=engflow:CiCdUri=$uri" >> .bazelrc.evergreen_engflow_creds
+          echo "build --bes_keywords=evg:project=${project}" >> .bazelrc.evergreen_engflow_creds
+          echo "build --workspace_status_command=./evergreen/engflow_workspace_status.sh" >> .bazelrc.evergreen_engflow_creds
+        fi
   "get project":
     command: git.get_project
     type: setup

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -78,7 +78,8 @@ functions:
             else
               export PATH=/opt/mongodbtoolchain/v4/bin:$PATH
             fi
-
+  # Since Bazel (currently used in SCons) uses EngFlow's remote execution system instead of icecream,
+  # additional credentials need to be setup to maintain efficient compilation speed.
   "get engflow creds": &get_engflow_creds
   - command: s3.get
     display_name: "get engflow key"
@@ -105,8 +106,8 @@ functions:
         set -o errexit
         set -o verbose
 
-        # Pulled from evergreen/generate_evergreen_engflow_bazelrc.sh consider
-        # consolidating once prelude.sh is runnable in the perf project.
+        # Pulled from evergreen/generate_evergreen_engflow_bazelrc.sh
+        # TODO(SERVER-86966): consider consolidating once prelude.sh is runnable in the perf project.
 
         source ./evergreen/bazel_RBE_supported.sh
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -79,6 +79,29 @@ functions:
               export PATH=/opt/mongodbtoolchain/v4/bin:$PATH
             fi
 
+  "get engflow creds": &get_engflow_creds
+  - command: s3.get
+    display_name: "get engflow key"
+    params:
+      aws_key: ${engflow_key}
+      aws_secret: ${engflow_secret}
+      remote_file: engflow/engflow.key
+      bucket: serverengflow
+      local_file: "mongo/engflow.key"
+  - command: s3.get
+    display_name: "get engflow cert"
+    params:
+      aws_key: ${engflow_key}
+      aws_secret: ${engflow_secret}
+      remote_file: engflow/engflow.cert
+      bucket: serverengflow
+      local_file: "mongo/engflow.cert"
+  - command: subprocess.exec
+    params:
+      display_name: "generate evergreen engflow bazelrc"
+      binary: bash
+      args:
+      - "mongo/evergreen/generate_evergreen_engflow_bazelrc.sh"
   "get project":
     command: git.get_project
     type: setup
@@ -3841,6 +3864,7 @@ tasks:
           timeout_secs: 86400
       - func: "fetch mongo repo"
       - func: "get project"
+      - func: "get engflow creds"
       - func: "import wiredtiger into mongo"
       - func: "compile mongodb"
       - func: "fetch mongo-tests repo"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -107,7 +107,7 @@ functions:
         set -o verbose
 
         # Pulled from evergreen/generate_evergreen_engflow_bazelrc.sh
-        # TODO(SERVER-86966): consider consolidating once prelude.sh is runnable in the perf project.
+        # FIXME-SERVER-86966: consider consolidating once prelude.sh is runnable in the perf project.
 
         source ./evergreen/bazel_RBE_supported.sh
 


### PR DESCRIPTION
As part of https://jira.mongodb.org/browse/DEVPROD-257 Bazel is about to be enabled on all platforms by default. This will cause certain targets to be built with Bazel instead of SCons.

Since Bazel uses EngFlow's remote execution system instead of icecream, additional credentials need to be setup to maintain efficient compilation speed.

WT scons.py invocation: https://github.com/10gen/mongo/blob/master/src/third_party/wiredtiger/test/evergreen.yml#L152

The following evergreen function needs to be invoked before the call to SCons above: https://github.com/10gen/mongo/blob/master/etc/evergreen_yml_components/definitions.yml#L178