### PR TITLE
WT-11239 Add CLANG_C/CXX_VERSION compile flags to the configure wiredtiger task (#10128) (v7.0 backport)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -121,6 +121,8 @@ functions:
           ${HAVE_DIAGNOSTIC|} \
           ${GNU_C_VERSION|} \
           ${GNU_CXX_VERSION|} \
+          ${CLANG_C_VERSION|} \
+          ${CLANG_CXX_VERSION|} \
           ${ENABLE_AZURE|} \
           ${ENABLE_CPPSUITE|} \
           ${ENABLE_GCP|} \
@@ -1202,12 +1204,6 @@ tasks:
           HAVE_DIAGNOSTIC: -DHAVE_DIAGNOSTIC=0
       - func: "compile wiredtiger"
         vars:
-          CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
-          CLANG_C_VERSION: -DCLANG_C_VERSION=6.0
-          CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=6.0
-      - func: "compile wiredtiger"
-        vars:
-          CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
           CLANG_C_VERSION: -DCLANG_C_VERSION=7
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=7
       - func: "compile wiredtiger"


### PR DESCRIPTION
(cherry picked from commit 9cce4b9c0e91df6176cd8071fdf1e395fa56aa2d)