### PR TITLE
WT-12868 Handle 0 length files with git diff for the Code Change Report

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3050,8 +3050,8 @@ tasks:
 
             if [ ${is_patch|false} = true ]; then
               echo "This is a patch build"
-              # Obtain the diff for the changes in this patch
-              git diff `git merge-base develop HEAD` > coverage_report/diff.txt
+              # Obtain the diff for the changes in this patch, excluding newly added 0-length files.
+              python3 test/evergreen/code_change_report/git_diff_tool.py -g . -d coverage_report/diff.txt -v
               EXTRA_CODE_CHANGE_PARAMETERS='-d coverage_report/diff.txt'
               # Generate an HTML friendly version of the diff for
               sed 's/$/<br>/' coverage_report/diff.txt > coverage_report/diff.html

--- a/test/evergreen/code_change_report/code_change_report.py
+++ b/test/evergreen/code_change_report/code_change_report.py
@@ -439,7 +439,7 @@ def generate_html_report_as_text(code_change_info: dict, verbose: bool):
     # Create table with a list of changed files
     report.append("<table class=\"center\">\n")
     report.append("  <tr>\n")
-    report.append("    <th>Changed File(s)</th>\n")
+    report.append("    <th>Changed File(s), excluding any new 0-length files</th>\n")
     report.append("  </tr>\n")
     for file in change_info_list:
         escaped_file = html.escape(file, quote=True)

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -63,7 +63,7 @@ def find_zero_length_files(directory: str) -> List[str]:
 def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -> None:
     # Exclude files with 0-length from the diff, as pygit2 doesn't handle such diffs well
     zero_length_files = find_zero_length_files(git_working_tree_dir)
-    exclude_files_param = ' '.join(["':(exclude){}'".format(file) for file in zero_length_files])
+    exclude_files_param = ' '.join([f"':(exclude){file}'" for file in zero_length_files])
 
     repository_path = discover_repository(git_working_tree_dir)
     assert repository_path is not None

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -102,8 +102,8 @@ def main():
         print('Diff Generation')
         print('===============')
         print('Configuration:')
-        print('  Git root path:              {}'.format(git_working_tree_dir))
-        print('  Git diff output file path:  {}'.format(git_diff_file))
+        print(f'  Git root path:              {git_working_tree_dir}')
+        print(f'  Git diff output file path:  {git_diff_file}')
 
     create_diff_file(git_working_tree_dir=git_working_tree_dir, diff_file=git_diff_file, verbose=verbose)
 

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -54,7 +54,7 @@ def run_command(directory: str, command: str) -> str:
 
 def find_zero_length_files(directory: str) -> List[str]:
     working_directory = PushWorkingDirectory(directory)
-    files = glob.glob('./**/*'.format(directory), recursive=True)
+    files = glob.glob('./**/*', recursive=True)
     zero_length_files = [x for x in files if os.stat(x).st_size == 0]
     working_directory.pop()
     return zero_length_files

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -74,10 +74,10 @@ def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -
     diff_command = f"git diff {merge_base_commit} -- {exclude_files_param}"
 
     if verbose:
-        print("head_commit:       {}".format(head_commit))
-        print("merge_base_commit: {}".format(merge_base_commit))
-        print("zero_length_files = {}".format(zero_length_files))
-        print("diff_command:    {}".format(diff_command))
+        print(f"head_commit:       {head_commit}")
+        print(f"merge_base_commit: {merge_base_commit}")
+        print(f"zero_length_files = {zero_length_files}")
+        print(f"diff_command:    {diff_command}")
 
     diff_output = run_command(git_working_tree_dir, diff_command)
     diff_output += "\n"   # Ensure there is a newline on the end of the diff before writing to a file.

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -80,6 +80,7 @@ def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -
         print("diff_command:    {}".format(diff_command))
 
     diff_output = run_command(git_working_tree_dir, diff_command)
+    diff_output += "\n"   # Ensure there is a newline on the end of the diff before writing to a file.
 
     file = open(diff_file, "w")
     file.write(diff_output)

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+
+#
+# The code in this file is used to generate diff files that exclude any newly added 0-length files
+# as loading diff files that contain newly added 0-length files does not work in pygit2.
+#
+# Note: 0-length means empty files with no content. Files containing only blank lines are not 0-length, and
+# diffs including such files work in pygit2.
+#
+
+import argparse
+import glob
+import os
+import subprocess
+from typing import List
+from pygit2 import discover_repository, Repository
+from push_working_directory import PushWorkingDirectory
+
+
+def run_command(directory: str, command: str) -> str:
+    working_directory = PushWorkingDirectory(directory)
+    completed_process = subprocess.run(command, capture_output=True, check=True, shell=True)
+    output = completed_process.stdout
+    working_directory.pop()
+    return output.decode().strip()
+
+
+def find_zero_length_files(directory: str) -> List[str]:
+    working_directory = PushWorkingDirectory(directory)
+    files = glob.glob('./**/*'.format(directory), recursive=True)
+    zero_length_files = [x for x in files if os.stat(x).st_size == 0]
+    working_directory.pop()
+    return zero_length_files
+
+
+def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -> None:
+    # Exclude files with 0-length from the diff, as pygit2 doesn't handle such diffs well
+    zero_length_files = find_zero_length_files(git_working_tree_dir)
+    exclude_files_param = ' '.join(["':(exclude){}'".format(file) for file in zero_length_files])
+
+    repository_path = discover_repository(git_working_tree_dir)
+    assert repository_path is not None
+    repo = Repository(repository_path)
+
+    head_commit = repo.head.target
+    merge_base_commit = run_command(git_working_tree_dir, "git merge-base develop HEAD")
+    diff_command = "git diff {} -- {}".format(merge_base_commit, exclude_files_param)
+
+    if verbose:
+        print("head_commit:       {}".format(head_commit))
+        print("merge_base_commit: {}".format(merge_base_commit))
+        print("zero_length_files = {}".format(zero_length_files))
+        print("diff_command:    {}".format(diff_command))
+
+    diff_output = run_command(git_working_tree_dir, diff_command)
+
+    file = open(diff_file, "w")
+    file.write(diff_output)
+    file.close()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-g', '--git_root', required=True, help='path of the Git working directory')
+    parser.add_argument('-d', '--git_diff_file', required=True, help='Path to the git diff file that will be created')
+    parser.add_argument('-v', '--verbose', action="store_true", help='be verbose')
+    args = parser.parse_args()
+
+    verbose = args.verbose
+    git_diff_file = args.git_diff_file
+    git_working_tree_dir = args.git_root
+
+    if verbose:
+        print('Diff Generation')
+        print('===============')
+        print('Configuration:')
+        print('  Git root path:              {}'.format(git_working_tree_dir))
+        print('  Git diff output file path:  {}'.format(git_diff_file))
+
+    create_diff_file(git_working_tree_dir=git_working_tree_dir, diff_file=git_diff_file, verbose=verbose)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -74,10 +74,10 @@ def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -
     diff_command = f"git diff {merge_base_commit} -- {exclude_files_param}"
 
     if verbose:
-        print(f"head_commit:       {head_commit}")
-        print(f"merge_base_commit: {merge_base_commit}")
+        print(f"head_commit:        {head_commit}")
+        print(f"merge_base_commit:  {merge_base_commit}")
         print(f"zero_length_files = {zero_length_files}")
-        print(f"diff_command:    {diff_command}")
+        print(f"diff_command:       {diff_command}")
 
     diff_output = run_command(git_working_tree_dir, diff_command)
     diff_output += "\n"   # Ensure there is a newline on the end of the diff before writing to a file.

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -71,7 +71,7 @@ def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -
 
     head_commit = repo.head.target
     merge_base_commit = run_command(git_working_tree_dir, "git merge-base develop HEAD")
-    diff_command = "git diff {} -- {}".format(merge_base_commit, exclude_files_param)
+    diff_command = f"git diff {merge_base_commit} -- {exclude_files_param}"
 
     if verbose:
         print("head_commit:       {}".format(head_commit))

--- a/test/evergreen/code_change_report/push_working_directory.py
+++ b/test/evergreen/code_change_report/push_working_directory.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+
+
+class PushWorkingDirectory:
+    def __init__(self, new_working_directory: str) -> None:
+        self.original_working_directory = os.getcwd()
+        self.new_working_directory = new_working_directory
+        os.chdir(self.new_working_directory)
+
+    def pop(self):
+        os.chdir(self.original_working_directory)
+


### PR DESCRIPTION
Implemented a Python tool to create a diff file that excludes newly-added 0-length files (as they cause issues with pygit2 in the code change report), and switched to using it for the code change report.
