### PR TITLE
WT-11218 Suppress MSan false positives by wrapping *stat functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,9 +142,8 @@ add_subdirectory(ext)
 # Collect all the library sources we need to compile from the source filelist.
 parse_filelist_source(${CMAKE_CURRENT_LIST_DIR}/dist/filelist wt_sources)
 
-# Only build msan_suppression_wrappers.c when compiling with MSan.
 if("${CMAKE_BUILD_TYPE}" MATCHES "^MSan$")
-    list(APPEND wt_sources ${CMAKE_SOURCE_DIR}/test/evergreen/msan_suppression_wrappers.c)
+    list(APPEND wt_sources ${CMAKE_SOURCE_DIR}/src/support/msan_fstat_suppression_wrappers.c)
 endif()
 
 if(WT_WIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,12 @@ add_subdirectory(ext)
 
 # Collect all the library sources we need to compile from the source filelist.
 parse_filelist_source(${CMAKE_CURRENT_LIST_DIR}/dist/filelist wt_sources)
+
+# Only build msan_suppression_wrappers.c when compiling with MSan.
+if("${CMAKE_BUILD_TYPE}" MATCHES "^MSan$")
+    list(APPEND wt_sources ${CMAKE_SOURCE_DIR}/test/evergreen/msan_suppression_wrappers.c)
+endif()
+
 if(WT_WIN)
     list(APPEND wt_source ${CMAKE_SOURCE_DIR}/cmake/configs/wiredtiger.def)
     set_source_files_properties(${CMAKE_SOURCE_DIR}/cmake/configs/wiredtiger.def PROPERTIES HEADER_FILE_ONLY TRUE)

--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -53,6 +53,14 @@ function(define_build_mode mode)
         set(CMAKE_REQUIRED_LIBRARIES "${DEFINE_BUILD_LIBS}")
         list(APPEND linker_flags "${DEFINE_BUILD_LIBS}")
     endif()
+
+    # FIXME-WT-13103 MSan reports false positives when using *stat functions, so we override 
+    # the wrap the functions with a custom implementation that suppresses the issue.
+    # Once the correction to MSan is available in LLVM 14 we can remove these flags.
+    if("${CMAKE_BUILD_TYPE}" MATCHES "^MSan$")
+        list(APPEND linker_flags "-Wl,--wrap=fstat, -Wl,--wrap=stat")
+    endif()
+
     # Check if the compiler flags are available to ensure its a valid build mode.
     if(DEFINE_BUILD_C_COMPILER_FLAGS)
         check_c_compiler_flag("${DEFINE_BUILD_C_COMPILER_FLAGS}" HAVE_BUILD_MODE_C_FLAGS)

--- a/dist/s_export
+++ b/dist/s_export
@@ -29,8 +29,8 @@ check()
     # Functions beginning with __ut are intentionally exposed to support unit testing when
     # Wiredtiger is compiled with HAVE_UNITTEST=1.
     grep -E -v '^__ut' |
-    # __wrap functions suppress MSan false positives. They're only present when compiled with MSan.
-    grep -E -v '^__wrap_' |
+    # __wrap_f?stat functions suppress MSan false positives. They're only present when compiled with MSan.
+    grep -E -v '^__wrap_f?stat' |
     # MSan injected symbol present when origin tracking is enabled.
     grep -E -v '^__msan_track_origins' |
     grep -E -vi '^__wt') |

--- a/dist/s_export
+++ b/dist/s_export
@@ -29,6 +29,8 @@ check()
     # Functions beginning with __ut are intentionally exposed to support unit testing when
     # Wiredtiger is compiled with HAVE_UNITTEST=1.
     grep -E -v '^__ut' |
+    # __wrap functions suppress MSan false positives. They're only present when compiled with MSan.
+    grep -E -v '^__wrap_' |
     # MSan injected symbol present when origin tracking is enabled.
     grep -E -v '^__msan_track_origins' |
     grep -E -vi '^__wt') |

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -207,6 +207,7 @@ Keyedness
 Kounavis
 LANGID
 LF
+LLVM
 LLVMFuzzerTestOneInput
 LOGOP
 LOGREC
@@ -451,6 +452,7 @@ WiredTigerLog
 WiredTigerPreplog
 WiredTigerTmplog
 WithSeeds
+Wl
 Wmissing
 WriteFile
 Wuninitialized
@@ -1009,6 +1011,7 @@ mn
 mnt
 mongod
 mrs
+msan
 msecs
 msg
 msvc

--- a/ext/storage_sources/dir_store/CMakeLists.txt
+++ b/ext/storage_sources/dir_store/CMakeLists.txt
@@ -1,6 +1,11 @@
 project(dir_store C)
 
 set(sources "dir_store.c")
+
+if("${CMAKE_BUILD_TYPE}" MATCHES "^MSan$")
+    list(APPEND sources ${CMAKE_SOURCE_DIR}/test/evergreen/msan_suppression_wrappers.c)
+endif()
+
 add_library(wiredtiger_dir_store MODULE ${sources})
 
 target_include_directories(

--- a/ext/storage_sources/dir_store/CMakeLists.txt
+++ b/ext/storage_sources/dir_store/CMakeLists.txt
@@ -3,7 +3,7 @@ project(dir_store C)
 set(sources "dir_store.c")
 
 if("${CMAKE_BUILD_TYPE}" MATCHES "^MSan$")
-    list(APPEND sources ${CMAKE_SOURCE_DIR}/test/evergreen/msan_suppression_wrappers.c)
+    list(APPEND sources ${CMAKE_SOURCE_DIR}/src/support/msan_fstat_suppression_wrappers.c)
 endif()
 
 add_library(wiredtiger_dir_store MODULE ${sources})

--- a/src/support/msan_fstat_suppression_wrappers.c
+++ b/src/support/msan_fstat_suppression_wrappers.c
@@ -27,9 +27,9 @@ extern int __real_fstat(int fd, struct stat *statbuf);
  * is built with MSan.
  */
 #ifndef __clang__
-#error "msan_suppression_wrappers.c should only be compiled with Clang"
+#error "msan_fstat_suppression_wrappers.c should only be compiled with Clang"
 #elif !__has_feature(memory_sanitizer)
-#error "msan_suppression_wrappers.c should only be compiled with MSan"
+#error "msan_fstat_suppression_wrappers.c should only be compiled with MSan"
 #endif
 
 /*

--- a/test/evergreen/msan_suppression_wrappers.c
+++ b/test/evergreen/msan_suppression_wrappers.c
@@ -32,6 +32,15 @@ extern int __real_fstat(int fd, struct stat *statbuf);
 #error "msan_suppression_wrappers.c should only be compiled with MSan"
 #endif
 
+/*
+ * We've already checked that we're building with Clang above. LLVM and Clang versions are identical
+ * so Clang 14+ implies we're building with LLVM 14+.
+ */
+#if __clang_major__ >= 14
+#pragma message( \
+  "Building with Clang 14 or later. Please check if we can close WT-13103 and delete this file.")
+#endif
+
 int __wrap_stat(const char *path, struct stat *buf);
 int __wrap_fstat(int fd, struct stat *buf);
 

--- a/test/evergreen/msan_suppression_wrappers.c
+++ b/test/evergreen/msan_suppression_wrappers.c
@@ -1,0 +1,58 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <sys/stat.h>
+#include "string.h"
+
+/*
+ * FIXME-WT-13103 If you add this file to the list of compiled sources and build with the
+ * `-Wl,--wrap=XXX` linker flag the compiler will wrap calls to function XXX with the respective
+ * __wrap_XXX function defined below. We need this because MSan reports false positives when setting
+ * memory via *stat() calls, so we've defined __wrap_*stat functions that first zero the memory to
+ * suppress the false positive. Once WiredTiger's minimum supported LLVM version is 14 this fix
+ * (https://github.com/llvm/llvm-project/commit/4e1a6c07052b466a2a1cd0c3ff150e4e89a6d87a) is
+ * available and this file can be deleted.
+ */
+
+extern int __real_stat(const char *path, struct stat *buf);
+extern int __real_fstat(int fd, struct stat *statbuf);
+
+/*
+ * MSan is only supported on Clang and these __wrap_* functions should only be used when WiredTiger
+ * is built with MSan.
+ */
+#ifndef __clang__
+#error "msan_suppression_wrappers.c should only be compiled with Clang"
+#elif !__has_feature(memory_sanitizer)
+#error "msan_suppression_wrappers.c should only be compiled with MSan"
+#endif
+
+int __wrap_stat(const char *path, struct stat *buf);
+int __wrap_fstat(int fd, struct stat *buf);
+
+/*
+ * __wrap_stat --
+ *     Zero out memory before setting it with stat(). This suppresses an MSan false positive.
+ */
+int
+__wrap_stat(const char *path, struct stat *buf)
+{
+    memset(buf, 0, sizeof(*buf));
+    return (__real_stat(path, buf));
+}
+
+/*
+ * __wrap_fstat --
+ *     Zero out memory before setting it with fstat(). This suppresses an MSan false positive.
+ */
+int
+__wrap_fstat(int fd, struct stat *buf)
+{
+    memset(buf, 0, sizeof(*buf));
+    return (__real_fstat(fd, buf));
+}


### PR DESCRIPTION
Add logic to wrap `*stat()` calls and zero out memory first. This is done to suppress false positives reported by MSan and only applies when building with `CMAKE_BUILD_TYPE=MSan`. It can be removed once our minimum supported LLVM version is 14
