### PR TITLE
WT-12974 Delete unneeded loop in __rec_hs_wrapup()

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2683,13 +2683,6 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
      */
     WT_ERR(__wt_hs_delete_updates(session, r));
 
-    /* Check if there's work to do. */
-    for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
-        if (multi->supd != NULL)
-            break;
-    if (i == r->multi_next)
-        return (0);
-
     for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
         if (multi->supd != NULL) {
             WT_ERR(__wt_hs_insert_updates(session, r, multi));
@@ -2700,6 +2693,7 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         }
 
 err:
+    /* If there is no work to do __wt_hs_insert_updaates() is not called and this returns 0. */
     return (ret);
 }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2693,7 +2693,6 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         }
 
 err:
-    /* If there is no work to do __wt_hs_insert_updates() is not called and this returns 0. */
     return (ret);
 }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2693,7 +2693,7 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         }
 
 err:
-    /* If there is no work to do __wt_hs_insert_updaates() is not called and this returns 0. */
+    /* If there is no work to do __wt_hs_insert_updates() is not called and this returns 0. */
     return (ret);
 }
 


### PR DESCRIPTION
A loop returns 0 if the loop goes all the way to the end. This is not needed since the following loop loops over the same range, has the same check within the loop, and also results in return 0 if the first loop would have gone all the way to the end. The first loop is not accomplishing anything.