### PR TITLE
WT-12792 Don't set timestamps in test/format if disabled through the config

### DIFF
--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -102,6 +102,9 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
     uint64_t oldest_timestamp, stable_timestamp, stop_timestamp;
     char buf[WT_TS_HEX_STRING_SIZE * 2 + 64];
 
+    /* Ensure timestamps are used. */
+    testutil_assert(g.transaction_timestamps_config);
+
     conn = g.wts_conn;
 
     /* Get the maximum not-in-use timestamp, noting that it may not be set. */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -483,7 +483,8 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
 
     if (lastrun) {
         tinfo_teardown();
-        timestamp_teardown(session);
+        if (g.transaction_timestamps_config)
+            timestamp_teardown(session);
     }
 
     wt_wrap_close_session(session);


### PR DESCRIPTION
- We should only be executing `timestamp_once` when timestamps are used as it sets the stable/oldest ts.
- There is one function called `timestamp_teardown` that is called at the end of a run that bumps the stable/oldest ts. It should not be called if timestamps are disabled.