### PR TITLE
WT-12733 Decode JSON strings into the original code points

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -73,6 +73,7 @@ Castagnoli
 Cclmpv
 Ceil
 CentOS
+Charset
 Checkpointing
 Checksums
 CityHash
@@ -423,6 +424,7 @@ Vixie
 VloaY
 Vo
 VxWorks
+WCHAR
 WILLNEED
 WIREDTIGER
 WRLSN
@@ -563,6 +565,7 @@ cerr
 cfg
 cfko
 chacha
+charset
 chdir
 checkfmt
 checkkey

--- a/test/model/CMakeLists.txt
+++ b/test/model/CMakeLists.txt
@@ -43,6 +43,8 @@ target_compile_options(
     PRIVATE ${COMPILER_DIAGNOSTIC_CXX_FLAGS}
 )
 
+find_package(Iconv REQUIRED)
+target_link_libraries(wiredtiger_model Iconv::Iconv)
 target_link_libraries(wiredtiger_model wt::wiredtiger)
 
 # Build the tests and the tools.

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -48,9 +48,13 @@ namespace model {
 static void
 from_json(const json &j, debug_log_parser::col_put &out)
 {
+    std::string value;
+
     j.at("fileid").get_to(out.fileid);
     j.at("recno").get_to(out.recno);
-    j.at("value").get_to(out.value);
+    j.at("value").get_to(value);
+
+    out.value = decode_charset_bytes(value);
 }
 
 /*
@@ -108,9 +112,14 @@ from_json(const json &j, debug_log_parser::prev_lsn &out)
 static void
 from_json(const json &j, debug_log_parser::row_put &out)
 {
+    std::string key, value;
+
     j.at("fileid").get_to(out.fileid);
-    j.at("key").get_to(out.key);
-    j.at("value").get_to(out.value);
+    j.at("key").get_to(key);
+    j.at("value").get_to(value);
+
+    out.key = decode_charset_bytes(key);
+    out.value = decode_charset_bytes(value);
 }
 
 /*
@@ -120,8 +129,12 @@ from_json(const json &j, debug_log_parser::row_put &out)
 static void
 from_json(const json &j, debug_log_parser::row_remove &out)
 {
+    std::string key;
+
     j.at("fileid").get_to(out.fileid);
-    j.at("key").get_to(out.key);
+    j.at("key").get_to(key);
+
+    out.key = decode_charset_bytes(key);
 }
 
 /*
@@ -131,10 +144,15 @@ from_json(const json &j, debug_log_parser::row_remove &out)
 static void
 from_json(const json &j, debug_log_parser::row_truncate &out)
 {
+    std::string start, stop;
+
     j.at("fileid").get_to(out.fileid);
     j.at("mode").get_to(out.mode);
-    j.at("start").get_to(out.start);
-    j.at("stop").get_to(out.stop);
+    j.at("start").get_to(start);
+    j.at("stop").get_to(stop);
+
+    out.start = decode_charset_bytes(start);
+    out.stop = decode_charset_bytes(stop);
 }
 
 /*

--- a/test/model/src/driver/debug_log_parser.cpp
+++ b/test/model/src/driver/debug_log_parser.cpp
@@ -54,7 +54,7 @@ from_json(const json &j, debug_log_parser::col_put &out)
     j.at("recno").get_to(out.recno);
     j.at("value").get_to(value);
 
-    out.value = decode_charset_bytes(value);
+    out.value = decode_utf8(value);
 }
 
 /*
@@ -118,8 +118,8 @@ from_json(const json &j, debug_log_parser::row_put &out)
     j.at("key").get_to(key);
     j.at("value").get_to(value);
 
-    out.key = decode_charset_bytes(key);
-    out.value = decode_charset_bytes(value);
+    out.key = decode_utf8(key);
+    out.value = decode_utf8(value);
 }
 
 /*
@@ -134,7 +134,7 @@ from_json(const json &j, debug_log_parser::row_remove &out)
     j.at("fileid").get_to(out.fileid);
     j.at("key").get_to(key);
 
-    out.key = decode_charset_bytes(key);
+    out.key = decode_utf8(key);
 }
 
 /*
@@ -151,8 +151,8 @@ from_json(const json &j, debug_log_parser::row_truncate &out)
     j.at("start").get_to(start);
     j.at("stop").get_to(stop);
 
-    out.start = decode_charset_bytes(start);
-    out.stop = decode_charset_bytes(stop);
+    out.start = decode_utf8(start);
+    out.stop = decode_utf8(stop);
 }
 
 /*

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -500,6 +500,12 @@ private:
 };
 
 /*
+ * decode_charset_bytes --
+ *     Decode one-byte code points. Throw an exception on error.
+ */
+std::string decode_charset_bytes(const std::string &str, const char *src_charset = "UTF-8");
+
+/*
  * parse_uint64 --
  *     Parse the string into a number. Throw an exception on error.
  */

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -500,10 +500,10 @@ private:
 };
 
 /*
- * decode_charset_bytes --
- *     Decode one-byte code points. Throw an exception on error.
+ * decode_utf8 --
+ *     Decode a UTF-8 string into one-byte code points. Throw an exception on error.
  */
-std::string decode_charset_bytes(const std::string &str, const char *src_charset = "UTF-8");
+std::string decode_utf8(const std::string &str);
 
 /*
  * parse_uint64 --

--- a/test/model/test/model_basic/main.cpp
+++ b/test/model/test/model_basic/main.cpp
@@ -1260,6 +1260,41 @@ test_model_oldest_wt(void)
 }
 
 /*
+ * test_model_debug_log_verify_wt --
+ *     Test the debug log based verification.
+ */
+static void
+test_model_debug_log_verify_wt(void)
+{
+    model::kv_database database;
+    model::kv_table_ptr table = database.create_table("table");
+
+    /* Create the test's home directory and database. */
+    WT_CONNECTION *conn;
+    WT_SESSION *session;
+    const char *uri = "table:table";
+
+    std::string test_home = std::string(home) + DIR_DELIM_STR + "debug-log";
+    testutil_recreate_dir(test_home.c_str());
+    testutil_wiredtiger_open(opts, test_home.c_str(), ENV_CONFIG, nullptr, &conn, false, false);
+    testutil_check(conn->open_session(conn, nullptr, nullptr, &session));
+    testutil_check(
+      session->create(session, uri, "key_format=Q,value_format=Q,log=(enabled=false)"));
+
+    /* Insert a few key-value pairs to check that the debug log parser unpacks numbers correctly. */
+    for (uint64_t i = 0; i < 10 * WT_MILLION; i = (i * 7) + 1)
+        wt_model_insert_both(table, uri, model::data_value(i), model::data_value(2 * i));
+
+    /* Checkpoint and clean up. */
+    wt_model_ckpt_create_both(nullptr);
+    testutil_check(session->close(session, nullptr));
+    testutil_check(conn->close(conn, nullptr));
+
+    /* Verify using the debug log. */
+    verify_using_debug_log(opts, test_home.c_str(), true);
+}
+
+/*
  * usage --
  *     Print usage help for the program.
  */
@@ -1325,6 +1360,7 @@ main(int argc, char *argv[])
         test_model_truncate_column_fix_wt(true);
         test_model_oldest();
         test_model_oldest_wt();
+        test_model_debug_log_verify_wt();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;
         ret = EXIT_FAILURE;


### PR DESCRIPTION
The JSON library uses UTF-8 encoding, which has the unfortunate consequence of encoding all keys and values from the debug log JSON into UTF-8. As a result, we need to decode keys and values from UTF-8 back to their original bytes before unpacking them via `data_value::unpack`.

I used the `iconv` library to do the work, because it is standard on POSIX systems. I would have preferred to use something like `codecvt` if I could, but it just got deprecated, and I didn't want to add a dependency on a non-standard library. And no, I didn't find a way to get our JSON library to use a different encoding; it looks like UTF-8 is hard-coded in.