### PR TITLE
WT-12401 Make a efficient API for retrieving session stats

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1236,6 +1236,7 @@ srch
 ss
 ssize
 statlog
+statsp
 stb
 stderr
 stdin

--- a/dist/stat.py
+++ b/dist/stat.py
@@ -46,12 +46,15 @@ sorted_dsrc_statistics = dsrc_stats
 sorted_dsrc_statistics.extend(conn_dsrc_stats)
 sorted_dsrc_statistics = sorted(sorted_dsrc_statistics, key=attrgetter('desc'))
 
-def print_struct(title, name, base, stats):
+def print_struct(title, name, base, stats, partial=False):
     '''Print the structures for the stat.h file.'''
     f.write('/*\n')
     f.write(' * Statistics entries for ' + title + '.\n')
     f.write(' */\n')
     f.write('#define\tWT_' + name.upper() + '_STATS_BASE\t' + str(base) + '\n')
+    if partial:
+        return
+    
     f.write('struct __wt_' + name + '_stats {\n')
 
     for l in stats:
@@ -74,7 +77,7 @@ for line in open('../src/include/stat.h', 'r'):
         print_struct('connections', 'connection', 1000, sorted_conn_stats)
         print_struct('data sources', 'dsrc', 2000, sorted_dsrc_statistics)
         print_struct('join cursors', 'join', 3000, join_stats)
-        print_struct('session', 'session', 4000, session_stats)
+        print_struct('session', 'session', 4000, session_stats, True)
 f.close()
 format_srcfile(tmp_file)
 compare_srcfile(tmp_file, '../src/include/stat.h')

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1572,6 +1572,8 @@ extern int __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri
 extern int __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri,
   const char *checkpoint, const char *cfg[], uint32_t flags)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __session_get_session_stats(WT_SESSION *wt_session, WT_SESSION_STATS *session_statsp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_lock_checkpoint(WT_SESSION_IMPL *session, const char *checkpoint)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_deadp)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1572,8 +1572,6 @@ extern int __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri
 extern int __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri,
   const char *checkpoint, const char *cfg[], uint32_t flags)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __session_get_session_stats(WT_SESSION *wt_session, WT_SESSION_STATS *session_statsp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_lock_checkpoint(WT_SESSION_IMPL *session, const char *checkpoint)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_deadp)

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1361,6 +1361,4 @@ struct __wt_join_stats {
  * Statistics entries for session.
  */
 #define WT_SESSION_STATS_BASE 4000
-
-
 /* Statistics section: END */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1361,15 +1361,6 @@ struct __wt_join_stats {
  * Statistics entries for session.
  */
 #define WT_SESSION_STATS_BASE 4000
-struct __wt_session_stats {
-    int64_t bytes_read;
-    int64_t bytes_write;
-    int64_t lock_dhandle_wait;
-    int64_t txn_bytes_dirty;
-    int64_t read_time;
-    int64_t write_time;
-    int64_t lock_schema_wait;
-    int64_t cache_time;
-};
+
 
 /* Statistics section: END */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -177,6 +177,8 @@ struct __wt_modify {
  */
 #define WT_INTPACK32_MAXSIZE    ((int)sizeof(int32_t) + 1)
 
+#if !defined(SWIG) && !defined(DOXYGEN)
+
 /*!
  * A set of statistics for WT_SESSION.
  */
@@ -190,6 +192,8 @@ struct __wt_session_stats {
     int64_t lock_schema_wait;
     int64_t cache_time;
 };
+
+#endif
 
 /*!
  * A WT_CURSOR handle is the interface to a cursor.
@@ -2084,7 +2088,9 @@ struct __wt_session {
      * @errors
      */
     int __F(transaction_pinned_range)(WT_SESSION* session, uint64_t *range);
+    /*! @} */
 
+#if !defined(SWIG) && !defined(DOXYGEN)
     /*!
      * Get session statistics.
      *
@@ -2093,8 +2099,7 @@ struct __wt_session {
      * @errors
      */
     int __F(get_session_stats)(WT_SESSION *session, WT_SESSION_STATS* session_statsp);
-
-    /*! @} */
+#endif
 
 #ifndef DOXYGEN
     /*!

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -78,6 +78,8 @@ struct __wt_file_system;    typedef struct __wt_file_system WT_FILE_SYSTEM;
 struct __wt_item;       typedef struct __wt_item WT_ITEM;
 struct __wt_modify;     typedef struct __wt_modify WT_MODIFY;
 struct __wt_session;        typedef struct __wt_session WT_SESSION;
+struct __wt_session_stats;  typedef struct __wt_session_stats WT_SESSION_STATS;
+
 #if !defined(DOXYGEN)
 struct __wt_storage_source; typedef struct __wt_storage_source WT_STORAGE_SOURCE;
 #endif
@@ -174,6 +176,20 @@ struct __wt_modify {
  * function will pack single integers into at most this many bytes.
  */
 #define WT_INTPACK32_MAXSIZE    ((int)sizeof(int32_t) + 1)
+
+/*!
+ * A set of statistics for WT_SESSION.
+ */
+struct __wt_session_stats {
+    int64_t bytes_read;
+    int64_t bytes_write;
+    int64_t lock_dhandle_wait;
+    int64_t txn_bytes_dirty;
+    int64_t read_time;
+    int64_t write_time;
+    int64_t lock_schema_wait;
+    int64_t cache_time;
+};
 
 /*!
  * A WT_CURSOR handle is the interface to a cursor.
@@ -2068,6 +2084,16 @@ struct __wt_session {
      * @errors
      */
     int __F(transaction_pinned_range)(WT_SESSION* session, uint64_t *range);
+
+    /*!
+     * Get session statistics.
+     *
+     * @param session the session handle
+     * @param[out] session_statsp pointer to WT_SESSION_STATS
+     * @errors
+     */
+    int __F(get_session_stats)(WT_SESSION *session, WT_SESSION_STATS* session_statsp);
+
     /*! @} */
 
 #ifndef DOXYGEN

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -379,8 +379,6 @@ struct __wt_session_impl;
 typedef struct __wt_session_impl WT_SESSION_IMPL;
 struct __wt_session_stash;
 typedef struct __wt_session_stash WT_SESSION_STASH;
-struct __wt_session_stats;
-typedef struct __wt_session_stats WT_SESSION_STATS;
 struct __wt_shutdown_timeline;
 typedef struct __wt_shutdown_timeline WT_SHUTDOWN_TIMELINE;
 struct __wt_size;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2489,6 +2489,25 @@ __wt_session_breakpoint(WT_SESSION *wt_session)
 }
 
 /*
+ * __session_get_session_stats --
+ *     WT_SESSION->get_session_stats method.
+ */
+int
+__session_get_session_stats(WT_SESSION *wt_session, WT_SESSION_STATS *session_statsp)
+{
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+
+    session = (WT_SESSION_IMPL *)wt_session;
+    SESSION_API_CALL_NOCONF(session, get_session_stats);
+
+    memcpy(session_statsp, &session->stats, sizeof(session->stats));
+
+err:
+    API_END_RET(session, ret);
+}
+
+/*
  * __open_session --
  *     Allocate a session handle.
  */
@@ -2505,7 +2524,8 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __session_commit_transaction, __session_prepare_transaction, __session_rollback_transaction,
         __session_query_timestamp, __session_timestamp_transaction,
         __session_timestamp_transaction_uint, __session_checkpoint, __session_reset_snapshot,
-        __session_transaction_pinned_range, __session_get_rollback_reason, __wt_session_breakpoint},
+        __session_transaction_pinned_range, __session_get_session_stats,
+        __session_get_rollback_reason, __wt_session_breakpoint},
       stds_min = {NULL, NULL, __session_close, __session_reconfigure_notsup, __wt_session_strerror,
         __session_open_cursor, __session_alter_readonly, __session_bind_configuration,
         __session_create_readonly, __wt_session_compact_readonly, __session_drop_readonly,
@@ -2517,7 +2537,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __session_query_timestamp_notsup, __session_timestamp_transaction_notsup,
         __session_timestamp_transaction_uint_notsup, __session_checkpoint_readonly,
         __session_reset_snapshot_notsup, __session_transaction_pinned_range_notsup,
-        __session_get_rollback_reason, __wt_session_breakpoint},
+        __session_get_session_stats, __session_get_rollback_reason, __wt_session_breakpoint},
       stds_readonly = {NULL, NULL, __session_close, __session_reconfigure, __wt_session_strerror,
         __session_open_cursor, __session_alter_readonly, __session_bind_configuration,
         __session_create_readonly, __wt_session_compact_readonly, __session_drop_readonly,
@@ -2528,8 +2548,8 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __session_prepare_transaction_readonly, __session_rollback_transaction,
         __session_query_timestamp, __session_timestamp_transaction,
         __session_timestamp_transaction_uint, __session_checkpoint_readonly,
-        __session_reset_snapshot, __session_transaction_pinned_range, __session_get_rollback_reason,
-        __wt_session_breakpoint};
+        __session_reset_snapshot, __session_transaction_pinned_range, __session_get_session_stats,
+        __session_get_rollback_reason, __wt_session_breakpoint};
     WT_DECL_RET;
     WT_SESSION_IMPL *session, *session_ret;
     uint32_t i;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2492,7 +2492,7 @@ __wt_session_breakpoint(WT_SESSION *wt_session)
  * __session_get_session_stats --
  *     WT_SESSION->get_session_stats method.
  */
-int
+static int
 __session_get_session_stats(WT_SESSION *wt_session, WT_SESSION_STATS *session_statsp)
 {
     WT_DECL_RET;


### PR DESCRIPTION
While investigating the MongoDB transactions in TPCC, WiredTigerStats::WiredTigerStats method spends an excessive amount of time opening a cursor, iterating the cursor and then closing the cursor to retrieve 7 uint64_t metrics.

This PR adds an API to WT_SESSION to memcpy the metrics out instead of using the cursor. Memcpy is cheaper then the WT cursor API.

This work is needed to improve performance and to support the query stats with disk usage project.

Full End to End Change across WT and MongoDB POC: https://github.com/10gen/mongo/commit/51e943b8ea8b41cf182068d93bb1e3806189471a