### PR TITLE
WT-12922 Use the right cell size when using dictionary

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -332,6 +332,9 @@ __wt_cell_pack_value_match(
         if (rle) /* Skip RLE */
             WT_RET(__wt_vunpack_uint(&a, 0, &v));
         WT_RET(__wt_vunpack_uint(&a, 0, &alen)); /* Length */
+        /* Adjust the size of data cells without a validity window or run-length encoding. */
+        if (!validity && !rle)
+            alen += WT_CELL_SIZE_ADJUST;
     } else
         return (0);
 
@@ -361,6 +364,9 @@ __wt_cell_pack_value_match(
         if (rle) /* Skip RLE */
             WT_RET(__wt_vunpack_uint(&b, 0, &v));
         WT_RET(__wt_vunpack_uint(&b, 0, &blen)); /* Length */
+        /* Adjust the size of data cells without a validity window or run-length encoding. */
+        if (!validity && !rle)
+            blen += WT_CELL_SIZE_ADJUST;
     } else
         return (0);
 

--- a/test/suite/test_dictionary01.py
+++ b/test/suite/test_dictionary01.py
@@ -30,7 +30,7 @@
 # compression
 # [END_TAGS]
 #
-# test_dictionary.py
+# test_dictionary01.py
 #       Smoke test dictionary compression.
 
 from wtscenario import make_scenarios
@@ -39,7 +39,7 @@ from wiredtiger import stat
 import wttest
 
 # Smoke test dictionary compression.
-class test_dictionary(wttest.WiredTigerTestCase):
+class test_dictionary01(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     scenarios = make_scenarios([
         ('row', dict(key_format='S')),
@@ -47,9 +47,9 @@ class test_dictionary(wttest.WiredTigerTestCase):
     ])
 
     # Smoke test dictionary compression.
-    def test_dictionary(self):
+    def test_dictionary01(self):
         nentries = 25000
-        uri = 'file:test_dictionary'    # This is a btree layer test.
+        uri = 'file:test_dictionary01'    # This is a btree layer test.
 
         # Create the object, open the cursor, insert some records with identical values. Use
         # a reasonably large page size so most of the items fit on a page. Use alternating

--- a/test/suite/test_dictionary02.py
+++ b/test/suite/test_dictionary02.py
@@ -59,11 +59,11 @@ class test_dictionary02(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
             ',stable_timestamp=' + self.timestamp_str(1))
 
-        # Write two values that should lead to two unique dictionary entries.
+        # Write two values that will lead to two unique dictionary entries.
         cursor[simple_key(cursor, 1)] = self.value_a
         cursor[simple_key(cursor, 2)] = self.value_b
 
-        # The next cells should reuse an existing dictionary entry and have RLE information for
+        # The next cells will reuse an existing dictionary entry and have RLE information for
         # VLCS.
         for i in range(3, 10):
             cursor[simple_key(cursor, i)] = self.value_a
@@ -76,10 +76,10 @@ class test_dictionary02(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor('statistics:' + uri, None, None)
         dict_value = cursor[stat.dsrc.rec_dictionary][2]
         if self.key_format == 'S':
-            # Each cell is written for row-store and each should reuse the existing dictionary
+            # Each cell is written for row-store and each will reuse the existing dictionary
             # entry.
             self.assertEqual(dict_value, 7)
         else:
-            # For VLCS, we should benefit from the RLE, only one cell should be written and reuse
+            # For VLCS, we will benefit from the RLE, only one cell will be written and reuse
             # the dictionary entry.
             self.assertEqual(dict_value, 1)

--- a/test/suite/test_dictionary02.py
+++ b/test/suite/test_dictionary02.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_dictionary02.py
+#       Test cells with same values are reused through the dictionary despite RLE information.
+
+from wtscenario import make_scenarios
+from wtdataset import simple_key
+from wiredtiger import stat
+import wttest
+
+class test_dictionary02(wttest.WiredTigerTestCase):
+    scenarios = make_scenarios([
+        ('row', dict(key_format='S')),
+        ('var', dict(key_format='r')),
+    ])
+
+    value_a = "aaa" * 100
+    value_b = "bbb" * 100
+
+    def test_dictionary02(self):
+        uri = 'file:test_dictionary02'
+
+        # Use a reasonably large page size so all of the items fit on a page.
+        config=f'leaf_page_max=64K,dictionary=100,value_format=S,key_format={self.key_format}'
+        self.session.create(uri, config)
+        cursor = self.session.open_cursor(uri, None)
+
+        # Write two values that should lead to two unique dictionary entries.
+        cursor[simple_key(cursor, 1)] = self.value_a
+        cursor[simple_key(cursor, 2)] = self.value_b
+
+        # The next cells should reuse an existing dictionary entry and have RLE information for
+        # VLCS.
+        for i in range(3, 10):
+            cursor[simple_key(cursor, i)] = self.value_a
+        cursor.close()
+
+        # Checkpoint to force the pages through reconciliation.
+        self.session.checkpoint()
+
+        # Confirm the dictionary was effective.
+        cursor = self.session.open_cursor('statistics:' + uri, None, None)
+        dict_value = cursor[stat.dsrc.rec_dictionary][2]
+        if self.key_format == 'S':
+            # Each cell is written for row-store and each should reuse the existing dictionary
+            # entry.
+            self.assertEqual(dict_value, 7)
+        else:
+            # For VLCS, we should benefit from the RLE, only one cell should be written and reuse
+            # the dictionary entry.
+            self.assertEqual(dict_value, 1)

--- a/test/suite/test_dictionary02.py
+++ b/test/suite/test_dictionary02.py
@@ -26,6 +26,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+# [TEST_TAGS]
+# compression
+# [END_TAGS]
+#
 # test_dictionary02.py
 #       Test cells with same values are reused through the dictionary despite RLE information.
 

--- a/test/suite/test_dictionary02.py
+++ b/test/suite/test_dictionary02.py
@@ -55,6 +55,10 @@ class test_dictionary02(wttest.WiredTigerTestCase):
         self.session.create(uri, config)
         cursor = self.session.open_cursor(uri, None)
 
+        # Pin timestamps to ensure new modifications are not globally visible.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
         # Write two values that should lead to two unique dictionary entries.
         cursor[simple_key(cursor, 1)] = self.value_a
         cursor[simple_key(cursor, 2)] = self.value_b

--- a/test/suite/test_dictionary03.py
+++ b/test/suite/test_dictionary03.py
@@ -26,6 +26,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+# [TEST_TAGS]
+# compression
+# [END_TAGS]
+#
 # test_dictionary03.py
 #       Test cells with same values are reused through the dictionary despite time window
 #       information.

--- a/test/suite/test_dictionary03.py
+++ b/test/suite/test_dictionary03.py
@@ -60,11 +60,11 @@ class test_dictionary03(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
             ',stable_timestamp=' + self.timestamp_str(1))
 
-        # Write two values that should lead to two unique dictionary entries.
+        # Write two values that will lead to two unique dictionary entries.
         cursor[simple_key(cursor, 1)] = self.value_a
         cursor[simple_key(cursor, 2)] = self.value_b
 
-        # The next cells should reuse an existing dictionary entry and have time window validity.
+        # The next cells will reuse an existing dictionary entry and have time window validity.
         self.session.begin_transaction()
         cursor[simple_key(cursor, 3)] = self.value_a
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))

--- a/test/suite/test_dictionary03.py
+++ b/test/suite/test_dictionary03.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_dictionary03.py
+#       Test cells with same values are reused through the dictionary despite time window
+#       information.
+
+from wtscenario import make_scenarios
+from wtdataset import simple_key
+from wiredtiger import stat
+import wttest
+
+class test_dictionary03(wttest.WiredTigerTestCase):
+    scenarios = make_scenarios([
+        ('row', dict(key_format='S')),
+        ('var', dict(key_format='r')),
+    ])
+
+    value_a = "aaa" * 100
+    value_b = "bbb" * 100
+
+    def test_dictionary03(self):
+        uri = 'file:test_dictionary03'
+
+        # Use a reasonably large page size so all of the items fit on a page.
+        config=f'leaf_page_max=64K,dictionary=100,value_format=S,key_format={self.key_format}'
+        self.session.create(uri, config)
+        cursor = self.session.open_cursor(uri, None)
+
+        # Write two values that should lead to two unique dictionary entries.
+        cursor[simple_key(cursor, 1)] = self.value_a
+        cursor[simple_key(cursor, 2)] = self.value_b
+
+        # The next cells should reuse an existing dictionary entry and have time window validity.
+        self.session.begin_transaction()
+        cursor[simple_key(cursor, 3)] = self.value_a
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+        cursor.close()
+
+        # Checkpoint to force the pages through reconciliation.
+        self.session.checkpoint()
+
+        # Confirm the dictionary was effective.
+        cursor = self.session.open_cursor('statistics:' + uri, None, None)
+        dict_value = cursor[stat.dsrc.rec_dictionary][2]
+        self.assertEqual(dict_value, 1)

--- a/test/suite/test_dictionary03.py
+++ b/test/suite/test_dictionary03.py
@@ -56,6 +56,10 @@ class test_dictionary03(wttest.WiredTigerTestCase):
         self.session.create(uri, config)
         cursor = self.session.open_cursor(uri, None)
 
+        # Pin timestamps to ensure new modifications are not globally visible.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
         # Write two values that should lead to two unique dictionary entries.
         cursor[simple_key(cursor, 1)] = self.value_a
         cursor[simple_key(cursor, 2)] = self.value_b

--- a/test/suite/test_dictionary04.py
+++ b/test/suite/test_dictionary04.py
@@ -60,11 +60,11 @@ class test_dictionary04(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
             ',stable_timestamp=' + self.timestamp_str(1))
 
-        # Write two values that should lead to two unique dictionary entries.
+        # Write two values that will lead to two unique dictionary entries.
         cursor[simple_key(cursor, 1)] = self.value_a
         cursor[simple_key(cursor, 2)] = self.value_b
 
-        # The next cells should reuse an existing dictionary entry and have:
+        # The next cells will reuse an existing dictionary entry and have:
         # - time window information,
         # - RLE information for VLCS only.
         self.session.begin_transaction()
@@ -80,10 +80,10 @@ class test_dictionary04(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor('statistics:' + uri, None, None)
         dict_value = cursor[stat.dsrc.rec_dictionary][2]
         if self.key_format == 'S':
-            # Each cell is written for row-store and each should reuse the existing dictionary
+            # Each cell is written for row-store and each will reuse the existing dictionary
             # entry.
             self.assertEqual(dict_value, 7)
         else:
-            # For VLCS, we should benefit from the RLE, only one cell should be written and reuse
+            # For VLCS, we will benefit from the RLE, only one cell will be written and reuse
             # the dictionary entry.
             self.assertEqual(dict_value, 1)

--- a/test/suite/test_dictionary04.py
+++ b/test/suite/test_dictionary04.py
@@ -56,6 +56,10 @@ class test_dictionary04(wttest.WiredTigerTestCase):
         self.session.create(uri, config)
         cursor = self.session.open_cursor(uri, None)
 
+        # Pin timestamps to ensure new modifications are not globally visible.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
         # Write two values that should lead to two unique dictionary entries.
         cursor[simple_key(cursor, 1)] = self.value_a
         cursor[simple_key(cursor, 2)] = self.value_b

--- a/test/suite/test_dictionary04.py
+++ b/test/suite/test_dictionary04.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_dictionary04.py
+#       Test cells with same values are reused through the dictionary despite RLE and time window
+#       information.
+
+from wtscenario import make_scenarios
+from wtdataset import simple_key
+from wiredtiger import stat
+import wttest
+
+class test_dictionary04(wttest.WiredTigerTestCase):
+    scenarios = make_scenarios([
+        ('row', dict(key_format='S')),
+        ('var', dict(key_format='r')),
+    ])
+
+    value_a = "aaa" * 100
+    value_b = "bbb" * 100
+
+    def test_dictionary04(self):
+        uri = 'file:test_dictionary04'
+
+        # Use a reasonably large page size so all of the items fit on a page.
+        config=f'leaf_page_max=64K,dictionary=100,value_format=S,key_format={self.key_format}'
+        self.session.create(uri, config)
+        cursor = self.session.open_cursor(uri, None)
+
+        # Write two values that should lead to two unique dictionary entries.
+        cursor[simple_key(cursor, 1)] = self.value_a
+        cursor[simple_key(cursor, 2)] = self.value_b
+
+        # The next cells should reuse an existing dictionary entry and have:
+        # - time window information,
+        # - RLE information for VLCS only.
+        self.session.begin_transaction()
+        for i in range(3, 10):
+            cursor[simple_key(cursor, i)] = self.value_a
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+        cursor.close()
+
+        # Checkpoint to force the pages through reconciliation.
+        self.session.checkpoint()
+
+        # Confirm the dictionary was effective.
+        cursor = self.session.open_cursor('statistics:' + uri, None, None)
+        dict_value = cursor[stat.dsrc.rec_dictionary][2]
+        if self.key_format == 'S':
+            # Each cell is written for row-store and each should reuse the existing dictionary
+            # entry.
+            self.assertEqual(dict_value, 7)
+        else:
+            # For VLCS, we should benefit from the RLE, only one cell should be written and reuse
+            # the dictionary entry.
+            self.assertEqual(dict_value, 1)

--- a/test/suite/test_dictionary04.py
+++ b/test/suite/test_dictionary04.py
@@ -26,6 +26,10 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+# [TEST_TAGS]
+# compression
+# [END_TAGS]
+#
 # test_dictionary04.py
 #       Test cells with same values are reused through the dictionary despite RLE and time window
 #       information.

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -16,7 +16,7 @@
 |Checkpoint|Metadata|[test_checkpoint_snapshot01.py](../test/suite/test_checkpoint_snapshot01.py)
 |Checkpoint|Obsolete Data|[test_checkpoint08.py](../test/suite/test_checkpoint08.py)
 |Checkpoint|Recovery|[test_bug029.py](../test/suite/test_bug029.py)
-|Compression||[test_dictionary.py](../test/suite/test_dictionary.py)
+|Compression||[test_dictionary01.py](../test/suite/test_dictionary01.py), [test_dictionary02.py](../test/suite/test_dictionary02.py), [test_dictionary03.py](../test/suite/test_dictionary03.py), [test_dictionary04.py](../test/suite/test_dictionary04.py)
 |Config Api||[test_base02.py](../test/suite/test_base02.py), [test_config02.py](../test/suite/test_config02.py)
 |Connection Api||[test_version.py](../test/suite/test_version.py)
 |Connection Api|Reconfigure|[test_reconfig01.py](../test/suite/test_reconfig01.py), [test_reconfig02.py](../test/suite/test_reconfig02.py)


### PR DESCRIPTION
The changes address the issue where `__wt_cell_pack_value_match` would not compare cells correctly as it would not use the right size for the cells to compare when there is no time window validity or RLE information.