### PR TITLE
WT-12901:txn timestamp's log improve

### DIFF
--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -15,7 +15,7 @@
 char *
 __wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string)
 {
-    WT_IGNORE_RET(__wt_snprintf(ts_string, WT_TS_INT_STRING_SIZE, "(%" PRIu32 ", %" PRIu32 ")",
+    WT_IGNORE_RET(__wt_snprintf(ts_string, WT_TS_INT_STRING_SIZE, "(0x%" PRIx32 ", 0x%" PRIx32 ")",
       (uint32_t)((ts >> 32) & 0xffffffff), (uint32_t)(ts & 0xffffffff)));
     return (ts_string);
 }

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -113,10 +113,11 @@ __wt_timestamp_to_hex_string(wt_timestamp_t ts, char *hex_timestamp)
 void
 __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, const char *msg)
 {
-    char hex_timestamp[WT_TS_HEX_STRING_SIZE];
+    char hex_timestamp[WT_TS_HEX_STRING_SIZE], ts_string[WT_TS_INT_STRING_SIZE];
 
     __wt_timestamp_to_hex_string(ts, hex_timestamp);
-    __wt_verbose(session, WT_VERB_TIMESTAMP, "Timestamp 0x%s: %s", hex_timestamp, msg);
+    __wt_verbose(session, WT_VERB_TIMESTAMP, "Timestamp 0x%s%s: %s", hex_timestamp,
+      __wt_timestamp_to_string(ts, ts_string), msg);
 }
 
 #define WT_TIME_VALIDATE_RET(session, ...)        \

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -116,7 +116,7 @@ __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, const char *
     char hex_timestamp[WT_TS_HEX_STRING_SIZE];
 
     __wt_timestamp_to_hex_string(ts, hex_timestamp);
-    __wt_verbose(session, WT_VERB_TIMESTAMP, "Timestamp %s: %s", hex_timestamp, msg);
+    __wt_verbose(session, WT_VERB_TIMESTAMP, "Timestamp 0x%s: %s", hex_timestamp, msg);
 }
 
 #define WT_TIME_VALIDATE_RET(session, ...)        \

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -15,7 +15,7 @@
 char *
 __wt_timestamp_to_string(wt_timestamp_t ts, char *ts_string)
 {
-    WT_IGNORE_RET(__wt_snprintf(ts_string, WT_TS_INT_STRING_SIZE, "(0x%" PRIx32 ", 0x%" PRIx32 ")",
+    WT_IGNORE_RET(__wt_snprintf(ts_string, WT_TS_INT_STRING_SIZE, "(%" PRIu32 ", %" PRIu32 ")",
       (uint32_t)((ts >> 32) & 0xffffffff), (uint32_t)(ts & 0xffffffff)));
     return (ts_string);
 }
@@ -113,10 +113,10 @@ __wt_timestamp_to_hex_string(wt_timestamp_t ts, char *hex_timestamp)
 void
 __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, const char *msg)
 {
-    char ts_string[WT_TS_INT_STRING_SIZE];
+    char hex_timestamp[WT_TS_HEX_STRING_SIZE];
 
-    __wt_verbose(
-      session, WT_VERB_TIMESTAMP, "Timestamp %s: %s", __wt_timestamp_to_string(ts, ts_string), msg);
+    __wt_timestamp_to_hex_string(ts, hex_timestamp);
+    __wt_verbose(session, WT_VERB_TIMESTAMP, "Timestamp %s: %s", hex_timestamp, msg);
 }
 
 #define WT_TIME_VALIDATE_RET(session, ...)        \


### PR DESCRIPTION
The set_timestamp time parameter is hexadecimal:
testutil_check(conn->set_timestamp(conn, "oldest_timestamp=10, stable_timestamp=10"));

the log info as following(be hexadecimal):
[1714312199:96018][105276:0x7fa976f4f800], WT_CONNECTION.__conn_set_timestamp: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp (0, 16): Updated global oldest timestamp
[1714312199:96023][105276:0x7fa976f4f800], WT_CONNECTION.__conn_set_timestamp: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp (0, 16): Updated global stable timestamp
[1714312199:96034][105276:0x7fa976f4f800], WT_CONNECTION.__conn_set_timestamp: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp (0, 16): Updated pinned timestamp
[1714312199:96040][105276:0x7fa976f4f800], WT_CONNECTION.__conn_set_timestamp: [WT_VERB_API][DEBUG_1]: CALL: WT_CONNECTION:__conn_set_timestamp


The set_timestamp time parameter is hexadecimal, so it is recommended that timestamp output also be hexadecimal, so that it is consistent.

The first time I saw the log, I thought the log output was wrong because I mistakenly thought the set_timestamp parameter was decimal.


after this pr: Print both decimal and hexadecimal timestamp
[1722093404:857945][125189:0x7fa9a8ff9700], WT_CONNECTION.set_timestamp: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp 0x3b9aca10(0, 1000000016): Updated global oldest timestamp
[1722093404:857949][125189:0x7fa9a8ff9700], WT_CONNECTION.set_timestamp: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp 0x3b9aca10(0, 1000000016): Updated global stable timestamp
[1722093404:857986][125189:0x7fa9a8ff9700], WT_CONNECTION.set_timestamp: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp 0x3b9aca10(0, 1000000016): Updated pinned timestamp