### PR TITLE
WT-12664 Increase the size of COPY_BUF_SIZE in test_random_directio

### DIFF
--- a/test/csuite/random_directio/util.c
+++ b/test/csuite/random_directio/util.c
@@ -37,7 +37,7 @@
  * util.c
  * 	Utility functions for test that simulates system crashes.
  */
-#define COPY_BUF_SIZE ((size_t)(64 * 1024))
+#define COPY_BUF_SIZE ((size_t)(128 * 1024))
 
 /*
  * copy_directory --

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -882,8 +882,6 @@ tasks:
           configure_env_vars: CC=clang-8 CXX=clang++-8 ADD_CFLAGS="-ggdb -fPIC"
 
   - name: make-check-test
-    depends_on:
-      - name: compile
     commands:
       - func: "get project"
       - func: "compile wiredtiger"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -882,6 +882,8 @@ tasks:
           configure_env_vars: CC=clang-8 CXX=clang++-8 ADD_CFLAGS="-ggdb -fPIC"
 
   - name: make-check-test
+    depends_on:
+      - name: compile
     commands:
       - func: "get project"
       - func: "compile wiredtiger"


### PR DESCRIPTION
Increase `COPY_BUF_SIZE` to 128KB since it must be larger than `sb.st_blksize` and on RHEL8 PPC `st_blksize` is 64KB.