### PR TITLE
WT-12620 Coverity buffer management

### DIFF
--- a/bench/wtperf/wtperf_misc.c
+++ b/bench/wtperf/wtperf_misc.c
@@ -119,7 +119,6 @@ backup_read(WTPERF *wtperf, WT_SESSION *session)
     WT_DECL_RET;
     uint32_t buf_size, size, total;
     int rfd;
-    size_t len;
     ssize_t rdsize;
     char *buf;
     const char *filename;
@@ -140,9 +139,7 @@ backup_read(WTPERF *wtperf, WT_SESSION *session)
 
         rfd = -1;
         /* Open the file handle. */
-        len = strlen(wtperf->home) + strlen(filename) + 10;
-        testutil_assert(len <= WT_BACKUP_COPY_SIZE);
-        testutil_snprintf(buf, len, "%s/%s", wtperf->home, filename);
+        testutil_snprintf(buf, WT_BACKUP_COPY_SIZE, "%s/%s", wtperf->home, filename);
         error_sys_check(rfd = open(buf, O_RDONLY, 0644));
 
         /* Get the file's size. */

--- a/bench/wtperf/wtperf_misc.c
+++ b/bench/wtperf/wtperf_misc.c
@@ -134,22 +134,21 @@ backup_read(WTPERF *wtperf, WT_SESSION *session)
     if (ret != 0)
         goto err;
 
+    buf = dmalloc(WT_BACKUP_COPY_SIZE);
     while ((ret = backup_cursor->next(backup_cursor)) == 0) {
         testutil_check(backup_cursor->get_key(backup_cursor, &filename));
 
         rfd = -1;
         /* Open the file handle. */
         len = strlen(wtperf->home) + strlen(filename) + 10;
-        buf = dmalloc(len);
+        testutil_assert(len <= WT_BACKUP_COPY_SIZE);
         testutil_snprintf(buf, len, "%s/%s", wtperf->home, filename);
         error_sys_check(rfd = open(buf, O_RDONLY, 0644));
 
         /* Get the file's size. */
         testutil_check(stat(buf, &st));
         size = (uint32_t)st.st_size;
-        free(buf);
 
-        buf = dmalloc(WT_BACKUP_COPY_SIZE);
         total = 0;
         buf_size = WT_MIN(size, WT_BACKUP_COPY_SIZE);
         while (total < size) {


### PR DESCRIPTION
This is a Coverity fix. For the other ticket I moved code into one function. No need to free and reallocate the buffer all the time. Just allocate the larger size once and use it.