### PR TITLE
WT-12587 Re-enable compile-clang tasks for older versions of clang

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -884,17 +884,16 @@ tasks:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
+          configure_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+          compile_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
+          test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
           posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake -DENABLE_STRICT=1 -DHAVE_DIAGNOSTIC=0
-      # FIXME-WT-11239 - Re-enable these tasks once libstdc++.so can be found by older versions of clang.
-      # - func: "compile wiredtiger"
-      #   vars:
-      #     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake -DCLANG_C_VERSION=6.0 -DCLANG_CXX_VERSION=6.0 -DCMAKE_C_FLAGS="-ggdb" -DWITH_PIC=1
-      # - func: "compile wiredtiger"
-      #   vars:
-      #     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake -DCLANG_C_VERSION=7 -DCLANG_CXX_VERSION=7 -DCMAKE_C_FLAGS="-ggdb" -DWITH_PIC=1
-      # - func: "compile wiredtiger"
-      #   vars:
-      #     posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake -DCLANG_C_VERSION=8 -DCLANG_CXX_VERSION=8 -DCMAKE_C_FLAGS="-ggdb" -DWITH_PIC=1
+      - func: "compile wiredtiger"
+        vars:
+          posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake -DCLANG_C_VERSION=7 -DCLANG_CXX_VERSION=7 -DCMAKE_C_FLAGS="-ggdb" -DWITH_PIC=1
+      - func: "compile wiredtiger"
+        vars:
+          posix_configure_flags: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake -DCLANG_C_VERSION=8 -DCLANG_CXX_VERSION=8 -DCMAKE_C_FLAGS="-ggdb" -DWITH_PIC=1
 
   - name: make-check-test
     commands:
@@ -4002,9 +4001,6 @@ buildvariants:
   run_on:
   - ubuntu2004-wt-build
   expansions:
-    configure_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
-    compile_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
-    test_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH
     posix_configure_flags: 
       -DHAVE_DIAGNOSTIC=1
       -DENABLE_STRICT=1


### PR DESCRIPTION
This PR addresses the issues reported in WT-11239, but since `evergreen.yml` has had significant changes between 7.0 and 6.0 this is a new implementation to resolve the same issue. Note that we're targeting the 6.0 branch in this PR.

Now that the host toolchain has been fixed the `compile-clang` tasks for older versions of clang can be re-enabled. As part of this we've also removed the clang 6.0 test since WiredTiger's minimum supported version of clang is now 7.0.1.