### PR TITLE
WT-12605 Fix reporting in dist scripts

### DIFF
--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -70,9 +70,8 @@ for f in "$@"; do
     cat "$f" | \
             clang-format --fallback-style=none | \
             python3 dist/s_comment.py > "$t" || exit 1
-    cmp -s "$f" "$t"
-    if test $? -ne 0; then
-        if test $# -eq 0 ; then
+    if ! cmp -s "$f" "$t"; then
+        if [[ -n "$S_RECURSE" ]] ; then
             echo "Modifying $f"
         fi
         cp "$t" "$f"

--- a/test/unittest/tests/test_acquire_release_macros.cpp
+++ b/test/unittest/tests/test_acquire_release_macros.cpp
@@ -72,8 +72,8 @@ TEST_RELEASE_TYPE(uint8_t, 1);
  */
 TEST_CASE("Demonstrate hash define int size workaround", "[acqrel]")
 {
-    /* If we don't cast this value the test won't compile. */
-    #define TEST_VALUE ((int8_t)6)
+/* If we don't cast this value the test won't compile. */
+#define TEST_VALUE ((int8_t)6)
 
     int8_t a;
     int8_t *ap = &a;


### PR DESCRIPTION
Summary of changes:
* Fixed reporting in s_clang_format. The trick is that it's getting called from other scripts like log.py to format the generated code in a temp file. s_clang_format then needs to make a distinction between an actual recursive call vs being called with a file argument.
* Fixed passing of return code from recursive call in do_in_parallel.
* Stopped automatic propagation of `S_RECURSE` down from a "recursive" call. This is useful in case a script will call other scripts.
* Fixed a formatting issue caused by not reporting changes previously. Without it, automatic commit would fail.