### PR TITLE
WT-12989 Remove WT_ASSERT in background compaction related to run_once

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -539,12 +539,12 @@ __background_compact_server(void *arg)
 
         /* The server has been signalled to change state. */
         if (conn->background_compact.signalled) {
+
             /* If configured to run once, start from the beginning. */
-            if (conn->background_compact.run_once) {
-                WT_ASSERT(session, running);
+            if (running && conn->background_compact.run_once)
                 WT_ERR(__wt_buf_set(session, uri, WT_BACKGROUND_COMPACT_URI_PREFIX,
                   strlen(WT_BACKGROUND_COMPACT_URI_PREFIX) + 1));
-            }
+
             conn->background_compact.signalled = false;
             WT_STAT_CONN_SET(session, background_compact_running, running);
         }


### PR DESCRIPTION
This `WT_ASSERT` is invalid as background compaction could be enabled and disabled, while this code has not been executed yet.