### PR TITLE
WT-9121 Eviction Server full key range swipe

### DIFF
--- a/src/btree/bt_misc.c
+++ b/src/btree/bt_misc.c
@@ -198,7 +198,7 @@ __wt_page_npos(WT_SESSION_IMPL *session, WT_REF *ref)
 /*
  * __wt_get_page_from_npos --
  *     Go to a leaf page given its normalized position. (The code is largely borrowed from
- *     __wt_get_page_from_position)
+ *     __wt_random_descent)
  */
 int
 __wt_get_page_from_npos(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags, double npos)

--- a/src/btree/bt_misc.c
+++ b/src/btree/bt_misc.c
@@ -139,3 +139,172 @@ __wt_page_type_string(u_int type) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
     }
     /* NOTREACHED */
 }
+
+/*
+ * __wt_page_is_root --
+ *     Returns true if the page is a root page.
+ */
+static WT_INLINE bool
+__wt_page_is_root(WT_PAGE *page)
+{
+    return (page->pg_intl_parent_ref == NULL || page->pg_intl_parent_ref->home == NULL);
+}
+
+/*
+ * __wt_page_npos --
+ *     Get the page's normalized position in the tree.
+ */
+double
+__wt_page_npos(WT_SESSION_IMPL *session, WT_REF *ref)
+{
+    WT_PAGE *page, *parent_page;
+    WT_REF *self_ref;
+    double npos;
+    uint32_t idx, entries;
+
+    npos = 0.5;
+    page = ref->home;
+    if (!page)
+        return (npos);
+
+    for (;;) {
+        WT_ASSERT(session, page != NULL);
+        WT_ASSERT(session, WT_PAGE_IS_INTERNAL(page));
+
+        self_ref = page->pg_intl_parent_ref; /* The field name is deceptive */
+        parent_page = self_ref->home;
+
+        idx = ref->pindex_hint;
+        // ?? should be used with WT_WITH_PAGE_INDEX and WT_INTL_INDEX_GET()?
+        entries = WT_INTL_INDEX_GET_SAFE(page)->entries;
+
+        if (idx < entries)
+            npos = (idx + npos) / entries;
+        /*
+         * If idx is incorrect, just leave the position as it is. We can scan all entries for the
+         * correct position, but it's not worth it.
+         */
+
+        if (!parent_page || page == parent_page || __wt_page_is_root(page))
+            break;
+
+        ref = self_ref;
+        page = parent_page;
+    }
+
+    return (npos);
+}
+
+/*
+ * __wt_get_page_from_npos --
+ *     Go to a leaf page given its normalized position. (The code is largely borrowed from
+ *     __wt_get_page_from_position)
+ */
+int
+__wt_get_page_from_npos(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags, double npos)
+{
+    WT_BTREE *btree;
+    WT_DECL_RET;
+    WT_PAGE *page;
+    WT_PAGE_INDEX *pindex;
+    WT_REF *current, *descent;
+    double npos2;
+    int i, idx, idx2, entries;
+    bool eviction;
+
+    *refp = NULL;
+
+    btree = S2BT(session);
+    current = NULL;
+    /*
+     * This function is called by eviction to find a page in the cache. That case is indicated by
+     * the WT_READ_CACHE flag. Ordinary lookups in a tree will read pages into cache as needed.
+     */
+    eviction = LF_ISSET(WT_READ_CACHE);
+
+    if (0) {
+restart:
+        /*
+         * Discard the currently held page and restart the search from the root.
+         */
+        WT_RET(__wt_page_release(session, current, flags));
+    }
+
+    /* Search the internal pages of the tree. */
+    current = &btree->root;
+    npos2 = npos;
+    for (;;) {
+        if (F_ISSET(current, WT_REF_FLAG_LEAF))
+            break;
+
+        page = current->page;
+        // WT_INTL_INDEX_GET(session, page, pindex);
+        pindex = WT_INTL_INDEX_GET_SAFE(page);
+        entries = (int)pindex->entries;
+
+        npos2 *= entries;
+        idx = (int)npos2;
+        idx = WT_CLAMP(idx, 0, entries - 1);
+        npos2 -= idx;
+        descent = pindex->index[idx];
+
+        /* Eviction just wants any child. */
+        if (eviction)
+            goto descend;
+
+        /*
+         * There may be empty pages in the tree, and they're useless to us. Find a closest non-empty
+         * page.
+         */
+        if (descent->state == WT_REF_DISK || descent->state == WT_REF_MEM)
+            goto descend;
+
+        for (i = 1; i < entries && descent != NULL; ++i) {
+            descent = NULL;
+
+            idx2 = idx - i;
+            if (idx2 >= 0) {
+                descent = pindex->index[idx2];
+                if (descent->state == WT_REF_DISK || descent->state == WT_REF_MEM)
+                    goto descend;
+            }
+
+            idx2 = idx + i;
+            if (idx2 < entries) {
+                descent = pindex->index[idx2];
+                if (descent->state == WT_REF_DISK || descent->state == WT_REF_MEM)
+                    goto descend;
+            }
+        }
+
+        /* Unable to find any suitable page */
+
+        WT_RET(__wt_page_release(session, current, flags));
+        return (WT_NOTFOUND);
+
+        /*
+         * Swap the current page for the child page. If the page splits while we're retrieving it,
+         * restart the search at the root.
+         *
+         * On other error, simply return, the swap call ensures we're holding nothing on failure.
+         */
+descend:
+        if ((ret = __wt_page_swap(session, current, descent, flags)) == 0) {
+            current = descent;
+            continue;
+        }
+        if (eviction && (ret == WT_NOTFOUND || ret == WT_RESTART))
+            break;
+        if (ret == WT_RESTART)
+            goto restart;
+        return (ret);
+    }
+
+    /*
+     * There is no point starting with the root page: the walk will exit immediately. In that case
+     * we aren't holding a hazard pointer so there is nothing to release.
+     */
+    if (!eviction || !__wt_ref_is_root(current))
+        *refp = current;
+    return (0);
+}

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -449,7 +449,7 @@ descend:
      */
     if (!eviction || !__wt_ref_is_root(current))
         *refp = current;
-    return (0);
+    return (0);  /* TODO: Possible bug: should this return `ret`? */
 }
 
 /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1859,10 +1859,10 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
         WT_STAT_CONN_INCR(session, cache_eviction_target_strategy_both_clean_and_dirty);
 
     if (btree->evict_ref == NULL) {
-        (void)__wt_get_page_from_npos(session, &btree->evict_ref,
+        WT_UNUSED(__wt_get_page_from_npos(session, &btree->evict_ref,
                 WT_READ_CACHE | WT_READ_NO_EVICT | WT_READ_NO_GEN | WT_READ_NO_WAIT |
                 WT_READ_NOTFOUND_OK | WT_READ_RESTART_OK,
-                btree->evict_pos);
+                btree->evict_pos));
         __wt_verbose_debug1(session, WT_VERB_EVICTSERVER, "__evict_walk_tree: restored saved position from %lf => %p",
             btree->evict_pos, (void*)btree->evict_ref);
     }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1542,18 +1542,6 @@ retry:
         }
 
         /*
-         * Skip files if we have too many active walks.
-         *
-         * This used to be limited by the configured maximum number of hazard pointers per session.
-         * Even though that ceiling has been removed, we need to test eviction with huge numbers of
-         * active trees before allowing larger numbers of hazard pointers in the walk session.
-         */
-        if (btree->evict_ref == NULL && session->hazards.num_active > WT_EVICT_MAX_TREES) {
-            WT_STAT_CONN_INCR(session, cache_eviction_server_skip_trees_too_many_active_walks);
-            continue;
-        }
-
-        /*
          * If we are filling the queue, skip files that haven't been useful in the past.
          */
         if (btree->evict_walk_period != 0 && btree->evict_walk_skips++ < btree->evict_walk_period) {

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2169,7 +2169,7 @@ fast:
         btree->evict_ref = ref;
         __evict_clear_walk(session);  /* We use soft refs - no need to pin the page */
     } else {
-        btree->evict_pos = 0.0;
+        btree->evict_pos = 0.0; /* Reached the end - reset the position */
     }
 
     WT_STAT_CONN_INCRV(session, cache_eviction_walk, refs_walked);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1859,10 +1859,10 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
         WT_STAT_CONN_INCR(session, cache_eviction_target_strategy_both_clean_and_dirty);
 
     if (btree->evict_ref == NULL) {
-        WT_UNUSED(__wt_get_page_from_npos(session, &btree->evict_ref,
+        (void)!__wt_get_page_from_npos(session, &btree->evict_ref,
                 WT_READ_CACHE | WT_READ_NO_EVICT | WT_READ_NO_GEN | WT_READ_NO_WAIT |
                 WT_READ_NOTFOUND_OK | WT_READ_RESTART_OK,
-                btree->evict_pos));
+                btree->evict_pos);
         __wt_verbose_debug1(session, WT_VERB_EVICTSERVER, "__evict_walk_tree: restored saved position from %lf => %p",
             btree->evict_pos, (void*)btree->evict_ref);
     }

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -83,13 +83,6 @@ typedef enum {
     CKSUM_UNENCRYPTED = 4   /* Unencrypted blocks only */
 } WT_BTREE_CHECKSUM;
 
-typedef enum { /* Start position for eviction walk */
-    WT_EVICT_WALK_NEXT,
-    WT_EVICT_WALK_PREV,
-    WT_EVICT_WALK_RAND_NEXT,
-    WT_EVICT_WALK_RAND_PREV
-} WT_EVICT_WALK_TYPE;
-
 /* An invalid btree file ID value. ID 0 is reserved for the metadata file. */
 #define WT_BTREE_ID_INVALID UINT32_MAX
 
@@ -240,6 +233,7 @@ struct __wt_btree {
      * code.
      */
     WT_REF *evict_ref;                         /* Eviction thread's location */
+    double evict_pos;                          /* Eviction thread's location */
     uint64_t evict_priority;                   /* Relative priority of cached pages */
     uint32_t evict_walk_progress;              /* Eviction walk progress */
     uint32_t evict_walk_target;                /* Eviction walk target */
@@ -250,7 +244,6 @@ struct __wt_btree {
     bool evict_disabled_open;                  /* Eviction disabled on open */
     wt_shared volatile uint32_t evict_busy;    /* Count of threads in eviction */
     wt_shared volatile uint32_t prefetch_busy; /* Count of threads in prefetch */
-    WT_EVICT_WALK_TYPE evict_start_type;
 
 /*
  * Flag values up to 0xfff are reserved for WT_DHANDLE_XXX. See comment with dhandle flags for an

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -92,6 +92,8 @@ extern const char *__wt_strerror(WT_SESSION_IMPL *session, int error, char *errb
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_wiredtiger_error(int error)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern double __wt_page_npos(WT_SESSION_IMPL *session, WT_REF *ref)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_apply_single_idx(WT_SESSION_IMPL *session, WT_INDEX *idx, WT_CURSOR *cur,
   WT_CURSOR_TABLE *ctable, int (*f)(WT_CURSOR *)) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_background_compact_end(WT_SESSION_IMPL *session)
@@ -875,6 +877,8 @@ extern int __wt_fopen(WT_SESSION_IMPL *session, const char *name, uint32_t open_
   uint32_t flags, WT_FSTREAM **fstrp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_fsync_background(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_get_page_from_npos(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags,
+  double npos) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_getopt(const char *progname, int nargc, char *const *nargv, const char *ostr)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -108,6 +108,7 @@
 /* Min, max. */
 #define WT_MIN(a, b) ((a) < (b) ? (a) : (b))
 #define WT_MAX(a, b) ((a) < (b) ? (b) : (a))
+#define WT_CLAMP(x, low, high) (WT_MIN(WT_MAX((x), (low)), (high)))
 
 /* Ceil for unsigned/positive real numbers. */
 #define WT_CEIL_POS(a) ((a) - (double)(uintmax_t)(a) > 0.0 ? (uintmax_t)(a) + 1 : (uintmax_t)(a))


### PR DESCRIPTION
Summary of changes:
* Added 2 functions to calculate the page's normalized position and restore a page from its position.
* Eviction server doesn't store the page reference for long time anymore but uses a normalized position to continue the walk.
* If no pages were queued after a walk, we don't attempt to change the scanning behavior anymore but rather continue the scan next time.