### PR TITLE
WT-10994 Prevent user creating a bulk cursor when a transaction is running (#9102) (v7.0 backport)

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1130,6 +1130,9 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, c
             WT_RET_MSG(session, EINVAL, "Value for 'bulk' must be a boolean or 'bitmap'");
 
         if (bulk) {
+            if (F_ISSET(session->txn, WT_TXN_RUNNING))
+                WT_RET_MSG(session, EINVAL, "Bulk cursors can't be opened inside a transaction");
+
             WT_RET(__wt_config_gets(session, cfg, "checkpoint_wait", &cval));
             checkpoint_wait = cval.val != 0;
         }


### PR DESCRIPTION
This PR contains changes (plus associated tests) to:
* Prevent user creating a bulk cursor when a transaction is running

(cherry picked from commit b66c52a0deaf7a2f45ea40100d40b352e2a11ab8)