### PR TITLE
WT-12999 Add csv to wt_binary_decode with durable history metadata stats

### DIFF
--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -214,11 +214,11 @@ def get_int(b, size):
 def unpack_int(b):
     marker = _ord(b[0])
     if marker < NEG_MULTI_MARKER or marker >= 0xf0:
-        raise Exception('Not a packed integer')
+        raise ValueError('Not a packed integer')
     elif marker < NEG_2BYTE_MARKER:
         sz = 8 - getbits(marker, 4)
         if sz < 0:
-            raise Exception('Not a valid packed integer')
+            raise ValueError('Not a valid packed integer')
         part1 = (-1 << (sz << 3))
         part2 = get_int(b[1:], sz)
         part3 = b[sz+1:]
@@ -868,13 +868,16 @@ def row_decode(p, b, pagehead, blockhead, pagestats):
                     s = 'short val {} bytes'.format(l)
                 x = b.read(l)
 
-            # Comment this out if you need it
-            # There is likely a bug in here
-            # if s != '?':
-            #    p.rint_v(f'{desc_str}{s}:')
-            #    p.rint_v(raw_bytes(x))
-            # else:
-            #    dumpraw(p, b, cellpos)
+            try:
+                if s != '?':
+                    p.rint_v(f'{desc_str}{s}:')
+                    p.rint_v(raw_bytes(x))
+                else:
+                    dumpraw(p, b, cellpos)
+            except (IndexError, ValueError):
+                # FIXME-WT-13000 theres a bug in raw_bytes
+                pass
+
         finally:
             p.end_cell()
 

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -89,11 +89,11 @@ class PageStats:
 
     @property
     def num_ts(self) -> int:
-        return self.num_start_ts + self.num_stop_ts
+        return self.num_d_start_ts + self.num_d_stop_ts + self.num_start_ts + self.num_stop_ts
     
     @property
     def ts_sz(self) -> int:
-        return self.start_ts_sz + self.stop_ts_sz
+        return self.d_start_ts_sz + self.d_stop_ts_sz + self.start_ts_sz + self.stop_ts_sz
     
     @property
     def num_txn(self) -> int:
@@ -108,6 +108,10 @@ class PageStats:
         return [
             'num keys',
             'keys size',
+            'num durable start ts',
+            'durable start ts size',
+            'num durable stop ts',
+            'durable stop ts size',
             'num start ts',
             'start ts size',
             'num stop ts',
@@ -126,6 +130,10 @@ class PageStats:
         return [
             self.num_keys,
             self.keys_sz,
+            self.num_d_start_ts,
+            self.d_start_ts_sz,
+            self.num_d_stop_ts,
+            self.d_stop_ts_sz,
             self.num_start_ts,
             self.start_ts_sz,
             self.num_stop_ts,

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -65,12 +65,6 @@ class BlockHeader:
 # A container for page stats
 @dataclass
 class PageStats:
-    # constants
-    csv_order: typing.ClassVar[list[str]] = [
-        "num_keys",
-    ]
-
-    # attributes
     num_keys: int = 0
     keys_sz: int = 0
     num_start_ts: int = 0

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -70,6 +70,14 @@ class BlockHeader:
 class PageStats:
     num_keys: int = 0
     keys_sz: int = 0
+
+    # prepared updates (not reported currently)
+    num_d_start_ts: int = 0
+    d_start_ts_sz: int = 0
+    num_d_stop_ts: int = 0
+    d_stop_ts_sz: int = 0
+
+    # durable history
     num_start_ts: int = 0
     start_ts_sz: int = 0
     num_stop_ts: int = 0
@@ -533,13 +541,13 @@ def process_timestamps(p, b, extra, pagestats):
             p.rint_v(' prepared')
         if extra & WT_CELL_TS_DURABLE_START != 0:
             t, sz = unpack_uint64_with_sz(b)
-            pagestats.start_ts_sz += sz
-            pagestats.num_start_ts += 1
+            pagestats.d_start_ts_sz += sz
+            pagestats.num_d_start_ts += 1
             p.rint_v(' durable start ts: ' + ts(t))
         if extra & WT_CELL_TS_DURABLE_STOP != 0:
             t, sz = unpack_uint64_with_sz(b)
-            pagestats.stop_ts_sz += sz
-            pagestats.num_stop_ts += 1
+            pagestats.d_stop_ts_sz += sz
+            pagestats.num_d_stop_ts += 1
             p.rint_v(' durable stop ts: ' + ts(t))
         if extra & WT_CELL_TS_START != 0:
             t, sz = unpack_uint64_with_sz(b)


### PR DESCRIPTION
This script (indiscriminantly) walks a `wt` file, parsing as much as it can and printing helpful output for debugging.
Prior to this change it supported printing some information about page + cell metadata, but this wasn't easily machine readable.

This change adds a `--csv` option which will write the respective stats per page to a csv file for later analysis.
We are using this to analyse the ratio of durable history metadata vs key sizes in index files, but there are many other uses for which this may be helpful.