### PR TITLE
WT-12883 Change the dhandle fail error message into verbose message

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -405,10 +405,12 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
 
     /* Open a handle for processing. */
     ret = __wt_session_get_dhandle(session, uri->data, NULL, NULL, 0);
-    if (ret != 0)
+    if (ret != 0) {
         __wt_verbose_debug1(session, WT_VERB_CHECKPOINT_CLEANUP, "%s: unable to open handle%s",
           (char *)uri->data,
           ret == EBUSY ? ", error indicates handle is unavailable due to concurrent use" : "");
+        return (ret);
+    }
 
     btree = S2BT(session);
     /* There is nothing to do on an empty tree. */

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -406,7 +406,8 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
     /* Open a handle for processing. */
     ret = __wt_session_get_dhandle(session, uri->data, NULL, NULL, 0);
     if (ret != 0)
-        WT_RET_MSG(session, ret, "%s: unable to open handle%s", (char *)uri->data,
+        __wt_verbose_debug1(session, WT_VERB_CHECKPOINT_CLEANUP, "%s: unable to open handle%s",
+          (char *)uri->data,
           ret == EBUSY ? ", error indicates handle is unavailable due to concurrent use" : "");
 
     btree = S2BT(session);


### PR DESCRIPTION
Unavailablity of a dhandle for the checkpoint cleanup utility thread is not a problem, it just skips that dhandle and continue with the next one available. Printing the unavailablity error message in the log file is unnecessarily confusing the applications/users.