### PR TITLE
WT-13040 Add /data/mci to the gdb auto-load paths in print_stack_trace.py

### DIFF
--- a/test/evergreen/print_stack_trace.py
+++ b/test/evergreen/print_stack_trace.py
@@ -120,6 +120,16 @@ def main():
     parser.add_argument('-l', '--lib_path', help='library path')
     args = parser.parse_args()
 
+    # Add /data/mci to gdb's auto load safe paths. Otherwise gdb refuses to load our custom gdb scripts and raises a warning.
+    gdbinit_file = os.path.expanduser('~/.gdbinit')
+    if not os.path.exists(gdbinit_file):
+        # Touch the file if it doesn't exist
+        open(gdbinit_file, 'a').close()
+
+    with open(gdbinit_file, 'r+') as file:
+        if "add-auto-load-safe-path /data/mci/" not in file.read():
+            file.write("\nadd-auto-load-safe-path /data/mci/\n")
+
     # If the lib_path is not provided then search the current dir.
     lib_path = "." if args.lib_path is None else args.lib_path
 


### PR DESCRIPTION
Add /data/mci to gdb's auto-load paths when running print_stack_trace.py. This resolves the `auto-loading has been declined` warnings reported by gdb.