### PR TITLE
WT-13186 Use file_cursors, not hs cursors when truncating the history store 

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1184,7 +1184,11 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     WT_SESSION_IMPL *session;
 
     session = trunc_info->session;
-    start_file_cursor = ((WT_CURSOR_HS *)trunc_info->start)->file_cursor;
+    /*
+     * Special case: trunc_info typically stores the top level cursor, but for hs_cursors we store
+     * their backing file cursor instead.
+     */
+    start_file_cursor = trunc_info->start;
     stop_file_cursor = NULL;
 
     WT_STAT_DSRC_INCR(session, cursor_truncate);
@@ -1192,7 +1196,11 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     WT_ASSERT(session, F_ISSET(start_file_cursor, WT_CURSTD_KEY_INT));
     WT_RET(__wt_cursor_localkey(start_file_cursor));
     if (F_ISSET(trunc_info, WT_TRUNC_EXPLICIT_STOP)) {
-        stop_file_cursor = ((WT_CURSOR_HS *)trunc_info->stop)->file_cursor;
+        /*
+         * Special case: trunc_info typically stores the top level cursor, but for hs_cursors we
+         * store their backing file cursor instead.
+         */
+        stop_file_cursor = trunc_info->stop;
         WT_ASSERT(session, F_ISSET(stop_file_cursor, WT_CURSTD_KEY_INT));
         WT_RET(__wt_cursor_localkey(stop_file_cursor));
     }
@@ -1210,13 +1218,14 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
 int
 __wt_curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
 {
-    WT_CURSOR *start_file_cursor;
     WT_DECL_RET;
 
-    start_file_cursor = ((WT_CURSOR_HS *)trunc_info->start)->file_cursor;
-
+    /*
+     * Special case: trunc_info typically stores the top level cursor, but for hs_cursors we store
+     * their backing file cursor instead.
+     */
     WT_WITH_BTREE(
-      trunc_info->session, CUR2BT(start_file_cursor), ret = __curhs_range_truncate(trunc_info));
+      trunc_info->session, CUR2BT(trunc_info->start), ret = __curhs_range_truncate(trunc_info));
 
     return (ret);
 }

--- a/src/rollback_to_stable/rts_history.c
+++ b/src/rollback_to_stable/rts_history.c
@@ -154,9 +154,13 @@ __wti_rts_history_btree_hs_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
         hs_cursor_stop->get_key(hs_cursor_stop, &hs_btree_id, hs_key, &hs_start_ts, &hs_counter);
     } while (hs_btree_id != btree_id);
 
-    if (!dryrun)
-        WT_ERR(truncate_session->truncate(
-          truncate_session, NULL, hs_cursor_start, hs_cursor_stop, NULL));
+    if (!dryrun) {
+        WT_ASSERT(session, hs_cursor_start != NULL);
+        WT_ASSERT(session, hs_cursor_stop != NULL);
+        WT_ERR(truncate_session->truncate(truncate_session, NULL,
+          ((WT_CURSOR_HS *)hs_cursor_start)->file_cursor,
+          ((WT_CURSOR_HS *)hs_cursor_stop)->file_cursor, NULL));
+    }
 
     WT_RTS_STAT_CONN_DATA_INCR(session, cache_hs_btree_truncate);
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1577,7 +1577,6 @@ int
 __wt_session_range_truncate(
   WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *start, WT_CURSOR *stop)
 {
-    WT_CURSOR *start_file_cursor, *stop_file_cursor;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_ITEM(orig_start_key);
     WT_DECL_ITEM(orig_stop_key);
@@ -1669,25 +1668,14 @@ __wt_session_range_truncate(
     trunc_info->orig_stop_key = orig_stop_key;
     trunc_info->uri = actual_uri;
 
-    if (start != NULL && strcmp(start->uri, WT_HS_URI) == 0)
-        start_file_cursor = ((WT_CURSOR_HS *)start)->file_cursor;
-    else
-        start_file_cursor = start;
-
-    if (stop != NULL && strcmp(stop->uri, WT_HS_URI) == 0)
-        stop_file_cursor = ((WT_CURSOR_HS *)stop)->file_cursor;
-    else
-        stop_file_cursor = stop;
-
     /*
      * Don't use bounded cursors for FLCS as it isn't supported, additionally skip using them for
      * complex types such as column groups and indexes. We can't check support for those complex
      * types at this abstraction level.
      */
-    if (CUR2BT(start_file_cursor) == NULL || CUR2BT(start_file_cursor)->type == BTREE_COL_FIX)
+    if (CUR2BT(start) == NULL || CUR2BT(start)->type == BTREE_COL_FIX)
         supports_bounds = false;
-    if (stop_file_cursor != NULL &&
-      (CUR2BT(stop_file_cursor) == NULL || CUR2BT(stop_file_cursor)->type == BTREE_COL_FIX))
+    if (stop != NULL && (CUR2BT(stop) == NULL || CUR2BT(stop)->type == BTREE_COL_FIX))
         supports_bounds = false;
 
     /*


### PR DESCRIPTION
`__wt_session_range_truncate` expects `WT_CURSOR_BTREE`s to be provided when setting a truncation range, but `__wti_rts_history_btree_hs_truncate` provided `WT_CURSOR_HS` cursors instead.
This change updates `__wti_rts_history_btree_hs_truncate` to pass in the HS cursor's backing file cursors instead, which are WT_CURSOR_BTREE as expected.

Note this means we will store the the `file_cursor`s in `trunc_info` instead of the HS cursors. However all neccesary information is provided by the `file_cursor` so we'll note this is a special case when reading the cursor from trunc_info.