### PR TITLE
WT-13169 Re-read the txn_global->current_id prior to logging in case it has updated concurrently

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -570,16 +570,17 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
     if (WT_TXNID_LT(__wt_atomic_loadv64(&txn_global->last_running), last_running)) {
         __wt_atomic_storev64(&txn_global->last_running, last_running);
 
-        /* Output a verbose message about long-running transactions,
-         * but only when some progress is being made. */
+        /*
+         * Output a verbose message about long-running transactions, but only when some progress is
+         * being made.
+         */
         current_id = __wt_atomic_loadv64(&txn_global->current);
         WT_ASSERT(session, WT_TXNID_LE(oldest_id, current_id));
         if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
           current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL) {
             __wt_verbose(session, WT_VERB_TRANSACTION,
-              "current snapshot %" PRIu64 ", old snapshot %" PRIu64 " pinned in session %" PRIu32
-              " [%s] with snap_min %" PRIu64,
-              current_id, oldest_id, oldest_session->id, oldest_session->lastop,
+              "oldest id %" PRIu64 " pinned in session %" PRIu32 " [%s] with snap_min %" PRIu64,
+              oldest_id, oldest_session->id, oldest_session->lastop,
               oldest_session->txn->snapshot_data.snap_min);
         }
     }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -577,7 +577,7 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
         if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
           current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL) {
             __wt_verbose(session, WT_VERB_TRANSACTION,
-              "current snapshot %" PRIu64 "old snapshot %" PRIu64 " pinned in session %" PRIu32
+              "current snapshot %" PRIu64 ", old snapshot %" PRIu64 " pinned in session %" PRIu32
               " [%s] with snap_min %" PRIu64,
               current_id, oldest_id, oldest_session->id, oldest_session->lastop,
               oldest_session->txn->snapshot_data.snap_min);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -573,7 +573,7 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
         /* Output a verbose message about long-running transactions,
          * but only when some progress is being made. */
         current_id = __wt_atomic_loadv64(&txn_global->current);
-        WT_ASSERT(session, WT_TXNID_LE(prev_oldest_id, current_id));
+        WT_ASSERT(session, WT_TXNID_LE(oldest_id, current_id));
         if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
           current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL) {
             __wt_verbose(session, WT_VERB_TRANSACTION,

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -572,11 +572,14 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
 
         /* Output a verbose message about long-running transactions,
          * but only when some progress is being made. */
+        current_id = __wt_atomic_loadv64(&txn_global->current);
+        WT_ASSERT(session, WT_TXNID_LE(prev_oldest_id, current_id));
         if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
           current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL) {
             __wt_verbose(session, WT_VERB_TRANSACTION,
-              "old snapshot %" PRIu64 " pinned in session %" PRIu32 " [%s] with snap_min %" PRIu64,
-              oldest_id, oldest_session->id, oldest_session->lastop,
+              "current snapshot %" PRIu64 "old snapshot %" PRIu64 " pinned in session %" PRIu32
+              " [%s] with snap_min %" PRIu64,
+              current_id, oldest_id, oldest_session->id, oldest_session->lastop,
               oldest_session->txn->snapshot_data.snap_min);
         }
     }

--- a/test/suite/test_txn06.py
+++ b/test/suite/test_txn06.py
@@ -65,4 +65,4 @@ class test_txn06(wttest.WiredTigerTestCase, suite_subprocess):
             c[k] = v
 
         # We were trying to generate a message matching this pattern.
-        self.captureout.checkAdditionalPattern(self, "old snapshot")
+        self.captureout.checkAdditionalPattern(self, "pinned in session")


### PR DESCRIPTION
![image](https://github.com/wiredtiger/wiredtiger/assets/14356223/ba2240f8-526a-4ad5-b1ce-c34c4705c89b)
[1718635584:874036][4903:0x7f4c9ffff700], WT_CONNECTION.set_timestamp: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp (0, 1000098713): Updated global stable timestamp
[1718635584:874043][4903:0x7f4cadffb700], eviction-server: [WT_VERB_TIMESTAMP][DEBUG_1]: Timestamp (0, 1000098713): Updated pinned timestamp
[1718635584:874317][4903:0x7f4cadffb700], eviction-server: [WT_VERB_TRANSACTION][DEBUG_1]: current snapshot 65827 old snapshot 65839 pinned in session 20 [WT_CURSOR.insert] with snap_min 65839

current snapshot < old snapshot, The condition is satisfied because a negative number with a signed number is actually a very large positive number.
