### PR TITLE
WT-10967 Rewrite the "wiredtiger memory model" comment in gcc.h

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -157,6 +157,7 @@ Fsync
 Fuerst
 GBR
 GC
+GCC's
 GCP
 GCP's
 GF
@@ -244,6 +245,7 @@ MacOS
 MapViewOfFile
 Marsaglia
 Marsaglia's
+McKenney
 Mellor
 Mitzenmacher
 MongoDB
@@ -323,6 +325,7 @@ RETRYABLE
 RHEL
 RLE
 RLEs
+RMW
 RNG
 RNGs
 RPC
@@ -1166,6 +1169,7 @@ reentrant
 refp
 regionp
 relocked
+reorderings
 repl
 repositioned
 repositions

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -157,7 +157,6 @@ Fsync
 Fuerst
 GBR
 GC
-GCC's
 GCP
 GCP's
 GF

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -43,8 +43,6 @@
  * same location simultaneously, the result must be one of the two values, not some combination of
  * both.
  *
- * # Multi copy atomicity #
- *
  * # No Aggregated Writes of Adjacent Memory Locations #
  * To reduce memory requirements, WiredTiger may use a 32-bit type on 64-bit machines, which is OK
  * if the compiler doesn't turn a 32-bit load/store into a 64-bit load/store, where the 64 bits


### PR DESCRIPTION
This comment aims to describe wiredtiger's memory model. It is an adaption and additional to what Chenhao wrote in a PM-3220 document in the past.

This PR isn't urgent and is a lot to review. So please take your time reviewing it.