### PR TITLE
WT-12889 Identify and skip malformed workloads in counterexample reduction

### DIFF
--- a/test/model/src/driver/kv_workload.cpp
+++ b/test/model/src/driver/kv_workload.cpp
@@ -209,6 +209,112 @@ parse(const char *str)
 } /* namespace operation */
 
 /*
+ * kv_workload_generator::assert_timestamps --
+ *     Assert that the timestamps are assigned correctly. Call this function one sequence at a time.
+ */
+void
+kv_workload::assert_timestamps(const operation::any &op, timestamp_t &oldest, timestamp_t &stable)
+{
+    if (std::holds_alternative<operation::set_stable_timestamp>(op)) {
+        timestamp_t t = std::get<operation::set_stable_timestamp>(op).stable_timestamp;
+        if (t < stable) {
+            std::ostringstream err;
+            err << "The stable timestamp went backwards: " << stable << " -> " << t;
+            throw model_exception(err.str());
+        }
+        if (t < oldest && oldest != k_timestamp_none) {
+            std::ostringstream err;
+            err << "The stable timestamp must not be smaller than the oldest timestamp: " << t
+                << " < " << oldest;
+            throw model_exception(err.str());
+        }
+        stable = t;
+    }
+
+    if (std::holds_alternative<operation::set_oldest_timestamp>(op)) {
+        timestamp_t t = std::get<operation::set_oldest_timestamp>(op).oldest_timestamp;
+        if (t < oldest) {
+            std::ostringstream err;
+            err << "The oldest timestamp went backwards: " << oldest << " -> " << t;
+            throw model_exception(err.str());
+        }
+        if (t > stable && stable != k_timestamp_none) {
+            std::ostringstream err;
+            err << "The oldest timestamp must not be later than the stable timestamp: " << t
+                << " > " << stable;
+            throw model_exception(err.str());
+        }
+        oldest = t;
+    }
+
+    if (std::holds_alternative<operation::prepare_transaction>(op)) {
+        timestamp_t t = std::get<operation::prepare_transaction>(op).prepare_timestamp;
+        if (t < stable) {
+            std::ostringstream err;
+            err << "Prepare timestamp is before the stable timestamp: " << t << " < " << stable;
+            throw model_exception(err.str());
+        }
+    }
+
+    if (std::holds_alternative<operation::set_commit_timestamp>(op)) {
+        timestamp_t t = std::get<operation::set_commit_timestamp>(op).commit_timestamp;
+        if (t < stable) {
+            std::ostringstream err;
+            err << "Commit timestamp is before the stable timestamp: " << t << " < " << stable;
+            throw model_exception(err.str());
+        }
+    }
+
+    if (std::holds_alternative<operation::commit_transaction>(op)) {
+        timestamp_t t = std::get<operation::commit_transaction>(op).commit_timestamp;
+        if (t < stable) {
+            std::ostringstream err;
+            err << "Commit timestamp is before the stable timestamp: " << t << " < " << stable;
+            throw model_exception(err.str());
+        }
+        t = std::get<operation::commit_transaction>(op).durable_timestamp;
+        if (t < stable && t != k_timestamp_none) {
+            std::ostringstream err;
+            err << "Durable timestamp is before the stable timestamp: " << t << " < " << stable;
+            throw model_exception(err.str());
+        }
+    }
+}
+
+/*
+ * kv_workload::assert_timestamps --
+ *     Assert that all timestamps in the entire workload are assigned correctly. Throw an exception
+ *     on error.
+ */
+void
+kv_workload::assert_timestamps()
+{
+    timestamp_t ckpt_oldest = k_timestamp_none;
+    timestamp_t ckpt_stable = k_timestamp_none;
+    timestamp_t oldest = k_timestamp_none;
+    timestamp_t stable = k_timestamp_none;
+
+    for (size_t i = 0; i < _operations.size(); i++) {
+        const operation::any &op = _operations[i].operation;
+        assert_timestamps(op, oldest, stable);
+
+        if (std::holds_alternative<operation::checkpoint>(op) ||
+          std::holds_alternative<operation::restart>(op) ||
+          std::holds_alternative<operation::rollback_to_stable>(op)) {
+            ckpt_oldest = oldest;
+            ckpt_stable = stable;
+            if (ckpt_stable == k_timestamp_none)
+                ckpt_oldest = k_timestamp_none;
+        }
+        if (std::holds_alternative<operation::crash>(op) ||
+          std::holds_alternative<operation::restart>(op)) {
+            oldest = ckpt_oldest;
+            stable = ckpt_stable;
+        }
+    }
+}
+
+/*
  * kv_workload::run --
  *     Run the workload in the model. Return the return codes of the workload operations.
  */

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -283,14 +283,13 @@ kv_workload_generator::assign_timestamps(kv_workload_sequence &sequence, timesta
                 std::get<operation::commit_transaction>(*op).durable_timestamp =
                   std::min((timestamp_t)x, last);
             }
-        }
-        if (std::holds_alternative<operation::prepare_transaction>(*op))
+        } else if (std::holds_alternative<operation::prepare_transaction>(*op))
             std::get<operation::prepare_transaction>(*op).prepare_timestamp = t;
-        if (std::holds_alternative<operation::set_commit_timestamp>(*op))
+        else if (std::holds_alternative<operation::set_commit_timestamp>(*op))
             std::get<operation::set_commit_timestamp>(*op).commit_timestamp = t;
-        if (std::holds_alternative<operation::set_oldest_timestamp>(*op))
+        else if (std::holds_alternative<operation::set_oldest_timestamp>(*op))
             std::get<operation::set_oldest_timestamp>(*op).oldest_timestamp = oldest = t;
-        if (std::holds_alternative<operation::set_stable_timestamp>(*op))
+        else if (std::holds_alternative<operation::set_stable_timestamp>(*op))
             std::get<operation::set_stable_timestamp>(*op).stable_timestamp = stable = t;
     }
 }

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -235,86 +235,6 @@ kv_workload_generator::sequence_traversal::complete_one(sequence_state *s)
 }
 
 /*
- * kv_workload_generator::assert_timestamps --
- *     Assert that the timestamps are assigned correctly. Call this function one sequence at a time.
- */
-void
-kv_workload_generator::assert_timestamps(const kv_workload_sequence &sequence,
-  const operation::any &op, timestamp_t &oldest, timestamp_t &stable)
-{
-    if (std::holds_alternative<operation::set_stable_timestamp>(op)) {
-        timestamp_t t = std::get<operation::set_stable_timestamp>(op).stable_timestamp;
-        if (t < stable) {
-            std::ostringstream err;
-            err << "The stable timestamp went backwards: " << stable << " -> " << t << " (sequence "
-                << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-        if (t < oldest && oldest != k_timestamp_none) {
-            std::ostringstream err;
-            err << "The stable timestamp must not be smaller than the oldest timestamp: " << t
-                << " < " << oldest << " (sequence " << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-        stable = t;
-    }
-
-    if (std::holds_alternative<operation::set_oldest_timestamp>(op)) {
-        timestamp_t t = std::get<operation::set_oldest_timestamp>(op).oldest_timestamp;
-        if (t < oldest) {
-            std::ostringstream err;
-            err << "The oldest timestamp went backwards: " << oldest << " -> " << t << " (sequence "
-                << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-        if (t > stable && stable != k_timestamp_none) {
-            std::ostringstream err;
-            err << "The oldest timestamp must not be later than the stable timestamp: " << t
-                << " > " << stable << " (sequence " << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-        oldest = t;
-    }
-
-    if (std::holds_alternative<operation::prepare_transaction>(op)) {
-        timestamp_t t = std::get<operation::prepare_transaction>(op).prepare_timestamp;
-        if (t < stable) {
-            std::ostringstream err;
-            err << "Prepare timestamp is before the stable timestamp: " << t << " < " << stable
-                << " (sequence " << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-    }
-
-    if (std::holds_alternative<operation::set_commit_timestamp>(op)) {
-        timestamp_t t = std::get<operation::set_commit_timestamp>(op).commit_timestamp;
-        if (t < stable) {
-            std::ostringstream err;
-            err << "Commit timestamp is before the stable timestamp: " << t << " < " << stable
-                << " (sequence " << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-    }
-
-    if (std::holds_alternative<operation::commit_transaction>(op)) {
-        timestamp_t t = std::get<operation::commit_transaction>(op).commit_timestamp;
-        if (t < stable) {
-            std::ostringstream err;
-            err << "Commit timestamp is before the stable timestamp: " << t << " < " << stable
-                << " (sequence " << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-        t = std::get<operation::commit_transaction>(op).durable_timestamp;
-        if (t < stable && t != k_timestamp_none) {
-            std::ostringstream err;
-            err << "Durable timestamp is before the stable timestamp: " << t << " < " << stable
-                << " (sequence " << sequence.seq_no() << ")" << std::endl;
-            throw model_exception(err.str());
-        }
-    }
-}
-
-/*
  * kv_workload_generator::assign_timestamps --
  *     Assign timestamps to operations in a sequence.
  */
@@ -712,10 +632,6 @@ kv_workload_generator::run()
      * traversing the sequences in dependency order, and at each step, choosing one runnable
      * operation at random.
      */
-    ckpt_oldest = k_timestamp_none;
-    ckpt_stable = k_timestamp_none;
-    oldest = k_timestamp_none;
-    stable = k_timestamp_none;
     for (sequence_traversal t(_sequences); t.has_more();) {
         const std::deque<sequence_state *> &runnable = t.runnable();
 
@@ -729,22 +645,6 @@ kv_workload_generator::run()
         const operation::any &op = (*s->sequence)[s->next_operation_index++];
         _workload << kv_workload_operation(op, s->sequence->seq_no());
 
-        /* Validate that we filled in the timestamps in the correct order. */
-        assert_timestamps(*s->sequence, op, oldest, stable);
-        if (std::holds_alternative<operation::checkpoint>(op) ||
-          std::holds_alternative<operation::restart>(op) ||
-          std::holds_alternative<operation::rollback_to_stable>(op)) {
-            ckpt_oldest = oldest;
-            ckpt_stable = stable;
-            if (ckpt_stable == k_timestamp_none)
-                ckpt_oldest = k_timestamp_none;
-        }
-        if (std::holds_alternative<operation::crash>(op) ||
-          std::holds_alternative<operation::restart>(op)) {
-            oldest = ckpt_oldest;
-            stable = ckpt_stable;
-        }
-
         /* If the operation resulted in a database crash or restart, stop all started sequences. */
         if (std::holds_alternative<operation::crash>(op) ||
           std::holds_alternative<operation::restart>(op)) {
@@ -756,6 +656,9 @@ kv_workload_generator::run()
         if (s->next_operation_index >= s->sequence->size())
             t.complete_one(s);
     }
+
+    /* Validate that we filled in the timestamps in the correct order. */
+    _workload.assert_timestamps();
 }
 
 /*

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -1008,6 +1008,29 @@ public:
     }
 
     /*
+     * kv_workload::assert_timestamps --
+     *     Assert that all timestamps in the entire workload are assigned correctly. Throw an
+     *     exception on error.
+     */
+    void assert_timestamps();
+
+    /*
+     * kv_workload::verify_timestamps --
+     *     Verify that all timestamps in the entire workload are assigned correctly; just return
+     *     true or false instead of throwing an exception.
+     */
+    bool
+    verify_timestamps()
+    {
+        try {
+            assert_timestamps();
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    /*
      * kv_workload::run --
      *     Run the workload in the model. Return the return codes of the workload operations.
      */
@@ -1019,6 +1042,14 @@ public:
      */
     std::vector<int> run_in_wiredtiger(const char *home, const char *connection_config = nullptr,
       const char *table_config = nullptr) const;
+
+protected:
+    /*
+     * kv_workload::assert_timestamps --
+     *     Assert that the timestamps are assigned correctly. Call this function one sequence at a
+     *     time.
+     */
+    void assert_timestamps(const operation::any &op, timestamp_t &oldest, timestamp_t &stable);
 
 private:
     std::deque<kv_workload_operation> _operations;

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -446,15 +446,6 @@ protected:
         return _workload_ptr;
     }
 
-protected:
-    /*
-     * kv_workload_generator::assert_timestamps --
-     *     Assert that the timestamps are assigned correctly. Call this function one sequence at a
-     *     time.
-     */
-    void assert_timestamps(const kv_workload_sequence &sequence, const operation::any &op,
-      timestamp_t &oldest, timestamp_t &stable);
-
     /*
      * kv_workload_generator::assign_timestamps --
      *     Assign timestamps to operations in a sequence.

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -390,7 +390,13 @@ reduce_counterexample(std::shared_ptr<model::kv_workload> workload, const std::s
                 *w << op;
         }
 
-        /* Validate that we didn't produce a malformed workload. */
+        /*
+         * Validate that we didn't just produce a malformed workload.
+         *
+         * The workload construction algorithm above already guarantees that the transactions are
+         * included or removed in their entirety and that the workload creates all of its tables, so
+         * we don't need to check for undefined transaction or table IDs.
+         */
         bool skip = false;
         if (!w->verify_timestamps())
             skip = true;

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -390,12 +390,22 @@ reduce_counterexample(std::shared_ptr<model::kv_workload> workload, const std::s
                 *w << op;
         }
 
+        /* Validate that we didn't produce a malformed workload. */
+        bool skip = false;
+        if (!w->verify_timestamps())
+            skip = true;
+
         /* Clean up the previous database directory, if it exists. */
-        testutil_remove(home.c_str());
+        if (!skip)
+            testutil_remove(home.c_str());
 
         /* Try the reduced workload. */
         try {
-            run_and_verify(w, home, conn_config, table_config);
+            if (!skip)
+                run_and_verify(w, home, conn_config, table_config);
+            else
+                std::cout << "Counterexample reduction: Skip running a malformed workload"
+                          << std::endl;
 
             /* There was no error, so try removing only just the halves. */
             if (range.first + 1 < range.second) {


### PR DESCRIPTION
Counterexample reduction sometimes produces invalid workloads that do not actually reproduce the failure of the original workload, but instead fail because the reduction process itself generated a malformed workload. So far I've only seen this happening due to producing a workload with invalid use of timestamps—so check for timestamps early and skip testing malformed workloads.