### PR TITLE
WT-13158 Fix issue with coverage-report-per-test task on non-patch builds

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3028,7 +3028,11 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-            test/evergreen/code_coverage/coverage-report-per-test.sh ${is_patch|false} ${num_jobs|1}
+            if [ ${is_patch|false} = true ]; then
+              test/evergreen/code_coverage/coverage-report-per-test.sh true ${num_jobs|1}
+            else
+              test/evergreen/code_coverage/coverage-report-per-test.sh false ${num_jobs|1}
+            fi
       - func: "code coverage publish report"
   - name: coverage-report-catch2
     # This task measures code coverage achieved by only the Catch2-based unit tests.


### PR DESCRIPTION
Change the handling of is_patch to work when it's not set for non-patch builds.