### PR TITLE
WT-9126 Avoid alarm in ctest for UBSAN builds

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -387,6 +387,7 @@ ThreadListWrapper
 Timespec
 Tput
 TryCV
+UBSAN
 UDF
 UID
 UIDs

--- a/test/csuite/wt4105_large_doc_small_upd/main.c
+++ b/test/csuite/wt4105_large_doc_small_upd/main.c
@@ -151,9 +151,10 @@ main(int argc, char *argv[])
             /*
              * FIXME-WT-6113: extend timeout to pass the test.
              *
-             * Ignore this alarm for MSan builds due to the typical slowdown introduced by MSan.
+             * Ignore this alarm for some sanitizer builds due to the typical slowdown they
+             * introduce.
              */
-            if (!testutil_is_flag_set("TESTUTIL_MSAN"))
+            if (!(testutil_is_flag_set("TESTUTIL_MSAN") || testutil_is_flag_set("TESTUTIL_UBSAN")))
                 (void)alarm(15);
             testutil_check(c->modify(c, &modify_entry, 1));
             (void)alarm(0);

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -64,6 +64,7 @@ functions:
               export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:verbosity=3"
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ UBSan ]]; then
               export UBSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_stacktrace=1"
+              export TESTUTIL_UBSAN=1
             fi
 
             ${additional_env_vars}


### PR DESCRIPTION
See the ticket comments for context.

I tried a pile of patch builds with this check added, and none of them timed out. But the original timeout was rare, so it's not clear whether I've managed to prove anything by doing that.