### PR TITLE
WT-9057 Address null address read in compact walk. (5.0 backport)

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -222,6 +222,8 @@ __compact_walk_internal(WT_SESSION_IMPL *session, WT_REF *parent)
     WT_REF *ref;
     bool overall_progress, skipp;
 
+    WT_ASSERT(session, F_ISSET(parent, WT_REF_FLAG_INTERNAL));
+
     ref = NULL; /* [-Wconditional-uninitialized] */
 
     /*
@@ -359,7 +361,15 @@ __wt_compact(WT_SESSION_IMPL *session)
         if (ref == NULL)
             break;
 
-        WT_WITH_PAGE_INDEX(session, ret = __compact_walk_internal(session, ref));
+        /*
+         * The compact walk only flags internal pages for review, but there is a rare case where an
+         * WT_REF in the WT_REF_DISK state pointing to an internal page, can transition to a leaf
+         * page when it is being read in. Handle that here, by re-checking the page type now that
+         * the page is in memory.
+         */
+        if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+            WT_WITH_PAGE_INDEX(session, ret = __compact_walk_internal(session, ref));
+
         WT_ERR(ret);
     }
 


### PR DESCRIPTION
The code now only calls __compact_walk_internal() from __wt_compact() on internal pages, and asserts in __compact_walk_internal() that it is being called on an internal page.

Co-authored-by: Jeremy Thorp <jeremy.thorp@mongodb.com>
(cherry picked from commit 05522bc83f71b61a3d44a5c77d2998d83fc4c0ce)