### PR TITLE
WT-13124 Give WT_INTL_INDEX_GET acquire semantics, add TSan support

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -376,7 +376,8 @@ __free_page_int(WT_SESSION_IMPL *session, WT_PAGE *page)
     WT_PAGE_INDEX *pindex;
     uint32_t i;
 
-    for (pindex = WT_INTL_INDEX_GET_SAFE(page), i = 0; i < pindex->entries; ++i)
+    WT_INTL_INDEX_GET_SAFE(page, pindex);
+    for (i = 0; i < pindex->entries; ++i)
         __wti_free_ref(session, pindex->index[i], page->type, false);
 
     __wt_free(session, pindex);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -728,7 +728,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
         WT_ERR(__wt_page_alloc(session, WT_PAGE_COL_INT, 1, true, &root));
         root->pg_intl_parent_ref = &btree->root;
 
-        pindex = WT_INTL_INDEX_GET_SAFE(root);
+        WT_INTL_INDEX_GET_SAFE(root, pindex);
         ref = pindex->index[0];
         ref->home = root;
         ref->page = NULL;
@@ -741,7 +741,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool creation)
         WT_ERR(__wt_page_alloc(session, WT_PAGE_ROW_INT, 1, true, &root));
         root->pg_intl_parent_ref = &btree->root;
 
-        pindex = WT_INTL_INDEX_GET_SAFE(root);
+        WT_INTL_INDEX_GET_SAFE(root, pindex);
         ref = pindex->index[0];
         ref->home = root;
         ref->page = NULL;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -90,7 +90,8 @@ __wt_page_alloc(
             }
         if (0) {
 err:
-            if ((pindex = WT_INTL_INDEX_GET_SAFE(page)) != NULL) {
+            WT_INTL_INDEX_GET_SAFE(page, pindex);
+            if (pindex != NULL) {
                 for (i = 0; i < pindex->entries; ++i)
                     __wt_free(session, pindex->index[i]);
                 __wt_free(session, pindex);
@@ -693,7 +694,7 @@ __inmem_col_int(WT_SESSION_IMPL *session, WT_PAGE *page, uint64_t page_recno)
      * Walk the page, building references: the page contains value items. The value items are
      * on-page items (WT_CELL_VALUE).
      */
-    pindex = WT_INTL_INDEX_GET_SAFE(page);
+    WT_INTL_INDEX_GET_SAFE(page, pindex);
     refp = pindex->index;
     hint = 0;
     WT_CELL_FOREACH_ADDR (session, page->dsk, unpack) {
@@ -840,7 +841,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
      * Walk the page, instantiating keys: the page contains sorted key and location cookie pairs.
      * Keys are on-page/overflow items and location cookies are WT_CELL_ADDR_XXX items.
      */
-    pindex = WT_INTL_INDEX_GET_SAFE(page);
+    WT_INTL_INDEX_GET_SAFE(page, pindex);
     refp = pindex->index;
     overflow_keys = false;
     hint = 0;

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -1214,7 +1214,7 @@ __slvg_col_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
     WT_RET(__wt_page_alloc(session, WT_PAGE_COL_INT, leaf_cnt, true, &page));
     WT_ERR(__slvg_modify_init(session, page));
 
-    pindex = WT_INTL_INDEX_GET_SAFE(page);
+    WT_INTL_INDEX_GET_SAFE(page, pindex);
     for (refp = pindex->index, i = 0; i < ss->pages_next; ++i) {
         if ((trk = ss->pages[i]) == NULL)
             continue;
@@ -1820,7 +1820,7 @@ __slvg_row_build_internal(WT_SESSION_IMPL *session, uint32_t leaf_cnt, WT_STUFF 
     WT_RET(__wt_page_alloc(session, WT_PAGE_ROW_INT, leaf_cnt, true, &page));
     WT_ERR(__slvg_modify_init(session, page));
 
-    pindex = WT_INTL_INDEX_GET_SAFE(page);
+    WT_INTL_INDEX_GET_SAFE(page, pindex);
     for (refp = pindex->index, i = 0; i < ss->pages_next; ++i) {
         if ((trk = ss->pages[i]) == NULL)
             continue;

--- a/src/evict/evict_stat.c
+++ b/src/evict/evict_stat.c
@@ -135,7 +135,7 @@ __wt_curstat_cache_walk(WT_SESSION_IMPL *session)
       session, cache_state_gen_current, __wt_atomic_load64(&conn->cache->evict_pass_gen));
 
     /* Root page statistics */
-    root_idx = WT_INTL_INDEX_GET_SAFE(btree->root.page);
+    WT_INTL_INDEX_GET_SAFE(btree->root.page, root_idx);
     WT_STAT_DSRC_SET(session, cache_state_root_entries, root_idx->entries);
     WT_STAT_DSRC_SET(
       session, cache_state_root_size, __wt_atomic_loadsize(&btree->root.page->memory_footprint));

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -630,8 +630,8 @@ struct __wt_page {
         WT_ASSERT(session, __wt_session_gen(session, WT_GEN_SPLIT) != 0); \
         WT_INTL_INDEX_GET_SAFE(page, (pindex));                           \
     } while (0)
-#define WT_INTL_INDEX_SET(page, v)                                       \
-    do {                                                                 \
+#define WT_INTL_INDEX_SET(page, v)                                        \
+    do {                                                                  \
         __atomic_store_n(&(page)->u.intl.__index, (v), __ATOMIC_RELEASE); \
     } while (0)
 #else

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -616,11 +616,15 @@ struct __wt_page {
  * but it's not always required: for example, if a page is locked for splitting, or being created or
  * destroyed.
  */
-#define WT_INTL_INDEX_GET_SAFE(page) __wt_atomic_load_pointer(&(page)->u.intl.__index)
+#define WT_INTL_INDEX_GET_SAFE(page, pindex)                          \
+    do {                                                              \
+        WT_ACQUIRE_BARRIER();                                         \
+        (pindex) = __wt_atomic_load_pointer(&(page)->u.intl.__index); \
+    } while (0)
 #define WT_INTL_INDEX_GET(session, page, pindex)                          \
     do {                                                                  \
         WT_ASSERT(session, __wt_session_gen(session, WT_GEN_SPLIT) != 0); \
-        (pindex) = WT_INTL_INDEX_GET_SAFE(page);                          \
+        WT_INTL_INDEX_GET_SAFE(page, (pindex));                           \
     } while (0)
 #define WT_INTL_INDEX_SET(page, v)                               \
     do {                                                         \

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -635,11 +635,7 @@ struct __wt_page {
         __atomic_store_n(&(page)->u.intl.__index, (v), __ATOMIC_RELEASE); \
     } while (0)
 #else
-#define WT_INTL_INDEX_GET_SAFE(page, pindex)                          \
-    do {                                                              \
-        WT_ACQUIRE_BARRIER();                                         \
-        (pindex) = __wt_atomic_load_pointer(&(page)->u.intl.__index); \
-    } while (0)
+#define WT_INTL_INDEX_GET_SAFE(page, pindex) WT_ACQUIRE_READ((pindex), (page)->u.intl.__index)
 #define WT_INTL_INDEX_GET(session, page, pindex)                          \
     do {                                                                  \
         WT_ASSERT(session, __wt_session_gen(session, WT_GEN_SPLIT) != 0); \

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -635,6 +635,7 @@ struct __wt_page {
         __atomic_store_n(&(page)->u.intl.__index, (v), __ATOMIC_RELEASE); \
     } while (0)
 #else
+/* Use WT_ACQUIRE_READ to enforce acquire semantics rather than relying on address dependencies. */
 #define WT_INTL_INDEX_GET_SAFE(page, pindex) WT_ACQUIRE_READ((pindex), (page)->u.intl.__index)
 #define WT_INTL_INDEX_GET(session, page, pindex)                          \
     do {                                                                  \

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2217,7 +2217,7 @@ __wt_bulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
      * Get a reference to the empty leaf page; we have exclusive access so we can take a copy of the
      * page, confident the parent won't split.
      */
-    pindex = WT_INTL_INDEX_GET_SAFE(btree->root.page);
+    WT_INTL_INDEX_GET_SAFE(btree->root.page, pindex);
     cbulk->ref = pindex->index[0];
     cbulk->leaf = cbulk->ref->page;
 

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -29,7 +29,10 @@ race:__ref_track_state
 race:__wt_configure_method
 
 # FIXME-WT-13074 This Work has been split out into a separate ticket to keep PR sizes down.
-race:__wt_calloc
+race:__wt_free_int
+race:__wt_free_update_list
+race:__wt_page_out
+race:__read_blocked
 race:__sweep_mark
 race:__posix_file_close
 race:__log_newfile


### PR DESCRIPTION
Update `WT_INTL_INDEX_GET_SAFE` to add an `ACQUIRE_BARRIER` that pairs with the `RELEASE_BARRIER` already present in `WT_INTL_INDEX_SET`. 

This change also adds a TSan compatible implementation of the `WT_INTL_INDEX_*` macros which use __atomics instead of barriers. The semantics of both implementations are identical, but __atomics can be understood by TSan.