### PR TITLE
WT-12940 Upload failing test/model workloads to Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -15,6 +15,7 @@ post:
   - func: "dump stacktraces"
   - func: "upload stacktraces"
   - func: "upload test/format config"
+  - func: "upload test/model workloads"
   - func: "dump stderr/stdout"
   - func: "upload artifact"
     vars:
@@ -396,6 +397,19 @@ functions:
       aws_key: ${aws_key}
       local_files_include_filter:
         - wiredtiger/cmake_build/test/format/RUNDIR*/CONFIG
+      bucket: build_external
+      permissions: public-read
+      content_type: text/plain
+      remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}/
+      preserve_path: true
+  "upload test/model workloads":
+    command: s3.put
+    type: setup
+    params:
+      aws_secret: ${aws_secret}
+      aws_key: ${aws_key}
+      local_files_include_filter:
+        - wiredtiger/cmake_build/test/model/tools/WT_TEST*/*.workload
       bucket: build_external
       permissions: public-read
       content_type: text/plain
@@ -3826,6 +3840,12 @@ tasks:
             # Keep repeating the model test for 30 minutes
             ./model_test -l 2000-3000 -t 1800
 
+            # Print the reduced failed workload to make it easy to grab from the logs:
+            if [ -f WT_TEST/reduced.workload ]; then
+              echo "Failed workload:"
+              cat WT_TEST/reduced.workload
+            fi
+
   - name: model-test-long-with-coverage
     tags: ["model_checking"]
     commands:
@@ -3854,6 +3874,12 @@ tasks:
 
             # Keep repeating the model test for 600 seconds
             ./model_test -l 2000-3000 -t 600
+
+            # Print the reduced failed workload to make it easy to grab from the logs:
+            if [ -f WT_TEST/reduced.workload ]; then
+              echo "Failed workload:"
+              cat WT_TEST/reduced.workload
+            fi
 
             # Record the end time, in seconds
             date +%s >> ../../../../time.txt

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3840,12 +3840,6 @@ tasks:
             # Keep repeating the model test for 30 minutes
             ./model_test -l 2000-3000 -t 1800
 
-            # Print the reduced failed workload to make it easy to grab from the logs:
-            if [ -f WT_TEST/reduced.workload ]; then
-              echo "Failed workload:"
-              cat WT_TEST/reduced.workload
-            fi
-
   - name: model-test-long-with-coverage
     tags: ["model_checking"]
     commands:
@@ -3874,12 +3868,6 @@ tasks:
 
             # Keep repeating the model test for 600 seconds
             ./model_test -l 2000-3000 -t 600
-
-            # Print the reduced failed workload to make it easy to grab from the logs:
-            if [ -f WT_TEST/reduced.workload ]; then
-              echo "Failed workload:"
-              cat WT_TEST/reduced.workload
-            fi
 
             # Record the end time, in seconds
             date +%s >> ../../../../time.txt


### PR DESCRIPTION
This PR uploads the failed model/test workload and its reduced version to Evergreen as a separate Artifact file.

The PR also renamed the workload files, and placed the reduced workload file alongside the main workload file, not inside the REDUCE directory, which was actually wrong—the reduce directory could correspond to a different reduction round.