### PR TITLE
WT-12619 Fix TSan warnings for ref->state

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -926,7 +926,7 @@ __debug_tree_shape_worker(WT_DBG *ds, WT_REF *ref, int level)
           "%d %s\n",
           level * 3, " ", level, __debug_tree_shape_info(ref, buf, sizeof(buf))));
         WT_INTL_FOREACH_BEGIN (session, ref->page, walk) {
-            if (walk->state == WT_REF_MEM)
+            if (__wt_atomic_loadv8(&walk->state) == WT_REF_MEM)
                 WT_RET(__debug_tree_shape_worker(ds, walk, level + 1));
         }
         WT_INTL_FOREACH_END;
@@ -1384,7 +1384,7 @@ __debug_page_col_int(WT_DBG *ds, WT_PAGE *page)
 
     if (F_ISSET(ds, WT_DEBUG_TREE_WALK)) {
         WT_INTL_FOREACH_BEGIN (session, page, ref) {
-            if (ref->state == WT_REF_MEM) {
+            if (__wt_atomic_loadv8(&ref->state) == WT_REF_MEM) {
                 WT_RET(ds->f(ds, "\n"));
                 WT_RET(__debug_page(ds, ref));
             }
@@ -1467,7 +1467,7 @@ __debug_page_row_int(WT_DBG *ds, WT_PAGE *page)
 
     if (F_ISSET(ds, WT_DEBUG_TREE_WALK)) {
         WT_INTL_FOREACH_BEGIN (session, page, ref) {
-            if (ref->state == WT_REF_MEM) {
+            if (__wt_atomic_loadv8(&ref->state) == WT_REF_MEM) {
                 WT_RET(ds->f(ds, "\n"));
                 WT_RET(__debug_page(ds, ref));
             }
@@ -1719,7 +1719,7 @@ __debug_ref(WT_DBG *ds, WT_REF *ref)
     session = ds->session;
 
     WT_RET(ds->f(ds, "ref: %p", (void *)ref));
-    WT_RET(ds->f(ds, " | ref_state: %s", __debug_ref_state(ref->state)));
+    WT_RET(ds->f(ds, " | ref_state: %s", __debug_ref_state(__wt_atomic_loadv8(&ref->state))));
     if (ref->flags != 0) {
         WT_RET(ds->f(ds, " | page_type: ["));
         if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -112,7 +112,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     *skipp = false;
 
     /* If we have a clean page in memory, attempt to evict it. */
-    previous_state = ref->state;
+    previous_state = __wt_atomic_loadv8(&ref->state);
     if (previous_state == WT_REF_MEM &&
       WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED)) {
         if (__wt_page_is_modified(ref->page)) {
@@ -131,7 +131,7 @@ __wt_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     /*
      * Fast check to see if it's worth locking, then atomically switch the page's state to lock it.
      */
-    previous_state = ref->state;
+    previous_state = __wt_atomic_loadv8(&ref->state);
     switch (previous_state) {
     case WT_REF_DISK:
         break;
@@ -221,7 +221,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
 
     /* Lock the reference. We cannot access ref->page_del except when locked. */
     for (locked = false, sleep_usecs = yield_count = 0;;) {
-        switch (current_state = ref->state) {
+        switch (current_state = __wt_atomic_loadv8(&ref->state)) {
         case WT_REF_LOCKED:
             break;
         case WT_REF_DELETED:
@@ -307,7 +307,7 @@ __delete_redo_window_cleanup_internal(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ASSERT(session, F_ISSET(ref, WT_REF_FLAG_INTERNAL));
     if (ref->page != NULL) {
         WT_INTL_FOREACH_BEGIN (session, ref->page, child) {
-            if (child->state == WT_REF_DELETED && child->page_del != NULL)
+            if (__wt_atomic_loadv8(&child->state) == WT_REF_DELETED && child->page_del != NULL)
                 __cell_redo_page_del_cleanup(session, ref->page->dsk, child->page_del);
         }
         WT_INTL_FOREACH_END;

--- a/src/btree/bt_prefetch.c
+++ b/src/btree/bt_prefetch.c
@@ -76,8 +76,9 @@ __wt_btree_prefetch(WT_SESSION_IMPL *session, WT_REF *ref)
          * these deleted pages into the cache if the fast truncate information is visible in the
          * session transaction snapshot.
          */
-        if (next_ref->state == WT_REF_DISK && F_ISSET(next_ref, WT_REF_FLAG_LEAF) &&
-          next_ref->page_del == NULL && !F_ISSET(next_ref, WT_REF_FLAG_PREFETCH)) {
+        if (__wt_atomic_loadv8(&next_ref->state) == WT_REF_DISK &&
+          F_ISSET(next_ref, WT_REF_FLAG_LEAF) && next_ref->page_del == NULL &&
+          !F_ISSET(next_ref, WT_REF_FLAG_PREFETCH)) {
             ret = __wt_conn_prefetch_queue_push(session, next_ref);
             if (ret == EBUSY) {
                 ret = 0;
@@ -114,7 +115,7 @@ __wt_prefetch_page_in(WT_SESSION_IMPL *session, WT_PREFETCH_QUEUE_ENTRY *pe)
     WT_PREFETCH_ASSERT(
       session, !F_ISSET(pe->ref, WT_REF_FLAG_INTERNAL), prefetch_skipped_internal_page);
 
-    if (pe->ref->state != WT_REF_DISK) {
+    if (__wt_atomic_loadv8(&pe->ref->state) != WT_REF_DISK) {
         WT_STAT_CONN_INCR(session, prefetch_pages_fail);
         return (0);
     }

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -358,6 +358,7 @@ __wt_random_descent(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags, WT_
     WT_PAGE_INDEX *pindex;
     WT_REF *current, *descent;
     uint32_t i, entries, retry;
+    uint8_t descent_state;
     bool eviction;
 
     *refp = NULL;
@@ -408,13 +409,15 @@ restart:
         descent = NULL;
         for (i = 0; i < entries; ++i) {
             descent = pindex->index[__wt_random(rnd) % entries];
-            if (descent->state == WT_REF_DISK || descent->state == WT_REF_MEM)
+            WT_READ_ONCE(descent_state, descent->state);
+            if (descent_state == WT_REF_DISK || descent_state == WT_REF_MEM)
                 break;
         }
         if (i == entries)
             for (i = 0; i < entries; ++i) {
                 descent = pindex->index[i];
-                if (descent->state == WT_REF_DISK || descent->state == WT_REF_MEM)
+                WT_READ_ONCE(descent_state, descent->state);
+                if (descent_state == WT_REF_DISK || descent_state == WT_REF_MEM)
                     break;
             }
         if (i == entries || descent == NULL) {

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -106,7 +106,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     WT_CLEAR(tmp);
 
     /* Lock the WT_REF. */
-    switch (previous_state = ref->state) {
+    switch (previous_state = __wt_atomic_loadv8(&ref->state)) {
     case WT_REF_DISK:
     case WT_REF_DELETED:
         if (WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
@@ -296,7 +296,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
 
     for (evict_skip = stalled = wont_need = false, force_attempts = 0, sleep_usecs = yield_cnt = 0;
          ;) {
-        switch (current_state = ref->state) {
+        switch (current_state = __wt_atomic_loadv8(&ref->state)) {
         case WT_REF_DELETED:
             /* Optionally limit reads to cache-only. */
             if (LF_ISSET(WT_READ_CACHE | WT_READ_NO_WAIT))

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -685,7 +685,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     if (!WT_BTREE_SYNCING(btree) || WT_SESSION_BTREE_SYNC(session))
         for (i = 0; i < parent_entries; ++i) {
             next_ref = pindex->index[i];
-            WT_ASSERT(session, next_ref->state != WT_REF_SPLIT);
+            WT_ASSERT(session, __wt_atomic_loadv8(&next_ref->state) != WT_REF_SPLIT);
 
             /*
              * Protect against including the replaced WT_REF in the list of deleted items. Also, in
@@ -695,7 +695,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
              * unless we update the internal page's start recno on the fly and restart the search,
              * which seems like asking for trouble.)
              */
-            if (next_ref != ref && next_ref->state == WT_REF_DELETED &&
+            if (next_ref != ref && __wt_atomic_loadv8(&next_ref->state) == WT_REF_DELETED &&
               (btree->type != BTREE_COL_VAR || i != 0) &&
               __wt_delete_page_skip(session, next_ref, true) &&
               WT_REF_CAS_STATE(session, next_ref, WT_REF_DELETED, WT_REF_LOCKED)) {
@@ -806,13 +806,13 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
      * the WT_REF state.
      */
     if (discard) {
-        WT_ASSERT(session, exclusive || ref->state == WT_REF_LOCKED);
+        WT_ASSERT(session, exclusive || __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED);
         WT_TRET(
           __split_parent_discard_ref(session, ref, parent, &parent_decr, split_gen, exclusive));
     }
     for (i = 0; i < deleted_entries; ++i) {
         next_ref = pindex->index[deleted_refs[i]];
-        WT_ASSERT(session, next_ref->state == WT_REF_LOCKED);
+        WT_ASSERT(session, __wt_atomic_loadv8(&next_ref->state) == WT_REF_LOCKED);
         WT_TRET(__split_parent_discard_ref(
           session, next_ref, parent, &parent_decr, split_gen, exclusive));
     }
@@ -860,7 +860,7 @@ err:
         /* Unlock WT_REFs locked because they were in a deleted state. */
         for (i = 0; i < deleted_entries; ++i) {
             next_ref = pindex->index[deleted_refs[i]];
-            WT_ASSERT(session, next_ref->state == WT_REF_LOCKED);
+            WT_ASSERT(session, __wt_atomic_loadv8(&next_ref->state) == WT_REF_LOCKED);
             WT_REF_SET_STATE(next_ref, WT_REF_DELETED);
         }
 
@@ -1803,7 +1803,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     child->home = ref->home;
     child->pindex_hint = ref->pindex_hint;
     F_SET(child, WT_REF_FLAG_LEAF);
-    child->state = WT_REF_MEM; /* Visible as soon as the split completes. */
+    __wt_atomic_storev8(&child->state, WT_REF_MEM); /* Visible as soon as the split completes. */
     child->addr = ref->addr;
     if (type == WT_PAGE_ROW_LEAF) {
         __wt_ref_key(ref->home, ref, &key, &key_size);
@@ -1843,7 +1843,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     child = split_ref[1];
     child->page = right;
     F_SET(child, WT_REF_FLAG_LEAF);
-    child->state = WT_REF_MEM; /* Visible as soon as the split completes. */
+    __wt_atomic_storev8(&child->state, WT_REF_MEM); /* Visible as soon as the split completes. */
     if (type == WT_PAGE_ROW_LEAF) {
         WT_ERR(__wt_row_ikey(
           session, 0, WT_INSERT_KEY(moved_ins), WT_INSERT_KEY_SIZE(moved_ins), child));

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -137,13 +137,13 @@ __sync_page_skip(
      * existing page on disk contains the right information and will be linked into the checkpoint
      * as the internal tree structure is built.
      */
-    if (ref->state == WT_REF_DELETED) {
+    if (__wt_atomic_loadv8(&ref->state) == WT_REF_DELETED) {
         *skipp = true;
         return (0);
     }
 
     /* If the page is in-memory, we want to look at it. */
-    if (ref->state != WT_REF_DISK)
+    if (__wt_atomic_loadv8(&ref->state) != WT_REF_DISK)
         return (0);
 
     /*

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -190,7 +190,7 @@ static int
 __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_DECL_RET;
-    uint8_t new_state, previous_state;
+    uint8_t new_state, previous_state, ref_state;
     bool busy, ref_deleted;
 
     busy = ref_deleted = false;
@@ -216,7 +216,8 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
      * checks. That's OK - in the worst case we might not review the ref this time, but we will on
      * subsequent reconciliations.
      */
-    if (ref->state == WT_REF_DELETED || ref->state == WT_REF_DISK) {
+    WT_READ_ONCE(ref_state, ref->state);
+    if (ref_state == WT_REF_DELETED || ref_state == WT_REF_DISK) {
         WT_REF_LOCK(session, ref, &previous_state);
         /*
          * There are two possible outcomes from the subsequent checks:
@@ -234,7 +235,7 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
         }
         WT_REF_UNLOCK(ref, new_state);
         WT_RET(ret);
-    } else if (ref->state == WT_REF_MEM) {
+    } else if (ref_state == WT_REF_MEM) {
         /*
          * Reviewing in-memory pages requires looking at page reconciliation results and we must
          * ensure we don't race with page reconciliation as it's writing the page modify

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -433,7 +433,7 @@ descend:
             /*
              * If we see any child states other than deleted, the page isn't empty.
              */
-            current_state = ref->state;
+            current_state = __wt_atomic_loadv8(&ref->state);
             if (current_state != WT_REF_DELETED && !LF_ISSET(WT_READ_TRUNCATE))
                 empty_internal = false;
 
@@ -585,7 +585,8 @@ __tree_walk_skip_count_callback(
     /*
      * Skip deleted pages visible to us.
      */
-    if (ref->state == WT_REF_DELETED && __wt_delete_page_skip(session, ref, visible_all))
+    if (__wt_atomic_loadv8(&ref->state) == WT_REF_DELETED &&
+      __wt_delete_page_skip(session, ref, visible_all))
         *skipp = true;
     else if (*skipleafcntp > 0 && F_ISSET(ref, WT_REF_FLAG_LEAF)) {
         --*skipleafcntp;

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -419,7 +419,7 @@ __wt_row_ikey(
          * after a split.
          */
         WT_ASSERT(session, oldv == 0 || (oldv & WT_IK_FLAG) != 0);
-        WT_ASSERT(session, ref->state != WT_REF_SPLIT);
+        WT_ASSERT(session, __wt_atomic_loadv8(&ref->state) != WT_REF_SPLIT);
         WT_ASSERT(session, __wt_atomic_cas_ptr(&ref->ref_ikey, (WT_IKEY *)oldv, ikey));
     }
 #else

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -89,7 +89,8 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
         switch (syncop) {
         case WT_SYNC_CLOSE:
             /* Evict the page. */
-            WT_ERR(__wt_evict(session, ref, ref->state, WT_EVICT_CALL_CLOSING));
+            WT_ERR(
+              __wt_evict(session, ref, __wt_atomic_loadv8(&ref->state), WT_EVICT_CALL_CLOSING));
             break;
         case WT_SYNC_DISCARD:
             /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -200,7 +200,7 @@ __wt_evict_list_clear_page(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_CACHE *cache;
 
-    WT_ASSERT(session, __wt_ref_is_root(ref) || ref->state == WT_REF_LOCKED);
+    WT_ASSERT(session, __wt_ref_is_root(ref) || __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED);
 
     /* Fast path: if the page isn't in the queue, don't bother searching. */
     if (!F_ISSET_ATOMIC_16(ref->page, WT_PAGE_EVICT_LRU))
@@ -2173,7 +2173,8 @@ fast:
             ref = NULL;
         } else {
             while (ref != NULL &&
-              (ref->state != WT_REF_MEM || __wt_readgen_evict_soon(&ref->page->read_gen)))
+              (__wt_atomic_loadv8(&ref->state) != WT_REF_MEM ||
+                __wt_readgen_evict_soon(&ref->page->read_gen)))
                 WT_RET_NOTFOUND_OK(__wt_tree_walk_count(session, &ref, &refs_walked, walk_flags));
         }
         btree->evict_ref = ref;
@@ -2321,7 +2322,7 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
          * Lock the page while holding the eviction mutex to prevent multiple attempts to evict it.
          * For pages that are already being evicted, this operation will fail and we will move on.
          */
-        if ((previous_state = evict->ref->state) != WT_REF_MEM ||
+        if ((previous_state = __wt_atomic_loadv8(&evict->ref->state)) != WT_REF_MEM ||
           !WT_REF_CAS_STATE(session, evict->ref, previous_state, WT_REF_LOCKED)) {
             __evict_list_clear(session, evict);
             continue;
@@ -2373,7 +2374,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
     WT_TRACK_OP_INIT(session);
 
     WT_RET_TRACK(__evict_get_ref(session, is_server, &btree, &ref, &previous_state));
-    WT_ASSERT(session, ref->state == WT_REF_LOCKED);
+    WT_ASSERT(session, __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED);
 
     cache = S2C(session)->cache;
     time_start = 0;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -20,7 +20,7 @@ static int __evict_review(WT_SESSION_IMPL *, WT_REF *, uint32_t, bool *);
 static WT_INLINE void
 __evict_exclusive_clear(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_state)
 {
-    WT_ASSERT(session, ref->state == WT_REF_LOCKED && ref->page != NULL);
+    WT_ASSERT(session, __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED && ref->page != NULL);
 
     WT_REF_SET_STATE(ref, previous_state);
 }
@@ -32,7 +32,7 @@ __evict_exclusive_clear(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t previous_
 static WT_INLINE int
 __evict_exclusive(WT_SESSION_IMPL *session, WT_REF *ref)
 {
-    WT_ASSERT(session, ref->state == WT_REF_LOCKED);
+    WT_ASSERT(session, __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED);
 
     /*
      * Check for a hazard pointer indicating another thread is using the page, meaning the page
@@ -65,7 +65,7 @@ __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
      * we can get exclusive access. Take some care with order of operations: if we release the
      * hazard pointer without first locking the page, it could be evicted in between.
      */
-    previous_state = ref->state;
+    previous_state = __wt_atomic_loadv8(&ref->state);
     locked =
       previous_state == WT_REF_MEM && WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED);
     if ((ret = __wt_hazard_clear(session, ref)) != 0 || !locked) {
@@ -390,7 +390,7 @@ __evict_delete_ref(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
                 /*
                  * The child must be locked after a failed reverse split.
                  */
-                WT_ASSERT(session, ref->state == WT_REF_LOCKED);
+                WT_ASSERT(session, __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED);
             }
         }
     }
@@ -564,7 +564,7 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
             break;
         }
 
-        switch (child->state) {
+        switch (__wt_atomic_loadv8(&child->state)) {
         case WT_REF_DISK:    /* On-disk */
         case WT_REF_DELETED: /* On-disk, deleted */
             break;
@@ -580,7 +580,7 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
         return (__wt_set_return(session, EBUSY));
 
     WT_INTL_FOREACH_REVERSE_BEGIN (session, parent->page, child) {
-        switch (child->state) {
+        switch (__wt_atomic_loadv8(&child->state)) {
         case WT_REF_DISK:    /* On-disk */
         case WT_REF_DELETED: /* On-disk, deleted */
             break;
@@ -604,7 +604,7 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
      */
     WT_INTL_FOREACH_BEGIN (session, parent->page, child) {
 
-        switch (child->state) {
+        switch (__wt_atomic_loadv8(&child->state)) {
         case WT_REF_DISK: /* On-disk */
             break;
         case WT_REF_DELETED: /* On-disk, deleted */
@@ -664,7 +664,7 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
             else
                 visible = __wt_page_del_visible_all(session, child->page_del, false);
             /* FIXME-WT-9780: is there a reason this doesn't use WT_REF_UNLOCK? */
-            child->state = WT_REF_DELETED;
+            __wt_atomic_storev8(&child->state, WT_REF_DELETED);
             if (!visible)
                 return (__wt_set_return(session, EBUSY));
             break;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1272,7 +1272,7 @@ struct __wt_ref {
     do {                                                                       \
         uint8_t __previous_state;                                              \
         for (;; __wt_yield()) {                                                \
-            __previous_state = (ref)->state;                                   \
+            __previous_state = __wt_atomic_loadv8(&(ref)->state);              \
             if (__previous_state != WT_REF_LOCKED &&                           \
               WT_REF_CAS_STATE(session, ref, __previous_state, WT_REF_LOCKED)) \
                 break;                                                         \

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -18,6 +18,20 @@ __wt_ref_is_root(WT_REF *ref)
     return (ref->home == NULL);
 }
 
+#ifdef HAVE_REF_TRACK
+/*
+ * __ref_save_state --
+ *     Save tracking data when REF_TRACK is enabled. This function wraps the WT_REF_SAVE_STATE macro
+ *     so we can suppress it in our TSan ignore list.
+ */
+static inline void
+__ref_save_state(
+  WT_SESSION_IMPL *session, WT_REF *ref, uint8_t new_state, const char *func, int line)
+{
+    WT_REF_SAVE_STATE(ref, new_state, func, line);
+}
+#endif
+
 /*
  * __wt_ref_cas_state_int --
  *     Try to do a compare and swap, if successful update the ref history in diagnostic mode.
@@ -41,7 +55,7 @@ __wt_ref_cas_state_int(WT_SESSION_IMPL *session, WT_REF *ref, uint8_t old_state,
      * above but before the history has been updated.
      */
     if (cas_result)
-        WT_REF_SAVE_STATE(ref, new_state, func, line);
+        __ref_save_state(session, ref, new_state, func, line);
 #endif
     return (cas_result);
 }
@@ -2131,7 +2145,7 @@ __wt_btree_lsm_over_size(WT_SESSION_IMPL *session, uint64_t maxsize)
         return (true);
 
     first = pindex->index[0];
-    if (first->state != WT_REF_MEM) /* no child page, ignore */
+    if (__wt_atomic_loadv8(&first->state) != WT_REF_MEM) /* no child page, ignore */
         return (false);
 
     /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -21,8 +21,8 @@ __wt_ref_is_root(WT_REF *ref)
 #ifdef HAVE_REF_TRACK
 /*
  * __ref_save_state --
- *     Save tracking data when REF_TRACK is enabled. This function wraps the WT_REF_SAVE_STATE macro
- *     so we can suppress it in our TSan ignore list.
+ *     Record the state change of a ref when REF_TRACK is enabled. This function wraps the
+ *     WT_REF_SAVE_STATE macro so we can suppress it in our TSan ignore list.
  */
 static inline void
 __ref_save_state(

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -324,7 +324,7 @@ __txn_op_delete_commit_apply_page_del_timestamp(WT_SESSION_IMPL *session, WT_REF
     txn = session->txn;
     page_del = ref->page_del;
 
-    WT_ASSERT(session, ref->state == WT_REF_LOCKED);
+    WT_ASSERT(session, __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED);
 
     if (page_del != NULL && page_del->timestamp == WT_TS_NONE) {
         page_del->timestamp = txn->commit_timestamp;

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -213,7 +213,7 @@ __wt_rec_child_modify(
      * use, there are other page states that must be considered.
      */
     for (;; __wt_yield()) {
-        switch (r->tested_ref_state = ref->state) {
+        switch (r->tested_ref_state = __wt_atomic_loadv8(&ref->state)) {
         case WT_REF_DISK:
             /* On disk, not modified by definition. */
             WT_ASSERT(session, ref->addr != NULL);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2612,7 +2612,7 @@ split:
             WT_REF_LOCK(session, ref, &previous_ref_state);
             WT_ASSERT(session, previous_ref_state == WT_REF_MEM);
         } else
-            WT_ASSERT(session, ref->state == WT_REF_LOCKED);
+            WT_ASSERT(session, __wt_atomic_loadv8(&ref->state) == WT_REF_LOCKED);
 
         /* Check the instantiated flag again in case it got cleared while we waited. */
         if (mod->instantiated) {

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -48,7 +48,7 @@ __rts_btree_walk_page_skip(
      * there's no way to get correct behavior and skipping matches the historic behavior. Note that
      * eviction is running; we must lock the WT_REF before examining the fast-delete information.
      */
-    if (ref->state == WT_REF_DELETED &&
+    if (__wt_atomic_loadv8(&ref->state) == WT_REF_DELETED &&
       WT_REF_CAS_STATE(session, ref, WT_REF_DELETED, WT_REF_LOCKED)) {
         page_del = ref->page_del;
         if (page_del == NULL ||
@@ -90,7 +90,7 @@ __rts_btree_walk_page_skip(
     }
 
     /* Otherwise, if the page state is other than on disk, we want to look at it. */
-    if (ref->state != WT_REF_DISK)
+    if (__wt_atomic_loadv8(&ref->state) != WT_REF_DISK)
         return (0);
 
     /*

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -85,7 +85,7 @@ __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
      * If there isn't a valid page, we're done. This read can race with eviction and splits, we
      * re-check it after a barrier to make sure we have a valid reference.
      */
-    current_state = ref->state;
+    current_state = __wt_atomic_loadv8(&ref->state);
     if (current_state != WT_REF_MEM) {
         *busyp = true;
         return (0);
@@ -156,7 +156,7 @@ __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *busyp
     /*
      * Check if the page state is still valid, where valid means a state of WT_REF_MEM.
      */
-    current_state = ref->state;
+    current_state = __wt_atomic_loadv8(&ref->state);
     if (current_state == WT_REF_MEM) {
         ++session->hazards.num_active;
 

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -23,3 +23,6 @@ race:__conn_open_session
 
 # __tiered_queue_peek_empty is intentionally unsafe to avoid taking the tiered lock when it's not needed.
 race:__tiered_queue_peek_empty
+
+# The ref track code is diagnostic only and allows for races
+race:__ref_save_state


### PR DESCRIPTION
Address TSan warnings for ref->state. This work was split out from the WT-12589 PR to manage PR size.