### PR TITLE
WT-12110 Disable timestamp_abort backup tests in the compatibility mode (v.7.0 backport)

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -1734,6 +1734,13 @@ main(int argc, char *argv[])
      */
     testutil_parse_end_opt(opts);
 
+    /*
+     * Don't allow testing backups in the compatibility mode. MongoDB no longer uses it, and the
+     * compatibility mode is inherently incompatible with backup-related fixes that add new log
+     * records. So disallow the test.
+     */
+    testutil_assert(!(opts->compat && use_backups));
+
     testutil_work_dir_from_path(home, sizeof(home), opts->home);
 
     /*

--- a/test/csuite/timestamp_abort/smoke.sh
+++ b/test/csuite/timestamp_abort/smoke.sh
@@ -33,6 +33,9 @@ $TEST_WRAPPER $test_bin -m $default_test_args -c
 #$TEST_WRAPPER $test_bin -m $default_test_args -L
 $TEST_WRAPPER $test_bin -C $default_test_args
 $TEST_WRAPPER $test_bin -C $default_test_args -c
-$TEST_WRAPPER $test_bin -C $default_test_args -B -I 3
 $TEST_WRAPPER $test_bin -C -m $default_test_args
 $TEST_WRAPPER $test_bin -C -m $default_test_args -c
+
+# Don't test backups in the compatibility mode. MongoDB no longer uses it, and the compatibility
+# mode is inherently incompatible with backup-related fixes that add new log records.
+#$TEST_WRAPPER $test_bin -C $default_test_args -B -I 3


### PR DESCRIPTION
(cherry picked from commit 592eea605d234e810c720e302f1aa59ea6e54ef4)

Co-authored-by: Peter Macko <peter.macko@mongodb.com>
(cherry picked from commit be4538d91a80cd5dbe3a3a78315ba298a71336f0)