### PR TITLE
WT-13101 Change FIXME to correct ticket number.

### DIFF
--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -22,7 +22,7 @@ metrics_monitor=
     ),
     stat_cache_size=
     (
-        # FIXME-WT-9339
+        # FIXME-WT-12931
         # Re-enable the runtime check once we manage cache better.
         max=200,
         runtime=false,


### PR DESCRIPTION
The original ticket was closed as a dup of the new ticket, and the FIXME got left.