### PR TITLE
WT-12563 Add more tests to the examples-c-tsan task

### DIFF
--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -120,6 +120,7 @@ __WT_MISC_H
 __wt_atomic_and_generic
 __wt_atomic_load_generic
 __wt_atomic_or_generic
+__wt_atomic_store_generic
 __wt_bswap16
 __wt_checksum_with_seed
 __wt_conf_gets

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -114,7 +114,7 @@ err:
     /* Increment the cache statistics. */
     __wt_cache_page_inmem_incr(session, page, size);
     (void)__wt_atomic_add64(&cache->pages_inmem, 1);
-    page->cache_create_gen = cache->evict_pass_gen;
+    page->cache_create_gen = __wt_atomic_load64(&cache->evict_pass_gen);
 
     *pagep = page;
     return (0);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -227,7 +227,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
     internal_bytes = leaf_bytes = 0;
     internal_pages = leaf_pages = 0;
-    saved_pinned_id = WT_SESSION_TXN_SHARED(session)->pinned_id;
+    saved_pinned_id = __wt_atomic_loadv64(&WT_SESSION_TXN_SHARED(session)->pinned_id);
     time_start = WT_VERBOSE_ISSET(session, WT_VERB_CHECKPOINT) ? __wt_clock(session) : 0;
 
     switch (syncop) {

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -370,7 +370,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * any page modify structure. (It needs to be ordered else a page could be dirtied after
              * taking the local reference.)
              */
-            WT_ACQUIRE_READ_WITH_BARRIER(dirty, __wt_page_is_modified(page));
+            dirty = __wt_page_is_modified(page);
+            WT_ACQUIRE_BARRIER();
 
             /* Skip clean pages, but always update the maximum transaction ID. */
             if (!dirty) {

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -436,7 +436,7 @@ __wt_update_obsolete_check(
          * moved forwards.
          */
         if (count > 20) {
-            page->modify->obsolete_check_txn = txn_global->last_running;
+            page->modify->obsolete_check_txn = __wt_atomic_loadv64(&txn_global->last_running);
             if (txn_global->has_pinned_timestamp)
                 page->modify->obsolete_check_timestamp = txn_global->pinned_timestamp;
         }

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -331,7 +331,7 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(
       session, stats, cache_pages_dirty, cache->pages_dirty_intl + cache->pages_dirty_leaf);
 
-    WT_STAT_SET(session, stats, cache_eviction_state, cache->flags);
+    WT_STAT_SET(session, stats, cache_eviction_state, __wt_atomic_load32(&cache->flags));
     WT_STAT_SET(session, stats, cache_eviction_aggressive_set, cache->evict_aggressive_score);
     WT_STAT_SET(session, stats, cache_eviction_empty_score, cache->evict_empty_score);
 

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -241,7 +241,8 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
      * The lowest possible page read-generation has a special meaning, it marks a page for forcible
      * eviction; don't let it happen by accident.
      */
-    cache->read_gen = cache->read_gen_oldest = WT_READGEN_START_VALUE;
+    cache->read_gen_oldest = WT_READGEN_START_VALUE;
+    __wt_atomic_store64(&cache->read_gen, WT_READGEN_START_VALUE);
 
     /*
      * The target size must be lower than the trigger size or we will never get any work done.

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -474,7 +474,7 @@ __cache_pool_assess(WT_SESSION_IMPL *session, uint64_t *phighest)
          *
          * Count pages read, using virtual memory page size.
          */
-        tmp = cache->bytes_read / (uint64_t)entry->page_size;
+        tmp = __wt_atomic_load64(&cache->bytes_read) / (uint64_t)entry->page_size;
         if (tmp >= cache->cp_saved_read)
             reads = tmp - cache->cp_saved_read;
         else

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -77,7 +77,7 @@ __wt_conn_stat_init(WT_SESSION_IMPL *session)
     __wt_txn_stats_update(session);
 
     WT_STAT_SET(session, stats, file_open, conn->open_file_count);
-    WT_STAT_SET(session, stats, cursor_open_count, conn->open_cursor_count);
+    WT_STAT_SET(session, stats, cursor_open_count, __wt_atomic_load32(&conn->open_cursor_count));
     WT_STAT_SET(session, stats, dh_conn_handle_count, conn->dhandle_count);
     WT_STAT_SET(session, stats, rec_split_stashed_objects, conn->stashed_objects);
     WT_STAT_SET(session, stats, rec_split_stashed_bytes, conn->stashed_bytes);

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -382,7 +382,8 @@ __tier_storage_copy(WT_SESSION_IMPL *session)
          * checkpoint is not running, we can process the items with the read generation count. If
          * the checkpoint starts after checking, it would push flush units of a higher count.
          */
-        WT_ACQUIRE_READ_WITH_BARRIER(ckpt_gen, __wt_gen(session, WT_GEN_CHECKPOINT));
+        ckpt_gen = __wt_gen(session, WT_GEN_CHECKPOINT);
+        WT_ACQUIRE_BARRIER();
         WT_ACQUIRE_READ_WITH_BARRIER(ckpt_running, conn->txn_global.checkpoint_running);
         __wt_tiered_get_flush(session, (ckpt_running ? ckpt_gen : ckpt_gen + 1), &entry);
         if (entry == NULL)

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2509,7 +2509,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
          * below 100%, limit the work to 5 evictions and return. If that's not the case, we can do
          * more.
          */
-        if (!busy && txn_shared->pinned_id != WT_TXN_NONE &&
+        if (!busy && __wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE &&
           txn_global->current != txn_global->oldest_id)
             busy = true;
         max_progress = busy ? 5 : 20;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -624,7 +624,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
     flags = 0;
 
     if (!F_ISSET(conn, WT_CONN_EVICTION_RUN)) {
-        cache->flags = 0;
+        __wt_atomic_store32(&cache->flags, 0);
         return (false);
     }
 
@@ -700,7 +700,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
     }
 
     /* Update the global eviction state. */
-    cache->flags = flags;
+    __wt_atomic_store32(&cache->flags, flags);
 
     return (F_ISSET(cache, WT_CACHE_EVICT_ALL | WT_CACHE_EVICT_URGENT));
 }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -798,7 +798,8 @@ __evict_pass(WT_SESSION_IMPL *session)
                 if (cache->evict_aggressive_score < WT_EVICT_SCORE_MAX)
                     ++cache->evict_aggressive_score;
                 oldest_id = __wt_atomic_loadv64(&txn_global->oldest_id);
-                if (prev_oldest_id == oldest_id && txn_global->current != oldest_id &&
+                if (prev_oldest_id == oldest_id &&
+                  __wt_atomic_loadv64(&txn_global->current) != oldest_id &&
                   cache->evict_aggressive_score < WT_EVICT_SCORE_MAX)
                     ++cache->evict_aggressive_score;
                 time_prev = time_now;
@@ -2514,7 +2515,7 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
          * more.
          */
         if (!busy && __wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE &&
-          txn_global->current != __wt_atomic_loadv64(&txn_global->oldest_id))
+          __wt_atomic_loadv64(&txn_global->current) != __wt_atomic_loadv64(&txn_global->oldest_id))
             busy = true;
         max_progress = busy ? 5 : 20;
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2093,7 +2093,8 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
         if (!__wt_page_evict_retry(session, page)) {
             WT_STAT_CONN_INCR(session, cache_eviction_server_skip_pages_retry);
             continue;
-        } else if (modified && page->modify->update_txn >= conn->txn_global.last_running) {
+        } else if (modified &&
+          page->modify->update_txn >= __wt_atomic_loadv64(&conn->txn_global.last_running)) {
             /*
              * FIXME-WT-11805: The assumption that the eviction will fail if most recent update on
              * the page from the transaction that is greater than the last running transaction has

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -846,7 +846,8 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
      * running application transaction.
      */
     use_snapshot_for_app_thread = !F_ISSET(session, WT_SESSION_INTERNAL) &&
-      !WT_IS_METADATA(session->dhandle) && WT_SESSION_TXN_SHARED(session)->id != WT_TXN_NONE &&
+      !WT_IS_METADATA(session->dhandle) &&
+      __wt_atomic_loadv64(&WT_SESSION_TXN_SHARED(session)->id) != WT_TXN_NONE &&
       F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT);
     is_eviction_thread = F_ISSET(session, WT_SESSION_EVICTION);
 

--- a/src/evict/evict_stat.c
+++ b/src/evict/evict_stat.c
@@ -78,11 +78,13 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
             continue;
 
         if (page->evict_pass_gen == 0) {
-            unvisited_age_gap_sum += (cache->evict_pass_gen - page->cache_create_gen);
+            unvisited_age_gap_sum +=
+              (__wt_atomic_load64(&cache->evict_pass_gen) - page->cache_create_gen);
             ++unvisited_count;
         } else {
-            visited_age_gap_sum += (cache->evict_pass_gen - page->cache_create_gen);
-            gen_gap = cache->evict_pass_gen - page->evict_pass_gen;
+            visited_age_gap_sum +=
+              (__wt_atomic_load64(&cache->evict_pass_gen) - page->cache_create_gen);
+            gen_gap = __wt_atomic_load64(&cache->evict_pass_gen) - page->evict_pass_gen;
             if (gen_gap > gen_gap_max)
                 gen_gap_max = gen_gap;
             gen_gap_sum += gen_gap;
@@ -129,7 +131,8 @@ __wt_curstat_cache_walk(WT_SESSION_IMPL *session)
     conn = S2C(session);
 
     /* Set statistics that don't require walking the cache. */
-    WT_STAT_DATA_SET(session, cache_state_gen_current, conn->cache->evict_pass_gen);
+    WT_STAT_DATA_SET(
+      session, cache_state_gen_current, __wt_atomic_load64(&conn->cache->evict_pass_gen));
 
     /* Root page statistics */
     root_idx = WT_INTL_INDEX_GET_SAFE(btree->root.page);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -706,7 +706,7 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     last_running = 0;
     if (page->modify->page_state == WT_PAGE_CLEAN)
-        last_running = S2C(session)->txn_global.last_running;
+        last_running = __wt_atomic_loadv64(&S2C(session)->txn_global.last_running);
 
     /*
      * We depend on the atomic operation being a release barrier, that is, a barrier to ensure all

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1545,7 +1545,8 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
      * WT_ADDRs and swapped into place. The content of the two WT_ADDRs are identical, and we don't
      * care which version we get as long as we don't mix-and-match the two.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(addr, (WT_ADDR *)ref->addr);
+    addr = (WT_ADDR *)ref->addr;
+    WT_ACQUIRE_BARRIER();
 
     /* If NULL, there is no information. */
     if (addr == NULL)

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1879,7 +1879,7 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
         return (true);
 
     /* Retry if the global transaction state has moved forward. */
-    if (txn_global->current == __wt_atomic_loadv64(&txn_global->oldest_id) ||
+    if (__wt_atomic_loadv64(&txn_global->current) == __wt_atomic_loadv64(&txn_global->oldest_id) ||
       mod->last_eviction_id != __wt_txn_oldest_id(session))
         return (true);
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1875,7 +1875,7 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
      * a reasonable amount of time is currently pretty arbitrary.
      */
     if (__wt_cache_aggressive(session) ||
-      mod->last_evict_pass_gen + 5 < S2C(session)->cache->evict_pass_gen)
+      mod->last_evict_pass_gen + 5 < __wt_atomic_load64(&S2C(session)->cache->evict_pass_gen))
         return (true);
 
     /* Retry if the global transaction state has moved forward. */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1879,7 +1879,7 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
         return (true);
 
     /* Retry if the global transaction state has moved forward. */
-    if (txn_global->current == txn_global->oldest_id ||
+    if (txn_global->current == __wt_atomic_loadv64(&txn_global->oldest_id) ||
       mod->last_eviction_id != __wt_txn_oldest_id(session))
         return (true);
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -83,8 +83,8 @@ struct __wt_cache {
      * History store cache usage. TODO: The values for these variables are cached and potentially
      * outdated.
      */
-    uint64_t bytes_hs;       /* History store bytes inmem */
-    uint64_t bytes_hs_dirty; /* History store bytes inmem dirty */
+    wt_shared uint64_t bytes_hs; /* History store bytes inmem */
+    uint64_t bytes_hs_dirty;     /* History store bytes inmem dirty */
 
     wt_shared uint64_t pages_dirty_intl;
     wt_shared uint64_t pages_dirty_leaf;

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -472,7 +472,7 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
     busy = busy || __wt_atomic_loadv64(&txn_shared->id) != WT_TXN_NONE ||
       session->hazards.num_active > 0 ||
       (__wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE &&
-        txn_global->current != __wt_atomic_loadv64(&txn_global->oldest_id));
+        __wt_atomic_loadv64(&txn_global->current) != __wt_atomic_loadv64(&txn_global->oldest_id));
 
     /*
      * LSM sets the "ignore cache size" flag when holding the LSM tree lock, in that case, or when

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -469,8 +469,10 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
      */
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
-    busy = busy || txn_shared->id != WT_TXN_NONE || session->hazards.num_active > 0 ||
-      (txn_shared->pinned_id != WT_TXN_NONE && txn_global->current != txn_global->oldest_id);
+    busy = busy || __wt_atomic_loadv64(&txn_shared->id) != WT_TXN_NONE ||
+      session->hazards.num_active > 0 ||
+      (__wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE &&
+        txn_global->current != txn_global->oldest_id);
 
     /*
      * LSM sets the "ignore cache size" flag when holding the LSM tree lock, in that case, or when

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -472,7 +472,7 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
     busy = busy || __wt_atomic_loadv64(&txn_shared->id) != WT_TXN_NONE ||
       session->hazards.num_active > 0 ||
       (__wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE &&
-        txn_global->current != txn_global->oldest_id);
+        txn_global->current != __wt_atomic_loadv64(&txn_global->oldest_id));
 
     /*
      * LSM sets the "ignore cache size" flag when holding the LSM tree lock, in that case, or when

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -145,7 +145,7 @@ __wt_cache_bytes_plus_overhead(WT_CACHE *cache, uint64_t sz)
 static WT_INLINE uint64_t
 __wt_cache_bytes_inuse(WT_CACHE *cache)
 {
-    return (__wt_cache_bytes_plus_overhead(cache, cache->bytes_inmem));
+    return (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_inmem)));
 }
 
 /*
@@ -155,8 +155,8 @@ __wt_cache_bytes_inuse(WT_CACHE *cache)
 static WT_INLINE uint64_t
 __wt_cache_dirty_inuse(WT_CACHE *cache)
 {
-    return (
-      __wt_cache_bytes_plus_overhead(cache, cache->bytes_dirty_intl + cache->bytes_dirty_leaf));
+    return (__wt_cache_bytes_plus_overhead(cache,
+      __wt_atomic_load64(&cache->bytes_dirty_intl) + __wt_atomic_load64(&cache->bytes_dirty_leaf)));
 }
 
 /*
@@ -166,7 +166,7 @@ __wt_cache_dirty_inuse(WT_CACHE *cache)
 static WT_INLINE uint64_t
 __wt_cache_dirty_leaf_inuse(WT_CACHE *cache)
 {
-    return (__wt_cache_bytes_plus_overhead(cache, cache->bytes_dirty_leaf));
+    return (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_dirty_leaf)));
 }
 
 /*
@@ -176,7 +176,7 @@ __wt_cache_dirty_leaf_inuse(WT_CACHE *cache)
 static WT_INLINE uint64_t
 __wt_cache_bytes_updates(WT_CACHE *cache)
 {
-    return (__wt_cache_bytes_plus_overhead(cache, cache->bytes_updates));
+    return (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_updates)));
 }
 
 /*
@@ -186,8 +186,8 @@ __wt_cache_bytes_updates(WT_CACHE *cache)
 static WT_INLINE uint64_t
 __wt_cache_bytes_image(WT_CACHE *cache)
 {
-    return (
-      __wt_cache_bytes_plus_overhead(cache, cache->bytes_image_intl + cache->bytes_image_leaf));
+    return (__wt_cache_bytes_plus_overhead(cache,
+      __wt_atomic_load64(&cache->bytes_image_intl) + __wt_atomic_load64(&cache->bytes_image_leaf)));
 }
 
 /*
@@ -202,8 +202,8 @@ __wt_cache_bytes_other(WT_CACHE *cache)
     /*
      * Reads can race with changes to the values, so check that the calculation doesn't go negative.
      */
-    bytes_other =
-      __wt_safe_sub(cache->bytes_inmem, cache->bytes_image_intl + cache->bytes_image_leaf);
+    bytes_other = __wt_safe_sub(__wt_atomic_load64(&cache->bytes_inmem),
+      __wt_atomic_load64(&cache->bytes_image_intl) + __wt_atomic_load64(&cache->bytes_image_leaf));
     return (__wt_cache_bytes_plus_overhead(cache, bytes_other));
 }
 

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -23,7 +23,7 @@ __wt_cache_aggressive(WT_SESSION_IMPL *session)
 static WT_INLINE uint64_t
 __wt_cache_read_gen(WT_SESSION_IMPL *session)
 {
-    return (S2C(session)->cache->read_gen);
+    return (__wt_atomic_load64(&S2C(session)->cache->read_gen));
 }
 
 /*
@@ -33,7 +33,7 @@ __wt_cache_read_gen(WT_SESSION_IMPL *session)
 static WT_INLINE void
 __wt_cache_read_gen_incr(WT_SESSION_IMPL *session)
 {
-    ++S2C(session)->cache->read_gen;
+    (void)__wt_atomic_add64(&S2C(session)->cache->read_gen, 1);
 }
 
 /*

--- a/src/include/column_inline.h
+++ b/src/include/column_inline.h
@@ -21,7 +21,8 @@ __col_insert_search_gt(WT_INSERT_HEAD *ins_head, uint64_t recno)
      *
      * Place an acquire barrier to avoid this issue.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(ins, WT_SKIP_LAST(ins_head));
+    ins = WT_SKIP_LAST(ins_head);
+    WT_ACQUIRE_BARRIER();
 
     /* If there's no insert chain to search, we're done. */
     if (ins == NULL)
@@ -92,7 +93,8 @@ __col_insert_search_lt(WT_INSERT_HEAD *ins_head, uint64_t recno)
      *
      * Place an acquire barrier to avoid this issue.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(ins, WT_SKIP_FIRST(ins_head));
+    ins = WT_SKIP_FIRST(ins_head);
+    WT_ACQUIRE_BARRIER();
 
     /* If there's no insert chain to search, we're done. */
     if (ins == NULL)
@@ -142,7 +144,8 @@ __col_insert_search_match(WT_INSERT_HEAD *ins_head, uint64_t recno)
      *
      * Place an acquire barrier to avoid this issue.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(ins, WT_SKIP_LAST(ins_head));
+    ins = WT_SKIP_LAST(ins_head);
+    WT_ACQUIRE_BARRIER();
 
     /* If there's no insert chain to search, we're done. */
     if (ins == NULL)
@@ -203,7 +206,8 @@ __col_insert_search(
      *
      * Place an acquire barrier to avoid this issue.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(ret_ins, WT_SKIP_LAST(ins_head));
+    ret_ins = WT_SKIP_LAST(ins_head);
+    WT_ACQUIRE_BARRIER();
 
     /* If there's no insert chain to search, we're done. */
     if (ret_ins == NULL)

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -208,6 +208,7 @@ __wt_atomic_storebool(bool *vp, bool v)
 #define __wt_atomic_and_generic(vp, v) __atomic_and_fetch(vp, v, __ATOMIC_RELAXED)
 #define __wt_atomic_or_generic(vp, v) __atomic_or_fetch(vp, v, __ATOMIC_RELAXED)
 #define __wt_atomic_load_generic(vp) __atomic_load_n(vp, __ATOMIC_RELAXED)
+#define __wt_atomic_store_generic(vp, v) __atomic_store_n(vp, v, __ATOMIC_RELAXED)
 
 /* Compile read-write barrier */
 #define WT_COMPILER_BARRIER() __asm__ volatile("" ::: "memory")

--- a/src/include/hardware.h
+++ b/src/include/hardware.h
@@ -21,10 +21,10 @@
  * Release write a value to a shared location. All previous stores must complete before the value is
  * made public.
  */
-#define WT_RELEASE_WRITE_WITH_BARRIER(v, val) \
-    do {                                      \
-        WT_RELEASE_BARRIER();                 \
-        (v) = (val);                          \
+#define WT_RELEASE_WRITE_WITH_BARRIER(v, val)   \
+    do {                                        \
+        WT_RELEASE_BARRIER();                   \
+        __wt_atomic_store_generic(&(v), (val)); \
     } while (0)
 
 /*
@@ -76,10 +76,10 @@
 /*
  * Read a shared location and guarantee that subsequent reads do not see any earlier state.
  */
-#define WT_ACQUIRE_READ_WITH_BARRIER(v, val) \
-    do {                                     \
-        (v) = (val);                         \
-        WT_ACQUIRE_BARRIER();                \
+#define WT_ACQUIRE_READ_WITH_BARRIER(v, val)    \
+    do {                                        \
+        (v) = __wt_atomic_load_generic(&(val)); \
+        WT_ACQUIRE_BARRIER();                   \
     } while (0)
 
 /*

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -108,6 +108,13 @@ __wt_atomic_storebool(bool *vp, bool v)
 }
 
 /*
+ * Generic atomic functions that accept any type. The typed macros above should be preferred since
+ * they provide better type checking.
+ */
+#define __wt_atomic_load_generic(vp) (*(vp))
+#define __wt_atomic_store_generic(vp, v) (*(vp) = (v))
+
+/*
  * __wt_atomic_cas_ptr --
  *     Pointer compare and swap.
  */

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -73,27 +73,41 @@ typedef enum {
  * while this operation is in progress). Check for those cases: the bugs they cause are hard to
  * debug.
  */
-#define WT_WITH_TXN_ISOLATION(s, iso, op)                                       \
-    do {                                                                        \
-        WT_TXN_ISOLATION saved_iso = (s)->isolation;                            \
-        WT_TXN_ISOLATION saved_txn_iso = (s)->txn->isolation;                   \
-        WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(s);                   \
-        WT_TXN_SHARED saved_txn_shared = *txn_shared;                           \
-        (s)->txn->forced_iso++;                                                 \
-        (s)->isolation = (s)->txn->isolation = (iso);                           \
-        op;                                                                     \
-        (s)->isolation = saved_iso;                                             \
-        (s)->txn->isolation = saved_txn_iso;                                    \
-        WT_ASSERT((s), (s)->txn->forced_iso > 0);                               \
-        (s)->txn->forced_iso--;                                                 \
-        WT_ASSERT((s),                                                          \
-          txn_shared->id == saved_txn_shared.id &&                              \
-            (txn_shared->metadata_pinned == saved_txn_shared.metadata_pinned || \
-              saved_txn_shared.metadata_pinned == WT_TXN_NONE) &&               \
-            (txn_shared->pinned_id == saved_txn_shared.pinned_id ||             \
-              saved_txn_shared.pinned_id == WT_TXN_NONE));                      \
-        txn_shared->metadata_pinned = saved_txn_shared.metadata_pinned;         \
-        txn_shared->pinned_id = saved_txn_shared.pinned_id;                     \
+#define WT_WITH_TXN_ISOLATION(s, iso, op)                                                        \
+    do {                                                                                         \
+        WT_TXN_ISOLATION saved_iso = (s)->isolation;                                             \
+        WT_TXN_ISOLATION saved_txn_iso = (s)->txn->isolation;                                    \
+        WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(s);                                    \
+        WT_TXN_SHARED saved_txn_shared = *txn_shared;                                            \
+        uint64_t txn_shared_id = __wt_atomic_loadv64(&txn_shared->id);                           \
+        uint64_t txn_shared_metadata_pinned = __wt_atomic_loadv64(&txn_shared->metadata_pinned); \
+        uint64_t txn_shared_pinned_id = __wt_atomic_loadv64(&txn_shared->pinned_id);             \
+        uint64_t saved_txn_shared_id = __wt_atomic_loadv64(&saved_txn_shared.id);                \
+        uint64_t saved_txn_shared_metadata_pinned =                                              \
+          __wt_atomic_loadv64(&saved_txn_shared.metadata_pinned);                                \
+        uint64_t saved_txn_shared_pinned_id = __wt_atomic_loadv64(&saved_txn_shared.pinned_id);  \
+                                                                                                 \
+        /* The following variables are only used inside an assert. */                            \
+        WT_UNUSED(txn_shared_id);                                                                \
+        WT_UNUSED(txn_shared_metadata_pinned);                                                   \
+        WT_UNUSED(txn_shared_pinned_id);                                                         \
+        WT_UNUSED(saved_txn_shared_id);                                                          \
+                                                                                                 \
+        (s)->txn->forced_iso++;                                                                  \
+        (s)->isolation = (s)->txn->isolation = (iso);                                            \
+        op;                                                                                      \
+        (s)->isolation = saved_iso;                                                              \
+        (s)->txn->isolation = saved_txn_iso;                                                     \
+        WT_ASSERT((s), (s)->txn->forced_iso > 0);                                                \
+        (s)->txn->forced_iso--;                                                                  \
+        WT_ASSERT((s),                                                                           \
+          txn_shared_id == saved_txn_shared_id &&                                                \
+            (txn_shared_metadata_pinned == saved_txn_shared_metadata_pinned ||                   \
+              saved_txn_shared_metadata_pinned == WT_TXN_NONE) &&                                \
+            (txn_shared_pinned_id == saved_txn_shared_pinned_id ||                               \
+              saved_txn_shared_pinned_id == WT_TXN_NONE));                                       \
+        __wt_atomic_storev64(&txn_shared->metadata_pinned, saved_txn_shared_metadata_pinned);    \
+        __wt_atomic_storev64(&txn_shared->pinned_id, saved_txn_shared_pinned_id);                \
     } while (0)
 
 struct __wt_txn_shared {

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -63,7 +63,8 @@ typedef enum {
     (S2C(s)->txn_global.txn_shared_list == NULL ? NULL : \
                                                   &S2C(s)->txn_global.txn_shared_list[(s)->id])
 
-#define WT_SESSION_IS_CHECKPOINT(s) ((s)->id != 0 && (s)->id == S2C(s)->txn_global.checkpoint_id)
+#define WT_SESSION_IS_CHECKPOINT(s) \
+    ((s)->id != 0 && (s)->id == __wt_atomic_loadv32(&S2C(s)->txn_global.checkpoint_id))
 
 /*
  * Perform an operation at the specified isolation level.

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1804,8 +1804,10 @@ __wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
      */
     WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
-    *txn_active = (__wt_atomic_loadv64(&txn_global->oldest_id) != txn_global->current ||
-      __wt_atomic_loadv64(&txn_global->metadata_pinned) != txn_global->current);
+    *txn_active =
+      (__wt_atomic_loadv64(&txn_global->oldest_id) != __wt_atomic_loadv64(&txn_global->current) ||
+        __wt_atomic_loadv64(&txn_global->metadata_pinned) !=
+          __wt_atomic_loadv64(&txn_global->current));
 
     return (0);
 }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1804,7 +1804,7 @@ __wt_txn_activity_check(WT_SESSION_IMPL *session, bool *txn_active)
      */
     WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
-    *txn_active = (txn_global->oldest_id != txn_global->current ||
+    *txn_active = (__wt_atomic_loadv64(&txn_global->oldest_id) != txn_global->current ||
       __wt_atomic_loadv64(&txn_global->metadata_pinned) != txn_global->current);
 
     return (0);

--- a/src/lsm/lsm_cursor.c
+++ b/src/lsm/lsm_cursor.c
@@ -209,7 +209,7 @@ __clsm_enter(WT_CURSOR_LSM *clsm, bool reset, bool update)
             clsm->nupdates = 1;
             if (txn->isolation == WT_ISO_SNAPSHOT && F_ISSET(clsm, WT_CLSM_OPEN_SNAPSHOT)) {
                 WT_ASSERT(session, F_ISSET(txn, WT_TXN_HAS_SNAPSHOT));
-                pinned_id = WT_SESSION_TXN_SHARED(session)->pinned_id;
+                pinned_id = __wt_atomic_loadv64(&WT_SESSION_TXN_SHARED(session)->pinned_id);
                 for (i = clsm->nchunks - 2; clsm->nupdates < clsm->nchunks; clsm->nupdates++, i--) {
                     switch_txn = clsm->chunks[i]->switch_txn;
                     if (WT_TXNID_LT(switch_txn, pinned_id))

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -524,7 +524,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *first_upd
     max_ts = WT_TS_NONE;
     max_txn = WT_TXN_NONE;
     is_hs_page = F_ISSET(session->dhandle, WT_DHANDLE_HS);
-    session_txnid = WT_SESSION_TXN_SHARED(session)->id;
+    session_txnid = __wt_atomic_loadv64(&WT_SESSION_TXN_SHARED(session)->id);
     seen_prepare = false;
 
     for (upd = first_upd; upd != NULL; upd = upd->next) {
@@ -844,7 +844,7 @@ __wt_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins, W
      */
     WT_ASSERT_ALWAYS(session,
       !WT_IS_METADATA(session->dhandle) || upd == NULL || upd->txnid == WT_TXN_NONE ||
-        upd->txnid != S2C(session)->txn_global.checkpoint_txn_shared.id ||
+        upd->txnid != __wt_atomic_loadv64(&S2C(session)->txn_global.checkpoint_txn_shared.id) ||
         WT_SESSION_IS_CHECKPOINT(session),
       "Metadata updates written from a checkpoint in a concurrent session");
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -128,7 +128,7 @@ __reconcile_save_evict_state(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
     if (LF_ISSET(WT_REC_EVICT)) {
         mod->last_eviction_id = oldest_id;
         __wt_txn_pinned_timestamp(session, &mod->last_eviction_timestamp);
-        mod->last_evict_pass_gen = S2C(session)->cache->evict_pass_gen;
+        mod->last_evict_pass_gen = __wt_atomic_load64(&S2C(session)->cache->evict_pass_gen);
     }
 
 #ifdef HAVE_DIAGNOSTIC

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2364,7 +2364,7 @@ __session_transaction_pinned_range(WT_SESSION *wt_session, uint64_t *prange)
     if (pinned == WT_TXN_NONE)
         *prange = 0;
     else
-        *prange = S2C(session)->txn_global.current - pinned;
+        *prange = __wt_atomic_loadv64(&S2C(session)->txn_global.current) - pinned;
 
 err:
     API_END_RET(session, ret);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -165,7 +165,7 @@ __wt_session_copy_values(WT_SESSION_IMPL *session)
              */
             WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(session);
             WT_ASSERT(session,
-              txn_shared->pinned_id != WT_TXN_NONE ||
+              __wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE ||
                 (WT_BTREE_PREFIX(cursor->uri) &&
                   WT_DHANDLE_IS_CHECKPOINT(((WT_CURSOR_BTREE *)cursor)->dhandle)));
 #endif
@@ -2354,10 +2354,12 @@ __session_transaction_pinned_range(WT_SESSION *wt_session, uint64_t *prange)
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
     /* Assign pinned to the lesser of id or snap_min */
-    if (txn_shared->id != WT_TXN_NONE && WT_TXNID_LT(txn_shared->id, txn_shared->pinned_id))
-        pinned = txn_shared->id;
+    if (__wt_atomic_loadv64(&txn_shared->id) != WT_TXN_NONE &&
+      WT_TXNID_LT(
+        __wt_atomic_loadv64(&txn_shared->id), __wt_atomic_loadv64(&txn_shared->pinned_id)))
+        pinned = __wt_atomic_loadv64(&txn_shared->id);
     else
-        pinned = txn_shared->pinned_id;
+        pinned = __wt_atomic_loadv64(&txn_shared->pinned_id);
 
     if (pinned == WT_TXN_NONE)
         *prange = 0;

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -527,7 +527,8 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
          * will not be equal to the latest one. We want both variables to be read in as early as
          * possible in this loop, acquire reads encourage this.
          */
-        WT_ACQUIRE_READ_WITH_BARRIER(ckpt_gen, __wt_gen(session, WT_GEN_CHECKPOINT));
+        ckpt_gen = __wt_gen(session, WT_GEN_CHECKPOINT);
+        WT_ACQUIRE_BARRIER();
         WT_ACQUIRE_READ_WITH_BARRIER(ckpt_running, S2C(session)->txn_global.checkpoint_running);
 
         if (!must_resolve)

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -155,7 +155,8 @@ __wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility
      * of the random state so we can ensure that the calculation operates on the state consistently
      * regardless of concurrent calls with the same random state.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(rnd, *rnd_state);
+    rnd = *rnd_state;
+    WT_ACQUIRE_BARRIER();
     w = M_W(rnd);
     z = M_Z(rnd);
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -821,8 +821,10 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
      * Sanity check that the oldest ID hasn't moved on before we have cleared our entry.
      */
     WT_ASSERT(session,
-      WT_TXNID_LE(txn_global->oldest_id, __wt_atomic_loadv64(&txn_shared->id)) &&
-        WT_TXNID_LE(txn_global->oldest_id, __wt_atomic_loadv64(&txn_shared->pinned_id)));
+      WT_TXNID_LE(
+        __wt_atomic_loadv64(&txn_global->oldest_id), __wt_atomic_loadv64(&txn_shared->id)) &&
+        WT_TXNID_LE(__wt_atomic_loadv64(&txn_global->oldest_id),
+          __wt_atomic_loadv64(&txn_shared->pinned_id)));
 
     /*
      * Clear our entry from the global transaction session table. Any operation that needs to know

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -548,7 +548,7 @@ __checkpoint_wait_reduce_dirty_cache(WT_SESSION_IMPL *session)
     if (cache->eviction_checkpoint_target < DBL_EPSILON)
         return;
 
-    bytes_written_start = cache->bytes_written;
+    bytes_written_start = __wt_atomic_load64(&cache->bytes_written);
 
     /*
      * If the cache size is zero or very small, we're done. The cache size can briefly become zero
@@ -585,7 +585,7 @@ __checkpoint_wait_reduce_dirty_cache(WT_SESSION_IMPL *session)
          * Don't wait indefinitely: there might be dirty pages that can't be evicted. If we can't
          * meet the target, give up and start the checkpoint for real.
          */
-        bytes_written_total = cache->bytes_written - bytes_written_start;
+        bytes_written_total = __wt_atomic_load64(&cache->bytes_written) - bytes_written_start;
         if (bytes_written_total > max_write)
             break;
     }

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -804,8 +804,8 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
      *
      * We never do checkpoints in the default session (with id zero).
      */
-    WT_ASSERT(session, session->id != 0 && txn_global->checkpoint_id == 0);
-    txn_global->checkpoint_id = session->id;
+    WT_ASSERT(session, session->id != 0 && __wt_atomic_loadv32(&txn_global->checkpoint_id) == 0);
+    __wt_atomic_storev32(&txn_global->checkpoint_id, session->id);
 
     /*
      * Remove the checkpoint transaction from the global table.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1637,7 +1637,7 @@ tasks:
         vars:
           directory: examples/c
           # We're starting small with just ex_hello. This will grow over time.
-          extra_args: -R "ex_hello" -j ${num_jobs}
+          extra_args: -R "(ex_hello|ex_cursor)" -j ${num_jobs}
 
   - name: examples-c-production-disable-shared-test
     tags: ["pull_request"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1636,8 +1636,7 @@ tasks:
       - func: "make check directory"
         vars:
           directory: examples/c
-          # We're starting small with just ex_hello. This will grow over time.
-          extra_args: -R "(ex_hello|ex_cursor)" -j ${num_jobs}
+          extra_args: -R "(ex_access|ex_col_store|ex_config_parse|ex_cursor|ex_event_handler|ex_extending|ex_extra_diagnostics|ex_extractor|ex_hello|ex_pack|ex_process|ex_schema|ex_smoke|ex_verbose)" -j ${num_jobs}
 
   - name: examples-c-production-disable-shared-test
     tags: ["pull_request"]

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -4,3 +4,8 @@
 
 # FIXME-WT-12512 TSan is raising warnings about mutexes that are non-intuitive. These will be investigated separately.
 mutex:src
+
+# FIXME-WT-12514 Some of our shared variables are floats or doubles which can't be accessed using atomic instrinsics.
+race:__wt_eviction_dirty_target
+race:__wt_eviction_dirty_needed
+race:__evict_update_work

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -9,3 +9,6 @@ mutex:src
 race:__wt_eviction_dirty_target
 race:__wt_eviction_dirty_needed
 race:__evict_update_work
+
+# Stats are allowed to be fuzzy. Ignore races in TSan
+race:src/include/stat.h


### PR DESCRIPTION
Add an additional 13 `examples/c` tests to the `examples-c-tsan` task and resolve all TSan warnings raised by running the tests. This continues on from work in WT-12422.

This PR is rather mechanical with the interesting change being in 37b4c217940539da950a8393684192ac43e1d6b9 where atomics have been added inside the `WT_ACQUIRE_READ_WITH_BARRIER` and `WT_RELEASE_WRITE_WITH_BARRIER` macros. In a few cases this made the compiler unhappy and required breaking the macros out into a read from memory and a separate `WT_AQUIRE_BARRIER`.

Perf tests show no change from mainline.