### PR TITLE
WT-12680 Add a log when parallel compaction is executed on the same table

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -18,12 +18,10 @@ int
 __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
 
-    if (block->compact_session_id != WT_SESSION_ID_INVALID) {
-        __wt_verbose_info(session, WT_VERB_COMPACT,
-          "Compaction already happening on data handle %s by session %" PRIu32 ", returning EBUSY.",
-          block->name, session->id);
-        return (EBUSY);
-    }
+    if (block->compact_session_id != WT_SESSION_ID_INVALID)
+        WT_RET_MSG(session, EBUSY,
+          "Compaction already happening on data handle %s by session %" PRIu32, block->name,
+          session->id);
 
     /* Switch to first-fit allocation. */
     __wt_block_configure_first_fit(block, true);

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -18,8 +18,12 @@ int
 __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
 
-    if (block->compact_session_id != WT_SESSION_ID_INVALID)
+    if (block->compact_session_id != WT_SESSION_ID_INVALID) {
+        __wt_verbose_info(session, WT_VERB_COMPACT,
+          "Compaction already happening on data handle %s by session %p, returning EBUSY.",
+          block->name, (void *)session);
         return (EBUSY);
+    }
 
     /* Switch to first-fit allocation. */
     __wt_block_configure_first_fit(block, true);

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -20,8 +20,8 @@ __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
 
     if (block->compact_session_id != WT_SESSION_ID_INVALID) {
         __wt_verbose_info(session, WT_VERB_COMPACT,
-          "Compaction already happening on data handle %s by session %p, returning EBUSY.",
-          block->name, (void *)session);
+          "Compaction already happening on data handle %s by session %" PRIu32 ", returning EBUSY.",
+          block->name, session->id);
         return (EBUSY);
     }
 


### PR DESCRIPTION
Example of output:
```
[1710901899:206528][3983514:0xffff8899a020], test_compact04.test_compact04.test_compact04, file:test_compact04-0.wt, WT_SESSION.compact: [WT_VERB_DEFAULT][ERROR]: __wt_block_compact_start, 22: Compaction already happening on data handle test_compact04-0.wt by session 15: Device or resource busy
```