### PR TITLE
WT-10807 Skip in-memory deleted pages as part of the tree walk (v7.3 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1049,6 +1049,9 @@ conn_dsrc_stats = [
     CursorStat('cursor_reposition_failed', 'Total number of times cursor fails to temporarily release pinned page to encourage eviction of hot or large page'),
     CursorStat('cursor_search_near_prefix_fast_paths', 'Total number of times a search near has exited due to prefix config'),
     CursorStat('cursor_skip_hs_cur_position', 'Total number of entries skipped to position the history store cursor'),
+    CursorStat('cursor_tree_walk_del_page_skip', 'Total number of deleted pages skipped during tree walk'),
+    CursorStat('cursor_tree_walk_ondisk_del_page_skip', 'Total number of on-disk deleted pages skipped during tree walk'),
+    CursorStat('cursor_tree_walk_inmem_del_page_skip', 'Total number of in-memory deleted pages skipped during tree walk'),
 
     ##########################################
     # Cursor API error statistics

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -768,6 +768,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_PAGE *page;
+    WT_PAGE_WALK_SKIP_STATS walk_skip_stats;
     WT_SESSION_IMPL *session;
     size_t total_skipped, skipped;
     uint32_t flags;
@@ -781,6 +782,8 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
     key_out_of_bounds = need_walk = newpage = repositioned = false;
     session = CUR2S(cbt);
     total_skipped = 0;
+    walk_skip_stats.total_del_pages_skipped = 0;
+    walk_skip_stats.total_inmem_del_pages_skipped = 0;
 
     WT_STAT_CONN_DATA_INCR(session, cursor_next);
 
@@ -921,8 +924,8 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
          */
         if (session->txn->isolation == WT_ISO_SNAPSHOT &&
           !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE))
-            WT_ERR(
-              __wt_tree_walk_custom_skip(session, &cbt->ref, __wt_btcur_skip_page, NULL, flags));
+            WT_ERR(__wt_tree_walk_custom_skip(
+              session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));
         else
             WT_ERR(__wt_tree_walk(session, &cbt->ref, flags));
         WT_ERR_TEST(cbt->ref == NULL, WT_NOTFOUND, false);
@@ -938,6 +941,12 @@ err:
     }
 
     WT_STAT_CONN_DATA_INCRV(session, cursor_next_skip_total, total_skipped);
+    if (walk_skip_stats.total_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(
+          session, cursor_tree_walk_del_page_skip, walk_skip_stats.total_del_pages_skipped);
+    if (walk_skip_stats.total_inmem_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(session, cursor_tree_walk_inmem_del_page_skip,
+          walk_skip_stats.total_inmem_del_pages_skipped);
 
     switch (ret) {
     case 0:

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -235,6 +235,7 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     __wt_free(session, page->modify->ovfl_track);
     __wt_free(session, page->modify->inst_updates);
+    __wt_free(session, page->modify->stop_ta);
     __wt_spin_destroy(session, &page->modify->page_lock);
 
     __wt_free(session, page->modify);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -432,6 +432,13 @@ struct __wt_page_modify {
     WT_OVFL_TRACK *ovfl_track;
 
     /*
+     * Stop aggregated timestamp information when all the keys on the page are removed. This time
+     * aggregate information is used to skip these deleted pages as part of the tree walk if the
+     * delete operation is visible to the reader.
+     */
+    wt_shared WT_TIME_AGGREGATE *stop_ta;
+
+    /*
      * Page-delete information for newly instantiated deleted pages. The instantiated flag remains
      * set until the page is reconciled successfully; this indicates that the page_del information
      * in the ref remains valid. The update list remains set (if set at all) until the transaction
@@ -789,6 +796,15 @@ struct __wt_page {
  */
 #define WT_PAGE_DISK_OFFSET(page, p) WT_PTRDIFF32(p, (page)->dsk)
 #define WT_PAGE_REF_OFFSET(page, o) ((void *)((uint8_t *)((page)->dsk) + (o)))
+
+/*
+ * WT_PAGE_WALK_SKIP_STATS --
+ *	Statistics to track how many deleted pages are skipped as part of the tree walk.
+ */
+struct __wt_page_walk_skip_stats {
+    size_t total_del_pages_skipped;
+    size_t total_inmem_del_pages_skipped;
+};
 
 /*
  * Prepare update states.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2117,6 +2117,8 @@ static inline bool __wt_eviction_updates_needed(WT_SESSION_IMPL *session, double
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_failpoint(WT_SESSION_IMPL *session, uint64_t conn_flag, u_int probability)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page,
+  WT_TIME_AGGREGATE **ta) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isalnum(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isalpha(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isascii(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -697,9 +697,12 @@ struct __wt_connection_stats {
     int64_t fsync_io;
     int64_t read_io;
     int64_t write_io;
+    int64_t cursor_tree_walk_del_page_skip;
     int64_t cursor_next_skip_total;
     int64_t cursor_prev_skip_total;
     int64_t cursor_skip_hs_cur_position;
+    int64_t cursor_tree_walk_inmem_del_page_skip;
+    int64_t cursor_tree_walk_ondisk_del_page_skip;
     int64_t cursor_search_near_prefix_fast_paths;
     int64_t cursor_reposition_failed;
     int64_t cursor_reposition;
@@ -1204,9 +1207,12 @@ struct __wt_dsrc_stats {
     int64_t compress_write_ratio_hist_16;
     int64_t compress_write_ratio_hist_32;
     int64_t compress_write_ratio_hist_64;
+    int64_t cursor_tree_walk_del_page_skip;
     int64_t cursor_next_skip_total;
     int64_t cursor_prev_skip_total;
     int64_t cursor_skip_hs_cur_position;
+    int64_t cursor_tree_walk_inmem_del_page_skip;
+    int64_t cursor_tree_walk_ondisk_del_page_skip;
     int64_t cursor_search_near_prefix_fast_paths;
     int64_t cursor_reposition_failed;
     int64_t cursor_reposition;

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -231,3 +231,7 @@
         (out_ta)->newest_stop_ts = WT_MAX((out_ta)->newest_stop_ts, (in_ta)->newest_stop_ts);    \
         (out_ta)->newest_stop_txn = WT_MAX((out_ta)->newest_stop_txn, (in_ta)->newest_stop_txn); \
     } while (0)
+
+/* Check if the stop time aggregate is set. */
+#define WT_TIME_AGGREGATE_HAS_STOP(ta) \
+    ((ta)->newest_stop_txn != WT_TXN_MAX || (ta)->newest_stop_ts != WT_TS_MAX)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -907,6 +907,8 @@ static inline bool
 __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
 {
+    WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
+
     /* Transaction snapshot minimum check. */
     if (!WT_TXNID_LT(id, session->txn->snapshot_data.snap_min))
         return (false);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6220,800 +6220,809 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_READ_IO				1334
 /*! connection: total write I/Os */
 #define	WT_STAT_CONN_WRITE_IO				1335
+/*! cursor: Total number of deleted pages skipped during tree walk */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1336
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1336
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1337
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1337
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1338
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1338
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1339
+/*!
+ * cursor: Total number of in-memory deleted pages skipped during tree
+ * walk
+ */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1340
+/*! cursor: Total number of on-disk deleted pages skipped during tree walk */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1341
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1339
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1342
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1340
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1343
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1341
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1344
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1342
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1345
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1343
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1346
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1344
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1347
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1345
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1348
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1346
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1349
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1347
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1350
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1348
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1351
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1349
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1352
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1350
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1353
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1351
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1354
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1352
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1355
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1353
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1356
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1354
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1357
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1355
+#define	WT_STAT_CONN_CURSOR_CACHE			1358
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1356
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1359
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1357
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1360
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1358
+#define	WT_STAT_CONN_CURSOR_CREATE			1361
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1359
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1362
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1360
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1363
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1361
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1364
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1362
+#define	WT_STAT_CONN_CURSOR_INSERT			1365
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1363
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1366
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1364
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1367
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1365
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1368
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1366
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1369
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1367
+#define	WT_STAT_CONN_CURSOR_MODIFY			1370
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1368
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1371
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1369
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1372
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1370
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1373
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1371
+#define	WT_STAT_CONN_CURSOR_NEXT			1374
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1372
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1375
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1373
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1376
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1374
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1377
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1375
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1378
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1376
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1379
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1377
+#define	WT_STAT_CONN_CURSOR_RESTART			1380
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1378
+#define	WT_STAT_CONN_CURSOR_PREV			1381
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1379
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1382
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1380
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1383
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1381
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1384
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1382
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1385
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1383
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1386
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1384
+#define	WT_STAT_CONN_CURSOR_REMOVE			1387
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1385
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1388
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1386
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1389
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1387
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1390
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1388
+#define	WT_STAT_CONN_CURSOR_RESERVE			1391
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1389
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1392
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1390
+#define	WT_STAT_CONN_CURSOR_RESET			1393
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1391
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1394
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1392
+#define	WT_STAT_CONN_CURSOR_SEARCH			1395
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1393
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1396
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1394
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1397
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1395
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1398
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1396
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1399
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1397
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1400
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1398
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1401
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1399
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1402
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1400
+#define	WT_STAT_CONN_CURSOR_SWEEP			1403
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1401
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1404
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1402
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1405
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1403
+#define	WT_STAT_CONN_CURSOR_UPDATE			1406
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1404
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1407
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1405
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1408
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1406
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1409
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1407
+#define	WT_STAT_CONN_CURSOR_REOPEN			1410
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1408
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1411
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1409
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1412
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1410
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1413
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1411
+#define	WT_STAT_CONN_DH_SWEEP_REF			1414
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1412
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1415
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1413
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1416
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1414
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1417
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1415
+#define	WT_STAT_CONN_DH_SWEEPS				1418
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1416
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1419
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1417
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1420
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1418
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1421
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1419
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1422
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1420
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1423
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1421
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1424
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1422
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1425
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1423
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1426
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1424
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1427
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1425
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1428
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1426
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1429
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1427
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1430
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1428
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1431
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1429
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1432
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1430
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1433
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1431
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1434
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1432
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1435
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1433
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1436
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1434
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1437
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1435
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1438
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1436
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1439
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1437
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1440
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1438
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1441
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1439
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1442
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1440
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1443
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1441
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1444
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1442
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1445
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1443
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1446
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1444
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1447
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1445
+#define	WT_STAT_CONN_LOG_FLUSH				1448
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1446
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1449
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1447
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1450
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1448
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1451
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1449
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1452
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1450
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1453
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1451
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1454
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1452
+#define	WT_STAT_CONN_LOG_SCANS				1455
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1453
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1456
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1454
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1457
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1455
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1458
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1456
+#define	WT_STAT_CONN_LOG_SYNC				1459
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1457
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1460
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1458
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1461
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1459
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1462
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1460
+#define	WT_STAT_CONN_LOG_WRITES				1463
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1461
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1464
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1462
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1465
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1463
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1466
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1464
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1467
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1465
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1468
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1466
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1469
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1467
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1470
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1468
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1471
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1469
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1472
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1470
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1473
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1471
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1474
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1472
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1475
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1473
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1476
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1474
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1477
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1475
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1478
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1476
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1479
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1477
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1480
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1478
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1481
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1479
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1482
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1480
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1483
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1481
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1484
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1482
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1485
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1483
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1486
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1484
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1487
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1485
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1488
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1486
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1489
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1487
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1490
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1488
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1491
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1489
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1492
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1490
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1493
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1491
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1494
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1492
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1495
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1493
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1496
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1494
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1497
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1495
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1498
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1496
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1499
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1497
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1500
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1498
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1501
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1499
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1502
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1500
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1503
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1501
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1504
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1502
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1505
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1503
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1506
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1504
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1507
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1505
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1508
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1506
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1509
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1507
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1510
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1508
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1511
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1509
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1512
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1510
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1513
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1511
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1514
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1512
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1515
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1513
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1516
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1514
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1517
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1515
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1518
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1516
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1519
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1517
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1520
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1518
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1521
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1519
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1522
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1520
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1523
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1521
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1524
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1522
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1525
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1523
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1526
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1524
+#define	WT_STAT_CONN_REC_PAGES				1527
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1525
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1528
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1526
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1529
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1527
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1530
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1528
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1531
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1529
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1532
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1530
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1533
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1531
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1534
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1532
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1535
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1533
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1536
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1534
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1537
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1535
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1538
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1536
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1539
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1537
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1540
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1538
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1541
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1539
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1542
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1540
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1543
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1541
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1544
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1542
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1545
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1543
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1546
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1544
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1547
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1545
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1548
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1546
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1549
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1547
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1550
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1548
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1551
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1549
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1552
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1550
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1553
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1551
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1554
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1552
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1555
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1553
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1556
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1554
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1557
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1555
+#define	WT_STAT_CONN_FLUSH_TIER				1558
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1556
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1559
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1557
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1560
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1558
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1561
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1559
+#define	WT_STAT_CONN_SESSION_OPEN			1562
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1560
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1563
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1561
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1564
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1562
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1565
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1563
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1566
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1564
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1567
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1565
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1568
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1566
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1569
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1567
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1570
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1568
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1571
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1569
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1572
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1570
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1573
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1571
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1574
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1572
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1575
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1573
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1576
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1574
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1577
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1575
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1578
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1576
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1579
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1577
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1580
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1578
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1581
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1579
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1582
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1580
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1583
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1581
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1584
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1582
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1585
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1583
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1586
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1584
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1587
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1585
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1588
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1586
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1589
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1587
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1590
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1588
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1591
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1589
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1592
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1590
+#define	WT_STAT_CONN_TIERED_RETENTION			1593
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1591
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1594
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1592
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1595
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1593
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1596
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1594
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1597
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1595
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1598
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1596
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1599
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1597
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1600
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1598
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1601
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1599
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1602
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1600
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1603
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1601
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1604
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1602
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1605
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1603
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1606
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1604
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1607
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1605
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1608
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1606
+#define	WT_STAT_CONN_PAGE_SLEEP				1609
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1607
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1610
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1608
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1611
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1609
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1612
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1610
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1613
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1611
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1614
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1612
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1615
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1613
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1616
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1614
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1617
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1615
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1618
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1616
+#define	WT_STAT_CONN_TXN_PREPARE			1619
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1617
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1620
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1618
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1621
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1619
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1622
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1620
+#define	WT_STAT_CONN_TXN_QUERY_TS			1623
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1621
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1624
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1622
+#define	WT_STAT_CONN_TXN_RTS				1625
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1623
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1626
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1624
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1627
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1625
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1628
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1626
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1629
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1627
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1630
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1628
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1631
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1629
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1632
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1630
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1633
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1631
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1634
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1632
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1635
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1633
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1636
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1634
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1637
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1635
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1638
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1636
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1639
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1637
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1640
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1638
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1641
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1639
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1642
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1640
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1643
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1641
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1644
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1642
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1645
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1643
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1646
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1644
+#define	WT_STAT_CONN_TXN_SET_TS				1647
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1645
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1648
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1646
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1649
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1647
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1650
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1648
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1651
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1649
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1652
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1650
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1653
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1651
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1654
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1652
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1655
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1653
+#define	WT_STAT_CONN_TXN_BEGIN				1656
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1654
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1657
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1655
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1658
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1656
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1659
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1657
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1660
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1658
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1661
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1659
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1662
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1660
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1663
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1661
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1664
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1662
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1665
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1663
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1666
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1664
+#define	WT_STAT_CONN_TXN_COMMIT				1667
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1665
+#define	WT_STAT_CONN_TXN_ROLLBACK			1668
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1666
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1669
 
 /*!
  * @}
@@ -7574,339 +7583,348 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * 64
  */
 #define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2168
+/*! cursor: Total number of deleted pages skipped during tree walk */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2169
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2169
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2170
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2170
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2171
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2171
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2172
+/*!
+ * cursor: Total number of in-memory deleted pages skipped during tree
+ * walk
+ */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2173
+/*! cursor: Total number of on-disk deleted pages skipped during tree walk */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2174
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2172
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2175
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2173
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2176
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2174
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2177
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2175
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2178
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2176
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2179
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2177
+#define	WT_STAT_DSRC_CURSOR_CACHE			2180
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2178
+#define	WT_STAT_DSRC_CURSOR_CREATE			2181
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2179
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2182
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2180
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2183
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2181
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2184
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2182
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2185
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2183
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2186
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2184
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2187
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2185
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2188
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2186
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2189
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2187
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2190
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2188
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2191
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2189
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2192
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2190
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2193
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2191
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2194
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2192
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2195
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2193
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2196
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2194
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2197
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2195
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2198
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2196
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2199
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2197
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2200
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2198
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2201
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2199
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2202
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2200
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2203
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2201
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2204
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2202
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2205
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2203
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2206
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2204
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2207
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2205
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2208
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2206
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2209
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2207
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2210
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2208
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2211
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2209
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2212
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2210
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2213
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2211
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2214
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2212
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2215
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2213
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2216
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2214
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2217
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2215
+#define	WT_STAT_DSRC_CURSOR_INSERT			2218
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2216
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2219
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2217
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2220
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2218
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2221
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2219
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2222
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2220
+#define	WT_STAT_DSRC_CURSOR_NEXT			2223
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2221
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2224
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2222
+#define	WT_STAT_DSRC_CURSOR_RESTART			2225
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2223
+#define	WT_STAT_DSRC_CURSOR_PREV			2226
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2224
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2227
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2225
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2228
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2226
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2229
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2227
+#define	WT_STAT_DSRC_CURSOR_RESET			2230
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2228
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2231
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2229
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2232
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2230
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2233
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2231
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2234
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2232
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2235
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2233
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2236
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2234
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2237
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2235
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2238
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2236
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2239
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2237
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2240
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2238
+#define	WT_STAT_DSRC_REC_DICTIONARY			2241
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2239
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2242
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2240
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2243
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2241
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2244
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2242
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2245
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2243
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2246
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2244
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2247
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2245
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2248
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2246
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2249
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2247
+#define	WT_STAT_DSRC_REC_PAGES				2250
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2248
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2251
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2249
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2252
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2250
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2253
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2251
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2254
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2252
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2255
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2253
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2256
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2254
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2257
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2255
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2258
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2256
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2259
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2257
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2260
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2258
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2261
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2259
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2262
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2260
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2263
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2261
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2264
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2262
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2265
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2263
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2266
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2264
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2267
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2265
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2268
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2266
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2269
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2267
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2270
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2268
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2271
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2269
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2272
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2270
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2273
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2271
+#define	WT_STAT_DSRC_SESSION_COMPACT			2274
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2272
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2275
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2273
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2276
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2274
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2277
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2275
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2278
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2276
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2279
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2277
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2280
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2278
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2281
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2279
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2282
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2280
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2283
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2281
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2284
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2282
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2285
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2283
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2286
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2284
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2287
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2285
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2288
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2286
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2289
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2287
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2290
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2288
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2291
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2289
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2292
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2290
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2293
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2291
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2294
 
 /*!
  * @}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -327,6 +327,8 @@ struct __wt_page_index;
 typedef struct __wt_page_index WT_PAGE_INDEX;
 struct __wt_page_modify;
 typedef struct __wt_page_modify WT_PAGE_MODIFY;
+struct __wt_page_walk_skip_stats;
+typedef struct __wt_page_walk_skip_stats WT_PAGE_WALK_SKIP_STATS;
 struct __wt_prefetch;
 typedef struct __wt_prefetch WT_PREFETCH;
 struct __wt_prefetch_queue_entry;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2370,6 +2370,37 @@ __rec_split_dump_keys(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 }
 
 /*
+ * __rec_page_modify_ta_safe_free --
+ *     Any thread that is reviewing the page modify time aggregate in a WT_REF, must also be holding
+ *     a split generation to ensure that the page index they are using remains valid. Use that same
+ *     split generation to ensure that the page modify time aggregate inside the WT_REF remains
+ *     valid while it is being reviewed.
+ */
+static void
+__rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
+{
+    WT_DECL_RET;
+    uint64_t split_gen;
+    void *p;
+
+    p = *(void **)ta;
+    if (p == NULL)
+        return;
+
+    do {
+        WT_READ_ONCE(p, *ta);
+        if (p == NULL)
+            break;
+    } while (!__wt_atomic_cas_ptr(ta, p, NULL));
+
+    split_gen = __wt_gen(session, WT_GEN_SPLIT);
+
+    if (__wt_stash_add(session, WT_GEN_SPLIT, split_gen, p, sizeof(WT_TIME_AGGREGATE)) != 0)
+        WT_IGNORE_RET(__wt_panic(session, ret, "fatal error during page modify ta free"));
+    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+}
+
+/*
  * __rec_write_wrapup --
  *     Finish the reconciliation.
  */
@@ -2379,9 +2410,11 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     WT_BM *bm;
     WT_BTREE *btree;
     WT_DECL_RET;
+    WT_MULTI *multi;
     WT_PAGE_MODIFY *mod;
     WT_REF *ref;
-    WT_TIME_AGGREGATE ta;
+    WT_TIME_AGGREGATE stop_ta, *stop_tap, ta;
+    uint32_t i;
     uint8_t previous_ref_state;
 
     btree = S2BT(session);
@@ -2461,6 +2494,14 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     /* Reset the reconciliation state. */
     mod->rec_result = 0;
 
+    /*
+     * When the page is being reconciled as part of the checkpoint operation, the REF is not locked.
+     * Concurrent access to the page can be enabled by safe-releasing the time aggregate
+     * information.
+     */
+    __rec_page_modify_ta_safe_free(session, &mod->stop_ta);
+    WT_TIME_AGGREGATE_INIT_MERGE(&stop_ta);
+
     __wt_verbose(session, WT_VERB_RECONCILE, "%p reconciled into %" PRIu32 " pages", (void *)ref,
       r->multi_next);
 
@@ -2514,10 +2555,12 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
             r->multi->addr.addr = NULL;
             mod->mod_disk_image = r->multi->disk_image;
             r->multi->disk_image = NULL;
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
         } else {
             __wt_checkpoint_tree_reconcile_update(session, &r->multi->addr.ta);
             WT_RET(__rec_write(session, r->wrapup_checkpoint, NULL, NULL, NULL, true,
               F_ISSET(r, WT_REC_CHECKPOINT), r->wrapup_checkpoint_compressed));
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &r->multi->addr.ta);
         }
 
         mod->rec_result = WT_PM_REC_REPLACE;
@@ -2539,6 +2582,10 @@ split:
 
         r->multi = NULL;
         r->multi_next = 0;
+
+        /* Calculate the max stop time point by traversing all multi addresses. */
+        for (multi = mod->mod_multi, i = 0; i < mod->mod_multi_entries; ++multi, ++i)
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &multi->addr.ta);
         break;
     }
 
@@ -2578,6 +2625,12 @@ split:
 
         if (!F_ISSET(r, WT_REC_EVICT))
             WT_REF_UNLOCK(ref, previous_ref_state);
+    }
+
+    if (WT_TIME_AGGREGATE_HAS_STOP(&stop_ta)) {
+        WT_RET(__wt_calloc_one(session, &stop_tap));
+        WT_TIME_AGGREGATE_COPY(stop_tap, &stop_ta);
+        WT_PUBLISH(mod->stop_ta, stop_tap);
     }
 
     return (0);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -185,9 +185,12 @@ static const char *const __stats_dsrc_desc[] = {
   "compression: pages written to disk with compression ratio smaller than 16",
   "compression: pages written to disk with compression ratio smaller than 32",
   "compression: pages written to disk with compression ratio smaller than 64",
+  "cursor: Total number of deleted pages skipped during tree walk",
   "cursor: Total number of entries skipped by cursor next calls",
   "cursor: Total number of entries skipped by cursor prev calls",
   "cursor: Total number of entries skipped to position the history store cursor",
+  "cursor: Total number of in-memory deleted pages skipped during tree walk",
+  "cursor: Total number of on-disk deleted pages skipped during tree walk",
   "cursor: Total number of times a search near has exited due to prefix config",
   "cursor: Total number of times cursor fails to temporarily release pinned page to encourage "
   "eviction of hot or large page",
@@ -524,9 +527,12 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->compress_write_ratio_hist_16 = 0;
     stats->compress_write_ratio_hist_32 = 0;
     stats->compress_write_ratio_hist_64 = 0;
+    stats->cursor_tree_walk_del_page_skip = 0;
     stats->cursor_next_skip_total = 0;
     stats->cursor_prev_skip_total = 0;
     stats->cursor_skip_hs_cur_position = 0;
+    stats->cursor_tree_walk_inmem_del_page_skip = 0;
+    stats->cursor_tree_walk_ondisk_del_page_skip = 0;
     stats->cursor_search_near_prefix_fast_paths = 0;
     stats->cursor_reposition_failed = 0;
     stats->cursor_reposition = 0;
@@ -850,9 +856,12 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->compress_write_ratio_hist_16 += from->compress_write_ratio_hist_16;
     to->compress_write_ratio_hist_32 += from->compress_write_ratio_hist_32;
     to->compress_write_ratio_hist_64 += from->compress_write_ratio_hist_64;
+    to->cursor_tree_walk_del_page_skip += from->cursor_tree_walk_del_page_skip;
     to->cursor_next_skip_total += from->cursor_next_skip_total;
     to->cursor_prev_skip_total += from->cursor_prev_skip_total;
     to->cursor_skip_hs_cur_position += from->cursor_skip_hs_cur_position;
+    to->cursor_tree_walk_inmem_del_page_skip += from->cursor_tree_walk_inmem_del_page_skip;
+    to->cursor_tree_walk_ondisk_del_page_skip += from->cursor_tree_walk_ondisk_del_page_skip;
     to->cursor_search_near_prefix_fast_paths += from->cursor_search_near_prefix_fast_paths;
     to->cursor_reposition_failed += from->cursor_reposition_failed;
     to->cursor_reposition += from->cursor_reposition;
@@ -1185,9 +1194,14 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->compress_write_ratio_hist_16 += WT_STAT_READ(from, compress_write_ratio_hist_16);
     to->compress_write_ratio_hist_32 += WT_STAT_READ(from, compress_write_ratio_hist_32);
     to->compress_write_ratio_hist_64 += WT_STAT_READ(from, compress_write_ratio_hist_64);
+    to->cursor_tree_walk_del_page_skip += WT_STAT_READ(from, cursor_tree_walk_del_page_skip);
     to->cursor_next_skip_total += WT_STAT_READ(from, cursor_next_skip_total);
     to->cursor_prev_skip_total += WT_STAT_READ(from, cursor_prev_skip_total);
     to->cursor_skip_hs_cur_position += WT_STAT_READ(from, cursor_skip_hs_cur_position);
+    to->cursor_tree_walk_inmem_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_inmem_del_page_skip);
+    to->cursor_tree_walk_ondisk_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_ondisk_del_page_skip);
     to->cursor_search_near_prefix_fast_paths +=
       WT_STAT_READ(from, cursor_search_near_prefix_fast_paths);
     to->cursor_reposition_failed += WT_STAT_READ(from, cursor_reposition_failed);
@@ -1675,9 +1689,12 @@ static const char *const __stats_connection_desc[] = {
   "connection: total fsync I/Os",
   "connection: total read I/Os",
   "connection: total write I/Os",
+  "cursor: Total number of deleted pages skipped during tree walk",
   "cursor: Total number of entries skipped by cursor next calls",
   "cursor: Total number of entries skipped by cursor prev calls",
   "cursor: Total number of entries skipped to position the history store cursor",
+  "cursor: Total number of in-memory deleted pages skipped during tree walk",
+  "cursor: Total number of on-disk deleted pages skipped during tree walk",
   "cursor: Total number of times a search near has exited due to prefix config",
   "cursor: Total number of times cursor fails to temporarily release pinned page to encourage "
   "eviction of hot or large page",
@@ -2392,9 +2409,12 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->fsync_io = 0;
     stats->read_io = 0;
     stats->write_io = 0;
+    stats->cursor_tree_walk_del_page_skip = 0;
     stats->cursor_next_skip_total = 0;
     stats->cursor_prev_skip_total = 0;
     stats->cursor_skip_hs_cur_position = 0;
+    stats->cursor_tree_walk_inmem_del_page_skip = 0;
+    stats->cursor_tree_walk_ondisk_del_page_skip = 0;
     stats->cursor_search_near_prefix_fast_paths = 0;
     stats->cursor_reposition_failed = 0;
     stats->cursor_reposition = 0;
@@ -3140,9 +3160,14 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->fsync_io += WT_STAT_READ(from, fsync_io);
     to->read_io += WT_STAT_READ(from, read_io);
     to->write_io += WT_STAT_READ(from, write_io);
+    to->cursor_tree_walk_del_page_skip += WT_STAT_READ(from, cursor_tree_walk_del_page_skip);
     to->cursor_next_skip_total += WT_STAT_READ(from, cursor_next_skip_total);
     to->cursor_prev_skip_total += WT_STAT_READ(from, cursor_prev_skip_total);
     to->cursor_skip_hs_cur_position += WT_STAT_READ(from, cursor_skip_hs_cur_position);
+    to->cursor_tree_walk_inmem_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_inmem_del_page_skip);
+    to->cursor_tree_walk_ondisk_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_ondisk_del_page_skip);
     to->cursor_search_near_prefix_fast_paths +=
       WT_STAT_READ(from, cursor_search_near_prefix_fast_paths);
     to->cursor_reposition_failed += WT_STAT_READ(from, cursor_reposition_failed);

--- a/test/suite/test_checkpoint32.py
+++ b/test/suite/test_checkpoint32.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading, time
+import wttest
+import wiredtiger
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+# test_checkpoint32.py
+#
+# Test that skipping in-memory reconciled deleted pages as part of the tree walk.
+class test_checkpoint32(wttest.WiredTigerTestCase):
+
+    format_values = [
+        # FLCS doesn't support skipping pages based on aggregated time.
+        ('column', dict(key_format='r', value_format='S', extraconfig='')),
+        ('string_row', dict(key_format='S', value_format='S', extraconfig='')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def check(self, ds, nrows, value):
+        cursor = self.session.open_cursor(ds.uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, value)
+            count += 1
+        self.assertEqual(count, nrows)
+        cursor.close()
+
+    def test_checkpoint(self):
+        uri = 'table:checkpoint32'
+        nrows = 1000
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        value_a = "aaaaa" * 100
+
+        # Write some initial data.
+        cursor = self.session.open_cursor(ds.uri, None, None)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = value_a
+            self.session.commit_transaction()
+
+        # Create a reader transaction that will not be able to see what happens next.
+        # We don't need to do anything with this; it just needs to exist.
+        session2 = self.conn.open_session()
+        session2.begin_transaction()
+
+        # Now remove all data.
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor.set_key(ds.key(i))
+            self.assertEqual(cursor.remove(), 0)
+            self.session.commit_transaction()
+
+        # Checkpoint.
+        self.session.checkpoint()
+
+        # Get the existing in-memory delete page skip statistic value.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        prev_cur_inmem_del_page_skip = stat_cursor[stat.conn.cursor_tree_walk_inmem_del_page_skip][2]
+        stat_cursor.close()
+
+        # Now read the removed data.
+        self.check(ds, 0, value_a)
+
+        # Get the new in-memory delete page skip statistic value.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        cur_inmem_del_page_skip = stat_cursor[stat.conn.cursor_tree_walk_inmem_del_page_skip][2]
+        stat_cursor.close()
+
+        self.assertGreater(cur_inmem_del_page_skip, prev_cur_inmem_del_page_skip)
+
+        # Tidy up.
+        session2.rollback_transaction()
+        session2.close()
+        cursor.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Traversing an in-memory page that contains all the deleted values that are visible to the current transaction led to an increase in latency due to the time spent skipping these deleted values.

By saving the aggregated timestamp information in the ref when the page has all deleted values, this aggregated information can be validated against the transaction snapshot to skip traversing the page completely and improve the latency when there are many deleted pages.

The downside of this approach is that the in-memory size of each ref is increased by 8 more bytes, but this increase shouldn't cause any problem.

(cherry picked from commit d121cca3b711efd1951a36aa48348ec6df5803fe)