### PR TITLE
WT-12934 Address remaining issues with zero length files and git diffs in the Code Change Report

### DIFF
--- a/test/evergreen/code_change_report/code_change_report.py
+++ b/test/evergreen/code_change_report/code_change_report.py
@@ -441,7 +441,7 @@ def generate_html_report_as_text(code_change_info: dict, verbose: bool):
     # Create table with a list of changed files
     report.append("<table class=\"center\">\n")
     report.append("  <tr>\n")
-    report.append("    <th>Changed File(s), excluding any new 0-length files</th>\n")
+    report.append("    <th>Changed File(s), excluding any new/moved 0-length files</th>\n")
     report.append("  </tr>\n")
     for file in change_info_list:
         escaped_file = html.escape(file, quote=True)

--- a/test/evergreen/code_change_report/code_change_report.py
+++ b/test/evergreen/code_change_report/code_change_report.py
@@ -441,7 +441,7 @@ def generate_html_report_as_text(code_change_info: dict, verbose: bool):
     # Create table with a list of changed files
     report.append("<table class=\"center\">\n")
     report.append("  <tr>\n")
-    report.append("    <th>Changed File(s), excluding any new/moved 0-length files</th>\n")
+    report.append("    <th>Changed File(s), excluding all 0-length or deleted files</th>\n")
     report.append("  </tr>\n")
     for file in change_info_list:
         escaped_file = html.escape(file, quote=True)

--- a/test/evergreen/code_change_report/git_diff_tool.py
+++ b/test/evergreen/code_change_report/git_diff_tool.py
@@ -52,6 +52,11 @@ def run_command(directory: str, command: str) -> str:
     return output.decode()
 
 
+def get_merge_base_commit(git_working_tree_dir: str) -> str:
+    merge_base_commit = run_command(git_working_tree_dir, "git merge-base develop HEAD").strip()
+    return merge_base_commit
+
+
 def find_zero_length_files(directory: str) -> List[str]:
     working_directory = PushWorkingDirectory(directory)
     files = glob.glob('./**/*', recursive=True)
@@ -60,24 +65,55 @@ def find_zero_length_files(directory: str) -> List[str]:
     return zero_length_files
 
 
+def find_deleted_files(git_working_tree_dir: str) -> List[str]:
+    working_directory = PushWorkingDirectory(git_working_tree_dir)
+    merge_base_commit = get_merge_base_commit(git_working_tree_dir)
+    result = run_command(git_working_tree_dir, f"git diff --name-status {merge_base_commit} --diff-filter D")
+    deleted_files = result.replace("D\t", "./").splitlines()
+    working_directory.pop()
+    return deleted_files
+
+
+def find_moved_zero_length_files(git_working_tree_dir: str) -> List[str]:
+    zero_length_files = find_zero_length_files(directory=git_working_tree_dir)
+    working_directory = PushWorkingDirectory(git_working_tree_dir)
+    merge_base_commit = get_merge_base_commit(git_working_tree_dir)
+    result = run_command(git_working_tree_dir, f"git diff --name-status {merge_base_commit} --diff-filter R")
+    moved_zero_length_files = []
+    for line in result.splitlines():
+        line_parts = line.split()
+        file_name_1 = './' + line_parts[1]
+        file_name_2 = './' + line_parts[2]
+        if file_name_1 in zero_length_files or file_name_2 in zero_length_files:
+            moved_zero_length_files.append(file_name_1)
+            moved_zero_length_files.append(file_name_2)
+    working_directory.pop()
+    return moved_zero_length_files
+
+
 def create_diff_file(git_working_tree_dir: str, diff_file: str, verbose: bool) -> None:
     # Exclude files with 0-length from the diff, as pygit2 doesn't handle such diffs well
-    zero_length_files = find_zero_length_files(git_working_tree_dir)
-    exclude_files_param = ' '.join([f"':(exclude){file}'" for file in zero_length_files])
+    zero_length_files = find_zero_length_files(directory=git_working_tree_dir)
+    deleted_files = find_deleted_files(git_working_tree_dir=git_working_tree_dir)
+    moved_zero_length_files = find_moved_zero_length_files(git_working_tree_dir=git_working_tree_dir)
+    exclude_files = zero_length_files + deleted_files + moved_zero_length_files
+    exclude_files_param = ' '.join([f"':(exclude){file}'" for file in exclude_files])
 
     repository_path = discover_repository(git_working_tree_dir)
     assert repository_path is not None
     repo = Repository(repository_path)
 
     head_commit = repo.head.target
-    merge_base_commit = run_command(git_working_tree_dir, "git merge-base develop HEAD").strip()
+    merge_base_commit = get_merge_base_commit(git_working_tree_dir)
     diff_command = f"git diff {merge_base_commit} -- {exclude_files_param}"
 
     if verbose:
-        print(f"head_commit:        {head_commit}")
-        print(f"merge_base_commit:  {merge_base_commit}")
-        print(f"zero_length_files = {zero_length_files}")
-        print(f"diff_command:       {diff_command}")
+        print(f"head_commit:            {head_commit}")
+        print(f"merge_base_commit:      {merge_base_commit}")
+        print(f"zero_length_files:      {zero_length_files}")
+        print(f"moved_zero_length_files {moved_zero_length_files}")
+        print(f"deleted_files:          {deleted_files}")
+        print(f"diff_command:           {diff_command}")
 
     diff_output = run_command(git_working_tree_dir, diff_command)
     diff_output += "\n"   # Ensure there is a newline on the end of the diff before writing to a file.


### PR DESCRIPTION
[WT-12868](https://jira.mongodb.org/browse/WT-12868) created a workaround for newly added 0-length files, however @bzm-jas 's PR for [WT-12837](https://jira.mongodb.org/browse/WT-12837) also has some deleted 0-length files. Each of these files can generate either a deleted file record in the diff, or it may generate a record moving that file to another location as it sees a match in the (0-length) content.

The solution is to also exclude from the diff output file:

- Any deleted files
- Any moved files where the record includes the path of a 0-length file.