### PR TITLE
WT-10576 __drop_table(): The only difference between force=true and force=false is now only force=true returns success (0) if the table does not exist.

### DIFF
--- a/src/include/api.h
+++ b/src/include/api.h
@@ -100,11 +100,11 @@
         if ((config) != NULL)                                                               \
     WT_ERR(__wt_config_check((s), WT_CONFIG_REF(s, struct_name##_##func_name), (config), 0))
 
-#define API_END(s, ret)                                                                    \
+#define API_END_OK(s, ret, okerr)                                                          \
     if ((s) != NULL) {                                                                     \
         WT_TRACK_OP_END(s);                                                                \
         WT_SINGLE_THREAD_CHECK_STOP(s);                                                    \
-        if ((ret) != 0 && __set_err)                                                       \
+        if ((ret) != 0 && (ret) != (okerr) && __set_err)                                   \
             __wt_txn_err_set(s, (ret));                                                    \
         if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL))                \
             __wt_op_timer_stop(s);                                                         \
@@ -121,6 +121,8 @@
     }                                                                                      \
     }                                                                                      \
     while (0)
+
+#define API_END(s, ret) API_END_OK((s), (ret), 0)
 
 /* An API call wrapped in a transaction if necessary. */
 #define TXN_API_CALL(s, struct_name, func_name, dh, config, cfg)            \
@@ -208,6 +210,10 @@
 
 #define API_END_RET_NOTFOUND_MAP(s, ret) \
     API_END(s, ret);                     \
+    return ((ret) == WT_NOTFOUND ? ENOENT : (ret))
+
+#define API_END_RET_NOTFOUND_MAP_OK(s, ret, okerr) \
+    API_END_OK((s), (ret), (okerr));               \
     return ((ret) == WT_NOTFOUND ? ENOENT : (ret))
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -543,8 +543,8 @@ extern int __wt_conn_dhandle_alloc(WT_SESSION_IMPL *session, const char *uri,
   const char *checkpoint) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_conn_dhandle_close_all(WT_SESSION_IMPL *session, const char *uri, bool removed,
-  bool mark_dead) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_conn_dhandle_close_all(WT_SESSION_IMPL *session, const char *uri, bool removed)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_dhandle_discard(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_conn_dhandle_discard_single(WT_SESSION_IMPL *session, bool final, bool mark_dead)

--- a/src/schema/schema_alter.c
+++ b/src/schema/schema_alter.c
@@ -219,7 +219,7 @@ __alter_tiered(WT_SESSION_IMPL *session, const char *uri, const char *newcfg[], 
      */
     if (FLD_ISSET(flags, WT_DHANDLE_EXCLUSIVE)) {
         WT_WITH_HANDLE_LIST_WRITE_LOCK(
-          session, ret = __wt_conn_dhandle_close_all(session, uri, false, false));
+          session, ret = __wt_conn_dhandle_close_all(session, uri, false));
         WT_RET(ret);
     }
 

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -32,8 +32,7 @@ __rename_file(WT_SESSION_IMPL *session, const char *uri, const char *newuri)
     WT_RET(__wt_schema_backup_check(session, filename));
     WT_RET(__wt_schema_backup_check(session, newfile));
     /* Close any btree handles in the file. */
-    WT_WITH_HANDLE_LIST_WRITE_LOCK(
-      session, ret = __wt_conn_dhandle_close_all(session, uri, true, false));
+    WT_WITH_HANDLE_LIST_WRITE_LOCK(session, ret = __wt_conn_dhandle_close_all(session, uri, true));
     WT_ERR(ret);
     WT_ERR(__wt_scr_alloc(session, 1024, &buf));
 

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -24,7 +24,7 @@ __wt_execute_handle_operation(WT_SESSION_IMPL *session, const char *uri,
      */
     if (FLD_ISSET(open_flags, WT_DHANDLE_EXCLUSIVE)) {
         WT_WITH_HANDLE_LIST_WRITE_LOCK(
-          session, ret = __wt_conn_dhandle_close_all(session, uri, false, false));
+          session, ret = __wt_conn_dhandle_close_all(session, uri, false));
         WT_RET(ret);
     }
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1291,7 +1291,7 @@ err:
         WT_STAT_CONN_INCR(session, session_table_drop_success);
 
     /* Note: drop operations cannot be unrolled (yet?). */
-    API_END_RET_NOTFOUND_MAP(session, ret);
+    API_END_RET_NOTFOUND_MAP_OK(session, ret, EBUSY);
 }
 
 /*

--- a/test/suite/test_cursor06.py
+++ b/test/suite/test_cursor06.py
@@ -66,7 +66,7 @@ class test_cursor06(wttest.WiredTigerTestCase):
     def test_reconfigure_overwrite(self):
         uri = self.type + self.name
         for open_config in (None, "overwrite=0", "overwrite=1"):
-            self.session.drop(uri, "force")
+            self.dropUntilSuccess(self.session, uri, "force")
             self.populate(uri)
             cursor = self.ds.open_cursor(uri, None, open_config)
             if open_config != "overwrite=0":
@@ -85,7 +85,7 @@ class test_cursor06(wttest.WiredTigerTestCase):
     def test_reconfigure_readonly(self):
         uri = self.type + self.name
         for open_config in (None, "readonly=0", "readonly=1"):
-            self.session.drop(uri, "force")
+            self.dropUntilSuccess(self.session, uri, "force")
             self.populate(uri)
             cursor = self.ds.open_cursor(uri, None, open_config)
             msg = '/Unsupported cursor/'

--- a/test/suite/test_drop.py
+++ b/test/suite/test_drop.py
@@ -29,6 +29,7 @@
 import wiredtiger, wttest
 from helper import confirm_does_not_exist
 from wtdataset import SimpleDataSet, ComplexDataSet
+from wtdataset import SimpleIndexDataSet
 from wtscenario import make_scenarios
 
 # test_drop.py
@@ -45,45 +46,117 @@ class test_drop(wttest.WiredTigerTestCase):
     ])
 
     # Populate an object, remove it and confirm it no longer exists.
-    def drop(self, dataset, with_cursor, reopen, drop_index):
+    def drop(self, dataset, with_cursor, reopen, with_transaction, drop_index):
         uri = self.uri + self.name
         ds = dataset(self, uri, 10, config=self.extra_config)
+        # Set first values to variant 1.
+        self.session.begin_transaction()
         ds.populate()
+        variant = 1
+        self.session.commit_transaction(),
 
         # Open cursors should cause failure.
-        if with_cursor:
+        if with_cursor and not with_transaction:
             cursor = self.session.open_cursor(uri, None, None)
             self.assertRaises(wiredtiger.WiredTigerError,
                 lambda: self.session.drop(uri, None))
             cursor.close()
+            # Check that the table works and has not changed.
+            ds.check()
+
+        # Open cursors should cause failure again.
+        if with_cursor and with_transaction:
+            self.session.begin_transaction()
+            cursor = self.session.open_cursor(uri, None, None)
+            # Change from variant 1 to variant 2 within transaction A.
+            ds.populate(False, 2)
+            variant = 2
+            # Fail to drop the table.
+            self.assertRaises(wiredtiger.WiredTigerError,
+                lambda: self.session.drop(uri, None))
+            cursor.close()
+            # Check that transaction A needs rollback by failing to commit it.
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.session.commit_transaction(),
+                "/transaction requires rollback: Invalid argument/")
+            variant = 1
+            # Test that we are back to variant 1.
+            ds.check(1)
+
+        # Active transaction should cause failure.
+        if not with_cursor and with_transaction:
+            self.session.begin_transaction()
+            # Change from variant 1 to variant 2 within transaction A.
+            ds.populate(False, 2)
+            variant = 2
+            # Fail to drop the table.
+            self.assertRaises(wiredtiger.WiredTigerError,
+                lambda: self.session.drop(uri, None))
+            # Check that transaction A needs rollback by failing to commit it.
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.session.commit_transaction(),
+                "/transaction requires rollback: Invalid argument/")
+            variant = 1
+            # Test that we are back to variant 1.
+            ds.check(1)
 
         if reopen:
             self.reopen_conn()
+            # Check that the table still contains the proper variant.
+            ds.check(variant)
 
         if drop_index:
-            drop_uri = ds.index_name(0)
+            if dataset == SimpleIndexDataSet:
+                drop_uri = ds.indexname
+            else:
+                drop_uri = ds.index_name(0)
+            self.dropUntilSuccess(self.session, drop_uri)
+            # Check that the table still contains the proper variant.
+            ds.check(variant)
         else:
             drop_uri = uri
-        self.dropUntilSuccess(self.session, drop_uri)
+            self.dropUntilSuccess(self.session, drop_uri)
+
         confirm_does_not_exist(self, drop_uri)
+
+        # Test dropping a non-existent table
+        # Fail without force or force=false
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.drop(drop_uri, None))
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.drop(drop_uri, "force=false"))
+        # Succeed with force=true.
+        self.session.drop(drop_uri, "force=true")
 
     # Test drop of an object.
     def test_drop(self):
-        # Simple file or table object.
+        # SimpleDataSet: Simple file or table object.
         # Try all combinations except dropping the index, the simple
         # case has no indices.
         for with_cursor in [False, True]:
             for reopen in [False, True]:
-                self.drop(SimpleDataSet, with_cursor, reopen, False)
+                for with_transaction in [False, True]:
+                    self.drop(SimpleDataSet, with_cursor, reopen, with_transaction, False)
 
-        # A complex, multi-file table object.
+        # SimpleIndexDataSet: A table with an index
+        # Try almost all test combinations.
+        if self.uri == "table:":
+            for with_cursor in [False, True]:
+                for reopen in [False, True]:
+                    for with_transaction in [False, True]:
+                        # drop_index == False since it does not work.
+                        self.drop(SimpleIndexDataSet, with_cursor,
+                                  reopen, with_transaction, False)
+
+        # ComplexDataSet: A complex, multi-file table object.
         # Try all test combinations.
         if self.uri == "table:":
             for with_cursor in [False, True]:
                 for reopen in [False, True]:
-                    for drop_index in [False, True]:
-                        self.drop(ComplexDataSet, with_cursor,
-                                  reopen, drop_index)
+                    for with_transaction in [False, True]:
+                        for drop_index in [False, True]:
+                            self.drop(ComplexDataSet, with_cursor,
+                                      reopen, with_transaction, drop_index)
 
     # Test drop of a non-existent object: force succeeds, without force fails.
     def test_drop_dne(self):
@@ -97,12 +170,15 @@ class test_drop(wttest.WiredTigerTestCase):
         self.session.drop(uri, 'force')
         self.assertRaises(
             wiredtiger.WiredTigerError, lambda: self.session.drop(uri, None))
+
         self.session.drop(cguri, 'force')
         self.assertRaises(
             wiredtiger.WiredTigerError, lambda: self.session.drop(cguri, None))
+
         self.session.drop(idxuri, 'force')
         self.assertRaises(
             wiredtiger.WiredTigerError, lambda: self.session.drop(idxuri, None))
+
         self.session.drop(lsmuri, 'force')
         self.assertRaises(
             wiredtiger.WiredTigerError, lambda: self.session.drop(lsmuri, None))

--- a/test/suite/test_drop03.py
+++ b/test/suite/test_drop03.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper import confirm_does_not_exist
+
+# test_drop03.py
+# Test dropping a collection under an active transaction. We should return EBUSY.
+class test_drop03(wttest.WiredTigerTestCase):
+    uri = 'table:test_drop03'
+
+    def verify_value(self, uri, session, key, value):
+        cursor = session.open_cursor(uri, None)
+        value_read = cursor[key]
+        self.assertTrue(value_read == value)
+        cursor.close()
+
+    def test_drop_during_txn(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        # Set values before active transaction
+        self.prout("Set first values before active transaction.")
+        cursor = self.session.open_cursor(self.uri, None)
+        self.session.begin_transaction()
+        cursor['key: aaa'] = 'value: aaa1'
+        cursor['key: aab'] = 'value: aab1'
+        cursor['key: aac'] = 'value: aac1'
+        cursor['key: aad'] = 'value: aad1'
+        cursor['key: bbb'] = 'value: bbb1'
+        cursor.close()
+        self.prout("Set first values. commit_transaction().")
+        self.session.commit_transaction()
+        # Verify values
+        self.prout("Verify values before active transaction.")
+        self.verify_value(self.uri, self.session, 'key: aaa', 'value: aaa1')
+        self.verify_value(self.uri, self.session, 'key: aab', 'value: aab1')
+        self.verify_value(self.uri, self.session, 'key: aac', 'value: aac1')
+        self.verify_value(self.uri, self.session, 'key: aad', 'value: aad1')
+        self.verify_value(self.uri, self.session, 'key: bbb', 'value: bbb1')
+        # Open active transaction
+        self.prout("Set second values within active transaction.")
+        cursor = self.session.open_cursor(self.uri, None)
+        self.session.begin_transaction()
+        cursor['key: aaa'] = 'value: aaa'
+        cursor['key: aab'] = 'value: aab'
+        cursor['key: aac'] = 'value: aac'
+        cursor['key: aad'] = 'value: aad'
+        cursor['key: bbb'] = 'value: bbb'
+        cursor.close()
+        # Drop call should fail without the force option.
+        self.prout("drop force=false with active transaction throws an exception.")
+        self.assertRaises(wiredtiger.WiredTigerError,
+            lambda: self.session.drop(self.uri, "force=false")) # XXX Pass: Exception
+
+        # Check that the transaction needs to be rolled back by failing to commit it.
+        self.prout("commit_transaction fails and rollsback.")
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                                     lambda: self.session.commit_transaction(),
+                                     "/transaction requires rollback: Invalid argument/")
+        # Verify values after drop with force=false and transaction rollback.
+        self.prout("Verify values after drop force=false and transaction rollback.")
+        self.verify_value(self.uri, self.session, 'key: aaa', 'value: aaa1')
+        self.verify_value(self.uri, self.session, 'key: aab', 'value: aab1')
+        self.verify_value(self.uri, self.session, 'key: aac', 'value: aac1')
+        self.verify_value(self.uri, self.session, 'key: aad', 'value: aad1')
+        self.verify_value(self.uri, self.session, 'key: bbb', 'value: bbb1')
+
+        # Drop call should succeed without the force option.
+        self.prout("drop force=false without active transaction should succeed.")
+        self.dropUntilSuccess(self.session, self.uri, "force=false")
+
+        # Check that the table is dropped.
+        self.prout("Does not exist after successful drop. confirm_does_not_exist().")
+        confirm_does_not_exist(self, self.uri)
+
+        # Drop call of non-existent table should fail without the force option.
+        self.prout("drop force=false without active transaction should succeed.")
+        self.assertRaises(wiredtiger.WiredTigerError,
+                          lambda: self.session.drop(self.uri, "force=false"))
+
+        # Drop call of non-existent table should succeed with the force option.
+        self.prout("drop force=true of non-existent table should succeed.")
+        self.session.drop(self.uri, "force=true")
+
+        self.prout("Done.")
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_sweep03.py
+++ b/test/suite/test_sweep03.py
@@ -123,7 +123,7 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
         stat_cursor.close()
 
         # We force the drop in this case to confirm that the handle is closed
-        self.session.drop(drop_uri, "force=true")
+        self.dropUntilSuccess(self.session, drop_uri, "force=true")
 
         sweep_baseline = self.wait_for_sweep(sweep_baseline)
 

--- a/test/suite/test_tiered20.py
+++ b/test/suite/test_tiered20.py
@@ -80,7 +80,7 @@ class test_tiered20(TieredConfigMixin, wttest.WiredTigerTestCase):
                 self.assertTrue(len(got) != 0)
             self.session.drop(uri, "remove_files=true,remove_shared={}".format(wt_boolean(remove_shared)))
         else:
-            self.session.drop(uri, "force=true")
+            self.dropUntilSuccess(self.session, uri, "force=true")
 
     # Return True iff the binary file contains the given string.
     def file_contains(self, fname, match):

--- a/test/unittest/tests/cursors/test_bulk_cursor.cpp
+++ b/test/unittest/tests/cursors/test_bulk_cursor.cpp
@@ -189,7 +189,7 @@ cache_destroy_memory_check(
  */
 static void
 cursor_test(std::string const &config, bool close, int expected_open_cursor_result,
-  int expected_commit_result, bool diagnostics)
+  int expected_commit_result, int expected_commit_result_with_drop, bool diagnostics)
 {
     ConnectionWrapper conn(DB_HOME);
     WT_SESSION_IMPL *session_impl = conn.createSession();
@@ -245,7 +245,7 @@ cursor_test(std::string const &config, bool close, int expected_open_cursor_resu
                 REQUIRE(cursor->close(cursor) == 0);
             }
 
-            REQUIRE(session->commit_transaction(session, "") == expected_commit_result);
+            REQUIRE(session->commit_transaction(session, "") == expected_commit_result_with_drop);
         }
 
         SECTION("Checkpoint in 2nd thread during transaction then rollback: config = " + config +
@@ -367,10 +367,10 @@ TEST_CASE("Cursor: bulk, non-bulk, checkpoint and drop combinations", "[cursor]"
     cache_destroy_memory_check("", 0, diagnostics);
     cache_destroy_memory_check("bulk", EINVAL, diagnostics);
 
-    cursor_test("", false, 0, EINVAL, diagnostics);
-    // cursor_test("", true, 0, EINVAL, diagnostics);
-    cursor_test("bulk", false, EINVAL, 0, diagnostics);
-    cursor_test("bulk", true, EINVAL, 0, diagnostics);
+    cursor_test("", false, 0, EINVAL, 0, diagnostics);
+    // cursor_test("", true, 0, EINVAL, 0, diagnostics);
+    cursor_test("bulk", false, EINVAL, 0, 0, diagnostics);
+    cursor_test("bulk", true, EINVAL, 0, 0, diagnostics);
 
     // multiple_drop_test("", 0, EINVAL, false, diagnostics);
     // multiple_drop_test("", 0, EINVAL, true, diagnostics);


### PR DESCRIPTION
Second: __drop_table(): The only difference between force=true and force=false is force=true returns success (0) if the table does not exist.

Also test changes.
* wtdataset.py: Added variants.
* test_drop.py: Test drop fails while a transaction is active and to verify a table is usable after drop table fails.
* test_drop.py: Added testing SimpleIndexDataSet too.
* test_drop03.py: New test.
* test_cursor06.py: Change self.session.drop() to self.dropUntilSuccess() twice.
* test_sweep03.py: Change self.session.drop() to self.dropUntilSuccess() once.
* test_tiered20.py: Change self.session.drop() to self.dropUntilSuccess() once.
* test_bulk_cursor.cpp: Fix error return check for error return changes of drop_table().