### PR TITLE
WT-12201 Update the gcc.h macro definitions for all listed hardwares

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT WT_ARCH)
     # Defer to our hosts architecture as our target architecture.
     # PROCESSOR_ARCHITECTURE env variable could be unset on certain Windows systems,
     # in that case map the architecture to x86.
-    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(x86_64|i686|AMD64|)$")
+    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(x86_64|AMD64|)$")
         set(WT_ARCH "x86")
     elseif ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(arm64|aarch64)$")
         set(WT_ARCH "aarch64")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(NOT WT_ARCH)
     # Defer to our hosts architecture as our target architecture.
     # PROCESSOR_ARCHITECTURE env variable could be unset on certain Windows systems,
     # in that case map the architecture to x86.
-    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(x86_64|i686|i386|AMD64|)$")
+    if ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(x86_64|i686|AMD64|)$")
         set(WT_ARCH "x86")
     elseif ("${CMAKE_HOST_SYSTEM_PROCESSOR}" MATCHES "^(arm64|aarch64)$")
         set(WT_ARCH "aarch64")

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -469,7 +469,6 @@ abcdef
 abcdefghijklmnopqrstuvwxyz
 ackSstu
 acqrel
-addl
 addr
 addrs
 addtw

--- a/src/docs/arch-fs-os.dox
+++ b/src/docs/arch-fs-os.dox
@@ -56,6 +56,6 @@ is mainly used for non-critical functionalities such as writing verbose messages
 writing to WiredTiger statistics logs.
 
 @section filesystem_usage Multiple System Architecture Support
-WiredTiger supports x86_64, i386, mips, ppc, aarch64, s390x, riscv64, loongarch64 and sparc system
+WiredTiger supports x86_64, mips, ppc, aarch64, s390x, riscv64, loongarch64 and sparc system
 architectures which are found in gcc.h.
 */

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -346,10 +346,7 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
         __asm__ volatile("membar #StoreLoad" ::: "memory"); \
     } while (0)
 
-/*
- * On UltraSparc machines, TSO is used, and so there is no need for membar. READ_BARRIER =
- * #LoadLoad, and WRITE_BARRIER = #StoreStore are noop.
- */
+/* On UltraSparc machines, TSO is used, and so there is no need for membar. */
 #define WT_ACQUIRE_BARRIER() WT_COMPILER_BARRIER()
 #define WT_RELEASE_BARRIER() WT_COMPILER_BARRIER()
 
@@ -374,9 +371,7 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
  * https://five-embeddev.com/riscv-isa-manual/latest/memory.html#sec:mm:fence
  *
  * On RISC-V, the fence instruction takes explicit flags that indicate the predecessor and successor
- * sets. Based on the file comment description of WT_ACQUIRE_BARRIER and WT_RELEASE_BARRIER, those
- * barriers only synchronize read/read and write/write respectively. The predecessor and successor
- * sets here are selected to match that description.
+ * sets.
  */
 #define WT_FULL_BARRIER()                              \
     do {                                               \

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -255,16 +255,6 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
 #define WT_ACQUIRE_BARRIER() WT_COMPILER_BARRIER()
 #define WT_RELEASE_BARRIER() WT_COMPILER_BARRIER()
 
-#elif defined(i386) || defined(__i386__)
-#define WT_PAUSE() __asm__ volatile("pause\n" ::: "memory")
-#define WT_FULL_BARRIER()                                         \
-    do {                                                          \
-        __asm__ volatile("lock; addl $0, 0(%%esp)" ::: "memory"); \
-    } while (0)
-#define WT_ACQUIRE_BARRIER() WT_FULL_BARRIER()
-#define WT_ACQUIRE_BARRIER() WT_FULL_BARRIER()
-#define WT_RELEASE_BARRIER() WT_FULL_BARRIER()
-
 #elif defined(__mips64el__) || defined(__mips__) || defined(__mips64__) || defined(__mips64)
 #define WT_PAUSE() __asm__ volatile("pause\n" ::: "memory")
 #define WT_FULL_BARRIER()                                                                  \

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -403,14 +403,8 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
     do {                                         \
         __asm__ volatile("dbar 0" ::: "memory"); \
     } while (0)
-#define WT_ACQUIRE_BARRIER()                     \
-    do {                                         \
-        __asm__ volatile("dbar 0" ::: "memory"); \
-    } while (0)
-#define WT_RELEASE_BARRIER()                     \
-    do {                                         \
-        __asm__ volatile("dbar 0" ::: "memory"); \
-    } while (0)
+#define WT_ACQUIRE_BARRIER() WT_FULL_BARRIER()
+#define WT_RELEASE_BARRIER() WT_FULL_BARRIER()
 #else
-#error "No release barrier implementation for this hardware"
+#error "No barrier implementation for this hardware"
 #endif

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -261,14 +261,8 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
     do {                                                                                   \
         __asm__ volatile("sync; ld $0, %0" ::"m"(*(long *)0xffffffff80000000) : "memory"); \
     } while (0)
-#define WT_ACQUIRE_BARRIER()                                                               \
-    do {                                                                                   \
-        __asm__ volatile("sync; ld $0, %0" ::"m"(*(long *)0xffffffff80000000) : "memory"); \
-    } while (0)
-#define WT_RELEASE_BARRIER()                                                               \
-    do {                                                                                   \
-        __asm__ volatile("sync; ld $0, %0" ::"m"(*(long *)0xffffffff80000000) : "memory"); \
-    } while (0)
+#define WT_ACQUIRE_BARRIER() WT_FULL_BARRIER()
+#define WT_RELEASE_BARRIER() WT_FULL_BARRIER()
 
 #elif defined(__PPC64__) || defined(PPC64)
 /* ori 0,0,0 is the PPC64 noop instruction */

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -356,14 +356,8 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
  * On UltraSparc machines, TSO is used, and so there is no need for membar. READ_BARRIER =
  * #LoadLoad, and WRITE_BARRIER = #StoreStore are noop.
  */
-#define WT_ACQUIRE_BARRIER()               \
-    do {                                   \
-        __asm__ volatile("" ::: "memory"); \
-    } while (0)
-#define WT_RELEASE_BARRIER()               \
-    do {                                   \
-        __asm__ volatile("" ::: "memory"); \
-    } while (0)
+#define WT_ACQUIRE_BARRIER() WT_COMPILER_BARRIER()
+#define WT_RELEASE_BARRIER() WT_COMPILER_BARRIER()
 
 #elif defined(__riscv) && (__riscv_xlen == 64)
 
@@ -394,13 +388,13 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
     do {                                               \
         __asm__ volatile("fence rw, rw" ::: "memory"); \
     } while (0)
-#define WT_ACQUIRE_BARRIER()                         \
-    do {                                             \
-        __asm__ volatile("fence r, r" ::: "memory"); \
+#define WT_ACQUIRE_BARRIER()                          \
+    do {                                              \
+        __asm__ volatile("fence r, rw" ::: "memory"); \
     } while (0)
-#define WT_RELEASE_BARRIER()                         \
-    do {                                             \
-        __asm__ volatile("fence w, w" ::: "memory"); \
+#define WT_RELEASE_BARRIER()                          \
+    do {                                              \
+        __asm__ volatile("fence rw, w" ::: "memory"); \
     } while (0)
 
 #elif defined(__loongarch64)

--- a/src/include/time_inline.h
+++ b/src/include/time_inline.h
@@ -17,14 +17,7 @@
 static WT_INLINE uint64_t
 __wt_rdtsc(void)
 {
-#if defined(__i386)
-    {
-        uint64_t x;
-
-        __asm__ volatile("rdtsc" : "=A"(x));
-        return (x);
-    }
-#elif defined(__amd64)
+#if defined(__amd64)
     {
         uint64_t a, d;
 

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -93,7 +93,7 @@ __global_calibrate_ticks(void)
     __wt_process.tsc_nsec_ratio = WT_TSC_DEFAULT_RATIO;
     __wt_process.use_epochtime = true;
 
-#if defined(__i386) || defined(__amd64) || defined(__aarch64__)
+#if defined(__amd64) || defined(__aarch64__)
     {
         struct timespec start, stop;
         double ratio;


### PR DESCRIPTION
RISC-V was the only obvious community supported hardware, thanks to it's very nice barrier instruction definitions. For all other community hardwares I have deferred to a `FULL_BARRIER` as we don't support these ourselves.

Also I couldn't drop `s390x` as it turns out that that is a weird name for z/Architecture aka what we call zseries. I did validate that the `BCR 15, 0` was correct though. Per the linux architecture's own definition here: https://github.com/torvalds/linux/blob/2bfcfd584ff5ccc8bb7acde19b42570414bf880b/arch/s390/include/asm/barrier.h#L21.