### PR TITLE
WT-12545 Import an existing workload file into the model

### DIFF
--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -294,7 +294,8 @@ parse_uint64(const char *str, char **end)
         throw std::runtime_error("Cannot parse a number");
 
     char *p = nullptr;
-    uint64_t r = (uint64_t)strtoull(str, &p, 0 /* automatically detect "0x" for hex numbers */);
+    uint64_t r =
+      (uint64_t)std::strtoull(str, &p, 0 /* automatically detect "0x" for hex numbers */);
     if (end != nullptr)
         *end = p;
     if (str == p || (end == nullptr && p[0] != '\0'))

--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -284,6 +284,26 @@ shared_memory::~shared_memory()
 }
 
 /*
+ * parse_uint64 --
+ *     Parse the string into a number. Throw an exception on error.
+ */
+uint64_t
+parse_uint64(const char *str, char **end)
+{
+    if (str == nullptr || str[0] == '\0')
+        throw std::runtime_error("Cannot parse a number");
+
+    char *p = nullptr;
+    uint64_t r = (uint64_t)strtoull(str, &p, 0 /* automatically detect "0x" for hex numbers */);
+    if (end != nullptr)
+        *end = p;
+    if (str == p || (end == nullptr && p[0] != '\0'))
+        throw std::runtime_error("Cannot parse a number");
+
+    return r;
+}
+
+/*
  * wt_list_tables --
  *     Get the list of WiredTiger tables.
  */

--- a/test/model/src/driver/kv_workload.cpp
+++ b/test/model/src/driver/kv_workload.cpp
@@ -37,6 +37,168 @@ extern "C" {
 
 namespace model {
 
+namespace operation {
+
+/*
+ * parse --
+ *     Parse an operation from a string. Throw an exception on error.
+ */
+any
+parse(const char *str)
+{
+    const char *p = str;
+
+    /* Get the operation name. */
+    std::string name;
+    while (*p != '\0' && (std::isalnum(*p) || *p == '_'))
+        name += *(p++);
+
+    while (*p != '\0' && std::isspace(*p))
+        p++;
+    if (*(p++) != '(')
+        throw model_exception("Expected '('");
+
+    /* Get the arguments. */
+    std::vector<std::string> args;
+    std::string current;
+    bool done = false;
+    bool escaped = false;
+    bool had_quotes = false;
+    bool quotes = false;
+    while (*p != '\0') {
+        char c = *(p++);
+
+        if (escaped) {
+            current += c;
+            escaped = false;
+            continue;
+        }
+
+        if (quotes) {
+            if (c == '\"') {
+                quotes = false;
+                continue;
+            }
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+            current += c;
+            continue;
+        }
+
+        if (std::isspace(c))
+            continue;
+
+        if (c == '\"') {
+            quotes = true;
+            had_quotes = true;
+            continue;
+        }
+
+        if (c == ',' || c == ')') {
+            if (!(c == ')' && current.empty() && !had_quotes))
+                args.push_back(current);
+            current = "";
+            had_quotes = false;
+            if (c == ')') {
+                done = true;
+                break;
+            }
+            continue;
+        }
+
+        current += c;
+    }
+
+    if (!done)
+        throw model_exception("Expected ')'");
+    while (*p != '\0' && std::isspace(*p))
+        p++;
+    if (*(p++) != '\0')
+        throw model_exception("Extra characters at the end of the string.");
+
+#define CHECK_NUM_ARGS(expected)   \
+    if (args.size() != (expected)) \
+        throw model_exception("Expected " + std::to_string(expected) + " arguments");
+#define CHECK_NUM_ARGS_RANGE(min, max)                                              \
+    if (args.size() < min || args.size() > max)                                     \
+        throw model_exception("Expected between " + std::to_string(min) + " and " + \
+          std::to_string(max) + " arguments");
+
+    /* Now actually parse the operation. */
+    /* FIXME: We currently only support unsigned integer keys. */
+    if (name == "begin_transaction") {
+        CHECK_NUM_ARGS(1);
+        return begin_transaction(parse_uint64(args[0]));
+    }
+    if (name == "checkpoint") {
+        CHECK_NUM_ARGS_RANGE(0, 1);
+        return checkpoint(args.size() == 0 ? nullptr : args[0].c_str());
+    }
+    if (name == "commit_transaction") {
+        CHECK_NUM_ARGS_RANGE(1, 3);
+        return commit_transaction(parse_uint64(args[0]),
+          args.size() < 1 ? k_timestamp_none : parse_uint64(args[1]),
+          args.size() < 2 ? k_timestamp_none : parse_uint64(args[2]));
+    }
+    if (name == "crash") {
+        CHECK_NUM_ARGS(0);
+        return crash();
+    }
+    if (name == "create_table") {
+        CHECK_NUM_ARGS(4);
+        return create_table(
+          parse_uint64(args[0]), args[1].c_str(), args[2].c_str(), args[3].c_str());
+    }
+    if (name == "insert") {
+        CHECK_NUM_ARGS(4);
+        return insert(parse_uint64(args[0]), parse_uint64(args[1]),
+          data_value(parse_uint64(args[2])), data_value(parse_uint64(args[3])));
+    }
+    if (name == "prepare_transaction") {
+        CHECK_NUM_ARGS(2);
+        return prepare_transaction(parse_uint64(args[0]), parse_uint64(args[1]));
+    }
+    if (name == "remove") {
+        CHECK_NUM_ARGS(3);
+        return remove(
+          parse_uint64(args[0]), parse_uint64(args[1]), data_value(parse_uint64(args[2])));
+    }
+    if (name == "restart") {
+        CHECK_NUM_ARGS(0);
+        return restart();
+    }
+    if (name == "rollback_to_stable") {
+        CHECK_NUM_ARGS(0);
+        return rollback_to_stable();
+    }
+    if (name == "rollback_transaction") {
+        CHECK_NUM_ARGS(1);
+        return rollback_transaction(parse_uint64(args[0]));
+    }
+    if (name == "set_commit_timestamp") {
+        CHECK_NUM_ARGS(2);
+        return set_commit_timestamp(parse_uint64(args[0]), parse_uint64(args[1]));
+    }
+    if (name == "set_stable_timestamp") {
+        CHECK_NUM_ARGS(1);
+        return set_stable_timestamp(parse_uint64(args[0]));
+    }
+    if (name == "truncate") {
+        CHECK_NUM_ARGS(4);
+        return truncate(parse_uint64(args[0]), parse_uint64(args[1]),
+          data_value(parse_uint64(args[2])), data_value(parse_uint64(args[3])));
+    }
+
+#undef CHECK_NUM_ARGS
+#undef CHECK_NUM_ARGS_RANGE
+
+    throw model_exception("Cannot parse operation: Unknown operation \"" + name + "\"");
+}
+
+} /* namespace operation */
+
 /*
  * kv_workload::run --
  *     Run the workload in the model.

--- a/test/model/src/driver/kv_workload.cpp
+++ b/test/model/src/driver/kv_workload.cpp
@@ -127,7 +127,7 @@ parse(const char *str)
           std::to_string(max) + " arguments");
 
     /* Now actually parse the operation. */
-    /* FIXME: We currently only support unsigned integer keys. */
+    /* FIXME: We currently only support unsigned numbers for keys and values. */
     if (name == "begin_transaction") {
         CHECK_NUM_ARGS(1);
         return begin_transaction(parse_uint64(args[0]));

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -259,8 +259,8 @@ struct create_table {
     inline bool
     operator==(const create_table &other) const noexcept
     {
-        return table_id == other.table_id && name == other.name &&
-          key_format == other.value_format && value_format == other.value_format;
+        return table_id == other.table_id && name == other.name && key_format == other.key_format &&
+          value_format == other.value_format;
     }
 
     /*

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -30,7 +30,6 @@
 
 #include <deque>
 #include <iostream>
-#include <sstream>
 #include <variant>
 #include "model/core.h"
 #include "model/data_value.h"

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -30,6 +30,7 @@
 
 #include <deque>
 #include <iostream>
+#include <sstream>
 #include <variant>
 #include "model/core.h"
 #include "model/data_value.h"
@@ -57,6 +58,26 @@ struct begin_transaction {
      *     Create the operation.
      */
     inline begin_transaction(txn_id_t txn_id) : txn_id(txn_id) {}
+
+    /*
+     * begin_transaction::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const begin_transaction &other) const noexcept
+    {
+        return txn_id == other.txn_id;
+    }
+
+    /*
+     * begin_transaction::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const begin_transaction &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -82,6 +103,26 @@ struct checkpoint {
      *     Create the operation.
      */
     inline checkpoint(const char *name = nullptr) : name(name == nullptr ? "" : name) {}
+
+    /*
+     * checkpoint::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const checkpoint &other) const noexcept
+    {
+        return name == other.name;
+    }
+
+    /*
+     * begin_transaction::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const checkpoint &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -113,6 +154,27 @@ struct commit_transaction {
         : txn_id(txn_id), commit_timestamp(commit_timestamp), durable_timestamp(durable_timestamp)
     {
     }
+
+    /*
+     * commit_transaction::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const commit_transaction &other) const noexcept
+    {
+        return txn_id == other.txn_id && commit_timestamp == other.commit_timestamp &&
+          durable_timestamp == other.durable_timestamp;
+    }
+
+    /*
+     * commit_transaction::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const commit_transaction &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -138,6 +200,26 @@ struct crash {
      *     Create the operation.
      */
     inline crash() {}
+
+    /*
+     * crash::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const crash &other) const noexcept
+    {
+        return true;
+    }
+
+    /*
+     * crash::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const crash &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -169,6 +251,27 @@ struct create_table {
       table_id_t table_id, const char *name, const char *key_format, const char *value_format)
         : table_id(table_id), name(name), key_format(key_format), value_format(value_format)
     {
+    }
+
+    /*
+     * create_table::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const create_table &other) const noexcept
+    {
+        return table_id == other.table_id && name == other.name &&
+          key_format == other.value_format && value_format == other.value_format;
+    }
+
+    /*
+     * create_table::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const create_table &other) const noexcept
+    {
+        return !(*this == other);
     }
 };
 
@@ -203,6 +306,27 @@ struct insert {
         : table_id(table_id), txn_id(txn_id), key(key), value(value)
     {
     }
+
+    /*
+     * insert::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const insert &other) const noexcept
+    {
+        return table_id == other.table_id && txn_id == other.txn_id && key == other.key &&
+          value == other.value;
+    }
+
+    /*
+     * insert::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const insert &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -232,6 +356,26 @@ struct prepare_transaction {
     inline prepare_transaction(txn_id_t txn_id, timestamp_t prepare_timestamp)
         : txn_id(txn_id), prepare_timestamp(prepare_timestamp)
     {
+    }
+
+    /*
+     * prepare_transaction::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const prepare_transaction &other) const noexcept
+    {
+        return txn_id == other.txn_id && prepare_timestamp == other.prepare_timestamp;
+    }
+
+    /*
+     * prepare_transaction::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const prepare_transaction &other) const noexcept
+    {
+        return !(*this == other);
     }
 };
 
@@ -263,6 +407,26 @@ struct remove {
         : table_id(table_id), txn_id(txn_id), key(key)
     {
     }
+
+    /*
+     * remove::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const remove &other) const noexcept
+    {
+        return table_id == other.table_id && txn_id == other.txn_id && key == other.key;
+    }
+
+    /*
+     * remove::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const remove &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -287,6 +451,26 @@ struct restart {
      *     Create the operation.
      */
     inline restart() {}
+
+    /*
+     * restart::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const restart &other) const noexcept
+    {
+        return true;
+    }
+
+    /*
+     * restart::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const restart &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -311,6 +495,26 @@ struct rollback_to_stable {
      *     Create the operation.
      */
     inline rollback_to_stable() {}
+
+    /*
+     * rollback_to_stable::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const rollback_to_stable &other) const noexcept
+    {
+        return true;
+    }
+
+    /*
+     * rollback_to_stable::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const rollback_to_stable &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -336,6 +540,26 @@ struct rollback_transaction {
      *     Create the operation.
      */
     inline rollback_transaction(txn_id_t txn_id) : txn_id(txn_id) {}
+
+    /*
+     * rollback_transaction::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const rollback_transaction &other) const noexcept
+    {
+        return txn_id == other.txn_id;
+    }
+
+    /*
+     * rollback_transaction::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const rollback_transaction &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -365,6 +589,26 @@ struct set_commit_timestamp {
         : txn_id(txn_id), commit_timestamp(commit_timestamp)
     {
     }
+
+    /*
+     * set_commit_timestamp::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const set_commit_timestamp &other) const noexcept
+    {
+        return txn_id == other.txn_id && commit_timestamp == other.commit_timestamp;
+    }
+
+    /*
+     * set_commit_timestamp::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const set_commit_timestamp &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -391,6 +635,26 @@ struct set_stable_timestamp {
      */
     inline set_stable_timestamp(timestamp_t stable_timestamp) : stable_timestamp(stable_timestamp)
     {
+    }
+
+    /*
+     * set_stable_timestamp::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const set_stable_timestamp &other) const noexcept
+    {
+        return stable_timestamp == other.stable_timestamp;
+    }
+
+    /*
+     * set_stable_timestamp::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const set_stable_timestamp &other) const noexcept
+    {
+        return !(*this == other);
     }
 };
 
@@ -424,6 +688,27 @@ struct truncate {
         : table_id(table_id), txn_id(txn_id), start(start), stop(stop)
     {
     }
+
+    /*
+     * truncate::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const truncate &other) const noexcept
+    {
+        return table_id == other.table_id && txn_id == other.txn_id && start == other.start &&
+          stop == other.stop;
+    }
+
+    /*
+     * truncate::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const truncate &other) const noexcept
+    {
+        return !(*this == other);
+    }
 };
 
 /*
@@ -455,6 +740,22 @@ operator<<(std::ostream &out, const any &op)
 {
     std::visit([&out](auto &&x) { out << x; }, op);
     return out;
+}
+
+/*
+ * parse --
+ *     Parse an operation from a string. Throw an exception on error.
+ */
+any parse(const char *str);
+
+/*
+ * parse --
+ *     Parse an operation from a string. Throw an exception on error.
+ */
+inline any
+parse(const std::string &str)
+{
+    return parse(str.c_str());
 }
 
 } /* namespace operation */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -429,6 +429,22 @@ private:
 };
 
 /*
+ * parse_uint64 --
+ *     Parse the string into a number. Throw an exception on error.
+ */
+uint64_t parse_uint64(const char *str, char **end = nullptr);
+
+/*
+ * parse_uint64 --
+ *     Parse the string into a number. Throw an exception on error.
+ */
+inline uint64_t
+parse_uint64(const std::string &str)
+{
+    return parse_uint64(str.c_str());
+}
+
+/*
  * starts_with --
  *     Check whether the string has the given prefix. (C++ does not have this until C++20.)
  */

--- a/test/model/test/common/include/model/test/util.h
+++ b/test/model/test/common/include/model/test/util.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <utility>
 #include "model/driver/kv_workload.h"
+#include "model/util.h"
 
 extern "C" {
 #include "test_util.h"
@@ -65,7 +66,12 @@ double current_time();
  * parse_uint64 --
  *     Parse the string into a number. Throw an exception on error.
  */
-uint64_t parse_uint64(const char *str, char **end = nullptr);
+inline uint64_t
+parse_uint64(const char *str, char **end = nullptr)
+{
+    /* Convenience function, at least until we refactor these utilities. */
+    return model::parse_uint64(str, end);
+}
 
 /*
  * parse_uint64_range --

--- a/test/model/test/common/util.cpp
+++ b/test/model/test/common/util.cpp
@@ -83,26 +83,6 @@ current_time()
 }
 
 /*
- * parse_uint64 --
- *     Parse the string into a number. Throw an exception on error.
- */
-uint64_t
-parse_uint64(const char *str, char **end)
-{
-    if (str == nullptr || str[0] == '\0')
-        throw std::runtime_error("Cannot parse a number");
-
-    char *p = nullptr;
-    uint64_t r = (uint64_t)strtoull(str, &p, 0 /* automatically detect "0x" for hex numbers */);
-    if (end != nullptr)
-        *end = p;
-    if (str == p || (end == nullptr && p[0] != '\0'))
-        throw std::runtime_error("Cannot parse a number");
-
-    return r;
-}
-
-/*
  * parse_uint64_range --
  *     Parse the string into a range of numbers (two numbers separated by '-'). Throw an exception
  *     on error.

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -352,6 +352,18 @@ test_workload_parse(void)
       model::operation::any(model::operation::create_table(1, "table\" \\", "Q", "")));
     testutil_assert(model::operation::parse("create_table\t\n(0x1 ,\"table\" \"1\", \"Q\", S )") ==
       model::operation::any(model::operation::create_table(1, "table1", "Q", "S")));
+
+    /* Test optional arguments. */
+    testutil_assert(model::operation::parse("checkpoint()") ==
+      model::operation::any(model::operation::checkpoint()));
+    testutil_assert(model::operation::parse("checkpoint(\"test\")") ==
+      model::operation::any(model::operation::checkpoint("test")));
+    testutil_assert(model::operation::parse("commit_transaction(1)") ==
+      model::operation::any(model::operation::commit_transaction(1)));
+    testutil_assert(model::operation::parse("commit_transaction(1, 2)") ==
+      model::operation::any(model::operation::commit_transaction(1, 2)));
+    testutil_assert(model::operation::parse("commit_transaction(1, 2, 3)") ==
+      model::operation::any(model::operation::commit_transaction(1, 2, 3)));
 }
 
 /*

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -318,15 +318,18 @@ test_workload_parse(void)
       << model::operation::prepare_transaction(1, 10)
       << model::operation::prepare_transaction(2, 15)
       << model::operation::commit_transaction(1, 20, 21)
-      << model::operation::commit_transaction(2, 25, 26)
-      << model::operation::set_stable_timestamp(22) << model::operation::begin_transaction(1)
+      << model::operation::rollback_transaction(2) << model::operation::set_stable_timestamp(22)
+      << model::operation::begin_transaction(1)
       << model::operation::remove(k_table1_id, 1, model::data_value(1ULL))
       << model::operation::checkpoint() << model::operation::crash()
       << model::operation::begin_transaction(1)
       << model::operation::insert(k_table1_id, 1, model::data_value(3ULL), model::data_value(3ULL))
+      << model::operation::truncate(
+           k_table1_id, 2, model::data_value(1ULL), model::data_value(2ULL))
       << model::operation::prepare_transaction(1, 23)
       << model::operation::commit_transaction(1, 24, 25)
-      << model::operation::set_stable_timestamp(25);
+      << model::operation::set_stable_timestamp(25) << model::operation::rollback_to_stable()
+      << model::operation::restart();
 
     /* Convert to string, parse, and compare each operation. */
     for (size_t i = 0; i < workload.size(); i++) {

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -310,26 +310,28 @@ test_workload_parse(void)
     model::kv_workload workload;
 
     /* The workload parser currently supports only unsigned integers as key and values. */
-    workload
-      << model::operation::create_table(k_table1_id, "table1", "Q", "Q")
-      << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
-      << model::operation::insert(k_table1_id, 1, model::data_value(1ULL), model::data_value(1ULL))
-      << model::operation::insert(k_table1_id, 2, model::data_value(2ULL), model::data_value(2ULL))
-      << model::operation::prepare_transaction(1, 10)
-      << model::operation::prepare_transaction(2, 15)
-      << model::operation::commit_transaction(1, 20, 21)
-      << model::operation::rollback_transaction(2) << model::operation::set_stable_timestamp(22)
-      << model::operation::begin_transaction(1)
-      << model::operation::remove(k_table1_id, 1, model::data_value(1ULL))
-      << model::operation::checkpoint() << model::operation::crash()
-      << model::operation::begin_transaction(1)
-      << model::operation::insert(k_table1_id, 1, model::data_value(3ULL), model::data_value(3ULL))
-      << model::operation::truncate(
-           k_table1_id, 2, model::data_value(1ULL), model::data_value(2ULL))
-      << model::operation::prepare_transaction(1, 23)
-      << model::operation::commit_transaction(1, 24, 25)
-      << model::operation::set_stable_timestamp(25) << model::operation::rollback_to_stable()
-      << model::operation::restart();
+    workload << model::operation::create_table(k_table1_id, "table1", "Q", "Q")
+             << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
+             << model::operation::insert(
+                  k_table1_id, 1, model::data_value((uint64_t)1), model::data_value((uint64_t)1))
+             << model::operation::insert(
+                  k_table1_id, 2, model::data_value((uint64_t)2), model::data_value((uint64_t)2))
+             << model::operation::prepare_transaction(1, 10)
+             << model::operation::prepare_transaction(2, 15)
+             << model::operation::commit_transaction(1, 20, 21)
+             << model::operation::rollback_transaction(2)
+             << model::operation::set_stable_timestamp(22) << model::operation::begin_transaction(1)
+             << model::operation::remove(k_table1_id, 1, model::data_value((uint64_t)1))
+             << model::operation::checkpoint() << model::operation::crash()
+             << model::operation::begin_transaction(1)
+             << model::operation::insert(
+                  k_table1_id, 1, model::data_value((uint64_t)3), model::data_value((uint64_t)3))
+             << model::operation::truncate(
+                  k_table1_id, 2, model::data_value((uint64_t)1), model::data_value((uint64_t)2))
+             << model::operation::prepare_transaction(1, 23)
+             << model::operation::commit_transaction(1, 24, 25)
+             << model::operation::set_stable_timestamp(25) << model::operation::rollback_to_stable()
+             << model::operation::restart();
 
     /* Convert to string, parse, and compare each operation. */
     for (size_t i = 0; i < workload.size(); i++) {

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -338,6 +338,18 @@ test_workload_parse(void)
         model::operation::any op = model::operation::parse(ss.str());
         testutil_assert(workload[i] == op);
     }
+
+    /* Additional tests for different allowed parsing behaviors. */
+    testutil_assert(model::operation::parse("create_table(1, table1, Q, Q)") ==
+      model::operation::any(model::operation::create_table(1, "table1", "Q", "Q")));
+    testutil_assert(model::operation::parse("create_table(1, \"table1\", \"Q\", \"Q\")") ==
+      model::operation::any(model::operation::create_table(1, "table1", "Q", "Q")));
+    testutil_assert(model::operation::parse("create_table   (   0x1,table1, \"Q\",  Q      )  ") ==
+      model::operation::any(model::operation::create_table(1, "table1", "Q", "Q")));
+    testutil_assert(model::operation::parse("create_table(1, \"table\\\" \\\\\", \"Q\", \"\")") ==
+      model::operation::any(model::operation::create_table(1, "table\" \\", "Q", "")));
+    testutil_assert(model::operation::parse("create_table\t\n(0x1 ,\"table\" \"1\", \"Q\", S )") ==
+      model::operation::any(model::operation::create_table(1, "table1", "Q", "S")));
 }
 
 /*

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -309,7 +309,7 @@ test_workload_parse(void)
 {
     model::kv_workload workload;
 
-    /* The workload parser currently supports only unsigned integers as key and values. */
+    /* The workload parser currently supports only unsigned numbers for keys and values. */
     workload << model::operation::create_table(k_table1_id, "table1", "Q", "Q")
              << model::operation::begin_transaction(1) << model::operation::begin_transaction(2)
              << model::operation::insert(


### PR DESCRIPTION
The PR adds the ability to parse workload operations from a string, and it also adds a new option to `model_test` to re-run an existing workload that was saved to a file. This is, for example, useful when debugging a failed model-based test.

The PR also adds `operator==` and `operator!=` to all workload operations, so that the test can check whether the operations were parsed correctly.