### PR TITLE
WT-11373 Search should return any record below the greatest existing record in FLCS

### DIFF
--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -73,10 +73,7 @@ __wt_col_search(
     uint64_t recno;
     uint32_t base, indx, limit, read_flags;
     int depth;
-    /*
-     * In FLCS, when looking for an implicit record, we want to return it as long as a greater
-     * record exists in the tree.
-     */
+    /* Whenever there is a greater record in the tree, FLCS should return the requested record. */
     bool greater_recno_exists_flcs;
 
     session = CUR2S(cbt);
@@ -339,9 +336,8 @@ past_end:
         else if (recno < cbt->recno)
             cbt->compare = 1;
         /*
-         * Special case for FLCS: the searched-for record number is greater then the record the
-         * cursor is positioned on but there is a row larger than the searched-for key. This means
-         * we are looking for an implicit record.
+         * Special case for FLCS: the requested record number is greater than the record the
+         * cursor is positioned on but a greater record number exists.
          */
         else if (greater_recno_exists_flcs)
             cbt->compare = 1;

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -337,8 +337,8 @@ past_end:
         else if (recno < cbt->recno)
             cbt->compare = 1;
         /*
-         * Special case for FLCS: the requested record number is greater than the record the
-         * cursor is positioned on but a greater record number exists.
+         * Special case for FLCS: the requested record number is greater than the record the cursor
+         * is positioned on but a greater record number exists.
          */
         else if (greater_recno_exists_flcs)
             cbt->compare = 1;

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -73,10 +73,18 @@ __wt_col_search(
     uint64_t recno;
     uint32_t base, indx, limit, read_flags;
     int depth;
+    /*
+     * In FLCS, when looking for an implicit record, we want to return it as long as a greater
+     * record exists in the tree.
+     */
+    bool greater_recno_exists_flcs;
+    bool is_flcs;
 
     session = CUR2S(cbt);
     btree = S2BT(session);
+    is_flcs = btree->type == BTREE_COL_FIX;
     current = NULL;
+    greater_recno_exists_flcs = false;
 
     /*
      * Assert the session and cursor have the right relationship (not search specific, but search is
@@ -133,6 +141,9 @@ restart:
         WT_INTL_INDEX_GET(session, page, pindex);
         base = pindex->entries;
         descent = pindex->index[base - 1];
+
+        if (is_flcs && !greater_recno_exists_flcs && descent->ref_recno > recno)
+            greater_recno_exists_flcs = true;
 
         /* Fast path appends. */
         if (recno >= descent->ref_recno) {
@@ -328,8 +339,12 @@ past_end:
             cbt->compare = 0;
         else if (recno < cbt->recno)
             cbt->compare = 1;
-        else
+        else {
             cbt->compare = -1;
+            /* Special case for FLCS: indicate there is a row larger than the searched-for key. */
+            if (greater_recno_exists_flcs)
+                cbt->compare = 1;
+        }
     }
     return (0);
 }

--- a/src/btree/col_srch.c
+++ b/src/btree/col_srch.c
@@ -137,6 +137,7 @@ restart:
         base = pindex->entries;
         descent = pindex->index[base - 1];
 
+        /* For FLCS, save if we have encountered a record number greater than the requested one. */
         if (btree->type == BTREE_COL_FIX && !greater_recno_exists_flcs &&
           descent->ref_recno > recno)
             greater_recno_exists_flcs = true;

--- a/test/suite/test_flcs07.py
+++ b/test/suite/test_flcs07.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+
+# test_flcs07.py
+#
+# Test that implicit records smaller than the greatest record inserted can be found.
+class test_flcs07(wttest.WiredTigerTestCase):
+
+    def get_cache_inmem_split(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        value = stat_cursor[stat.conn.cache_inmem_split][2]
+        stat_cursor.close()
+        return value
+
+    def test_flcs(self):
+        uri = "table:test_flcs07"
+        inmem_split = False
+        nrows = 1000000
+        ds = SimpleDataSet(self, uri, 0, key_format='r', value_format='8t')
+        ds.populate()
+
+        # Insert N records with gaps between them.
+        gap_size = 10
+        cursor = self.session.open_cursor(uri)
+        for i in range(10, nrows, gap_size):
+            cursor[ds.key(i)] = ds.value(i)
+            # As soon as an in-memory split is detected, exit.
+            if self.get_cache_inmem_split() > 0:
+                inmem_split = True
+                break
+        
+        assert inmem_split, "At least one in-memory split is expected"
+
+        # Look for every single record smaller than the last one inserted.
+        for i in range(i, 1, -1):
+            cursor.set_key(ds.key(i))
+            self.assertEqual(cursor.search(), 0)
+
+            # Check the value.
+            if i % gap_size == 0:
+                assert(cursor.get_value() == ds.value(i))
+            else:
+                assert(cursor.get_value() == 0)
+
+            # FIXME-WT-12682
+            # Do a search near on the same key.
+            # self.assertEqual(cursor.search_near(), 0)
+
+            # Check the value.
+            # if i % gap_size == 0:
+            #     assert(cursor.get_value() == ds.value(i))
+            # else:
+            #     assert(cursor.get_value() == 0)

--- a/test/suite/test_flcs07.py
+++ b/test/suite/test_flcs07.py
@@ -57,7 +57,7 @@ class test_flcs07(wttest.WiredTigerTestCase):
             if self.get_cache_inmem_split() > 0:
                 inmem_split = True
                 break
-        
+
         assert inmem_split, "At least one in-memory split is expected"
 
         # Look for every single record smaller than the last one inserted.


### PR DESCRIPTION
When looking for an implicit record in FLCS and a greater valid record exists, ensure `search()` returns the requested record.