### PR TITLE
WT-12587 Re-enable compile-clang tasks for older versions of clang (#10302) (v5.0 backport)

### DIFF
--- a/test/cppsuite/test_harness/test.cxx
+++ b/test/cppsuite/test_harness/test.cxx
@@ -28,6 +28,7 @@
 
 /* Required to build using older versions of g++. */
 #include <cinttypes>
+#include <memory>
 #include <mutex>
 
 #include "connection_manager.h"

--- a/test/cppsuite/test_harness/test.h
+++ b/test/cppsuite/test_harness/test.h
@@ -29,6 +29,7 @@
 #ifndef TEST_H
 #define TEST_H
 
+#include <memory>
 #include <vector>
 #include <string>
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -870,22 +870,16 @@ tasks:
         vars:
           configure_env_vars: CC=gcc-9 CXX=g++-9 ADD_CFLAGS="-ggdb -fPIC"
 
-  # FIXME-WT-11239: This is a build issue as this test intentionally does not use the mongodbtoolchain
-  # and recent platform changes have caused issues with the system toolchain. We will be fixing this as 
-  # part of WT-11239.
-  # - name: compile-clang
-  #   tags: ["pull_request", "pull_request_compilers"]
-  #   commands:
-  #     - func: "get project"
-  #     - func: "compile wiredtiger"
-  #       vars:
-  #         configure_env_vars: CC=clang-6.0 CXX=clang++-6.0 ADD_CFLAGS="-ggdb -fPIC"
-  #     - func: "compile wiredtiger"
-  #       vars:
-  #         configure_env_vars: CC=clang-7 CXX=clang++-7 ADD_CFLAGS="-ggdb -fPIC"
-  #     - func: "compile wiredtiger"
-  #       vars:
-  #         configure_env_vars: CC=clang-8 CXX=clang++-8 ADD_CFLAGS="-ggdb -fPIC"
+  - name: compile-clang
+    tags: ["pull_request", "pull_request_compilers"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          configure_env_vars: CC=clang-7 CXX=clang++-7 ADD_CFLAGS="-ggdb -fPIC"
+      - func: "compile wiredtiger"
+        vars:
+          configure_env_vars: CC=clang-8 CXX=clang++-8 ADD_CFLAGS="-ggdb -fPIC"
 
   - name: make-check-test
     depends_on:


### PR DESCRIPTION
cherry picked from commit https://github.com/wiredtiger/wiredtiger/commit/92a92da1d173b9252c1bf883446302448787f585