### PR TITLE
WT-13130 On ARM64 utilize the process frequency register

### DIFF
--- a/dist/filelist
+++ b/dist/filelist
@@ -113,6 +113,7 @@ src/history/hs_conn.c
 src/history/hs_cursor.c
 src/history/hs_rec.c
 src/history/hs_verify.c
+src/hw/aarch64.c            ARM64_HOST
 src/log/log.c
 src/log/log_auto.c
 src/log/log_slot.c

--- a/src/hw/aarch64.c
+++ b/src/hw/aarch64.c
@@ -12,24 +12,17 @@
  * __aarch64_nsec_per_tick --
  *     Return the nsec/tick calculated using the cntfrq_el0 register.
  */
-static double
-__aarch64_nsec_per_tick(void)
+static uint64_t
+__aarch64_proc_freq_hz(void)
 {
-    static const double NSEC_PER_SEC = 1.e9;
     uint64_t freq;
-
-    __asm__ volatile("\tmrs\t%0, cntfrq_el0\n" : "=r"(freq));
-
     /*
      * The Armv8-A documentation warns that on a WARM reset the register is set to "an
      * architecturally UNKNOWN value". We assume the OS will take care of that scenario, but protect
      * against div 0 out of an abundance of caution.
      */
-    if (freq == 0)
-        return (0.0);
-
-    /* The reported frequency is in Hz. */
-    return (freq / NSEC_PER_SEC);
+    __asm__ volatile("\tmrs\t%0, cntfrq_el0\n" : "=r"(freq));
+    return (freq);
 }
 
-double __wti_hw_nsec_per_tick(void) __attribute__((weak, alias("__aarch64_nsec_per_tick")));
+uint64_t __wti_hw_proc_freq_hz(void) __attribute__((weak, alias("__aarch64_proc_freq_hz")));

--- a/src/hw/aarch64.c
+++ b/src/hw/aarch64.c
@@ -1,0 +1,35 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+#include <stdint.h>
+#include <math.h>
+
+/*
+ * __aarch64_nsec_per_tick --
+ *     Return the nsec/tick calculated using the cntfrq_el0 register.
+ */
+static double
+__aarch64_nsec_per_tick(void)
+{
+    static const double NSEC_PER_SEC = 1.e9;
+    uint64_t freq;
+
+    __asm__ volatile("\tmrs\t%0, cntfrq_el0\n" : "=r"(freq));
+
+    /*
+     * The Armv8-A documentation warns that on a WARM reset the register is set to "an
+     * architecturally UNKNOWN value". We assume the OS will take care of that scenario, but protect
+     * against div 0 out of an abundance of caution.
+     */
+    if (freq == 0)
+        return (0.0);
+
+    /* The reported frequency is in Hz. */
+    return (freq / NSEC_PER_SEC);
+}
+
+void __wti_hw_nsec_per_tick(void) __attribute__((weak, alias("__aarch64_nsec_per_tick")));

--- a/src/hw/aarch64.c
+++ b/src/hw/aarch64.c
@@ -32,4 +32,4 @@ __aarch64_nsec_per_tick(void)
     return (freq / NSEC_PER_SEC);
 }
 
-void __wti_hw_nsec_per_tick(void) __attribute__((weak, alias("__aarch64_nsec_per_tick")));
+double __wti_hw_nsec_per_tick(void) __attribute__((weak, alias("__aarch64_nsec_per_tick")));

--- a/src/include/hw.h
+++ b/src/include/hw.h
@@ -1,0 +1,15 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+#pragma once
+
+/*
+ * -- __wti_hw_nsec_per_tick
+ *      Return the number of nanoseconds per cpu "tick". If the value is unknown
+ *      the function returns 0.
+ */
+double __wti_hw_nsec_per_tick(void);

--- a/src/include/hw.h
+++ b/src/include/hw.h
@@ -8,8 +8,8 @@
 #pragma once
 
 /*
- * -- __wti_hw_nsec_per_tick
+ * -- __wti_hw_proc_freq_hz
  *      Return the number of nanoseconds per cpu "tick". If the value is unknown
  *      the function returns 0.
  */
-double __wti_hw_nsec_per_tick(void);
+uint64_t __wti_hw_proc_freq_hz(void);

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -140,7 +140,6 @@ __global_calibrate_tick_ratio(void)
 static void
 __global_config_tsc_nsec_ratio(void)
 {
-    static const double NSEC_PER_SEC = 1.e9;
     /*
      * Default to using __wt_epoch until we have a good value for the ratio.
      */
@@ -151,6 +150,7 @@ __global_config_tsc_nsec_ratio(void)
     __global_calibrate_tick_ratio();
 #elif defined(__aarch64__)
     {
+        static const double NSEC_PER_SEC = 1.e9;
         uint64_t hz;
         hz = __wti_hw_proc_freq_hz();
         if (hz != 0) {

--- a/src/support/global.c
+++ b/src/support/global.c
@@ -140,6 +140,7 @@ __global_calibrate_tick_ratio(void)
 static void
 __global_config_tsc_nsec_ratio(void)
 {
+    static const double NSEC_PER_SEC = 1.e9;
     /*
      * Default to using __wt_epoch until we have a good value for the ratio.
      */
@@ -150,9 +151,10 @@ __global_config_tsc_nsec_ratio(void)
     __global_calibrate_tick_ratio();
 #elif defined(__aarch64__)
     {
-        double nsec_per_tick = __wti_hw_nsec_per_tick();
-        if (nsec_per_tick > 0.0) {
-            __wt_process.tsc_nsec_ratio = nsec_per_tick;
+        uint64_t hz;
+        hz = __wti_hw_proc_freq_hz();
+        if (hz != 0) {
+            __wt_process.tsc_nsec_ratio = __wti_hw_proc_freq_hz() / NSEC_PER_SEC;
             __wt_process.use_epochtime = false;
         } else {
             __global_calibrate_tick_ratio();

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -426,3 +426,11 @@ define_c_test(
     ARGUMENTS
     DEPENDS "WT_POSIX"
 )
+
+define_c_test(
+    TARGET tsc_ratio
+    SOURCES tsc_ratio/main.c
+    DIR_NAME tsc_ratio
+    ARGUMENTS
+    DEPENDS "WT_POSIX"
+)

--- a/test/csuite/tsc_ratio/main.c
+++ b/test/csuite/tsc_ratio/main.c
@@ -1,0 +1,64 @@
+#include <math.h>
+
+#include "test_util.h"
+
+/*
+ * main --
+ *     Initialize the library and if it determines a tick -> nsec ratio, test that ratio looks
+ *     reasonable.
+ */
+int
+main(int argc, char *argv[])
+{
+    static double NSEC_PER_SEC = 1.e9;
+
+    /* Maximum number of attempts to find the smallest error. */
+    static const int ATTEMPT_MAX = 3;
+
+    /* Maximum acceptable error as a fraction of measurement. */
+    static double ERR_TOLERANCE = 0.001;
+
+    TEST_OPTS *opts, _opts;
+    uint64_t tick_start, tick_stop;
+    double elapsed_nsec, diff_nsec, err, min_err;
+    int i;
+
+    opts = &_opts;
+    memset(opts, 0, sizeof(*opts));
+    testutil_check(testutil_parse_opts(argc, argv, opts));
+
+    testutil_assert(__wt_library_init() == 0);
+
+    if (__wt_process.use_epochtime) {
+        if (opts->verbose)
+            printf("tsc -> nsec not support on this platform.");
+        goto exit_test;
+    }
+
+    if (opts->verbose)
+        printf("nsec/tick ratio = %.6g\n", __wt_process.tsc_nsec_ratio);
+
+    min_err = DBL_MAX;
+    for (i = 0; i < ATTEMPT_MAX; i++) {
+        tick_start = __wt_rdtsc();
+        __wt_sleep(1, 0);
+        tick_stop = __wt_rdtsc();
+
+        elapsed_nsec = __wt_clock_to_nsec(tick_stop, tick_start);
+
+        diff_nsec = (double)elapsed_nsec - NSEC_PER_SEC;
+        err = fabs(diff_nsec / NSEC_PER_SEC);
+
+        if (opts->verbose)
+            printf("attempt=%d  period(ns)=%8g  actual(ns)=%8g  diff(ns)=%8g  error(ns)=%8g\n",
+              i + 1, NSEC_PER_SEC, elapsed_nsec, diff_nsec, err);
+
+        min_err = WT_MIN(err, min_err);
+    }
+
+    testutil_assert(min_err < ERR_TOLERANCE);
+
+exit_test:
+    testutil_cleanup(opts);
+    return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
Utilize the cntfrq_el0 on Aarch64 Armv8 to calculate the ticks to nsec ratio.

Add a unit test to ensure the tick to nsec ratio is representative.