### PR TITLE
WT-12897 Fix potential data race condition in fail_fs.c

### DIFF
--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -244,6 +244,7 @@ fail_file_read(
         ret = fail_fs_simulate_fail(fail_fh, session, read_ops, "read");
         goto err;
     }
+    fail_fs_unlock(&fail_fs->lock);
 
     /* Break reads larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
@@ -257,8 +258,10 @@ fail_file_read(
             break;
         }
     }
+    if (0) {
 err:
-    fail_fs_unlock(&fail_fs->lock);
+        fail_fs_unlock(&fail_fs->lock);
+    }
     return (ret);
 }
 
@@ -369,8 +372,10 @@ fail_file_write(
             break;
         }
     }
+    if (0) {
 err:
-    fail_fs_unlock(&fail_fs->lock);
+        fail_fs_unlock(&fail_fs->lock);
+    }
     return (ret);
 }
 

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -241,10 +241,9 @@ fail_file_read(
 
     if (fail_fs->fail_enabled && fail_fs->allow_reads != 0 &&
       read_ops % fail_fs->allow_reads == 0) {
-        fail_fs_unlock(&fail_fs->lock);
-        return (fail_fs_simulate_fail(fail_fh, session, read_ops, "read"));
+        ret = fail_fs_simulate_fail(fail_fh, session, read_ops, "read");
+        goto err;
     }
-    fail_fs_unlock(&fail_fs->lock);
 
     /* Break reads larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
@@ -258,6 +257,8 @@ fail_file_read(
             break;
         }
     }
+err:
+    fail_fs_unlock(&fail_fs->lock);
     return (ret);
 }
 
@@ -352,10 +353,9 @@ fail_file_write(
 
     if (fail_fs->fail_enabled && fail_fs->allow_writes != 0 &&
       write_ops % fail_fs->allow_writes == 0) {
-        fail_fs_unlock(&fail_fs->lock);
-        return (fail_fs_simulate_fail(fail_fh, session, write_ops, "write"));
+        ret = fail_fs_simulate_fail(fail_fh, session, write_ops, "write");
+        goto err;
     }
-    fail_fs_unlock(&fail_fs->lock);
 
     /* Break writes larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
@@ -369,6 +369,8 @@ fail_file_write(
             break;
         }
     }
+err:
+    fail_fs_unlock(&fail_fs->lock);
     return (ret);
 }
 

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -239,10 +239,12 @@ fail_file_read(
     } else
         read_ops = ++fail_fs->read_ops;
 
-    fail_fs_unlock(&fail_fs->lock);
-
-    if (fail_fs->fail_enabled && fail_fs->allow_reads != 0 && read_ops % fail_fs->allow_reads == 0)
+    if (fail_fs->fail_enabled && fail_fs->allow_reads != 0 &&
+      read_ops % fail_fs->allow_reads == 0) {
+        fail_fs_unlock(&fail_fs->lock);
         return (fail_fs_simulate_fail(fail_fh, session, read_ops, "read"));
+    }
+    fail_fs_unlock(&fail_fs->lock);
 
     /* Break reads larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
@@ -348,11 +350,12 @@ fail_file_write(
     } else
         write_ops = ++fail_fs->write_ops;
 
-    fail_fs_unlock(&fail_fs->lock);
-
     if (fail_fs->fail_enabled && fail_fs->allow_writes != 0 &&
-      write_ops % fail_fs->allow_writes == 0)
+      write_ops % fail_fs->allow_writes == 0) {
+        fail_fs_unlock(&fail_fs->lock);
         return (fail_fs_simulate_fail(fail_fh, session, write_ops, "write"));
+    }
+    fail_fs_unlock(&fail_fs->lock);
 
     /* Break writes larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {

--- a/ext/test/fail_fs/fail_fs.c
+++ b/ext/test/fail_fs/fail_fs.c
@@ -359,6 +359,7 @@ fail_file_write(
         ret = fail_fs_simulate_fail(fail_fh, session, write_ops, "write");
         goto err;
     }
+    fail_fs_unlock(&fail_fs->lock);
 
     /* Break writes larger than 1GB into 1GB chunks. */
     for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {


### PR DESCRIPTION
It was not possible to hit the race condition before this fix. The `fail_fs->fail_enabled` would only change if the environment variable was changed underneath the caller of the function. Now the change ensures that fail_enabled, allow_reads are only read under a lock.