### PR TITLE
WT-12736 Mark the page clean after re-instantiating the page with prepared updates.

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -810,6 +810,7 @@ dsrc_stats = [
     # Btree statistics
     ##########################################
     BtreeStat('btree_checkpoint_generation', 'btree checkpoint generation', 'no_clear,no_scale'),
+    BtreeStat('btree_checkpoint_pages_reconciled', 'btree number of pages caused to be reconciled during checkpoint', 'no_clear,no_scale'),
     BtreeStat('btree_clean_checkpoint_timer', 'btree clean tree checkpoint expiration time', 'no_clear,no_scale'),
     BtreeStat('btree_column_deleted', 'column-store variable-size deleted values', 'no_scale,tree_walk'),
     BtreeStat('btree_column_fix', 'column-store fixed-size leaf pages', 'no_scale,tree_walk'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -810,7 +810,7 @@ dsrc_stats = [
     # Btree statistics
     ##########################################
     BtreeStat('btree_checkpoint_generation', 'btree checkpoint generation', 'no_clear,no_scale'),
-    BtreeStat('btree_checkpoint_pages_reconciled', 'btree number of pages caused to be reconciled during checkpoint', 'no_clear,no_scale'),
+    BtreeStat('btree_checkpoint_pages_reconciled', 'btree number of pages reconciled during checkpoint', 'no_clear,no_scale'),
     BtreeStat('btree_clean_checkpoint_timer', 'btree clean tree checkpoint expiration time', 'no_clear,no_scale'),
     BtreeStat('btree_column_deleted', 'column-store variable-size deleted values', 'no_scale,tree_walk'),
     BtreeStat('btree_column_fix', 'column-store fixed-size leaf pages', 'no_scale,tree_walk'),

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -312,7 +312,10 @@ __wt_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
 
-    /* Mark the page clean after re-instantiating prepared updates. */
+    /*
+     * The data is written to the disk so we can mark the page clean after re-instantiating prepared
+     * updates to avoid reconciling the page every time.
+     */
     __wt_page_modify_clear(session, page);
     __wt_cache_page_inmem_incr(session, page, total_size);
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -312,6 +312,8 @@ __wt_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
 
+    /* Mark the page clean after re-instantiating prepared updates. */
+    __wt_page_modify_clear(session, page);
     __wt_cache_page_inmem_incr(session, page, total_size);
 
     if (0) {

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -434,6 +434,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             tried_eviction = false;
 
             WT_STAT_CONN_INCR(session, checkpoint_pages_reconciled);
+            WT_STAT_INCR(session, btree->dhandle->stats, btree_checkpoint_pages_reconciled);
             if (FLD_ISSET(rec_flags, WT_REC_HS))
                 WT_STAT_CONN_INCR(session, checkpoint_hs_pages_reconciled);
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1091,6 +1091,7 @@ struct __wt_dsrc_stats {
     int64_t btree_compact_pages_skipped;
     int64_t btree_compact_bytes_rewritten_expected;
     int64_t btree_compact_pages_rewritten_expected;
+    int64_t btree_checkpoint_pages_reconciled;
     int64_t btree_compact_skipped;
     int64_t btree_column_fix;
     int64_t btree_column_tws;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7158,840 +7158,842 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BTREE_COMPACT_BYTES_REWRITTEN_EXPECTED	2031
 /*! btree: btree expected number of compact pages rewritten */
 #define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN_EXPECTED	2032
+/*! btree: btree number of pages caused to be reconciled during checkpoint */
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2033
 /*! btree: btree skipped by compaction as process would not reduce size */
-#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2033
+#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2034
 /*!
  * btree: column-store fixed-size leaf pages, only reported if tree_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2034
+#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2035
 /*!
  * btree: column-store fixed-size time windows, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_TWS			2035
+#define	WT_STAT_DSRC_BTREE_COLUMN_TWS			2036
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2036
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2037
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2037
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2038
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2038
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2039
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2039
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2040
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2040
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2041
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2041
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2042
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2042
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2043
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2043
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2044
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2044
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2045
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2045
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2046
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2046
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2047
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2047
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2048
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2048
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2049
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2049
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2050
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2050
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2051
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2051
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2052
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2052
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2053
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2053
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2054
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2054
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2055
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2055
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2056
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2056
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2057
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2057
+#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2058
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2058
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2059
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2059
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2060
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2060
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2061
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2061
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2062
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2062
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2063
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2063
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2064
 /*! cache: eviction walk passes of a file */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2064
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2065
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2065
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2066
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2066
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2067
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2067
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2068
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2068
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2069
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2069
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2070
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2070
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2071
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2071
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2072
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2072
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2073
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2073
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2074
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2074
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2075
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2075
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2076
 /*! cache: eviction walks restarted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_RESTART	2076
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_RESTART	2077
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2077
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2078
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2078
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2079
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2079
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2080
 /*! cache: history store table insert calls */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT			2080
+#define	WT_STAT_DSRC_CACHE_HS_INSERT			2081
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2081
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2082
 /*! cache: history store table reads */
-#define	WT_STAT_DSRC_CACHE_HS_READ			2082
+#define	WT_STAT_DSRC_CACHE_HS_READ			2083
 /*! cache: history store table reads missed */
-#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2083
+#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2084
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2084
+#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2085
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2085
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2086
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2086
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2087
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2087
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2088
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2088
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2089
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2089
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2090
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2090
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2091
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2091
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2092
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2092
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2093
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2093
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2094
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2094
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2095
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2095
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2096
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2096
+#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2097
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2097
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2098
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2098
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2099
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2099
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2100
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2100
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2101
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2101
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2102
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2102
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2103
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2103
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2104
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	2104
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	2105
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2105
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2106
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2106
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2107
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2107
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2108
 /*! cache: page written requiring history store records */
-#define	WT_STAT_DSRC_CACHE_WRITE_HS			2108
+#define	WT_STAT_DSRC_CACHE_WRITE_HS			2109
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2109
+#define	WT_STAT_DSRC_CACHE_READ				2110
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2110
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2111
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2111
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2112
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2112
+#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2113
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2113
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2114
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2114
+#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2115
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2115
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2116
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2116
+#define	WT_STAT_DSRC_CACHE_WRITE			2117
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2117
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2118
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2118
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2119
 /*! cache: reverse splits performed */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2119
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2120
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2120
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2121
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2121
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2122
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2122
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2123
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2123
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2124
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2124
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2125
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2125
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2126
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2126
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2127
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2127
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2128
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2128
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2129
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2129
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2130
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2130
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2131
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2131
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2132
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2132
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2133
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2133
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2134
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2134
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2135
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2135
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2136
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2136
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2137
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2137
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2138
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2138
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2139
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2139
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2140
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2140
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2141
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2141
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2142
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2142
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2143
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2143
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2144
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2144
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2145
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2145
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2146
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2146
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2147
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2147
+#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2148
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2148
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2149
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2149
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2150
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2150
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2151
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2151
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2152
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_CHECKPOINT_OBSOLETE_APPLIED	2152
+#define	WT_STAT_DSRC_CHECKPOINT_OBSOLETE_APPLIED	2153
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2153
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2154
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2154
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2155
 /*! compression: page written to disk failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2155
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2156
 /*! compression: page written to disk was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2156
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2157
 /*! compression: pages read from disk */
-#define	WT_STAT_DSRC_COMPRESS_READ			2157
+#define	WT_STAT_DSRC_COMPRESS_READ			2158
 /*!
  * compression: pages read from disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2158
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2159
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2159
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2160
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2160
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2161
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2161
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2162
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2162
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2163
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2163
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2164
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2164
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2165
 /*! compression: pages written to disk */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2165
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2166
 /*!
  * compression: pages written to disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2166
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2167
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2167
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2168
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2168
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2169
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2169
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2170
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2170
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2171
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2171
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2172
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2172
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2173
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2173
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2174
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2174
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2175
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2175
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2176
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2176
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2177
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2177
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2178
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2178
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2179
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2179
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2180
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2180
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2181
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2181
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2182
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2182
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2183
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2183
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2184
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2184
+#define	WT_STAT_DSRC_CURSOR_CACHE			2185
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2185
+#define	WT_STAT_DSRC_CURSOR_CREATE			2186
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2186
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2187
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2187
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2188
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2188
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2189
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2189
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2190
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2190
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2191
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2191
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2192
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2192
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2193
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2193
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2194
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2194
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2195
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2195
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2196
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2196
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2197
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2197
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2198
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2198
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2199
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2199
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2200
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2200
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2201
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2201
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2202
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2202
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2203
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2203
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2204
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2204
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2205
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2205
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2206
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2206
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2207
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2207
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2208
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2208
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2209
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2209
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2210
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2210
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2211
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2211
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2212
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2212
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2213
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2213
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2214
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2214
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2215
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2215
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2216
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2216
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2217
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2217
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2218
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2218
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2219
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2219
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2220
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2220
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2221
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2221
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2222
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2222
+#define	WT_STAT_DSRC_CURSOR_INSERT			2223
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2223
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2224
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2224
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2225
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2225
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2226
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2226
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2227
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2227
+#define	WT_STAT_DSRC_CURSOR_NEXT			2228
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2228
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2229
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2229
+#define	WT_STAT_DSRC_CURSOR_RESTART			2230
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2230
+#define	WT_STAT_DSRC_CURSOR_PREV			2231
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2231
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2232
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2232
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2233
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2233
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2234
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2234
+#define	WT_STAT_DSRC_CURSOR_RESET			2235
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2235
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2236
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2236
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2237
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2237
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2238
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2238
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2239
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2239
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2240
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2240
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2241
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2241
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2242
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2242
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2243
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2243
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2244
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2244
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2245
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2245
+#define	WT_STAT_DSRC_REC_DICTIONARY			2246
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2246
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2247
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2247
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2248
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2248
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2249
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2249
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2250
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2250
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2251
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2251
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2252
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2252
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2253
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2253
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2254
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2254
+#define	WT_STAT_DSRC_REC_PAGES				2255
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2255
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2256
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2256
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2257
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2257
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2258
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2258
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2259
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2259
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2260
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2260
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2261
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2261
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2262
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2262
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2263
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2263
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2264
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2264
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2265
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2265
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2266
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2266
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2267
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2267
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2268
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2268
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2269
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2269
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2270
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2270
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2271
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2271
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2272
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2272
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2273
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2273
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2274
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2274
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2275
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2275
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2276
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2276
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2277
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2277
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2278
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2278
+#define	WT_STAT_DSRC_SESSION_COMPACT			2279
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2279
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2280
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2280
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2281
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2281
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2282
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2282
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2283
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2283
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2284
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2284
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2285
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2285
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2286
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2286
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2287
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2287
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2288
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2288
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2289
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2289
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2290
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2290
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2291
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2291
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2292
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2292
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2293
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2293
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2294
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2294
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2295
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2295
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2296
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2296
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2297
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2297
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2298
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2298
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2299
 
 /*!
  * @}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7158,7 +7158,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BTREE_COMPACT_BYTES_REWRITTEN_EXPECTED	2031
 /*! btree: btree expected number of compact pages rewritten */
 #define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN_EXPECTED	2032
-/*! btree: btree number of pages caused to be reconciled during checkpoint */
+/*! btree: btree number of pages reconciled during checkpoint */
 #define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2033
 /*! btree: btree skipped by compaction as process would not reduce size */
 #define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2034

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -36,6 +36,7 @@ static const char *const __stats_dsrc_desc[] = {
   "btree: btree compact pages skipped",
   "btree: btree expected number of compact bytes rewritten",
   "btree: btree expected number of compact pages rewritten",
+  "btree: btree number of pages caused to be reconciled during checkpoint",
   "btree: btree skipped by compaction as process would not reduce size",
   "btree: column-store fixed-size leaf pages",
   "btree: column-store fixed-size time windows",
@@ -395,6 +396,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     /* not clearing btree_compact_pages_skipped */
     /* not clearing btree_compact_bytes_rewritten_expected */
     /* not clearing btree_compact_pages_rewritten_expected */
+    /* not clearing btree_checkpoint_pages_reconciled */
     /* not clearing btree_compact_skipped */
     stats->btree_column_fix = 0;
     stats->btree_column_tws = 0;
@@ -713,6 +715,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->btree_compact_pages_skipped += from->btree_compact_pages_skipped;
     to->btree_compact_bytes_rewritten_expected += from->btree_compact_bytes_rewritten_expected;
     to->btree_compact_pages_rewritten_expected += from->btree_compact_pages_rewritten_expected;
+    to->btree_checkpoint_pages_reconciled += from->btree_checkpoint_pages_reconciled;
     to->btree_compact_skipped += from->btree_compact_skipped;
     to->btree_column_fix += from->btree_column_fix;
     to->btree_column_tws += from->btree_column_tws;
@@ -1043,6 +1046,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
       WT_STAT_READ(from, btree_compact_bytes_rewritten_expected);
     to->btree_compact_pages_rewritten_expected +=
       WT_STAT_READ(from, btree_compact_pages_rewritten_expected);
+    to->btree_checkpoint_pages_reconciled += WT_STAT_READ(from, btree_checkpoint_pages_reconciled);
     to->btree_compact_skipped += WT_STAT_READ(from, btree_compact_skipped);
     to->btree_column_fix += WT_STAT_READ(from, btree_column_fix);
     to->btree_column_tws += WT_STAT_READ(from, btree_column_tws);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -36,7 +36,7 @@ static const char *const __stats_dsrc_desc[] = {
   "btree: btree compact pages skipped",
   "btree: btree expected number of compact bytes rewritten",
   "btree: btree expected number of compact pages rewritten",
-  "btree: btree number of pages caused to be reconciled during checkpoint",
+  "btree: btree number of pages reconciled during checkpoint",
   "btree: btree skipped by compaction as process would not reduce size",
   "btree: column-store fixed-size leaf pages",
   "btree: column-store fixed-size time windows",

--- a/test/suite/test_scrub_eviction_prepare.py
+++ b/test/suite/test_scrub_eviction_prepare.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
+
+# test_scrub_eviction_prepare.py
+#
+# Test to do the following steps.
+# 1. Prepare an update with one key
+# 2. Force evict
+# 3. Read the page back in memory
+# 4. Checkpoint
+# 5. Repeat steps 3,4 and validate that the page read back into memory should
+#    not be reconciled everytime.
+class test_scrub_eviction_prepare(wttest.WiredTigerTestCase):
+
+    def conn_config(self):
+        config = 'cache_size=100MB,statistics=(all),statistics_log=(json,on_close,wait=1)'
+        return config
+
+    def get_stats(self, uri):
+        stat_cursor = self.session.open_cursor('statistics:' + uri)
+        btree_ckpt_pages_rec = stat_cursor[stat.dsrc.btree_checkpoint_pages_reconciled][2]
+        stat_cursor.close()
+        return btree_ckpt_pages_rec
+
+    def read_key(self, uri):
+        cur2 = self.session.open_cursor(uri)
+        cur2.set_key(1)
+        self.assertRaisesException(WiredTigerError,
+            lambda: cur2.search(),
+            exceptionString='/conflict with a prepared update/')
+        cur2.close()
+
+    def test_scrub_eviction_prepare(self):
+        uri = 'table:test_scrub_eviction_prepare'
+
+        # Create a table.
+        self.session.create(uri, 'key_format=i,value_format=S')
+        session2 = self.conn.open_session()
+        cursor2 = session2.open_cursor(uri)
+
+        session2.begin_transaction()
+        cursor2[1] = '10'
+        session2.prepare_transaction('prepare_timestamp=10')
+
+        # Evict the page txn1 containing modifications from both txn1 and txn2.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        evict_cursor.set_key(1)
+        self.assertRaisesException(WiredTigerError,
+            lambda: evict_cursor.search(),
+            exceptionString='/conflict with a prepared update/')
+        self.assertEqual(evict_cursor.reset(), 0)
+        evict_cursor.close()
+
+        self.session.checkpoint()
+        self.assertEqual(1, self.get_stats(uri))
+
+        self.read_key(uri)
+        self.session.checkpoint()
+
+        # The page with prepared update should not be reconciled again.
+        self.assertEqual(1, self.get_stats(uri))
+
+        self.read_key(uri)
+        self.session.checkpoint()
+
+        # The page with prepared update should not be reconciled again.
+        self.assertEqual(1, self.get_stats(uri))


### PR DESCRIPTION
This pull request has the following changes:
- Mark the page clean after instantiating it with prepared updates.
- A new Btree stat that tracks the number of pages reconciled during reconciliation.
- Python test to verify the fix