### PR TITLE
WT-11280 Generation tracking might not be properly synchronized (v4.2 backport)

### DIFF
--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -194,7 +194,14 @@ __gen_oldest(WT_SESSION_IMPL *session, int which)
      * the sessions that could have been active when we started our check.
      */
     WT_ORDERED_READ(session_cnt, conn->session_cnt);
-    for (oldest = conn->generations[which], s = conn->sessions, i = 0; i < session_cnt; ++s, ++i) {
+    /*
+     * We need to order the read of the connection generation before the read of the session
+     * generation. If the session generation read is ordered before the connection generation read
+     * it could read an earlier session generation value. This would then violate the acquisition
+     * semantics and could result in us reading 0 for the session generation when it is non-zero.
+     */
+    WT_ORDERED_READ(oldest, conn->generations[which]);
+    for (s = conn->sessions, i = 0; i < session_cnt; ++s, ++i) {
         if (!s->active)
             continue;
 
@@ -278,11 +285,16 @@ __wt_session_gen_enter(WT_SESSION_IMPL *session, int which)
      * Assign the thread's resource generation and publish it, ensuring threads waiting on a
      * resource to drain see the new value. Check we haven't raced with a generation update after
      * publishing, we rely on the published value not being missed when scanning for the oldest
-     * generation.
+     * generation and for draining.
+     *
+     * This requires a full barrier as the second read of the connection generation needs to be
+     * ordered after the write of our session's generation. If it is reordered it could be read, for
+     * example before we do the first read. This would make re-checking redundant and in this case
+     * can result in the generation drain and generation oldest code not working correctly.
      */
     do {
         session->generations[which] = __wt_gen(session, which);
-        WT_WRITE_BARRIER();
+        WT_FULL_BARRIER();
     } while (session->generations[which] != __wt_gen(session, which));
 }
 

--- a/tools/litmus_tests/README.md
+++ b/tools/litmus_tests/README.md
@@ -1,0 +1,15 @@
+# WiredTiger litmus tests
+In order to support lock free algorithms in the WiredTiger codebase, we define a number of litmus test. These test are intended to be run by the herd7 simulator.
+
+For any algorithm which has defined litmus tests they can be found under that algorithm's subdirectory.
+
+To run the litmus tests either install and run herd7, instructions [here](https://github.com/herd/herdtools7/blob/master/INSTALL.md). Or run them from the web interface found [here](http://diy.inria.fr/www/#).
+
+If a litmus test is required for X86 there should be one defined for ARM64 as well. The reverse is not neccesarily true as X86 has a stronger memory model than ARM.
+
+### Litmus test style in WiredTiger
+WiredTiger litmus tests must use spaces and not have any tabs in the file. There needs to be a single whitespace between the intial state definition block {}, and the process definition block. There must also be an additional whitespace line before the exists clause.
+
+Test names should be separated with underscores, e.g. wt_gen_drain.
+
+Additionally per WiredTiger's usual style there should be a newline at the end of the file.

--- a/tools/litmus_tests/generations/gen_drain_arm64.litmus
+++ b/tools/litmus_tests/generations/gen_drain_arm64.litmus
@@ -1,0 +1,14 @@
+AArch64 wt_gen_drain
+{
+conn_gen=5;
+0:X0=conn_gen; 0:X1=sess_gen;
+1:X0=conn_gen; 1:X1=sess_gen;
+}
+
+ P0                   | P1             ;
+ MOV X9, #1           | LDR X2, [X0]   ;
+ ldaddal X9, X2, [X0] | STR X2, [X1]   ;
+ LDR X2, [X1]         | dmb ish        ;
+                      | LDR X3, [X0]   ;
+
+exists (0:X2=0 /\ 1:X2=5 /\ 1:X3=5)

--- a/tools/litmus_tests/generations/gen_drain_x86.litmus
+++ b/tools/litmus_tests/generations/gen_drain_x86.litmus
@@ -1,0 +1,12 @@
+X86 wt_gen_drain
+{
+conn_gen=5;
+}
+
+ P0                       | P1                    ;
+ LOCK; ADD [conn_gen], $1 | MOV EAX,[conn_gen]    ;
+ MOV EAX, [sess_gen]      | MOV [sess_gen], EAX   ;
+                          | MFENCE                ;
+                          | MOV EBX,[conn_gen]    ;
+
+exists (0:EAX=0 /\ 1:EAX=5 /\ 1:EBX=5)

--- a/tools/litmus_tests/generations/gen_oldest_arm64.litmus
+++ b/tools/litmus_tests/generations/gen_oldest_arm64.litmus
@@ -1,0 +1,15 @@
+AArch64 wt_gen_oldest
+{
+conn_gen=5;sess_gen=0;
+0:X0=conn_gen; 0:X1=sess_gen;
+1:X0=conn_gen; 1:X1=sess_gen;
+2:X0=conn_gen; 2:X1=sess_gen;
+}
+
+ P0            | P1           | P2                   ;
+ LDR X2, [X0]  | LDR X2, [X0] | MOV W9, #1           ;
+ dmb ishld     | STR X2, [X1] | ldaddal W9, W1, [X0] ;
+ LDR X3, [X1]  | dmb ish      |                      ;
+               | LDR X4, [X0] |                      ;
+
+exists (0:X2=6 /\ 0:X3=0 /\ 1:X2=5 /\ 1:X4=5)

--- a/tools/litmus_tests/generations/gen_oldest_x86.litmus
+++ b/tools/litmus_tests/generations/gen_oldest_x86.litmus
@@ -1,0 +1,12 @@
+X86 wt_gen_oldest
+{
+conn_gen=5;
+}
+
+P0                   | P1                   | P2                       ;
+MOV EAX, [conn_gen]  | MOV EAX,[conn_gen]   | LOCK; ADD [conn_gen], $1 ;
+MOV EBX, [sess_gen]  | MOV [sess_gen], EAX  |                          ;
+                     | MFENCE               |                          ;
+                     | MOV EBX,[conn_gen]   |                          ;
+
+exists (0:EAX=6 /\ 0:EBX=0 /\ 1:EAX=5 /\ 1:EBX=5)


### PR DESCRIPTION
…03) (#9828) (#9964) (#10171)

* Adding a number of litmus tests to the codebase
* Adding a litmus test readme with style guide

(cherry picked from commit a732cfc0301310e90abd627b35f0d1cf8c07151c)

Co-authored-by: Luke Pearson <luke.pearson@mongodb.com>
(cherry picked from commit bb790d3dba0f32ba587e6b917a10fd34268c981a) (cherry picked from commit 9a121b3a83803791c96bf92a959ca69fe231e6fd) (cherry picked from commit 842d96a785873a5731782d286da2f158331e1d3c) (cherry picked from commit d79240a8f58d3b3b4f92dd4151a54f9133f540cb)