### PR TITLE
WT-13116: adjust wtperf pause sleep 2 usleep

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -436,7 +436,7 @@ worker(void *arg)
 
     while (!wtperf->stop) {
         if (workload->pause != 0)
-            (void)sleep((unsigned int)workload->pause);
+            (void)usleep((unsigned int)workload->pause);
         /*
          * Generate the next key and setup operation specific statistics tracking objects.
          */


### PR DESCRIPTION
The normal process for MongoDB to access WT is: client-- >Mongo server----->wiredtiger

Our wtperf test flow is missing the following link :client-- >Mongo server, so we can simulate the client-- >Mongo server time with the pause configuration.

However, the unit of pause is second, which does not conform to the normal client- >Mongo server time.