### PR TITLE
WT-12927 Avoid checkpoint cleanup processing empty or newly created files

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -474,7 +474,7 @@ __checkpoint_cleanup_eligibility(WT_SESSION_IMPL *session, const char *uri, cons
 
     WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
     __wt_config_subinit(session, &ckptconf, &cval);
-    for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
+    while ((ret = __wt_config_next(&ckptconf, &key, &cval)) == 0) {
         ret = __wt_config_subgets(session, &cval, "newest_stop_durable_ts", &value);
         if (ret == 0)
             newest_stop_durable_ts = WT_MAX(newest_stop_durable_ts, (wt_timestamp_t)value.val);
@@ -484,6 +484,7 @@ __checkpoint_cleanup_eligibility(WT_SESSION_IMPL *session, const char *uri, cons
             addr_size = value.len;
         WT_RET_NOTFOUND_OK(ret);
     }
+    WT_RET_NOTFOUND_OK(ret);
 
     /*
      * The checkpoint cleanup eligibility is decided based on the following:

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -485,20 +485,18 @@ __checkpoint_cleanup_eligibility(WT_SESSION_IMPL *session, const char *uri, cons
         WT_RET_NOTFOUND_OK(ret);
     }
 
-    /* Ignore the tables that are empty or newly created. */
-    if (addr_size == 0)
-        return (false);
-
     /*
      * The checkpoint cleanup eligibility is decided based on the following:
-     * 1. The file has a durable stop timestamp.
-     * 2. Logged table. The logged tables do not support timestamps, so we need
+     * 1. Not an empty or newly created table.
+     * 2. The table has a durable stop timestamp.
+     * 3. Logged table. The logged tables do not support timestamps, so we need
      *    to check for obsolete pages in them.
-     * 3. History store table. This table contains the historical versions that
+     * 4. History store table. This table contains the historical versions that
      *    are needed to be removed regularly. This condition is required when
      *    timestamps are not in use, otherwise, the first condition will be satisfied.
      */
-    if (newest_stop_durable_ts != WT_TS_NONE || logged || strcmp(uri, WT_HS_URI) == 0)
+    if ((addr_size != 0) &&
+      (newest_stop_durable_ts != WT_TS_NONE || logged || strcmp(uri, WT_HS_URI) == 0))
         return (true);
 
     return (false);

--- a/test/suite/test_cc06.py
+++ b/test/suite/test_cc06.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from test_cc01 import test_cc_base
+from wiredtiger import stat
+from wtdataset import SimpleDataSet, simple_key, simple_value
+from wtscenario import make_scenarios
+
+# test_cc06.py
+# Verify checkpoint cleanup ignores the empty or newly created files.
+
+class test_cc06(test_cc_base):
+    conn_config = 'cache_size=50MB,statistics=(all)'
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='S', extraconfig='')),
+        ('column_fix', dict(key_format='r', value_format='8t',
+            extraconfig=',allocation_size=512,leaf_page_max=512')),
+        ('integer_row', dict(key_format='i', value_format='S', extraconfig='')),
+    ]
+    scenarios = make_scenarios(format_values)
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def test_cc(self):
+        uri = "table:cc06"
+
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config='log=(enabled=false)'+self.extraconfig)
+        ds.populate()
+
+        # Set the oldest and stable timestamps to 10.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10) +
+            ',stable_timestamp=' + self.timestamp_str(10))
+
+        self.session.checkpoint("debug=(checkpoint_cleanup=true)")
+        # Check statistics.
+        self.assertEqual(self.get_stat(stat.conn.checkpoint_cleanup_pages_visited), 0)
+
+        # Reopen the database.
+        self.reopen_conn()
+
+        self.session.checkpoint("debug=(checkpoint_cleanup=true)")
+        # Check statistics.
+        self.assertEqual(self.get_stat(stat.conn.checkpoint_cleanup_pages_visited), 0)


### PR DESCRIPTION
Accessing the empty or newly created files by checkpoint cleanup leads to marking them dirty unnecessarily and causing problems to open the bulk cursor when these are dirtied tables are processed by the checkpoint thread.