### PR TITLE
WT-12702 Handle error message related to parallel compaction in compact07

### DIFF
--- a/test/suite/test_compact07.py
+++ b/test/suite/test_compact07.py
@@ -212,3 +212,4 @@ class test_compact07(wttest.WiredTigerTestCase):
         # Background compaction may have been inspecting a table when disabled, which is considered
         # as an interruption, ignore that message.
         self.ignoreStdoutPatternIfExists('background compact interrupted by application')
+        self.ignoreStderrPatternIfExists('Compaction already happening')


### PR DESCRIPTION
Same as #10403 but replaced `ignoreStdoutPatternIfExists` with `ignoreStderrPatternIfExists` as the error message goes to `stderr`.