### PR TITLE
WT-12603 Convert chunkcache chunk valid flag to a bool

### DIFF
--- a/src/include/block_chunkcache.h
+++ b/src/include/block_chunkcache.h
@@ -59,7 +59,7 @@ struct __wt_chunkcache_chunk {
     uint8_t *chunk_memory;
     wt_off_t chunk_offset;
     size_t chunk_size;
-    wt_shared volatile uint32_t valid; /* Availability to read data from the chunk marked. */
+    wt_shared volatile bool valid; /* Availability to read data from the chunk marked. */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CHUNK_FROM_METADATA 0x1u


### PR DESCRIPTION
Updates the datatype for the `valid` flag for `__wt_chunkcache_chunk` struct to allow for some macro conversions in the future.