### PR TITLE
WT-12819 Allow larger block sizes with wt_binary_decode.py

### DIFF
--- a/tools/checksum_bitflip/checksum_bitflip.c
+++ b/tools/checksum_bitflip/checksum_bitflip.c
@@ -105,8 +105,6 @@ main(int argc, char *argv[])
             buffer[byte] ^= mask;
             mask <<= 1;
         }
-        if (byte % 4096 == 0)
-            printf ("Tested %" WT_SIZET_FMT " bytes\n", byte);
     }
     printf("No checksum match\n");
     return (1);

--- a/tools/checksum_bitflip/checksum_bitflip.c
+++ b/tools/checksum_bitflip/checksum_bitflip.c
@@ -105,6 +105,8 @@ main(int argc, char *argv[])
             buffer[byte] ^= mask;
             mask <<= 1;
         }
+        if (byte % 4096 == 0)
+            printf ("Tested %" WT_SIZET_FMT " bytes\n", byte);
     }
     printf("No checksum match\n");
     return (1);

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -538,8 +538,8 @@ def block_decode(p, b, opts):
     if uint8(b_page) != 0 or uint8(b_page) != 0 or uint8(b_page) != 0:
         p.rint('garbage in unused bytes')
         return
-    if blockhead.disk_size > 512 * 1024:
-        # This is probably not a valid block
+    if blockhead.disk_size > 17 * 1024 * 1024:
+        # The maximum document size in MongoDB is 16MB. Larger block sizes are suspect.
         p.rint('the block is too big')
         return
     if blockhead.disk_size < 40:


### PR DESCRIPTION
The wt_binary_decode.py tool is hard coded to assume that a block size larger than 512K indicates a corrupt block – i.e., that the size as stored in the page header is likely corrupt/garbage if it too big. MongoDB supports document sizes up to 16MB, so we can legitimately have blocks at least that big.

This PR increases the cut-off to 17MB, allowing for some slop around a single large document.