### PR TITLE
WT-12514 Move eviction target modifications into their own functions to suppress tsan warnings more granularly

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1165,18 +1165,6 @@ err:
 }
 
 /*
- * __conn_ramp_eviction_targets --
- *     Ramp the eviction dirty target down to encourage eviction threads to clear dirty content out
- *     of cache.
- */
-static inline void
-__conn_ramp_eviction_targets(WT_CONNECTION_IMPL *conn)
-{
-    conn->cache->eviction_dirty_trigger = 1.0;
-    conn->cache->eviction_dirty_target = 0.1;
-}
-
-/*
  * __conn_close --
  *     WT_CONNECTION->close method.
  */
@@ -1195,7 +1183,13 @@ __conn_close(WT_CONNECTION *wt_conn, const char *config)
 err:
 
     __wt_timer_start(session, &timer);
-    __conn_ramp_eviction_targets(conn);
+
+    /*
+     * Ramp the eviction dirty target down to encourage eviction threads to clear dirty content out
+     * of cache.
+     */
+    __wt_set_shared_double(&conn->cache->eviction_dirty_trigger, 1.0);
+    __wt_set_shared_double(&conn->cache->eviction_dirty_target, 0.1);
 
     if (conn->default_session->event_handler->handle_general != NULL &&
       F_ISSET(conn, WT_CONN_MINIMAL | WT_CONN_READY))

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1165,6 +1165,18 @@ err:
 }
 
 /*
+ * __conn_ramp_eviction_targets --
+ *     Ramp the eviction dirty target down to encourage eviction threads to clear dirty content out
+ *     of cache.
+ */
+static inline void
+__conn_ramp_eviction_targets(WT_CONNECTION_IMPL *conn)
+{
+    conn->cache->eviction_dirty_trigger = 1.0;
+    conn->cache->eviction_dirty_target = 0.1;
+}
+
+/*
  * __conn_close --
  *     WT_CONNECTION->close method.
  */
@@ -1183,13 +1195,7 @@ __conn_close(WT_CONNECTION *wt_conn, const char *config)
 err:
 
     __wt_timer_start(session, &timer);
-
-    /*
-     * Ramp the eviction dirty target down to encourage eviction threads to clear dirty content out
-     * of cache.
-     */
-    conn->cache->eviction_dirty_trigger = 1.0;
-    conn->cache->eviction_dirty_target = 0.1;
+    __conn_ramp_eviction_targets(conn);
 
     if (conn->default_session->event_handler->handle_general != NULL &&
       F_ISSET(conn, WT_CONN_MINIMAL | WT_CONN_READY))

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -122,16 +122,15 @@ struct __wt_cache {
      * Eviction threshold percentages use double type to allow for specifying percentages less than
      * one.
      */
-    double eviction_dirty_target;    /* Percent to allow dirty */
-    double eviction_dirty_trigger;   /* Percent to trigger dirty eviction */
-    double eviction_trigger;         /* Percent to trigger eviction */
-    double eviction_target;          /* Percent to end eviction */
-    double eviction_updates_target;  /* Percent to allow for updates */
-    double eviction_updates_trigger; /* Percent of updates to trigger eviction */
+    wt_shared double eviction_dirty_target;  /* Percent to allow dirty */
+    wt_shared double eviction_dirty_trigger; /* Percent to trigger dirty eviction */
+    double eviction_trigger;                 /* Percent to trigger eviction */
+    double eviction_target;                  /* Percent to end eviction */
+    double eviction_updates_target;          /* Percent to allow for updates */
+    double eviction_updates_trigger;         /* Percent of updates to trigger eviction */
 
-    double eviction_checkpoint_target; /* Percent to reduce dirty
-                                        to during checkpoint scrubs */
-    double eviction_scrub_target;      /* Current scrub target */
+    double eviction_checkpoint_target;       /* Percent to reduce dirty to during checkpoint scrubs */
+    wt_shared double eviction_scrub_target;  /* Current scrub target */
 
     u_int overhead_pct;              /* Cache percent adjustment */
     uint64_t cache_max_wait_us;      /* Maximum time an operation waits for space in cache */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -129,8 +129,8 @@ struct __wt_cache {
     double eviction_updates_target;          /* Percent to allow for updates */
     double eviction_updates_trigger;         /* Percent of updates to trigger eviction */
 
-    double eviction_checkpoint_target;       /* Percent to reduce dirty to during checkpoint scrubs */
-    wt_shared double eviction_scrub_target;  /* Current scrub target */
+    double eviction_checkpoint_target; /* Percent to reduce dirty to during checkpoint scrubs */
+    wt_shared double eviction_scrub_target; /* Current scrub target */
 
     u_int overhead_pct;              /* Cache percent adjustment */
     uint64_t cache_max_wait_us;      /* Maximum time an operation waits for space in cache */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2605,6 +2605,7 @@ static WT_INLINE void __wt_row_leaf_value_set(WT_ROW *rip, WT_CELL_UNPACK_KV *un
 static WT_INLINE void __wt_scr_free(WT_SESSION_IMPL *session, WT_ITEM **bufp);
 static WT_INLINE void __wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp);
 static WT_INLINE void __wt_seconds32(WT_SESSION_IMPL *session, uint32_t *secondsp);
+static WT_INLINE void __wt_set_shared_double(double *to_set, double value);
 static WT_INLINE void __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs);
 static WT_INLINE void __wt_spin_destroy(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static WT_INLINE void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -296,6 +296,16 @@ __wt_failpoint(WT_SESSION_IMPL *session, uint64_t conn_flag, u_int probability)
 }
 
 /*
+ * __wt_set_shared_double --
+ *     This function enables suppressing TSan warnings about setting doubles in a shared context.
+ */
+static WT_INLINE void
+__wt_set_shared_double(double *to_set, double value)
+{
+    *to_set = value;
+}
+
+/*
  * The hardware-accelerated checksum code that originally shipped on Windows did not correctly
  * handle memory that wasn't 8B aligned and a multiple of 8B. It's likely that calculations were
  * always 8B aligned, but there's some risk.

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -531,7 +531,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
  * __checkpoint_set_scrub_target --
  *     Set the scrub target for the checkpoint.
  */
-static inline void
+static WT_INLINE void
 __checkpoint_set_scrub_target(WT_SESSION_IMPL *session, double target)
 {
     __wt_set_shared_double(&S2C(session)->cache->eviction_scrub_target, target);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -534,7 +534,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 static inline void
 __checkpoint_set_scrub_target(WT_SESSION_IMPL *session, double target)
 {
-    S2C(session)->cache->eviction_scrub_target = target;
+    __wt_set_shared_double(&S2C(session)->cache->eviction_scrub_target, target);
     WT_STAT_CONN_SET(session, checkpoint_scrub_target, (int64_t)target);
 }
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -528,6 +528,17 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
+ * __checkpoint_set_scrub_target --
+ *     Set the scrub target for the checkpoint.
+ */
+static inline void
+__checkpoint_set_scrub_target(WT_SESSION_IMPL *session, double target)
+{
+    S2C(session)->cache->eviction_scrub_target = target;
+    WT_STAT_CONN_SET(session, checkpoint_scrub_target, (int64_t)target);
+}
+
+/*
  * __checkpoint_wait_reduce_dirty_cache --
  *     Try to reduce the amount of dirty data in cache so there is less work do during the critical
  *     section of the checkpoint.
@@ -566,8 +577,7 @@ __checkpoint_wait_reduce_dirty_cache(WT_SESSION_IMPL *session)
     max_write = __wt_cache_dirty_leaf_inuse(cache);
 
     /* Set the dirty trigger to the target value. */
-    cache->eviction_scrub_target = cache->eviction_checkpoint_target;
-    WT_STAT_CONN_SET(session, checkpoint_scrub_target, (int64_t)cache->eviction_scrub_target);
+    __checkpoint_set_scrub_target(session, cache->eviction_checkpoint_target);
 
     /* Wait while the dirty level is going down. */
     for (;;) {
@@ -1242,8 +1252,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
      * Unblock updates -- we can figure out that any updates to clean pages after this point are too
      * new to be written in the checkpoint.
      */
-    cache->eviction_scrub_target = 0.0;
-    WT_STAT_CONN_SET(session, checkpoint_scrub_target, 0);
+    __checkpoint_set_scrub_target(session, 0.0);
 
     /* Tell logging that we have started a database checkpoint. */
     if (full && logging) {
@@ -1480,8 +1489,7 @@ err:
     if (tracking)
         WT_TRET(__wt_meta_track_off(session, false, failed));
 
-    cache->eviction_scrub_target = 0.0;
-    WT_STAT_CONN_SET(session, checkpoint_scrub_target, 0);
+    __checkpoint_set_scrub_target(session, 0.0);
 
     if (F_ISSET(txn, WT_TXN_RUNNING)) {
         /*

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -5,10 +5,8 @@
 # FIXME-WT-12512 TSan is raising warnings about mutexes that are non-intuitive. These will be investigated separately.
 mutex:src
 
-# These function modifh eviction targets concurrently. We can't do floats atomically so we'll just
-# ignore it.
-race:__conn_ramp_eviction_targets
-race:__checkpoint_set_scrub_target
+# This function enables threads to set double values in a shared context, and catches all TSan warnings.
+race:__wt_set_shared_double
 
 # Stats are allowed to be fuzzy. Ignore races in TSan
 race:src/include/stat.h

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -5,10 +5,10 @@
 # FIXME-WT-12512 TSan is raising warnings about mutexes that are non-intuitive. These will be investigated separately.
 mutex:src
 
-# FIXME-WT-12514 Some of our shared variables are floats or doubles which can't be accessed using atomic instrinsics.
-race:__wt_eviction_dirty_target
-race:__wt_eviction_dirty_needed
-race:__evict_update_work
+# These function modifh eviction targets concurrently. We can't do floats atomically so we'll just
+# ignore it.
+race:__conn_ramp_eviction_targets
+race:__checkpoint_set_scrub_target
 
 # Stats are allowed to be fuzzy. Ignore races in TSan
 race:src/include/stat.h


### PR DESCRIPTION
In doing so we don't have to suppress whole functions like `__conn_close`.