### PR TITLE
WT-11457 Increase timeout to 5 hours for split stress test (#9508) (v7.0 backport)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3895,8 +3895,8 @@ tasks:
 
   - name: split-stress-test
     tags: ["stress-test-1", "stress-test-ppc-1", "stress-test-zseries-1"]
-    # Set 2.5 hours timeout (60 * 60 * 2.5)
-    exec_timeout_secs: 9000
+    # Set 5 hours timeout (60 * 60 * 5)
+    exec_timeout_secs: 18000
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -3904,8 +3904,8 @@ tasks:
 
   - name: split-stress-test-nonstandalone
     tags: ["stress-test-1-nonstandalone"]
-    # Set 2.5 hours timeout (60 * 60 * 2.5)
-    exec_timeout_secs: 9000
+    # Set 5 hours timeout (60 * 60 * 5)
+    exec_timeout_secs: 18000
     commands:
       - func: "get project"
       - func: "compile wiredtiger"


### PR DESCRIPTION
(cherry picked from commit 518f22ed709defa8f55fa81c87175832b8bd7953)