### PR TITLE
WT-12701 Add ex_encrypt to examples-c-tsan

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -532,7 +532,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
 
     btree->modified = false; /* Clean */
 
-    btree->syncing = WT_BTREE_SYNC_OFF;                           /* Not syncing */
+    __wt_atomic_store_enum(&btree->syncing, WT_BTREE_SYNC_OFF);   /* Not syncing */
     btree->checkpoint_gen = __wt_gen(session, WT_GEN_CHECKPOINT); /* Checkpoint generation */
 
     /*

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -42,7 +42,7 @@ __wt_btree_stat_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
 
     WT_STAT_SET(session, stats, cache_bytes_dirty, __wt_btree_dirty_inuse(session));
     WT_STAT_SET(session, stats, cache_bytes_dirty_total,
-      __wt_cache_bytes_plus_overhead(S2C(session)->cache, btree->bytes_dirty_total));
+      __wt_cache_bytes_plus_overhead(S2C(session)->cache, &btree->bytes_dirty_total));
     WT_STAT_SET(session, stats, cache_bytes_inuse, __wt_btree_bytes_inuse(session));
 
     WT_STAT_SET(session, stats, compress_precomp_leaf_max_page_size, btree->maxleafpage_precomp);

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -42,7 +42,8 @@ __wt_btree_stat_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
 
     WT_STAT_SET(session, stats, cache_bytes_dirty, __wt_btree_dirty_inuse(session));
     WT_STAT_SET(session, stats, cache_bytes_dirty_total,
-      __wt_cache_bytes_plus_overhead(S2C(session)->cache, &btree->bytes_dirty_total));
+      __wt_cache_bytes_plus_overhead(
+        S2C(session)->cache, __wt_atomic_load64(&btree->bytes_dirty_total)));
     WT_STAT_SET(session, stats, cache_bytes_inuse, __wt_btree_bytes_inuse(session));
 
     WT_STAT_SET(session, stats, compress_precomp_leaf_max_page_size, btree->maxleafpage_precomp);

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -335,7 +335,8 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(session, stats, cache_eviction_aggressive_set, cache->evict_aggressive_score);
     WT_STAT_SET(session, stats, cache_eviction_empty_score, cache->evict_empty_score);
 
-    WT_STAT_SET(session, stats, cache_eviction_active_workers, conn->evict_threads.current_threads);
+    WT_STAT_SET(session, stats, cache_eviction_active_workers,
+      __wt_atomic_load32(&conn->evict_threads.current_threads));
     WT_STAT_SET(
       session, stats, cache_eviction_stable_state_workers, cache->evict_tune_workers_best);
 

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -301,7 +301,7 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     stats = conn->stats;
 
     inuse = __wt_cache_bytes_inuse(cache);
-    intl = __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_internal));
+    intl = __wt_cache_bytes_plus_overhead(cache, &cache->bytes_internal);
     /*
      * There are races updating the different cache tracking values so be paranoid calculating the
      * leaf byte usage.
@@ -314,9 +314,9 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
 
     WT_STAT_SET(session, stats, cache_bytes_dirty, __wt_cache_dirty_inuse(cache));
     WT_STAT_SET(session, stats, cache_bytes_dirty_total,
-      __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_dirty_total)));
-    WT_STAT_SET(session, stats, cache_bytes_hs,
-      __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_hs)));
+      __wt_cache_bytes_plus_overhead(cache, &cache->bytes_dirty_total));
+    WT_STAT_SET(
+      session, stats, cache_bytes_hs, __wt_cache_bytes_plus_overhead(cache, &cache->bytes_hs));
     WT_STAT_SET(session, stats, cache_bytes_image, __wt_cache_bytes_image(cache));
     WT_STAT_SET(session, stats, cache_pages_inuse, __wt_cache_pages_inuse(cache));
     WT_STAT_SET(session, stats, cache_bytes_internal, intl);

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -301,7 +301,7 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     stats = conn->stats;
 
     inuse = __wt_cache_bytes_inuse(cache);
-    intl = __wt_cache_bytes_plus_overhead(cache, &cache->bytes_internal);
+    intl = __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_internal));
     /*
      * There are races updating the different cache tracking values so be paranoid calculating the
      * leaf byte usage.
@@ -314,9 +314,9 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
 
     WT_STAT_SET(session, stats, cache_bytes_dirty, __wt_cache_dirty_inuse(cache));
     WT_STAT_SET(session, stats, cache_bytes_dirty_total,
-      __wt_cache_bytes_plus_overhead(cache, &cache->bytes_dirty_total));
-    WT_STAT_SET(
-      session, stats, cache_bytes_hs, __wt_cache_bytes_plus_overhead(cache, &cache->bytes_hs));
+      __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_dirty_total)));
+    WT_STAT_SET(session, stats, cache_bytes_hs,
+      __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_hs)));
     WT_STAT_SET(session, stats, cache_bytes_image, __wt_cache_bytes_image(cache));
     WT_STAT_SET(session, stats, cache_pages_inuse, __wt_cache_pages_inuse(cache));
     WT_STAT_SET(session, stats, cache_bytes_internal, intl);

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -639,7 +639,8 @@ __log_file_server(void *arg)
                  */
                 if (conn->hot_backup_start == 0 && conn->log_cursors == 0) {
                     WT_WITH_HOTBACKUP_READ_LOCK(session,
-                      ret = __wt_ftruncate(session, close_fh, close_end_lsn.l.offset), NULL);
+                      ret = __wt_ftruncate(session, close_fh, __wt_lsn_offset(&close_end_lsn)),
+                      NULL);
                     WT_ERR_ERROR_OK(ret, ENOTSUP, false);
                 }
                 WT_SET_LSN(&close_end_lsn, close_end_lsn.l.file + 1, 0);
@@ -679,7 +680,7 @@ typedef struct {
 #define WT_WRLSN_ENTRY_CMP_LT(entry1, entry2)        \
     ((entry1).lsn.l.file < (entry2).lsn.l.file ||    \
       ((entry1).lsn.l.file == (entry2).lsn.l.file && \
-        (entry1).lsn.l.offset < (entry2).lsn.l.offset))
+        __wt_lsn_offset(&(entry1).lsn) < __wt_lsn_offset(&(entry2).lsn)))
 
 /*
  * __wt_log_wrlsn --
@@ -785,8 +786,8 @@ restart:
                  * so that the checkpoint LSN is close to the end of the record.
                  */
                 slot_last_offset = (uint32_t)__wt_atomic_loadiv64(&slot->slot_last_offset);
-                if (slot->slot_start_lsn.l.offset != slot_last_offset)
-                    slot->slot_start_lsn.l.offset = slot_last_offset;
+                if (__wt_lsn_offset(&slot->slot_start_lsn) != slot_last_offset)
+                    __wt_atomic_add32(&slot->slot_start_lsn.l.offset, slot_last_offset);
                 WT_ASSIGN_LSN(&log->write_start_lsn, &slot->slot_start_lsn);
                 WT_ASSIGN_LSN(&log->write_lsn, &slot->slot_end_lsn);
                 __wt_cond_signal(session, log->log_write_cond);

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -787,7 +787,7 @@ restart:
                  */
                 slot_last_offset = (uint32_t)__wt_atomic_loadiv64(&slot->slot_last_offset);
                 if (__wt_lsn_offset(&slot->slot_start_lsn) != slot_last_offset)
-                    __wt_atomic_add32(&slot->slot_start_lsn.l.offset, slot_last_offset);
+                    __wt_atomic_store32(&slot->slot_start_lsn.l.offset, slot_last_offset);
                 WT_ASSIGN_LSN(&log->write_start_lsn, &slot->slot_start_lsn);
                 WT_ASSIGN_LSN(&log->write_lsn, &slot->slot_end_lsn);
                 __wt_cond_signal(session, log->log_write_cond);

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -180,7 +180,7 @@ __curlog_kv(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
      * The log cursor sets the LSN and step count as the cursor key and log record related data in
      * the value. The data in the value contains any operation key/value that was in the log record.
      */
-    __wt_cursor_set_key(cursor, cl->cur_lsn->l.file, cl->cur_lsn->l.offset, key_count);
+    __wt_cursor_set_key(cursor, cl->cur_lsn->l.file, __wt_lsn_offset(cl->cur_lsn), key_count);
     __wt_cursor_set_value(cursor, cl->txnid, cl->rectype, optype, fileid, cl->opkey, cl->opvalue);
 
 err:

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1466,7 +1466,7 @@ __evict_walk(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue)
      */
     total_candidates = (u_int)(F_ISSET(cache, WT_CACHE_EVICT_CLEAN | WT_CACHE_EVICT_UPDATES) ?
         __wt_cache_pages_inuse(cache) :
-        cache->pages_dirty_leaf);
+        __wt_atomic_load64(&cache->pages_dirty_leaf));
     max_entries = WT_MIN(max_entries, 1 + total_candidates / 2);
 
 retry:
@@ -2844,7 +2844,7 @@ __wt_verbose_dump_cache(WT_SESSION_IMPL *session)
     /*
      * Apply the overhead percentage so our total bytes are comparable with the tracked value.
      */
-    total_bytes = __wt_cache_bytes_plus_overhead(conn->cache, total_bytes);
+    total_bytes = __wt_cache_bytes_plus_overhead(conn->cache, &total_bytes);
     cache_bytes_updates = __wt_cache_bytes_updates(cache);
 
     bytes_inmem = __wt_atomic_load64(&cache->bytes_inmem);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2846,7 +2846,7 @@ __wt_verbose_dump_cache(WT_SESSION_IMPL *session)
     /*
      * Apply the overhead percentage so our total bytes are comparable with the tracked value.
      */
-    total_bytes = __wt_cache_bytes_plus_overhead(conn->cache, &total_bytes);
+    total_bytes = __wt_cache_bytes_plus_overhead(conn->cache, total_bytes);
     cache_bytes_updates = __wt_cache_bytes_updates(cache);
 
     bytes_inmem = __wt_atomic_load64(&cache->bytes_inmem);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -20,7 +20,7 @@ static void __evict_tune_workers(WT_SESSION_IMPL *session);
 static int __evict_walk(WT_SESSION_IMPL *, WT_EVICT_QUEUE *);
 static int __evict_walk_tree(WT_SESSION_IMPL *, WT_EVICT_QUEUE *, u_int, u_int *);
 
-#define WT_EVICT_HAS_WORKERS(s) (S2C(s)->evict_threads.current_threads > 1)
+#define WT_EVICT_HAS_WORKERS(s) (__wt_atomic_load32(&S2C(s)->evict_threads.current_threads) > 1)
 
 /*
  * __evict_lock_handle_list --
@@ -1033,6 +1033,7 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
     WT_CONNECTION_IMPL *conn;
     uint64_t delta_msec, delta_pages;
     uint64_t eviction_progress, eviction_progress_rate, time_diff;
+    uint32_t current_threads;
     int32_t cur_threads, i, target_threads, thread_surplus;
 
     conn = S2C(session);
@@ -1066,8 +1067,8 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
         cache->evict_tune_progress_rate_max = 0;
 
         /* Reduce the number of eviction workers by one */
-        thread_surplus =
-          (int32_t)conn->evict_threads.current_threads - (int32_t)conn->evict_threads_min;
+        thread_surplus = (int32_t)__wt_atomic_load32(&conn->evict_threads.current_threads) -
+          (int32_t)conn->evict_threads_min;
 
         if (thread_surplus > 0) {
             __wt_thread_group_stop_one(session, &conn->evict_threads);
@@ -1107,7 +1108,7 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
      */
     if (eviction_progress_rate > cache->evict_tune_progress_rate_max) {
         cache->evict_tune_progress_rate_max = eviction_progress_rate;
-        cache->evict_tune_workers_best = conn->evict_threads.current_threads;
+        cache->evict_tune_workers_best = __wt_atomic_load32(&conn->evict_threads.current_threads);
     }
 
     /*
@@ -1118,19 +1119,20 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
      * back to the best observed number of workers and settle into a stable state.
      */
     if (cache->evict_tune_num_points >= cache->evict_tune_datapts_needed) {
-        if (cache->evict_tune_workers_best == conn->evict_threads.current_threads &&
-          conn->evict_threads.current_threads < conn->evict_threads_max) {
+        current_threads = __wt_atomic_load32(&conn->evict_threads.current_threads);
+        if (cache->evict_tune_workers_best == current_threads &&
+          current_threads < conn->evict_threads_max) {
             /*
              * Keep adding workers. We will check again at the next check point.
              */
             cache->evict_tune_datapts_needed += WT_MIN(EVICT_TUNE_DATAPT_MIN,
-              (conn->evict_threads_max - conn->evict_threads.current_threads) / EVICT_TUNE_BATCH);
+              (conn->evict_threads_max - current_threads) / EVICT_TUNE_BATCH);
         } else {
             /*
              * We are past the inflection point. Choose the best number of eviction workers observed
              * and settle into a stable state.
              */
-            thread_surplus = (int32_t)conn->evict_threads.current_threads -
+            thread_surplus = (int32_t)__wt_atomic_load32(&conn->evict_threads.current_threads) -
               (int32_t)cache->evict_tune_workers_best;
 
             for (i = 0; i < thread_surplus; i++) {
@@ -1151,7 +1153,7 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
         cache->evict_tune_datapts_needed = EVICT_TUNE_DATAPT_MIN;
 
     if (F_ISSET(cache, WT_CACHE_EVICT_ALL)) {
-        cur_threads = (int32_t)conn->evict_threads.current_threads;
+        cur_threads = (int32_t)__wt_atomic_load32(&conn->evict_threads.current_threads);
         target_threads = WT_MIN(cur_threads + EVICT_TUNE_BATCH, (int32_t)conn->evict_threads_max);
         /*
          * Start the new threads.

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -179,7 +179,7 @@ struct __wt_btree {
 
     wt_shared uint64_t checkpoint_gen; /* Checkpoint generation */
     WT_SESSION_IMPL *sync_session;     /* Syncing session */
-    WT_BTREE_SYNC syncing;             /* Sync status */
+    wt_shared WT_BTREE_SYNC syncing;   /* Sync status */
 
 /*
  * Helper macros: WT_BTREE_SYNCING indicates if a sync is active (either waiting to start or already
@@ -188,10 +188,11 @@ struct __wt_btree {
  * WT_SESSION_BTREE_SYNC_SAFE checks whether it is safe to perform an operation that would conflict
  * with a sync.
  */
-#define WT_BTREE_SYNCING(btree) ((btree)->syncing != WT_BTREE_SYNC_OFF)
+#define WT_BTREE_SYNCING(btree) (__wt_atomic_load_enum(&(btree)->syncing) != WT_BTREE_SYNC_OFF)
 #define WT_SESSION_BTREE_SYNC(session) (S2BT(session)->sync_session == (session))
-#define WT_SESSION_BTREE_SYNC_SAFE(session, btree) \
-    ((btree)->syncing != WT_BTREE_SYNC_RUNNING || (btree)->sync_session == (session))
+#define WT_SESSION_BTREE_SYNC_SAFE(session, btree)                        \
+    (__wt_atomic_load_enum(&(btree)->syncing) != WT_BTREE_SYNC_RUNNING || \
+      (btree)->sync_session == (session))
 
     wt_shared uint64_t bytes_dirty_intl;  /* Bytes in dirty internal pages. */
     wt_shared uint64_t bytes_dirty_leaf;  /* Bytes in dirty leaf pages. */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -176,7 +176,7 @@ __wt_btree_bytes_inuse(WT_SESSION_IMPL *session)
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
-    return (__wt_cache_bytes_plus_overhead(cache, &btree->bytes_inmem));
+    return (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&btree->bytes_inmem)));
 }
 
 /*
@@ -200,8 +200,7 @@ __wt_btree_bytes_evictable(WT_SESSION_IMPL *session)
     bytes_root = root_page == NULL ? 0 : root_page->memory_footprint;
     evictable_bytes = bytes_inmem - bytes_root;
 
-    return (
-      bytes_inmem <= bytes_root ? 0 : __wt_cache_bytes_plus_overhead(cache, &evictable_bytes));
+    return (bytes_inmem <= bytes_root ? 0 : __wt_cache_bytes_plus_overhead(cache, evictable_bytes));
 }
 
 /*
@@ -220,7 +219,7 @@ __wt_btree_dirty_inuse(WT_SESSION_IMPL *session)
 
     dirty_inuse =
       __wt_atomic_load64(&btree->bytes_dirty_intl) + __wt_atomic_load64(&btree->bytes_dirty_leaf);
-    return (__wt_cache_bytes_plus_overhead(cache, &dirty_inuse));
+    return (__wt_cache_bytes_plus_overhead(cache, dirty_inuse));
 }
 
 /*
@@ -236,7 +235,7 @@ __wt_btree_dirty_leaf_inuse(WT_SESSION_IMPL *session)
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
-    return (__wt_cache_bytes_plus_overhead(cache, &btree->bytes_dirty_leaf));
+    return (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&btree->bytes_dirty_leaf)));
 }
 
 /*
@@ -252,7 +251,7 @@ __wt_btree_bytes_updates(WT_SESSION_IMPL *session)
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
-    return (__wt_cache_bytes_plus_overhead(cache, &btree->bytes_updates));
+    return (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&btree->bytes_updates)));
 }
 
 /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -176,7 +176,7 @@ __wt_btree_bytes_inuse(WT_SESSION_IMPL *session)
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
-    return (__wt_cache_bytes_plus_overhead(cache, btree->bytes_inmem));
+    return (__wt_cache_bytes_plus_overhead(cache, &btree->bytes_inmem));
 }
 
 /*
@@ -190,17 +190,18 @@ __wt_btree_bytes_evictable(WT_SESSION_IMPL *session)
     WT_CACHE *cache;
     WT_PAGE *root_page;
     uint64_t bytes_inmem, bytes_root;
+    uint64_t evictable_bytes;
 
     btree = S2BT(session);
     cache = S2C(session)->cache;
     root_page = btree->root.page;
 
-    bytes_inmem = btree->bytes_inmem;
+    bytes_inmem = __wt_atomic_load64(&btree->bytes_inmem);
     bytes_root = root_page == NULL ? 0 : root_page->memory_footprint;
+    evictable_bytes = bytes_inmem - bytes_root;
 
-    return (bytes_inmem <= bytes_root ?
-        0 :
-        __wt_cache_bytes_plus_overhead(cache, bytes_inmem - bytes_root));
+    return (
+      bytes_inmem <= bytes_root ? 0 : __wt_cache_bytes_plus_overhead(cache, &evictable_bytes));
 }
 
 /*
@@ -212,12 +213,14 @@ __wt_btree_dirty_inuse(WT_SESSION_IMPL *session)
 {
     WT_BTREE *btree;
     WT_CACHE *cache;
+    uint64_t dirty_inuse;
 
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
-    return (
-      __wt_cache_bytes_plus_overhead(cache, btree->bytes_dirty_intl + btree->bytes_dirty_leaf));
+    dirty_inuse =
+      __wt_atomic_load64(&btree->bytes_dirty_intl) + __wt_atomic_load64(&btree->bytes_dirty_leaf);
+    return (__wt_cache_bytes_plus_overhead(cache, &dirty_inuse));
 }
 
 /*
@@ -233,7 +236,7 @@ __wt_btree_dirty_leaf_inuse(WT_SESSION_IMPL *session)
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
-    return (__wt_cache_bytes_plus_overhead(cache, btree->bytes_dirty_leaf));
+    return (__wt_cache_bytes_plus_overhead(cache, &btree->bytes_dirty_leaf));
 }
 
 /*
@@ -249,7 +252,7 @@ __wt_btree_bytes_updates(WT_SESSION_IMPL *session)
     btree = S2BT(session);
     cache = S2C(session)->cache;
 
-    return (__wt_cache_bytes_plus_overhead(cache, btree->bytes_updates));
+    return (__wt_cache_bytes_plus_overhead(cache, &btree->bytes_updates));
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2512,7 +2512,7 @@ static WT_INLINE uint64_t __wt_cache_bytes_inuse(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_bytes_other(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE uint64_t __wt_cache_bytes_plus_overhead(WT_CACHE *cache, uint64_t *sz)
+static WT_INLINE uint64_t __wt_cache_bytes_plus_overhead(WT_CACHE *cache, uint64_t sz)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_bytes_updates(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2512,7 +2512,7 @@ static WT_INLINE uint64_t __wt_cache_bytes_inuse(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_bytes_other(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE uint64_t __wt_cache_bytes_plus_overhead(WT_CACHE *cache, uint64_t sz)
+static WT_INLINE uint64_t __wt_cache_bytes_plus_overhead(WT_CACHE *cache, uint64_t *sz)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_bytes_updates(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2494,6 +2494,8 @@ static WT_INLINE u_int __wt_cell_type_raw(WT_CELL *cell)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE u_int __wt_skip_choose_depth(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE uint32_t __wt_lsn_offset(WT_LSN *lsn)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_btree_bytes_evictable(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_btree_bytes_inuse(WT_SESSION_IMPL *session)

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -227,6 +227,8 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
  * Generic atomic functions that accept any type. The typed macros above should be preferred since
  * they provide better type checking.
  */
+#define __wt_atomic_load_enum(vp) __atomic_load_n(vp, __ATOMIC_RELAXED)
+#define __wt_atomic_store_enum(vp, v) __atomic_store_n(vp, v, __ATOMIC_RELAXED)
 #define __wt_atomic_and_generic(vp, v) __atomic_and_fetch(vp, v, __ATOMIC_RELAXED)
 #define __wt_atomic_or_generic(vp, v) __atomic_or_fetch(vp, v, __ATOMIC_RELAXED)
 #define __wt_atomic_load_generic(vp) __atomic_load_n(vp, __ATOMIC_RELAXED)

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -55,8 +55,9 @@ union __wt_lsn {
  * least clang address sanitizer) does not do atomic 64-bit structure assignment so we need to
  * explicitly assign the 64-bit field. And WT_SET_LSN atomically sets the LSN given a file/offset.
  */
-#define WT_ASSIGN_LSN(dstl, srcl) (dstl)->file_offset = (srcl)->file_offset
-#define WT_SET_LSN(l, f, o) (l)->file_offset = (((uint64_t)(f) << 32) + (o))
+#define WT_ASSIGN_LSN(dstl, srcl) \
+    __wt_atomic_store64(&(dstl)->file_offset, __wt_atomic_load64(&(srcl)->file_offset))
+#define WT_SET_LSN(l, f, o) __wt_atomic_store64(&(l)->file_offset, (((uint64_t)(f) << 32) + (o)))
 
 #define WT_INIT_LSN(l) WT_SET_LSN((l), 1, 0)
 
@@ -67,7 +68,7 @@ union __wt_lsn {
 /*
  * Test for initial LSN. We only need to shift the 1 for comparison.
  */
-#define WT_IS_INIT_LSN(l) ((l)->file_offset == ((uint64_t)1 << 32))
+#define WT_IS_INIT_LSN(l) (__wt_atomic_load64(&(l)->file_offset) == ((uint64_t)1 << 32))
 /*
  * Original tested INT32_MAX. But if we read one from an older release we may see UINT32_MAX.
  */
@@ -76,7 +77,7 @@ union __wt_lsn {
 /*
  * Test for zero LSN.
  */
-#define WT_IS_ZERO_LSN(l) ((l)->file_offset == 0)
+#define WT_IS_ZERO_LSN(l) (__wt_atomic_load64(&(l)->file_offset) == 0)
 
 /*
  * Macro to print an LSN.

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -36,7 +36,7 @@ union __wt_lsn {
         uint32_t file;
         uint32_t offset;
 #else
-        uint32_t offset;
+        wt_shared uint32_t offset;
         uint32_t file;
 #endif
     } l;

--- a/src/include/log_inline.h
+++ b/src/include/log_inline.h
@@ -21,8 +21,8 @@ __wt_log_cmp(WT_LSN *lsn1, WT_LSN *lsn2)
      * Read LSNs into local variables so that we only read each field once and all comparisons are
      * on the same values.
      */
-    l1 = ((volatile WT_LSN *)lsn1)->file_offset;
-    l2 = ((volatile WT_LSN *)lsn2)->file_offset;
+    WT_READ_ONCE(l1, lsn1->file_offset);
+    WT_READ_ONCE(l2, lsn2->file_offset);
 
     return (l1 < l2 ? -1 : (l1 > l2 ? 1 : 0));
 }

--- a/src/include/log_inline.h
+++ b/src/include/log_inline.h
@@ -28,6 +28,16 @@ __wt_log_cmp(WT_LSN *lsn1, WT_LSN *lsn2)
 }
 
 /*
+ * __wt_lsn_offset --
+ *     Return a log sequence number's offset.
+ */
+static WT_INLINE uint32_t
+__wt_lsn_offset(WT_LSN *lsn)
+{
+    return (__wt_atomic_load32(&lsn->l.offset));
+}
+
+/*
  * __wt_log_op --
  *     Return if an operation should be logged.
  */

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -138,6 +138,8 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
  * Generic atomic functions that accept any type. The typed macros above should be preferred since
  * they provide better type checking.
  */
+#define __wt_atomic_load_enum(vp) (*(vp))
+#define __wt_atomic_store_enum(vp, v) (*(vp) = (v))
 #define __wt_atomic_load_generic(vp) (*(vp))
 #define __wt_atomic_store_generic(vp, v) (*(vp) = (v))
 

--- a/src/include/thread_group.h
+++ b/src/include/thread_group.h
@@ -49,10 +49,10 @@ struct __wt_thread {
  *	Encapsulation of a group of utility threads.
  */
 struct __wt_thread_group {
-    uint32_t alloc;           /* Size of allocated group */
-    uint32_t max;             /* Max threads in group */
-    uint32_t min;             /* Min threads in group */
-    uint32_t current_threads; /* Number of active threads */
+    uint32_t alloc;                     /* Size of allocated group */
+    uint32_t max;                       /* Max threads in group */
+    uint32_t min;                       /* Min threads in group */
+    wt_shared uint32_t current_threads; /* Number of active threads */
 
     const char *name; /* Name */
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -235,7 +235,7 @@ __log_fsync_dir(WT_SESSION_IMPL *session, WT_LSN *min_lsn, const char *method)
     if (log->sync_dir_lsn.l.file < min_lsn->l.file) {
         WT_ASSERT(session, log->log_dir_fh != NULL);
         __wt_verbose(session, WT_VERB_LOG, "%s: sync directory %s to LSN %" PRIu32 "/%" PRIu32,
-          method, log->log_dir_fh->name, min_lsn->l.file, min_lsn->l.offset);
+          method, log->log_dir_fh->name, min_lsn->l.file, __wt_lsn_offset(min_lsn));
         time_start = __wt_clock(session);
         WT_RET(__wt_fsync(session, log->log_dir_fh, true));
         time_stop = __wt_clock(session);
@@ -277,7 +277,7 @@ __log_fsync_file(WT_SESSION_IMPL *session, WT_LSN *min_lsn, const char *method, 
         else
             log_fh = log->log_fh;
         __wt_verbose(session, WT_VERB_LOG, "%s: sync %s to LSN %" PRIu32 "/%" PRIu32, method,
-          log_fh->name, min_lsn->l.file, min_lsn->l.offset);
+          log_fh->name, min_lsn->l.file, __wt_lsn_offset(min_lsn));
         time_start = __wt_clock(session);
         WT_ERR(__wt_fsync(session, log_fh, true));
         time_stop = __wt_clock(session);
@@ -415,7 +415,7 @@ __wt_log_needs_recovery(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn, bool *recp)
      * log. If there are none then we can skip recovery.
      */
     WT_RET(__wt_curlog_open(session, "log:", NULL, &c));
-    c->set_key(c, ckp_lsn->l.file, ckp_lsn->l.offset, 0);
+    c->set_key(c, ckp_lsn->l.file, __wt_lsn_offset(ckp_lsn), 0);
     if ((ret = c->search(c)) == 0) {
         while ((ret = c->next(c)) == 0) {
             /*
@@ -664,11 +664,12 @@ __log_size_fit(WT_SESSION_IMPL *session, WT_LSN *lsn, uint64_t recsize)
 {
     WT_CONNECTION_IMPL *conn;
     WT_LOG *log;
+    uint32_t offset;
 
     conn = S2C(session);
     log = conn->log;
-    return (
-      lsn->l.offset == log->first_record || lsn->l.offset + (wt_off_t)recsize < conn->log_file_max);
+    offset = __wt_lsn_offset(lsn);
+    return (offset == log->first_record || offset + (wt_off_t)recsize < conn->log_file_max);
 }
 
 /*
@@ -754,7 +755,7 @@ __wt_log_fill(
     WT_STAT_CONN_INCRV(session, log_bytes_written, record->size);
     if (lsnp != NULL) {
         WT_ASSIGN_LSN(lsnp, &myslot->slot->slot_start_lsn);
-        lsnp->l.offset += (uint32_t)myslot->offset;
+        __wt_atomic_add32(&lsnp->l.offset, (uint32_t)myslot->offset);
     }
 err:
     if (ret != 0 && myslot->slot->slot_error == 0)
@@ -1377,7 +1378,7 @@ __wt_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WT_LOGSLOT *slot)
      * Pre-allocate on the first real write into the log file, if it was just created (i.e. not
      * pre-allocated).
      */
-    if (log->alloc_lsn.l.offset == log->first_record && created_log)
+    if (__wt_lsn_offset(&log->alloc_lsn) == log->first_record && created_log)
         WT_RET(__log_prealloc(session, log->log_fh));
     /*
      * Initialize the slot for activation.
@@ -1455,7 +1456,7 @@ __log_truncate(WT_SESSION_IMPL *session, WT_LSN *lsn, bool this_log, bool salvag
      * future truncates.
      */
     WT_ERR(__log_openfile(session, lsn->l.file, 0, &log_fh));
-    WT_ERR(__log_truncate_file(session, log_fh, lsn->l.offset));
+    WT_ERR(__log_truncate_file(session, log_fh, __wt_lsn_offset(lsn)));
     WT_ERR(__wt_fsync(session, log_fh, true));
     WT_ERR(__wt_close(session, &log_fh));
 
@@ -2137,10 +2138,10 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *start_lsnp, WT_LSN *end_lsnp, ui
          * WT_NOTFOUND. It is not an error. But if it is from recovery, we expect valid LSNs so give
          * more information about that.
          */
-        if (start_lsnp->l.offset % allocsize != 0) {
+        if (__wt_lsn_offset(start_lsnp) % allocsize != 0) {
             if (LF_ISSET(WT_LOGSCAN_RECOVER | WT_LOGSCAN_RECOVER_METADATA))
                 WT_ERR_MSG(session, WT_NOTFOUND, "__wt_log_scan unaligned LSN %" PRIu32 "/%" PRIu32,
-                  start_lsnp->l.file, start_lsnp->l.offset);
+                  start_lsnp->l.file, __wt_lsn_offset(start_lsnp));
             else
                 WT_ERR(WT_NOTFOUND);
         }
@@ -2153,7 +2154,7 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *start_lsnp, WT_LSN *end_lsnp, ui
             if (LF_ISSET(WT_LOGSCAN_RECOVER | WT_LOGSCAN_RECOVER_METADATA))
                 WT_ERR_MSG(session, WT_NOTFOUND,
                   "__wt_log_scan LSN %" PRIu32 "/%" PRIu32 " larger than biggest log file %" PRIu32,
-                  start_lsnp->l.file, start_lsnp->l.offset, lastlog);
+                  start_lsnp->l.file, __wt_lsn_offset(start_lsnp), lastlog);
             else
                 WT_ERR(WT_NOTFOUND);
         }
@@ -2177,16 +2178,16 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *start_lsnp, WT_LSN *end_lsnp, ui
     WT_ERR(__wt_scr_alloc(session, 0, &decryptitem));
     WT_ERR(__wt_scr_alloc(session, 0, &uncitem));
     for (;;) {
-        if (rd_lsn.l.offset + allocsize > log_size) {
+        if (__wt_lsn_offset(&rd_lsn) + allocsize > log_size) {
 advance:
-            if (rd_lsn.l.offset == log_size)
+            if (__wt_lsn_offset(&rd_lsn) == log_size)
                 partial_record = false;
             else {
                 /*
                  * See if there is anything non-zero at the end of this log file.
                  */
-                WT_ERR(__log_has_hole(
-                  session, log_fh, log_size, rd_lsn.l.offset, &bad_offset, &partial_record));
+                WT_ERR(__log_has_hole(session, log_fh, log_size, __wt_lsn_offset(&rd_lsn),
+                  &bad_offset, &partial_record));
                 if (bad_offset != 0) {
                     need_salvage = true;
                     WT_ERR(__log_salvage_message(session, log_fh->name, "", bad_offset));
@@ -2203,7 +2204,7 @@ advance:
              */
             if (LF_ISSET(WT_LOGSCAN_RECOVER) && __wt_log_cmp(&rd_lsn, &log->trunc_lsn) < 0) {
                 __wt_verbose(session, WT_VERB_LOG, "Truncate end of log %" PRIu32 "/%" PRIu32,
-                  rd_lsn.l.file, rd_lsn.l.offset);
+                  rd_lsn.l.file, __wt_lsn_offset(&rd_lsn));
                 WT_ERR(__log_truncate(session, &rd_lsn, true, false));
             }
             /*
@@ -2232,7 +2233,8 @@ advance:
              * record. This detects a "hole" at the end of the previous log file.
              */
             if (LF_ISSET(WT_LOGSCAN_RECOVER) && !WT_IS_INIT_LSN(&prev_lsn) &&
-              !WT_IS_ZERO_LSN(&prev_lsn) && prev_lsn.l.offset != prev_eof.l.offset) {
+              !WT_IS_ZERO_LSN(&prev_lsn) &&
+              __wt_lsn_offset(&prev_lsn) != __wt_lsn_offset(&prev_eof)) {
                 WT_ASSERT(session, prev_eof.l.file == prev_lsn.l.file);
                 break;
             }
@@ -2256,7 +2258,8 @@ advance:
          */
         WT_ASSERT(session, buf->memsize >= allocsize);
         need_salvage = F_ISSET(conn, WT_CONN_SALVAGE);
-        WT_ERR(__log_fs_read(session, log_fh, rd_lsn.l.offset, (size_t)allocsize, buf->mem));
+        WT_ERR(
+          __log_fs_read(session, log_fh, __wt_lsn_offset(&rd_lsn), (size_t)allocsize, buf->mem));
         need_salvage = false;
         /*
          * See if we need to read more than the allocation size. We expect that we rarely will have
@@ -2275,7 +2278,8 @@ advance:
          * the file and remove any later log files that may exist.
          */
         if (reclen == 0) {
-            WT_ERR(__log_has_hole(session, log_fh, log_size, rd_lsn.l.offset, &bad_offset, &eol));
+            WT_ERR(__log_has_hole(
+              session, log_fh, log_size, __wt_lsn_offset(&rd_lsn), &bad_offset, &eol));
             if (bad_offset != 0) {
                 need_salvage = true;
                 WT_ERR(__log_salvage_message(session, log_fh->name, "", bad_offset));
@@ -2292,7 +2296,7 @@ advance:
              * The log file end could be the middle of this log record. If we have a partially
              * written record then this is considered the end of the log.
              */
-            if (rd_lsn.l.offset + rdup_len > log_size) {
+            if (__wt_lsn_offset(&rd_lsn) + rdup_len > log_size) {
                 eol = true;
                 break;
             }
@@ -2300,7 +2304,8 @@ advance:
              * We need to round up and read in the full padded record, especially for direct I/O.
              */
             WT_ERR(__wt_buf_grow(session, buf, rdup_len));
-            WT_ERR(__log_fs_read(session, log_fh, rd_lsn.l.offset, (size_t)rdup_len, buf->mem));
+            WT_ERR(
+              __log_fs_read(session, log_fh, __wt_lsn_offset(&rd_lsn), (size_t)rdup_len, buf->mem));
             WT_STAT_CONN_INCR(session, log_scan_rereads);
         }
         /*
@@ -2349,17 +2354,19 @@ advance:
                  * that must be salvaged.
                  */
                 need_salvage = true;
-                WT_TRET(
-                  __log_salvage_message(session, log_fh->name, ", bad checksum", rd_lsn.l.offset));
+                WT_TRET(__log_salvage_message(
+                  session, log_fh->name, ", bad checksum", __wt_lsn_offset(&rd_lsn)));
             } else {
                 /*
                  * It may be a partial write, or it's possible that the header is corrupt. Make a
                  * sanity check of the log record header.
                  */
-                WT_TRET(__log_record_verify(session, log_fh, rd_lsn.l.offset, logrec, &corrupt));
+                WT_TRET(
+                  __log_record_verify(session, log_fh, __wt_lsn_offset(&rd_lsn), logrec, &corrupt));
                 if (corrupt) {
                     need_salvage = true;
-                    WT_TRET(__log_salvage_message(session, log_fh->name, "", rd_lsn.l.offset));
+                    WT_TRET(
+                      __log_salvage_message(session, log_fh->name, "", __wt_lsn_offset(&rd_lsn)));
                 }
             }
             break;
@@ -2371,8 +2378,8 @@ advance:
          */
         WT_STAT_CONN_INCR(session, log_scan_records);
         WT_ASSIGN_LSN(&next_lsn, &rd_lsn);
-        next_lsn.l.offset += rdup_len;
-        if (rd_lsn.l.offset != 0) {
+        __wt_atomic_add32(&next_lsn.l.offset, rdup_len);
+        if (__wt_lsn_offset(&rd_lsn) != 0) {
             /*
              * We need to manage the different buffers here. Buf is the buffer this function uses to
              * read from the disk. The callback buffer may change based on whether encryption and
@@ -2411,7 +2418,7 @@ advance:
     if (LF_ISSET(WT_LOGSCAN_RECOVER) && __wt_log_cmp(&rd_lsn, &log->trunc_lsn) < 0) {
         __wt_verbose(session, WT_VERB_LOG,
           "End of recovery truncate end of log %" PRIu32 "/%" PRIu32, rd_lsn.l.file,
-          rd_lsn.l.offset);
+          __wt_lsn_offset(&rd_lsn));
         /* Preserve prior error and fall through to error handling. */
         WT_TRET(__log_truncate(session, &rd_lsn, false, false));
     }
@@ -2825,7 +2832,7 @@ __wt_log_flush(WT_SESSION_IMPL *session, uint32_t flags)
      * to be flushed. Otherwise, if the workload is single-threaded we could wait here forever
      * because the write LSN doesn't switch into the new file until it contains a record.
      */
-    if (last_lsn.l.offset == log->first_record)
+    if (__wt_lsn_offset(&last_lsn) == log->first_record)
         WT_ASSIGN_LSN(&last_lsn, &log->log_close_lsn);
 
     /*
@@ -2837,7 +2844,8 @@ __wt_log_flush(WT_SESSION_IMPL *session, uint32_t flags)
     }
 
     __wt_verbose_debug2(session, WT_VERB_LOG,
-      "log_flush: flags %#" PRIx32 " LSN %" PRIu32 "/%" PRIu32, flags, lsn.l.file, lsn.l.offset);
+      "log_flush: flags %#" PRIx32 " LSN %" PRIu32 "/%" PRIu32, flags, lsn.l.file,
+      __wt_lsn_offset(&lsn));
     /*
      * If the user wants write-no-sync, there is nothing more to do. If the user wants background
      * sync, set the LSN and we're done. If the user wants sync, force it now.

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1287,7 +1287,7 @@ __wt_meta_ckptlist_set(
     has_lsn = ckptlsn != NULL;
     if (ckptlsn != NULL)
         WT_ERR(__wt_buf_catfmt(session, buf, ",checkpoint_lsn=(%" PRIu32 ",%" PRIuMAX ")",
-          ckptlsn->l.file, (uintmax_t)ckptlsn->l.offset));
+          ckptlsn->l.file, (uintmax_t)__wt_lsn_offset(ckptlsn)));
 
     if (dhandle->type == WT_DHANDLE_TYPE_TIERED)
         WT_ERR(__wt_tiered_set_metadata(session, (WT_TIERED *)dhandle, buf));

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -84,7 +84,7 @@ __thread_group_shrink(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
         __wt_verbose(session, WT_VERB_THREAD_GROUP, "Stopping utility thread: %s:%" PRIu32,
           group->name, thread->id);
         if (F_ISSET(thread, WT_THREAD_ACTIVE))
-            --group->current_threads;
+            __wt_atomic_sub32(&group->current_threads, 1);
         F_CLR(thread, WT_THREAD_ACTIVE | WT_THREAD_RUN);
         /*
          * Signal the thread in case it is in a long timeout.
@@ -147,7 +147,8 @@ __thread_group_resize(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
       group->name, group->min, new_min, group->max, new_max);
 
     WT_ASSERT(session,
-      group->current_threads <= group->alloc && __wt_rwlock_islocked(session, &group->lock));
+      __wt_atomic_load32(&group->current_threads) <= group->alloc &&
+        __wt_rwlock_islocked(session, &group->lock));
 
     if (new_min == group->min && new_max == group->max)
         return (0);
@@ -207,7 +208,7 @@ __thread_group_resize(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
 
     group->max = new_max;
     group->min = new_min;
-    while (group->current_threads < new_min)
+    while (__wt_atomic_load32(&group->current_threads) < new_min)
         __wt_thread_group_start_one(session, group, true);
     return (0);
 
@@ -338,15 +339,15 @@ __wt_thread_group_start_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, bo
 {
     WT_THREAD *thread;
 
-    if (group->current_threads >= group->max)
+    if (__wt_atomic_load32(&group->current_threads) >= group->max)
         return;
 
     if (!is_locked)
         __wt_writelock(session, &group->lock);
 
     /* Recheck the bounds now that we hold the lock */
-    if (group->current_threads < group->max) {
-        thread = group->threads[group->current_threads++];
+    if (__wt_atomic_load32(&group->current_threads) < group->max) {
+        thread = group->threads[__wt_atomic_fetch_add32(&group->current_threads, 1)];
         WT_ASSERT(session, thread != NULL);
         __wt_verbose(session, WT_VERB_THREAD_GROUP, "Activating utility thread: %s:%" PRIu32,
           group->name, thread->id);
@@ -367,13 +368,13 @@ __wt_thread_group_stop_one(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group)
 {
     WT_THREAD *thread;
 
-    if (group->current_threads <= group->min)
+    if (__wt_atomic_load32(&group->current_threads) <= group->min)
         return;
 
     __wt_writelock(session, &group->lock);
     /* Recheck the bounds now that we hold the lock */
-    if (group->current_threads > group->min) {
-        thread = group->threads[--group->current_threads];
+    if (__wt_atomic_load32(&group->current_threads) > group->min) {
+        thread = group->threads[__wt_atomic_sub32(&group->current_threads, 1)];
         __wt_verbose(session, WT_VERB_THREAD_GROUP, "Pausing utility thread: %s:%" PRIu32,
           group->name, thread->id);
         WT_ASSERT(session, F_ISSET(thread, WT_THREAD_ACTIVE));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2835,7 +2835,7 @@ __wt_verbose_dump_txn_one(
         __wt_timestamp_to_string(txn->prepare_timestamp, ts_string[3]),
         __wt_timestamp_to_string(txn_shared->pinned_durable_timestamp, ts_string[4]),
         __wt_timestamp_to_string(txn_shared->read_timestamp, ts_string[5]), txn->ckpt_lsn.l.file,
-        txn->ckpt_lsn.l.offset, txn->full_ckpt ? "true" : "false",
+        __wt_lsn_offset(&txn->ckpt_lsn), txn->full_ckpt ? "true" : "false",
         txn->rollback_reason == NULL ? "" : txn->rollback_reason, txn->flags, iso_tag));
 
     /*

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -528,11 +528,12 @@ __wt_txn_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_
         rectype = WT_LOGREC_CHECKPOINT;
         fmt = WT_UNCHECKED_STRING(IIIIu);
         WT_ERR(__wt_struct_size(session, &recsize, fmt, rectype, ckpt_lsn->l.file,
-          ckpt_lsn->l.offset, txn->ckpt_nsnapshot, ckpt_snapshot));
+          __wt_lsn_offset(ckpt_lsn), txn->ckpt_nsnapshot, ckpt_snapshot));
         WT_ERR(__wt_logrec_alloc(session, recsize, &logrec));
 
-        WT_ERR(__wt_struct_pack(session, (uint8_t *)logrec->data + logrec->size, recsize, fmt,
-          rectype, ckpt_lsn->l.file, ckpt_lsn->l.offset, txn->ckpt_nsnapshot, ckpt_snapshot));
+        WT_ERR(
+          __wt_struct_pack(session, (uint8_t *)logrec->data + logrec->size, recsize, fmt, rectype,
+            ckpt_lsn->l.file, __wt_lsn_offset(ckpt_lsn), txn->ckpt_nsnapshot, ckpt_snapshot));
         logrec->size += (uint32_t)recsize;
         WT_ERR(__wt_log_write(
           session, logrec, lsnp, F_ISSET(conn, WT_CONN_CKPT_SYNC) ? WT_LOG_FSYNC : 0));
@@ -696,7 +697,7 @@ __txn_printlog(WT_SESSION_IMPL *session, WT_ITEM *rawrec, WT_LSN *lsnp, WT_LSN *
         WT_RET(__wt_fprintf(session, args->fs, ",\n"));
 
     WT_RET(__wt_fprintf(session, args->fs, "  { \"lsn\" : [%" PRIu32 ",%" PRIu32 "],\n",
-      lsnp->l.file, lsnp->l.offset));
+      lsnp->l.file, __wt_lsn_offset(lsnp)));
     WT_RET(__wt_fprintf(
       session, args->fs, "    \"hdr_flags\" : \"%s\",\n", compressed ? "compressed" : ""));
     WT_RET(__wt_fprintf(session, args->fs, "    \"rec_len\" : %" PRIu32 ",\n", logrec->len));

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -177,12 +177,12 @@ __txn_system_op_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const ui
             __wt_verbose_multi(session, WT_VERB_RECOVERY_ALL,
               "Backup ID: LSN [%" PRIu32 ",%" PRIu32 "]: Applying slot %" PRIu32
               " granularity %" PRIu64 " ID string %s",
-              lsnp->l.file, lsnp->l.offset, index, granularity, id_str);
+              lsnp->l.file, __wt_lsn_offset(lsnp), index, granularity, id_str);
             WT_ERR(__wt_backup_set_blkincr(session, index, granularity, id_str, strlen(id_str)));
         } else {
             __wt_verbose_multi(session, WT_VERB_RECOVERY_ALL,
               "Backup ID: LSN [%" PRIu32 ",%" PRIu32 "]: Clearing slot %" PRIu32, lsnp->l.file,
-              lsnp->l.offset, index);
+              __wt_lsn_offset(lsnp), index);
             /* This is the result of a force stop, clear the entry. */
             WT_CLEAR(*blk);
         }
@@ -194,7 +194,7 @@ done:
     return (0);
 err:
     __wt_err(session, ret, "backup id apply failed during recovery: at LSN %" PRIu32 "%" PRIu32,
-      lsnp->l.file, lsnp->l.offset);
+      lsnp->l.file, __wt_lsn_offset(lsnp));
     return (ret);
 }
 
@@ -222,7 +222,7 @@ __txn_system_apply(WT_RECOVERY *r, WT_LSN *lsnp, const uint8_t **pp, const uint8
       ret != 0         ? "Error" :                                         \
         cursor == NULL ? "Skipping" :                                      \
                          "Applying",                                       \
-      optype, fileid, (lsnp)->l.file, (lsnp)->l.offset);                   \
+      optype, fileid, (lsnp)->l.file, __wt_lsn_offset(lsnp));              \
     WT_ERR(ret);                                                           \
     if (cursor == NULL)                                                    \
     break
@@ -441,7 +441,7 @@ err:
     __wt_err(session, ret,
       "operation apply failed during recovery: operation type %" PRIu32 " at LSN %" PRIu32
       "/%" PRIu32,
-      optype, lsnp->l.file, lsnp->l.offset);
+      optype, lsnp->l.file, __wt_lsn_offset(lsnp));
     return (ret);
 }
 
@@ -731,7 +731,7 @@ __recovery_setup_file(WT_RECOVERY *r, const char *uri, const char *config)
 
     __wt_verbose(r->session, WT_VERB_RECOVERY,
       "Recovering %s with id %" PRIu32 " @ (%" PRIu32 ", %" PRIu32 ")", uri, fileid, lsn.l.file,
-      lsn.l.offset);
+      __wt_lsn_offset(&lsn));
 
     if ((!WT_IS_MAX_LSN(&lsn) && !WT_IS_INIT_LSN(&lsn)) &&
       (WT_IS_MAX_LSN(&r->max_ckpt_lsn) || __wt_log_cmp(&lsn, &r->max_ckpt_lsn) > 0))
@@ -1056,7 +1056,8 @@ __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
     r.metadata_only = false;
     __wt_verbose_multi(session, WT_VERB_RECOVERY_ALL,
       "Main recovery loop: starting at %" PRIu32 "/%" PRIu32 " to %" PRIu32 "/%" PRIu32,
-      r.ckpt_lsn.l.file, r.ckpt_lsn.l.offset, r.max_rec_lsn.l.file, r.max_rec_lsn.l.offset);
+      r.ckpt_lsn.l.file, __wt_lsn_offset(&r.ckpt_lsn), r.max_rec_lsn.l.file,
+      __wt_lsn_offset(&r.max_rec_lsn));
     WT_ERR(__wt_log_needs_recovery(session, &r.ckpt_lsn, &needs_rec));
     /*
      * Check if the database was shut down cleanly. If not return an error if the user does not want

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1645,7 +1645,7 @@ tasks:
       - func: "make check directory"
         vars:
           directory: examples/c
-          extra_args: -R "(ex_access|ex_col_store|ex_config_parse|ex_cursor|ex_event_handler|ex_extending|ex_extra_diagnostics|ex_extractor|ex_hello|ex_pack|ex_process|ex_schema|ex_smoke|ex_thread|ex_tiered|ex_verbose)" -j ${num_jobs}
+          extra_args: -R "(ex_access|ex_col_store|ex_config_parse|ex_cursor|ex_encrypt|ex_event_handler|ex_extending|ex_extra_diagnostics|ex_extractor|ex_hello|ex_pack|ex_process|ex_schema|ex_smoke|ex_thread|ex_tiered|ex_verbose)" -j ${num_jobs}
 
   - name: examples-c-production-disable-shared-test
     tags: ["pull_request"]


### PR DESCRIPTION
Add `ex_encrypt` to `examples-c-tsan` and update WiredTiger to resolve warnings raised by running `ex_encrypt`.
This PR also contain additional changes that aren't required by `ex_encrypt`, but will be needed for the addition of future tests. I've tried to move some changes into this PR to balance the workload with future PRs.