### PR TITLE
WT-12907: give txn read timestamp‘s Abnormal cause

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -757,6 +757,7 @@ conn_stats = [
     TxnStat('txn_rts_upd_aborted', 'rollback to stable updates aborted'),
     TxnStat('txn_rts_upd_aborted_dryrun', 'rollback to stable updates that would have been aborted in non-dryrun mode'),
     TxnStat('txn_sessions_walked', 'sessions scanned in each walk of concurrent sessions'),
+    TxnStat('txn_set_read_timestamp_more_than_oldest_timestamp', 'set read timestamp more less than oldest timestamp'),
     TxnStat('txn_set_ts', 'set timestamp calls'),
     TxnStat('txn_set_ts_durable', 'set timestamp durable calls'),
     TxnStat('txn_set_ts_durable_upd', 'set timestamp durable updates'),

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1033,6 +1033,7 @@ struct __wt_connection_stats {
     int64_t txn_rts_upd_aborted_dryrun;
     int64_t txn_rts_hs_removed_dryrun;
     int64_t txn_sessions_walked;
+    int64_t txn_set_read_timestamp_more_than_oldest_timestamp;
     int64_t txn_set_ts;
     int64_t txn_set_ts_durable;
     int64_t txn_set_ts_durable_upd;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7067,64 +7067,66 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1666
 /*! transaction: sessions scanned in each walk of concurrent sessions */
 #define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1667
+/*! transaction: set read timestamp more less than oldest timestamp */
+#define	WT_STAT_CONN_TXN_SET_READ_TIMESTAMP_MORE_THAN_OLDEST_TIMESTAMP	1668
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1668
+#define	WT_STAT_CONN_TXN_SET_TS				1669
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1669
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1670
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1670
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1671
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1671
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1672
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1672
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1673
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1673
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1674
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1674
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1675
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1675
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1676
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1676
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1677
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1677
+#define	WT_STAT_CONN_TXN_BEGIN				1678
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1678
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1679
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1679
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1680
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1680
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1681
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1681
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1682
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1682
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1683
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1683
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1684
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1684
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1685
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1685
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1686
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1686
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1687
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1687
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1688
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1688
+#define	WT_STAT_CONN_TXN_COMMIT				1689
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1689
+#define	WT_STAT_CONN_TXN_ROLLBACK			1690
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1690
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1691
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2062,6 +2062,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: rollback to stable updates that would have been removed from history store in "
   "non-dryrun mode",
   "transaction: sessions scanned in each walk of concurrent sessions",
+  "transaction: set read timestamp more less than oldest timestamp",
   "transaction: set timestamp calls",
   "transaction: set timestamp durable calls",
   "transaction: set timestamp durable updates",
@@ -2794,6 +2795,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->txn_rts_upd_aborted_dryrun = 0;
     stats->txn_rts_hs_removed_dryrun = 0;
     stats->txn_sessions_walked = 0;
+    stats->txn_set_read_timestamp_more_than_oldest_timestamp = 0;
     stats->txn_set_ts = 0;
     stats->txn_set_ts_durable = 0;
     stats->txn_set_ts_durable_upd = 0;
@@ -3587,6 +3589,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_rts_upd_aborted_dryrun += WT_STAT_READ(from, txn_rts_upd_aborted_dryrun);
     to->txn_rts_hs_removed_dryrun += WT_STAT_READ(from, txn_rts_hs_removed_dryrun);
     to->txn_sessions_walked += WT_STAT_READ(from, txn_sessions_walked);
+    to->txn_set_read_timestamp_more_than_oldest_timestamp +=
+      WT_STAT_READ(from, txn_set_read_timestamp_more_than_oldest_timestamp);
     to->txn_set_ts += WT_STAT_READ(from, txn_set_ts);
     to->txn_set_ts_durable += WT_STAT_READ(from, txn_set_ts_durable);
     to->txn_set_ts_durable_upd += WT_STAT_READ(from, txn_set_ts_durable_upd);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -859,6 +859,8 @@ __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
             __wt_readunlock(session, &txn_global->rwlock);
 
 #if !defined(WT_STANDALONE_BUILD) || defined(HAVE_DIAGNOSTIC)
+            WT_STAT_CONN_INCR(session, txn_set_read_timestamp_more_than_oldest_timestamp);
+
             /*
              * In some cases, MongoDB sets a read timestamp older than the oldest timestamp, relying
              * on WiredTiger's concurrency to detect and fail the set. In other cases it's a bug and

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -858,7 +858,7 @@ __wt_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
         } else {
             __wt_readunlock(session, &txn_global->rwlock);
 
-#if !defined(WT_STANDALONE_BUILD)
+#if !defined(WT_STANDALONE_BUILD) || defined(HAVE_DIAGNOSTIC)
             /*
              * In some cases, MongoDB sets a read timestamp older than the oldest timestamp, relying
              * on WiredTiger's concurrency to detect and fail the set. In other cases it's a bug and


### PR DESCRIPTION
 Background： in HAVE_DIAGNOSTIC mode, the following code is abnormal, but No root cause was given：
 testutil_check(conn->set_timestamp(conn, "oldest_timestamp=10, stable_timestamp=10"));
    for (i = 0; i < kv_num; i++) {
        error_check(session->begin_transaction(session, NULL));
        cursor->set_key(cursor, i); /* Insert a record. */
        cursor->set_value(cursor, "value: aaa");
        error_check(cursor->insert(cursor));
        testutil_check(session->timestamp_transaction(session, "commit_timestamp=20"));
        error_check(session->commit_transaction(session, NULL));
    }

    for (i = 0; i < kv_num; i++) {
        error_check(session->begin_transaction(session, NULL));
        cursor->set_key(cursor, i); /* Insert a record. */
        cursor->set_value(cursor, "value: bbb");
        error_check(cursor->insert(cursor));
        testutil_check(session->timestamp_transaction(session, "commit_timestamp=5"));
        error_check(session->commit_transaction(session, NULL));
    }



The log is as follows:
[1714395388:975693][35391:0x7f2b937b8800], WT_SESSION.__session_begin_transaction: [WT_VERB_API][DEBUG_1]: CALL: WT_SESSION:__session_begin_transaction
ex_access: FAILED: access_txn23_test/316: session->begin_transaction(session, "read_timestamp=5"): Invalid argument
ex_access: process aborting
WiredTiger Error: __wt_abort, 28: aborting WiredTiger library
Aborted (core dumped)








after this PR, the log info is:
[1714395512:946863][36783:0x7fa6955e1800], WT_SESSION.__session_begin_transaction: [WT_VERB_API][DEBUG_1]: CALL: WT_SESSION:__session_begin_transaction
**[1714395512:946892][36783:0x7fa6955e1800], WT_SESSION.__session_begin_transaction: [WT_VERB_TIMESTAMP][NOTICE]: read timestamp (0, 5) less than the oldest timestamp (0, 16)**
ex_access: FAILED: access_txn23_test/316: session->begin_transaction(session, "read_timestamp=5"): Invalid argument
ex_access: process aborting
WiredTiger Error: __wt_