### PR TITLE
WT-12954: optimizing Cluster performance jitter caused by checkpoint 

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -754,6 +754,10 @@ connection_runtime_config = [
             number of bytes per second available to the chunk cache. The minimum non-zero setting
             is 1MB.''',
             min='0', max='1TB'),
+        Config('checkpoint', '0', r'''
+            number of bytes per second available to the checkpoint. The minimum non-zero setting
+            is 1MB.''',
+            min='0', max='1TB'),
         ]),
     Config('json_output', '[]', r'''
         enable JSON formatted messages on the event handler interface. Options are given as a

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -337,6 +337,8 @@ static const uint8_t
     0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_io_capacity_subconfigs[] = {
+  {"checkpoint", "int", NULL, "min=0,max=1TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 56, 0,
+    1LL * WT_TERABYTE, NULL},
   {"chunk_cache", "int", NULL, "min=0,max=1TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 238, 0,
     1LL * WT_TERABYTE, NULL},
   {"total", "int", NULL, "min=0,max=1TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 237, 0,
@@ -347,8 +349,8 @@ static const uint8_t
   confchk_wiredtiger_open_io_capacity_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
 const char __WT_CONFIG_CHOICE_error[] = "error";
 const char __WT_CONFIG_CHOICE_message[] = "message";
 
@@ -635,7 +637,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 234,
     INT64_MIN, INT64_MAX, NULL},
-  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
+  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 3,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 236,
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
@@ -2844,7 +2846,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 293,
     INT64_MIN, INT64_MAX, NULL},
-  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
+  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 3,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 236,
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
@@ -3096,7 +3098,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 293,
     INT64_MIN, INT64_MAX, NULL},
-  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
+  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 3,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 236,
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
@@ -3343,7 +3345,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 234,
     INT64_MIN, INT64_MAX, NULL},
-  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
+  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 3,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 236,
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
@@ -3586,7 +3588,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 234,
     INT64_MIN, INT64_MAX, NULL},
-  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
+  {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 3,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 236,
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
@@ -3732,14 +3734,15 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_updates_trigger=0,extra_diagnostics=[],"
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
     "close_scan_interval=10),generation_drain_timeout_ms=240000,"
-    "history_store=(file_max=0),io_capacity=(chunk_cache=0,total=0),"
-    "json_output=[],log=(archive=true,os_cache_dirty_pct=0,"
-    "prealloc=true,prealloc_init_count=1,remove=true,zero_fill=false)"
-    ",lsm_manager=(merge=true,worker_thread_max=4),"
-    "operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),shared_cache=(chunk=10MB,name=,quota=0,reserve=0,"
-    "size=500MB),statistics=none,statistics_log=(json=false,"
-    "on_close=false,sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+    "history_store=(file_max=0),io_capacity=(checkpoint=0,"
+    "chunk_cache=0,total=0),json_output=[],log=(archive=true,"
+    "os_cache_dirty_pct=0,prealloc=true,prealloc_init_count=1,"
+    "remove=true,zero_fill=false),lsm_manager=(merge=true,"
+    "worker_thread_max=4),operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+    "statistics=none,statistics_log=(json=false,on_close=false,"
+    "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
     "tiered_storage=(local_retention=300),timing_stress_for_test=,"
     "verbose=[]",
     confchk_WT_CONNECTION_reconfigure, 35, confchk_WT_CONNECTION_reconfigure_jump, 11,
@@ -4048,7 +4051,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "close_scan_interval=10),generation_drain_timeout_ms=240000,"
     "hash=(buckets=512,dhandle_buckets=512),hazard_max=1000,"
     "history_store=(file_max=0),in_memory=false,"
-    "io_capacity=(chunk_cache=0,total=0),json_output=[],"
+    "io_capacity=(checkpoint=0,chunk_cache=0,total=0),json_output=[],"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
@@ -4098,7 +4101,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "close_scan_interval=10),generation_drain_timeout_ms=240000,"
     "hash=(buckets=512,dhandle_buckets=512),hazard_max=1000,"
     "history_store=(file_max=0),in_memory=false,"
-    "io_capacity=(chunk_cache=0,total=0),json_output=[],"
+    "io_capacity=(checkpoint=0,chunk_cache=0,total=0),json_output=[],"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
@@ -4148,20 +4151,20 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
     "close_scan_interval=10),generation_drain_timeout_ms=240000,"
     "hash=(buckets=512,dhandle_buckets=512),hazard_max=1000,"
-    "history_store=(file_max=0),io_capacity=(chunk_cache=0,total=0),"
-    "json_output=[],log=(archive=true,compressor=,enabled=false,"
-    "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
-    "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
-    "remove=true,zero_fill=false),lsm_manager=(merge=true,"
-    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
-    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),prefetch=(available=false,default=false),"
-    "readonly=false,salvage=false,session_max=100,"
-    "session_scratch_max=2MB,session_table_cache=true,"
-    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
-    "statistics=none,statistics_log=(json=false,on_close=false,"
-    "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
+    "history_store=(file_max=0),io_capacity=(checkpoint=0,"
+    "chunk_cache=0,total=0),json_output=[],log=(archive=true,"
+    "compressor=,enabled=false,file_max=100MB,force_write_wait=0,"
+    "os_cache_dirty_pct=0,path=\".\",prealloc=true,"
+    "prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
+    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
+    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "prefetch=(available=false,default=false),readonly=false,"
+    "salvage=false,session_max=100,session_scratch_max=2MB,"
+    "session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0,"
+    "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
+    ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
+    ",wait=0),tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,interval=60,local_retention=300,name=,"
     "shared=false),timing_stress_for_test=,"
     "transaction_sync=(enabled=false,method=fsync),verbose=[],"
@@ -4198,20 +4201,20 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
     "close_scan_interval=10),generation_drain_timeout_ms=240000,"
     "hash=(buckets=512,dhandle_buckets=512),hazard_max=1000,"
-    "history_store=(file_max=0),io_capacity=(chunk_cache=0,total=0),"
-    "json_output=[],log=(archive=true,compressor=,enabled=false,"
-    "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
-    "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
-    "remove=true,zero_fill=false),lsm_manager=(merge=true,"
-    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
-    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),prefetch=(available=false,default=false),"
-    "readonly=false,salvage=false,session_max=100,"
-    "session_scratch_max=2MB,session_table_cache=true,"
-    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
-    "statistics=none,statistics_log=(json=false,on_close=false,"
-    "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
+    "history_store=(file_max=0),io_capacity=(checkpoint=0,"
+    "chunk_cache=0,total=0),json_output=[],log=(archive=true,"
+    "compressor=,enabled=false,file_max=100MB,force_write_wait=0,"
+    "os_cache_dirty_pct=0,path=\".\",prealloc=true,"
+    "prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
+    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
+    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "prefetch=(available=false,default=false),readonly=false,"
+    "salvage=false,session_max=100,session_scratch_max=2MB,"
+    "session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0,"
+    "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
+    ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
+    ",wait=0),tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,interval=60,local_retention=300,name=,"
     "shared=false),timing_stress_for_test=,"
     "transaction_sync=(enabled=false,method=fsync),verbose=[],"

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -375,6 +375,9 @@ __throttle_checkpoint(WT_SESSION_IMPL *session, WT_CAPACITY *cap, uint64_t bytes
     if (capacity == 0 || F_ISSET(S2C(session), WT_CONN_RECOVERING))
         return;
 
+    if (cap->total > 0)
+        __capacity_signal(session);
+
     /* If we get sizes larger than this, later calculations may overflow. */
     WT_ASSERT(session, bytes < 16 * (uint64_t)WT_GIGABYTE);
     WT_ASSERT(session, capacity != 0);

--- a/src/include/capacity.h
+++ b/src/include/capacity.h
@@ -48,6 +48,7 @@ typedef enum {
 
 struct __wt_capacity {
     uint64_t chunkcache;      /* Bytes/sec chunk cache capacity */
+    uint64_t only_ckpt;       /* Bytes/sec only checkpoint capacity */
     uint64_t ckpt;            /* Bytes/sec checkpoint capacity */
     uint64_t evict;           /* Bytes/sec eviction capacity */
     uint64_t log;             /* Bytes/sec logging capacity */

--- a/src/include/conf.h
+++ b/src/include/conf.h
@@ -142,7 +142,7 @@ WT_CONF_API_DECLARE(WT_CONNECTION, debug_info, 1, 7);
 WT_CONF_API_DECLARE(WT_CONNECTION, load_extension, 1, 4);
 WT_CONF_API_DECLARE(WT_CONNECTION, open_session, 3, 9);
 WT_CONF_API_DECLARE(WT_CONNECTION, query_timestamp, 1, 1);
-WT_CONF_API_DECLARE(WT_CONNECTION, reconfigure, 17, 98);
+WT_CONF_API_DECLARE(WT_CONNECTION, reconfigure, 17, 99);
 WT_CONF_API_DECLARE(WT_CONNECTION, rollback_to_stable, 1, 2);
 WT_CONF_API_DECLARE(WT_CONNECTION, set_timestamp, 1, 4);
 WT_CONF_API_DECLARE(WT_CURSOR, bound, 1, 3);
@@ -173,10 +173,10 @@ WT_CONF_API_DECLARE(object, meta, 5, 64);
 WT_CONF_API_DECLARE(table, meta, 2, 13);
 WT_CONF_API_DECLARE(tier, meta, 5, 65);
 WT_CONF_API_DECLARE(tiered, meta, 5, 67);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 21, 161);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 21, 162);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 21, 156);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 21, 155);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 21, 162);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 21, 163);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 21, 157);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 21, 156);
 
 #define WT_CONF_API_ELEMENTS 56
 

--- a/src/include/conf_keys.h
+++ b/src/include/conf_keys.h
@@ -451,6 +451,7 @@ static const struct {
         uint64_t this_id;
     } Incremental;
     struct {
+        uint64_t checkpoint;
         uint64_t chunk_cache;
         uint64_t total;
     } Io_capacity;
@@ -819,6 +820,7 @@ static const struct {
     WT_CONF_ID_Incremental | (WT_CONF_ID_this_id << 16),
   },
   {
+    WT_CONF_ID_Io_capacity | (WT_CONF_ID_checkpoint << 16),
     WT_CONF_ID_Io_capacity | (WT_CONF_ID_chunk_cache << 16),
     WT_CONF_ID_Io_capacity | (WT_CONF_ID_total << 16),
   },

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2377,9 +2377,12 @@ struct __wt_connection {
      * @config{io_capacity = (, control how many bytes per second are written and read.  Exceeding
      * the capacity results in throttling., a set of related configuration options defined as
      * follows.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_cache, number of bytes per second available
-     * to the chunk cache.  The minimum non-zero setting is 1MB., an integer between \c 0 and \c
-     * 1TB; default \c 0.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint, number of bytes per second available to
+     * the checkpoint.  The minimum non-zero setting is 1MB., an integer between \c 0 and \c 1TB;
+     * default \c 0.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_cache, number of bytes per second
+     * available to the chunk cache.  The minimum non-zero setting is 1MB., an integer between \c 0
+     * and \c 1TB; default \c 0.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;total, number of bytes per second
      * available to all subsystems in total.  When set\, decisions about what subsystems are
      * throttled\, and in what proportion\, are made internally.  The minimum non-zero setting is
@@ -3242,12 +3245,16 @@ struct __wt_connection {
  * flag; default \c false.}
  * @config{io_capacity = (, control how many bytes per second are written and read.  Exceeding the
  * capacity results in throttling., a set of related configuration options defined as follows.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_cache, number of bytes per second available to the chunk
- * cache.  The minimum non-zero setting is 1MB., an integer between \c 0 and \c 1TB; default \c 0.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;total, number of bytes per second available to all subsystems in
- * total.  When set\, decisions about what subsystems are throttled\, and in what proportion\, are
- * made internally.  The minimum non-zero setting is 1MB., an integer between \c 0 and \c 1TB;
- * default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint, number of bytes per second available to the
+ * checkpoint.  The minimum non-zero setting is 1MB., an integer between \c 0 and \c 1TB; default \c
+ * 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;chunk_cache, number of bytes per second available to the
+ * chunk cache.  The minimum non-zero setting is 1MB., an integer between \c 0 and \c 1TB; default
+ * \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;total, number of bytes per second available to all
+ * subsystems in total.  When set\, decisions about what subsystems are throttled\, and in what
+ * proportion\, are made internally.  The minimum non-zero setting is 1MB., an integer between \c 0
+ * and \c 1TB; default \c 0.}
  * @config{ ),,}
  * @config{json_output, enable JSON formatted messages on the event handler interface.  Options are
  * given as a list\, where each option specifies an event handler category e.g.  'error' represents


### PR DESCRIPTION
Today, a user encountered a similar issue，they put a lot of pressure on us and requested us to resolve it within a week. I want to solve it by limiting the checkpoint speed, but I am not sure if this will solve the problem, and I am concerned about bugs in my code. Therefore, I need your help to ensure that everything is safe.

Through this PR, we can limit the checkpoint speed of MongoDB by using the following command：
db.adminCommand( { setParameter : 1, "wiredTigerEngineRuntimeConfig" : "io_capacity=(checkpoint=1M)"}) 

If convenient, please prioritize processing this PR, thank you.