### PR TITLE
WT-12378 Not enough memory error on arm64-small

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5538,7 +5538,7 @@ buildvariants:
     ENABLE_TCMALLOC: -DENABLE_TCMALLOC=1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: "Unix Makefiles"
-  # Using large distro for a few tests here as more memory is required. See WT-12378.
+  # Using large distro for a few tests here as more memory is required.
   tasks:
     - name: compile
     - name: make-check-test
@@ -5779,7 +5779,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-      # Using large distro as more memory is required. See WT-12378.
+      # Using large distro as more memory is required.
       distros: amazon2-arm64-large
     - name: unit-test
     - name: unit-test-extra-long

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5538,10 +5538,10 @@ buildvariants:
     ENABLE_TCMALLOC: -DENABLE_TCMALLOC=1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: "Unix Makefiles"
+  # Using medium distro for a few tests here as more memory is required. See WT-12378.
   tasks:
     - name: compile
     - name: make-check-test
-      # Using medium ditro as more memory is required. See WT-12378.
       distros: amazon2-arm64-medium
     - name: unit-test
     - name: fops
@@ -5553,11 +5553,9 @@ buildvariants:
       distros: amazon2-arm64-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
-      # Using medium ditro as more memory is required. See WT-12378.
       distros: amazon2-arm64-medium
     - name: wtperf-test
     - name: long-test
-      # Using medium ditro as more memory is required. See WT-12378.
       distros: amazon2-arm64-medium
     - name: format-smoke-test
     - name: s3-tiered-storage-extensions-test
@@ -5781,7 +5779,7 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-      # Using medium ditro as more memory is required. See WT-12378.
+      # Using medium distro as more memory is required. See WT-12378.
       distros: amazon2-arm64-medium
     - name: unit-test
     - name: unit-test-extra-long

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5541,6 +5541,8 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
+      # Using medium ditro as more memory is required. See WT-12378.
+      distros: amazon2-arm64-medium
     - name: unit-test
     - name: fops
     - name: format-failure-configs-test
@@ -5551,8 +5553,12 @@ buildvariants:
       distros: amazon2-arm64-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
+      # Using medium ditro as more memory is required. See WT-12378.
+      distros: amazon2-arm64-medium
     - name: wtperf-test
     - name: long-test
+      # Using medium ditro as more memory is required. See WT-12378.
+      distros: amazon2-arm64-medium
     - name: format-smoke-test
     - name: s3-tiered-storage-extensions-test
 
@@ -5764,7 +5770,7 @@ buildvariants:
 - name: amazon2-arm64-nonstandalone
   display_name: "Amazon Linux 2 ARM64 Non-standalone"
   run_on:
-  - amazon2-arm64-small
+  - amazon2-arm64-small 
   batchtime: 1440 # 24 hours
   expansions:
     ENABLE_TCMALLOC: -DENABLE_TCMALLOC=1
@@ -5775,6 +5781,8 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
+      # Using medium ditro as more memory is required. See WT-12378.
+      distros: amazon2-arm64-medium
     - name: unit-test
     - name: unit-test-extra-long
       distros: amazon2-arm64-large

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5538,11 +5538,11 @@ buildvariants:
     ENABLE_TCMALLOC: -DENABLE_TCMALLOC=1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: "Unix Makefiles"
-  # Using medium distro for a few tests here as more memory is required. See WT-12378.
+  # Using large distro for a few tests here as more memory is required. See WT-12378.
   tasks:
     - name: compile
     - name: make-check-test
-      distros: amazon2-arm64-medium
+      distros: amazon2-arm64-large
     - name: unit-test
     - name: fops
     - name: format-failure-configs-test
@@ -5553,10 +5553,10 @@ buildvariants:
       distros: amazon2-arm64-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
-      distros: amazon2-arm64-medium
+      distros: amazon2-arm64-large
     - name: wtperf-test
     - name: long-test
-      distros: amazon2-arm64-medium
+      distros: amazon2-arm64-large
     - name: format-smoke-test
     - name: s3-tiered-storage-extensions-test
 
@@ -5768,7 +5768,7 @@ buildvariants:
 - name: amazon2-arm64-nonstandalone
   display_name: "Amazon Linux 2 ARM64 Non-standalone"
   run_on:
-  - amazon2-arm64-small 
+  - amazon2-arm64-small
   batchtime: 1440 # 24 hours
   expansions:
     ENABLE_TCMALLOC: -DENABLE_TCMALLOC=1
@@ -5779,8 +5779,8 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
-      # Using medium distro as more memory is required. See WT-12378.
-      distros: amazon2-arm64-medium
+      # Using large distro as more memory is required. See WT-12378.
+      distros: amazon2-arm64-large
     - name: unit-test
     - name: unit-test-extra-long
       distros: amazon2-arm64-large


### PR DESCRIPTION
Fixed this error by assigning the tests that requires more memory to arm64-medium.