### PR TITLE
WT-12522 Add an option in Workgen to limit the number of files present in the database

### DIFF
--- a/bench/workgen/runner/example_dynamic_tables.py
+++ b/bench/workgen/runner/example_dynamic_tables.py
@@ -61,6 +61,7 @@ workload.options.create_interval = 5
 workload.options.create_count = 3
 workload.options.create_trigger = 100
 workload.options.create_target = 200
+workload.options.max_num_files = 100
 
 # Define a workload thread to drop tables periodically:
 #   - Start dropping tables when the database size exceeds 250 MB.

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -336,7 +336,7 @@ get_dir_size_mb(const std::string &dir)
 }
 
 /*
- * Get the number of files under the given directory.
+ * Get the number of WiredTiger tables under the given directory.
  */
 static uint32_t
 get_dir_num_files(const std::string &dir)

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -335,6 +335,22 @@ get_dir_size_mb(const std::string &dir)
     return result / WT_MEGABYTE;
 }
 
+/*
+ * Get the number of files under the given directory.
+ */
+static uint32_t
+get_dir_num_files(const std::string &dir)
+{
+    auto dirIter = std::filesystem::directory_iterator(dir);
+    uint32_t fileCount = std::count_if(
+        begin(dirIter),
+        end(dirIter),
+        [](auto& entry) { return entry.is_regular_file() && entry.path().extension() == ".wt"; }
+    );
+
+    return fileCount;
+}
+
 // 5 random characters + Null terminator
 #define DYNAMIC_TABLE_LEN 6
 /*

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -501,7 +501,7 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
         /*
          * Initially we start creating tables if:
          *  - the database size is less than the create target and
-         *  - then number of files is below the limit.
+         *  - the number of files is below the limit.
          */
         creating = db_size < create_target && num_files < max_files;
     }

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -549,12 +549,11 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
         int creates = 0, retries = 0;
         // Make sure not to exceed the maximum number of files that can exist in the database.
         int num_files_to_create = 0;
-        if (num_files < max_files) {
-            if (num_files + _workload->options.create_count > max_files)
-                num_files_to_create = max_files - num_files;
-            else
-                num_files_to_create = _workload->options.create_count;
-        }
+        if (num_files + _workload->options.create_count > max_files)
+            num_files_to_create = max_files - num_files;
+        else
+            num_files_to_create = _workload->options.create_count;
+
         while (!stopping && creates < num_files_to_create && retries < TABLE_MAX_RETRIES) {
             // Generate a table name from the user specified prefix and a random alphanumeric
             // sequence.

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -342,11 +342,8 @@ static uint32_t
 get_dir_num_files(const std::string &dir)
 {
     auto dirIter = std::filesystem::directory_iterator(dir);
-    uint32_t fileCount = std::count_if(
-        begin(dirIter),
-        end(dirIter),
-        [](auto& entry) { return entry.is_regular_file() && entry.path().extension() == ".wt"; }
-    );
+    uint32_t fileCount = std::count_if(begin(dirIter), end(dirIter),
+      [](auto &entry) { return entry.is_regular_file() && entry.path().extension() == ".wt"; });
 
     return fileCount;
 }
@@ -511,9 +508,9 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
     while (!stopping) {
         /*
          * When managing the database size: if we are creating tables, continue until we reach the
-         * create target size or the number the number of files limit. If we are not creating tables,
-         * begin to do so if the database size falls below the create trigger and we are allowed to
-         * create more files.
+         * create target size or the number the number of files limit. If we are not creating
+         * tables, begin to do so if the database size falls below the create trigger and we are
+         * allowed to create more files.
          */
         if (manage_db_size) {
             uint32_t db_size = get_dir_size_mb(_wt_home);
@@ -522,14 +519,19 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
                 creating = db_size < create_target && num_files < max_files;
                 if (!creating) {
                     VERBOSE(*_workload,
-                      "Stopped creating new tables. Database size is now " << db_size << " MB (target: " << create_target << "MB) and the number of files is " << num_files << " (limit: " << max_files << ").");
+                      "Stopped creating new tables. Database size is now "
+                        << db_size << " MB (target: " << create_target
+                        << "MB) and the number of files is " << num_files
+                        << " (limit: " << max_files << ").");
                 }
             } else {
                 creating = db_size < _workload->options.create_trigger && num_files < max_files;
                 if (creating) {
                     VERBOSE(*_workload,
                       "Started creating new tables. Database size is now "
-                        << db_size << " MB (trigger: " << _workload->options.create_trigger << " MB) and the number of files is " << num_files << " (limit: " << max_files << ").");
+                        << db_size << " MB (trigger: " << _workload->options.create_trigger
+                        << " MB) and the number of files is " << num_files
+                        << " (limit: " << max_files << ").");
                 }
             }
         }
@@ -547,8 +549,8 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
         int creates = 0, retries = 0;
         // Make sure not to exceed the maximum number of files that can exist in the database.
         int num_files_to_create = 0;
-        if(num_files < max_files) {
-            if(num_files + _workload->options.create_count > max_files)
+        if (num_files < max_files) {
+            if (num_files + _workload->options.create_count > max_files)
                 num_files_to_create = max_files - num_files;
             else
                 num_files_to_create = _workload->options.create_count;
@@ -3070,7 +3072,8 @@ WorkloadOptions::WorkloadOptions()
       timestamp_advance(0.0), max_idle_table_cycle_fatal(false), create_count(0),
       create_interval(0), create_prefix(""), create_target(0), create_trigger(0), drop_count(0),
       drop_interval(0), drop_target(0), drop_trigger(0), random_table_values(false),
-      mirror_tables(false), mirror_suffix("_mirror"), background_compact(0), max_num_files(INT_MAX), _options()
+      mirror_tables(false), mirror_suffix("_mirror"), background_compact(0), max_num_files(INT_MAX),
+      _options()
 {
     _options.add_int("max_latency", max_latency,
       "prints warning if any latency measured exceeds this number of "

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -3429,6 +3429,9 @@ WorkloadRunner::run_all(WT_CONNECTION *conn)
         if (options->create_count < 1) {
             std::cerr << "create_count needs to be greater than 0" << std::endl;
             stopping = true;
+        } else if (options->create_count > options->max_num_files) {
+            std::cerr << "create_count cannot be greater than max_num_files" << std::endl;
+            stopping = true;
         } else if (options->create_target > 0 && options->create_trigger <= 0) {
             std::cerr << "Need to specify a create_trigger when setting a create_target."
                       << std::endl;

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -3042,7 +3042,7 @@ WorkloadOptions::WorkloadOptions()
       timestamp_advance(0.0), max_idle_table_cycle_fatal(false), create_count(0),
       create_interval(0), create_prefix(""), create_target(0), create_trigger(0), drop_count(0),
       drop_interval(0), drop_target(0), drop_trigger(0), random_table_values(false),
-      mirror_tables(false), mirror_suffix("_mirror"), background_compact(0), _options()
+      mirror_tables(false), mirror_suffix("_mirror"), background_compact(0), max_num_files(INT_MAX), _options()
 {
     _options.add_int("max_latency", max_latency,
       "prints warning if any latency measured exceeds this number of "
@@ -3105,6 +3105,8 @@ WorkloadOptions::WorkloadOptions()
       "mirror_suffix", mirror_suffix, "the suffix to append to mirrored table names");
     _options.add_int("background_compact", background_compact,
       "minimum amount of space recoverable for compaction to proceed in MB, 0 to disable.");
+    _options.add_int("max_num_files", max_num_files,
+      "if specified, maximum number of files that can be present in the database.");
 }
 
 WorkloadOptions::WorkloadOptions(const WorkloadOptions &other)

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -490,8 +490,9 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
 
     ContextInternal *icontext = _workload->_context->_internal;
     int create_target = _workload->options.create_target;
+    int create_trigger = _workload->options.create_trigger;
     int max_files = _workload->options.max_num_files;
-    bool manage_db_size = create_target > 0 && _workload->options.create_trigger > 0;
+    bool manage_db_size = create_target > 0 && create_trigger > 0;
     bool creating = true;
 
     if (manage_db_size) {
@@ -525,11 +526,11 @@ WorkloadRunner::start_tables_create(WT_CONNECTION *conn)
                         << " (limit: " << max_files << ").");
                 }
             } else {
-                creating = db_size < _workload->options.create_trigger && num_files < max_files;
+                creating = db_size < create_trigger && num_files < max_files;
                 if (creating) {
                     VERBOSE(*_workload,
                       "Started creating new tables. Database size is now "
-                        << db_size << " MB (trigger: " << _workload->options.create_trigger
+                        << db_size << " MB (trigger: " << create_trigger
                         << " MB) and the number of files is " << num_files
                         << " (limit: " << max_files << ").");
                 }

--- a/bench/workgen/workgen.h
+++ b/bench/workgen/workgen.h
@@ -451,6 +451,7 @@ struct WorkloadOptions {
     int max_idle_table_cycle;
     bool max_idle_table_cycle_fatal;
     int max_latency;
+    int max_num_files;
     std::string mirror_suffix;
     bool mirror_tables;
     double oldest_timestamp_lag;


### PR DESCRIPTION
- Added a new setting `max_num_files` to limit the number of files present in the Workgn database
- Tables are no longer dynamically created if the limit has been reached