### PR TITLE
WT-12463 Remove connection->configure_method examples

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -694,7 +694,6 @@ dmb
 dmsg
 drealloc
 dryrun
-ds
 dsb
 dsbs
 dsk
@@ -994,7 +993,6 @@ mkdir
 mmap
 mmrand
 mn
-mnt
 mongod
 mrs
 msecs

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1073,26 +1073,6 @@ connection_ops(WT_CONNECTION *conn)
         session_ops(session);
     }
 
-    /*! [Configure method configuration] */
-    /*
-     * Applications opening a cursor for the data-source object "my_data" have an additional
-     * configuration option "entries", which is an integer type, defaults to 5, and must be an
-     * integer between 1 and 10.
-     *
-     * The method being configured is specified using a concatenation of the handle name, a period
-     * and the method name.
-     */
-    error_check(conn->configure_method(
-      conn, "WT_SESSION.open_cursor", "my_data:", "entries=5", "int", "min=1,max=10"));
-
-    /*
-     * Applications opening a cursor for the data-source object "my_data" have an additional
-     * configuration option "devices", which is a list of strings.
-     */
-    error_check(
-      conn->configure_method(conn, "WT_SESSION.open_cursor", "my_data:", "devices", "list", NULL));
-    /*! [Configure method configuration] */
-
     /*! [Close a connection] */
     error_check(conn->close(conn, NULL));
     /*! [Close a connection] */

--- a/examples/c/ex_data_source.c
+++ b/examples/c/ex_data_source.c
@@ -565,55 +565,6 @@ main(int argc, char *argv[])
         /*! [WT_DATA_SOURCE register] */
     }
 
-    /*! [WT_DATA_SOURCE configure boolean] */
-    /* my_boolean defaults to true. */
-    error_check(conn->configure_method(
-      conn, "WT_SESSION.open_cursor", NULL, "my_boolean=true", "boolean", NULL));
-    /*! [WT_DATA_SOURCE configure boolean] */
-
-    /*! [WT_DATA_SOURCE configure integer] */
-    /* my_integer defaults to 5. */
-    error_check(
-      conn->configure_method(conn, "WT_SESSION.open_cursor", NULL, "my_integer=5", "int", NULL));
-    /*! [WT_DATA_SOURCE configure integer] */
-
-    /*! [WT_DATA_SOURCE configure string] */
-    /* my_string defaults to "name". */
-    error_check(conn->configure_method(
-      conn, "WT_SESSION.open_cursor", NULL, "my_string=name", "string", NULL));
-    /*! [WT_DATA_SOURCE configure string] */
-
-    /*! [WT_DATA_SOURCE configure list] */
-    /* my_list defaults to "first" and "second". */
-    error_check(conn->configure_method(
-      conn, "WT_SESSION.open_cursor", NULL, "my_list=[first, second]", "list", NULL));
-    /*! [WT_DATA_SOURCE configure list] */
-
-    /*! [WT_DATA_SOURCE configure integer with checking] */
-    /*
-     * Limit the number of devices to between 1 and 30; the default is 5.
-     */
-    error_check(conn->configure_method(
-      conn, "WT_SESSION.open_cursor", NULL, "devices=5", "int", "min=1, max=30"));
-    /*! [WT_DATA_SOURCE configure integer with checking] */
-
-    /*! [WT_DATA_SOURCE configure string with checking] */
-    /*
-     * Limit the target string to one of /device, /home or /target; default to /home.
-     */
-    error_check(conn->configure_method(conn, "WT_SESSION.open_cursor", NULL, "target=/home",
-      "string", "choices=[/device, /home, /target]"));
-    /*! [WT_DATA_SOURCE configure string with checking] */
-
-    /*! [WT_DATA_SOURCE configure list with checking] */
-    /*
-     * Limit the paths list to one or more of /device, /home, /mnt or
-     * /target; default to /mnt.
-     */
-    error_check(conn->configure_method(conn, "WT_SESSION.open_cursor", NULL, "paths=[/mnt]", "list",
-      "choices=[/device, /home, /mnt, /target]"));
-    /*! [WT_DATA_SOURCE configure list with checking] */
-
     /*! [WT_EXTENSION_API default_session] */
     (void)wt_api->msg_printf(wt_api, NULL, "configuration complete");
     /*! [WT_EXTENSION_API default_session] */

--- a/src/docs/custom-data-sources.dox
+++ b/src/docs/custom-data-sources.dox
@@ -159,65 +159,6 @@ of a configuration string as follows:
 
 @snippet ex_data_source.c WT_EXTENSION config_get
 
-@subsection custom_ds_config_add Creating data-specific configuration strings
-
-Applications can add their own configuration strings to WiredTiger
-methods using WT_CONNECTION::configure_method.
-
-WT_CONNECTION::configure_method takes the following arguments:
-
-- the method being extended, where the name is the concatenation of the handle
-name, a period and the method name.  For example, \c "WT_SESSION.create"
-would add new configuration strings to the WT_SESSION::create method,
-and \c "WT_SESSION.open_cursor" would add the configuration string to the
-WT_SESSION::open_cursor method.
-
-- the object type of the data source being extended.  For example, \c "table:"
-would extend the configuration arguments for table objects, and \c "my_data:"
-could be used to extend the configuration arguments for a data source with
-URIs beginning with the "my_data" prefix.  A NULL value for the object type
-implies all object types.
-
-- the additional configuration string, which consists of the name of the
-configuration string and an optional default value.  The default value
-is specified by appending an equals sign and a value.  For example, for
-a new configuration string with the name \c "device", specifying either
-\c "device=/path" or \c "device=35" would configure the default values.
-
-- the type of the additional configuration, which must one of \c "boolean",
-\c "int", \c "list" or \c "string".
-
-- value checking information for the additional configuration, or NULL if
-no checking information is provided.
-
-For example, an application might add new boolean, integer, list or
-string type configuration strings as follows:
-
-@snippet ex_data_source.c WT_DATA_SOURCE configure boolean
-@snippet ex_data_source.c WT_DATA_SOURCE configure integer
-@snippet ex_data_source.c WT_DATA_SOURCE configure list
-@snippet ex_data_source.c WT_DATA_SOURCE configure string
-
-Once these additional configuration calls have returned, application calls to
-the WT_SESSION::open_cursor method could then include configuration strings
-such as \c my_boolean=false, or \c my_integer=37, or \c my_source=/home.
-
-Additional checking information can be provided for \c int, \c list or
-\c string type configuration strings.
-
-For integers, either or both of a maximum or minimum value can be
-provided, so an error will result if the application attempts to set the
-value outside of the acceptable range:
-
-@snippet ex_data_source.c WT_DATA_SOURCE configure integer with checking
-
-For lists and strings, a set of valid choices can also be provided, so
-an error will result if the application attempts to set the value to a
-string not listed as a valid choice:
-
-@snippet ex_data_source.c WT_DATA_SOURCE configure string with checking
-@snippet ex_data_source.c WT_DATA_SOURCE configure list with checking
-
 @section custom_ds_cursor_collator WT_COLLATOR
 
 Custom data sources do not support custom ordering of records, and

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2537,10 +2537,7 @@ struct __wt_connection {
         const char *str, const char **compiled);
 
     /*!
-     * Add configuration options for a method.  See
-     * @ref custom_ds_config_add for more information.
-     *
-     * @snippet ex_all.c Configure method configuration
+     * Add configuration options for a method.
      *
      * @param connection the connection handle
      * @param method the method being configured


### PR DESCRIPTION
No tests for this one, just the two sections of examples. As far as I can tell, they only used the "call" side, and never used the configuration attached to the methods.