### PR TITLE
WT-13179: big transaction improve, add big transaction rollback surport

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -774,6 +774,10 @@ connection_runtime_config = [
             merge LSM chunks where possible''',
             type='boolean')
         ]),
+    Config('max_transaction_modify_count', '0', r'''
+        the maximum number of modify count in a big trasaction, If exceeds this value,
+        the transaction should be rolled back. Default not limit''',
+        min=0),
     Config('operation_timeout_ms', '0', r'''
         this option is no longer supported, retained for backward compatibility.''',
         min=0),
@@ -1143,6 +1147,11 @@ session_config = [
     Config('isolation', 'snapshot', r'''
         the default isolation level for operations in this session''',
         choices=['read-uncommitted', 'read-committed', 'snapshot']),
+    Config('max_transaction_modify_count', '0', r'''
+        the maximum number of modify count in a big trasaction, If exceeds this value,
+        the transaction should be rolled back. Default value will be the global setting of the
+        connection config''',
+        min=0),
     Config('prefetch', '', r'''
         Enable automatic detection of scans by applications, and attempt to pre-fetch future
         content into the cache''',

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1169,6 +1169,7 @@ conn_dsrc_stats = [
     ##########################################
     # Transaction statistics
     ##########################################
+    TxnStat('txn_big_transaction_rollback', 'rollback count for big transaction'),
     TxnStat('txn_read_overflow_remove', 'number of times overflow removed value is read'),
     TxnStat('txn_read_race_prepare_update', 'race to read prepared update retry'),
     TxnStat('txn_read_race_prepare_commit', 'a reader raced with a prepared transaction commit and skipped an update or updates'),

--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -246,6 +246,8 @@ test_config = [
         Enables write ahead logs''', type='boolean'),
     Config('in_memory', 'false', r'''
         Enables WiredTiger's in memory mode.''', type='boolean'),
+    Config('max_transaction_modify_count', 0, r'''
+        The strict equivalent of big_transaction_modify_count defined in wiredtiger.''', min=0),
     Config('reverse_collator', 'false', r'''
         Configure the database files to use the reverse collator.''', type='boolean'),
     Config('statistics_config', '', r'''

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -42,13 +42,13 @@ static const uint8_t confchk_WT_CONNECTION_debug_info_jump[WT_CONFIG_JUMP_TABLE_
   3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_load_extension[] = {
-  {"config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 261, INT64_MIN,
+  {"config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 262, INT64_MIN,
     INT64_MAX, NULL},
-  {"early_load", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 262,
+  {"early_load", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 263,
     INT64_MIN, INT64_MAX, NULL},
-  {"entry", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 263, INT64_MIN,
+  {"entry", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 264, INT64_MIN,
     INT64_MAX, NULL},
-  {"terminate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 264, INT64_MIN,
+  {"terminate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 265, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -60,8 +60,8 @@ static const uint8_t confchk_WT_CONNECTION_load_extension_jump[WT_CONFIG_JUMP_TA
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_open_session_debug_subconfigs[] = {
   {"checkpoint_fail_before_turtle_update", "boolean", NULL, NULL, NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_BOOLEAN, 266, INT64_MIN, INT64_MAX, NULL},
-  {"release_evict_page", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 267,
+    WT_CONFIG_COMPILED_TYPE_BOOLEAN, 267, INT64_MIN, INT64_MAX, NULL},
+  {"release_evict_page", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 268,
     INT64_MIN, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -91,30 +91,32 @@ static const uint8_t
     0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_open_session[] = {
-  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 265,
+  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 266,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 187, 0,
     INT64_MAX, NULL},
   {"debug", "category", NULL, NULL, confchk_WT_CONNECTION_open_session_debug_subconfigs, 2,
     confchk_WT_CONNECTION_open_session_debug_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 122,
     INT64_MIN, INT64_MAX, NULL},
-  {"ignore_cache_size", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 268,
+  {"ignore_cache_size", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 269,
     INT64_MIN, INT64_MAX, NULL},
   {"isolation", "string", NULL,
     "choices=[\"read-uncommitted\",\"read-committed\","
     "\"snapshot\"]",
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 155, INT64_MIN, INT64_MAX,
     confchk_isolation_choices},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    249, 0, INT64_MAX, NULL},
   {"prefetch", "category", NULL, NULL, confchk_WT_CONNECTION_open_session_prefetch_subconfigs, 1,
     confchk_WT_CONNECTION_open_session_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    269, INT64_MIN, INT64_MAX, NULL},
+    270, INT64_MIN, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_WT_CONNECTION_open_session_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3,
-  3, 3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6};
+  3, 3, 3, 3, 5, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
 const char __WT_CONFIG_CHOICE_all_durable[] = "all_durable";
 const char __WT_CONFIG_CHOICE_last_checkpoint[] = "last_checkpoint";
 const char __WT_CONFIG_CHOICE_oldest[] = "oldest";
@@ -394,7 +396,7 @@ static const uint8_t
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_operation_tracking_subconfigs[] = {
   {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 37, INT64_MIN,
     INT64_MAX, NULL},
-  {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 250, INT64_MIN,
+  {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 251, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -406,13 +408,13 @@ static const uint8_t
     0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_shared_cache_subconfigs[] = {
-  {"chunk", "int", NULL, "min=1MB,max=10TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 252,
+  {"chunk", "int", NULL, "min=1MB,max=10TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 253,
     1LL * WT_MEGABYTE, 10LL * WT_TERABYTE, NULL},
   {"name", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"quota", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 253, INT64_MIN,
+  {"quota", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 254, INT64_MIN,
     INT64_MAX, NULL},
-  {"reserve", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 254, INT64_MIN,
+  {"reserve", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 255, INT64_MIN,
     INT64_MAX, NULL},
   {"size", "int", NULL, "min=1MB,max=10TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 181,
     1LL * WT_MEGABYTE, 10LL * WT_TERABYTE, NULL},
@@ -434,13 +436,13 @@ static const char *confchk_statistics_choices[] = {__WT_CONFIG_CHOICE_all,
   __WT_CONFIG_CHOICE_clear, __WT_CONFIG_CHOICE_tree_walk, NULL};
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure_statistics_log_subconfigs[] = {
-  {"json", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 256, INT64_MIN,
+  {"json", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 257, INT64_MIN,
     INT64_MAX, NULL},
-  {"on_close", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 257,
+  {"on_close", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 258,
     INT64_MIN, INT64_MAX, NULL},
-  {"sources", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 258, INT64_MIN,
+  {"sources", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 259, INT64_MIN,
     INT64_MAX, NULL},
-  {"timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 259, INT64_MIN,
+  {"timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 260, INT64_MIN,
     INT64_MAX, NULL},
   {"wait", "int", NULL, "min=0,max=100000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 193, 0,
     100000, NULL},
@@ -647,14 +649,16 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2,
     confchk_wiredtiger_open_lsm_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 246,
     INT64_MIN, INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    249, 0, INT64_MAX, NULL},
   {"operation_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 157, 0,
     INT64_MAX, NULL},
   {"operation_tracking", "category", NULL, NULL,
     confchk_wiredtiger_open_operation_tracking_subconfigs, 2,
     confchk_wiredtiger_open_operation_tracking_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    249, INT64_MIN, INT64_MAX, NULL},
+    250, INT64_MIN, INT64_MAX, NULL},
   {"shared_cache", "category", NULL, NULL, confchk_wiredtiger_open_shared_cache_subconfigs, 5,
-    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 251,
+    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 252,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics", "list", NULL,
     "choices=[\"all\",\"cache_walk\",\"fast\",\"none\","
@@ -664,7 +668,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
   {"statistics_log", "category", NULL, NULL,
     confchk_WT_CONNECTION_reconfigure_statistics_log_subconfigs, 5,
     confchk_WT_CONNECTION_reconfigure_statistics_log_subconfigs_jump,
-    WT_CONFIG_COMPILED_TYPE_CATEGORY, 255, INT64_MIN, INT64_MAX, NULL},
+    WT_CONFIG_COMPILED_TYPE_CATEGORY, 256, INT64_MIN, INT64_MAX, NULL},
   {"tiered_storage", "category", NULL, NULL,
     confchk_WT_CONNECTION_reconfigure_tiered_storage_subconfigs, 1,
     confchk_WT_CONNECTION_reconfigure_tiered_storage_subconfigs_jump,
@@ -683,7 +687,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
     "\"sleep_before_read_overflow_onpage\",\"split_1\",\"split_2\","
     "\"split_3\",\"split_4\",\"split_5\",\"split_6\",\"split_7\","
     "\"split_8\",\"tiered_flush_finish\"]",
-    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 260, INT64_MIN, INT64_MAX,
+    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 261, INT64_MIN, INT64_MAX,
     confchk_timing_stress_for_test_choices},
   {"verbose", "list", NULL,
     "choices=[\"all\",\"api\",\"backup\",\"block\","
@@ -705,13 +709,13 @@ static const uint8_t confchk_WT_CONNECTION_reconfigure_jump[WT_CONFIG_JUMP_TABLE
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 9,
-  10, 20, 21, 22, 23, 24, 25, 25, 27, 27, 27, 29, 29, 29, 29, 32, 34, 34, 35, 35, 35, 35, 35, 35,
-  35, 35, 35};
+  10, 20, 21, 22, 23, 24, 25, 25, 27, 28, 28, 30, 30, 30, 30, 33, 35, 35, 36, 36, 36, 36, 36, 36,
+  36, 36, 36};
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_rollback_to_stable[] = {
   {"dryrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 98, INT64_MIN,
     INT64_MAX, NULL},
-  {"threads", "int", NULL, "min=0,max=10", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 271, 0, 10,
+  {"threads", "int", NULL, "min=0,max=10", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 272, 0, 10,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -726,7 +730,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_set_timestamp[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"force", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 110, INT64_MIN,
     INT64_MAX, NULL},
-  {"oldest_timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 270,
+  {"oldest_timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 271,
     INT64_MIN, INT64_MAX, NULL},
   {"stable_timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 152,
     INT64_MIN, INT64_MAX, NULL},
@@ -1501,30 +1505,32 @@ static const char *confchk_isolation3_choices[] = {__WT_CONFIG_CHOICE_read_uncom
   __WT_CONFIG_CHOICE_read_committed, __WT_CONFIG_CHOICE_snapshot, NULL};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_reconfigure[] = {
-  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 265,
+  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 266,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 187, 0,
     INT64_MAX, NULL},
   {"debug", "category", NULL, NULL, confchk_WT_CONNECTION_open_session_debug_subconfigs, 2,
     confchk_WT_CONNECTION_open_session_debug_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 122,
     INT64_MIN, INT64_MAX, NULL},
-  {"ignore_cache_size", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 268,
+  {"ignore_cache_size", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 269,
     INT64_MIN, INT64_MAX, NULL},
   {"isolation", "string", NULL,
     "choices=[\"read-uncommitted\",\"read-committed\","
     "\"snapshot\"]",
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 155, INT64_MIN, INT64_MAX,
     confchk_isolation3_choices},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    249, 0, INT64_MAX, NULL},
   {"prefetch", "category", NULL, NULL, confchk_WT_CONNECTION_open_session_prefetch_subconfigs, 1,
     confchk_WT_CONNECTION_open_session_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    269, INT64_MIN, INT64_MAX, NULL},
+    270, INT64_MIN, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_WT_SESSION_reconfigure_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 3,
-  3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6};
+  3, 3, 3, 5, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7};
 
 static const WT_CONFIG_CHECK confchk_WT_SESSION_rollback_transaction[] = {
   {"operation_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 157, 0,
@@ -2506,21 +2512,21 @@ static const char *confchk_type_choices[] = {
   __WT_CONFIG_CHOICE_FILE, __WT_CONFIG_CHOICE_DRAM, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_chunk_cache_subconfigs[] = {
-  {"capacity", "int", NULL, "min=512KB,max=100TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 276,
+  {"capacity", "int", NULL, "min=512KB,max=100TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 277,
     512LL * WT_KILOBYTE, 100LL * WT_TERABYTE, NULL},
   {"chunk_cache_evict_trigger", "int", NULL, "min=0,max=100", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 277, 0, 100, NULL},
+    WT_CONFIG_COMPILED_TYPE_INT, 278, 0, 100, NULL},
   {"chunk_size", "int", NULL, "min=512KB,max=100GB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 77,
     512LL * WT_KILOBYTE, 100LL * WT_GIGABYTE, NULL},
   {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 37, INT64_MIN,
     INT64_MAX, NULL},
   {"flushed_data_cache_insertion", "boolean", NULL, NULL, NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_BOOLEAN, 279, INT64_MIN, INT64_MAX, NULL},
+    WT_CONFIG_COMPILED_TYPE_BOOLEAN, 280, INT64_MIN, INT64_MAX, NULL},
   {"hashsize", "int", NULL, "min=64,max=1048576", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 182,
     64, 1048576LL, NULL},
   {"pinned", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 197, INT64_MIN,
     INT64_MAX, NULL},
-  {"storage_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 278,
+  {"storage_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 279,
     INT64_MIN, INT64_MAX, NULL},
   {"type", "string", NULL, "choices=[\"FILE\",\"DRAM\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN, INT64_MAX, confchk_type_choices},
@@ -2536,9 +2542,9 @@ static const uint8_t
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_compatibility_subconfigs[] = {
   {"release", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 199, INT64_MIN,
     INT64_MAX, NULL},
-  {"require_max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 280,
+  {"require_max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 281,
     INT64_MIN, INT64_MAX, NULL},
-  {"require_min", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 281,
+  {"require_min", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 282,
     INT64_MIN, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -2558,7 +2564,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_encryption_subconfigs[] = {
     INT64_MAX, NULL},
   {"name", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"secretkey", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 286, INT64_MIN,
+  {"secretkey", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 287, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -2579,10 +2585,10 @@ static const char *confchk_file_extend_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_hash_subconfigs[] = {
-  {"buckets", "int", NULL, "min=64,max=65536", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 290, 64,
+  {"buckets", "int", NULL, "min=64,max=65536", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 291, 64,
     65536, NULL},
   {"dhandle_buckets", "int", NULL, "min=64,max=65536", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    291, 64, 65536, NULL},
+    292, 64, 65536, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_wiredtiger_open_hash_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0,
@@ -2600,24 +2606,24 @@ static const char *confchk_recover_choices[] = {
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_log_subconfigs[] = {
   {"archive", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 240, INT64_MIN,
     INT64_MAX, NULL},
-  {"compressor", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 294,
+  {"compressor", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 295,
     INT64_MIN, INT64_MAX, NULL},
   {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 37, INT64_MIN,
     INT64_MAX, NULL},
   {"file_max", "int", NULL, "min=100KB,max=2GB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 235,
     100LL * WT_KILOBYTE, 2LL * WT_GIGABYTE, NULL},
-  {"force_write_wait", "int", NULL, "min=1,max=60", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 295,
+  {"force_write_wait", "int", NULL, "min=1,max=60", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 296,
     1, 60, NULL},
   {"os_cache_dirty_pct", "int", NULL, "min=0,max=100", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     241, 0, 100, NULL},
-  {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 250, INT64_MIN,
+  {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 251, INT64_MIN,
     INT64_MAX, NULL},
   {"prealloc", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 242,
     INT64_MIN, INT64_MAX, NULL},
   {"prealloc_init_count", "int", NULL, "min=1,max=500", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     243, 1, 500, NULL},
   {"recover", "string", NULL, "choices=[\"error\",\"on\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_STRING, 296, INT64_MIN, INT64_MAX, confchk_recover_choices},
+    WT_CONFIG_COMPILED_TYPE_STRING, 297, INT64_MIN, INT64_MAX, confchk_recover_choices},
   {"remove", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 244, INT64_MIN,
     INT64_MAX, NULL},
   {"zero_fill", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 245,
@@ -2631,9 +2637,9 @@ static const uint8_t confchk_wiredtiger_open_log_subconfigs_jump[WT_CONFIG_JUMP_
   2, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 9, 9, 11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_prefetch_subconfigs[] = {
-  {"available", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 300,
+  {"available", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 301,
     INT64_MIN, INT64_MAX, NULL},
-  {"default", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 301, INT64_MIN,
+  {"default", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 302, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -2648,15 +2654,15 @@ static const char *confchk_statistics3_choices[] = {__WT_CONFIG_CHOICE_all,
   __WT_CONFIG_CHOICE_clear, __WT_CONFIG_CHOICE_tree_walk, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_statistics_log_subconfigs[] = {
-  {"json", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 256, INT64_MIN,
+  {"json", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 257, INT64_MIN,
     INT64_MAX, NULL},
-  {"on_close", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 257,
+  {"on_close", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 258,
     INT64_MIN, INT64_MAX, NULL},
-  {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 250, INT64_MIN,
+  {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 251, INT64_MIN,
     INT64_MAX, NULL},
-  {"sources", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 258, INT64_MIN,
+  {"sources", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 259, INT64_MIN,
     INT64_MAX, NULL},
-  {"timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 259, INT64_MIN,
+  {"timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 260, INT64_MIN,
     INT64_MAX, NULL},
   {"wait", "int", NULL, "min=0,max=100000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 193, 0,
     100000, NULL},
@@ -2678,7 +2684,7 @@ static const WT_CONFIG_CHECK confchk_tiered_storage_subconfigs[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"cache_directory", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 51,
     INT64_MIN, INT64_MAX, NULL},
-  {"interval", "int", NULL, "min=1,max=1000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 306, 1,
+  {"interval", "int", NULL, "min=1,max=1000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 307, 1,
     1000, NULL},
   {"local_retention", "int", NULL, "min=0,max=10000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     52, 0, 10000, NULL},
@@ -2751,16 +2757,16 @@ static const char *confchk_write_through_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 272,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 273,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 176,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    273, -1, 1LL * WT_MEGABYTE, NULL},
+    274, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    274, INT64_MIN, INT64_MAX, NULL},
-  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 265,
+    275, INT64_MIN, INT64_MAX, NULL},
+  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 266,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 187, 0,
     INT64_MAX, NULL},
@@ -2777,7 +2783,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     194, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 275,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
@@ -2786,16 +2792,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 198,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 282, 500, INT64_MAX, NULL},
-  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 283,
+    WT_CONFIG_COMPILED_TYPE_INT, 283, 500, INT64_MAX, NULL},
+  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 284,
     INT64_MIN, INT64_MAX, NULL},
-  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 284, INT64_MIN,
+  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 285, INT64_MIN,
     INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 15,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 200,
     INT64_MIN, INT64_MAX, NULL},
   {"direct_io", "list", NULL, "choices=[\"checkpoint\",\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 285, INT64_MIN, INT64_MAX, confchk_direct_io_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 286, INT64_MIN, INT64_MAX, confchk_direct_io_choices},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
     INT64_MIN, INT64_MAX, NULL},
@@ -2820,7 +2826,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 227, 0, 10LL * WT_TERABYTE, NULL},
   {"exclusive", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 103,
     INT64_MIN, INT64_MAX, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 287, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -2830,21 +2836,21 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 228, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics2_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN, INT64_MAX, confchk_file_extend_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN, INT64_MAX, confchk_file_extend_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 229,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     233, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 289, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 290, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 292, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 293, 15,
     INT64_MAX, NULL},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 234,
     INT64_MIN, INT64_MAX, NULL},
-  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 293,
+  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 294,
     INT64_MIN, INT64_MAX, NULL},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 236,
@@ -2857,33 +2863,35 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2,
     confchk_wiredtiger_open_lsm_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 246,
     INT64_MIN, INT64_MAX, NULL},
-  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 297, INT64_MIN,
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    249, 0, INT64_MAX, NULL},
+  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298, INT64_MIN,
     INT64_MAX, NULL},
-  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298,
+  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
     INT64_MIN, INT64_MAX, NULL},
-  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
+  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 300,
     INT64_MIN, INT64_MAX, NULL},
   {"operation_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 157, 0,
     INT64_MAX, NULL},
   {"operation_tracking", "category", NULL, NULL,
     confchk_wiredtiger_open_operation_tracking_subconfigs, 2,
     confchk_wiredtiger_open_operation_tracking_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    249, INT64_MIN, INT64_MAX, NULL},
+    250, INT64_MIN, INT64_MAX, NULL},
   {"prefetch", "category", NULL, NULL, confchk_wiredtiger_open_prefetch_subconfigs, 2,
-    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 269,
+    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"readonly", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 60, INT64_MIN,
     INT64_MAX, NULL},
-  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 302, INT64_MIN,
+  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 303, INT64_MIN,
     INT64_MAX, NULL},
-  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 303, 1,
+  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304, 1,
     INT64_MAX, NULL},
-  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304,
+  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 305,
     INT64_MIN, INT64_MAX, NULL},
   {"session_table_cache", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN,
-    305, INT64_MIN, INT64_MAX, NULL},
+    306, INT64_MIN, INT64_MAX, NULL},
   {"shared_cache", "category", NULL, NULL, confchk_wiredtiger_open_shared_cache_subconfigs, 5,
-    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 251,
+    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 252,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics", "list", NULL,
     "choices=[\"all\",\"cache_walk\",\"fast\",\"none\","
@@ -2891,7 +2899,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 140, INT64_MIN, INT64_MAX,
     confchk_statistics3_choices},
   {"statistics_log", "category", NULL, NULL, confchk_wiredtiger_open_statistics_log_subconfigs, 6,
-    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 255,
+    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 256,
     INT64_MIN, INT64_MAX, NULL},
   {"tiered_storage", "category", NULL, NULL, confchk_tiered_storage_subconfigs, 8,
     confchk_tiered_storage_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 47, INT64_MIN,
@@ -2910,15 +2918,15 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     "\"sleep_before_read_overflow_onpage\",\"split_1\",\"split_2\","
     "\"split_3\",\"split_4\",\"split_5\",\"split_6\",\"split_7\","
     "\"split_8\",\"tiered_flush_finish\"]",
-    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 260, INT64_MIN, INT64_MAX,
+    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 261, INT64_MIN, INT64_MAX,
     confchk_timing_stress_for_test2_choices},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2, confchk_wiredtiger_open_transaction_sync_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    307, INT64_MIN, INT64_MAX, NULL},
-  {"use_environment", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 308,
+    308, INT64_MIN, INT64_MAX, NULL},
+  {"use_environment", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 309,
     INT64_MIN, INT64_MAX, NULL},
   {"use_environment_priv", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN,
-    309, INT64_MIN, INT64_MAX, NULL},
+    310, INT64_MIN, INT64_MAX, NULL},
   {"verbose", "list", NULL,
     "choices=[\"all\",\"api\",\"backup\",\"block\","
     "\"block_cache\",\"checkpoint\",\"checkpoint_cleanup\","
@@ -2934,17 +2942,17 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     "\"verify\",\"version\",\"write\"]",
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 10, INT64_MIN, INT64_MAX,
     confchk_verbose13_choices},
-  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 310,
+  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 311,
     INT64_MIN, INT64_MAX, NULL},
   {"write_through", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 311, INT64_MIN, INT64_MAX, confchk_write_through_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 312, INT64_MIN, INT64_MAX, confchk_write_through_choices},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_wiredtiger_open_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 17, 19, 32, 34,
-  35, 38, 40, 41, 41, 43, 46, 46, 48, 49, 49, 50, 57, 60, 62, 64, 65, 65, 65, 65, 65, 65, 65, 65};
+  35, 38, 40, 41, 41, 43, 47, 47, 49, 50, 50, 51, 58, 61, 63, 65, 66, 66, 66, 66, 66, 66, 66, 66};
 
 static const char *confchk_direct_io2_choices[] = {
   __WT_CONFIG_CHOICE_checkpoint, __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
@@ -3004,16 +3012,16 @@ static const char *confchk_write_through2_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 272,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 273,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 176,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    273, -1, 1LL * WT_MEGABYTE, NULL},
+    274, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    274, INT64_MIN, INT64_MAX, NULL},
-  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 265,
+    275, INT64_MIN, INT64_MAX, NULL},
+  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 266,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 187, 0,
     INT64_MAX, NULL},
@@ -3030,7 +3038,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     194, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 275,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
@@ -3039,16 +3047,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 198,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 282, 500, INT64_MAX, NULL},
-  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 283,
+    WT_CONFIG_COMPILED_TYPE_INT, 283, 500, INT64_MAX, NULL},
+  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 284,
     INT64_MIN, INT64_MAX, NULL},
-  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 284, INT64_MIN,
+  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 285, INT64_MIN,
     INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 15,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 200,
     INT64_MIN, INT64_MAX, NULL},
   {"direct_io", "list", NULL, "choices=[\"checkpoint\",\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 285, INT64_MIN, INT64_MAX, confchk_direct_io2_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 286, INT64_MIN, INT64_MAX, confchk_direct_io2_choices},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
     INT64_MIN, INT64_MAX, NULL},
@@ -3073,7 +3081,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 227, 0, 10LL * WT_TERABYTE, NULL},
   {"exclusive", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 103,
     INT64_MIN, INT64_MAX, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 287, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -3083,21 +3091,21 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 228, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics3_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN, INT64_MAX, confchk_file_extend2_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN, INT64_MAX, confchk_file_extend2_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 229,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     233, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 289, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 290, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 292, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 293, 15,
     INT64_MAX, NULL},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 234,
     INT64_MIN, INT64_MAX, NULL},
-  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 293,
+  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 294,
     INT64_MIN, INT64_MAX, NULL},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 236,
@@ -3110,33 +3118,35 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2,
     confchk_wiredtiger_open_lsm_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 246,
     INT64_MIN, INT64_MAX, NULL},
-  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 297, INT64_MIN,
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    249, 0, INT64_MAX, NULL},
+  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298, INT64_MIN,
     INT64_MAX, NULL},
-  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298,
+  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
     INT64_MIN, INT64_MAX, NULL},
-  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
+  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 300,
     INT64_MIN, INT64_MAX, NULL},
   {"operation_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 157, 0,
     INT64_MAX, NULL},
   {"operation_tracking", "category", NULL, NULL,
     confchk_wiredtiger_open_operation_tracking_subconfigs, 2,
     confchk_wiredtiger_open_operation_tracking_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    249, INT64_MIN, INT64_MAX, NULL},
+    250, INT64_MIN, INT64_MAX, NULL},
   {"prefetch", "category", NULL, NULL, confchk_wiredtiger_open_prefetch_subconfigs, 2,
-    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 269,
+    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"readonly", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 60, INT64_MIN,
     INT64_MAX, NULL},
-  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 302, INT64_MIN,
+  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 303, INT64_MIN,
     INT64_MAX, NULL},
-  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 303, 1,
+  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304, 1,
     INT64_MAX, NULL},
-  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304,
+  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 305,
     INT64_MIN, INT64_MAX, NULL},
   {"session_table_cache", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN,
-    305, INT64_MIN, INT64_MAX, NULL},
+    306, INT64_MIN, INT64_MAX, NULL},
   {"shared_cache", "category", NULL, NULL, confchk_wiredtiger_open_shared_cache_subconfigs, 5,
-    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 251,
+    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 252,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics", "list", NULL,
     "choices=[\"all\",\"cache_walk\",\"fast\",\"none\","
@@ -3144,7 +3154,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 140, INT64_MIN, INT64_MAX,
     confchk_statistics4_choices},
   {"statistics_log", "category", NULL, NULL, confchk_wiredtiger_open_statistics_log_subconfigs, 6,
-    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 255,
+    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 256,
     INT64_MIN, INT64_MAX, NULL},
   {"tiered_storage", "category", NULL, NULL, confchk_tiered_storage_subconfigs, 8,
     confchk_tiered_storage_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 47, INT64_MIN,
@@ -3163,15 +3173,15 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     "\"sleep_before_read_overflow_onpage\",\"split_1\",\"split_2\","
     "\"split_3\",\"split_4\",\"split_5\",\"split_6\",\"split_7\","
     "\"split_8\",\"tiered_flush_finish\"]",
-    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 260, INT64_MIN, INT64_MAX,
+    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 261, INT64_MIN, INT64_MAX,
     confchk_timing_stress_for_test3_choices},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2, confchk_wiredtiger_open_transaction_sync_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    307, INT64_MIN, INT64_MAX, NULL},
-  {"use_environment", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 308,
+    308, INT64_MIN, INT64_MAX, NULL},
+  {"use_environment", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 309,
     INT64_MIN, INT64_MAX, NULL},
   {"use_environment_priv", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN,
-    309, INT64_MIN, INT64_MAX, NULL},
+    310, INT64_MIN, INT64_MAX, NULL},
   {"verbose", "list", NULL,
     "choices=[\"all\",\"api\",\"backup\",\"block\","
     "\"block_cache\",\"checkpoint\",\"checkpoint_cleanup\","
@@ -3187,20 +3197,20 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     "\"verify\",\"version\",\"write\"]",
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 10, INT64_MIN, INT64_MAX,
     confchk_verbose14_choices},
-  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 310,
+  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 311,
     INT64_MIN, INT64_MAX, NULL},
   {"version", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 62, INT64_MIN,
     INT64_MAX, NULL},
   {"write_through", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 311, INT64_MIN, INT64_MAX, confchk_write_through2_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 312, INT64_MIN, INT64_MAX, confchk_write_through2_choices},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_wiredtiger_open_all_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 17, 19, 32,
-  34, 35, 38, 40, 41, 41, 43, 46, 46, 48, 49, 49, 50, 57, 60, 62, 65, 66, 66, 66, 66, 66, 66, 66,
-  66};
+  34, 35, 38, 40, 41, 41, 43, 47, 47, 49, 50, 50, 51, 58, 61, 63, 66, 67, 67, 67, 67, 67, 67, 67,
+  67};
 
 static const char *confchk_direct_io3_choices[] = {
   __WT_CONFIG_CHOICE_checkpoint, __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
@@ -3260,16 +3270,16 @@ static const char *confchk_write_through3_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 272,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 273,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 176,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    273, -1, 1LL * WT_MEGABYTE, NULL},
+    274, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    274, INT64_MIN, INT64_MAX, NULL},
-  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 265,
+    275, INT64_MIN, INT64_MAX, NULL},
+  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 266,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 187, 0,
     INT64_MAX, NULL},
@@ -3286,7 +3296,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     194, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 275,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
@@ -3295,12 +3305,12 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 198,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 282, 500, INT64_MAX, NULL},
+    WT_CONFIG_COMPILED_TYPE_INT, 283, 500, INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 15,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 200,
     INT64_MIN, INT64_MAX, NULL},
   {"direct_io", "list", NULL, "choices=[\"checkpoint\",\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 285, INT64_MIN, INT64_MAX, confchk_direct_io3_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 286, INT64_MIN, INT64_MAX, confchk_direct_io3_choices},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
     INT64_MIN, INT64_MAX, NULL},
@@ -3323,7 +3333,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 226, 0, 10LL * WT_TERABYTE, NULL},
   {"eviction_updates_trigger", "int", NULL, "min=0,max=10TB", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_INT, 227, 0, 10LL * WT_TERABYTE, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 287, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -3333,16 +3343,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 228, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics4_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN, INT64_MAX, confchk_file_extend3_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN, INT64_MAX, confchk_file_extend3_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 229,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     233, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 289, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 290, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 292, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 293, 15,
     INT64_MAX, NULL},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 234,
@@ -3358,33 +3368,35 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2,
     confchk_wiredtiger_open_lsm_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 246,
     INT64_MIN, INT64_MAX, NULL},
-  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 297, INT64_MIN,
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    249, 0, INT64_MAX, NULL},
+  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298, INT64_MIN,
     INT64_MAX, NULL},
-  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298,
+  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
     INT64_MIN, INT64_MAX, NULL},
-  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
+  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 300,
     INT64_MIN, INT64_MAX, NULL},
   {"operation_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 157, 0,
     INT64_MAX, NULL},
   {"operation_tracking", "category", NULL, NULL,
     confchk_wiredtiger_open_operation_tracking_subconfigs, 2,
     confchk_wiredtiger_open_operation_tracking_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    249, INT64_MIN, INT64_MAX, NULL},
+    250, INT64_MIN, INT64_MAX, NULL},
   {"prefetch", "category", NULL, NULL, confchk_wiredtiger_open_prefetch_subconfigs, 2,
-    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 269,
+    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"readonly", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 60, INT64_MIN,
     INT64_MAX, NULL},
-  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 302, INT64_MIN,
+  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 303, INT64_MIN,
     INT64_MAX, NULL},
-  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 303, 1,
+  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304, 1,
     INT64_MAX, NULL},
-  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304,
+  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 305,
     INT64_MIN, INT64_MAX, NULL},
   {"session_table_cache", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN,
-    305, INT64_MIN, INT64_MAX, NULL},
+    306, INT64_MIN, INT64_MAX, NULL},
   {"shared_cache", "category", NULL, NULL, confchk_wiredtiger_open_shared_cache_subconfigs, 5,
-    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 251,
+    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 252,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics", "list", NULL,
     "choices=[\"all\",\"cache_walk\",\"fast\",\"none\","
@@ -3392,7 +3404,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 140, INT64_MIN, INT64_MAX,
     confchk_statistics5_choices},
   {"statistics_log", "category", NULL, NULL, confchk_wiredtiger_open_statistics_log_subconfigs, 6,
-    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 255,
+    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 256,
     INT64_MIN, INT64_MAX, NULL},
   {"tiered_storage", "category", NULL, NULL, confchk_tiered_storage_subconfigs, 8,
     confchk_tiered_storage_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 47, INT64_MIN,
@@ -3411,11 +3423,11 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     "\"sleep_before_read_overflow_onpage\",\"split_1\",\"split_2\","
     "\"split_3\",\"split_4\",\"split_5\",\"split_6\",\"split_7\","
     "\"split_8\",\"tiered_flush_finish\"]",
-    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 260, INT64_MIN, INT64_MAX,
+    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 261, INT64_MIN, INT64_MAX,
     confchk_timing_stress_for_test4_choices},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2, confchk_wiredtiger_open_transaction_sync_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    307, INT64_MIN, INT64_MAX, NULL},
+    308, INT64_MIN, INT64_MAX, NULL},
   {"verbose", "list", NULL,
     "choices=[\"all\",\"api\",\"backup\",\"block\","
     "\"block_cache\",\"checkpoint\",\"checkpoint_cleanup\","
@@ -3431,20 +3443,20 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     "\"verify\",\"version\",\"write\"]",
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 10, INT64_MIN, INT64_MAX,
     confchk_verbose15_choices},
-  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 310,
+  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 311,
     INT64_MIN, INT64_MAX, NULL},
   {"version", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 62, INT64_MIN,
     INT64_MAX, NULL},
   {"write_through", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 311, INT64_MIN, INT64_MAX, confchk_write_through3_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 312, INT64_MIN, INT64_MAX, confchk_write_through3_choices},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_wiredtiger_open_basecfg_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 15, 17,
-  29, 31, 32, 35, 36, 37, 37, 39, 42, 42, 44, 45, 45, 46, 53, 56, 56, 59, 60, 60, 60, 60, 60, 60,
-  60, 60};
+  29, 31, 32, 35, 36, 37, 37, 39, 43, 43, 45, 46, 46, 47, 54, 57, 57, 60, 61, 61, 61, 61, 61, 61,
+  61, 61};
 
 static const char *confchk_direct_io4_choices[] = {
   __WT_CONFIG_CHOICE_checkpoint, __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
@@ -3504,16 +3516,16 @@ static const char *confchk_write_through4_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 272,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 273,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 176,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    273, -1, 1LL * WT_MEGABYTE, NULL},
+    274, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    274, INT64_MIN, INT64_MAX, NULL},
-  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 265,
+    275, INT64_MIN, INT64_MAX, NULL},
+  {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 266,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 187, 0,
     INT64_MAX, NULL},
@@ -3530,7 +3542,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     194, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 275,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
@@ -3539,12 +3551,12 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 198,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 282, 500, INT64_MAX, NULL},
+    WT_CONFIG_COMPILED_TYPE_INT, 283, 500, INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 15,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 200,
     INT64_MIN, INT64_MAX, NULL},
   {"direct_io", "list", NULL, "choices=[\"checkpoint\",\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 285, INT64_MIN, INT64_MAX, confchk_direct_io4_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 286, INT64_MIN, INT64_MAX, confchk_direct_io4_choices},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
     INT64_MIN, INT64_MAX, NULL},
@@ -3567,7 +3579,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 226, 0, 10LL * WT_TERABYTE, NULL},
   {"eviction_updates_trigger", "int", NULL, "min=0,max=10TB", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_INT, 227, 0, 10LL * WT_TERABYTE, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 287, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -3577,16 +3589,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 228, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics5_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 288, INT64_MIN, INT64_MAX, confchk_file_extend4_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN, INT64_MAX, confchk_file_extend4_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 229,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     233, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 289, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 290, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 292, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 293, 15,
     INT64_MAX, NULL},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 234,
@@ -3602,33 +3614,35 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
   {"lsm_manager", "category", NULL, NULL, confchk_wiredtiger_open_lsm_manager_subconfigs, 2,
     confchk_wiredtiger_open_lsm_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 246,
     INT64_MIN, INT64_MAX, NULL},
-  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 297, INT64_MIN,
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    249, 0, INT64_MAX, NULL},
+  {"mmap", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298, INT64_MIN,
     INT64_MAX, NULL},
-  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298,
+  {"mmap_all", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
     INT64_MIN, INT64_MAX, NULL},
-  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 299,
+  {"multiprocess", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 300,
     INT64_MIN, INT64_MAX, NULL},
   {"operation_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 157, 0,
     INT64_MAX, NULL},
   {"operation_tracking", "category", NULL, NULL,
     confchk_wiredtiger_open_operation_tracking_subconfigs, 2,
     confchk_wiredtiger_open_operation_tracking_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    249, INT64_MIN, INT64_MAX, NULL},
+    250, INT64_MIN, INT64_MAX, NULL},
   {"prefetch", "category", NULL, NULL, confchk_wiredtiger_open_prefetch_subconfigs, 2,
-    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 269,
+    confchk_wiredtiger_open_prefetch_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"readonly", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 60, INT64_MIN,
     INT64_MAX, NULL},
-  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 302, INT64_MIN,
+  {"salvage", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 303, INT64_MIN,
     INT64_MAX, NULL},
-  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 303, 1,
+  {"session_max", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304, 1,
     INT64_MAX, NULL},
-  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 304,
+  {"session_scratch_max", "int", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 305,
     INT64_MIN, INT64_MAX, NULL},
   {"session_table_cache", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN,
-    305, INT64_MIN, INT64_MAX, NULL},
+    306, INT64_MIN, INT64_MAX, NULL},
   {"shared_cache", "category", NULL, NULL, confchk_wiredtiger_open_shared_cache_subconfigs, 5,
-    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 251,
+    confchk_wiredtiger_open_shared_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 252,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics", "list", NULL,
     "choices=[\"all\",\"cache_walk\",\"fast\",\"none\","
@@ -3636,7 +3650,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 140, INT64_MIN, INT64_MAX,
     confchk_statistics6_choices},
   {"statistics_log", "category", NULL, NULL, confchk_wiredtiger_open_statistics_log_subconfigs, 6,
-    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 255,
+    confchk_wiredtiger_open_statistics_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 256,
     INT64_MIN, INT64_MAX, NULL},
   {"tiered_storage", "category", NULL, NULL, confchk_tiered_storage_subconfigs, 8,
     confchk_tiered_storage_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 47, INT64_MIN,
@@ -3655,11 +3669,11 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     "\"sleep_before_read_overflow_onpage\",\"split_1\",\"split_2\","
     "\"split_3\",\"split_4\",\"split_5\",\"split_6\",\"split_7\","
     "\"split_8\",\"tiered_flush_finish\"]",
-    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 260, INT64_MIN, INT64_MAX,
+    NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 261, INT64_MIN, INT64_MAX,
     confchk_timing_stress_for_test5_choices},
   {"transaction_sync", "category", NULL, NULL, confchk_wiredtiger_open_transaction_sync_subconfigs,
     2, confchk_wiredtiger_open_transaction_sync_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
-    307, INT64_MIN, INT64_MAX, NULL},
+    308, INT64_MIN, INT64_MAX, NULL},
   {"verbose", "list", NULL,
     "choices=[\"all\",\"api\",\"backup\",\"block\","
     "\"block_cache\",\"checkpoint\",\"checkpoint_cleanup\","
@@ -3675,18 +3689,18 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     "\"verify\",\"version\",\"write\"]",
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 10, INT64_MIN, INT64_MAX,
     confchk_verbose16_choices},
-  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 310,
+  {"verify_metadata", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 311,
     INT64_MIN, INT64_MAX, NULL},
   {"write_through", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 311, INT64_MIN, INT64_MAX, confchk_write_through4_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 312, INT64_MIN, INT64_MAX, confchk_write_through4_choices},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_wiredtiger_open_usercfg_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 15, 17,
-  29, 31, 32, 35, 36, 37, 37, 39, 42, 42, 44, 45, 45, 46, 53, 56, 56, 58, 59, 59, 59, 59, 59, 59,
-  59, 59};
+  29, 31, 32, 35, 36, 37, 37, 39, 43, 43, 45, 46, 46, 47, 54, 57, 57, 59, 60, 60, 60, 60, 60, 60,
+  60, 60};
 
 static const WT_CONFIG_ENTRY config_entries[] = {
   {"WT_CONNECTION.add_collator", "", NULL, 0, NULL, 0, WT_CONF_SIZING_NONE, false},
@@ -3712,8 +3726,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "cache_cursors=true,cache_max_wait_ms=0,"
     "debug=(checkpoint_fail_before_turtle_update=false,"
     "release_evict_page=false),ignore_cache_size=false,"
-    "isolation=snapshot,prefetch=(enabled=false)",
-    confchk_WT_CONNECTION_open_session, 6, confchk_WT_CONNECTION_open_session_jump, 9,
+    "isolation=snapshot,max_transaction_modify_count=0,"
+    "prefetch=(enabled=false)",
+    confchk_WT_CONNECTION_open_session, 7, confchk_WT_CONNECTION_open_session_jump, 9,
     WT_CONF_SIZING_NONE, false},
   {"WT_CONNECTION.query_timestamp", "get=all_durable", confchk_WT_CONNECTION_query_timestamp, 1,
     confchk_WT_CONNECTION_query_timestamp_jump, 10, WT_CONF_SIZING_NONE, false},
@@ -3742,13 +3757,14 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "json_output=[],log=(archive=true,os_cache_dirty_pct=0,"
     "prealloc=true,prealloc_init_count=1,remove=true,zero_fill=false)"
     ",lsm_manager=(merge=true,worker_thread_max=4),"
-    "operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),shared_cache=(chunk=10MB,name=,quota=0,reserve=0,"
-    "size=500MB),statistics=none,statistics_log=(json=false,"
-    "on_close=false,sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+    "max_transaction_modify_count=0,operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+    "statistics=none,statistics_log=(json=false,on_close=false,"
+    "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
     "tiered_storage=(local_retention=300),timing_stress_for_test=,"
     "verbose=[]",
-    confchk_WT_CONNECTION_reconfigure, 35, confchk_WT_CONNECTION_reconfigure_jump, 11,
+    confchk_WT_CONNECTION_reconfigure, 36, confchk_WT_CONNECTION_reconfigure_jump, 11,
     WT_CONF_SIZING_NONE, false},
   {"WT_CONNECTION.rollback_to_stable", "dryrun=false,threads=4",
     confchk_WT_CONNECTION_rollback_to_stable, 2, confchk_WT_CONNECTION_rollback_to_stable_jump, 12,
@@ -3852,8 +3868,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "cache_cursors=true,cache_max_wait_ms=0,"
     "debug=(checkpoint_fail_before_turtle_update=false,"
     "release_evict_page=false),ignore_cache_size=false,"
-    "isolation=snapshot,prefetch=(enabled=false)",
-    confchk_WT_SESSION_reconfigure, 6, confchk_WT_SESSION_reconfigure_jump, 32, WT_CONF_SIZING_NONE,
+    "isolation=snapshot,max_transaction_modify_count=0,"
+    "prefetch=(enabled=false)",
+    confchk_WT_SESSION_reconfigure, 7, confchk_WT_SESSION_reconfigure_jump, 32, WT_CONF_SIZING_NONE,
     false},
   {"WT_SESSION.reset", "", NULL, 0, NULL, 33, WT_CONF_SIZING_NONE, false},
   {"WT_SESSION.reset_snapshot", "", NULL, 0, NULL, 34, WT_CONF_SIZING_NONE, false},
@@ -4057,8 +4074,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
-    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
-    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "lsm_manager=(merge=true,worker_thread_max=4),"
+    "max_transaction_modify_count=0,mmap=true,mmap_all=false,"
+    "multiprocess=false,operation_timeout_ms=0,"
     "operation_tracking=(enabled=false,path=\".\"),"
     "prefetch=(available=false,default=false),readonly=false,"
     "salvage=false,session_max=100,session_scratch_max=2MB,"
@@ -4071,7 +4089,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "transaction_sync=(enabled=false,method=fsync),"
     "use_environment=true,use_environment_priv=false,verbose=[],"
     "verify_metadata=false,write_through=",
-    confchk_wiredtiger_open, 65, confchk_wiredtiger_open_jump, 51, WT_CONF_SIZING_NONE, false},
+    confchk_wiredtiger_open, 66, confchk_wiredtiger_open_jump, 51, WT_CONF_SIZING_NONE, false},
   {"wiredtiger_open_all",
     "backup_restore_target=,"
     "block_cache=(blkcache_eviction_aggression=1800,"
@@ -4107,8 +4125,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
-    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
-    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "lsm_manager=(merge=true,worker_thread_max=4),"
+    "max_transaction_modify_count=0,mmap=true,mmap_all=false,"
+    "multiprocess=false,operation_timeout_ms=0,"
     "operation_tracking=(enabled=false,path=\".\"),"
     "prefetch=(available=false,default=false),readonly=false,"
     "salvage=false,session_max=100,session_scratch_max=2MB,"
@@ -4121,7 +4140,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "transaction_sync=(enabled=false,method=fsync),"
     "use_environment=true,use_environment_priv=false,verbose=[],"
     "verify_metadata=false,version=(major=0,minor=0),write_through=",
-    confchk_wiredtiger_open_all, 66, confchk_wiredtiger_open_all_jump, 52, WT_CONF_SIZING_NONE,
+    confchk_wiredtiger_open_all, 67, confchk_wiredtiger_open_all_jump, 52, WT_CONF_SIZING_NONE,
     false},
   {"wiredtiger_open_basecfg",
     "backup_restore_target=,"
@@ -4158,20 +4177,20 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
     "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
     "remove=true,zero_fill=false),lsm_manager=(merge=true,"
-    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
-    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),prefetch=(available=false,default=false),"
-    "readonly=false,salvage=false,session_max=100,"
-    "session_scratch_max=2MB,session_table_cache=true,"
-    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
-    "statistics=none,statistics_log=(json=false,on_close=false,"
-    "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
+    "worker_thread_max=4),max_transaction_modify_count=0,mmap=true,"
+    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "prefetch=(available=false,default=false),readonly=false,"
+    "salvage=false,session_max=100,session_scratch_max=2MB,"
+    "session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0,"
+    "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
+    ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
+    ",wait=0),tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,interval=60,local_retention=300,name=,"
     "shared=false),timing_stress_for_test=,"
     "transaction_sync=(enabled=false,method=fsync),verbose=[],"
     "verify_metadata=false,version=(major=0,minor=0),write_through=",
-    confchk_wiredtiger_open_basecfg, 60, confchk_wiredtiger_open_basecfg_jump, 53,
+    confchk_wiredtiger_open_basecfg, 61, confchk_wiredtiger_open_basecfg_jump, 53,
     WT_CONF_SIZING_NONE, false},
   {"wiredtiger_open_usercfg",
     "backup_restore_target=,"
@@ -4208,20 +4227,20 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
     "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
     "remove=true,zero_fill=false),lsm_manager=(merge=true,"
-    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
-    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),prefetch=(available=false,default=false),"
-    "readonly=false,salvage=false,session_max=100,"
-    "session_scratch_max=2MB,session_table_cache=true,"
-    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
-    "statistics=none,statistics_log=(json=false,on_close=false,"
-    "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
-    "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
+    "worker_thread_max=4),max_transaction_modify_count=0,mmap=true,"
+    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "prefetch=(available=false,default=false),readonly=false,"
+    "salvage=false,session_max=100,session_scratch_max=2MB,"
+    "session_table_cache=true,shared_cache=(chunk=10MB,name=,quota=0,"
+    "reserve=0,size=500MB),statistics=none,statistics_log=(json=false"
+    ",on_close=false,path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\""
+    ",wait=0),tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
     "cache_directory=,interval=60,local_retention=300,name=,"
     "shared=false),timing_stress_for_test=,"
     "transaction_sync=(enabled=false,method=fsync),verbose=[],"
     "verify_metadata=false,write_through=",
-    confchk_wiredtiger_open_usercfg, 59, confchk_wiredtiger_open_usercfg_jump, 54,
+    confchk_wiredtiger_open_usercfg, 60, confchk_wiredtiger_open_usercfg_jump, 54,
     WT_CONF_SIZING_NONE, false},
   {NULL, NULL, NULL, 0, NULL, 0, WT_CONF_SIZING_NONE, false}};
 

--- a/src/config/test_config.c
+++ b/src/config/test_config.c
@@ -3,14 +3,14 @@
 #include "wt_internal.h"
 
 static const WT_CONFIG_CHECK confchk_cache_hs_insert_subconfigs[] = {
-  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 12, INT64_MIN,
+  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 13, INT64_MIN,
     INT64_MAX, NULL},
-  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 11, 0, INT64_MAX, NULL},
-  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 13, INT64_MIN,
+  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 12, 0, INT64_MAX, NULL},
+  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
     INT64_MAX, NULL},
-  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
+  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
     INT64_MAX, NULL},
-  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
+  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 16, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -21,14 +21,14 @@ static const uint8_t confchk_cache_hs_insert_subconfigs_jump[WT_CONFIG_JUMP_TABL
   0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const WT_CONFIG_CHECK confchk_cc_pages_removed_subconfigs[] = {
-  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 12, INT64_MIN,
+  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 13, INT64_MIN,
     INT64_MAX, NULL},
-  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 11, 0, INT64_MAX, NULL},
-  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 13, INT64_MIN,
+  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 12, 0, INT64_MAX, NULL},
+  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
     INT64_MAX, NULL},
-  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
+  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
     INT64_MAX, NULL},
-  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
+  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 16, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -39,14 +39,14 @@ static const uint8_t confchk_cc_pages_removed_subconfigs_jump[WT_CONFIG_JUMP_TAB
   0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const WT_CONFIG_CHECK confchk_stat_cache_size_subconfigs[] = {
-  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 12, INT64_MIN,
+  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 13, INT64_MIN,
     INT64_MAX, NULL},
-  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 11, 0, INT64_MAX, NULL},
-  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 13, INT64_MIN,
+  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 12, 0, INT64_MAX, NULL},
+  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
     INT64_MAX, NULL},
-  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
+  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
     INT64_MAX, NULL},
-  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
+  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 16, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -57,14 +57,14 @@ static const uint8_t confchk_stat_cache_size_subconfigs_jump[WT_CONFIG_JUMP_TABL
   0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const WT_CONFIG_CHECK confchk_stat_db_size_subconfigs[] = {
-  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 12, INT64_MIN,
+  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 13, INT64_MIN,
     INT64_MAX, NULL},
-  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 11, 0, INT64_MAX, NULL},
-  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 13, INT64_MIN,
+  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 12, 0, INT64_MAX, NULL},
+  {"postrun", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
     INT64_MAX, NULL},
-  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 14, INT64_MIN,
+  {"runtime", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
     INT64_MAX, NULL},
-  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 15, INT64_MIN,
+  {"save", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 16, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -76,20 +76,20 @@ static const uint8_t confchk_stat_db_size_subconfigs_jump[WT_CONFIG_JUMP_TABLE_S
 
 static const WT_CONFIG_CHECK confchk_metrics_monitor_subconfigs[] = {
   {"cache_hs_insert", "category", NULL, NULL, confchk_cache_hs_insert_subconfigs, 5,
-    confchk_cache_hs_insert_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 10, INT64_MIN,
+    confchk_cache_hs_insert_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 11, INT64_MIN,
     INT64_MAX, NULL},
   {"cc_pages_removed", "category", NULL, NULL, confchk_cc_pages_removed_subconfigs, 5,
-    confchk_cc_pages_removed_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 16, INT64_MIN,
+    confchk_cc_pages_removed_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 17, INT64_MIN,
     INT64_MAX, NULL},
-  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 8, INT64_MIN,
+  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 9, INT64_MIN,
     INT64_MAX, NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
   {"stat_cache_size", "category", NULL, NULL, confchk_stat_cache_size_subconfigs, 5,
-    confchk_stat_cache_size_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 17, INT64_MIN,
+    confchk_stat_cache_size_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 18, INT64_MIN,
     INT64_MAX, NULL},
   {"stat_db_size", "category", NULL, NULL, confchk_stat_db_size_subconfigs, 5,
-    confchk_stat_db_size_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 18, INT64_MIN,
+    confchk_stat_db_size_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -100,13 +100,13 @@ static const uint8_t confchk_metrics_monitor_subconfigs_jump[WT_CONFIG_JUMP_TABL
   3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6};
 
 static const WT_CONFIG_CHECK confchk_operation_tracker_subconfigs[] = {
-  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 8, INT64_MIN,
+  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 9, INT64_MIN,
     INT64_MAX, NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
-  {"tracking_key_format", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 20,
+  {"tracking_key_format", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 21,
     INT64_MIN, INT64_MAX, NULL},
-  {"tracking_value_format", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 21,
+  {"tracking_value_format", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 22,
     INT64_MIN, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -119,7 +119,7 @@ static const uint8_t confchk_operation_tracker_subconfigs_jump[WT_CONFIG_JUMP_TA
 static const WT_CONFIG_CHECK confchk_statistics_config_subconfigs[] = {
   {"enable_logging", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 5,
     INT64_MIN, INT64_MAX, NULL},
-  {"type", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 24, INT64_MIN,
+  {"type", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -130,13 +130,13 @@ static const uint8_t confchk_statistics_config_subconfigs_jump[WT_CONFIG_JUMP_TA
   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
 
 static const WT_CONFIG_CHECK confchk_timestamp_manager_subconfigs[] = {
-  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 8, INT64_MIN,
+  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 9, INT64_MIN,
     INT64_MAX, NULL},
-  {"oldest_lag", "int", NULL, "min=0,max=1000000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 27,
+  {"oldest_lag", "int", NULL, "min=0,max=1000000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 28,
     0, 1000000, NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
-  {"stable_lag", "int", NULL, "min=0,max=1000000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 28,
+  {"stable_lag", "int", NULL, "min=0,max=1000000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 29,
     0, 1000000, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -147,11 +147,11 @@ static const uint8_t confchk_timestamp_manager_subconfigs_jump[WT_CONFIG_JUMP_TA
   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
 
 static const WT_CONFIG_CHECK confchk_background_compact_config_subconfigs[] = {
-  {"free_space_target_mb", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 33,
+  {"free_space_target_mb", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 34,
     INT64_MIN, INT64_MAX, NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
-  {"thread_count", "int", NULL, "min=0,max=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 32, 0, 1,
+  {"thread_count", "int", NULL, "min=0,max=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 33, 0, 1,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -162,9 +162,9 @@ static const uint8_t confchk_background_compact_config_subconfigs_jump[WT_CONFIG
     0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
 
 static const WT_CONFIG_CHECK confchk_checkpoint_config_subconfigs[] = {
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
-  {"thread_count", "int", NULL, "min=0,max=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 32, 0, 1,
+  {"thread_count", "int", NULL, "min=0,max=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 33, 0, 1,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -175,9 +175,9 @@ static const uint8_t confchk_checkpoint_config_subconfigs_jump[WT_CONFIG_JUMP_TA
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
 
 static const WT_CONFIG_CHECK confchk_ops_per_transaction_subconfigs[] = {
-  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 12, INT64_MIN,
+  {"max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 13, INT64_MIN,
     INT64_MAX, NULL},
-  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 11, 0, INT64_MAX, NULL},
+  {"min", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 12, 0, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_ops_per_transaction_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0,
@@ -187,16 +187,16 @@ static const uint8_t confchk_ops_per_transaction_subconfigs_jump[WT_CONFIG_JUMP_
   0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
 
 static const WT_CONFIG_CHECK confchk_custom_config_subconfigs[] = {
-  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 37, 1, INT64_MAX,
+  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
     NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
   {"ops_per_transaction", "category", NULL, NULL, confchk_ops_per_transaction_subconfigs, 2,
-    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
+    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 37, INT64_MIN,
     INT64_MAX, NULL},
-  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 32, 0,
+  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 33, 0,
     INT64_MAX, NULL},
-  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
+  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 39, 1, INT64_MAX,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -207,16 +207,16 @@ static const uint8_t confchk_custom_config_subconfigs_jump[WT_CONFIG_JUMP_TABLE_
   0, 0, 0, 0, 0, 1, 1, 1, 1, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const WT_CONFIG_CHECK confchk_insert_config_subconfigs[] = {
-  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 37, 1, INT64_MAX,
+  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
     NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
   {"ops_per_transaction", "category", NULL, NULL, confchk_ops_per_transaction_subconfigs, 2,
-    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
+    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 37, INT64_MIN,
     INT64_MAX, NULL},
-  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 32, 0,
+  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 33, 0,
     INT64_MAX, NULL},
-  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
+  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 39, 1, INT64_MAX,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -228,14 +228,14 @@ static const uint8_t confchk_insert_config_subconfigs_jump[WT_CONFIG_JUMP_TABLE_
 
 static const WT_CONFIG_CHECK confchk_populate_config_subconfigs[] = {
   {"collection_count", "int", NULL, "min=0,max=200000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    41, 0, 200000, NULL},
+    42, 0, 200000, NULL},
   {"key_count_per_collection", "int", NULL, "min=0,max=1000000", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 42, 0, 1000000, NULL},
-  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 37, 1, INT64_MAX,
+    WT_CONFIG_COMPILED_TYPE_INT, 43, 0, 1000000, NULL},
+  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
     NULL},
-  {"thread_count", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 32,
+  {"thread_count", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 33,
     INT64_MIN, INT64_MAX, NULL},
-  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
+  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 39, 1, INT64_MAX,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -246,16 +246,16 @@ static const uint8_t confchk_populate_config_subconfigs_jump[WT_CONFIG_JUMP_TABL
   1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const WT_CONFIG_CHECK confchk_read_config_subconfigs[] = {
-  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 37, 1, INT64_MAX,
+  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
     NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
   {"ops_per_transaction", "category", NULL, NULL, confchk_ops_per_transaction_subconfigs, 2,
-    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
+    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 37, INT64_MIN,
     INT64_MAX, NULL},
-  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 32, 0,
+  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 33, 0,
     INT64_MAX, NULL},
-  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
+  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 39, 1, INT64_MAX,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -266,12 +266,12 @@ static const uint8_t confchk_read_config_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SI
   0, 0, 0, 0, 0, 1, 1, 1, 1, 3, 3, 3, 3, 3, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5};
 
 static const WT_CONFIG_CHECK confchk_remove_config_subconfigs[] = {
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
   {"ops_per_transaction", "category", NULL, NULL, confchk_ops_per_transaction_subconfigs, 2,
-    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
+    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 37, INT64_MIN,
     INT64_MAX, NULL},
-  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 32, 0,
+  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 33, 0,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -282,16 +282,16 @@ static const uint8_t confchk_remove_config_subconfigs_jump[WT_CONFIG_JUMP_TABLE_
   0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
 
 static const WT_CONFIG_CHECK confchk_update_config_subconfigs[] = {
-  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 37, 1, INT64_MAX,
+  {"key_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
     NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
   {"ops_per_transaction", "category", NULL, NULL, confchk_ops_per_transaction_subconfigs, 2,
-    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
+    confchk_ops_per_transaction_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 37, INT64_MIN,
     INT64_MAX, NULL},
-  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 32, 0,
+  {"thread_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 33, 0,
     INT64_MAX, NULL},
-  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 38, 1, INT64_MAX,
+  {"value_size", "int", NULL, "min=1", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 39, 1, INT64_MAX,
     NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -304,32 +304,32 @@ static const uint8_t confchk_update_config_subconfigs_jump[WT_CONFIG_JUMP_TABLE_
 static const WT_CONFIG_CHECK confchk_workload_manager_subconfigs[] = {
   {"background_compact_config", "category", NULL, NULL,
     confchk_background_compact_config_subconfigs, 3,
-    confchk_background_compact_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31,
+    confchk_background_compact_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 32,
     INT64_MIN, INT64_MAX, NULL},
   {"checkpoint_config", "category", NULL, NULL, confchk_checkpoint_config_subconfigs, 2,
-    confchk_checkpoint_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 34, INT64_MIN,
+    confchk_checkpoint_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 35, INT64_MIN,
     INT64_MAX, NULL},
   {"custom_config", "category", NULL, NULL, confchk_custom_config_subconfigs, 5,
-    confchk_custom_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 35, INT64_MIN,
+    confchk_custom_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
     INT64_MAX, NULL},
-  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 8, INT64_MIN,
+  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 9, INT64_MIN,
     INT64_MAX, NULL},
   {"insert_config", "category", NULL, NULL, confchk_insert_config_subconfigs, 5,
-    confchk_insert_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 39, INT64_MIN,
+    confchk_insert_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 40, INT64_MIN,
     INT64_MAX, NULL},
-  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN,
+  {"op_rate", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 10, INT64_MIN,
     INT64_MAX, NULL},
   {"populate_config", "category", NULL, NULL, confchk_populate_config_subconfigs, 5,
-    confchk_populate_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 40, INT64_MIN,
+    confchk_populate_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 41, INT64_MIN,
     INT64_MAX, NULL},
   {"read_config", "category", NULL, NULL, confchk_read_config_subconfigs, 5,
-    confchk_read_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 44, INT64_MIN, INT64_MAX,
+    confchk_read_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 45, INT64_MIN, INT64_MAX,
     NULL},
   {"remove_config", "category", NULL, NULL, confchk_remove_config_subconfigs, 3,
-    confchk_remove_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 43, INT64_MIN,
+    confchk_remove_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 44, INT64_MIN,
     INT64_MAX, NULL},
   {"update_config", "category", NULL, NULL, confchk_update_config_subconfigs, 5,
-    confchk_update_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 45, INT64_MIN,
+    confchk_update_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 46, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -354,26 +354,28 @@ static const WT_CONFIG_CHECK confchk_api_instruction_count_benchmarks[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -381,7 +383,8 @@ static const uint8_t confchk_api_instruction_count_benchmarks_jump[WT_CONFIG_JUM
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-  4, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  4, 5, 6, 6, 6, 6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16,
+  16};
 
 static const WT_CONFIG_CHECK confchk_api_timing_benchmarks[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -398,26 +401,28 @@ static const WT_CONFIG_CHECK confchk_api_timing_benchmarks[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -425,7 +430,7 @@ static const uint8_t confchk_api_timing_benchmarks_jump[WT_CONFIG_JUMP_TABLE_SIZ
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6,
-  6, 6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  6, 6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_background_compact[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -442,26 +447,28 @@ static const WT_CONFIG_CHECK confchk_background_compact[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -469,7 +476,7 @@ static const uint8_t confchk_background_compact_jump[WT_CONFIG_JUMP_TABLE_SIZE] 
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6,
-  6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_bounded_cursor_perf[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -486,26 +493,28 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_perf[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -513,7 +522,7 @@ static const uint8_t confchk_bounded_cursor_perf_jump[WT_CONFIG_JUMP_TABLE_SIZE]
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6,
-  6, 6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  6, 6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_indices[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -530,26 +539,28 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_indices[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -557,7 +568,7 @@ static const uint8_t confchk_bounded_cursor_prefix_indices_jump[WT_CONFIG_JUMP_T
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4,
-  5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  5, 6, 6, 6, 6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_search_near[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -574,26 +585,28 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_search_near[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -601,7 +614,8 @@ static const uint8_t confchk_bounded_cursor_prefix_search_near_jump[WT_CONFIG_JU
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-  4, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  4, 5, 6, 6, 6, 6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16,
+  16};
 
 static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_stat[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -618,28 +632,30 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_prefix_stat[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
-  {"search_near_threads", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 46,
+  {"search_near_threads", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 47,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -647,7 +663,7 @@ static const uint8_t confchk_bounded_cursor_prefix_stat_jump[WT_CONFIG_JUMP_TABL
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5,
-  6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
+  6, 6, 6, 6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 14, 15, 15, 16, 17, 17, 17, 17, 17, 17, 17, 17};
 
 static const WT_CONFIG_CHECK confchk_bounded_cursor_stress[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -664,26 +680,28 @@ static const WT_CONFIG_CHECK confchk_bounded_cursor_stress[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -691,12 +709,12 @@ static const uint8_t confchk_bounded_cursor_stress_jump[WT_CONFIG_JUMP_TABLE_SIZ
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6,
-  6, 6, 7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  6, 6, 7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_burst_inserts[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_BOOLEAN, 0, INT64_MIN, INT64_MAX, NULL},
-  {"burst_duration", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 47,
+  {"burst_duration", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 48,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 1, 0,
     INT64_MAX, NULL},
@@ -710,26 +728,28 @@ static const WT_CONFIG_CHECK confchk_burst_inserts[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -737,7 +757,7 @@ static const uint8_t confchk_burst_inserts_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 5, 6, 7, 7, 7, 7,
-  8, 8, 8, 8, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
+  8, 8, 8, 8, 10, 10, 11, 11, 11, 12, 14, 15, 15, 16, 17, 17, 17, 17, 17, 17, 17, 17};
 
 static const WT_CONFIG_CHECK confchk_cache_resize[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -754,26 +774,28 @@ static const WT_CONFIG_CHECK confchk_cache_resize[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -781,7 +803,7 @@ static const uint8_t confchk_cache_resize_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6, 7,
-  7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_hs_cleanup[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -798,26 +820,28 @@ static const WT_CONFIG_CHECK confchk_hs_cleanup[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -825,7 +849,7 @@ static const uint8_t confchk_hs_cleanup_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6, 7,
-  7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_operations_test[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -842,26 +866,28 @@ static const WT_CONFIG_CHECK confchk_operations_test[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -869,7 +895,7 @@ static const uint8_t confchk_operations_test_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6,
-  7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_reverse_split[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -886,26 +912,28 @@ static const WT_CONFIG_CHECK confchk_reverse_split[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -913,7 +941,7 @@ static const uint8_t confchk_reverse_split_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6,
-  7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_search_near_01[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -930,28 +958,30 @@ static const WT_CONFIG_CHECK confchk_search_near_01[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
-  {"search_near_threads", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 46,
+  {"search_near_threads", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 47,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -959,7 +989,7 @@ static const uint8_t confchk_search_near_01_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6,
-  7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
+  7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 14, 15, 15, 16, 17, 17, 17, 17, 17, 17, 17, 17};
 
 static const WT_CONFIG_CHECK confchk_search_near_02[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -976,26 +1006,28 @@ static const WT_CONFIG_CHECK confchk_search_near_02[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -1003,7 +1035,7 @@ static const uint8_t confchk_search_near_02_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6,
-  7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_search_near_03[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -1020,26 +1052,28 @@ static const WT_CONFIG_CHECK confchk_search_near_03[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -1047,7 +1081,7 @@ static const uint8_t confchk_search_near_03_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6,
-  7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_CHECK confchk_test_template[] = {
   {"background_compact_debug_mode", "boolean", NULL, NULL, NULL, 0, NULL,
@@ -1064,26 +1098,28 @@ static const WT_CONFIG_CHECK confchk_test_template[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 6, INT64_MIN,
     INT64_MAX, NULL},
+  {"max_transaction_modify_count", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    7, 0, INT64_MAX, NULL},
   {"metrics_monitor", "category", NULL, NULL, confchk_metrics_monitor_subconfigs, 6,
-    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 7, INT64_MIN,
+    confchk_metrics_monitor_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 8, INT64_MIN,
     INT64_MAX, NULL},
   {"operation_tracker", "category", NULL, NULL, confchk_operation_tracker_subconfigs, 4,
-    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19, INT64_MIN,
+    confchk_operation_tracker_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 22,
+  {"reverse_collator", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 23,
     INT64_MIN, INT64_MAX, NULL},
   {"statistics_config", "category", NULL, NULL, confchk_statistics_config_subconfigs, 2,
-    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 23, INT64_MIN,
+    confchk_statistics_config_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 24, INT64_MIN,
     INT64_MAX, NULL},
-  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 25,
+  {"sweep_interval", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 26,
     INT64_MIN, INT64_MAX, NULL},
   {"timestamp_manager", "category", NULL, NULL, confchk_timestamp_manager_subconfigs, 4,
-    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 26, INT64_MIN,
+    confchk_timestamp_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 27, INT64_MIN,
     INT64_MAX, NULL},
-  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 29, INT64_MIN,
+  {"validate", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 30, INT64_MIN,
     INT64_MAX, NULL},
   {"workload_manager", "category", NULL, NULL, confchk_workload_manager_subconfigs, 10,
-    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 30, INT64_MIN,
+    confchk_workload_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 31, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -1091,13 +1127,14 @@ static const uint8_t confchk_test_template_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 6, 6, 6, 6,
-  7, 7, 7, 7, 8, 8, 9, 9, 9, 10, 12, 13, 13, 14, 15, 15, 15, 15, 15, 15, 15, 15};
+  7, 7, 7, 7, 9, 9, 10, 10, 10, 11, 13, 14, 14, 15, 16, 16, 16, 16, 16, 16, 16, 16};
 
 static const WT_CONFIG_ENTRY config_entries[] = {
   {"api_instruction_count_benchmarks",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1121,12 +1158,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_api_instruction_count_benchmarks, 15, confchk_api_instruction_count_benchmarks_jump, 0,
+    confchk_api_instruction_count_benchmarks, 16, confchk_api_instruction_count_benchmarks_jump, 0,
     WT_CONF_SIZING_NONE, false},
   {"api_timing_benchmarks",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1150,12 +1188,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_api_timing_benchmarks, 15, confchk_api_timing_benchmarks_jump, 1, WT_CONF_SIZING_NONE,
+    confchk_api_timing_benchmarks, 16, confchk_api_timing_benchmarks_jump, 1, WT_CONF_SIZING_NONE,
     false},
   {"background_compact",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1179,11 +1218,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_background_compact, 15, confchk_background_compact_jump, 2, WT_CONF_SIZING_NONE, false},
+    confchk_background_compact, 16, confchk_background_compact_jump, 2, WT_CONF_SIZING_NONE, false},
   {"bounded_cursor_perf",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1207,12 +1247,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_bounded_cursor_perf, 15, confchk_bounded_cursor_perf_jump, 3, WT_CONF_SIZING_NONE,
+    confchk_bounded_cursor_perf, 16, confchk_bounded_cursor_perf_jump, 3, WT_CONF_SIZING_NONE,
     false},
   {"bounded_cursor_prefix_indices",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1236,12 +1277,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_bounded_cursor_prefix_indices, 15, confchk_bounded_cursor_prefix_indices_jump, 4,
+    confchk_bounded_cursor_prefix_indices, 16, confchk_bounded_cursor_prefix_indices_jump, 4,
     WT_CONF_SIZING_NONE, false},
   {"bounded_cursor_prefix_search_near",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1265,12 +1307,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_bounded_cursor_prefix_search_near, 15, confchk_bounded_cursor_prefix_search_near_jump,
+    confchk_bounded_cursor_prefix_search_near, 16, confchk_bounded_cursor_prefix_search_near_jump,
     5, WT_CONF_SIZING_NONE, false},
   {"bounded_cursor_prefix_stat",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1295,12 +1338,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_bounded_cursor_prefix_stat, 16, confchk_bounded_cursor_prefix_stat_jump, 6,
+    confchk_bounded_cursor_prefix_stat, 17, confchk_bounded_cursor_prefix_stat_jump, 6,
     WT_CONF_SIZING_NONE, false},
   {"bounded_cursor_stress",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1324,12 +1368,13 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_bounded_cursor_stress, 15, confchk_bounded_cursor_stress_jump, 7, WT_CONF_SIZING_NONE,
+    confchk_bounded_cursor_stress, 16, confchk_bounded_cursor_stress_jump, 7, WT_CONF_SIZING_NONE,
     false},
   {"burst_inserts",
     "background_compact_debug_mode=false,burst_duration=90,"
     "cache_max_wait_ms=0,cache_size_mb=0,compression_enabled=false,"
     "duration_seconds=0,enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1353,11 +1398,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_burst_inserts, 16, confchk_burst_inserts_jump, 8, WT_CONF_SIZING_NONE, false},
+    confchk_burst_inserts, 17, confchk_burst_inserts_jump, 8, WT_CONF_SIZING_NONE, false},
   {"cache_resize",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1381,11 +1427,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_cache_resize, 15, confchk_cache_resize_jump, 9, WT_CONF_SIZING_NONE, false},
+    confchk_cache_resize, 16, confchk_cache_resize_jump, 9, WT_CONF_SIZING_NONE, false},
   {"hs_cleanup",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1409,11 +1456,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_hs_cleanup, 15, confchk_hs_cleanup_jump, 10, WT_CONF_SIZING_NONE, false},
+    confchk_hs_cleanup, 16, confchk_hs_cleanup_jump, 10, WT_CONF_SIZING_NONE, false},
   {"operations_test",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1437,11 +1485,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_operations_test, 15, confchk_operations_test_jump, 11, WT_CONF_SIZING_NONE, false},
+    confchk_operations_test, 16, confchk_operations_test_jump, 11, WT_CONF_SIZING_NONE, false},
   {"reverse_split",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1465,11 +1514,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_reverse_split, 15, confchk_reverse_split_jump, 12, WT_CONF_SIZING_NONE, false},
+    confchk_reverse_split, 16, confchk_reverse_split_jump, 12, WT_CONF_SIZING_NONE, false},
   {"search_near_01",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1494,11 +1544,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_search_near_01, 16, confchk_search_near_01_jump, 13, WT_CONF_SIZING_NONE, false},
+    confchk_search_near_01, 17, confchk_search_near_01_jump, 13, WT_CONF_SIZING_NONE, false},
   {"search_near_02",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1522,11 +1573,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_search_near_02, 15, confchk_search_near_02_jump, 14, WT_CONF_SIZING_NONE, false},
+    confchk_search_near_02, 16, confchk_search_near_02_jump, 14, WT_CONF_SIZING_NONE, false},
   {"search_near_03",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1550,11 +1602,12 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_search_near_03, 15, confchk_search_near_03_jump, 15, WT_CONF_SIZING_NONE, false},
+    confchk_search_near_03, 16, confchk_search_near_03_jump, 15, WT_CONF_SIZING_NONE, false},
   {"test_template",
     "background_compact_debug_mode=false,cache_max_wait_ms=0,"
     "cache_size_mb=0,compression_enabled=false,duration_seconds=0,"
     "enable_logging=false,in_memory=false,"
+    "max_transaction_modify_count=0,"
     "metrics_monitor=(cache_hs_insert=(max=1,min=0,postrun=false,"
     "runtime=false,save=false),cc_pages_removed=(max=1,min=0,"
     "postrun=false,runtime=false,save=false),enabled=true,op_rate=1s,"
@@ -1578,7 +1631,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "remove_config=(op_rate=1s,ops_per_transaction=(max=1,min=0),"
     "thread_count=0),update_config=(key_size=5,op_rate=1s,"
     "ops_per_transaction=(max=1,min=0),thread_count=0,value_size=5))",
-    confchk_test_template, 15, confchk_test_template_jump, 16, WT_CONF_SIZING_NONE, false},
+    confchk_test_template, 16, confchk_test_template_jump, 16, WT_CONF_SIZING_NONE, false},
   {NULL, NULL, NULL, 0, NULL, 0, WT_CONF_SIZING_NONE, false}};
 
 /*

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -166,6 +166,9 @@ __cache_config_local(WT_SESSION_IMPL *session, bool shared, const char *cfg[])
     WT_RET(__wt_config_gets(session, cfg, "cache_stuck_timeout_ms", &cval));
     cache->cache_stuck_timeout_ms = (uint64_t)cval.val;
 
+    WT_RET(__wt_config_gets(session, cfg, "max_transaction_modify_count", &cval));
+    conn->max_transaction_modify_count = (uint64_t)(cval.val);
+
     return (0);
 }
 

--- a/src/include/conf.h
+++ b/src/include/conf.h
@@ -140,9 +140,9 @@ struct __wt_conf_value {
 WT_CONF_API_DECLARE(WT_CONNECTION, close, 1, 3);
 WT_CONF_API_DECLARE(WT_CONNECTION, debug_info, 1, 7);
 WT_CONF_API_DECLARE(WT_CONNECTION, load_extension, 1, 4);
-WT_CONF_API_DECLARE(WT_CONNECTION, open_session, 3, 9);
+WT_CONF_API_DECLARE(WT_CONNECTION, open_session, 3, 10);
 WT_CONF_API_DECLARE(WT_CONNECTION, query_timestamp, 1, 1);
-WT_CONF_API_DECLARE(WT_CONNECTION, reconfigure, 17, 98);
+WT_CONF_API_DECLARE(WT_CONNECTION, reconfigure, 17, 99);
 WT_CONF_API_DECLARE(WT_CONNECTION, rollback_to_stable, 1, 2);
 WT_CONF_API_DECLARE(WT_CONNECTION, set_timestamp, 1, 4);
 WT_CONF_API_DECLARE(WT_CURSOR, bound, 1, 3);
@@ -159,7 +159,7 @@ WT_CONF_API_DECLARE(WT_SESSION, log_flush, 1, 1);
 WT_CONF_API_DECLARE(WT_SESSION, open_cursor, 3, 29);
 WT_CONF_API_DECLARE(WT_SESSION, prepare_transaction, 1, 1);
 WT_CONF_API_DECLARE(WT_SESSION, query_timestamp, 1, 1);
-WT_CONF_API_DECLARE(WT_SESSION, reconfigure, 3, 9);
+WT_CONF_API_DECLARE(WT_SESSION, reconfigure, 3, 10);
 WT_CONF_API_DECLARE(WT_SESSION, rollback_transaction, 1, 1);
 WT_CONF_API_DECLARE(WT_SESSION, salvage, 1, 1);
 WT_CONF_API_DECLARE(WT_SESSION, timestamp_transaction, 1, 4);
@@ -173,10 +173,10 @@ WT_CONF_API_DECLARE(object, meta, 5, 64);
 WT_CONF_API_DECLARE(table, meta, 2, 13);
 WT_CONF_API_DECLARE(tier, meta, 5, 65);
 WT_CONF_API_DECLARE(tiered, meta, 5, 67);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 21, 161);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 21, 162);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 21, 156);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 21, 155);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 21, 162);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 21, 163);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 21, 157);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 21, 156);
 
 #define WT_CONF_API_ELEMENTS 55
 

--- a/src/include/conf_keys.h
+++ b/src/include/conf_keys.h
@@ -27,7 +27,7 @@
 #define WT_CONF_ID_Eviction 217ULL
 #define WT_CONF_ID_File_manager 229ULL
 #define WT_CONF_ID_Flush_tier 165ULL
-#define WT_CONF_ID_Hash 289ULL
+#define WT_CONF_ID_Hash 290ULL
 #define WT_CONF_ID_History_store 234ULL
 #define WT_CONF_ID_Import 104ULL
 #define WT_CONF_ID_Incremental 127ULL
@@ -36,13 +36,13 @@
 #define WT_CONF_ID_Lsm 68ULL
 #define WT_CONF_ID_Lsm_manager 246ULL
 #define WT_CONF_ID_Merge_custom 78ULL
-#define WT_CONF_ID_Operation_tracking 249ULL
-#define WT_CONF_ID_Prefetch 269ULL
+#define WT_CONF_ID_Operation_tracking 250ULL
+#define WT_CONF_ID_Prefetch 270ULL
 #define WT_CONF_ID_Roundup_timestamps 159ULL
-#define WT_CONF_ID_Shared_cache 251ULL
-#define WT_CONF_ID_Statistics_log 255ULL
+#define WT_CONF_ID_Shared_cache 252ULL
+#define WT_CONF_ID_Statistics_log 256ULL
 #define WT_CONF_ID_Tiered_storage 47ULL
-#define WT_CONF_ID_Transaction_sync 307ULL
+#define WT_CONF_ID_Transaction_sync 308ULL
 #define WT_CONF_ID_access_pattern_hint 12ULL
 #define WT_CONF_ID_action 93ULL
 #define WT_CONF_ID_allocation_size 13ULL
@@ -51,11 +51,11 @@
 #define WT_CONF_ID_archive 240ULL
 #define WT_CONF_ID_auth_token 48ULL
 #define WT_CONF_ID_auto_throttle 69ULL
-#define WT_CONF_ID_available 300ULL
+#define WT_CONF_ID_available 301ULL
 #define WT_CONF_ID_background 97ULL
 #define WT_CONF_ID_background_compact 201ULL
 #define WT_CONF_ID_backup 169ULL
-#define WT_CONF_ID_backup_restore_target 272ULL
+#define WT_CONF_ID_backup_restore_target 273ULL
 #define WT_CONF_ID_blkcache_eviction_aggression 179ULL
 #define WT_CONF_ID_block_allocation 14ULL
 #define WT_CONF_ID_block_compressor 15ULL
@@ -68,12 +68,12 @@
 #define WT_CONF_ID_bound 94ULL
 #define WT_CONF_ID_bucket 49ULL
 #define WT_CONF_ID_bucket_prefix 50ULL
-#define WT_CONF_ID_buckets 290ULL
-#define WT_CONF_ID_buffer_alignment 273ULL
-#define WT_CONF_ID_builtin_extension_config 274ULL
+#define WT_CONF_ID_buckets 291ULL
+#define WT_CONF_ID_buffer_alignment 274ULL
+#define WT_CONF_ID_builtin_extension_config 275ULL
 #define WT_CONF_ID_bulk 120ULL
 #define WT_CONF_ID_cache 170ULL
-#define WT_CONF_ID_cache_cursors 265ULL
+#define WT_CONF_ID_cache_cursors 266ULL
 #define WT_CONF_ID_cache_directory 51ULL
 #define WT_CONF_ID_cache_max_wait_ms 187ULL
 #define WT_CONF_ID_cache_on_checkpoint 177ULL
@@ -82,21 +82,21 @@
 #define WT_CONF_ID_cache_resident 16ULL
 #define WT_CONF_ID_cache_size 189ULL
 #define WT_CONF_ID_cache_stuck_timeout_ms 190ULL
-#define WT_CONF_ID_capacity 276ULL
+#define WT_CONF_ID_capacity 277ULL
 #define WT_CONF_ID_checkpoint 56ULL
 #define WT_CONF_ID_checkpoint_backup_info 57ULL
 #define WT_CONF_ID_checkpoint_cleanup 163ULL
-#define WT_CONF_ID_checkpoint_fail_before_turtle_update 266ULL
+#define WT_CONF_ID_checkpoint_fail_before_turtle_update 267ULL
 #define WT_CONF_ID_checkpoint_lsn 58ULL
 #define WT_CONF_ID_checkpoint_read_timestamp 123ULL
 #define WT_CONF_ID_checkpoint_retention 203ULL
-#define WT_CONF_ID_checkpoint_sync 275ULL
+#define WT_CONF_ID_checkpoint_sync 276ULL
 #define WT_CONF_ID_checkpoint_use_history 121ULL
 #define WT_CONF_ID_checkpoint_wait 109ULL
 #define WT_CONF_ID_checksum 17ULL
-#define WT_CONF_ID_chunk 252ULL
+#define WT_CONF_ID_chunk 253ULL
 #define WT_CONF_ID_chunk_cache 238ULL
-#define WT_CONF_ID_chunk_cache_evict_trigger 277ULL
+#define WT_CONF_ID_chunk_cache_evict_trigger 278ULL
 #define WT_CONF_ID_chunk_count_limit 75ULL
 #define WT_CONF_ID_chunk_max 76ULL
 #define WT_CONF_ID_chunk_size 77ULL
@@ -110,21 +110,21 @@
 #define WT_CONF_ID_commit_timestamp 2ULL
 #define WT_CONF_ID_compare 115ULL
 #define WT_CONF_ID_compare_timestamp 105ULL
-#define WT_CONF_ID_compile_configuration_count 282ULL
-#define WT_CONF_ID_compressor 294ULL
-#define WT_CONF_ID_config 261ULL
-#define WT_CONF_ID_config_base 283ULL
+#define WT_CONF_ID_compile_configuration_count 283ULL
+#define WT_CONF_ID_compressor 295ULL
+#define WT_CONF_ID_config 262ULL
+#define WT_CONF_ID_config_base 284ULL
 #define WT_CONF_ID_consolidate 128ULL
 #define WT_CONF_ID_corruption_abort 202ULL
 #define WT_CONF_ID_count 116ULL
-#define WT_CONF_ID_create 284ULL
+#define WT_CONF_ID_create 285ULL
 #define WT_CONF_ID_cursor_copy 204ULL
 #define WT_CONF_ID_cursor_reposition 205ULL
 #define WT_CONF_ID_cursors 171ULL
-#define WT_CONF_ID_default 301ULL
-#define WT_CONF_ID_dhandle_buckets 291ULL
+#define WT_CONF_ID_default 302ULL
+#define WT_CONF_ID_dhandle_buckets 292ULL
 #define WT_CONF_ID_dictionary 18ULL
-#define WT_CONF_ID_direct_io 285ULL
+#define WT_CONF_ID_direct_io 286ULL
 #define WT_CONF_ID_do_not_clear_txn_id 143ULL
 #define WT_CONF_ID_drop 164ULL
 #define WT_CONF_ID_dryrun 98ULL
@@ -138,9 +138,9 @@
 #define WT_CONF_ID_dump_pages 150ULL
 #define WT_CONF_ID_dump_version 124ULL
 #define WT_CONF_ID_durable_timestamp 3ULL
-#define WT_CONF_ID_early_load 262ULL
+#define WT_CONF_ID_early_load 263ULL
 #define WT_CONF_ID_enabled 37ULL
-#define WT_CONF_ID_entry 263ULL
+#define WT_CONF_ID_entry 264ULL
 #define WT_CONF_ID_error_prefix 216ULL
 #define WT_CONF_ID_evict_sample_inmem 220ULL
 #define WT_CONF_ID_eviction 206ULL
@@ -154,20 +154,20 @@
 #define WT_CONF_ID_exclude 99ULL
 #define WT_CONF_ID_exclusive 103ULL
 #define WT_CONF_ID_exclusive_refreshed 96ULL
-#define WT_CONF_ID_extensions 287ULL
+#define WT_CONF_ID_extensions 288ULL
 #define WT_CONF_ID_extra_diagnostics 228ULL
 #define WT_CONF_ID_extractor 63ULL
 #define WT_CONF_ID_file 129ULL
-#define WT_CONF_ID_file_extend 288ULL
+#define WT_CONF_ID_file_extend 289ULL
 #define WT_CONF_ID_file_max 235ULL
 #define WT_CONF_ID_file_metadata 107ULL
 #define WT_CONF_ID_final_flush 167ULL
 #define WT_CONF_ID_flush_time 85ULL
 #define WT_CONF_ID_flush_timestamp 86ULL
-#define WT_CONF_ID_flushed_data_cache_insertion 279ULL
+#define WT_CONF_ID_flushed_data_cache_insertion 280ULL
 #define WT_CONF_ID_force 110ULL
 #define WT_CONF_ID_force_stop 130ULL
-#define WT_CONF_ID_force_write_wait 295ULL
+#define WT_CONF_ID_force_write_wait 296ULL
 #define WT_CONF_ID_format 22ULL
 #define WT_CONF_ID_free_space_target 100ULL
 #define WT_CONF_ID_full_target 180ULL
@@ -176,24 +176,24 @@
 #define WT_CONF_ID_granularity 131ULL
 #define WT_CONF_ID_handles 172ULL
 #define WT_CONF_ID_hashsize 182ULL
-#define WT_CONF_ID_hazard_max 292ULL
+#define WT_CONF_ID_hazard_max 293ULL
 #define WT_CONF_ID_huffman_key 23ULL
 #define WT_CONF_ID_huffman_value 24ULL
 #define WT_CONF_ID_id 59ULL
-#define WT_CONF_ID_ignore_cache_size 268ULL
+#define WT_CONF_ID_ignore_cache_size 269ULL
 #define WT_CONF_ID_ignore_in_memory_cache_size 25ULL
 #define WT_CONF_ID_ignore_prepare 154ULL
 #define WT_CONF_ID_immutable 64ULL
-#define WT_CONF_ID_in_memory 293ULL
+#define WT_CONF_ID_in_memory 294ULL
 #define WT_CONF_ID_inclusive 95ULL
 #define WT_CONF_ID_index_key_columns 65ULL
 #define WT_CONF_ID_internal_item_max 26ULL
 #define WT_CONF_ID_internal_key_max 27ULL
 #define WT_CONF_ID_internal_key_truncate 28ULL
 #define WT_CONF_ID_internal_page_max 29ULL
-#define WT_CONF_ID_interval 306ULL
+#define WT_CONF_ID_interval 307ULL
 #define WT_CONF_ID_isolation 155ULL
-#define WT_CONF_ID_json 256ULL
+#define WT_CONF_ID_json 257ULL
 #define WT_CONF_ID_json_output 239ULL
 #define WT_CONF_ID_key_format 30ULL
 #define WT_CONF_ID_key_gap 31ULL
@@ -210,6 +210,7 @@
 #define WT_CONF_ID_log_retention 207ULL
 #define WT_CONF_ID_log_size 192ULL
 #define WT_CONF_ID_max_percent_overhead 183ULL
+#define WT_CONF_ID_max_transaction_modify_count 249ULL
 #define WT_CONF_ID_memory_page_image_max 38ULL
 #define WT_CONF_ID_memory_page_max 39ULL
 #define WT_CONF_ID_merge 248ULL
@@ -217,9 +218,9 @@
 #define WT_CONF_ID_merge_min 83ULL
 #define WT_CONF_ID_metadata_file 108ULL
 #define WT_CONF_ID_method 195ULL
-#define WT_CONF_ID_mmap 297ULL
-#define WT_CONF_ID_mmap_all 298ULL
-#define WT_CONF_ID_multiprocess 299ULL
+#define WT_CONF_ID_mmap 298ULL
+#define WT_CONF_ID_mmap_all 299ULL
+#define WT_CONF_ID_multiprocess 300ULL
 #define WT_CONF_ID_name 20ULL
 #define WT_CONF_ID_next_random 134ULL
 #define WT_CONF_ID_next_random_sample_size 135ULL
@@ -229,15 +230,15 @@
 #define WT_CONF_ID_object_target_size 53ULL
 #define WT_CONF_ID_old_chunks 84ULL
 #define WT_CONF_ID_oldest 88ULL
-#define WT_CONF_ID_oldest_timestamp 270ULL
-#define WT_CONF_ID_on_close 257ULL
+#define WT_CONF_ID_oldest_timestamp 271ULL
+#define WT_CONF_ID_on_close 258ULL
 #define WT_CONF_ID_operation 117ULL
 #define WT_CONF_ID_operation_timeout_ms 157ULL
 #define WT_CONF_ID_os_cache_dirty_max 40ULL
 #define WT_CONF_ID_os_cache_dirty_pct 241ULL
 #define WT_CONF_ID_os_cache_max 41ULL
 #define WT_CONF_ID_overwrite 91ULL
-#define WT_CONF_ID_path 250ULL
+#define WT_CONF_ID_path 251ULL
 #define WT_CONF_ID_percent_file_in_dram 185ULL
 #define WT_CONF_ID_pinned 197ULL
 #define WT_CONF_ID_prealloc 242ULL
@@ -249,7 +250,7 @@
 #define WT_CONF_ID_prepare_timestamp 162ULL
 #define WT_CONF_ID_prepared 160ULL
 #define WT_CONF_ID_priority 158ULL
-#define WT_CONF_ID_quota 253ULL
+#define WT_CONF_ID_quota 254ULL
 #define WT_CONF_ID_raw 137ULL
 #define WT_CONF_ID_read 161ULL
 #define WT_CONF_ID_read_corrupt 151ULL
@@ -258,31 +259,31 @@
 #define WT_CONF_ID_readonly 60ULL
 #define WT_CONF_ID_realloc_exact 208ULL
 #define WT_CONF_ID_realloc_malloc 209ULL
-#define WT_CONF_ID_recover 296ULL
+#define WT_CONF_ID_recover 297ULL
 #define WT_CONF_ID_release 199ULL
 #define WT_CONF_ID_release_evict 125ULL
-#define WT_CONF_ID_release_evict_page 267ULL
+#define WT_CONF_ID_release_evict_page 268ULL
 #define WT_CONF_ID_remove 244ULL
 #define WT_CONF_ID_remove_files 112ULL
 #define WT_CONF_ID_remove_shared 113ULL
 #define WT_CONF_ID_repair 106ULL
-#define WT_CONF_ID_require_max 280ULL
-#define WT_CONF_ID_require_min 281ULL
-#define WT_CONF_ID_reserve 254ULL
+#define WT_CONF_ID_require_max 281ULL
+#define WT_CONF_ID_require_min 282ULL
+#define WT_CONF_ID_reserve 255ULL
 #define WT_CONF_ID_rollback_error 210ULL
 #define WT_CONF_ID_run_once 101ULL
-#define WT_CONF_ID_salvage 302ULL
-#define WT_CONF_ID_secretkey 286ULL
-#define WT_CONF_ID_session_max 303ULL
-#define WT_CONF_ID_session_scratch_max 304ULL
-#define WT_CONF_ID_session_table_cache 305ULL
+#define WT_CONF_ID_salvage 303ULL
+#define WT_CONF_ID_secretkey 287ULL
+#define WT_CONF_ID_session_max 304ULL
+#define WT_CONF_ID_session_scratch_max 305ULL
+#define WT_CONF_ID_session_table_cache 306ULL
 #define WT_CONF_ID_sessions 174ULL
 #define WT_CONF_ID_shared 54ULL
 #define WT_CONF_ID_size 181ULL
 #define WT_CONF_ID_skip_sort_check 139ULL
 #define WT_CONF_ID_slow_checkpoint 211ULL
 #define WT_CONF_ID_source 8ULL
-#define WT_CONF_ID_sources 258ULL
+#define WT_CONF_ID_sources 259ULL
 #define WT_CONF_ID_split_deepen_min_child 44ULL
 #define WT_CONF_ID_split_deepen_per_child 45ULL
 #define WT_CONF_ID_split_pct 46ULL
@@ -290,7 +291,7 @@
 #define WT_CONF_ID_stable_timestamp 152ULL
 #define WT_CONF_ID_start_generation 80ULL
 #define WT_CONF_ID_statistics 140ULL
-#define WT_CONF_ID_storage_path 278ULL
+#define WT_CONF_ID_storage_path 279ULL
 #define WT_CONF_ID_strategy 118ULL
 #define WT_CONF_ID_stress_skiplist 212ULL
 #define WT_CONF_ID_strict 153ULL
@@ -299,36 +300,36 @@
 #define WT_CONF_ID_system_ram 186ULL
 #define WT_CONF_ID_table_logging 213ULL
 #define WT_CONF_ID_target 141ULL
-#define WT_CONF_ID_terminate 264ULL
+#define WT_CONF_ID_terminate 265ULL
 #define WT_CONF_ID_this_id 133ULL
-#define WT_CONF_ID_threads 271ULL
+#define WT_CONF_ID_threads 272ULL
 #define WT_CONF_ID_threads_max 218ULL
 #define WT_CONF_ID_threads_min 219ULL
 #define WT_CONF_ID_tiered_flush_error_continue 214ULL
 #define WT_CONF_ID_tiered_object 61ULL
 #define WT_CONF_ID_tiers 89ULL
 #define WT_CONF_ID_timeout 102ULL
-#define WT_CONF_ID_timestamp 259ULL
-#define WT_CONF_ID_timing_stress_for_test 260ULL
+#define WT_CONF_ID_timestamp 260ULL
+#define WT_CONF_ID_timing_stress_for_test 261ULL
 #define WT_CONF_ID_total 237ULL
 #define WT_CONF_ID_txn 175ULL
 #define WT_CONF_ID_type 9ULL
 #define WT_CONF_ID_update_restore_evict 215ULL
-#define WT_CONF_ID_use_environment 308ULL
-#define WT_CONF_ID_use_environment_priv 309ULL
+#define WT_CONF_ID_use_environment 309ULL
+#define WT_CONF_ID_use_environment_priv 310ULL
 #define WT_CONF_ID_use_timestamp 166ULL
 #define WT_CONF_ID_value_format 55ULL
 #define WT_CONF_ID_verbose 10ULL
-#define WT_CONF_ID_verify_metadata 310ULL
+#define WT_CONF_ID_verify_metadata 311ULL
 #define WT_CONF_ID_version 62ULL
 #define WT_CONF_ID_wait 193ULL
 #define WT_CONF_ID_worker_thread_max 247ULL
-#define WT_CONF_ID_write_through 311ULL
+#define WT_CONF_ID_write_through 312ULL
 #define WT_CONF_ID_write_timestamp 5ULL
 #define WT_CONF_ID_write_timestamp_usage 11ULL
 #define WT_CONF_ID_zero_fill 245ULL
 
-#define WT_CONF_ID_COUNT 312
+#define WT_CONF_ID_COUNT 313
 /*
  * API configuration keys: END
  */
@@ -644,6 +645,7 @@ static const struct {
     uint64_t leak_memory;
     uint64_t lock_wait;
     uint64_t log;
+    uint64_t max_transaction_modify_count;
     uint64_t memory_page_image_max;
     uint64_t memory_page_max;
     uint64_t mmap;
@@ -1012,6 +1014,7 @@ static const struct {
   WT_CONF_ID_leak_memory,
   WT_CONF_ID_lock_wait,
   WT_CONF_ID_log,
+  WT_CONF_ID_max_transaction_modify_count,
   WT_CONF_ID_memory_page_image_max,
   WT_CONF_ID_memory_page_max,
   WT_CONF_ID_mmap,

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -574,6 +574,8 @@ struct __wt_connection_impl {
     uint32_t evict_threads_min; /* Min eviction threads */
     bool evict_sample_inmem;
 
+    uint64_t max_transaction_modify_count; /* Maximum number of modify count in a big trasaction */
+
 #define WT_MAX_PREFETCH_QUEUE 120
 #define WT_PREFETCH_QUEUE_PER_TRIGGER 30
 #define WT_PREFETCH_THREAD_COUNT 8

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -246,9 +246,10 @@ struct __wt_session_impl {
     void *salvage_track;
 
     /* Sessions have an associated statistics bucket based on its ID. */
-    u_int stat_conn_bucket;     /* Statistics connection bucket offset */
-    u_int stat_dsrc_bucket;     /* Statistics data source bucket offset */
-    uint64_t cache_max_wait_us; /* Maximum time an operation waits for space in cache */
+    u_int stat_conn_bucket;                /* Statistics connection bucket offset */
+    u_int stat_dsrc_bucket;                /* Statistics data source bucket offset */
+    uint64_t cache_max_wait_us;            /* Maximum time an operation waits for space in cache */
+    uint64_t max_transaction_modify_count; /* Maximum number of modify count in a big trasaction */
 
 #ifdef HAVE_DIAGNOSTIC
     uint8_t dump_raw; /* Configure debugging page dump */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1065,6 +1065,7 @@ struct __wt_connection_stats {
     int64_t txn_prepare_rollback;
     int64_t txn_query_ts;
     int64_t txn_read_race_prepare_update;
+    int64_t txn_big_transaction_rollback;
     int64_t txn_rts;
     int64_t txn_rts_sweep_hs_keys_dryrun;
     int64_t txn_rts_hs_stop_older_than_newer_start;
@@ -1402,6 +1403,7 @@ struct __wt_dsrc_stats {
     int64_t txn_read_race_prepare_commit;
     int64_t txn_read_overflow_remove;
     int64_t txn_read_race_prepare_update;
+    int64_t txn_big_transaction_rollback;
     int64_t txn_rts_sweep_hs_keys_dryrun;
     int64_t txn_rts_hs_stop_older_than_newer_start;
     int64_t txn_rts_inconsistent_ckpt;

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -25,6 +25,7 @@
 #define WT_TXN_ROLLBACK_REASON_CONFLICT "conflict between concurrent operations"
 #define WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION \
     "oldest pinned transaction ID rolled back for eviction"
+#define WT_TXN_ROLLBACK_REASON_BIG_TRANSACTION "transaction rolled back because of big transaction"
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_TXN_LOG_CKPT_CLEANUP 0x01u

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -252,13 +252,11 @@ __txn_next_op(WT_SESSION_IMPL *session, WT_TXN_OP **opp)
     else
         max_transaction_modify_count = conn->max_transaction_modify_count;
 
-    //max_transaction_modify_count = 16;
-    //printf("yang test 111111111111111111111111  txn:%p  txn id:%lu, __txn_next_op num:%d\r\n", 
-    //    txn, txn->id, (int)txn->mod_count);
-    if (max_transaction_modify_count > 0 && txn->mod_count + 1 >= max_transaction_modify_count) {
+    if (max_transaction_modify_count > 0 && txn->mod_count >= max_transaction_modify_count) {
         WT_STAT_CONN_DSRC_INCR(session, txn_big_transaction_rollback);
         return (__wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_BIG_TRANSACTION));
     }
+
     /*
      * We're about to perform an update. Make sure we have allocated a transaction ID.
      */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -252,7 +252,10 @@ __txn_next_op(WT_SESSION_IMPL *session, WT_TXN_OP **opp)
     else
         max_transaction_modify_count = conn->max_transaction_modify_count;
 
-    if (txn->mod_count + 1 >= max_transaction_modify_count) {
+    //max_transaction_modify_count = 16;
+    //printf("yang test 111111111111111111111111  txn:%p  txn id:%lu, __txn_next_op num:%d\r\n", 
+    //    txn, txn->id, (int)txn->mod_count);
+    if (max_transaction_modify_count > 0 && txn->mod_count + 1 >= max_transaction_modify_count) {
         WT_STAT_CONN_DSRC_INCR(session, txn_big_transaction_rollback);
         return (__wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_BIG_TRANSACTION));
     }

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -884,6 +884,10 @@ struct __wt_session {
      * @config{isolation, the default isolation level for operations in this session., a string\,
      * chosen from the following options: \c "read-uncommitted"\, \c "read-committed"\, \c
      * "snapshot"; default \c snapshot.}
+     * @config{max_transaction_modify_count, the maximum number of modify count in a big
+     * trasaction\, If exceeds this value\, the transaction should be rolled back.  Default value
+     * will be the global setting of the connection config., an integer greater than or equal to \c
+     * 0; default \c 0.}
      * @config{prefetch = (, Enable automatic detection of scans by applications\, and attempt to
      * pre-fetch future content into the cache., a set of related configuration options defined as
      * follows.}
@@ -2401,6 +2405,9 @@ struct __wt_connection {
      * threads to manage merging LSM trees in the database.  Each worker thread uses a session
      * handle from the configured session_max., an integer between \c 3 and \c 20; default \c 4.}
      * @config{ ),,}
+     * @config{max_transaction_modify_count, the maximum number of modify count in a big
+     * trasaction\, If exceeds this value\, the transaction should be rolled back.  Default not
+     * limit., an integer greater than or equal to \c 0; default \c 0.}
      * @config{operation_timeout_ms, this option is no longer supported\, retained for backward
      * compatibility., an integer greater than or equal to \c 0; default \c 0.}
      * @config{operation_tracking = (, enable tracking of performance-critical functions.  See @ref
@@ -2588,6 +2595,10 @@ struct __wt_connection {
      * @config{isolation, the default isolation level for operations in this session., a string\,
      * chosen from the following options: \c "read-uncommitted"\, \c "read-committed"\, \c
      * "snapshot"; default \c snapshot.}
+     * @config{max_transaction_modify_count, the maximum number of modify count in a big
+     * trasaction\, If exceeds this value\, the transaction should be rolled back.  Default value
+     * will be the global setting of the connection config., an integer greater than or equal to \c
+     * 0; default \c 0.}
      * @config{prefetch = (, Enable automatic detection of scans by applications\, and attempt to
      * pre-fetch future content into the cache., a set of related configuration options defined as
      * follows.}
@@ -3281,6 +3292,9 @@ struct __wt_connection {
  * threads to manage merging LSM trees in the database.  Each worker thread uses a session handle
  * from the configured session_max., an integer between \c 3 and \c 20; default \c 4.}
  * @config{ ),,}
+ * @config{max_transaction_modify_count, the maximum number of modify count in a big trasaction\, If
+ * exceeds this value\, the transaction should be rolled back.  Default not limit., an integer
+ * greater than or equal to \c 0; default \c 0.}
  * @config{mmap, Use memory mapping when accessing files in a read-only mode., a boolean flag;
  * default \c true.}
  * @config{mmap_all, Use memory mapping to read and write all data files.  May not be configured
@@ -6997,132 +7011,134 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_QUERY_TS			1651
 /*! transaction: race to read prepared update retry */
 #define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1652
+/*! transaction: rollback count for big transaction */
+#define	WT_STAT_CONN_TXN_BIG_TRANSACTION_ROLLBACK	1653
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1653
+#define	WT_STAT_CONN_TXN_RTS				1654
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1654
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1655
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1655
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1656
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1656
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1657
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1657
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1658
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1658
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1659
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1659
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1660
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1660
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1661
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1661
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1662
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1662
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1663
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1663
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1664
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1664
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1665
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1665
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1666
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1666
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1667
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1667
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1668
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1668
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1669
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1669
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1670
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1670
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1671
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1671
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1672
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1672
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1673
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1673
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1674
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1674
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1675
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1675
+#define	WT_STAT_CONN_TXN_SET_TS				1676
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1676
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1677
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1677
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1678
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1678
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1679
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1679
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1680
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1680
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1681
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1681
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1682
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1682
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1683
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1683
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1684
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1684
+#define	WT_STAT_CONN_TXN_BEGIN				1685
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1685
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1686
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1686
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1687
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1687
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1688
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1688
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1689
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1689
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1690
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1690
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1691
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1691
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1692
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1692
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1693
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1693
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1694
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1694
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1695
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1695
+#define	WT_STAT_CONN_TXN_COMMIT				1696
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1696
+#define	WT_STAT_CONN_TXN_ROLLBACK			1697
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1697
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1698
 
 /*!
  * @}
@@ -7990,61 +8006,63 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2283
 /*! transaction: race to read prepared update retry */
 #define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2284
+/*! transaction: rollback count for big transaction */
+#define	WT_STAT_DSRC_TXN_BIG_TRANSACTION_ROLLBACK	2285
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2285
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2286
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2286
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2287
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2287
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2288
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2288
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2289
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2289
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2290
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2290
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2291
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2291
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2292
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2292
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2293
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2293
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2294
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2294
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2295
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2295
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2296
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2296
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2297
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2297
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2298
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2298
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2299
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2299
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2300
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2300
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2301
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2301
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2302
 
 /*!
  * @}

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -529,6 +529,11 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
         session->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
     WT_ERR_NOTFOUND_OK(ret, false);
 
+    ret = __wt_config_getones(session, config, "max_transaction_modify_count", &cval);
+    if (ret == 0 && cval.val)
+        session->max_transaction_modify_count = (uint64_t)(cval.val);
+    WT_ERR_NOTFOUND_OK(ret, false);
+
     if (S2C(session)->prefetch_auto_on)
         F_SET(session, WT_SESSION_PREFETCH_ENABLED);
     else

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -303,6 +303,7 @@ static const char *const __stats_dsrc_desc[] = {
   "transaction: a reader raced with a prepared transaction commit and skipped an update or updates",
   "transaction: number of times overflow removed value is read",
   "transaction: race to read prepared update retry",
+  "transaction: rollback count for big transaction",
   "transaction: rollback to stable history store keys that would have been swept in non-dryrun "
   "mode",
   "transaction: rollback to stable history store records with stop timestamps older than newer "
@@ -650,6 +651,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->txn_read_race_prepare_commit = 0;
     stats->txn_read_overflow_remove = 0;
     stats->txn_read_race_prepare_update = 0;
+    stats->txn_big_transaction_rollback = 0;
     stats->txn_rts_sweep_hs_keys_dryrun = 0;
     stats->txn_rts_hs_stop_older_than_newer_start = 0;
     stats->txn_rts_inconsistent_ckpt = 0;
@@ -989,6 +991,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->txn_read_race_prepare_commit += from->txn_read_race_prepare_commit;
     to->txn_read_overflow_remove += from->txn_read_overflow_remove;
     to->txn_read_race_prepare_update += from->txn_read_race_prepare_update;
+    to->txn_big_transaction_rollback += from->txn_big_transaction_rollback;
     to->txn_rts_sweep_hs_keys_dryrun += from->txn_rts_sweep_hs_keys_dryrun;
     to->txn_rts_hs_stop_older_than_newer_start += from->txn_rts_hs_stop_older_than_newer_start;
     to->txn_rts_inconsistent_ckpt += from->txn_rts_inconsistent_ckpt;
@@ -1353,6 +1356,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->txn_read_race_prepare_commit += WT_STAT_DSRC_READ(from, txn_read_race_prepare_commit);
     to->txn_read_overflow_remove += WT_STAT_DSRC_READ(from, txn_read_overflow_remove);
     to->txn_read_race_prepare_update += WT_STAT_DSRC_READ(from, txn_read_race_prepare_update);
+    to->txn_big_transaction_rollback += WT_STAT_DSRC_READ(from, txn_big_transaction_rollback);
     to->txn_rts_sweep_hs_keys_dryrun += WT_STAT_DSRC_READ(from, txn_rts_sweep_hs_keys_dryrun);
     to->txn_rts_hs_stop_older_than_newer_start +=
       WT_STAT_DSRC_READ(from, txn_rts_hs_stop_older_than_newer_start);
@@ -2052,6 +2056,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: prepared transactions rolled back",
   "transaction: query timestamp calls",
   "transaction: race to read prepared update retry",
+  "transaction: rollback count for big transaction",
   "transaction: rollback to stable calls",
   "transaction: rollback to stable history store keys that would have been swept in non-dryrun "
   "mode",
@@ -2796,6 +2801,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->txn_prepare_rollback = 0;
     stats->txn_query_ts = 0;
     stats->txn_read_race_prepare_update = 0;
+    stats->txn_big_transaction_rollback = 0;
     stats->txn_rts = 0;
     stats->txn_rts_sweep_hs_keys_dryrun = 0;
     stats->txn_rts_hs_stop_older_than_newer_start = 0;
@@ -3632,6 +3638,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_prepare_rollback += WT_STAT_CONN_READ(from, txn_prepare_rollback);
     to->txn_query_ts += WT_STAT_CONN_READ(from, txn_query_ts);
     to->txn_read_race_prepare_update += WT_STAT_CONN_READ(from, txn_read_race_prepare_update);
+    to->txn_big_transaction_rollback += WT_STAT_CONN_READ(from, txn_big_transaction_rollback);
     to->txn_rts += WT_STAT_CONN_READ(from, txn_rts);
     to->txn_rts_sweep_hs_keys_dryrun += WT_STAT_CONN_READ(from, txn_rts_sweep_hs_keys_dryrun);
     to->txn_rts_hs_stop_older_than_newer_start +=

--- a/test/suite/test_txn29.py
+++ b/test/suite/test_txn29.py
@@ -55,7 +55,6 @@ class test_txn29(wttest.WiredTigerTestCase):
                 msg1 = '/conflict between concurrent operations/'
                 msg2 = '/transaction rolled back because of big transaction/'
                 self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.insert(), msg1)
-                #print(session.get_rollback_reason())
                 self.assertEquals('/' + session.get_rollback_reason() + '/', msg2)
             else:
                 cursor.insert()

--- a/test/suite/test_txn29.py
+++ b/test/suite/test_txn29.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest, time
+
+# test_txn27.py
+#   Test that the API returning a rollback error sets the reason for the rollback.
+class test_txn27(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=100MB, max_transaction_modify_count=1000'
+
+    def test_rollback_reason(self):
+        uri = "table:txn28"
+        # Create and populate a table.
+        table_params = 'key_format=i,value_format=S'
+        session = self.session
+        session.create(uri, table_params)
+        cursor = session.open_cursor(uri, None)
+        for i in range(1, 1000):
+            if i == 1000:
+                msg = '/transaction rolled back because of big transaction/'
+                self.assertEquals('/' + session.get_rollback_reason() + '/', msg)
+            else:
+                cursor[i] = str(i)
+        cursor.close()


### PR DESCRIPTION
Background:
Our online MongoDB cluster has experienced several cluster unavailability issues due to large transactions. In large transaction scenarios, we can use the existing functions of wiredtiger to optimize the following configurations:
 db.adminCommand( { setParameter : 1, "wiredTigerEngineRuntimeConfig" : "cache_max_wait_ms=1000"})

However, this configuration is not applicable in some scenarios for the following reasons:
1. What is the most appropriate time setting? I don't know how reasonable the time setting is. When a cluster is overloaded with memory, CPU, etc., due to large transactions, the ordinary check time will also be very long.
2. It is easy to cause error, because a large number of write transactions in the same cluster, there are many analytical query SQL(analytical SQL execution time is generally very long), we have no way to distinguish those that need to be really rolled back.
3. This function only takes effect when the memory exceeds the hard evict limit, and will not work on some large mongod nodes(for example: 512G mem/64CPU).

Based on the above reasons, I submit this PR. The purpose of this PR is to limit the number of modifies in a single transaction and avoid causing long-term jitter in the cluster.