### PR TITLE
WT-10807 Skip in-memory deleted pages as part of the tree walk (6.0 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -898,6 +898,9 @@ conn_dsrc_stats = [
     CursorStat('cursor_prev_skip_total', 'Total number of entries skipped by cursor prev calls'),
     CursorStat('cursor_search_near_prefix_fast_paths', 'Total number of times a search near has exited due to prefix config'),
     CursorStat('cursor_skip_hs_cur_position', 'Total number of entries skipped to position the history store cursor'),
+    CursorStat('cursor_tree_walk_del_page_skip', 'Total number of deleted pages skipped during tree walk'),
+    CursorStat('cursor_tree_walk_inmem_del_page_skip', 'Total number of in-memory deleted pages skipped during tree walk'),
+
     ##########################################
     # Checkpoint cleanup statistics
     ##########################################

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -733,6 +733,7 @@ __wt_btcur_next_prefix(WT_CURSOR_BTREE *cbt, WT_ITEM *prefix, bool truncating)
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_PAGE *page;
+    WT_PAGE_WALK_SKIP_STATS walk_skip_stats;
     WT_SESSION_IMPL *session;
     size_t total_skipped, skipped;
     uint32_t flags;
@@ -742,6 +743,8 @@ __wt_btcur_next_prefix(WT_CURSOR_BTREE *cbt, WT_ITEM *prefix, bool truncating)
     prefix_key_out_of_bounds = false;
     session = CUR2S(cbt);
     total_skipped = 0;
+    walk_skip_stats.total_del_pages_skipped = 0;
+    walk_skip_stats.total_inmem_del_pages_skipped = 0;
 
     WT_STAT_CONN_DATA_INCR(session, cursor_next);
 
@@ -858,8 +861,8 @@ __wt_btcur_next_prefix(WT_CURSOR_BTREE *cbt, WT_ITEM *prefix, bool truncating)
          */
         if (session->txn->isolation == WT_ISO_SNAPSHOT &&
           !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE))
-            WT_ERR(
-              __wt_tree_walk_custom_skip(session, &cbt->ref, __wt_btcur_skip_page, NULL, flags));
+            WT_ERR(__wt_tree_walk_custom_skip(
+              session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));
         else
             WT_ERR(__wt_tree_walk(session, &cbt->ref, flags));
         WT_ERR_TEST(cbt->ref == NULL, WT_NOTFOUND, false);
@@ -872,6 +875,12 @@ err:
         WT_STAT_CONN_DATA_INCR(session, cursor_next_skip_ge_100);
 
     WT_STAT_CONN_DATA_INCRV(session, cursor_next_skip_total, total_skipped);
+    if (walk_skip_stats.total_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(
+          session, cursor_tree_walk_del_page_skip, walk_skip_stats.total_del_pages_skipped);
+    if (walk_skip_stats.total_inmem_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(session, cursor_tree_walk_inmem_del_page_skip,
+          walk_skip_stats.total_inmem_del_pages_skipped);
 
     switch (ret) {
     case 0:

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -854,12 +854,13 @@ __wt_btcur_next_prefix(WT_CURSOR_BTREE *cbt, WT_ITEM *prefix, bool truncating)
             LF_SET(WT_READ_VISIBLE_ALL);
 
         /*
-         * If we are running with snapshot isolation, and not interested in returning tombstones, we
-         * could potentially skip pages. The skip function looks at the aggregated timestamp
-         * information to determine if something is visible on the page. If nothing is, the page is
-         * skipped.
+         * If we are running with snapshot isolation, have a snapshot, and are not interested in
+         * returning tombstones, we could potentially skip pages. The skip function looks at the
+         * aggregated timestamp information to determine if something is visible on the page. If
+         * nothing is, the page is skipped.
          */
         if (session->txn->isolation == WT_ISO_SNAPSHOT &&
+          F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT) &&
           !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE))
             WT_ERR(__wt_tree_walk_custom_skip(
               session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -795,13 +795,14 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
             LF_SET(WT_READ_VISIBLE_ALL);
 
         /*
-         * If we are running with snapshot isolation, and not interested in returning tombstones, we
-         * could potentially skip pages. The skip function looks at the aggregated timestamp
-         * information to determine if something is visible on the page. If nothing is, the page is
-         * skipped.
+         * If we are running with snapshot isolation, have a snapshot, and are not interested in
+         * returning tombstones, we could potentially skip pages. The skip function looks at the
+         * aggregated timestamp information to determine if something is visible on the page. If
+         * nothing is, the page is skipped.
          */
         if (!F_ISSET(&cbt->iface, WT_CURSTD_KEY_ONLY) &&
           session->txn->isolation == WT_ISO_SNAPSHOT &&
+          F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT) &&
           !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE))
             WT_ERR(__wt_tree_walk_custom_skip(
               session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -675,6 +675,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_PAGE *page;
+    WT_PAGE_WALK_SKIP_STATS walk_skip_stats;
     WT_SESSION_IMPL *session;
     size_t total_skipped, skipped;
     uint32_t flags;
@@ -683,6 +684,8 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
     cursor = &cbt->iface;
     session = CUR2S(cbt);
     total_skipped = 0;
+    walk_skip_stats.total_del_pages_skipped = 0;
+    walk_skip_stats.total_inmem_del_pages_skipped = 0;
 
     WT_STAT_CONN_DATA_INCR(session, cursor_prev);
 
@@ -800,8 +803,8 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
         if (!F_ISSET(&cbt->iface, WT_CURSTD_KEY_ONLY) &&
           session->txn->isolation == WT_ISO_SNAPSHOT &&
           !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE))
-            WT_ERR(
-              __wt_tree_walk_custom_skip(session, &cbt->ref, __wt_btcur_skip_page, NULL, flags));
+            WT_ERR(__wt_tree_walk_custom_skip(
+              session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));
         else
             WT_ERR(__wt_tree_walk(session, &cbt->ref, flags));
         WT_ERR_TEST(cbt->ref == NULL, WT_NOTFOUND, false);
@@ -814,6 +817,12 @@ err:
         WT_STAT_CONN_DATA_INCR(session, cursor_prev_skip_ge_100);
 
     WT_STAT_CONN_DATA_INCRV(session, cursor_prev_skip_total, total_skipped);
+    if (walk_skip_stats.total_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(
+          session, cursor_tree_walk_del_page_skip, walk_skip_stats.total_del_pages_skipped);
+    if (walk_skip_stats.total_inmem_del_pages_skipped != 0)
+        WT_STAT_CONN_DATA_INCRV(session, cursor_tree_walk_inmem_del_page_skip,
+          walk_skip_stats.total_inmem_del_pages_skipped);
 
     switch (ret) {
     case 0:

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -230,6 +230,7 @@ __free_page_modify(WT_SESSION_IMPL *session, WT_PAGE *page)
     __wt_ovfl_discard_free(session, page);
 
     __wt_free(session, page->modify->ovfl_track);
+    __wt_free(session, page->modify->stop_ta);
     __wt_spin_destroy(session, &page->modify->page_lock);
 
     __wt_free(session, page->modify);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -441,6 +441,13 @@ struct __wt_page_modify {
     /* Overflow record tracking for reconciliation. */
     WT_OVFL_TRACK *ovfl_track;
 
+    /*
+     * Stop aggregated timestamp information when all the keys on the page are removed. This time
+     * aggregate information is used to skip these deleted pages as part of the tree walk if the
+     * delete operation is visible to the reader.
+     */
+    WT_TIME_AGGREGATE *stop_ta;
+
 #define WT_PAGE_LOCK(s, p) __wt_spin_lock((s), &(p)->modify->page_lock)
 #define WT_PAGE_TRYLOCK(s, p) __wt_spin_trylock((s), &(p)->modify->page_lock)
 #define WT_PAGE_UNLOCK(s, p) __wt_spin_unlock((s), &(p)->modify->page_lock)
@@ -745,6 +752,15 @@ struct __wt_page {
  */
 #define WT_PAGE_DISK_OFFSET(page, p) WT_PTRDIFF32(p, (page)->dsk)
 #define WT_PAGE_REF_OFFSET(page, o) ((void *)((uint8_t *)((page)->dsk) + (o)))
+
+/*
+ * WT_PAGE_WALK_SKIP_STATS --
+ *	Statistics to track how many deleted pages are skipped as part of the tree walk.
+ */
+struct __wt_page_walk_skip_stats {
+    size_t total_del_pages_skipped;
+    size_t total_inmem_del_pages_skipped;
+};
 
 /*
  * Prepare update states.

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1507,6 +1507,26 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
 }
 
 /*
+ * __wt_get_page_modify_ta --
+ *     Returns the page modify stop time aggregate information if exists.
+ */
+static inline bool
+__wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page, WT_TIME_AGGREGATE **ta)
+{
+    WT_ASSERT(session, __wt_session_gen(session, WT_GEN_SPLIT) != 0);
+
+    /* If NULL, there is no information. */
+    if (page->modify == NULL)
+        return (false);
+
+    if (page->modify->stop_ta == NULL)
+        return (false);
+
+    WT_ORDERED_READ(*ta, page->modify->stop_ta);
+    return (*ta != NULL);
+}
+
+/*
  * __wt_ref_block_free --
  *     Free the on-disk block for a reference and clear the address.
  */
@@ -2084,12 +2104,18 @@ __wt_btcur_skip_page(
   WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool visible_all, bool *skipp)
 {
     WT_ADDR_COPY addr;
+    WT_PAGE_WALK_SKIP_STATS *walk_skip_stats;
+    WT_TIME_AGGREGATE *ta;
     uint8_t previous_state;
+    bool clean_page;
 
-    WT_UNUSED(context);
     WT_UNUSED(visible_all);
 
     *skipp = false; /* Default to reading */
+
+    walk_skip_stats = (WT_PAGE_WALK_SKIP_STATS *)context;
+    ta = NULL;
+    clean_page = false;
 
     /* Don't skip pages in FLCS trees; deleted records need to read back as 0. */
     if (S2BT(session)->type == BTREE_COL_FIX)
@@ -2115,15 +2141,36 @@ __wt_btcur_skip_page(
         return (0);
 
     WT_REF_LOCK(session, ref, &previous_state);
-    if ((previous_state == WT_REF_DISK || previous_state == WT_REF_DELETED ||
-          (previous_state == WT_REF_MEM && !__wt_page_is_modified(ref->page))) &&
-      __wt_ref_addr_copy(session, ref, &addr) && addr.ta.newest_stop_txn != WT_TXN_MAX &&
-      addr.ta.newest_stop_ts != WT_TS_MAX &&
+
+    if (previous_state == WT_REF_MEM && !__wt_page_is_modified(ref->page))
+        clean_page = true;
+
+    /* Look at the disk address, if it exists. */
+    if ((previous_state == WT_REF_DISK || previous_state == WT_REF_DELETED || clean_page) &&
+      __wt_ref_addr_copy(session, ref, &addr)) {
+        /*
+         * Otherwise, check the timestamp information. We base this decision on the aggregate stop
+         * point added to the page during the last reconciliation.
+         */
+        if (WT_TIME_AGGREGATE_HAS_STOP(&addr.ta) &&
+          __wt_txn_snap_min_visible(session, addr.ta.newest_stop_txn, addr.ta.newest_stop_ts,
+            addr.ta.newest_stop_durable_ts)) {
+            *skipp = true;
+            walk_skip_stats->total_del_pages_skipped++;
+        }
+    } else if (clean_page && __wt_get_page_modify_ta(session, ref->page, &ta) &&
       __wt_txn_snap_min_visible(
-        session, addr.ta.newest_stop_txn, addr.ta.newest_stop_ts, addr.ta.newest_stop_durable_ts))
+        session, ta->newest_stop_txn, ta->newest_stop_ts, ta->newest_stop_durable_ts)) {
+        /*
+         * If the reader can see all of the deleted content, they can skip a deleted clean page.
+         * Before determining whether the deleted page is visible, copy the stop time aggregate
+         * information pointer because as part of the checkpoint operation, this pointer can be
+         * released in parallel.
+         */
         *skipp = true;
+        walk_skip_stats->total_inmem_del_pages_skipped++;
+    }
 
     WT_REF_UNLOCK(ref, previous_state);
-
     return (0);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1930,6 +1930,8 @@ static inline bool __wt_eviction_updates_needed(WT_SESSION_IMPL *session, double
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_failpoint(WT_SESSION_IMPL *session, uint64_t conn_flag, u_int probability)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline bool __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page,
+  WT_TIME_AGGREGATE **ta) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isalnum(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isalpha(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline bool __wt_isascii(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -568,9 +568,11 @@ struct __wt_connection_stats {
     int64_t fsync_io;
     int64_t read_io;
     int64_t write_io;
+    int64_t cursor_tree_walk_del_page_skip;
     int64_t cursor_next_skip_total;
     int64_t cursor_prev_skip_total;
     int64_t cursor_skip_hs_cur_position;
+    int64_t cursor_tree_walk_inmem_del_page_skip;
     int64_t cursor_search_near_prefix_fast_paths;
     int64_t cursor_bulk_count;
     int64_t cursor_cached_count;
@@ -1029,9 +1031,11 @@ struct __wt_dsrc_stats {
     int64_t compress_hist_ratio_8;
     int64_t compress_write_fail;
     int64_t compress_write_too_small;
+    int64_t cursor_tree_walk_del_page_skip;
     int64_t cursor_next_skip_total;
     int64_t cursor_prev_skip_total;
     int64_t cursor_skip_hs_cur_position;
+    int64_t cursor_tree_walk_inmem_del_page_skip;
     int64_t cursor_search_near_prefix_fast_paths;
     int64_t cursor_insert_bulk;
     int64_t cursor_reopen;

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -182,3 +182,39 @@
         if ((source)->prepare != 0)                                                           \
             (dest)->prepare = 1;                                                              \
     } while (0)
+
+/* Abstract away checking whether all records in an aggregated time window have been deleted. */
+#define WT_TIME_AGGREGATE_ALL_DELETED(ta) ((ta)->newest_stop_ts != WT_TS_MAX)
+
+/*
+ * Update a time aggregate in preparation for an obsolete visibility check. This deserves a macro,
+ * since the mechanism for identifying whether an aggregated time window contains only obsolete (i.e
+ * deleted) data requires checking two different timestamps. Note the output time aggregate might be
+ * either empty initialized, or have been populated via prior calls to this macro with other
+ * aggregated windows.
+ */
+#define WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, out_ta, in_ta)                         \
+    do {                                                                                         \
+        WT_ASSERT(session, (out_ta)->init_merge == 1);                                           \
+        (out_ta)->newest_stop_durable_ts =                                                       \
+          WT_MAX((out_ta)->newest_stop_durable_ts, (in_ta)->newest_stop_durable_ts);             \
+        /*                                                                                       \
+         * The durable and non-durable stop timestamps are interestingly different in that the   \
+         * non-durable version encodes whether all records are deleted by setting WT_TS_MAX in   \
+         * there are non-deleted records (the common case), but durable doesn't and records the  \
+         * largest timestamp associated with any deleted record. Use this copy-macro to abstract \
+         * that subtlety away. Since obsolete checks always want to know whether all content was \
+         * removed, copy that semantic into the durable stop timestamp to make visibility        \
+         * checking sensible.                                                                    \
+         */                                                                                      \
+        if (!WT_TIME_AGGREGATE_ALL_DELETED((in_ta)))                                             \
+            (out_ta)->newest_stop_durable_ts = WT_TS_MAX;                                        \
+                                                                                                 \
+        (out_ta)->newest_txn = WT_MAX((out_ta)->newest_txn, (in_ta)->newest_txn);                \
+        (out_ta)->newest_stop_ts = WT_MAX((out_ta)->newest_stop_ts, (in_ta)->newest_stop_ts);    \
+        (out_ta)->newest_stop_txn = WT_MAX((out_ta)->newest_stop_txn, (in_ta)->newest_stop_txn); \
+    } while (0)
+
+/* Check if the stop time aggregate is set. */
+#define WT_TIME_AGGREGATE_HAS_STOP(ta) \
+    ((ta)->newest_stop_txn != WT_TXN_MAX || (ta)->newest_stop_ts != WT_TS_MAX)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -751,6 +751,8 @@ __wt_txn_snap_min_visible(
     /* Not needed since 6.0 doesn't support checkpoint cursors. */
     WT_UNUSED(durable_timestamp);
 
+    WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
+
     /* Transaction snapshot minimum check. */
     if (!WT_TXNID_LT(id, session->txn->snapshot_data.snap_min))
         return (false);

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5741,751 +5741,758 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_READ_IO				1227
 /*! connection: total write I/Os */
 #define	WT_STAT_CONN_WRITE_IO				1228
+/*! cursor: Total number of deleted pages skipped during tree walk */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1229
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1229
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1230
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1230
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1231
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1231
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1232
+/*!
+ * cursor: Total number of in-memory deleted pages skipped during tree
+ * walk
+ */
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1233
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1232
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1234
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1233
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1235
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1234
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1236
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1235
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1237
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1236
+#define	WT_STAT_CONN_CURSOR_CACHE			1238
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1237
+#define	WT_STAT_CONN_CURSOR_CREATE			1239
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1238
+#define	WT_STAT_CONN_CURSOR_INSERT			1240
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1239
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1241
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1240
+#define	WT_STAT_CONN_CURSOR_MODIFY			1242
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1241
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1243
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1242
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1244
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1243
+#define	WT_STAT_CONN_CURSOR_NEXT			1245
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1244
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1246
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1245
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1247
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1246
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1248
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1247
+#define	WT_STAT_CONN_CURSOR_RESTART			1249
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1248
+#define	WT_STAT_CONN_CURSOR_PREV			1250
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1249
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1251
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1250
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1252
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1251
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1253
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1252
+#define	WT_STAT_CONN_CURSOR_REMOVE			1254
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1253
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1255
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1254
+#define	WT_STAT_CONN_CURSOR_RESERVE			1256
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1255
+#define	WT_STAT_CONN_CURSOR_RESET			1257
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1256
+#define	WT_STAT_CONN_CURSOR_SEARCH			1258
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1257
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1259
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1258
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1260
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1259
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1261
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1260
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1262
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1261
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1263
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1262
+#define	WT_STAT_CONN_CURSOR_SWEEP			1264
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1263
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1265
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1264
+#define	WT_STAT_CONN_CURSOR_UPDATE			1266
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1265
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1267
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1266
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1268
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1267
+#define	WT_STAT_CONN_CURSOR_REOPEN			1269
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1268
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1270
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1269
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1271
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1270
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1272
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1271
+#define	WT_STAT_CONN_DH_SWEEP_REF			1273
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1272
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1274
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1273
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1275
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1274
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1276
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1275
+#define	WT_STAT_CONN_DH_SWEEPS				1277
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1276
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1278
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1277
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1279
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1278
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1280
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1279
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1281
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1280
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1282
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1281
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1283
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1282
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1284
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1283
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1285
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1284
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1286
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1285
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1287
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1286
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1288
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1287
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1289
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1288
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1290
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1289
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1291
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1290
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1292
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1291
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1293
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1292
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1294
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1293
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1295
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1294
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1296
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1295
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1297
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1296
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1298
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1297
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1299
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1298
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1300
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1299
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1301
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1300
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1302
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1301
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1303
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1302
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1304
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1303
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1305
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1304
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1306
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1305
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1307
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1306
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1308
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1307
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1309
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1308
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1310
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1309
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1311
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1310
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1312
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1311
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1313
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1312
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1314
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1313
+#define	WT_STAT_CONN_LOG_FLUSH				1315
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1314
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1316
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1315
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1317
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1316
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1318
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1317
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1319
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1318
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1320
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1319
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1321
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1320
+#define	WT_STAT_CONN_LOG_SCANS				1322
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1321
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1323
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1322
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1324
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1323
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1325
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1324
+#define	WT_STAT_CONN_LOG_SYNC				1326
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1325
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1327
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1326
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1328
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1327
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1329
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1328
+#define	WT_STAT_CONN_LOG_WRITES				1330
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1329
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1331
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1330
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1332
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1331
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1333
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1332
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1334
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1333
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1335
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1334
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1336
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1335
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1337
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1336
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1338
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1337
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1339
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1338
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1340
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1339
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1341
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1340
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1342
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1341
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1343
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1342
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1344
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1343
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1345
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1344
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1346
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1345
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1347
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1346
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1348
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1347
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1349
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1348
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1350
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1349
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1351
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1350
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1352
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1351
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1353
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1352
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1354
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1353
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1355
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1354
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1356
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1355
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1357
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1356
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1358
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1357
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1359
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1358
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1360
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1359
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1361
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1360
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1362
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1361
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1363
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1362
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1364
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1363
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1365
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1364
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1366
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1365
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1367
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1366
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1368
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1367
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1369
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1368
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1370
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1369
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1371
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1370
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1372
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1371
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1373
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1372
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1374
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1373
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1375
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1374
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1376
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1375
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1377
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1376
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1378
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1377
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1379
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1378
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1380
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1379
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1381
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1380
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1382
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1381
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1383
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1382
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1384
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1383
+#define	WT_STAT_CONN_REC_PAGES				1385
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1384
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1386
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1385
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1387
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1386
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1388
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1387
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1389
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1388
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1390
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1389
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1391
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1390
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1392
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1391
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1393
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1392
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1394
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1393
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1395
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1394
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1396
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1395
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1397
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1396
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1398
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1397
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1399
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1398
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1400
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1399
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1401
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1400
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1402
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1401
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1403
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1402
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1404
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1403
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1405
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1404
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1406
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1405
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1407
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1406
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1408
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1407
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1409
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1408
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1410
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1409
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1411
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1410
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1412
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1411
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1413
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1412
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1414
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1413
+#define	WT_STAT_CONN_FLUSH_TIER				1415
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1414
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1416
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1415
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1417
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1416
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1418
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1417
+#define	WT_STAT_CONN_SESSION_OPEN			1419
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1418
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1420
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1419
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1421
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1420
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1422
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1421
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1423
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1422
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1424
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1423
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1425
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1424
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1426
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1425
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1427
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1426
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1428
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1427
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1429
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1428
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1430
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1429
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1431
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1430
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1432
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1431
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1433
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1432
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1434
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1433
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1435
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1434
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1436
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1435
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1437
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1436
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1438
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1437
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1439
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1438
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1440
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1439
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1441
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1440
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1442
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1441
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1443
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1442
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1444
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1443
+#define	WT_STAT_CONN_TIERED_RETENTION			1445
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1444
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1446
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1445
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1447
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1446
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1448
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1447
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1449
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1448
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1450
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1449
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1451
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1450
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1452
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1451
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1453
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1452
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1454
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1453
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1455
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1454
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1456
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1455
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1457
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1456
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1458
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1457
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1459
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1458
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1460
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1459
+#define	WT_STAT_CONN_PAGE_SLEEP				1461
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1460
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1462
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1461
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1463
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1462
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1464
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1463
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1465
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1464
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1466
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1465
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1467
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1466
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1468
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1467
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1469
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1468
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1470
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1469
+#define	WT_STAT_CONN_TXN_PREPARE			1471
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1470
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1472
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1471
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1473
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1472
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1474
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1473
+#define	WT_STAT_CONN_TXN_QUERY_TS			1475
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1474
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1476
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1475
+#define	WT_STAT_CONN_TXN_RTS				1477
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1476
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1478
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1477
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1479
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1478
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1480
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1479
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1481
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1480
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1482
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1481
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1483
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1482
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1484
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1483
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1485
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1484
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1486
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1485
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1487
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1486
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1488
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1487
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1489
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1488
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1490
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1489
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1491
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1490
+#define	WT_STAT_CONN_TXN_SET_TS				1492
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1491
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1493
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1492
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1494
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1493
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1495
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1494
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1496
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1495
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1497
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1496
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1498
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1497
+#define	WT_STAT_CONN_TXN_BEGIN				1499
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1498
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1500
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1499
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1501
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1500
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1502
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1501
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1503
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1502
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1504
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1503
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1505
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1504
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1506
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1505
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1507
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1506
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1508
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1507
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1509
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1508
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1510
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1509
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1511
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1510
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1512
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1511
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1513
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1512
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1514
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1513
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1515
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1514
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1516
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1515
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1517
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1516
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1518
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1517
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1519
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1518
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1520
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1519
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1521
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1520
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1522
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1521
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1523
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1522
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1524
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1523
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1525
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1524
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1526
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1525
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1527
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1526
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1528
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1527
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1529
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1528
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1530
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1529
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1531
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1530
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1532
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1531
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1533
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1532
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1534
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1533
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1535
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1534
+#define	WT_STAT_CONN_TXN_COMMIT				1536
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1535
+#define	WT_STAT_CONN_TXN_ROLLBACK			1537
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1536
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1538
 
 /*!
  * @}
@@ -6939,242 +6946,249 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2144
 /*! compression: page written was too small to compress */
 #define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2145
+/*! cursor: Total number of deleted pages skipped during tree walk */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2146
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2146
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2147
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2147
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2148
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2148
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2149
+/*!
+ * cursor: Total number of in-memory deleted pages skipped during tree
+ * walk
+ */
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2150
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2149
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2151
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2150
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2152
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2151
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2153
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2152
+#define	WT_STAT_DSRC_CURSOR_CACHE			2154
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2153
+#define	WT_STAT_DSRC_CURSOR_CREATE			2155
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2154
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2156
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2155
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2157
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2156
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2158
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2157
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2159
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2158
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2160
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2159
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2161
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2160
+#define	WT_STAT_DSRC_CURSOR_INSERT			2162
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2161
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2163
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2162
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2164
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2163
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2165
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2164
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2166
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2165
+#define	WT_STAT_DSRC_CURSOR_NEXT			2167
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2166
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2168
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2167
+#define	WT_STAT_DSRC_CURSOR_RESTART			2169
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2168
+#define	WT_STAT_DSRC_CURSOR_PREV			2170
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2169
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2171
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2170
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2172
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2171
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2173
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2172
+#define	WT_STAT_DSRC_CURSOR_RESET			2174
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2173
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2175
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2174
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2176
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2175
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2177
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2176
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2178
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2177
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2179
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2178
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2180
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2179
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2181
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2180
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2182
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2181
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2183
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2182
+#define	WT_STAT_DSRC_REC_DICTIONARY			2184
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2183
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2185
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2184
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2186
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2185
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2187
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2186
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2188
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2187
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2189
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2188
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2190
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2189
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2191
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2190
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2192
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2191
+#define	WT_STAT_DSRC_REC_PAGES				2193
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2192
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2194
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2193
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2195
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2194
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2196
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2195
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2197
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2196
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2198
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2197
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2199
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2198
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2200
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2199
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2201
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2200
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2202
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2201
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2203
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2202
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2204
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2203
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2205
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2204
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2206
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2205
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2207
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2206
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2208
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2207
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2209
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2208
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2210
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2209
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2211
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2210
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2212
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2211
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2213
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2212
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2214
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2213
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2215
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2214
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2216
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2215
+#define	WT_STAT_DSRC_SESSION_COMPACT			2217
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_DSRC_TIERED_WORK_UNITS_DEQUEUED		2216
+#define	WT_STAT_DSRC_TIERED_WORK_UNITS_DEQUEUED		2218
 /*! session: tiered operations scheduled */
-#define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2217
+#define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2219
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_DSRC_TIERED_RETENTION			2218
+#define	WT_STAT_DSRC_TIERED_RETENTION			2220
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2219
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2221
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2220
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2222
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2221
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2223
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2222
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2224
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2223
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2225
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2224
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2226
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2225
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2227
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2226
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2228
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2227
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2229
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2228
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2230
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2229
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2231
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2230
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2232
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2231
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2233
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2232
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2234
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2233
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2235
 
 /*!
  * @}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -291,6 +291,8 @@ struct __wt_page_index;
 typedef struct __wt_page_index WT_PAGE_INDEX;
 struct __wt_page_modify;
 typedef struct __wt_page_modify WT_PAGE_MODIFY;
+struct __wt_page_walk_skip_stats;
+typedef struct __wt_page_walk_skip_stats WT_PAGE_WALK_SKIP_STATS;
 struct __wt_process;
 typedef struct __wt_process WT_PROCESS;
 struct __wt_rec_chunk;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2331,6 +2331,37 @@ __rec_split_dump_keys(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 }
 
 /*
+ * __rec_page_modify_ta_safe_free --
+ *     Any thread that is reviewing the page modify time aggregate in a WT_REF, must also be holding
+ *     a split generation to ensure that the page index they are using remains valid. Use that same
+ *     split generation to ensure that the page modify time aggregate inside the WT_REF remains
+ *     valid while it is being reviewed.
+ */
+static void
+__rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
+{
+    WT_DECL_RET;
+    uint64_t split_gen;
+    void *p;
+
+    p = *(void **)ta;
+    if (p == NULL)
+        return;
+
+    do {
+        WT_ORDERED_READ(p, *ta);
+        if (p == NULL)
+            break;
+    } while (!__wt_atomic_cas_ptr(ta, p, NULL));
+
+    split_gen = __wt_gen(session, WT_GEN_SPLIT);
+
+    if (__wt_stash_add(session, WT_GEN_SPLIT, split_gen, p, sizeof(WT_TIME_AGGREGATE)) != 0)
+        WT_IGNORE_RET(__wt_panic(session, ret, "fatal error during page modify ta free"));
+    __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+}
+
+/*
  * __rec_write_wrapup --
  *     Finish the reconciliation.
  */
@@ -2340,9 +2371,11 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     WT_BM *bm;
     WT_BTREE *btree;
     WT_DECL_RET;
+    WT_MULTI *multi;
     WT_PAGE_MODIFY *mod;
     WT_REF *ref;
-    WT_TIME_AGGREGATE ta;
+    WT_TIME_AGGREGATE stop_ta, *stop_tap, ta;
+    uint32_t i;
 
     btree = S2BT(session);
     bm = btree->bm;
@@ -2420,6 +2453,14 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     /* Reset the reconciliation state. */
     mod->rec_result = 0;
 
+    /*
+     * When the page is being reconciled as part of the checkpoint operation, the REF is not locked.
+     * Concurrent access to the page can be enabled by safe-releasing the time aggregate
+     * information.
+     */
+    __rec_page_modify_ta_safe_free(session, &mod->stop_ta);
+    WT_TIME_AGGREGATE_INIT_MERGE(&stop_ta);
+
     __wt_verbose(session, WT_VERB_RECONCILE, "%p reconciled into %" PRIu32 " pages", (void *)ref,
       r->multi_next);
 
@@ -2472,10 +2513,12 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
             r->multi->addr.addr = NULL;
             mod->mod_disk_image = r->multi->disk_image;
             r->multi->disk_image = NULL;
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
         } else {
             __wt_checkpoint_tree_reconcile_update(session, &r->multi->addr.ta);
             WT_RET(__rec_write(session, r->wrapup_checkpoint, NULL, NULL, NULL, true,
               F_ISSET(r, WT_REC_CHECKPOINT), r->wrapup_checkpoint_compressed));
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &r->multi->addr.ta);
         }
 
         mod->rec_result = WT_PM_REC_REPLACE;
@@ -2497,7 +2540,17 @@ split:
 
         r->multi = NULL;
         r->multi_next = 0;
+
+        /* Calculate the max stop time point by traversing all multi addresses. */
+        for (multi = mod->mod_multi, i = 0; i < mod->mod_multi_entries; ++multi, ++i)
+            WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &multi->addr.ta);
         break;
+    }
+
+    if (WT_TIME_AGGREGATE_HAS_STOP(&stop_ta)) {
+        WT_RET(__wt_calloc_one(session, &stop_tap));
+        WT_TIME_AGGREGATE_COPY(stop_tap, &stop_ta);
+        WT_PUBLISH(mod->stop_ta, stop_tap);
     }
 
     return (0);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -159,9 +159,11 @@ static const char *const __stats_dsrc_desc[] = {
   "compression: number of blocks with compress ratio smaller than 8",
   "compression: page written failed to compress",
   "compression: page written was too small to compress",
+  "cursor: Total number of deleted pages skipped during tree walk",
   "cursor: Total number of entries skipped by cursor next calls",
   "cursor: Total number of entries skipped by cursor prev calls",
   "cursor: Total number of entries skipped to position the history store cursor",
+  "cursor: Total number of in-memory deleted pages skipped during tree walk",
   "cursor: Total number of times a search near has exited due to prefix config",
   "cursor: bulk loaded cursor insert calls",
   "cursor: cache cursors reuse count",
@@ -434,9 +436,11 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->compress_hist_ratio_8 = 0;
     stats->compress_write_fail = 0;
     stats->compress_write_too_small = 0;
+    stats->cursor_tree_walk_del_page_skip = 0;
     stats->cursor_next_skip_total = 0;
     stats->cursor_prev_skip_total = 0;
     stats->cursor_skip_hs_cur_position = 0;
+    stats->cursor_tree_walk_inmem_del_page_skip = 0;
     stats->cursor_search_near_prefix_fast_paths = 0;
     stats->cursor_insert_bulk = 0;
     stats->cursor_reopen = 0;
@@ -698,9 +702,11 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->compress_hist_ratio_8 += from->compress_hist_ratio_8;
     to->compress_write_fail += from->compress_write_fail;
     to->compress_write_too_small += from->compress_write_too_small;
+    to->cursor_tree_walk_del_page_skip += from->cursor_tree_walk_del_page_skip;
     to->cursor_next_skip_total += from->cursor_next_skip_total;
     to->cursor_prev_skip_total += from->cursor_prev_skip_total;
     to->cursor_skip_hs_cur_position += from->cursor_skip_hs_cur_position;
+    to->cursor_tree_walk_inmem_del_page_skip += from->cursor_tree_walk_inmem_del_page_skip;
     to->cursor_search_near_prefix_fast_paths += from->cursor_search_near_prefix_fast_paths;
     to->cursor_insert_bulk += from->cursor_insert_bulk;
     to->cursor_reopen += from->cursor_reopen;
@@ -965,9 +971,12 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->compress_hist_ratio_8 += WT_STAT_READ(from, compress_hist_ratio_8);
     to->compress_write_fail += WT_STAT_READ(from, compress_write_fail);
     to->compress_write_too_small += WT_STAT_READ(from, compress_write_too_small);
+    to->cursor_tree_walk_del_page_skip += WT_STAT_READ(from, cursor_tree_walk_del_page_skip);
     to->cursor_next_skip_total += WT_STAT_READ(from, cursor_next_skip_total);
     to->cursor_prev_skip_total += WT_STAT_READ(from, cursor_prev_skip_total);
     to->cursor_skip_hs_cur_position += WT_STAT_READ(from, cursor_skip_hs_cur_position);
+    to->cursor_tree_walk_inmem_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_inmem_del_page_skip);
     to->cursor_search_near_prefix_fast_paths +=
       WT_STAT_READ(from, cursor_search_near_prefix_fast_paths);
     to->cursor_insert_bulk += WT_STAT_READ(from, cursor_insert_bulk);
@@ -1308,9 +1317,11 @@ static const char *const __stats_connection_desc[] = {
   "connection: total fsync I/Os",
   "connection: total read I/Os",
   "connection: total write I/Os",
+  "cursor: Total number of deleted pages skipped during tree walk",
   "cursor: Total number of entries skipped by cursor next calls",
   "cursor: Total number of entries skipped by cursor prev calls",
   "cursor: Total number of entries skipped to position the history store cursor",
+  "cursor: Total number of in-memory deleted pages skipped during tree walk",
   "cursor: Total number of times a search near has exited due to prefix config",
   "cursor: bulk cursor count",
   "cursor: cached cursor count",
@@ -1889,9 +1900,11 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->fsync_io = 0;
     stats->read_io = 0;
     stats->write_io = 0;
+    stats->cursor_tree_walk_del_page_skip = 0;
     stats->cursor_next_skip_total = 0;
     stats->cursor_prev_skip_total = 0;
     stats->cursor_skip_hs_cur_position = 0;
+    stats->cursor_tree_walk_inmem_del_page_skip = 0;
     stats->cursor_search_near_prefix_fast_paths = 0;
     /* not clearing cursor_bulk_count */
     /* not clearing cursor_cached_count */
@@ -2484,9 +2497,12 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->fsync_io += WT_STAT_READ(from, fsync_io);
     to->read_io += WT_STAT_READ(from, read_io);
     to->write_io += WT_STAT_READ(from, write_io);
+    to->cursor_tree_walk_del_page_skip += WT_STAT_READ(from, cursor_tree_walk_del_page_skip);
     to->cursor_next_skip_total += WT_STAT_READ(from, cursor_next_skip_total);
     to->cursor_prev_skip_total += WT_STAT_READ(from, cursor_prev_skip_total);
     to->cursor_skip_hs_cur_position += WT_STAT_READ(from, cursor_skip_hs_cur_position);
+    to->cursor_tree_walk_inmem_del_page_skip +=
+      WT_STAT_READ(from, cursor_tree_walk_inmem_del_page_skip);
     to->cursor_search_near_prefix_fast_paths +=
       WT_STAT_READ(from, cursor_search_near_prefix_fast_paths);
     to->cursor_bulk_count += WT_STAT_READ(from, cursor_bulk_count);

--- a/test/suite/test_checkpoint32.py
+++ b/test/suite/test_checkpoint32.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading, time
+import wttest
+import wiredtiger
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+# test_checkpoint32.py
+#
+# Test that skipping in-memory reconciled deleted pages as part of the tree walk.
+class test_checkpoint32(wttest.WiredTigerTestCase):
+
+    format_values = [
+        # FLCS doesn't support skipping pages based on aggregated time.
+        ('column', dict(key_format='r', value_format='S', extraconfig='')),
+        ('string_row', dict(key_format='S', value_format='S', extraconfig='')),
+    ]
+
+    scenarios = make_scenarios(format_values)
+
+    def conn_config(self):
+        return 'statistics=(all)'
+
+    def check(self, ds, nrows, value):
+        cursor = self.session.open_cursor(ds.uri)
+        count = 0
+        for k, v in cursor:
+            self.assertEqual(v, value)
+            count += 1
+        self.assertEqual(count, nrows)
+        cursor.close()
+
+    def test_checkpoint(self):
+        uri = 'table:checkpoint32'
+        nrows = 1000
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        value_a = "aaaaa" * 100
+
+        # Write some initial data.
+        cursor = self.session.open_cursor(ds.uri, None, None)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = value_a
+            self.session.commit_transaction()
+
+        # Create a reader transaction that will not be able to see what happens next.
+        # We don't need to do anything with this; it just needs to exist.
+        session2 = self.conn.open_session()
+        session2.begin_transaction()
+
+        # Now remove all data.
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor.set_key(ds.key(i))
+            self.assertEqual(cursor.remove(), 0)
+            self.session.commit_transaction()
+
+        # Checkpoint.
+        self.session.checkpoint()
+
+        # Get the existing in-memory delete page skip statistic value.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        prev_cur_inmem_del_page_skip = stat_cursor[stat.conn.cursor_tree_walk_inmem_del_page_skip][2]
+        stat_cursor.close()
+
+        # Now read the removed data.
+        self.check(ds, 0, value_a)
+
+        # Get the new in-memory delete page skip statistic value.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        cur_inmem_del_page_skip = stat_cursor[stat.conn.cursor_tree_walk_inmem_del_page_skip][2]
+        stat_cursor.close()
+
+        self.assertGreater(cur_inmem_del_page_skip, prev_cur_inmem_del_page_skip)
+
+        # Tidy up.
+        session2.rollback_transaction()
+        session2.close()
+        cursor.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
Traversing an in-memory page that contains all the deleted values that are visible to the current transaction, leading to an increase in latency due
to the time spent skipping these deleted values.

By saving the aggregated timestamp information in the ref when the page has all deleted values, this aggregated information can be validated against the transaction snapshot to skip traversing the page completely and improve the latency when there are many deleted pages.

The downside of this approach is that the in-memory size of each ref is increased by 8 more bytes, but this increase shouldn't cause any problem.

(cherry picked from commit d121cca3b711efd1951a36aa48348ec6df5803fe) (cherry picked from commit eed05eb5666400b5874b28e5a7ae416a2a88497d)