### PR TITLE
WT-12609 Improve checkpoint cleanup and page eviction logic (#10324)

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -523,9 +523,6 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
         /* Write all dirty in-cache pages. */
         LF_SET(WT_READ_NO_EVICT);
 
-        /* Read pages with history store entries and evict them asap. */
-        LF_SET(WT_READ_WONT_NEED);
-
         /*
          * Perform checkpoint cleanup when not in startup or shutdown phase by traversing internal
          * pages looking for obsolete child pages. This is row-store specific, column-store pages
@@ -605,9 +602,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              *
              * Regardless of whether eviction succeeds or fails, the walk continues from the
              * previous location. We remember whether we tried eviction, and don't try again. Even
-             * if eviction fails (the page may stay in cache clean but with history that cannot be
-             * discarded), that is not wasted effort because checkpoint doesn't need to write the
-             * page again.
+             * if eviction fails (the page may stay in cache clean), that is not a wasted effort
+             * because checkpoint doesn't need to write the page again.
              *
              * Once the transaction has given up it's snapshot it is no longer safe to reconcile
              * pages. That happens prior to the final metadata checkpoint.


### PR DESCRIPTION
Checkpoint reads only internal pages into the cache for the purpose of removing any obsolete pages as part of the checkpoint cleanup. Evicting these internal pages asap can add an overhead to the next checkpoint to read them back again into the cache. Instead of evicting them asap, evict the internal pages read by the checkpoint like a regular page.

It is unnecessary to remove leaf pages tagged as READ WONT_NEED from the cache by the checkpoint because the checkpoint never reads any pages from the leaf pages (apart from history store pages used for reconciliation).  This will avoid the unnecessary slowdown of the checkpoint by evicting the pages that are not read by the checkpoint.

Co-authored-by: Hari Babu Kommi <haribabu.kommi@mongodb.com>
(cherry picked from commit a5ab39839f4efccbe6b1775a296e9de1adf63659)