### PR TITLE
WT-12784 Avoid building and checking of cfg entries for compiled configs

### DIFF
--- a/src/include/api.h
+++ b/src/include/api.h
@@ -385,9 +385,9 @@
     WT_CONF_API_TYPE(h, n) _conf; \
     WT_CONF *conf = NULL
 
-#define API_CONF(session, h, n, cfg, conf)                                      \
+#define API_CONF(session, h, n, config, conf)                                   \
     WT_ERR(__wt_conf_compile_api_call(session, WT_CONFIG_REF(session, h##_##n), \
-      WT_CONFIG_ENTRY_##h##_##n, cfg[1], &_conf, sizeof(_conf), &conf))
+      WT_CONFIG_ENTRY_##h##_##n, config, &_conf, sizeof(_conf), &conf))
 
 #define SESSION_API_CONF(session, n, cfg, conf) API_CONF(session, WT_SESSION, n, cfg, conf)
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1962,8 +1962,8 @@ __session_begin_transaction(WT_SESSION *wt_session, const char *config)
     WT_SESSION_IMPL *session;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL_PREPARE_NOT_ALLOWED(session, ret, begin_transaction, config, cfg);
-    SESSION_API_CONF(session, begin_transaction, cfg, conf);
+    SESSION_API_CALL_PREPARE_NOT_ALLOWED_NOCONF(session, ret, begin_transaction);
+    SESSION_API_CONF(session, begin_transaction, config, conf);
     WT_STAT_CONN_INCR(session, txn_begin);
     WT_STAT_SESSION_SET(session, txn_bytes_dirty, 0);
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -756,8 +756,6 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *txn_shared;
     uint64_t original_snap_min;
-    const char *txn_cfg[] = {
-      WT_CONFIG_BASE(session, WT_SESSION_begin_transaction), "isolation=snapshot", NULL};
     char ts_string[2][WT_TS_INT_STRING_SIZE];
     bool flush, flush_force, use_timestamp;
 
@@ -766,7 +764,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
     txn_global = &conn->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
-    API_CONF(session, WT_SESSION, begin_transaction, txn_cfg, txn_conf);
+    API_CONF(session, WT_SESSION, begin_transaction, "isolation=snapshot", txn_conf);
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
 


### PR DESCRIPTION
This is a perf improvement between 2-3% for the config microbenchmark (test_wt11126_compile_config).