### PR TITLE
WT-12923 Add workaround for poetry dependency issues in many-collection-tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -202,7 +202,14 @@ functions:
         virtualenv -p python3 venv
         source venv/bin/activate
         python3 -m pip install 'poetry==1.5.1'
+
+        export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+        # FIXME-WT-12911 - There's a dependency ordering issue in the mongo poetry.lock file. Running poetry install twice resolves it.
+        set +o errexit
         python3 -m poetry install --no-root --sync
+        set -o errexit
+        python3 -m poetry install --no-root --sync
+
         ./buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_gcc.vars --link-model=dynamic --ninja generate-ninja ICECC=icecc CCACHE=ccache
         ninja -j$(nproc --all) install-mongod
   "configure wiredtiger": &configure_wiredtiger


### PR DESCRIPTION
Run `poetry install` twice since this resolves dependency ordering issues present in mongo's `poetry.lock` file.