### PR TITLE
WT-12685 Fix new performance Coverity issues in test/model

### DIFF
--- a/test/model/src/core/kv_database.cpp
+++ b/test/model/src/core/kv_database.cpp
@@ -245,7 +245,7 @@ kv_database::rollback_to_stable(timestamp_t timestamp, kv_transaction_snapshot_p
     std::lock_guard lock_guard1(_tables_lock);
     std::lock_guard lock_guard2(_transactions_lock);
 
-    rollback_to_stable_nolock(timestamp, snapshot);
+    rollback_to_stable_nolock(timestamp, std::move(snapshot));
 }
 
 /*

--- a/test/model/src/core/kv_table_item.cpp
+++ b/test/model/src/core/kv_table_item.cpp
@@ -46,7 +46,7 @@ void
 kv_table_item::add_update(std::shared_ptr<kv_update> update, bool must_exist, bool must_not_exist)
 {
     std::lock_guard lock_guard(_lock);
-    add_update_nolock(update, must_exist, must_not_exist);
+    add_update_nolock(std::move(update), must_exist, must_not_exist);
 }
 
 /*
@@ -219,7 +219,7 @@ kv_table_item::exists() const
 bool
 kv_table_item::exists(kv_checkpoint_ptr checkpoint) const
 {
-    return get(checkpoint) != NONE;
+    return get(std::move(checkpoint)) != NONE;
 }
 
 /*

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -358,9 +358,10 @@ debug_log_parser::metadata_apply(kv_transaction_ptr txn, const row_put &op)
             auto &ckpt_metadata_map = _txn_ckpt_metadata[txn->id()];
             auto i = ckpt_metadata_map.find(ckpt_name);
             if (i == ckpt_metadata_map.end())
-                ckpt_metadata_map[ckpt_name] = m;
+                ckpt_metadata_map[ckpt_name] = std::move(m);
             else
-                ckpt_metadata_map[ckpt_name] = config_map::merge(ckpt_metadata_map[ckpt_name], m);
+                ckpt_metadata_map[ckpt_name] =
+                  config_map::merge(ckpt_metadata_map[ckpt_name], std::move(m));
         }
 
         /* Unsupported system URI. */
@@ -409,7 +410,7 @@ debug_log_parser::metadata_checkpoint_apply(
           write_gen, k_txn_max, k_txn_max, std::vector<uint64_t>());
 
     /* Create the checkpoint. */
-    _database.create_checkpoint(name.c_str(), snapshot, stable_timestamp);
+    _database.create_checkpoint(name.c_str(), std::move(snapshot), stable_timestamp);
 }
 
 /*
@@ -433,7 +434,7 @@ debug_log_parser::apply(kv_transaction_ptr txn, const row_put &op)
     data_value value = data_value::unpack(op.value, table->value_format());
 
     /* Perform the operation. */
-    int ret = table->insert(txn, key, value);
+    int ret = table->insert(std::move(txn), key, value);
     if (ret != 0)
         throw wiredtiger_exception(ret);
 }
@@ -456,7 +457,7 @@ debug_log_parser::apply(kv_transaction_ptr txn, const row_remove &op)
     data_value key = data_value::unpack(op.key, table->key_format());
 
     /* Perform the operation. */
-    int ret = table->remove(txn, key);
+    int ret = table->remove(std::move(txn), key);
     if (ret != 0)
         throw wiredtiger_exception(ret);
 }
@@ -510,7 +511,7 @@ debug_log_parser::apply(kv_transaction_ptr txn, const row_truncate &op)
         stop = data_value::unpack(op.stop, table->key_format());
 
     /* Perform the operation. */
-    int ret = table->truncate(txn, start, stop);
+    int ret = table->truncate(std::move(txn), start, stop);
     if (ret != 0)
         throw wiredtiger_exception(ret);
 }
@@ -663,7 +664,7 @@ from_debug_log_helper(WT_SESSION_IMPL *session, WT_ITEM *rawrec, WT_LSN *lsnp, W
             }
         }
 
-        args.parser.commit_transaction(txn);
+        args.parser.commit_transaction(std::move(txn));
         break;
     }
 
@@ -814,7 +815,7 @@ debug_log_parser::from_json(kv_database &database, const char *path)
             }
 
             /* Commit/finalize the transaction. */
-            parser.commit_transaction(txn);
+            parser.commit_transaction(std::move(txn));
             continue;
         }
 

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -83,7 +83,7 @@ kv_workload_generator::kv_workload_generator(kv_workload_generator_spec spec, ui
 kv_workload_generator::sequence_traversal::sequence_traversal(
   std::deque<kv_workload_sequence_ptr> &sequences,
   std::function<bool(kv_workload_sequence &)> barrier_fn)
-    : _sequences(sequences), _barrier_fn(barrier_fn)
+    : _sequences(sequences), _barrier_fn(std::move(barrier_fn))
 {
     for (kv_workload_sequence_ptr &seq : _sequences)
         _per_sequence_state.emplace(seq.get(), new sequence_state(seq.get()));
@@ -160,7 +160,7 @@ kv_workload_generator::sequence_traversal::complete_all()
             }
         }
 
-    _runnable = new_runnable;
+    _runnable = std::move(new_runnable);
     if (_runnable.empty())
         advance_barrier();
 }

--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -353,7 +353,7 @@ kv_workload_runner_wt::do_operation(const operation::create_table &op)
     std::string uri = std::string("table:") + op.name;
     ret = session->create(session, uri.c_str(), config_str.c_str());
     if (ret == 0)
-        add_table_uri(op.table_id, uri);
+        add_table_uri(op.table_id, std::move(uri));
     return ret;
 }
 

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -868,7 +868,7 @@ struct kv_workload_operation {
      *     Create a new workload operation.
      */
     inline kv_workload_operation(operation::any &&operation, size_t seq_no = k_no_seq_no)
-        : operation(operation), seq_no(seq_no){};
+        : operation(std::move(operation)), seq_no(seq_no){};
 };
 
 /*

--- a/test/model/src/include/model/driver/kv_workload_runner.h
+++ b/test/model/src/include/model/driver/kv_workload_runner.h
@@ -144,7 +144,7 @@ protected:
     {
         kv_table_ptr table = _database.create_table(op.name);
         table->set_key_value_format(op.key_format, op.value_format);
-        add_table(op.table_id, table);
+        add_table(op.table_id, std::move(table));
         return 0;
     }
 

--- a/test/model/src/include/model/kv_checkpoint.h
+++ b/test/model/src/include/model/kv_checkpoint.h
@@ -48,7 +48,7 @@ public:
      */
     inline kv_checkpoint(
       const char *name, kv_transaction_snapshot_ptr snapshot, timestamp_t stable_timestamp) noexcept
-        : _name(name), _snapshot(snapshot), _stable_timestamp(stable_timestamp)
+        : _name(name), _snapshot(std::move(snapshot)), _stable_timestamp(stable_timestamp)
     {
     }
 

--- a/test/model/src/include/model/kv_table.h
+++ b/test/model/src/include/model/kv_table.h
@@ -291,7 +291,7 @@ public:
     inline void
     verify(WT_CONNECTION *connection, kv_checkpoint_ptr ckpt = kv_checkpoint_ptr(nullptr))
     {
-        kv_table_verifier(*this).verify(connection, ckpt);
+        kv_table_verifier(*this).verify(connection, std::move(ckpt));
     }
 
     /*
@@ -303,7 +303,7 @@ public:
     verify_noexcept(
       WT_CONNECTION *connection, kv_checkpoint_ptr ckpt = kv_checkpoint_ptr(nullptr)) noexcept
     {
-        return kv_table_verifier(*this).verify_noexcept(connection, ckpt);
+        return kv_table_verifier(*this).verify_noexcept(connection, std::move(ckpt));
     }
 
     /*

--- a/test/model/src/include/model/kv_table_item.h
+++ b/test/model/src/include/model/kv_table_item.h
@@ -103,7 +103,7 @@ public:
     inline bool
     exists_opt(kv_checkpoint_ptr checkpoint) const
     {
-        return checkpoint ? exists(checkpoint) : exists();
+        return checkpoint ? exists(std::move(checkpoint)) : exists();
     }
 
     /*

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -73,7 +73,7 @@ public:
      */
     inline kv_transaction_snapshot_by_exclusion(
       txn_id_t exclude_after, std::unordered_set<txn_id_t> &&exclude_ids)
-        : _exclude_after(exclude_after), _exclude_ids(exclude_ids)
+        : _exclude_after(exclude_after), _exclude_ids(std::move(exclude_ids))
     {
     }
 

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -146,7 +146,8 @@ public:
     inline kv_transaction_guard(kv_transaction_ptr txn,
       timestamp_t commit_timestamp = k_timestamp_none,
       timestamp_t durable_timestamp = k_timestamp_none) noexcept
-        : _txn(txn), _commit_timestamp(commit_timestamp), _durable_timestamp(durable_timestamp){};
+        : _txn(std::move(txn)), _commit_timestamp(commit_timestamp),
+          _durable_timestamp(durable_timestamp){};
 
     /*
      * kv_transaction_guard::~kv_transaction_guard --
@@ -416,7 +417,7 @@ public:
      * at_cleanup::at_cleanup --
      *     Create the cleanup object.
      */
-    inline at_cleanup(std::function<void()> fn) : _fn(fn){};
+    inline at_cleanup(std::function<void()> fn) : _fn(std::move(fn)){};
 
     /* Delete the copy constructor. */
     at_cleanup(const at_cleanup &) = delete;

--- a/test/model/src/include/model/verify.h
+++ b/test/model/src/include/model/verify.h
@@ -84,7 +84,7 @@ public:
     {
         if (_iterator != _data.begin())
             throw model_exception("The cursor is not at the beginning");
-        _ckpt = ckpt;
+        _ckpt = std::move(ckpt);
     }
 
     /*
@@ -136,7 +136,7 @@ public:
       WT_CONNECTION *connection, kv_checkpoint_ptr ckpt = kv_checkpoint_ptr(nullptr)) noexcept
     {
         try {
-            verify(connection, ckpt);
+            verify(connection, std::move(ckpt));
         } catch (...) {
             return false;
         }

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -303,7 +303,7 @@ reduce_counterexample(std::shared_ptr<model::kv_workload> workload, const std::s
                 *seq.get() << op.operation;
                 op.seq_no = seq->seq_no();
                 sequences.push_back(seq);
-                txn_to_sequence[txn_id] = seq;
+                txn_to_sequence[txn_id] = std::move(seq);
             } else {
                 /* Existing transactions. */
                 auto itr = txn_to_sequence.find(txn_id);
@@ -325,7 +325,7 @@ reduce_counterexample(std::shared_ptr<model::kv_workload> workload, const std::s
               std::make_shared<model::kv_workload_sequence>(sequences.size());
             *seq.get() << op.operation;
             op.seq_no = seq->seq_no();
-            sequences.push_back(seq);
+            sequences.push_back(std::move(seq));
 
             /* Operations that clear the transaction state. */
             if (std::holds_alternative<model::operation::crash>(op.operation) ||


### PR DESCRIPTION
Fix new performance-related Coverity issues in the model, all of which are due to copying values when they could be moved via `std::move()`. These are all instances of Coverity's rule `COPY_INSTEAD_OF_MOVE`.