### PR TITLE
WT-11062 Safe free the ref addr to allow concurrent access (v5.0 backport)

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -234,6 +234,33 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
+ * __ref_addr_safe_free --
+ *     Any thread that is reviewing the address in a WT_REF, must also be holding a split generation
+ *     to ensure that the page index they are using remains valid. Utilize the same generation type
+ *     to safely free the address once all users of it have left the generation.
+ */
+static void
+__ref_addr_safe_free(WT_SESSION_IMPL *session, void *ref_addr)
+{
+    WT_DECL_RET;
+    uint64_t split_gen;
+
+    /*
+     * The reading thread is always inside a split generation when it reads the ref, so we make use
+     * of WT_GEN_SPLIT type generation mechanism to protect the address in a WT_REF rather than
+     * creating a whole new generation counter. There are no page splits taking place.
+     */
+    split_gen = __wt_gen(session, WT_GEN_SPLIT);
+    WT_TRET(__wt_stash_add(
+      session, WT_GEN_SPLIT, split_gen, ((WT_ADDR *)ref_addr)->addr, ((WT_ADDR *)ref_addr)->size));
+    WT_TRET(__wt_stash_add(session, WT_GEN_SPLIT, split_gen, ref_addr, sizeof(WT_ADDR)));
+    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+
+    if (ret != 0)
+        WT_IGNORE_RET(__wt_panic(session, ret, "fatal error during ref address free"));
+}
+
+/*
  * __wt_ref_addr_free --
  *     Free the address in a reference, if necessary.
  */
@@ -253,10 +280,8 @@ __wt_ref_addr_free(WT_SESSION_IMPL *session, WT_REF *ref)
             return;
     } while (!__wt_atomic_cas_ptr(&ref->addr, ref_addr, NULL));
 
-    if (ref->home == NULL || __wt_off_page(ref->home, ref_addr)) {
-        __wt_free(session, ((WT_ADDR *)ref_addr)->addr);
-        __wt_free(session, ref_addr);
-    }
+    if (ref->home == NULL || __wt_off_page(ref->home, ref_addr))
+        __ref_addr_safe_free(session, ref_addr);
 }
 
 /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -382,6 +382,7 @@ __verify_addr_string(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *buf)
     WT_DECL_RET;
     char time_string[WT_TIME_STRING_SIZE];
 
+    WT_ENTER_GENERATION(session, WT_GEN_SPLIT);
     WT_ERR(__wt_scr_alloc(session, 0, &tmp));
 
     if (__wt_ref_addr_copy(session, ref, &addr)) {
@@ -393,6 +394,7 @@ __verify_addr_string(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *buf)
 
 err:
     __wt_scr_free(session, &tmp);
+    WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);
     return (buf->data);
 }
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1383,3 +1383,21 @@ struct __wt_insert_head {
     WT_ENTER_PAGE_INDEX(session);      \
     (e);                               \
     WT_LEAVE_PAGE_INDEX(session)
+
+/*
+ * Manage the given generation number with support for re-entry. Re-entry is allowed as the previous
+ * generation as it must be as low as the current generation.
+ */
+#define WT_ENTER_GENERATION(session, generation)              \
+    do {                                                      \
+        bool __entered_##generation = false;                  \
+        if (__wt_session_gen((session), (generation)) == 0) { \
+            __wt_session_gen_enter((session), (generation));  \
+            __entered_##generation = true;                    \
+        }
+
+#define WT_LEAVE_GENERATION(session, generation)         \
+    if (__entered_##generation)                          \
+        __wt_session_gen_leave((session), (generation)); \
+    }                                                    \
+    while (0)


### PR DESCRIPTION
This had some merge conflicts and needs some attention. A good comparison is probably the v6.0 backport.

(cherry picked from commit 248864f3ecbe26aaa00ce6696f46d9cff8f481be)