### PR TITLE
WT-12454 Skip test_bug028 on PPC machines

### DIFF
--- a/test/suite/test_bug028.py
+++ b/test/suite/test_bug028.py
@@ -73,6 +73,11 @@ class test_bug028(wttest.WiredTigerTestCase, suite_subprocess):
         if os.name != 'posix':
             self.skipTest('skipping buffer alignment and direct I/O test on non-POSIX system')
 
+        # The PPC machines have known I/O bandwidth constraint and could take hours to complete
+        # this test.
+        if os.uname().machine == "ppc64le":
+            self.skipTest('skipping buffer alignment and direct I/O test on PPC machines')
+
         config = 'create'
         config += ",buffer_alignment=" + align
         config += ',direct_io=('

--- a/test/suite/test_bug028.py
+++ b/test/suite/test_bug028.py
@@ -75,7 +75,7 @@ class test_bug028(wttest.WiredTigerTestCase, suite_subprocess):
 
         # The PPC machines have known I/O bandwidth constraint and could take hours to complete
         # this test.
-        if os.uname().machine == "ppc64le":
+        if 'ppc' in os.uname().machine:
             self.skipTest('skipping buffer alignment and direct I/O test on PPC machines')
 
         config = 'create'


### PR DESCRIPTION
Skip running the "test_bug028" Python test on PPC machines, which have known I/O bandwidth issue that can take hours for the test to complete.