### PR TITLE
WT-13023 Fix not tracking latency for modify 

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -451,6 +451,7 @@ __curfile_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
     WT_CURSOR_BTREE *cbt;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
+    uint64_t time_start, time_stop;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     CURSOR_UPDATE_API_CALL_BTREE(cursor, session, ret, modify);
@@ -461,7 +462,10 @@ __curfile_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
     if (nentries <= 0)
         WT_ERR_MSG(session, EINVAL, "Illegal modify vector with %d entries", nentries);
 
+    time_start = __wt_clock(session);
     WT_ERR(__wt_btcur_modify(cbt, entries, nentries));
+    time_stop = __wt_clock(session);
+    __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
 
     /*
      * Modify maintains a position, key and value. Unlike update, it's not always an internal value.


### PR DESCRIPTION
Background:
At a certain point in time, mongod.log experienced severe jitter, with many second level slow logs, but the write latency of wt did not change much. The reason is that session. modify() did not perform write latency statistics.


mongo shell run:
db.setLogLevel(0, 'storage');
db.adminCommand({setParameter:1, wiredTigerEngineRuntimeConfig:'verbose=[api:2]'})
db.runCommand(    {      findAndModify: "people",      query: { name: "Tom", state: "active", rating: { $gt: 10 } },      sort: { rating: 1 },      update: { $inc: { score: 1 } }    } )


mongod.log as following:
{"t":{"$date":"2024-05-20T21:16:05.513+08:00"},"s":"D1", "c":"WT",       "id":22430,   "ctx":"conn57","msg":"WiredTiger message","attr":{"message":{"ts_sec":1716210965,"ts_usec":513276,"thread":"9599:0x7fb670a2e700","session_name":"WT_SESSION.open_cursor","category":"WT_VERB_API","category_id":0,"verbose_level":"DEBUG_1","verbose_level_id":1,"msg":"CALL: WT_SESSION:open_cursor"}}}
{"t":{"$date":"2024-05-20T21:16:05.513+08:00"},"s":"D1", "c":"WT",       "id":22430,   "ctx":"conn57","msg":"WiredTiger message","attr":{"message":{"ts_sec":1716210965,"ts_usec":513311,"thread":"9599:0x7fb670a2e700","session_name":"WT_CURSOR.set_key","category":"WT_VERB_API","category_id":0,"verbose_level":"DEBUG_1","verbose_level_id":1,"msg":"CALL: WT_CURSOR:set_key"}}}
{"t":{"$date":"2024-05-20T21:16:05.513+08:00"},"s":"D1", "c":"WT",       "id":22430,   "ctx":"conn57","msg":"WiredTiger message","attr":{"message":{"ts_sec":1716210965,"ts_usec":513351,"thread":"9599:0x7fb670a2e700","session_dhandle_name":"file:test/collection/23-1412021874329447210.wt","session_name":"WT_CURSOR.modify","category":"WT_VERB_API","category_id":0,"verbose_level":"DEBUG_1","verbose_level_id":1,"msg":"CALL: WT_CURSOR:modify"}}}

mongod.log has 3008 slow logs exceeding 1 second
![image](https://github.com/wiredtiger/wiredtiger/assets/14356223/20ff704b-a087-4642-93bc-fdeeadc772d0)


but, The diagnostic data analysis results are as follows, There is no significant change in write delay:
![image](https://github.com/wiredtiger/wiredtiger/assets/14356223/8ffe84ef-abb0-4aa6-a0e7-f8b43b60a6df)
