### PR TITLE
WT-12929 Compact to safe free the addr->addr while replacing ref addr

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -113,7 +113,7 @@ __compact_page_replace_addr(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY 
     WT_ASSERT(session, addr != NULL);
 
     if (__wt_off_page(ref->home, addr))
-        __wt_free(session, addr->addr);
+        __wt_addr_address_safe_free(session, addr);
     else {
         __wt_cell_unpack_addr(session, ref->home->dsk, (WT_CELL *)addr, &unpack);
 

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -113,7 +113,7 @@ __compact_page_replace_addr(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY 
     WT_ASSERT(session, addr != NULL);
 
     if (__wt_off_page(ref->home, addr))
-        __wt_safe_free(session, addr->addr, addr->size);
+        __wt_ref_addr_safe_free(session, addr->addr, addr->size);
     else {
         __wt_cell_unpack_addr(session, ref->home->dsk, (WT_CELL *)addr, &unpack);
 

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -113,7 +113,7 @@ __compact_page_replace_addr(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY 
     WT_ASSERT(session, addr != NULL);
 
     if (__wt_off_page(ref->home, addr))
-        __wt_addr_address_safe_free(session, addr);
+        __wt_safe_free(session, addr->addr, addr->size);
     else {
         __wt_cell_unpack_addr(session, ref->home->dsk, (WT_CELL *)addr, &unpack);
 

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -242,13 +242,13 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
- * __wt_safe_free --
+ * __wt_ref_addr_safe_free --
  *     Any thread that is reviewing the address in a WT_REF, must also be holding a split generation
  *     to ensure that the page index they are using remains valid. Utilize the same generation type
  *     to safely free the address once all users of it have left the generation.
  */
 void
-__wt_safe_free(WT_SESSION_IMPL *session, void *p, size_t len)
+__wt_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len)
 {
     WT_DECL_RET;
     uint64_t split_gen;
@@ -306,8 +306,8 @@ __wt_ref_addr_free(WT_SESSION_IMPL *session, WT_REF *ref)
     }
 
     if (home == NULL || __wt_off_page(home, ref_addr)) {
-        __wt_safe_free(session, ((WT_ADDR *)ref_addr)->addr, ((WT_ADDR *)ref_addr)->size);
-        __wt_safe_free(session, ref_addr, sizeof(WT_ADDR));
+        __wt_ref_addr_safe_free(session, ((WT_ADDR *)ref_addr)->addr, ((WT_ADDR *)ref_addr)->size);
+        __wt_ref_addr_safe_free(session, ref_addr, sizeof(WT_ADDR));
     }
 }
 

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -242,13 +242,13 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
- * __ref_addr_safe_free --
+ * __wt_safe_free --
  *     Any thread that is reviewing the address in a WT_REF, must also be holding a split generation
  *     to ensure that the page index they are using remains valid. Utilize the same generation type
  *     to safely free the address once all users of it have left the generation.
  */
-static void
-__ref_addr_safe_free(WT_SESSION_IMPL *session, void *ref_addr)
+void
+__wt_safe_free(WT_SESSION_IMPL *session, void *p, size_t len)
 {
     WT_DECL_RET;
     uint64_t split_gen;
@@ -259,9 +259,7 @@ __ref_addr_safe_free(WT_SESSION_IMPL *session, void *ref_addr)
      * creating a whole new generation counter. There are no page splits taking place.
      */
     split_gen = __wt_gen(session, WT_GEN_SPLIT);
-    WT_TRET(__wt_stash_add(
-      session, WT_GEN_SPLIT, split_gen, ((WT_ADDR *)ref_addr)->addr, ((WT_ADDR *)ref_addr)->size));
-    WT_TRET(__wt_stash_add(session, WT_GEN_SPLIT, split_gen, ref_addr, sizeof(WT_ADDR)));
+    WT_TRET(__wt_stash_add(session, WT_GEN_SPLIT, split_gen, p, len));
     __wt_gen_next(session, WT_GEN_SPLIT, NULL);
 
     if (ret != 0)
@@ -307,34 +305,10 @@ __wt_ref_addr_free(WT_SESSION_IMPL *session, WT_REF *ref)
         __wt_yield();
     }
 
-    if (home == NULL || __wt_off_page(home, ref_addr))
-        __ref_addr_safe_free(session, ref_addr);
-}
-
-/*
- * __wt_addr_address_safe_free --
- *     Any thread that is reviewing the address in a WT_ADDR, must also be holding a split
- *     generation to ensure that the page index they are using remains valid. Utilize the same
- *     generation type to safely free the addr address once all users of it have left the
- *     generation.
- */
-void
-__wt_addr_address_safe_free(WT_SESSION_IMPL *session, WT_ADDR *addr)
-{
-    WT_DECL_RET;
-    uint64_t split_gen;
-
-    /*
-     * The reading thread is always inside a split generation when it reads the ref, so we make use
-     * of WT_GEN_SPLIT type generation mechanism to protect the address in a WT_REF rather than
-     * creating a whole new generation counter. There are no page splits taking place.
-     */
-    split_gen = __wt_gen(session, WT_GEN_SPLIT);
-    WT_TRET(__wt_stash_add(session, WT_GEN_SPLIT, split_gen, addr->addr, addr->size));
-    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
-
-    if (ret != 0)
-        WT_IGNORE_RET(__wt_panic(session, ret, "fatal error during addr address free"));
+    if (home == NULL || __wt_off_page(home, ref_addr)) {
+        __wt_safe_free(session, ((WT_ADDR *)ref_addr)->addr, ((WT_ADDR *)ref_addr)->size);
+        __wt_safe_free(session, ref_addr, sizeof(WT_ADDR));
+    }
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1873,6 +1873,7 @@ extern uint64_t __wt_strtouq(const char *nptr, char **endptr, int base) WT_GCC_F
 extern void *__wt_ext_scr_alloc(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, size_t size);
 extern void __wt_abort(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn))
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
+extern void __wt_addr_address_safe_free(WT_SESSION_IMPL *session, WT_ADDR *addr);
 extern void __wt_backup_destroy(WT_SESSION_IMPL *session);
 extern void __wt_blkcache_destroy(WT_SESSION_IMPL *session);
 extern void __wt_blkcache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2020,6 +2020,7 @@ extern void __wt_rec_col_fix_write_auxheader(WT_SESSION_IMPL *session, uint32_t 
 extern void __wt_rec_dictionary_free(WT_SESSION_IMPL *session, WT_RECONCILE *r);
 extern void __wt_rec_dictionary_reset(WT_RECONCILE *r);
 extern void __wt_ref_addr_free(WT_SESSION_IMPL *session, WT_REF *ref);
+extern void __wt_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wt_ref_out(WT_SESSION_IMPL *session, WT_REF *ref);
 extern void __wt_rollback_to_stable_init(WT_CONNECTION_IMPL *conn);
 extern void __wt_root_ref_init(
@@ -2029,7 +2030,6 @@ extern void __wt_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_s
   uint64_t rollback_count, uint64_t max_count, uint64_t *rollback_msg_count, bool walk);
 extern void __wt_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);
 extern void __wt_rwlock_destroy(WT_SESSION_IMPL *session, WT_RWLOCK *l);
-extern void __wt_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wt_schema_destroy_colgroup(WT_SESSION_IMPL *session, WT_COLGROUP **colgroupp);
 extern void __wt_scr_discard(WT_SESSION_IMPL *session);
 extern void __wt_session_close_cache(WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1873,7 +1873,6 @@ extern uint64_t __wt_strtouq(const char *nptr, char **endptr, int base) WT_GCC_F
 extern void *__wt_ext_scr_alloc(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, size_t size);
 extern void __wt_abort(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn))
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_addr_address_safe_free(WT_SESSION_IMPL *session, WT_ADDR *addr);
 extern void __wt_backup_destroy(WT_SESSION_IMPL *session);
 extern void __wt_blkcache_destroy(WT_SESSION_IMPL *session);
 extern void __wt_blkcache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size,
@@ -2030,6 +2029,7 @@ extern void __wt_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_s
   uint64_t rollback_count, uint64_t max_count, uint64_t *rollback_msg_count, bool walk);
 extern void __wt_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);
 extern void __wt_rwlock_destroy(WT_SESSION_IMPL *session, WT_RWLOCK *l);
+extern void __wt_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wt_schema_destroy_colgroup(WT_SESSION_IMPL *session, WT_COLGROUP **colgroupp);
 extern void __wt_scr_discard(WT_SESSION_IMPL *session);
 extern void __wt_session_close_cache(WT_SESSION_IMPL *session);


### PR DESCRIPTION
Compact operation can rewrite the ref addr to compact the on-disk file. As part of the rewrite operation, it can free the existing address and create a new address for this ref on the disk file. During this time, it is possible that the same ref being accessed in parallel can lead to access the freed addr->addr. To avoid this problem, safe free the addr->addr from the compact operation.