### PR TITLE
WT-12230 fix many collection tests on older commits

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -201,7 +201,7 @@ functions:
         ${PREPARE_PATH}
         virtualenv -p python3 venv
         source venv/bin/activate
-        if [ -d "pyproject.toml" && -d "poetry.lock" ]; then
+        if [ -d "pyproject.toml" ] && [ -d "poetry.lock" ]; then
           python3 -m pip install 'poetry==1.5.1'
 
           export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -174,7 +174,7 @@ functions:
         set -o errexit
         set -o verbose
         mongo_repo=https://github.com/mongodb/mongo
-        branch=$(git branch --contains | -e "mongodb" | tr -d ' ')
+        branch=$(git branch --contains | grep -e "mongodb" | tr -d ' ')
         if [[ $branch =~ "mongodb-" ]]; then
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
@@ -201,7 +201,7 @@ functions:
         ${PREPARE_PATH}
         virtualenv -p python3 venv
         source venv/bin/activate
-        if [ -d "pyproject.toml" ] && [ -d "poetry.lock" ]; then
+        if [ -f "pyproject.toml" ] && [ -f "poetry.lock" ]; then
           python3 -m pip install 'poetry==1.5.1'
 
           export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -173,13 +173,16 @@ functions:
       script: |
         set -o errexit
         set -o verbose
+        dir=$(pwd)
+        cd wiredtiger
         mongo_repo=https://github.com/mongodb/mongo
-        branch=$(git branch --contains | grep -e "mongodb" | tr -d ' ')
+        branch=$(git branch --contains | grep -e "mongodb")
         if [[ $branch =~ "mongodb-" ]]; then
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
           mongo_branch=master
         fi
+        cd dir
         git clone $mongo_repo -b $mongo_branch
   "import wiredtiger into mongo" :
     command: shell.exec
@@ -201,19 +204,13 @@ functions:
         ${PREPARE_PATH}
         virtualenv -p python3 venv
         source venv/bin/activate
-        if [ -f "pyproject.toml" ] && [ -f "poetry.lock" ]; then
-          python3 -m pip install 'poetry==1.5.1'
-
-          export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-          # FIXME-WT-12911 - There's a dependency ordering issue in the mongo poetry.lock file. Running poetry install twice resolves it.
-          set +o errexit
-          python3 -m poetry install --no-root --sync
-          set -o errexit
-          python3 -m poetry install --no-root --sync
-        else
-          python3 -m ensurepip
-          pip3 install -r etc/pip/dev-requirements.txt
-        fi
+        python3 -m pip install 'poetry==1.5.1'
+        export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+        # FIXME-WT-12911 - There's a dependency ordering issue in the mongo poetry.lock file. Running poetry install twice resolves it.
+        set +o errexit
+        python3 -m poetry install --no-root --sync
+        set -o errexit
+        python3 -m poetry install --no-root --sync
 
         ./buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_gcc.vars --link-model=dynamic --ninja generate-ninja ICECC=icecc CCACHE=ccache
         ninja -j$(nproc --all) install-mongod

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -176,13 +176,13 @@ functions:
         dir=$(pwd)
         cd wiredtiger
         mongo_repo=https://github.com/mongodb/mongo
-        branch=$(git branch --contains | grep -e "mongodb")
+        branch=$(git branch --contains | grep -e "mongodb" -e "develop")
         if [[ $branch =~ "mongodb-" ]]; then
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
           mongo_branch=master
         fi
-        cd dir
+        cd $dir
         git clone $mongo_repo -b $mongo_branch
   "import wiredtiger into mongo" :
     command: shell.exec
@@ -4056,8 +4056,8 @@ tasks:
         params:
           exec_timeout_secs: 86400
           timeout_secs: 86400
-      - func: "fetch mongo repo"
       - func: "get project"
+      - func: "fetch mongo repo"
       - func: "get engflow creds"
       - func: "import wiredtiger into mongo"
       - func: "compile mongodb"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -174,7 +174,7 @@ functions:
         set -o errexit
         set -o verbose
         mongo_repo=https://github.com/mongodb/mongo
-        branch=${branch_name}
+        branch=$(git branch --contains | -e "mongodb" | tr -d ' ')
         if [[ $branch =~ "mongodb-" ]]; then
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
@@ -201,14 +201,19 @@ functions:
         ${PREPARE_PATH}
         virtualenv -p python3 venv
         source venv/bin/activate
-        python3 -m pip install 'poetry==1.5.1'
+        if [ -d "pyproject.toml" && -d "poetry.lock" ]; then
+          python3 -m pip install 'poetry==1.5.1'
 
-        export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
-        # FIXME-WT-12911 - There's a dependency ordering issue in the mongo poetry.lock file. Running poetry install twice resolves it.
-        set +o errexit
-        python3 -m poetry install --no-root --sync
-        set -o errexit
-        python3 -m poetry install --no-root --sync
+          export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+          # FIXME-WT-12911 - There's a dependency ordering issue in the mongo poetry.lock file. Running poetry install twice resolves it.
+          set +o errexit
+          python3 -m poetry install --no-root --sync
+          set -o errexit
+          python3 -m poetry install --no-root --sync
+        else
+          python3 -m ensurepip
+          pip3 install -r etc/pip/dev-requirements.txt
+        fi
 
         ./buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_gcc.vars --link-model=dynamic --ninja generate-ninja ICECC=icecc CCACHE=ccache
         ninja -j$(nproc --all) install-mongod

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -173,16 +173,18 @@ functions:
       script: |
         set -o errexit
         set -o verbose
-        dir=$(pwd)
-        cd wiredtiger
+        pushd wiredtiger
         mongo_repo=https://github.com/mongodb/mongo
+        # Find the equivalent mongodb branch that matches the same branch version to wiredtiger. In
+        # the case of patch builds, it is possible that the developer has a branch name that doesn't
+        # adhere to naming rules, therefore derive the base branch name from git.
         branch=$(git branch --contains | grep -e "mongodb" -e "develop")
         if [[ $branch =~ "mongodb-" ]]; then
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
           mongo_branch=master
         fi
-        cd $dir
+        popd
         git clone $mongo_repo -b $mongo_branch
   "import wiredtiger into mongo" :
     command: shell.exec


### PR DESCRIPTION
1. Update the fetch mongo repo to appear after we fetch the wiredtiger repo, as we need to perform git branch command
2. Utilise `git branch --contains` with the aim to get the checkout'd branch, so we can fetch the correct MongoDB repo

I realise we don't need to configure compile MongoDB (compilation is different v6.0 before and after), because any evergreen patches before 6.0 already compile the old way, and any patches after 6.0 use the new way.