### PR TITLE
WT-13046 Add ex_backup to examples-c-tsan

### DIFF
--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -40,7 +40,7 @@ __wti_block_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t len)
      * backups, which only copies log files, or targeted backups, stops all block truncation
      * unnecessarily). We may want a more targeted solution at some point.
      */
-    if (conn->hot_backup_start == 0)
+    if (__wt_atomic_load64(&conn->hot_backup_start) == 0)
         WT_WITH_HOTBACKUP_READ_LOCK(session, ret = __wt_ftruncate(session, block->fh, len), NULL);
 
     /*
@@ -156,7 +156,7 @@ __block_extend(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_FH *fh, wt_off_t of
      * The extend might fail (for example, the file is mapped into memory or a backup is in
      * progress), or discover file extension isn't supported; both are OK.
      */
-    if (S2C(session)->hot_backup_start == 0)
+    if (__wt_atomic_load64(&S2C(session)->hot_backup_start) == 0)
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __wt_fextend(session, fh, block->extend_size), NULL);
     return (ret == EBUSY || ret == ENOTSUP ? 0 : ret);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -885,7 +885,7 @@ __debug_tree_shape_info(WT_REF *ref, char *buf, size_t len)
     const char *unit;
 
     page = ref->page;
-    v = page->memory_footprint;
+    v = __wt_atomic_loadsize(&page->memory_footprint);
 
     if (v > WT_GIGABYTE) {
         v /= WT_GIGABYTE;
@@ -1289,7 +1289,8 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
         WT_RET(ds->f(ds, " | split_gen: %" PRIu64, split_gen));
     if (mod != NULL)
         WT_RET(ds->f(ds, " | page_state: %" PRIu32, __wt_atomic_load32(&mod->page_state)));
-    WT_RET(ds->f(ds, " | page_mem_size: %" WT_SIZET_FMT, page->memory_footprint));
+    WT_RET(
+      ds->f(ds, " | page_mem_size: %" WT_SIZET_FMT, __wt_atomic_loadsize(&page->memory_footprint)));
     return (ds->f(ds, "\n"));
 }
 

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -41,7 +41,7 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
      * the disk image size takes into account large values that have
      * already been written and should not trigger forced eviction.
      */
-    footprint = page->memory_footprint;
+    footprint = __wt_atomic_loadsize(&page->memory_footprint);
     if (page->dsk != NULL)
         footprint -= page->dsk->mem_size;
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1869,7 +1869,7 @@ __slvg_row_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
          * the reconciliation of the root page. For now, make sure the eviction threads don't see us
          * as a threat.
          */
-        if (page->memory_footprint > WT_MEGABYTE * 2)
+        if (__wt_atomic_loadsize(&page->memory_footprint) > WT_MEGABYTE * 2)
             __wt_cache_page_inmem_decr(session, page, WT_MEGABYTE);
     }
     __wt_root_ref_init(session, &ss->root_ref, page, false);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1251,7 +1251,7 @@ __split_internal_should_split(WT_SESSION_IMPL *session, WT_REF *ref)
      * Deepen the tree if the page's memory footprint is larger than the maximum size for a page in
      * memory (presumably putting eviction pressure on the cache).
      */
-    if (page->memory_footprint > btree->maxmempage)
+    if (__wt_atomic_loadsize(&page->memory_footprint) > btree->maxmempage)
         return (true);
 
     /*

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -188,7 +188,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * have to visit them anyway.
              */
             page = walk->page;
-            if (__wt_page_is_modified(page) && WT_TXNID_LT(page->modify->update_txn, oldest_id)) {
+            if (__wt_page_is_modified(page) &&
+              WT_TXNID_LT(__wt_atomic_load64(&page->modify->update_txn), oldest_id)) {
                 if (txn->isolation == WT_ISO_READ_COMMITTED)
                     __wt_txn_get_snapshot(session);
                 leaf_bytes += page->memory_footprint;

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -192,7 +192,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
               WT_TXNID_LT(__wt_atomic_load64(&page->modify->update_txn), oldest_id)) {
                 if (txn->isolation == WT_ISO_READ_COMMITTED)
                     __wt_txn_get_snapshot(session);
-                leaf_bytes += page->memory_footprint;
+                leaf_bytes += __wt_atomic_loadsize(&page->memory_footprint);
                 ++leaf_pages;
                 WT_ERR(__wt_reconcile(session, walk, NULL, WT_REC_CHECKPOINT));
             }
@@ -297,13 +297,13 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             }
 
             if (is_internal) {
-                internal_bytes += page->memory_footprint;
+                internal_bytes += __wt_atomic_loadsize(&page->memory_footprint);
                 ++internal_pages;
                 /* Slow down checkpoints. */
                 if (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_SLOW_CKPT))
                     __wt_sleep(0, 10 * WT_THOUSAND);
             } else {
-                leaf_bytes += page->memory_footprint;
+                leaf_bytes += __wt_atomic_loadsize(&page->memory_footprint);
                 ++leaf_pages;
             }
 
@@ -347,7 +347,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
              * Update checkpoint IO tracking data if configured to log verbose progress messages.
              */
             if (conn->ckpt_timer_start.tv_sec > 0) {
-                conn->ckpt_write_bytes += page->memory_footprint;
+                conn->ckpt_write_bytes += __wt_atomic_loadsize(&page->memory_footprint);
                 ++conn->ckpt_write_pages;
 
                 /* Periodically log checkpoint progress. */

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -332,7 +332,8 @@ __wti_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STATP_CONN_SET(session, stats, cache_bytes_updates, __wt_cache_bytes_updates(cache));
 
     WT_STATP_CONN_SET(session, stats, cache_eviction_maximum_page_size, cache->evict_max_page_size);
-    WT_STATP_CONN_SET(session, stats, cache_eviction_maximum_milliseconds, cache->evict_max_ms);
+    WT_STATP_CONN_SET(session, stats, cache_eviction_maximum_milliseconds,
+      __wt_atomic_load64(&cache->evict_max_ms));
     WT_STATP_CONN_SET(
       session, stats, cache_reentry_hs_eviction_milliseconds, cache->reentry_hs_eviction_ms);
     WT_STATP_CONN_SET(

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -331,7 +331,8 @@ __wti_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STATP_CONN_SET(session, stats, cache_bytes_other, __wt_cache_bytes_other(cache));
     WT_STATP_CONN_SET(session, stats, cache_bytes_updates, __wt_cache_bytes_updates(cache));
 
-    WT_STATP_CONN_SET(session, stats, cache_eviction_maximum_page_size, cache->evict_max_page_size);
+    WT_STATP_CONN_SET(session, stats, cache_eviction_maximum_page_size,
+      __wt_atomic_load64(&cache->evict_max_page_size));
     WT_STATP_CONN_SET(session, stats, cache_eviction_maximum_milliseconds,
       __wt_atomic_load64(&cache->evict_max_ms));
     WT_STATP_CONN_SET(

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -510,7 +510,7 @@ __background_compact_server(void *arg)
         /* If the server is configured to run once, stop it after a full iteration. */
         if (full_iteration && conn->background_compact.run_once) {
             __wt_spin_lock(session, &conn->background_compact.lock);
-            conn->background_compact.running = false;
+            __wt_atomic_storebool(&conn->background_compact.running, false);
             running = false;
             WT_STAT_CONN_SET(session, background_compact_running, running);
             __wt_spin_unlock(session, &conn->background_compact.lock);
@@ -542,7 +542,7 @@ __background_compact_server(void *arg)
             break;
 
         __wt_spin_lock(session, &conn->background_compact.lock);
-        running = conn->background_compact.running;
+        running = __wt_atomic_loadbool(&conn->background_compact.running);
 
         /* The server has been signalled to change state. */
         if (conn->background_compact.signalled) {
@@ -617,7 +617,7 @@ __background_compact_server(void *arg)
              */
             else if (ret == WT_ERROR) {
                 __wt_spin_lock(session, &conn->background_compact.lock);
-                running = conn->background_compact.running;
+                running = __wt_atomic_loadbool(&conn->background_compact.running);
                 __wt_spin_unlock(session, &conn->background_compact.lock);
                 if (!running) {
                     WT_STAT_CONN_INCR(session, background_compact_interrupted);
@@ -703,7 +703,7 @@ __wti_background_compact_server_destroy(WT_SESSION_IMPL *session)
 
     FLD_CLR(conn->server_flags, WT_CONN_SERVER_COMPACT);
     if (conn->background_compact.tid_set) {
-        conn->background_compact.running = false;
+        __wt_atomic_storebool(&conn->background_compact.running, false);
         __wt_cond_signal(session, conn->background_compact.cond);
         WT_TRET(__wt_thread_join(session, &conn->background_compact.tid));
         conn->background_compact.tid_set = false;
@@ -753,7 +753,7 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
         goto err;
     }
 
-    running = conn->background_compact.running;
+    running = __wt_atomic_loadbool(&conn->background_compact.running);
 
     WT_ERR(__wt_config_getones(session, config, "background", &cval));
     enable = cval.val;
@@ -781,7 +781,7 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
     }
 
     /* The background compaction has been signalled successfully, update its state. */
-    conn->background_compact.running = enable;
+    __wt_atomic_storebool(&conn->background_compact.running, enable);
     __wt_free(session, conn->background_compact.config);
     conn->background_compact.config = stripped_config;
     stripped_config = NULL;

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -448,7 +448,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
     if (!marked_dead) {
         F_CLR(dhandle, WT_DHANDLE_OPEN);
         if (dhandle->checkpoint == NULL)
-            --conn->open_btree_count;
+            __wt_atomic_sub32(&conn->open_btree_count, 1);
     }
     WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_DEAD) || !F_ISSET(dhandle, WT_DHANDLE_OPEN));
 
@@ -598,7 +598,7 @@ __wt_conn_dhandle_open(WT_SESSION_IMPL *session, const char *cfg[], uint32_t fla
      * better to ignore them.
      */
     if (dhandle->checkpoint == NULL)
-        ++S2C(session)->open_btree_count;
+        __wt_atomic_add32(&S2C(session)->open_btree_count, 1);
 
     if (0) {
 err:

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -1047,7 +1047,8 @@ __wti_verbose_dump_handles(WT_SESSION_IMPL *session)
             WT_RET(__wt_msg(session, "Checkpoint: %s", dhandle->checkpoint));
         WT_RET(__wt_msg(
           session, "  Handle session and tiered work references: %" PRIu32, dhandle->references));
-        WT_RET(__wt_msg(session, "  Sessions using handle: %" PRId32, dhandle->session_inuse));
+        WT_RET(__wt_msg(session, "  Sessions using handle: %" PRId32,
+          __wt_atomic_loadi32(&dhandle->session_inuse)));
         WT_RET(__wt_msg(session, "  Exclusive references to handle: %" PRIu32, dhandle->excl_ref));
         if (dhandle->excl_ref != 0)
             WT_RET(

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -66,7 +66,7 @@ __conn_dhandle_config_set(WT_SESSION_IMPL *session)
      * array, we must free it, after the copy, we don't want to free it.
      */
     WT_ERR(__wt_calloc_def(session, 3, &dhandle->cfg));
-    switch (dhandle->type) {
+    switch (__wt_atomic_load_enum(&dhandle->type)) {
     case WT_DHANDLE_TYPE_BTREE:
     case WT_DHANDLE_TYPE_TIERED:
         /*
@@ -95,7 +95,7 @@ __conn_dhandle_config_set(WT_SESSION_IMPL *session)
          */
         cfg[0] = tmp;
         cfg[1] = NULL;
-        if (dhandle->type == WT_DHANDLE_TYPE_TIERED)
+        if (__wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_TIERED)
             strip =
               "checkpoint=,checkpoint_backup_info=,checkpoint_lsn=,flush_time=,flush_timestamp=,"
               "last=,tiers=()";
@@ -139,7 +139,7 @@ __conn_dhandle_destroy(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle, bool f
 {
     WT_DECL_RET;
 
-    switch (dhandle->type) {
+    switch (__wt_atomic_load_enum(&dhandle->type)) {
     case WT_DHANDLE_TYPE_BTREE:
         WT_WITH_DHANDLE(session, dhandle, ret = __wt_btree_discard(session));
         break;
@@ -188,19 +188,19 @@ __wt_conn_dhandle_alloc(WT_SESSION_IMPL *session, const char *uri, const char *c
 
     if (WT_PREFIX_MATCH(uri, "file:")) {
         WT_RET(__wt_calloc_one(session, &dhandle));
-        dhandle->type = WT_DHANDLE_TYPE_BTREE;
+        __wt_atomic_store_enum(&dhandle->type, WT_DHANDLE_TYPE_BTREE);
     } else if (WT_PREFIX_MATCH(uri, "table:")) {
         WT_RET(__wt_calloc_one(session, &table));
         dhandle = (WT_DATA_HANDLE *)table;
-        dhandle->type = WT_DHANDLE_TYPE_TABLE;
+        __wt_atomic_store_enum(&dhandle->type, WT_DHANDLE_TYPE_TABLE);
     } else if (WT_PREFIX_MATCH(uri, "tier:")) {
         WT_RET(__wt_calloc_one(session, &tiered_tree));
         dhandle = (WT_DATA_HANDLE *)tiered_tree;
-        dhandle->type = WT_DHANDLE_TYPE_TIERED_TREE;
+        __wt_atomic_store_enum(&dhandle->type, WT_DHANDLE_TYPE_TIERED_TREE);
     } else if (WT_PREFIX_MATCH(uri, "tiered:")) {
         WT_RET(__wt_calloc_one(session, &tiered));
         dhandle = (WT_DATA_HANDLE *)tiered;
-        dhandle->type = WT_DHANDLE_TYPE_TIERED;
+        __wt_atomic_store_enum(&dhandle->type, WT_DHANDLE_TYPE_TIERED);
     } else
         WT_RET_PANIC(session, EINVAL, "illegal handle allocation URI %s", uri);
 
@@ -404,7 +404,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
         WT_TRET(__wt_evict_file(session, WT_SYNC_DISCARD));
 
     /* Close the underlying handle. */
-    switch (dhandle->type) {
+    switch (__wt_atomic_load_enum(&dhandle->type)) {
     case WT_DHANDLE_TYPE_BTREE:
         WT_TRET(__wt_btree_close(session));
         F_CLR(btree, WT_BTREE_SPECIAL_FLAGS);
@@ -544,7 +544,7 @@ __wt_conn_dhandle_open(WT_SESSION_IMPL *session, const char *cfg[], uint32_t fla
     WT_ERR(__conn_dhandle_config_set(session));
     WT_ERR(__conn_dhandle_config_parse_ts(session));
 
-    switch (dhandle->type) {
+    switch (__wt_atomic_load_enum(&dhandle->type)) {
     case WT_DHANDLE_TYPE_BTREE:
         /* Set any special flags on the btree handle. */
         F_SET(btree, LF_MASK(WT_BTREE_SPECIAL_FLAGS));
@@ -613,7 +613,8 @@ err:
          * We want to close the Btree for an object that lives in the local directory. It will
          * actually be part of the corresponding tiered Btree.
          */
-        if (dhandle->type == WT_DHANDLE_TYPE_BTREE && WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
+        if (__wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_BTREE &&
+          WT_SUFFIX_MATCH(dhandle->name, ".wtobj"))
             WT_TRET(__wt_btree_close(session));
     }
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -642,7 +642,7 @@ __log_file_server(void *arg)
                  * file system may not support truncate: both are OK, it's just more work during
                  * cursor traversal.
                  */
-                if (conn->hot_backup_start == 0 && conn->log_cursors == 0) {
+                if (__wt_atomic_load64(&conn->hot_backup_start) == 0 && conn->log_cursors == 0) {
                     WT_WITH_HOTBACKUP_READ_LOCK(session,
                       ret = __wt_ftruncate(session, close_fh, __wt_lsn_offset(&close_end_lsn)),
                       NULL);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -10,7 +10,8 @@
 
 #define WT_DHANDLE_CAN_DISCARD(dhandle)                           \
     (!F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_OPEN) && \
-      __wt_atomic_loadi32(&(dhandle)->session_inuse) == 0 && (dhandle)->references == 0)
+      __wt_atomic_loadi32(&(dhandle)->session_inuse) == 0 &&      \
+      __wt_atomic_load32(&(dhandle)->references) == 0)
 
 /*
  * __sweep_mark --

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -8,9 +8,9 @@
 
 #include "wt_internal.h"
 
-#define WT_DHANDLE_CAN_DISCARD(dhandle)                                                            \
-    (!F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_OPEN) && (dhandle)->session_inuse == 0 && \
-      (dhandle)->references == 0)
+#define WT_DHANDLE_CAN_DISCARD(dhandle)                           \
+    (!F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE | WT_DHANDLE_OPEN) && \
+      __wt_atomic_loadi32(&(dhandle)->session_inuse) == 0 && (dhandle)->references == 0)
 
 /*
  * __sweep_mark --

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -140,7 +140,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
         /*
          * For tables, we need to hold the table lock to avoid racing with cursor opens.
          */
-        if (dhandle->type == WT_DHANDLE_TYPE_TABLE)
+        if (__wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_TABLE)
             WT_WITH_TABLE_WRITE_LOCK(
               session, WT_WITH_DHANDLE(session, dhandle, ret = __sweep_expire_one(session)));
         else
@@ -242,7 +242,7 @@ __sweep_remove_handles(WT_SESSION_IMPL *session)
         if (!WT_DHANDLE_CAN_DISCARD(dhandle))
             continue;
 
-        if (dhandle->type == WT_DHANDLE_TYPE_TABLE)
+        if (__wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_TABLE)
             WT_WITH_TABLE_WRITE_LOCK(session,
               WT_WITH_HANDLE_LIST_WRITE_LOCK(
                 session, WT_WITH_DHANDLE(session, dhandle, ret = __sweep_remove_one(session))));

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -129,7 +129,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
         /*
          * Ignore open files once the btree file count is below the minimum number of handles.
          */
-        if (conn->open_btree_count < conn->sweep_handles_min)
+        if (__wt_atomic_load32(&conn->open_btree_count) < conn->sweep_handles_min)
             break;
 
         if (WT_IS_METADATA(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
@@ -405,7 +405,8 @@ __sweep_server(void *arg)
          * Close handles if we have reached the configured limit. If sweep_idle_time is 0, handles
          * never become idle.
          */
-        if (conn->sweep_idle_time != 0 && conn->open_btree_count >= conn->sweep_handles_min)
+        if (conn->sweep_idle_time != 0 &&
+          __wt_atomic_load32(&conn->open_btree_count) >= conn->sweep_handles_min)
             WT_ERR(__sweep_expire(session, now));
 
         WT_ERR(__sweep_discard_trees(session, &dead_handles));

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -284,7 +284,7 @@ __sweep_check_session_callback(
     WT_UNUSED(exit_walkp);
 
     last = array_session->last_cursor_big_sweep;
-    last_sweep = array_session->last_sweep;
+    last_sweep = __wt_atomic_load64(&array_session->last_sweep);
 
     /*
      * Get the earlier of the two timestamps, as they refer to sweeps of two different data

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -769,7 +769,7 @@ __backup_start(
      * Single thread hot backups: we're holding the schema lock, so we know we'll serialize with
      * other attempts to start a hot backup.
      */
-    if (conn->hot_backup_start != 0 && !is_dup)
+    if (__wt_atomic_load64(&conn->hot_backup_start) != 0 && !is_dup)
         WT_RET_MSG(session, EINVAL, "there is already a backup cursor open");
 
     if (F_ISSET(session, WT_SESSION_BACKUP_DUP) && is_dup)
@@ -940,7 +940,7 @@ __backup_stop(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb)
     WT_TRET(__wt_remove_if_exists(session, WT_EXPORT_BACKUP, true));
 
     /* Checkpoint deletion and next hot backup can proceed. */
-    WT_WITH_HOTBACKUP_WRITE_LOCK(session, conn->hot_backup_start = 0);
+    WT_WITH_HOTBACKUP_WRITE_LOCK(session, __wt_atomic_store64(&conn->hot_backup_start, 0));
     F_CLR(session, WT_SESSION_BACKUP_CURSOR);
 
     return (ret);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -292,8 +292,10 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      * force pages out before they're larger than the cache. We don't care about races, it's just a
      * statistic.
      */
-    if (__wt_atomic_loadsize(&page->memory_footprint) > conn->cache->evict_max_page_size)
-        conn->cache->evict_max_page_size = __wt_atomic_loadsize(&page->memory_footprint);
+    if (__wt_atomic_loadsize(&page->memory_footprint) >
+      __wt_atomic_load64(&conn->cache->evict_max_page_size))
+        __wt_atomic_store64(
+          &conn->cache->evict_max_page_size, __wt_atomic_loadsize(&page->memory_footprint));
 
     /* Figure out whether reconciliation was done on the page */
     if (__wt_page_evict_clean(page)) {

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -154,8 +154,8 @@ __evict_stats_update(WT_SESSION_IMPL *session, uint8_t flags)
     }
     if (!session->evict_timeline.reentry_hs_eviction) {
         eviction_time_milliseconds = eviction_time / WT_THOUSAND;
-        if (eviction_time_milliseconds > conn->cache->evict_max_ms)
-            conn->cache->evict_max_ms = eviction_time_milliseconds;
+        if (eviction_time_milliseconds > __wt_atomic_load64(&conn->cache->evict_max_ms))
+            __wt_atomic_store64(&conn->cache->evict_max_ms, eviction_time_milliseconds);
         if (eviction_time_milliseconds > WT_MINUTE * WT_THOUSAND)
             __wt_verbose_warning(session, WT_VERB_EVICT,
               "Eviction took more than 1 minute (%" PRIu64 "us). Building disk image took %" PRIu64

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -292,8 +292,8 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      * force pages out before they're larger than the cache. We don't care about races, it's just a
      * statistic.
      */
-    if (page->memory_footprint > conn->cache->evict_max_page_size)
-        conn->cache->evict_max_page_size = page->memory_footprint;
+    if (__wt_atomic_loadsize(&page->memory_footprint) > conn->cache->evict_max_page_size)
+        conn->cache->evict_max_page_size = __wt_atomic_loadsize(&page->memory_footprint);
 
     /* Figure out whether reconciliation was done on the page */
     if (__wt_page_evict_clean(page)) {

--- a/src/evict/evict_stat.c
+++ b/src/evict/evict_stat.c
@@ -43,8 +43,8 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
       next_walk != NULL) {
         ++seen_count;
         page = next_walk->page;
-        if (page->memory_footprint > max_pagesize)
-            max_pagesize = page->memory_footprint;
+        if (__wt_atomic_loadsize(&page->memory_footprint) > max_pagesize)
+            max_pagesize = __wt_atomic_loadsize(&page->memory_footprint);
 
         if (__wt_page_is_modified(page))
             ++pages_dirty;
@@ -137,7 +137,8 @@ __wt_curstat_cache_walk(WT_SESSION_IMPL *session)
     /* Root page statistics */
     root_idx = WT_INTL_INDEX_GET_SAFE(btree->root.page);
     WT_STAT_DSRC_SET(session, cache_state_root_entries, root_idx->entries);
-    WT_STAT_DSRC_SET(session, cache_state_root_size, btree->root.page->memory_footprint);
+    WT_STAT_DSRC_SET(
+      session, cache_state_root_size, __wt_atomic_loadsize(&btree->root.page->memory_footprint));
 
     __evict_stat_walk(session);
 }

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -323,7 +323,7 @@ struct __wt_page_modify {
     wt_timestamp_t rec_max_timestamp;
 
     /* The largest update transaction ID (approximate). */
-    uint64_t update_txn;
+    wt_shared uint64_t update_txn;
 
     /* Dirty bytes added to the cache. */
     wt_shared size_t bytes_dirty;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -616,16 +616,16 @@ struct __wt_page {
  * but it's not always required: for example, if a page is locked for splitting, or being created or
  * destroyed.
  */
-#define WT_INTL_INDEX_GET_SAFE(page) ((page)->u.intl.__index)
+#define WT_INTL_INDEX_GET_SAFE(page) __wt_atomic_load_pointer(&(page)->u.intl.__index)
 #define WT_INTL_INDEX_GET(session, page, pindex)                          \
     do {                                                                  \
         WT_ASSERT(session, __wt_session_gen(session, WT_GEN_SPLIT) != 0); \
         (pindex) = WT_INTL_INDEX_GET_SAFE(page);                          \
     } while (0)
-#define WT_INTL_INDEX_SET(page, v)      \
-    do {                                \
-        WT_RELEASE_BARRIER();           \
-        ((page)->u.intl.__index) = (v); \
+#define WT_INTL_INDEX_SET(page, v)                               \
+    do {                                                         \
+        WT_RELEASE_BARRIER();                                    \
+        __wt_atomic_store_pointer(&(page)->u.intl.__index, (v)); \
     } while (0)
 
 /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -327,7 +327,7 @@ __wt_cache_decr_check_size(WT_SESSION_IMPL *session, size_t *vp, size_t v, const
      * It's a bug if this accounting underflowed but allow the application to proceed - the
      * consequence is we use more cache than configured.
      */
-    *vp = 0;
+    __wt_atomic_storesize(vp, 0);
     __wt_errx(session, "%s went negative with decrement of %" WT_SIZET_FMT, fld, v);
 
 #ifdef HAVE_DIAGNOSTIC
@@ -342,7 +342,9 @@ __wt_cache_decr_check_size(WT_SESSION_IMPL *session, size_t *vp, size_t v, const
 static WT_INLINE void
 __wt_cache_decr_check_uint64(WT_SESSION_IMPL *session, uint64_t *vp, uint64_t v, const char *fld)
 {
-    uint64_t orig = *vp;
+    uint64_t orig;
+
+    orig = __wt_atomic_load64(vp);
 
     if (v == 0 || __wt_atomic_sub64(vp, v) < WT_EXABYTE)
         return;
@@ -351,7 +353,7 @@ __wt_cache_decr_check_uint64(WT_SESSION_IMPL *session, uint64_t *vp, uint64_t v,
      * It's a bug if this accounting underflowed but allow the application to proceed - the
      * consequence is we use more cache than configured.
      */
-    *vp = 0;
+    __wt_atomic_store64(vp, 0);
     __wt_errx(
       session, "%s was %" PRIu64 ", went negative with decrement of %" PRIu64, fld, orig, v);
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -729,8 +729,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     }
 
     /* Check if this is the largest transaction ID to update the page. */
-    if (WT_TXNID_LT(page->modify->update_txn, session->txn->id))
-        page->modify->update_txn = session->txn->id;
+    if (WT_TXNID_LT(__wt_atomic_load64(&page->modify->update_txn), session->txn->id))
+        __wt_atomic_store64(&page->modify->update_txn, session->txn->id);
 }
 
 /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -198,7 +198,7 @@ __wt_btree_bytes_evictable(WT_SESSION_IMPL *session)
     root_page = btree->root.page;
 
     bytes_inmem = __wt_atomic_load64(&btree->bytes_inmem);
-    bytes_root = root_page == NULL ? 0 : root_page->memory_footprint;
+    bytes_root = root_page == NULL ? 0 : __wt_atomic_loadsize(&root_page->memory_footprint);
     evictable_bytes = bytes_inmem - bytes_root;
 
     return (bytes_inmem <= bytes_root ? 0 : __wt_cache_bytes_plus_overhead(cache, evictable_bytes));
@@ -511,7 +511,7 @@ __wt_cache_dirty_incr(WT_SESSION_IMPL *session, WT_PAGE *page)
      *
      * Take care to read the memory_footprint once in case we are racing with updates.
      */
-    size = page->memory_footprint;
+    size = __wt_atomic_loadsize(&page->memory_footprint);
     if (WT_PAGE_IS_INTERNAL(page)) {
         (void)__wt_atomic_add64(&cache->pages_dirty_intl, 1);
         (void)__wt_atomic_add64(&cache->bytes_dirty_intl, size);
@@ -602,17 +602,17 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page)
     modify = page->modify;
 
     /* Update the bytes in-memory to reflect the eviction. */
-    __wt_cache_decr_check_uint64(
-      session, &btree->bytes_inmem, page->memory_footprint, "WT_BTREE.bytes_inmem");
-    __wt_cache_decr_check_uint64(
-      session, &cache->bytes_inmem, page->memory_footprint, "WT_CACHE.bytes_inmem");
+    __wt_cache_decr_check_uint64(session, &btree->bytes_inmem,
+      __wt_atomic_loadsize(&page->memory_footprint), "WT_BTREE.bytes_inmem");
+    __wt_cache_decr_check_uint64(session, &cache->bytes_inmem,
+      __wt_atomic_loadsize(&page->memory_footprint), "WT_CACHE.bytes_inmem");
 
     /* Update the bytes_internal value to reflect the eviction */
     if (WT_PAGE_IS_INTERNAL(page)) {
-        __wt_cache_decr_check_uint64(
-          session, &btree->bytes_internal, page->memory_footprint, "WT_BTREE.bytes_internal");
-        __wt_cache_decr_check_uint64(
-          session, &cache->bytes_internal, page->memory_footprint, "WT_CACHE.bytes_internal");
+        __wt_cache_decr_check_uint64(session, &btree->bytes_internal,
+          __wt_atomic_loadsize(&page->memory_footprint), "WT_BTREE.bytes_internal");
+        __wt_cache_decr_check_uint64(session, &cache->bytes_internal,
+          __wt_atomic_loadsize(&page->memory_footprint), "WT_CACHE.bytes_internal");
     }
 
     /* Update the cache's dirty-byte count. */
@@ -639,7 +639,7 @@ __wt_cache_page_evict(WT_SESSION_IMPL *session, WT_PAGE *page)
     }
 
     /* Update bytes and pages evicted. */
-    (void)__wt_atomic_add64(&cache->bytes_evict, page->memory_footprint);
+    (void)__wt_atomic_add64(&cache->bytes_evict, __wt_atomic_loadsize(&page->memory_footprint));
     (void)__wt_atomic_addv64(&cache->pages_evicted, 1);
 
     /*
@@ -1771,7 +1771,7 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
      * correctness (the page must be reconciled again before being evicted after the split,
      * information from a previous reconciliation will be wrong, so we can't evict immediately).
      */
-    if (page->memory_footprint < btree->splitmempage)
+    if (__wt_atomic_loadsize(&page->memory_footprint) < btree->splitmempage)
         return (false);
     if (WT_PAGE_IS_INTERNAL(page))
         return (false);
@@ -1795,7 +1795,7 @@ __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
  * are 5 items on the page.
  */
 #define WT_MAX_SPLIT_COUNT 5
-    if (page->memory_footprint > (size_t)btree->maxleafpage * 2) {
+    if (__wt_atomic_loadsize(&page->memory_footprint) > (size_t)btree->maxleafpage * 2) {
         for (count = 0, ins = ins_head->head[0]; ins != NULL; ins = ins->next[0]) {
             if (++count < WT_MAX_SPLIT_COUNT)
                 continue;
@@ -2101,7 +2101,7 @@ __wt_btree_lsm_over_size(WT_SESSION_IMPL *session, uint64_t maxsize)
     if (child->type != WT_PAGE_ROW_LEAF) /* not a single leaf page */
         return (true);
 
-    return (child->memory_footprint > maxsize);
+    return (__wt_atomic_loadsize(&child->memory_footprint) > maxsize);
 }
 
 /*

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -99,10 +99,10 @@ struct __wt_cache {
     uint64_t app_waits;  /* User threads waited for cache */
     uint64_t app_evicts; /* Pages evicted by user threads */
 
-    uint64_t evict_max_page_size;    /* Largest page seen at eviction */
-    wt_shared uint64_t evict_max_ms; /* Longest milliseconds spent at a single eviction */
-    uint64_t reentry_hs_eviction_ms; /* Total milliseconds spent inside a nested eviction */
-    struct timespec stuck_time;      /* Stuck time */
+    wt_shared uint64_t evict_max_page_size; /* Largest page seen at eviction */
+    wt_shared uint64_t evict_max_ms;        /* Longest milliseconds spent at a single eviction */
+    uint64_t reentry_hs_eviction_ms;        /* Total milliseconds spent inside a nested eviction */
+    struct timespec stuck_time;             /* Stuck time */
 
     /*
      * Read information.

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -100,7 +100,7 @@ struct __wt_cache {
     uint64_t app_evicts; /* Pages evicted by user threads */
 
     uint64_t evict_max_page_size;    /* Largest page seen at eviction */
-    uint64_t evict_max_ms;           /* Longest milliseconds spent at a single eviction */
+    wt_shared uint64_t evict_max_ms; /* Longest milliseconds spent at a single eviction */
     uint64_t reentry_hs_eviction_ms; /* Total milliseconds spent inside a nested eviction */
     struct timespec stuck_time;      /* Stuck time */
 

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -297,8 +297,8 @@ __wt_eviction_dirty_target(WT_CACHE *cache)
 {
     double dirty_target, scrub_target;
 
-    dirty_target = cache->eviction_dirty_target;
-    scrub_target = cache->eviction_scrub_target;
+    dirty_target = __wt_read_shared_double(&cache->eviction_dirty_target);
+    scrub_target = __wt_read_shared_double(&cache->eviction_scrub_target);
 
     return (scrub_target > 0 && scrub_target < dirty_target ? scrub_target : dirty_target);
 }

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -431,7 +431,7 @@ struct __wt_connection_impl {
     /* Locked: handles in each bucket */
     uint64_t *dh_bucket_count;
     uint64_t dhandle_count;                  /* Locked: handles in the queue */
-    u_int open_btree_count;                  /* Locked: open writable btree count */
+    wt_shared u_int open_btree_count;        /* Locked: open writable btree count */
     uint32_t next_file_id;                   /* Locked: file ID counter */
     wt_shared uint32_t open_file_count;      /* Atomic: open file handle count */
     wt_shared uint32_t open_cursor_count;    /* Atomic: open cursor handle count */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -285,10 +285,10 @@ struct __wt_name_flag {
  * WT_CONN_HOTBACKUP_START --
  *	Macro to set connection data appropriately for when we commence hot backup.
  */
-#define WT_CONN_HOTBACKUP_START(conn)                        \
-    do {                                                     \
-        (conn)->hot_backup_start = (conn)->ckpt_most_recent; \
-        (conn)->hot_backup_list = NULL;                      \
+#define WT_CONN_HOTBACKUP_START(conn)                                             \
+    do {                                                                          \
+        __wt_atomic_store64(&(conn)->hot_backup_start, (conn)->ckpt_most_recent); \
+        (conn)->hot_backup_list = NULL;                                           \
     } while (0)
 
 /*
@@ -467,8 +467,9 @@ struct __wt_connection_impl {
     uint32_t recovery_ckpt_snapshot_count;
 
     WT_RWLOCK hot_backup_lock; /* Hot backup serialization */
-    uint64_t hot_backup_start; /* Clock value of most recent checkpoint needed by hot backup */
-    char **hot_backup_list;    /* Hot backup file list */
+    wt_shared uint64_t
+      hot_backup_start;     /* Clock value of most recent checkpoint needed by hot backup */
+    char **hot_backup_list; /* Hot backup file list */
     uint32_t *partial_backup_remove_ids; /* Remove btree id list for partial backup */
 
     WT_SESSION_IMPL *ckpt_session;       /* Checkpoint thread session */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -86,7 +86,7 @@ struct __wt_background_compact_exclude {
  *	Structure dedicated to the background compaction server
  */
 struct __wt_background_compact {
-    bool running;             /* Compaction supposed to run */
+    wt_shared bool running;   /* Compaction supposed to run */
     bool run_once;            /* Background compaction is executed once */
     bool signalled;           /* Compact signalled */
     bool tid_set;             /* Thread set */

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -106,15 +106,16 @@ struct __wt_data_handle {
     WT_DATA_SOURCE *dsrc; /* Data source for this handle */
     void *handle;         /* Generic handle */
 
-    enum {
+    wt_shared enum {
         WT_DHANDLE_TYPE_BTREE,
         WT_DHANDLE_TYPE_TABLE,
         WT_DHANDLE_TYPE_TIERED,
         WT_DHANDLE_TYPE_TIERED_TREE
     } type;
 
-#define WT_DHANDLE_BTREE(dhandle) \
-    ((dhandle)->type == WT_DHANDLE_TYPE_BTREE || (dhandle)->type == WT_DHANDLE_TYPE_TIERED)
+#define WT_DHANDLE_BTREE(dhandle)                                        \
+    (__wt_atomic_load_enum(&(dhandle)->type) == WT_DHANDLE_TYPE_BTREE || \
+      __wt_atomic_load_enum(&(dhandle)->type) == WT_DHANDLE_TYPE_TIERED)
 
     bool compact_skip; /* If the handle failed to compact */
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2170,6 +2170,8 @@ static WT_INLINE const char *__wt_update_type_str(uint8_t val)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE double __wt_eviction_dirty_target(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE double __wt_read_shared_double(double *to_read)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_btcur_bounds_early_exit(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   bool next, bool *key_out_of_boundsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_btcur_skip_page(WT_SESSION_IMPL *session, WT_REF *ref, void *context,

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -306,6 +306,16 @@ __wt_set_shared_double(double *to_set, double value)
 }
 
 /*
+ * __wt_read_shared_double --
+ *     This function enables suppressing TSan warnings about reading doubles in a shared context.
+ */
+static WT_INLINE double
+__wt_read_shared_double(double *to_read)
+{
+    return (*to_read);
+}
+
+/*
  * The hardware-accelerated checksum code that originally shipped on Windows did not correctly
  * handle memory that wasn't 8B aligned and a multiple of 8B. It's likely that calculations were
  * always 8B aligned, but there's some risk.

--- a/src/include/os_fhandle_inline.h
+++ b/src/include/os_fhandle_inline.h
@@ -72,7 +72,8 @@ __wt_fextend(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset)
     /* Make sure we don't try to shrink the file during backup. */
     if (handle->fh_size != NULL) {
         WT_RET(handle->fh_size(handle, (WT_SESSION *)session, &cur_size));
-        WT_ASSERT(session, cur_size <= offset || S2C(session)->hot_backup_start == 0);
+        WT_ASSERT(
+          session, cur_size <= offset || __wt_atomic_load64(&S2C(session)->hot_backup_start) == 0);
     }
 #endif
     if (handle->fh_extend_nolock != NULL)
@@ -165,7 +166,8 @@ __wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset)
     /* Make sure we don't try to shrink the file during backup. */
     if (handle->fh_size != NULL) {
         WT_RET(handle->fh_size(handle, (WT_SESSION *)session, &cur_size));
-        WT_ASSERT(session, cur_size <= offset || S2C(session)->hot_backup_start == 0);
+        WT_ASSERT(
+          session, cur_size <= offset || __wt_atomic_load64(&S2C(session)->hot_backup_start) == 0);
     }
 #endif
     if (handle->fh_truncate != NULL)

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -301,7 +301,7 @@ struct __wt_import_list {
         if ((skipp) != (bool *)NULL)                                        \
             *(bool *)(skipp) = true;                                        \
         if (FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP)) {  \
-            if (__conn->hot_backup_start == 0) {                            \
+            if (__wt_atomic_load64(&__conn->hot_backup_start) == 0) {       \
                 if ((skipp) != (bool *)NULL)                                \
                     *(bool *)(skipp) = false;                               \
                 op;                                                         \
@@ -309,7 +309,7 @@ struct __wt_import_list {
         } else {                                                            \
             __wt_readlock(session, &__conn->hot_backup_lock);               \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ); \
-            if (__conn->hot_backup_start == 0) {                            \
+            if (__wt_atomic_load64(&__conn->hot_backup_start) == 0) {       \
                 if ((skipp) != (bool *)NULL)                                \
                     *(bool *)(skipp) = false;                               \
                 op;                                                         \

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -124,8 +124,8 @@ struct __wt_session_impl {
      */
     /* Session handle reference list */
     TAILQ_HEAD(__dhandles, __wt_data_handle_cache) dhandles;
-    uint64_t last_sweep;        /* Last sweep for dead handles */
-    struct timespec last_epoch; /* Last epoch time returned */
+    wt_shared uint64_t last_sweep; /* Last sweep for dead handles */
+    struct timespec last_epoch;    /* Last epoch time returned */
 
     WT_CURSOR_LIST cursors;          /* Cursors closed with the session */
     u_int ncursors;                  /* Count of active file cursors. */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1490,7 +1490,7 @@ __wt_meta_ckptlist_set(
         WT_ERR(__wt_buf_catfmt(session, buf, ",checkpoint_lsn=(%" PRIu32 ",%" PRIuMAX ")",
           ckptlsn->l.file, (uintmax_t)__wt_lsn_offset(ckptlsn)));
 
-    if (dhandle->type == WT_DHANDLE_TYPE_TIERED)
+    if (__wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_TIERED)
         WT_ERR(__wt_tiered_set_metadata(session, (WT_TIERED *)dhandle, buf));
 
     WT_ERR(__ckpt_set(session, fname, buf->mem, has_lsn));

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -26,7 +26,8 @@ __schema_backup_check_int(WT_SESSION_IMPL *session, const char *name)
      * There is a window at the end of a backup where the list has been cleared from the connection
      * but the flag is still set. It is safe to drop at that point.
      */
-    if (conn->hot_backup_start == 0 || (backup_list = conn->hot_backup_list) == NULL) {
+    if (__wt_atomic_load64(&conn->hot_backup_start) == 0 ||
+      (backup_list = conn->hot_backup_list) == NULL) {
         return (0);
     }
     for (i = 0; backup_list[i] != NULL; ++i) {
@@ -50,7 +51,7 @@ __wti_schema_backup_check(WT_SESSION_IMPL *session, const char *name)
     WT_DECL_RET;
 
     conn = S2C(session);
-    if (conn->hot_backup_start == 0)
+    if (__wt_atomic_load64(&conn->hot_backup_start) == 0)
         return (0);
     WT_WITH_HOTBACKUP_READ_LOCK_UNCOND(session, ret = __schema_backup_check_int(session, name));
     return (ret);

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -231,7 +231,7 @@ __wt_session_compact_check_interrupted(WT_SESSION_IMPL *session)
     if (session == conn->background_compact.session) {
         background_compaction = true;
         __wt_spin_lock(session, &conn->background_compact.lock);
-        if (!conn->background_compact.running)
+        if (!__wt_atomic_loadbool(&conn->background_compact.running))
             ret = WT_ERROR;
         __wt_spin_unlock(session, &conn->background_compact.lock);
     } else if (session->event_handler->handle_general != NULL) {

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -795,9 +795,9 @@ __wt_session_dhandle_sweep(WT_SESSION_IMPL *session)
      * Periodically sweep for dead handles; if we've swept recently, don't do it again.
      */
     __wt_seconds(session, &now);
-    if (now - session->last_sweep < conn->sweep_interval)
+    if (now - __wt_atomic_load64(&session->last_sweep) < conn->sweep_interval)
         return;
-    session->last_sweep = now;
+    __wt_atomic_store64(&session->last_sweep, now);
 
     WT_STAT_CONN_INCR(session, dh_session_sweeps);
 

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -16,8 +16,8 @@ bool
 __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     /* Disable pre-fetch work on tiered tables. */
-    if (session->dhandle->type == WT_DHANDLE_TYPE_TIERED ||
-      session->dhandle->type == WT_DHANDLE_TYPE_TIERED_TREE)
+    if (__wt_atomic_load_enum(&session->dhandle->type) == WT_DHANDLE_TYPE_TIERED ||
+      __wt_atomic_load_enum(&session->dhandle->type) == WT_DHANDLE_TYPE_TIERED_TREE)
         return (false);
 
     if (S2C(session)->prefetch_queue_count > WT_MAX_PREFETCH_QUEUE)

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -91,7 +91,7 @@ __tiered_dhandle_setup(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t i, 
 
     WT_RET(__wt_session_get_dhandle(session, name, NULL, NULL, 0));
     if (i == WT_TIERED_INDEX_INVALID) {
-        type = session->dhandle->type;
+        type = __wt_atomic_load_enum(&session->dhandle->type);
         if (type == WT_DHANDLE_TYPE_BTREE)
             id = WT_TIERED_INDEX_LOCAL;
         else if (type == WT_DHANDLE_TYPE_TIERED)
@@ -111,7 +111,7 @@ __tiered_dhandle_setup(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t i, 
     tier->tier = session->dhandle;
 
     /* The Btree needs to use the bucket storage to do file system operations. */
-    if (session->dhandle->type == WT_DHANDLE_TYPE_BTREE)
+    if (__wt_atomic_load_enum(&session->dhandle->type) == WT_DHANDLE_TYPE_BTREE)
         ((WT_BTREE *)session->dhandle->handle)->bstorage = tiered->bstorage;
 err:
     WT_RET(__wt_session_release_dhandle(session));
@@ -689,10 +689,10 @@ __wt_tiered_name(
 
     name = dhandle->name;
     /* Skip the prefix depending on what we're given. */
-    if (dhandle->type == WT_DHANDLE_TYPE_TIERED)
+    if (__wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_TIERED)
         WT_PREFIX_SKIP_REQUIRED(session, name, "tiered:");
     else {
-        WT_ASSERT(session, dhandle->type == WT_DHANDLE_TYPE_TIERED_TREE);
+        WT_ASSERT(session, __wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_TIERED_TREE);
         WT_ASSERT(session, !LF_ISSET(WT_TIERED_NAME_SHARED));
         WT_PREFIX_SKIP_REQUIRED(session, name, "tier:");
     }

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1157,7 +1157,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Reset the statistics tracked per checkpoint. */
     cache->evict_max_page_size = 0;
-    cache->evict_max_ms = 0;
+    __wt_atomic_store64(&cache->evict_max_ms, 0);
     cache->reentry_hs_eviction_ms = 0;
     conn->rec_maximum_hs_wrapup_milliseconds = 0;
     conn->rec_maximum_image_build_milliseconds = 0;

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1156,7 +1156,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     logging = FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED);
 
     /* Reset the statistics tracked per checkpoint. */
-    cache->evict_max_page_size = 0;
+    __wt_atomic_store64(&cache->evict_max_page_size, 0);
     __wt_atomic_store64(&cache->evict_max_ms, 0);
     cache->reentry_hs_eviction_ms = 0;
     conn->rec_maximum_hs_wrapup_milliseconds = 0;

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -545,7 +545,7 @@ __wt_txn_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_
          * connection close, only during a full checkpoint. A clean close may not update any
          * metadata LSN and we do not want to remove log files in that case.
          */
-        if (conn->hot_backup_start == 0 &&
+        if (__wt_atomic_load64(&conn->hot_backup_start) == 0 &&
           (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_RECOVER_DIRTY) ||
             FLD_ISSET(conn->log_flags, WT_CONN_LOG_FORCE_DOWNGRADE)) &&
           txn->full_ckpt)

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1668,7 +1668,7 @@ tasks:
       - func: "make check directory"
         vars:
           directory: examples/c
-          extra_args: -E "(ex_all|ex_backup|ex_backup_block)" -j ${num_jobs}
+          extra_args: -E "(ex_all|ex_backup_block)" -j ${num_jobs}
 
   - name: examples-c-production-disable-shared-test
     tags: ["pull_request"]

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -3,7 +3,8 @@
 # before running tests with TSan. history_size isn't required but it reduces the chance that TSan reports
 # an error that is missing information and the message "failed to restore the stack"
 
-# This function enables threads to set double values in a shared context, and catches all TSan warnings.
+# These functions enable threads to access double values in a shared context, and catch all TSan warnings.
+race:__wt_read_shared_double
 race:__wt_set_shared_double
 
 # Stats are allowed to be fuzzy. Ignore races in TSan

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -27,3 +27,26 @@ race:__ref_track_state
 
 # __wt_configure_method intentionally allows for races between threads to avoid the overhead of taking a lock on each API call.  
 race:__wt_configure_method
+
+# FIXME-WT-13074 This Work has been split out into a separate ticket to keep PR sizes down.
+race:__wt_calloc
+race:__sweep_mark
+race:__posix_file_close
+race:__log_newfile
+race:__handle_close
+race:__sweep_remove_handles
+race:__stash_discard
+race:__evict_lru_walk
+race:__log_file_server
+race:__tree_walk_internal
+race:__evict_queue_empty
+race:__evict_get_ref
+race:__evict_clear_all_walks
+race:__session_clear
+
+# FIXME-WT-13075 Address these warnings separately as they may have perf impacts
+race:hazard.c
+race:__wt_tree_modify_set
+race:__wt_cond_auto_wait_signal
+race:__wt_ref_addr_copy
+


### PR DESCRIPTION
Add `ex_backup` to the tsan tests and fix any resulting warnings.
This test triggered a large number of TSan warnings, so some warnings have been suppressed and will be handled in another ticket to keep PR sizes down. Some additional warnings touch performance critical paths and have been split off into a further ticket to be addressed independently.