### PR TITLE
WT-12962: Extend conn_api.c to support new get_version method

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1052,6 +1052,10 @@ connection_ops(WT_CONNECTION *conn)
     printf("The database home is %s\n", conn->get_home(conn));
     /*! [Get the database home directory] */
 
+    /*! [Get the wiredtiger's version] */
+    printf("The wiredtiger's version is %s\n", conn->get_version(conn));
+    /*! [Get the wiredtiger's version] */
+
     /*! [Check if the database is newly created] */
     if (conn->is_new(conn)) {
         /* First time initialization. */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1065,6 +1065,17 @@ __conn_get_home(WT_CONNECTION *wt_conn)
 }
 
 /*
+ * __conn_get_version --
+ *     WT_CONNECTION.get_version method.
+ */
+static const char *
+__conn_get_version(WT_CONNECTION *wt_conn)
+{
+    WT_UNUSED(wt_conn);
+    return (WIREDTIGER_VERSION_STRING);
+}
+
+/*
  * __conn_configure_method --
  *     WT_CONNECTION.configure_method method.
  */
@@ -2782,11 +2793,11 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
   WT_CONNECTION **connectionp)
 {
     static const WT_CONNECTION stdc = {__conn_close, __conn_debug_info, __conn_reconfigure,
-      __conn_get_home, __conn_compile_configuration, __conn_configure_method, __conn_is_new,
-      __conn_open_session, __conn_query_timestamp, __conn_set_timestamp, __conn_rollback_to_stable,
-      __conn_load_extension, __conn_add_data_source, __conn_add_collator, __conn_add_compressor,
-      __conn_add_encryptor, __conn_add_extractor, __conn_set_file_system, __conn_add_storage_source,
-      __conn_get_storage_source, __conn_get_extension_api};
+      __conn_get_home, __conn_get_version, __conn_compile_configuration, __conn_configure_method,
+      __conn_is_new, __conn_open_session, __conn_query_timestamp, __conn_set_timestamp,
+      __conn_rollback_to_stable, __conn_load_extension, __conn_add_data_source, __conn_add_collator,
+      __conn_add_compressor, __conn_add_encryptor, __conn_add_extractor, __conn_set_file_system,
+      __conn_add_storage_source, __conn_get_storage_source, __conn_get_extension_api};
     static const WT_NAME_FLAG file_types[] = {{"checkpoint", WT_DIRECT_IO_CHECKPOINT},
       {"data", WT_DIRECT_IO_DATA}, {"log", WT_DIRECT_IO_LOG}, {NULL, 0}};
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2512,6 +2512,15 @@ struct __wt_connection {
     const char *__F(get_home)(WT_CONNECTION *connection);
 
     /*!
+     * The wiredtiger's version of the connection.
+     *
+     * @snippet ex_all.c Get the wiredtiger's version
+     *
+     * @param connection the connection handle
+     * @returns a pointer to a string naming wiredtiger's version
+     */
+    const char *__F(get_version)(WT_CONNECTION *connection);
+    /*!
      * Compile a configuration string to be used with an API.  The string returned by this
      * method can be used with the indicated API call as its configuration argument.
      * Precompiled strings should be used where configuration parsing has proved to be a


### PR DESCRIPTION
Background:
We have encountered some user inquiries about how to obtain the wiredtiger version information, currently we can only go to the mongodb data directory, and then open the wiredtiger file to obtain the version information, this way is very inconvenient.

after this PR:
We can obtain the wiredtiger version information through the interface