### PR TITLE
WT-12580 Fix memory leak in prefetch queue push 

### DIFF
--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -141,6 +141,7 @@ int
 __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
     WT_PREFETCH_QUEUE_ENTRY *pe;
 
     conn = S2C(session);
@@ -154,17 +155,22 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
     /* Don't queue pages for trees that have eviction disabled. */
     if (S2BT(session)->evict_disabled > 0) {
         __wt_spin_unlock(session, &conn->prefetch_lock);
-        WT_RET(EBUSY);
+        WT_ERR(EBUSY);
     }
 
     F_SET(ref, WT_REF_FLAG_PREFETCH);
     TAILQ_INSERT_TAIL(&conn->pfqh, pe, q);
     ++conn->prefetch_queue_count;
     __wt_spin_unlock(session, &conn->prefetch_lock);
-
     __wt_cond_signal(session, conn->prefetch_threads.wait_cond);
-
     return (0);
+
+    if (0) {
+err:
+        __wt_free(session, pe);
+    }
+
+    return (ret);
 }
 
 /*

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -163,7 +163,6 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
     ++conn->prefetch_queue_count;
     __wt_spin_unlock(session, &conn->prefetch_lock);
     __wt_cond_signal(session, conn->prefetch_threads.wait_cond);
-    return (0);
 
     if (0) {
 err:


### PR DESCRIPTION
There was a memory leak caused by WT_RET(EBUSY) in the queue push logic. The calloced `pe` struct would not be freed in the event that we returned an error. 