### PR TITLE
WT-12917 Fix a race condtion and a memory corruption in __rts_btree_abort_ondisk_kv

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -539,7 +539,7 @@ __instantiate_col_var(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_DELETED *pa
                 WT_ASSERT(session, cbt.slot == WT_COL_SLOT(page, cip));
 
                 /* Attach the tombstone, using the update-restore path. */
-                WT_ERR(__wt_col_modify(&cbt, recno + j, NULL, upd, WT_UPDATE_INVALID, true, true));
+                WT_ERR(__wt_col_modify(&cbt, recno + j, NULL, &upd, WT_UPDATE_INVALID, true, true));
                 /* Null the pointer so we don't free it twice. */
                 upd = NULL;
             }

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -201,7 +201,7 @@ __page_inmem_prepare_update_col(WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR
 
     /* Search the page and apply the modification. */
     WT_RET(__wt_col_search(cbt, recno, ref, true, NULL));
-    WT_RET(__wt_col_modify(cbt, recno, NULL, *updp, WT_UPDATE_INVALID, true, true));
+    WT_RET(__wt_col_modify(cbt, recno, NULL, updp, WT_UPDATE_INVALID, true, true));
     return (0);
 }
 
@@ -307,7 +307,7 @@ __wti_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
 
             /* Search the page and apply the modification. */
             WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
-            WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true, true));
+            WT_ERR(__wt_row_modify(&cbt, key, NULL, &upd, WT_UPDATE_INVALID, true, true));
             upd = NULL;
         }
     }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1498,7 +1498,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             WT_ERR(__wt_col_search(&cbt, recno, ref, true, NULL));
 
             /* Apply the modification. */
-            WT_ERR(__wt_col_modify(&cbt, recno, NULL, upd, WT_UPDATE_INVALID, true, true));
+            WT_ERR(__wt_col_modify(&cbt, recno, NULL, &upd, WT_UPDATE_INVALID, true, true));
             break;
         case WT_PAGE_ROW_LEAF:
             /* Build a key. */
@@ -1513,7 +1513,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
 
             /* Apply the modification. */
-            WT_ERR(__wt_row_modify(&cbt, key, NULL, upd, WT_UPDATE_INVALID, true, true));
+            WT_ERR(__wt_row_modify(&cbt, key, NULL, &upd, WT_UPDATE_INVALID, true, true));
             break;
         default:
             WT_ERR(__wt_illegal_value(session, orig->type));

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -311,7 +311,10 @@ err:
         }
     }
 
-    /* If upd was freed, set the update argument to NULL to prevent use after free. */
+    /*
+     * If upd was freed or if we know that its ownership was moved to a page, set the update
+     * argument to NULL to prevent future use by the caller.
+     */
     if (upd == NULL && updp_arg != NULL)
         *updp_arg = NULL;
 

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -309,14 +309,14 @@ err:
             if (last_upd != NULL)
                 last_upd->next = NULL;
         }
-    }
 
-    /*
-     * If upd was freed or if we know that its ownership was moved to a page, set the update
-     * argument to NULL to prevent future use by the caller.
-     */
-    if (upd == NULL && updp_arg != NULL)
-        *updp_arg = NULL;
+        /*
+         * If upd was freed or if we know that its ownership was moved to a page, set the update
+         * argument to NULL to prevent future use by the caller.
+         */
+        if (upd == NULL && updp_arg != NULL)
+            *updp_arg = NULL;
+    }
 
     return (ret);
 }

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -15,7 +15,7 @@ static int __col_insert_alloc(WT_SESSION_IMPL *, uint64_t, u_int, WT_INSERT **, 
  *     Column-store delete, insert, and update.
  */
 int
-__wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_UPDATE *upd_arg,
+__wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_UPDATE **updp_arg,
   u_int modify_type, bool exclusive, bool restore)
 {
     WT_BTREE *btree;
@@ -25,7 +25,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
     WT_SESSION_IMPL *session;
-    WT_UPDATE *last_upd, *old_upd, *upd;
+    WT_UPDATE *last_upd, *old_upd, *upd, *upd_arg;
     wt_timestamp_t prev_upd_ts;
     size_t ins_size, upd_size;
     u_int i, skipdepth;
@@ -36,6 +36,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
     page = cbt->ref->page;
     session = CUR2S(cbt);
     last_upd = NULL;
+    upd_arg = updp_arg == NULL ? NULL : *updp_arg;
     upd = upd_arg;
     prev_upd_ts = WT_TS_NONE;
     added_to_txn = append = inserted_to_update_chain = false;
@@ -309,6 +310,10 @@ err:
                 last_upd->next = NULL;
         }
     }
+
+    /* If upd was freed, set the update argument to NULL to prevent use after free. */
+    if (upd == NULL && updp_arg != NULL)
+        *updp_arg = NULL;
 
     return (ret);
 }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -332,7 +332,10 @@ err:
         }
     }
 
-    /* If upd was freed, set the update argument to NULL to prevent use after free. */
+    /*
+     * If upd was freed or if we know that its ownership was moved to a page, set the update
+     * argument to NULL to prevent future use by the caller.
+     */
     if (upd == NULL && updp_arg != NULL)
         *updp_arg = NULL;
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -69,8 +69,8 @@ __row_insert_alloc(WT_SESSION_IMPL *session, const WT_ITEM *key, u_int skipdepth
  *     Row-store insert, update and delete.
  */
 int
-__wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, WT_UPDATE *upd_arg,
-  u_int modify_type, bool exclusive, bool restore)
+__wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
+  WT_UPDATE **updp_arg, u_int modify_type, bool exclusive, bool restore)
 {
     WT_DECL_RET;
     WT_INSERT *ins;
@@ -78,7 +78,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
     WT_SESSION_IMPL *session;
-    WT_UPDATE *last_upd, *old_upd, *upd, **upd_entry;
+    WT_UPDATE *last_upd, *old_upd, *upd, *upd_arg, **upd_entry;
     wt_timestamp_t prev_upd_ts;
     size_t ins_size, upd_size;
     uint32_t ins_slot;
@@ -89,6 +89,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value, 
     page = cbt->ref->page;
     session = CUR2S(cbt);
     last_upd = NULL;
+    upd_arg = updp_arg == NULL ? NULL : *updp_arg;
     upd = upd_arg;
     prev_upd_ts = WT_TS_NONE;
     added_to_txn = inserted_to_update_chain = false;
@@ -330,6 +331,10 @@ err:
                 last_upd->next = NULL;
         }
     }
+
+    /* If upd was freed, set the update argument to NULL to prevent use after free. */
+    if (upd == NULL && updp_arg != NULL)
+        *updp_arg = NULL;
 
     return (ret);
 }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -330,14 +330,14 @@ err:
             if (last_upd != NULL)
                 last_upd->next = NULL;
         }
-    }
 
-    /*
-     * If upd was freed or if we know that its ownership was moved to a page, set the update
-     * argument to NULL to prevent future use by the caller.
-     */
-    if (upd == NULL && updp_arg != NULL)
-        *updp_arg = NULL;
+        /*
+         * If upd was freed or if we know that its ownership was moved to a page, set the update
+         * argument to NULL to prevent future use by the caller.
+         */
+        if (upd == NULL && updp_arg != NULL)
+            *updp_arg = NULL;
+    }
 
     return (ret);
 }

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -26,8 +26,8 @@ __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
      * ensure that we're locking when inserting new keys to an insert list.
      */
     WT_WITH_BTREE(CUR2S(hs_cbt), CUR2BT(hs_cbt),
-      ret =
-        __wt_row_modify(hs_cbt, &hs_cbt->iface.key, NULL, hs_upd, WT_UPDATE_INVALID, false, false));
+      ret = __wt_row_modify(
+        hs_cbt, &hs_cbt->iface.key, NULL, &hs_upd, WT_UPDATE_INVALID, false, false));
     return (ret);
 }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -349,7 +349,7 @@ extern int __wt_close_connection_close(WT_SESSION_IMPL *session)
 extern int __wt_clsm_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value,
-  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive, bool restore)
+  WT_UPDATE **updp_arg, u_int modify_type, bool exclusive, bool restore)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_col_search(WT_CURSOR_BTREE *cbt, uint64_t search_recno, WT_REF *leaf,
   bool leaf_safe, bool *leaf_foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1049,7 +1049,7 @@ extern int __wt_row_leaf_key_copy(WT_SESSION_IMPL *session, WT_PAGE *page, WT_RO
 extern int __wt_row_leaf_key_work(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip_arg,
   WT_ITEM *keyb, bool instantiate) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
-  WT_UPDATE *upd_arg, u_int modify_type, bool exclusive, bool restore)
+  WT_UPDATE **updp_arg, u_int modify_type, bool exclusive, bool restore)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_row_search(WT_CURSOR_BTREE *cbt, WT_ITEM *srch_key, bool insert, WT_REF *leaf,
   bool leaf_safe, bool *leaf_foundp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -781,6 +781,9 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
      * __wti_rec_hs_clear_on_tombstone also removes the corresponding entries from the history
      * store, which is necessary for correctness. If the two threads try to remove the same history
      * store key at around the same time, we could get a WT_NOTFOUND here.
+     *
+     * FIXME-WT-13198: Check if this race can be avoided, in which case we can remove the check for
+     * WT_NOTFOUND and treat it like other errors.
      */
     if (rip != NULL)
         WT_ERR_NOTFOUND_OK(__rts_btree_row_modify(session, ref, &upd, key), true);

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -775,10 +775,21 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
       upd->type == WT_UPDATE_TOMBSTONE ? "true" : "false",
       __wt_key_string(session, key->data, key->size, S2BT(session)->key_format, key_string));
 
+    /*
+     * It is possible for both RTS and the eviction thread to remove entries from the history store
+     * at the same time: When we evict a key with a tombstone with durable timestamp "none,"
+     * __wti_rec_hs_clear_on_tombstone also removes the corresponding entries from the history
+     * store, which is necessary for correctness. If the two threads try to remove the same history
+     * store key at around the same time, we could get a WT_NOTFOUND here.
+     */
     if (rip != NULL)
-        WT_ERR(__rts_btree_row_modify(session, ref, &upd, key));
+        WT_ERR_NOTFOUND_OK(__rts_btree_row_modify(session, ref, &upd, key), true);
     else
-        WT_ERR(__rts_btree_col_modify(session, ref, &upd, recno));
+        WT_ERR_NOTFOUND_OK(__rts_btree_col_modify(session, ref, &upd, recno), true);
+    if (ret == WT_NOTFOUND && WT_IS_HS(session->dhandle))
+        ret = 0;
+    else
+        WT_ERR(ret);
 
     if (S2C(session)->rts->dryrun) {
 err:

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -124,23 +124,27 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_DECL_RET;
     WT_REF *ref;
     WT_TIMER timer;
+    uint32_t flags;
     uint64_t msg_count;
 
     __wt_timer_start(session, &timer);
+    flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
     msg_count = 0;
 
     /* Walk the tree, marking commits aborted where appropriate. */
     ref = NULL;
-    while (
-      (ret = __wt_tree_walk_custom_skip(session, &ref, __rts_btree_walk_page_skip,
-         &rollback_timestamp,
-         WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED)) == 0 &&
+    while ((ret = __wt_tree_walk_custom_skip(
+              session, &ref, __rts_btree_walk_page_skip, &rollback_timestamp, flags)) == 0 &&
       ref != NULL) {
         __wti_rts_progress_msg(session, &timer, 0, 0, &msg_count, true);
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))
-            WT_RET(__wti_rts_btree_abort_updates(session, ref, rollback_timestamp));
+            WT_ERR(__wti_rts_btree_abort_updates(session, ref, rollback_timestamp));
     }
+
+err:
+    /* On error, clear any left-over tree walk. */
+    WT_TRET(__wt_page_release(session, ref, flags));
     return (ret);
 }
 

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -124,8 +124,8 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_DECL_RET;
     WT_REF *ref;
     WT_TIMER timer;
-    uint32_t flags;
     uint64_t msg_count;
+    uint32_t flags;
 
     __wt_timer_start(session, &timer);
     flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1193,8 +1193,8 @@ __txn_append_tombstone(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_CURSOR_BTREE 
     WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &not_used));
     WT_WITH_BTREE(session, op->btree,
       ret = btree->type == BTREE_ROW ?
-        __wt_row_modify(cbt, &cbt->iface.key, NULL, tombstone, WT_UPDATE_INVALID, false, false) :
-        __wt_col_modify(cbt, cbt->recno, NULL, tombstone, WT_UPDATE_INVALID, false, false));
+        __wt_row_modify(cbt, &cbt->iface.key, NULL, &tombstone, WT_UPDATE_INVALID, false, false) :
+        __wt_col_modify(cbt, cbt->recno, NULL, &tombstone, WT_UPDATE_INVALID, false, false));
     WT_ERR(ret);
     tombstone = NULL;
 


### PR DESCRIPTION
This PR fixes the following three bugs in RTS:

1. A double-free if adding a tombstone via `__wt_update_serial` fails, in which case both `__wt_update_serial` and `__rts_btree_abort_ondisk_kv` would both free the same tombstone. This was fixed by making the `upd_arg` argument of `__wt_col_modify` and `__wt_row_modify` to be a double-star pointer; freeing the update would set the update to NULL, so that the caller would not also try to free it.
2. An error in `__rts_btree_walk` would leave an acquired hazard pointer behind. This was fixed by calling `__wt_page_release` during cleanup.
3. A race condition in `__rts_btree_abort_ondisk_kv`, in which case an RTS pass over the HS could race with `__wti_rec_hs_clear_on_tombstone`. Please refer to the ticket and the block comment in `__rts_btree_abort_ondisk_kv` for details.