### PR TITLE
WT-12925 - Fix divide-by-0 if the branch count is 0 when a Code Change Report attempts to push to a GitHub PR

### DIFF
--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -41,7 +41,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
     /* Walk the tree, discarding pages. */
-    walk_flags = WT_READ_CACHE | WT_READ_NO_EVICT | WT_READ_NO_GEN | WT_READ_NO_WAIT;
+    walk_flags = WT_READ_CACHE | WT_READ_NO_EVICT;
     if (!F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT))
         walk_flags |= WT_READ_VISIBLE_ALL;
 

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -41,7 +41,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
     /* Walk the tree, discarding pages. */
-    walk_flags = WT_READ_CACHE | WT_READ_NO_EVICT;
+    walk_flags = WT_READ_CACHE | WT_READ_NO_EVICT | WT_READ_NO_GEN | WT_READ_NO_WAIT;
     if (!F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT))
         walk_flags |= WT_READ_VISIBLE_ALL;
 

--- a/test/evergreen/code_change_report/code_change_report.py
+++ b/test/evergreen/code_change_report/code_change_report.py
@@ -488,24 +488,26 @@ def build_pr_comment(code_change_info: dict) -> str | None:
     pct_lines_covered = num_lines_covered / num_lines * 100
     num_branches = int(summary_info['num_branches'])
     num_branches_covered = int(summary_info['num_branches_covered'])
-    pct_branches_covered = num_branches_covered / num_branches * 100
+
     lines_covered = (
         f"{round(pct_lines_covered)}% ({num_lines_covered}/{num_lines})"
         if num_lines > 0 else
         "N/A"
     )
-    branches_covered = (
-        f"{round(pct_branches_covered)}% ({num_branches_covered}/{num_branches})"
-        if num_branches > 0 else
-        "N/A"
-    )
 
-    if pct_branches_covered >= 80:
-        coverage_note = "Woohoo, the code changed in this PR is pretty well tested! :tada:"
-    elif pct_branches_covered >= 50 and pct_lines_covered >= 80:
-        coverage_note = "Test coverage is ok, please try and improve it if that's feasible."
-    else:
-        coverage_note = "Test coverage is too low, this change probably shouldn't be merged as-is."
+    branches_covered = "N/A"
+    coverage_note = ""
+
+    if num_branches > 0:
+        pct_branches_covered = num_branches_covered / num_branches * 100
+        branches_covered = f"{round(pct_branches_covered)}% ({num_branches_covered}/{num_branches})"
+
+        if pct_branches_covered >= 80:
+            coverage_note = "Woohoo, the code changed in this PR is pretty well tested! :tada:"
+        elif pct_branches_covered >= 50 and pct_lines_covered >= 80:
+            coverage_note = "Test coverage is ok, please try and improve it if that's feasible."
+        else:
+            coverage_note = "Test coverage is too low, this change probably shouldn't be merged as-is."
 
     message += textwrap.dedent(f"""
         {coverage_note}

--- a/test/evergreen/code_change_report/code_change_report.py
+++ b/test/evergreen/code_change_report/code_change_report.py
@@ -488,26 +488,24 @@ def build_pr_comment(code_change_info: dict) -> str | None:
     pct_lines_covered = num_lines_covered / num_lines * 100
     num_branches = int(summary_info['num_branches'])
     num_branches_covered = int(summary_info['num_branches_covered'])
-
+    pct_branches_covered = num_branches_covered / num_branches * 100
     lines_covered = (
         f"{round(pct_lines_covered)}% ({num_lines_covered}/{num_lines})"
         if num_lines > 0 else
         "N/A"
     )
+    branches_covered = (
+        f"{round(pct_branches_covered)}% ({num_branches_covered}/{num_branches})"
+        if num_branches > 0 else
+        "N/A"
+    )
 
-    branches_covered = "N/A"
-    coverage_note = ""
-
-    if num_branches > 0:
-        pct_branches_covered = num_branches_covered / num_branches * 100
-        branches_covered = f"{round(pct_branches_covered)}% ({num_branches_covered}/{num_branches})"
-
-        if pct_branches_covered >= 80:
-            coverage_note = "Woohoo, the code changed in this PR is pretty well tested! :tada:"
-        elif pct_branches_covered >= 50 and pct_lines_covered >= 80:
-            coverage_note = "Test coverage is ok, please try and improve it if that's feasible."
-        else:
-            coverage_note = "Test coverage is too low, this change probably shouldn't be merged as-is."
+    if pct_branches_covered >= 80:
+        coverage_note = "Woohoo, the code changed in this PR is pretty well tested! :tada:"
+    elif pct_branches_covered >= 50 and pct_lines_covered >= 80:
+        coverage_note = "Test coverage is ok, please try and improve it if that's feasible."
+    else:
+        coverage_note = "Test coverage is too low, this change probably shouldn't be merged as-is."
 
     message += textwrap.dedent(f"""
         {coverage_note}

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -49,7 +49,7 @@ def run_command(directory: str, command: str) -> str:
     completed_process = subprocess.run(command, capture_output=True, check=True, shell=True)
     output = completed_process.stdout
     working_directory.pop()
-    return output.decode().strip()
+    return output.decode()
 
 
 def find_zero_length_files(directory: str) -> List[str]:

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -70,7 +70,7 @@ def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -
     repo = Repository(repository_path)
 
     head_commit = repo.head.target
-    merge_base_commit = run_command(git_working_tree_dir, "git merge-base develop HEAD")
+    merge_base_commit = run_command(git_working_tree_dir, "git merge-base develop HEAD").strip()
     diff_command = f"git diff {merge_base_commit} -- {exclude_files_param}"
 
     if verbose:


### PR DESCRIPTION
The solution is to avoid performing the percentage calculation if the number of branches is 0.