### PR TITLE
WT-12378 Not enough memory error on arm64-small (v7.3 backport)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5506,9 +5506,11 @@ buildvariants:
     ENABLE_TCMALLOC: -DENABLE_TCMALLOC=1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     cmake_generator: "Unix Makefiles"
+  # Using large distro for a few tests here as more memory is required.
   tasks:
     - name: compile
     - name: make-check-test
+      distros: amazon2-arm64-large
     - name: unit-test
     - name: fops
     - name: format-failure-configs-test
@@ -5519,8 +5521,10 @@ buildvariants:
       distros: amazon2-arm64-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
+      distros: amazon2-arm64-large
     - name: wtperf-test
     - name: long-test
+      distros: amazon2-arm64-large
     - name: format-smoke-test
     - name: s3-tiered-storage-extensions-test
 
@@ -5743,6 +5747,8 @@ buildvariants:
   tasks:
     - name: compile
     - name: make-check-test
+      # Using large distro as more memory is required.
+      distros: amazon2-arm64-large
     - name: unit-test
     - name: unit-test-extra-long
       distros: amazon2-arm64-large


### PR DESCRIPTION
Fixed this error by assigning the tests that requires more memory to
arm64-medium.

(cherry picked from commit 0e9d25ec4a20da65014e3297476824df7fea1e02)