### PR TITLE
WT-10807 Skip in-memory deleted pages as part of the tree walk (7.0 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -930,6 +930,9 @@ conn_dsrc_stats = [
     CursorStat('cursor_reposition_failed', 'Total number of times cursor fails to temporarily release pinned page to encourage eviction of hot or large page'),
     CursorStat('cursor_search_near_prefix_fast_paths', 'Total number of times a search near has exited due to prefix config'),
     CursorStat('cursor_skip_hs_cur_position', 'Total number of entries skipped to position the history store cursor'),
+    CursorStat('cursor_tree_walk_del_page_skip', 'Total number of deleted pages skipped during tree walk'),
+    CursorStat('cursor_tree_walk_ondisk_del_page_skip', 'Total number of on-disk deleted pages skipped during tree walk'),
+    CursorStat('cursor_tree_walk_inmem_del_page_skip', 'Total number of in-memory deleted pages skipped during tree walk'),
 
     ##########################################
     # Cursor API error statistics

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -768,6 +768,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_PAGE *page;
+    WT_PAGE_WALK_SKIP_STATS walk_skip_stats;
     WT_SESSION_IMPL *session;
     size_t total_skipped, skipped;
     uint32_t flags;
@@ -782,6 +783,8 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
     need_walk = false;
     session = CUR2S(cbt);
     total_skipped = 0;
+    walk_skip_stats.total_del_pages_skipped = 0;
+    walk_skip_stats.total_inmem_del_pages_skipped = 0;
 
     WT_STAT_CONN_DATA_INCR(session, cursor_next);
 
@@ -921,8 +924,8 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
          */
         if (session->txn->isolation == WT_ISO_SNAPSHOT &&
           !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE))
-            WT_ERR(
-              __wt_tree_walk_custom_skip(session, &cbt->ref, __wt_btcur_skip_page, NULL, flags));
+            WT_ERR(__wt_tree_walk_custom_skip(
+              session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));
         else
             WT_ERR(__wt_tree_walk(session, &cbt->ref, flags));
         WT_ERR_TEST(cbt->ref == NULL, WT_NOTFOUND, false);
@@ -938,6 +941,12 @@ err:
     }
 
     WT_STAT_CONN_DATA_INCRV(session, cursor_next_skip_total, total_skipped);
+    if (walk_skip_stats.total_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(
+          session, cursor_tree_walk_del_page_skip, walk_skip_stats.total_del_pages_skipped);
+    if (walk_skip_stats.total_inmem_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(session, cursor_tree_walk_inmem_del_page_skip,
+          walk_skip_stats.total_inmem_del_pages_skipped);
 
     switch (ret) {
     case 0:

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -732,6 +732,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_PAGE *page;
+    WT_PAGE_WALK_SKIP_STATS walk_skip_stats;
     WT_SESSION_IMPL *session;
     size_t total_skipped, skipped;
     uint32_t flags;
@@ -746,6 +747,8 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
     need_walk = false;
     session = CUR2S(cbt);
     total_skipped = 0;
+    walk_skip_stats.total_del_pages_skipped = 0;
+    walk_skip_stats.total_inmem_del_pages_skipped = 0;
 
     WT_STAT_CONN_DATA_INCR(session, cursor_prev);
 
@@ -882,8 +885,8 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
         if (!F_ISSET(&cbt->iface, WT_CURSTD_KEY_ONLY) &&
           session->txn->isolation == WT_ISO_SNAPSHOT &&
           !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE))
-            WT_ERR(
-              __wt_tree_walk_custom_skip(session, &cbt->ref, __wt_btcur_skip_page, NULL, flags));
+            WT_ERR(__wt_tree_walk_custom_skip(
+              session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));
         else
             WT_ERR(__wt_tree_walk(session, &cbt->ref, flags));
         WT_ERR_TEST(cbt->ref == NULL, WT_NOTFOUND, false);
@@ -899,6 +902,12 @@ err:
     }
 
     WT_STAT_CONN_DATA_INCRV(session, cursor_prev_skip_total, total_skipped);
+    if (walk_skip_stats.total_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(
+          session, cursor_tree_walk_del_page_skip, walk_skip_stats.total_del_pages_skipped);
+    if (walk_skip_stats.total_inmem_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(session, cursor_tree_walk_inmem_del_page_skip,
+          walk_skip_stats.total_inmem_del_pages_skipped);
 
     switch (ret) {
     case 0:

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -235,6 +235,7 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     __wt_free(session, page->modify->ovfl_track);
     __wt_free(session, page->modify->inst_updates);
+    __wt_free(session, page->modify->stop_ta);
     __wt_spin_destroy(session, &page->modify->page_lock);
 
     __wt_free(session, page->modify);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -430,6 +430,13 @@ struct __wt_page_modify {
     WT_OVFL_TRACK *ovfl_track;
 
     /*
+     * Stop aggregated timestamp information when all the keys on the page are removed. This time
+     * aggregate information is used to skip these deleted pages as part of the tree walk if the
+     * delete operation is visible to the reader.
+     */
+    wt_shared WT_TIME_AGGREGATE *stop_ta;
+
+    /*
      * Page-delete information for newly instantiated deleted pages. The instantiated flag remains
      * set until the page is reconciled successfully; this indicates that the page_del information
      * in the ref remains valid. The update list remains set (if set at all) until the transaction
@@ -750,6 +757,15 @@ struct __wt_page {
  */
 #define WT_PAGE_DISK_OFFSET(page, p) WT_PTRDIFF32(p, (page)->dsk)
 #define WT_PAGE_REF_OFFSET(page, o) ((void *)((uint8_t *)((page)->dsk) + (o)))
+
+/*
+ * WT_PAGE_WALK_SKIP_STATS --
+ *	Statistics to track how many deleted pages are skipped as part of the tree walk.
+ */
+struct __wt_page_walk_skip_stats {
+    size_t total_del_pages_skipped;
+    size_t total_inmem_del_pages_skipped;
+};
 
 /*
  * Prepare update states.

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -434,7 +434,7 @@ struct __wt_page_modify {
      * aggregate information is used to skip these deleted pages as part of the tree walk if the
      * delete operation is visible to the reader.
      */
-    wt_shared WT_TIME_AGGREGATE *stop_ta;
+    WT_TIME_AGGREGATE *stop_ta;
 
     /*
      * Page-delete information for newly instantiated deleted pages. The instantiated flag remains

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1593,6 +1593,27 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
 }
 
 /*
+ * __wt_get_page_modify_ta --
+ *     Returns the page modify stop time aggregate information if exists.
+ */
+static inline bool
+__wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page, WT_TIME_AGGREGATE **ta)
+{
+    WT_ASSERT_ALWAYS(session, __wt_session_gen(session, WT_GEN_SPLIT) != 0,
+      "Any thread accessing ref address must hold a valid split generation");
+
+    /* If NULL, there is no information. */
+    if (page->modify == NULL)
+        return (false);
+
+    if (page->modify->stop_ta == NULL)
+        return (false);
+
+    WT_READ_ONCE(*ta, page->modify->stop_ta);
+    return (*ta != NULL);
+}
+
+/*
  * __wt_ref_block_free --
  *     Free the on-disk block for a reference and clear the address.
  */
@@ -2280,7 +2301,10 @@ __wt_btcur_skip_page(
 {
     WT_ADDR_COPY addr;
     WT_BTREE *btree;
+    WT_PAGE_WALK_SKIP_STATS *walk_skip_stats;
+    WT_TIME_AGGREGATE *ta;
     uint8_t previous_state;
+    bool clean_page;
 
     WT_UNUSED(context);
     WT_UNUSED(visible_all);
@@ -2288,6 +2312,9 @@ __wt_btcur_skip_page(
     *skipp = false; /* Default to reading */
 
     btree = S2BT(session);
+    walk_skip_stats = (WT_PAGE_WALK_SKIP_STATS *)context;
+    ta = NULL;
+    clean_page = false;
 
     /* Don't skip pages in FLCS trees; deleted records need to read back as 0. */
     if (btree->type == BTREE_COL_FIX)
@@ -2328,20 +2355,19 @@ __wt_btcur_skip_page(
      */
     if (previous_state == WT_REF_DELETED && __wt_page_del_visible(session, ref->page_del, true)) {
         *skipp = true;
+        walk_skip_stats->total_del_pages_skipped++;
         goto unlock;
     }
 
-    /*
-     * Look at the disk address, if it exists, and if the page is unmodified. We must skip this test
-     * if the page has been modified since it was reconciled, since neither the delete information
-     * nor the timestamp information is necessarily up to date.
-     */
-    if ((previous_state == WT_REF_DISK ||
-          (previous_state == WT_REF_MEM && !__wt_page_is_modified(ref->page))) &&
-      __wt_ref_addr_copy(session, ref, &addr)) {
+    if (previous_state == WT_REF_MEM && !__wt_page_is_modified(ref->page))
+        clean_page = true;
+
+    /* Look at the disk address, if it exists. */
+    if ((previous_state == WT_REF_DISK || clean_page) && __wt_ref_addr_copy(session, ref, &addr)) {
         /* If there's delete information in the disk address, we can use it. */
         if (addr.del_set && __wt_page_del_visible(session, &addr.del, true)) {
             *skipp = true;
+            walk_skip_stats->total_del_pages_skipped++;
             goto unlock;
         }
 
@@ -2349,12 +2375,23 @@ __wt_btcur_skip_page(
          * Otherwise, check the timestamp information. We base this decision on the aggregate stop
          * point added to the page during the last reconciliation.
          */
-        if (addr.ta.newest_stop_txn != WT_TXN_MAX && addr.ta.newest_stop_ts != WT_TS_MAX &&
+        if (WT_TIME_AGGREGATE_HAS_STOP(&addr.ta) &&
           __wt_txn_snap_min_visible(session, addr.ta.newest_stop_txn, addr.ta.newest_stop_ts,
             addr.ta.newest_stop_durable_ts)) {
             *skipp = true;
-            goto unlock;
+            walk_skip_stats->total_del_pages_skipped++;
         }
+    } else if (clean_page && __wt_get_page_modify_ta(session, ref->page, &ta) &&
+      __wt_txn_snap_min_visible(
+        session, ta->newest_stop_txn, ta->newest_stop_ts, ta->newest_stop_durable_ts)) {
+        /*
+         * If the reader can see all of the deleted content, they can skip a deleted clean page.
+         * Before determining whether the deleted page is visible, copy the stop time aggregate
+         * information pointer because as part of the checkpoint operation, this pointer can be
+         * released in parallel.
+         */
+        *skipp = true;
+        walk_skip_stats->total_inmem_del_pages_skipped++;
     }
 
 unlock:

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1609,7 +1609,7 @@ __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page, WT_TIME_AGGREGA
     if (page->modify->stop_ta == NULL)
         return (false);
 
-    WT_READ_ONCE(*ta, page->modify->stop_ta);
+    WT_ORDERED_READ(*ta, page->modify->stop_ta);
     return (*ta != NULL);
 }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2031,6 +2031,8 @@ static inline bool __wt_eviction_updates_needed(WT_SESSION_IMPL *session, double
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_failpoint(WT_SESSION_IMPL *session, uint64_t conn_flag, u_int probability)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page,
+  WT_TIME_AGGREGATE **ta) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isalnum(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isalpha(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isascii(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -581,9 +581,12 @@ struct __wt_connection_stats {
     int64_t fsync_io;
     int64_t read_io;
     int64_t write_io;
+    int64_t cursor_tree_walk_del_page_skip;
     int64_t cursor_next_skip_total;
     int64_t cursor_prev_skip_total;
     int64_t cursor_skip_hs_cur_position;
+    int64_t cursor_tree_walk_inmem_del_page_skip;
+    int64_t cursor_tree_walk_ondisk_del_page_skip;
     int64_t cursor_search_near_prefix_fast_paths;
     int64_t cursor_reposition_failed;
     int64_t cursor_reposition;
@@ -1097,9 +1100,12 @@ struct __wt_dsrc_stats {
     int64_t compress_hist_ratio_8;
     int64_t compress_write_fail;
     int64_t compress_write_too_small;
+    int64_t cursor_tree_walk_del_page_skip;
     int64_t cursor_next_skip_total;
     int64_t cursor_prev_skip_total;
     int64_t cursor_skip_hs_cur_position;
+    int64_t cursor_tree_walk_inmem_del_page_skip;
+    int64_t cursor_tree_walk_ondisk_del_page_skip;
     int64_t cursor_search_near_prefix_fast_paths;
     int64_t cursor_reposition_failed;
     int64_t cursor_reposition;

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -231,3 +231,7 @@
         (out_ta)->newest_stop_ts = WT_MAX((out_ta)->newest_stop_ts, (in_ta)->newest_stop_ts);    \
         (out_ta)->newest_stop_txn = WT_MAX((out_ta)->newest_stop_txn, (in_ta)->newest_stop_txn); \
     } while (0)
+
+/* Check if the stop time aggregate is set. */
+#define WT_TIME_AGGREGATE_HAS_STOP(ta) \
+    ((ta)->newest_stop_txn != WT_TXN_MAX || (ta)->newest_stop_ts != WT_TS_MAX)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -835,6 +835,8 @@ static inline bool
 __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
 {
+    WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
+
     /* Transaction snapshot minimum check. */
     if (!WT_TXNID_LT(id, session->txn->snap_min))
         return (false);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5953,871 +5953,880 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_READ_IO				1240
 /*! connection: total write I/Os */
 #define	WT_STAT_CONN_WRITE_IO				1241
+/*! cursor: Total number of deleted pages skipped during tree walk */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1242
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1242
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1243
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1243
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1244
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1244
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1245
+/*!
+ * cursor: Total number of in-memory deleted pages skipped during tree
+ * walk
+ */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1246
+/*! cursor: Total number of on-disk deleted pages skipped during tree walk */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1247
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1245
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1248
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1246
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1249
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1247
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1250
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1248
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1251
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1249
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1252
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1250
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1253
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1251
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1254
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1252
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1255
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1253
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1256
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1254
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1257
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1255
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1258
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1256
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1259
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1257
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1260
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1258
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1261
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1259
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1262
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1260
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1263
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1261
+#define	WT_STAT_CONN_CURSOR_CACHE			1264
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1262
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1265
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1263
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1266
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1264
+#define	WT_STAT_CONN_CURSOR_CREATE			1267
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1265
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1268
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1266
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1269
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1267
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1270
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1268
+#define	WT_STAT_CONN_CURSOR_INSERT			1271
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1269
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1272
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1270
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1273
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1271
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1274
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1272
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1275
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1273
+#define	WT_STAT_CONN_CURSOR_MODIFY			1276
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1274
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1277
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1275
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1278
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1276
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1279
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1277
+#define	WT_STAT_CONN_CURSOR_NEXT			1280
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1278
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1281
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1279
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1282
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1280
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1283
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1281
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1284
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1282
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1285
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1283
+#define	WT_STAT_CONN_CURSOR_RESTART			1286
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1284
+#define	WT_STAT_CONN_CURSOR_PREV			1287
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1285
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1288
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1286
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1289
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1287
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1290
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1288
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1291
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1289
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1292
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1290
+#define	WT_STAT_CONN_CURSOR_REMOVE			1293
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1291
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1294
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1292
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1295
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1293
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1296
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1294
+#define	WT_STAT_CONN_CURSOR_RESERVE			1297
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1295
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1298
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1296
+#define	WT_STAT_CONN_CURSOR_RESET			1299
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1297
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1300
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1298
+#define	WT_STAT_CONN_CURSOR_SEARCH			1301
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1299
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1302
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1300
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1303
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1301
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1304
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1302
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1305
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1303
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1306
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1304
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1307
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1305
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1308
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1306
+#define	WT_STAT_CONN_CURSOR_SWEEP			1309
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1307
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1310
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1308
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1311
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1309
+#define	WT_STAT_CONN_CURSOR_UPDATE			1312
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1310
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1313
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1311
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1314
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1312
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1315
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1313
+#define	WT_STAT_CONN_CURSOR_REOPEN			1316
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1314
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1317
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1315
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1318
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1316
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1319
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1317
+#define	WT_STAT_CONN_DH_SWEEP_REF			1320
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1318
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1321
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1319
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1322
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1320
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1323
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1321
+#define	WT_STAT_CONN_DH_SWEEPS				1324
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1322
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1325
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1323
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1326
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1324
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1327
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1325
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1328
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1326
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1329
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1327
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1330
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1328
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1331
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1329
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1332
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1330
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1333
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1331
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1334
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1332
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1335
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1333
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1336
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1334
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1337
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1335
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1338
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1336
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1339
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1337
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1340
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1338
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1341
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1339
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1342
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1340
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1343
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1341
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1344
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1342
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1345
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1343
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1346
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1344
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1347
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1345
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1348
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1346
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1349
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1347
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1350
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1348
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1351
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1349
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1352
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1350
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1353
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1351
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1354
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1352
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1355
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1353
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1356
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1354
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1357
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1355
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1358
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1356
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1359
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1357
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1360
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1358
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1361
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1359
+#define	WT_STAT_CONN_LOG_FLUSH				1362
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1360
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1363
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1361
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1364
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1362
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1365
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1363
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1366
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1364
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1367
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1365
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1368
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1366
+#define	WT_STAT_CONN_LOG_SCANS				1369
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1367
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1370
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1368
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1371
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1369
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1372
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1370
+#define	WT_STAT_CONN_LOG_SYNC				1373
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1371
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1374
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1372
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1375
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1373
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1376
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1374
+#define	WT_STAT_CONN_LOG_WRITES				1377
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1375
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1378
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1376
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1379
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1377
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1380
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1378
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1381
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1379
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1382
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1380
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1383
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1381
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1384
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1382
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1385
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1383
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1386
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1384
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1387
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1385
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1388
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1386
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1389
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1387
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1390
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1388
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1391
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1389
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1392
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1390
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1393
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1391
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1394
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1392
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1395
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1393
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1396
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1394
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1397
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1395
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1398
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1396
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1399
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1397
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1400
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1398
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1401
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1399
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1402
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1400
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1403
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1401
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1404
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1402
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1405
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1403
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1406
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1404
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1407
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1405
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1408
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1406
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1409
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1407
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1410
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1408
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1411
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1409
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1412
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1410
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1413
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1411
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1414
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1412
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1415
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1413
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1416
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1414
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1417
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1415
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1418
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1416
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1419
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1417
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1420
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1418
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1421
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1419
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1422
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1420
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1423
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1421
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1424
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1422
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1425
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1423
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1426
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1424
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1427
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1425
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1428
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1426
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1429
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1427
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1430
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1428
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1431
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1429
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1432
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1430
+#define	WT_STAT_CONN_REC_PAGES				1433
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1431
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1434
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1432
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1435
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1433
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1436
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1434
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1437
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1435
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1438
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1436
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1439
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1437
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1440
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1438
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1441
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1439
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1442
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1440
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1443
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1441
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1444
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1442
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1445
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1443
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1446
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1444
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1447
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1445
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1448
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1446
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1449
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1447
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1450
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1448
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1451
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1449
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1452
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1450
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1453
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1451
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1454
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1452
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1455
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1453
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1456
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1454
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1457
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1458
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1459
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1457
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1460
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1458
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1461
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1459
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1462
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1460
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1463
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1461
+#define	WT_STAT_CONN_FLUSH_TIER				1464
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1462
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1465
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1463
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1466
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1464
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1467
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1465
+#define	WT_STAT_CONN_SESSION_OPEN			1468
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1466
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1469
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1467
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1470
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1468
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1471
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1469
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1472
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1470
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1473
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1471
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1474
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1472
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1475
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1473
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1476
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1474
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1477
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1475
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1478
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1476
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1479
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1477
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1480
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1478
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1481
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1479
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1482
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1480
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1483
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1481
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1484
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1482
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1485
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1483
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1486
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1484
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1487
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1485
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1488
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1486
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1489
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1487
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1490
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1488
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1491
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1489
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1492
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1490
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1493
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1491
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1494
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1492
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1495
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1493
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1496
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1494
+#define	WT_STAT_CONN_TIERED_RETENTION			1497
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1495
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1498
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1496
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1499
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1497
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1500
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1498
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1501
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1499
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1502
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1500
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1503
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1501
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1504
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1502
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1505
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1503
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1506
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1504
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1507
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1505
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1508
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1506
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1509
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1507
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1510
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1508
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1511
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1509
+#define	WT_STAT_CONN_PAGE_SLEEP				1512
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1510
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1513
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1511
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1514
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1512
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1515
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1513
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1516
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1514
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1517
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1515
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1518
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1516
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1519
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1517
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1520
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1518
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1521
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1519
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1522
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1520
+#define	WT_STAT_CONN_TXN_PREPARE			1523
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1521
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1524
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1522
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1525
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1523
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1526
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1524
+#define	WT_STAT_CONN_TXN_QUERY_TS			1527
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1525
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1528
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1526
+#define	WT_STAT_CONN_TXN_RTS				1529
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1527
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1530
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1528
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1531
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1529
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1532
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1530
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1533
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1531
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1534
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1532
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1535
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1533
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1536
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1534
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1537
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1535
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1538
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1536
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1539
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1537
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1540
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1538
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1541
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1539
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1542
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1540
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1543
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1541
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1544
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1542
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1545
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1543
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1546
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1544
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1547
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1545
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1548
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1546
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1549
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1547
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1550
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1548
+#define	WT_STAT_CONN_TXN_SET_TS				1551
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1549
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1552
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1550
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1553
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1551
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1554
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1552
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1555
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1553
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1556
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1554
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1557
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1555
+#define	WT_STAT_CONN_TXN_BEGIN				1558
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1556
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1559
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1557
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1560
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1558
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1561
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1559
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1562
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1560
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1563
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1561
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1564
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1562
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1565
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1563
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1566
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1564
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1567
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1565
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1568
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1566
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1569
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1567
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1570
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1568
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1571
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1569
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1572
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1570
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1573
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1571
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1574
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1572
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1575
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1573
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1576
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1574
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1577
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1575
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1578
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1576
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1579
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1577
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1580
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1578
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1581
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1579
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1582
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1580
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1583
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1581
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1584
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1582
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1585
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1583
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1586
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1584
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1587
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1585
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1588
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1586
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1589
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1587
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1590
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1588
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1591
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1589
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1592
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1590
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1593
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1591
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1594
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1592
+#define	WT_STAT_CONN_TXN_COMMIT				1595
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1593
+#define	WT_STAT_CONN_TXN_ROLLBACK			1596
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1594
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1597
 
 /*!
  * @}
@@ -7310,343 +7319,352 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2154
 /*! compression: page written was too small to compress */
 #define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2155
+/*! cursor: Total number of deleted pages skipped during tree walk */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2156
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2156
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2157
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2157
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2158
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2158
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2159
+/*!
+ * cursor: Total number of in-memory deleted pages skipped during tree
+ * walk
+ */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2160
+/*! cursor: Total number of on-disk deleted pages skipped during tree walk */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2161
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2159
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2162
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2160
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2163
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2161
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2164
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2162
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2165
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2163
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2166
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2164
+#define	WT_STAT_DSRC_CURSOR_CACHE			2167
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2165
+#define	WT_STAT_DSRC_CURSOR_CREATE			2168
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2166
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2169
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2167
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2170
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2168
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2171
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2169
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2172
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2170
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2173
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2171
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2174
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2172
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2175
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2173
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2176
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2174
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2177
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2175
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2178
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2176
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2179
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2177
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2180
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2178
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2181
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2179
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2182
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2180
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2183
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2181
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2184
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2182
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2185
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2183
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2186
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2184
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2187
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2185
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2188
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2186
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2189
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2187
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2190
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2188
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2191
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2189
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2192
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2190
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2193
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2191
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2194
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2192
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2195
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2193
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2196
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2194
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2197
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2195
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2198
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2196
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2199
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2197
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2200
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2198
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2201
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2199
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2202
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2200
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2203
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2201
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2204
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2202
+#define	WT_STAT_DSRC_CURSOR_INSERT			2205
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2203
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2206
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2204
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2207
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2205
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2208
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2206
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2209
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2207
+#define	WT_STAT_DSRC_CURSOR_NEXT			2210
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2208
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2211
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2209
+#define	WT_STAT_DSRC_CURSOR_RESTART			2212
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2210
+#define	WT_STAT_DSRC_CURSOR_PREV			2213
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2211
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2214
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2212
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2215
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2213
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2216
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2214
+#define	WT_STAT_DSRC_CURSOR_RESET			2217
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2215
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2218
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2216
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2219
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2217
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2220
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2218
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2221
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2219
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2222
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2220
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2223
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2221
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2224
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2222
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2225
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2223
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2226
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2224
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2227
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2225
+#define	WT_STAT_DSRC_REC_DICTIONARY			2228
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2226
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2229
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2227
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2230
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2228
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2231
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2229
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2232
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2230
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2233
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2231
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2234
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2232
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2235
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2233
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2236
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2234
+#define	WT_STAT_DSRC_REC_PAGES				2237
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2235
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2238
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2236
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2239
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2237
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2240
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2238
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2241
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2239
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2242
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2240
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2243
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2241
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2244
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2242
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2245
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2243
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2246
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2244
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2247
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2245
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2248
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2246
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2249
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2247
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2250
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2248
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2251
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2249
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2252
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2250
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2253
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2251
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2254
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2252
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2255
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2253
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2256
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2254
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2257
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2255
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2258
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2256
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2259
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2257
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2260
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2258
+#define	WT_STAT_DSRC_SESSION_COMPACT			2261
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2259
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2262
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2260
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2263
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2261
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2264
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2262
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2265
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2263
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2266
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2264
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2267
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2265
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2268
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2266
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2269
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2267
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2270
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2268
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2271
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2269
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2272
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2270
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2273
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2271
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2274
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2272
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2275
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2273
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2276
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2274
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2277
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2275
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2278
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2276
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2279
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2277
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2280
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2278
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2281
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2279
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2282
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2280
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2283
 
 /*!
  * @}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -299,6 +299,8 @@ struct __wt_page_index;
 typedef struct __wt_page_index WT_PAGE_INDEX;
 struct __wt_page_modify;
 typedef struct __wt_page_modify WT_PAGE_MODIFY;
+struct __wt_page_walk_skip_stats;
+typedef struct __wt_page_walk_skip_stats WT_PAGE_WALK_SKIP_STATS;
 struct __wt_process;
 typedef struct __wt_process WT_PROCESS;
 struct __wt_rec_chunk;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2362,7 +2362,7 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
         return;
 
     do {
-        WT_READ_ONCE(p, *ta);
+        WT_ORDERED_READ(p, *ta);
         if (p == NULL)
             break;
     } while (!__wt_atomic_cas_ptr(ta, p, NULL));
@@ -2604,7 +2604,7 @@ split:
     if (WT_TIME_AGGREGATE_HAS_STOP(&stop_ta)) {
         WT_RET(__wt_calloc_one(session, &stop_tap));
         WT_TIME_AGGREGATE_COPY(stop_tap, &stop_ta);
-        WT_RELEASE_WRITE_WITH_BARRIER(mod->stop_ta, stop_tap);
+        WT_PUBLISH(mod->stop_ta, stop_tap);
     }
 
     return (0);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2344,6 +2344,37 @@ __rec_split_dump_keys(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 }
 
 /*
+ * __rec_page_modify_ta_safe_free --
+ *     Any thread that is reviewing the page modify time aggregate in a WT_REF, must also be holding
+ *     a split generation to ensure that the page index they are using remains valid. Use that same
+ *     split generation to ensure that the page modify time aggregate inside the WT_REF remains
+ *     valid while it is being reviewed.
+ */
+static void
+__rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
+{
+    WT_DECL_RET;
+    uint64_t split_gen;
+    void *p;
+
+    p = *(void **)ta;
+    if (p == NULL)
+        return;
+
+    do {
+        WT_READ_ONCE(p, *ta);
+        if (p == NULL)
+            break;
+    } while (!__wt_atomic_cas_ptr(ta, p, NULL));
+
+    split_gen = __wt_gen(session, WT_GEN_SPLIT);
+
+    if (__wt_stash_add(session, WT_GEN_SPLIT, split_gen, p, sizeof(WT_TIME_AGGREGATE)) != 0)
+        WT_IGNORE_RET(__wt_panic(session, ret, "fatal error during page modify ta free"));
+    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+}
+
+/*
  * __rec_write_wrapup --
  *     Finish the reconciliation.
  */
@@ -2353,9 +2384,11 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     WT_BM *bm;
     WT_BTREE *btree;
     WT_DECL_RET;
+    WT_MULTI *multi;
     WT_PAGE_MODIFY *mod;
     WT_REF *ref;
-    WT_TIME_AGGREGATE ta;
+    WT_TIME_AGGREGATE stop_ta, *stop_tap, ta;
+    uint32_t i;
     uint8_t previous_ref_state;
 
     btree = S2BT(session);
@@ -2435,6 +2468,14 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     /* Reset the reconciliation state. */
     mod->rec_result = 0;
 
+    /*
+     * When the page is being reconciled as part of the checkpoint operation, the REF is not locked.
+     * Concurrent access to the page can be enabled by safe-releasing the time aggregate
+     * information.
+     */
+    __rec_page_modify_ta_safe_free(session, &mod->stop_ta);
+    WT_TIME_AGGREGATE_INIT_MERGE(&stop_ta);
+
     __wt_verbose(session, WT_VERB_RECONCILE, "%p reconciled into %" PRIu32 " pages", (void *)ref,
       r->multi_next);
 
@@ -2488,10 +2529,12 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
             r->multi->addr.addr = NULL;
             mod->mod_disk_image = r->multi->disk_image;
             r->multi->disk_image = NULL;
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
         } else {
             __wt_checkpoint_tree_reconcile_update(session, &r->multi->addr.ta);
             WT_RET(__rec_write(session, r->wrapup_checkpoint, NULL, NULL, NULL, true,
               F_ISSET(r, WT_REC_CHECKPOINT), r->wrapup_checkpoint_compressed));
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &r->multi->addr.ta);
         }
 
         mod->rec_result = WT_PM_REC_REPLACE;
@@ -2513,6 +2556,10 @@ split:
 
         r->multi = NULL;
         r->multi_next = 0;
+
+        /* Calculate the max stop time point by traversing all multi addresses. */
+        for (multi = mod->mod_multi, i = 0; i < mod->mod_multi_entries; ++multi, ++i)
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &multi->addr.ta);
         break;
     }
 
@@ -2552,6 +2599,12 @@ split:
 
         if (!F_ISSET(r, WT_REC_EVICT))
             WT_REF_UNLOCK(ref, previous_ref_state);
+    }
+
+    if (WT_TIME_AGGREGATE_HAS_STOP(&stop_ta)) {
+        WT_RET(__wt_calloc_one(session, &stop_tap));
+        WT_TIME_AGGREGATE_COPY(stop_tap, &stop_ta);
+        WT_RELEASE_WRITE_WITH_BARRIER(mod->stop_ta, stop_tap);
     }
 
     return (0);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -172,9 +172,12 @@ static const char *const __stats_dsrc_desc[] = {
   "compression: number of blocks with compress ratio smaller than 8",
   "compression: page written failed to compress",
   "compression: page written was too small to compress",
+  "cursor: Total number of deleted pages skipped during tree walk",
   "cursor: Total number of entries skipped by cursor next calls",
   "cursor: Total number of entries skipped by cursor prev calls",
   "cursor: Total number of entries skipped to position the history store cursor",
+  "cursor: Total number of in-memory deleted pages skipped during tree walk",
+  "cursor: Total number of on-disk deleted pages skipped during tree walk",
   "cursor: Total number of times a search near has exited due to prefix config",
   "cursor: Total number of times cursor fails to temporarily release pinned page to encourage "
   "eviction of hot or large page",
@@ -500,9 +503,12 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->compress_hist_ratio_8 = 0;
     stats->compress_write_fail = 0;
     stats->compress_write_too_small = 0;
+    stats->cursor_tree_walk_del_page_skip = 0;
     stats->cursor_next_skip_total = 0;
     stats->cursor_prev_skip_total = 0;
     stats->cursor_skip_hs_cur_position = 0;
+    stats->cursor_tree_walk_inmem_del_page_skip = 0;
+    stats->cursor_tree_walk_ondisk_del_page_skip = 0;
     stats->cursor_search_near_prefix_fast_paths = 0;
     stats->cursor_reposition_failed = 0;
     stats->cursor_reposition = 0;
@@ -814,9 +820,12 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->compress_hist_ratio_8 += from->compress_hist_ratio_8;
     to->compress_write_fail += from->compress_write_fail;
     to->compress_write_too_small += from->compress_write_too_small;
+    to->cursor_tree_walk_del_page_skip += from->cursor_tree_walk_del_page_skip;
     to->cursor_next_skip_total += from->cursor_next_skip_total;
     to->cursor_prev_skip_total += from->cursor_prev_skip_total;
     to->cursor_skip_hs_cur_position += from->cursor_skip_hs_cur_position;
+    to->cursor_tree_walk_inmem_del_page_skip += from->cursor_tree_walk_inmem_del_page_skip;
+    to->cursor_tree_walk_ondisk_del_page_skip += from->cursor_tree_walk_ondisk_del_page_skip;
     to->cursor_search_near_prefix_fast_paths += from->cursor_search_near_prefix_fast_paths;
     to->cursor_reposition_failed += from->cursor_reposition_failed;
     to->cursor_reposition += from->cursor_reposition;
@@ -1134,9 +1143,14 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->compress_hist_ratio_8 += WT_STAT_READ(from, compress_hist_ratio_8);
     to->compress_write_fail += WT_STAT_READ(from, compress_write_fail);
     to->compress_write_too_small += WT_STAT_READ(from, compress_write_too_small);
+    to->cursor_tree_walk_del_page_skip += WT_STAT_READ(from, cursor_tree_walk_del_page_skip);
     to->cursor_next_skip_total += WT_STAT_READ(from, cursor_next_skip_total);
     to->cursor_prev_skip_total += WT_STAT_READ(from, cursor_prev_skip_total);
     to->cursor_skip_hs_cur_position += WT_STAT_READ(from, cursor_skip_hs_cur_position);
+    to->cursor_tree_walk_inmem_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_inmem_del_page_skip);
+    to->cursor_tree_walk_ondisk_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_ondisk_del_page_skip);
     to->cursor_search_near_prefix_fast_paths +=
       WT_STAT_READ(from, cursor_search_near_prefix_fast_paths);
     to->cursor_reposition_failed += WT_STAT_READ(from, cursor_reposition_failed);
@@ -1532,9 +1546,12 @@ static const char *const __stats_connection_desc[] = {
   "connection: total fsync I/Os",
   "connection: total read I/Os",
   "connection: total write I/Os",
+  "cursor: Total number of deleted pages skipped during tree walk",
   "cursor: Total number of entries skipped by cursor next calls",
   "cursor: Total number of entries skipped by cursor prev calls",
   "cursor: Total number of entries skipped to position the history store cursor",
+  "cursor: Total number of in-memory deleted pages skipped during tree walk",
+  "cursor: Total number of on-disk deleted pages skipped during tree walk",
   "cursor: Total number of times a search near has exited due to prefix config",
   "cursor: Total number of times cursor fails to temporarily release pinned page to encourage "
   "eviction of hot or large page",
@@ -2177,9 +2194,12 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->fsync_io = 0;
     stats->read_io = 0;
     stats->write_io = 0;
+    stats->cursor_tree_walk_del_page_skip = 0;
     stats->cursor_next_skip_total = 0;
     stats->cursor_prev_skip_total = 0;
     stats->cursor_skip_hs_cur_position = 0;
+    stats->cursor_tree_walk_inmem_del_page_skip = 0;
+    stats->cursor_tree_walk_ondisk_del_page_skip = 0;
     stats->cursor_search_near_prefix_fast_paths = 0;
     stats->cursor_reposition_failed = 0;
     stats->cursor_reposition = 0;
@@ -2836,9 +2856,14 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->fsync_io += WT_STAT_READ(from, fsync_io);
     to->read_io += WT_STAT_READ(from, read_io);
     to->write_io += WT_STAT_READ(from, write_io);
+    to->cursor_tree_walk_del_page_skip += WT_STAT_READ(from, cursor_tree_walk_del_page_skip);
     to->cursor_next_skip_total += WT_STAT_READ(from, cursor_next_skip_total);
     to->cursor_prev_skip_total += WT_STAT_READ(from, cursor_prev_skip_total);
     to->cursor_skip_hs_cur_position += WT_STAT_READ(from, cursor_skip_hs_cur_position);
+    to->cursor_tree_walk_inmem_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_inmem_del_page_skip);
+    to->cursor_tree_walk_ondisk_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_ondisk_del_page_skip);
     to->cursor_search_near_prefix_fast_paths +=
       WT_STAT_READ(from, cursor_search_near_prefix_fast_paths);
     to->cursor_reposition_failed += WT_STAT_READ(from, cursor_reposition_failed);

--- a/test/suite/test_checkpoint32.py
+++ b/test/suite/test_checkpoint32.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading, time
+import wttest
+import wiredtiger
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+# test_checkpoint32.py
+#
+# Test that skipping in-memory reconciled deleted pages as part of the tree walk.
+class test_checkpoint32(wttest.WiredTigerTestCase):
+
+    format_values = [
+        # FLCS doesn't support skipping pages based on aggregated time.
+        ('column', dict(key_format='r', value_format='S', extraconfig='')),
+        ('string_row', dict(key_format='S', value_format='S', extraconfig='')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def check(self, ds, nrows, value):
+        cursor = self.session.open_cursor(ds.uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, value)
+            count += 1
+        self.assertEqual(count, nrows)
+        cursor.close()
+
+    def test_checkpoint(self):
+        uri = 'table:checkpoint32'
+        nrows = 1000
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        value_a = "aaaaa" * 100
+
+        # Write some initial data.
+        cursor = self.session.open_cursor(ds.uri, None, None)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = value_a
+            self.session.commit_transaction()
+
+        # Create a reader transaction that will not be able to see what happens next.
+        # We don't need to do anything with this; it just needs to exist.
+        session2 = self.conn.open_session()
+        session2.begin_transaction()
+
+        # Now remove all data.
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor.set_key(ds.key(i))
+            self.assertEqual(cursor.remove(), 0)
+            self.session.commit_transaction()
+
+        # Checkpoint.
+        self.session.checkpoint()
+
+        # Get the existing in-memory delete page skip statistic value.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        prev_cur_inmem_del_page_skip = stat_cursor[stat.conn.cursor_tree_walk_inmem_del_page_skip][2]
+        stat_cursor.close()
+
+        # Now read the removed data.
+        self.check(ds, 0, value_a)
+
+        # Get the new in-memory delete page skip statistic value.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        cur_inmem_del_page_skip = stat_cursor[stat.conn.cursor_tree_walk_inmem_del_page_skip][2]
+        stat_cursor.close()
+
+        self.assertGreater(cur_inmem_del_page_skip, prev_cur_inmem_del_page_skip)
+
+        # Tidy up.
+        session2.rollback_transaction()
+        session2.close()
+        cursor.close()
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -38,7 +38,7 @@
 |Reconciliation|Overflow Keys|[test_bug004.py](../test/suite/test_bug004.py)
 |Recovery||[test_txn04.py](../test/suite/test_txn04.py)
 |Recovery|Log Files|[test_txn19.py](../test/suite/test_txn19.py)
-|Rollback To Stable||[test_checkpoint_snapshot03.py](../test/suite/test_checkpoint_snapshot03.py), [test_rollback_to_stable16.py](../test/suite/test_rollback_to_stable16.py), [test_rollback_to_stable18.py](../test/suite/test_rollback_to_stable18.py)
+|Rollback To Stable||[test_checkpoint_snapshot03.py](../test/suite/test_checkpoint_snapshot03.py), [test_checkpoint_snapshot07.py](../test/suite/test_checkpoint_snapshot07.py), [test_rollback_to_stable16.py](../test/suite/test_rollback_to_stable16.py), [test_rollback_to_stable18.py](../test/suite/test_rollback_to_stable18.py)
 |Salvage|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py)
 |Schema Api||[test_schema03.py](../test/suite/test_schema03.py)
 |Session Api|Reconfigure|[test_reconfig04.py](../test/suite/test_reconfig04.py)

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -38,7 +38,7 @@
 |Reconciliation|Overflow Keys|[test_bug004.py](../test/suite/test_bug004.py)
 |Recovery||[test_txn04.py](../test/suite/test_txn04.py)
 |Recovery|Log Files|[test_txn19.py](../test/suite/test_txn19.py)
-|Rollback To Stable||[test_checkpoint_snapshot03.py](../test/suite/test_checkpoint_snapshot03.py), [test_checkpoint_snapshot07.py](../test/suite/test_checkpoint_snapshot07.py), [test_rollback_to_stable16.py](../test/suite/test_rollback_to_stable16.py), [test_rollback_to_stable18.py](../test/suite/test_rollback_to_stable18.py)
+|Rollback To Stable||[test_checkpoint_snapshot03.py](../test/suite/test_checkpoint_snapshot03.py), [test_rollback_to_stable16.py](../test/suite/test_rollback_to_stable16.py), [test_rollback_to_stable18.py](../test/suite/test_rollback_to_stable18.py)
 |Salvage|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py)
 |Schema Api||[test_schema03.py](../test/suite/test_schema03.py)
 |Session Api|Reconfigure|[test_reconfig04.py](../test/suite/test_reconfig04.py)


### PR DESCRIPTION
Traversing an in-memory page that contains all the deleted values that
are visible to the current transaction, leading to an increase in latency due
to the time spent skipping these deleted values.
    
By saving the aggregated timestamp information in the ref when the page
has all deleted values, this aggregated information can be validated
against the transaction snapshot to skip traversing the page completely
and improve the latency when there are many deleted pages.
    
The downside of this approach is that the in-memory size of each ref is
increased by 8 more bytes, but this increase shouldn't cause any
problem.
    
(cherry picked from commit d121cca3b711efd1951a36aa48348ec6df5803fe)