### PR TITLE
WT-13153 Fix data race on btree->rec_max_txn and btree->rec_max_timestamp

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2544,7 +2544,7 @@ static WT_INLINE void __wt_scr_free(WT_SESSION_IMPL *session, WT_ITEM **bufp);
 static WT_INLINE void __wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp);
 static WT_INLINE void __wt_seconds32(WT_SESSION_IMPL *session, uint32_t *secondsp);
 static WT_INLINE void __wt_set_shared_double(double *to_set, double value);
-static WT_INLINE void __wt_set_shared_maximum64(uint64_t *shared_value, uint64_t new_val);
+static WT_INLINE void __wt_set_shared_maximum_u64(uint64_t *shared_value, uint64_t new_val);
 static WT_INLINE void __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs);
 static WT_INLINE void __wt_spin_destroy(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static WT_INLINE void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2544,6 +2544,7 @@ static WT_INLINE void __wt_scr_free(WT_SESSION_IMPL *session, WT_ITEM **bufp);
 static WT_INLINE void __wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp);
 static WT_INLINE void __wt_seconds32(WT_SESSION_IMPL *session, uint32_t *secondsp);
 static WT_INLINE void __wt_set_shared_double(double *to_set, double value);
+static WT_INLINE void __wt_set_shared_maximum64(uint64_t *shared_value, uint64_t new_val);
 static WT_INLINE void __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs);
 static WT_INLINE void __wt_spin_destroy(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static WT_INLINE void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -336,6 +336,7 @@ __wt_set_shared_maximum64(uint64_t *shared_value, uint64_t new_val)
               shared_value, &current, new_val, true, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
             break;
 #else
+        /* This section exists to handle compilers that aren't GCC, or clang. E.g. MSVC. */
         if (__wt_atomic_cas64(shared_value, current, new_val))
             break;
         else

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -316,32 +316,20 @@ __wt_read_shared_double(double *to_read)
 }
 
 /*
- * __wt_set_shared_maximum64 --
- *     Given an integer in memory overwrite it with a new value if it is larger.
+ * __wt_set_shared_maximum_u64 --
+ *     Given an unsigned integer in memory overwrite it with a new value if it is larger.
  */
 static WT_INLINE void
-__wt_set_shared_maximum64(uint64_t *shared_value, uint64_t new_val)
+__wt_set_shared_maximum_u64(uint64_t *shared_value, uint64_t new_val)
 {
     uint64_t current;
 
     current = *shared_value;
     while (current < new_val) {
-#if defined(__GNUC__) || defined(__clang__)
-        /*
-         * We can't use the WiredTiger compare and swap as it doesn't allow the second argument to
-         * be a pointer. This method automatically places the value of shared_value into current on
-         * failure.
-         */
-        if (__atomic_compare_exchange_n(
-              shared_value, &current, new_val, true, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
-            break;
-#else
-        /* This section exists to handle compilers that aren't GCC, or clang. E.g. MSVC. */
         if (__wt_atomic_cas64(shared_value, current, new_val))
             break;
         else
             current = *shared_value;
-#endif
     }
 }
 

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -326,21 +326,21 @@ __wt_set_shared_maximum64(uint64_t *shared_value, uint64_t new_val)
 
     current = *shared_value;
     while (current < new_val) {
-        #if defined(__GNUC__) || defined(__clang__)
-            /*
-            * We can't use the WiredTiger compare and swap as it doesn't allow the second argument to
-            * be a pointer. This method automatically places the value of shared_value into current on
-            * failure.
-            */
-            if (__atomic_compare_exchange_n(
-                shared_value, &current, new_val, true, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
-                break;
-        #else
-            if (__wt_atomic_cas64(shared_value, current, new_val))
-                break;
-            else
-                current = *shared_value;
-        #endif
+#if defined(__GNUC__) || defined(__clang__)
+        /*
+         * We can't use the WiredTiger compare and swap as it doesn't allow the second argument to
+         * be a pointer. This method automatically places the value of shared_value into current on
+         * failure.
+         */
+        if (__atomic_compare_exchange_n(
+              shared_value, &current, new_val, true, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST))
+            break;
+#else
+        if (__wt_atomic_cas64(shared_value, current, new_val))
+            break;
+        else
+            current = *shared_value;
+#endif
     }
 }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -410,8 +410,8 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
      * Track the tree's maximum transaction ID (used to decide if it's safe to discard the tree) and
      * maximum timestamp.
      */
-    __wt_set_shared_maximum64(&btree->rec_max_txn, r->max_txn);
-    __wt_set_shared_maximum64(&btree->rec_max_timestamp, r->max_ts);
+    __wt_set_shared_maximum_u64(&btree->rec_max_txn, r->max_txn);
+    __wt_set_shared_maximum_u64(&btree->rec_max_timestamp, r->max_ts);
 
     /*
      * Set the page's status based on whether or not we cleaned the page.

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -410,10 +410,8 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
      * Track the tree's maximum transaction ID (used to decide if it's safe to discard the tree) and
      * maximum timestamp.
      */
-    if (WT_TXNID_LT(btree->rec_max_txn, r->max_txn))
-        btree->rec_max_txn = r->max_txn;
-    if (btree->rec_max_timestamp < r->max_ts)
-        btree->rec_max_timestamp = r->max_ts;
+    __wt_set_shared_maximum64(&btree->rec_max_txn, r->max_txn);
+    __wt_set_shared_maximum64(&btree->rec_max_timestamp, r->max_ts);
 
     /*
      * Set the page's status based on whether or not we cleaned the page.


### PR DESCRIPTION
Additionally create a standard function for setting a maximum of two values atomically.