### PR TITLE
WT-12890 Fix random seed initialization in the model

### DIFF
--- a/test/model/src/core/random.cpp
+++ b/test/model/src/core/random.cpp
@@ -70,4 +70,14 @@ random::next_index(size_t length)
     return (size_t)__wt_random(&_random_state) % length;
 }
 
+/*
+ * random::next_uint64 --
+ *     Get the next integer.
+ */
+uint64_t
+random::next_uint64() noexcept
+{
+    return (((uint64_t)__wt_random(&_random_state)) << 32) | __wt_random(&_random_state);
+}
+
 } /* namespace model */

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -635,7 +635,8 @@ kv_workload_generator::run()
 
             /* Simulate how checkpoints, crashes, and restarts manipulate the timestamps. */
             if (s->sequence->type() == kv_workload_sequence_type::checkpoint ||
-              s->sequence->type() == kv_workload_sequence_type::restart) {
+              s->sequence->type() == kv_workload_sequence_type::restart ||
+              s->sequence->type() == kv_workload_sequence_type::rollback_to_stable) {
                 ckpt_oldest = oldest;
                 ckpt_stable = stable;
                 if (ckpt_stable == k_timestamp_none)
@@ -688,7 +689,8 @@ kv_workload_generator::run()
         /* Validate that we filled in the timestamps in the correct order. */
         assert_timestamps(*s->sequence, op, oldest, stable);
         if (std::holds_alternative<operation::checkpoint>(op) ||
-          std::holds_alternative<operation::restart>(op)) {
+          std::holds_alternative<operation::restart>(op) ||
+          std::holds_alternative<operation::rollback_to_stable>(op)) {
             ckpt_oldest = oldest;
             ckpt_stable = stable;
             if (ckpt_stable == k_timestamp_none)

--- a/test/model/src/include/model/random.h
+++ b/test/model/src/include/model/random.h
@@ -51,6 +51,17 @@ public:
     random(uint64_t seed = 0) noexcept;
 
     /*
+     * random::next_seed --
+     *     Get the next seed starting from the given seen.
+     */
+    static uint64_t
+    next_seed(uint64_t seed)
+    {
+        random r(seed);
+        return r.next_uint64(std::numeric_limits<uint64_t>::max());
+    }
+
+    /*
      * random::next_double --
      *     Get the next double between 0 and 1.
      */

--- a/test/model/src/include/model/random.h
+++ b/test/model/src/include/model/random.h
@@ -52,13 +52,12 @@ public:
 
     /*
      * random::next_seed --
-     *     Get the next seed starting from the given seen.
+     *     Get the next seed starting from the given seed.
      */
     static uint64_t
     next_seed(uint64_t seed)
     {
-        random r(seed);
-        return r.next_uint64(std::numeric_limits<uint64_t>::max());
+        return random(seed).next_uint64();
     }
 
     /*
@@ -78,6 +77,12 @@ public:
      *     Get the next index from the list of the given length.
      */
     size_t next_index(size_t length);
+
+    /*
+     * random::next_uint64 --
+     *     Get the next integer.
+     */
+    uint64_t next_uint64() noexcept;
 
     /*
      * random::next_uint64 --

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -460,7 +460,7 @@ main(int argc, char *argv[])
 {
     model::kv_workload_generator_spec spec;
 
-    uint64_t base_seed = model::random::next_seed(time(NULL));
+    uint64_t base_seed = model::random::next_seed(__wt_rdtsc() ^ time(NULL));
     std::string home = "WT_TEST";
     uint64_t min_iterations = 1;
     uint64_t min_runtime_s = 0;

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -460,7 +460,7 @@ main(int argc, char *argv[])
 {
     model::kv_workload_generator_spec spec;
 
-    uint64_t base_seed = (uint64_t)time(NULL);
+    uint64_t base_seed = model::random::next_seed(time(NULL));
     std::string home = "WT_TEST";
     uint64_t min_iterations = 1;
     uint64_t min_runtime_s = 0;
@@ -593,10 +593,13 @@ main(int argc, char *argv[])
                 return EXIT_FAILURE;
             }
         }
-    else
+    else {
         /* Run the test, potentially many times. */
+        uint64_t next_seed = base_seed;
         for (uint64_t iteration = 1;; iteration++) {
-            uint64_t seed = base_seed + iteration - 1;
+            uint64_t seed = next_seed;
+            next_seed = model::random::next_seed(next_seed);
+
             std::cout << "Iteration " << iteration << ", seed 0x" << std::hex << seed << std::dec
                       << std::endl;
 
@@ -638,6 +641,7 @@ main(int argc, char *argv[])
             if (total_time >= min_runtime_s && iteration >= min_iterations)
                 break;
         }
+    }
 
     /* Clean up the database directory. */
     if (!preserve)


### PR DESCRIPTION
The PR adds more randomness when initializing and advancing the random seed.

It also fixes a bug in the workload generator, which did not account for `operation::rollback_to_stable` taking a checkpoint.