### PR TITLE
WT-13122: Optimized sesseion's Core time statistics, mongod.log direct locate time-consuming modules, Reduce the difficulty and time of problem analysis

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1215,11 +1215,22 @@ join_stats = sorted(join_stats, key=attrgetter('desc'))
 session_stats = [
     SessionStat('bytes_read', 'bytes read into cache'),
     SessionStat('bytes_write', 'bytes written from cache'),
+    SessionStat('cursor_read_time', 'cursor read time (usecs)'),
+    SessionStat('cursor_write_time', 'cursor write time (usecs)'),
     SessionStat('cache_time', 'time waiting for cache (usecs)'),
     SessionStat('lock_dhandle_wait', 'dhandle lock wait time (usecs)'),
     SessionStat('lock_schema_wait', 'schema lock wait time (usecs)'),
+    SessionStat('log_write_time', 'log write time (usecs)'),
+    SessionStat('page_insert_wait_pagelock_time', 'page insert wait pagelock time (usecs)'),
+    SessionStat('page_read_time', 'page read time (usecs)'),
+    SessionStat('page_split_insert_time', 'page split insert time (usecs)'),
+    SessionStat('page_split_multi_time', 'page split multi time (usecs)'),
+    SessionStat('page_split_reverse_time', 'page split reverse time (usecs)'),
+    SessionStat('page_split_rewrite_time', 'page split rewrite time (usecs)'),
+    SessionStat('ref_locked_and_yield_time', 'ref locked and yiled time (usecs)'),
     SessionStat('txn_bytes_dirty', 'dirty bytes in this txn'),
     SessionStat('read_time', 'page read from disk to cache time (usecs)'),
+    SessionStat('reconcile_time', 'reconcile time (usecs)'),
     SessionStat('write_time', 'page write from cache to disk time (usecs)'),
 ]
 

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -376,6 +376,11 @@ conn_stats = [
     CacheStat('cache_overhead', 'percentage overhead', 'no_clear,no_scale'),
     CacheStat('cache_pages_dirty', 'tracked dirty pages in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse', 'pages currently held in the cache', 'no_clear,no_scale'),
+    CacheStat('cache_page_insert_wait_pagelock_time', 'page insert wait pagelock time (msecs)', 'no_clear,no_scale'),
+    CacheStat('cache_page_split_insert_time', 'page split insert time (msecs)', 'no_clear,no_scale'),
+    CacheStat('cache_page_split_multi_time', 'page split multi time (msecs)', 'no_clear,no_scale'),
+    CacheStat('cache_page_split_reverse_time', 'page split reverse time (msecs)', 'no_clear,no_scale'),
+    CacheStat('cache_page_split_rewrite_time', 'page split rewrite time (msecs)', 'no_clear,no_scale'),
     CacheStat('cache_read_app_count', 'application threads page read from disk to cache count'),
     CacheStat('cache_read_app_time', 'application threads page read from disk to cache time (usecs)'),
     CacheStat('cache_timed_out_ops', 'operations timed out waiting for space in cache'),
@@ -605,6 +610,7 @@ conn_stats = [
     LogStat('log_write_lsn', 'log server thread advances write LSN'),
     LogStat('log_write_lsn_skip', 'log server thread write LSN walk skipped'),
     LogStat('log_writes', 'log write operations'),
+    LogStat('log_writes_time', 'log write time (msec)'),
     LogStat('log_zero_fills', 'log files manually zero-filled'),
 
     ##########################################

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -321,7 +321,7 @@ read:
             time_start = __wt_clock(session);
             WT_RET(__page_read(session, ref, flags));
             time_stop = __wt_clock(session);
-            WT_STAT_SESSION_INCRV(session, page_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
+            WT_STAT_SESSION_INCRV(session, page_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
             /* We just read a page, don't evict it before we have a chance to use it. */
             evict_skip = true;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -321,7 +321,7 @@ read:
             time_start = __wt_clock(session);
             WT_RET(__page_read(session, ref, flags));
             time_stop = __wt_clock(session);
-            WT_STAT_SESSION_INCRV(session, page_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+            WT_STAT_SESSION_INCRV(session, page_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 
             /* We just read a page, don't evict it before we have a chance to use it. */
             evict_skip = true;
@@ -498,7 +498,6 @@ skip_evict:
             return (__wt_illegal_value(session, current_state));
         }
 
-        time_start = __wt_clock(session);
         /*
          * We failed to get the page -- yield before retrying, and if we've yielded enough times,
          * start sleeping so we don't burn CPU to no purpose.
@@ -524,8 +523,6 @@ skip_evict:
         }
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
         WT_STAT_CONN_INCRV(session, page_sleep, sleep_usecs);
-        time_stop = __wt_clock(session);
-        WT_STAT_SESSION_INCRV(
-          session, ref_locked_and_yield_time, WT_CLOCKDIFF_US(time_stop, time_start));
+        WT_STAT_SESSION_INCRV(session, ref_locked_and_yield_time, sleep_usecs);
     }
 }

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -521,8 +521,10 @@ skip_evict:
             if (cache_work)
                 continue;
         }
+        time_start = __wt_clock(session);
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
+        time_stop = __wt_clock(session);
         WT_STAT_CONN_INCRV(session, page_sleep, sleep_usecs);
-        WT_STAT_SESSION_INCRV(session, ref_locked_and_yield_time, sleep_usecs);
+        WT_STAT_SESSION_INCRV(session, ref_locked_and_yield_time, WT_CLOCKDIFF_US(time_stop, time_start));
     }
 }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2090,6 +2090,8 @@ int
 __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_DECL_RET;
+    uint64_t time_start, time_stop;
+    time_start = __wt_clock(session);
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-insert", (void *)ref);
 
@@ -2098,6 +2100,9 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
      * eviction, then proceed with the insert split.
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_insert_lock(session, ref));
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, page_split_insert_time, WT_CLOCKDIFF_US(time_stop, time_start));
+
     return (ret);
 }
 
@@ -2202,6 +2207,8 @@ int
 __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
 {
     WT_DECL_RET;
+    uint64_t time_start, time_stop;
+    time_start = __wt_clock(session);
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-multi", (void *)ref);
 
@@ -2210,6 +2217,9 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
      * eviction, then proceed with the split.
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_multi_lock(session, ref, closing));
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, page_split_multi_time, WT_CLOCKDIFF_US(time_stop, time_start));
+
     return (ret);
 }
 
@@ -2238,6 +2248,8 @@ int
 __wt_split_reverse(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_DECL_RET;
+    uint64_t time_start, time_stop;
+    time_start = __wt_clock(session);
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: reverse-split", (void *)ref);
 
@@ -2246,6 +2258,9 @@ __wt_split_reverse(WT_SESSION_IMPL *session, WT_REF *ref)
      * eviction, then proceed with the reverse split.
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_reverse(session, ref));
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, page_split_reverse_time, WT_CLOCKDIFF_US(time_stop, time_start));
+
     return (ret);
 }
 
@@ -2259,7 +2274,9 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
     WT_DECL_RET;
     WT_PAGE *page;
     WT_REF *new;
+    uint64_t time_start, time_stop;
 
+    time_start = __wt_clock(session);
     page = ref->page;
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-rewrite", (void *)ref);
@@ -2308,9 +2325,15 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
     WT_REF_SET_STATE(ref, WT_REF_MEM);
 
     __wt_free(session, new);
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_US(time_stop, time_start));
+
     return (0);
 
 err:
     __split_multi_inmem_fail(session, page, multi, new);
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_US(time_stop, time_start));
+
     return (ret);
 }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2101,7 +2101,9 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_insert_lock(session, ref));
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_insert_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_insert_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_CONN_INCRV(
+      session, cache_page_split_insert_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
     return (ret);
 }
@@ -2218,7 +2220,10 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_multi_lock(session, ref, closing));
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_multi_time, WT_CLOCKDIFF_US(time_stop, time_start));
+
+    WT_STAT_CONN_INCRV(
+      session, cache_page_split_multi_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_multi_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
     return (ret);
 }
@@ -2259,7 +2264,9 @@ __wt_split_reverse(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_reverse(session, ref));
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_reverse_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_reverse_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_CONN_INCRV(
+      session, cache_page_split_reverse_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
     return (ret);
 }
@@ -2326,14 +2333,18 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 
     __wt_free(session, new);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_CONN_INCRV(
+      session, cache_page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
     return (0);
 
 err:
     __split_multi_inmem_fail(session, page, multi, new);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_CONN_INCRV(
+      session, cache_page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
     return (ret);
 }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2101,7 +2101,7 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_insert_lock(session, ref));
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_insert_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_insert_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_STAT_CONN_INCRV(
       session, cache_page_split_insert_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
@@ -2223,7 +2223,7 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
 
     WT_STAT_CONN_INCRV(
       session, cache_page_split_multi_time, WT_CLOCKDIFF_MS(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, page_split_multi_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_multi_time, WT_CLOCKDIFF_US(time_stop, time_start));
 
     return (ret);
 }
@@ -2264,7 +2264,7 @@ __wt_split_reverse(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     WT_WITH_PAGE_INDEX(session, ret = __split_reverse(session, ref));
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_reverse_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_reverse_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_STAT_CONN_INCRV(
       session, cache_page_split_reverse_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
@@ -2333,7 +2333,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 
     __wt_free(session, new);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_STAT_CONN_INCRV(
       session, cache_page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 
@@ -2342,7 +2342,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 err:
     __split_multi_inmem_fail(session, page, multi, new);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, page_split_rewrite_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_STAT_CONN_INCRV(
       session, cache_page_split_rewrite_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -199,7 +199,7 @@ err:
     API_RETRYABLE_END(session, ret);
     API_END_RET_STAT(session, ret, cursor_next);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -233,7 +233,7 @@ __wt_curfile_next_random(WT_CURSOR *cursor)
 err:
     API_END_RET_STAT(session, ret, cursor_next_random);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -270,7 +270,7 @@ err:
     CURSOR_REPOSITION_END(cursor, session);
     API_END_RET_STAT(session, ret, cursor_prev);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -343,7 +343,7 @@ err:
     API_END_RET_STAT(session, ret, cursor_search);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -382,7 +382,7 @@ err:
     API_END_RET_STAT(session, ret, cursor_search_near);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -424,7 +424,7 @@ err:
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_insert);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
     return (ret);
 }
 
@@ -493,7 +493,7 @@ err:
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_modify);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
     return (ret);
 }
 
@@ -528,7 +528,7 @@ err:
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_update);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
     return (ret);
 }
 
@@ -583,7 +583,7 @@ err:
       session, ret, !positioned || F_ISSET(cursor, WT_CURSTD_KEY_INT), cursor_remove);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
     return (ret);
 }
 

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -199,7 +199,7 @@ err:
     API_RETRYABLE_END(session, ret);
     API_END_RET_STAT(session, ret, cursor_next);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 }
 
 /*
@@ -233,7 +233,7 @@ __wt_curfile_next_random(WT_CURSOR *cursor)
 err:
     API_END_RET_STAT(session, ret, cursor_next_random);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 }
 
 /*
@@ -259,8 +259,6 @@ __curfile_prev(WT_CURSOR *cursor)
     time_start = __wt_clock(session);
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_prev(cbt, false));
     WT_ERR(ret);
-    time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 
     /* Prev maintains a position, key and value. */
     WT_ASSERT(session,
@@ -271,6 +269,8 @@ err:
     API_RETRYABLE_END(session, ret);
     CURSOR_REPOSITION_END(cursor, session);
     API_END_RET_STAT(session, ret, cursor_prev);
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 }
 
 /*
@@ -331,9 +331,6 @@ __curfile_search(WT_CURSOR *cursor)
     time_start = __wt_clock(session);
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_search(cbt));
     WT_ERR(ret);
-    time_stop = __wt_clock(session);
-    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 
     /* Search maintains a position, key and value. */
     WT_ASSERT(session,
@@ -344,6 +341,9 @@ err:
     CURSOR_REPOSITION_END(cursor, session);
     API_RETRYABLE_END(session, ret);
     API_END_RET_STAT(session, ret, cursor_search);
+    time_stop = __wt_clock(session);
+    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 }
 
 /*
@@ -370,9 +370,6 @@ __curfile_search_near(WT_CURSOR *cursor, int *exact)
     time_start = __wt_clock(session);
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_search_near(cbt, exact));
     WT_ERR(ret);
-    time_stop = __wt_clock(session);
-    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 
     /* Search-near maintains a position, key and value. */
     WT_ASSERT(session,
@@ -383,6 +380,9 @@ err:
     CURSOR_REPOSITION_END(cursor, session);
     API_RETRYABLE_END(session, ret);
     API_END_RET_STAT(session, ret, cursor_search_near);
+    time_stop = __wt_clock(session);
+    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 }
 
 /*
@@ -424,7 +424,7 @@ err:
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_insert);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
     return (ret);
 }
 
@@ -493,7 +493,7 @@ err:
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_modify);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
     return (ret);
 }
 
@@ -528,7 +528,7 @@ err:
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_update);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
     return (ret);
 }
 
@@ -583,7 +583,7 @@ err:
       session, ret, !positioned || F_ISSET(cursor, WT_CURSTD_KEY_INT), cursor_remove);
     time_stop = __wt_clock(session);
     __wt_stat_usecs_hist_incr_opwrite(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
     return (ret);
 }
 

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -187,6 +187,8 @@ __curfile_next(WT_CURSOR *cursor)
     WT_ERR(__curfile_check_cbt_txn(session, cbt));
 
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_next(cbt, false));
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_ERR(ret);
 
     /* Next maintains a position, key and value. */
@@ -198,8 +200,6 @@ err:
     CURSOR_REPOSITION_END(cursor, session);
     API_RETRYABLE_END(session, ret);
     API_END_RET_STAT(session, ret, cursor_next);
-    time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -223,6 +223,8 @@ __wt_curfile_next_random(WT_CURSOR *cursor)
 
     time_start = __wt_clock(session);
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_next_random(cbt));
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_ERR(ret);
 
     /* Next-random maintains a position, key and value. */
@@ -232,8 +234,6 @@ __wt_curfile_next_random(WT_CURSOR *cursor)
 
 err:
     API_END_RET_STAT(session, ret, cursor_next_random);
-    time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -258,6 +258,8 @@ __curfile_prev(WT_CURSOR *cursor)
 
     time_start = __wt_clock(session);
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_prev(cbt, false));
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_ERR(ret);
 
     /* Prev maintains a position, key and value. */
@@ -269,8 +271,6 @@ err:
     API_RETRYABLE_END(session, ret);
     CURSOR_REPOSITION_END(cursor, session);
     API_END_RET_STAT(session, ret, cursor_prev);
-    time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -330,6 +330,9 @@ __curfile_search(WT_CURSOR *cursor)
 
     time_start = __wt_clock(session);
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_search(cbt));
+    time_stop = __wt_clock(session);
+    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_ERR(ret);
 
     /* Search maintains a position, key and value. */
@@ -341,9 +344,6 @@ err:
     CURSOR_REPOSITION_END(cursor, session);
     API_RETRYABLE_END(session, ret);
     API_END_RET_STAT(session, ret, cursor_search);
-    time_stop = __wt_clock(session);
-    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*
@@ -369,6 +369,9 @@ __curfile_search_near(WT_CURSOR *cursor, int *exact)
 
     time_start = __wt_clock(session);
     WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_search_near(cbt, exact));
+    time_stop = __wt_clock(session);
+    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_ERR(ret);
 
     /* Search-near maintains a position, key and value. */
@@ -380,9 +383,6 @@ err:
     CURSOR_REPOSITION_END(cursor, session);
     API_RETRYABLE_END(session, ret);
     API_END_RET_STAT(session, ret, cursor_search_near);
-    time_stop = __wt_clock(session);
-    __wt_stat_usecs_hist_incr_opread(session, WT_CLOCKDIFF_US(time_stop, time_start));
-    WT_STAT_SESSION_INCRV(session, cursor_read_time, WT_CLOCKDIFF_US(time_stop, time_start));
 }
 
 /*

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -218,7 +218,7 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT_HEAD *ins_
             WT_PAGE_LOCK(session, page);
             stop = __wt_clock(session);
             WT_STAT_SESSION_INCRV(
-              session, page_insert_wait_pagelock_time, WT_CLOCKDIFF_MS(stop, start));
+              session, page_insert_wait_pagelock_time, WT_CLOCKDIFF_US(stop, start));
             WT_STAT_CONN_INCRV(
               session, cache_page_insert_wait_pagelock_time, WT_CLOCKDIFF_MS(stop, start));
         }

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -218,7 +218,9 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT_HEAD *ins_
             WT_PAGE_LOCK(session, page);
             stop = __wt_clock(session);
             WT_STAT_SESSION_INCRV(
-              session, page_insert_wait_pagelock_time, WT_CLOCKDIFF_US(stop, start));
+              session, page_insert_wait_pagelock_time, WT_CLOCKDIFF_MS(stop, start));
+            WT_STAT_CONN_INCRV(
+              session, cache_page_insert_wait_pagelock_time, WT_CLOCKDIFF_MS(stop, start));
         }
         ret = __insert_serial_func(session, ins_head, ins_stack, new_ins, skipdepth);
         if (!exclusive)

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -613,7 +613,12 @@ struct __wt_connection_stats {
     int64_t cache_read_overflow;
     int64_t cache_eviction_app_attempt;
     int64_t cache_eviction_app_fail;
+    int64_t cache_page_insert_wait_pagelock_time;
     int64_t cache_eviction_deepen;
+    int64_t cache_page_split_insert_time;
+    int64_t cache_page_split_multi_time;
+    int64_t cache_page_split_reverse_time;
+    int64_t cache_page_split_rewrite_time;
     int64_t cache_write_hs;
     int64_t cache_eviction_consider_prefetch;
     int64_t cache_pages_inuse;
@@ -890,6 +895,7 @@ struct __wt_connection_stats {
     int64_t log_sync_dir;
     int64_t log_sync_dir_duration;
     int64_t log_writes;
+    int64_t log_writes_time;
     int64_t log_slot_consolidated;
     int64_t log_max_filesize;
     int64_t log_prealloc_max;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1443,10 +1443,21 @@ struct __wt_join_stats {
 struct __wt_session_stats {
     int64_t bytes_read;
     int64_t bytes_write;
+    int64_t cursor_read_time;
+    int64_t cursor_write_time;
     int64_t lock_dhandle_wait;
     int64_t txn_bytes_dirty;
+    int64_t log_write_time;
+    int64_t page_insert_wait_pagelock_time;
     int64_t read_time;
+    int64_t page_read_time;
+    int64_t page_split_insert_time;
+    int64_t page_split_multi_time;
+    int64_t page_split_reverse_time;
+    int64_t page_split_rewrite_time;
     int64_t write_time;
+    int64_t reconcile_time;
+    int64_t ref_locked_and_yield_time;
     int64_t lock_schema_wait;
     int64_t cache_time;
 };

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5967,1186 +5967,1198 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_EVICTION_APP_ATTEMPT		1199
 /*! cache: page evict failures by application threads */
 #define	WT_STAT_CONN_CACHE_EVICTION_APP_FAIL		1200
+/*! cache: page insert wait pagelock time (msecs) */
+#define	WT_STAT_CONN_CACHE_PAGE_INSERT_WAIT_PAGELOCK_TIME	1201
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1201
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1202
+/*! cache: page split insert time (msecs) */
+#define	WT_STAT_CONN_CACHE_PAGE_SPLIT_INSERT_TIME	1203
+/*! cache: page split multi time (msecs) */
+#define	WT_STAT_CONN_CACHE_PAGE_SPLIT_MULTI_TIME	1204
+/*! cache: page split reverse time (msecs) */
+#define	WT_STAT_CONN_CACHE_PAGE_SPLIT_REVERSE_TIME	1205
+/*! cache: page split rewrite time (msecs) */
+#define	WT_STAT_CONN_CACHE_PAGE_SPLIT_REWRITE_TIME	1206
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1202
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1207
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1203
+#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1208
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1204
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1209
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1205
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1210
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1206
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1211
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1207
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1212
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1208
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1213
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1209
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1214
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1210
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1215
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1211
+#define	WT_STAT_CONN_CACHE_READ				1216
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1212
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1217
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1213
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1218
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1214
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1219
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1215
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1220
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1216
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1221
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1217
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1222
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1218
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1223
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1219
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1224
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1220
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1225
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1221
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1226
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1222
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1227
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1223
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1228
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1224
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1229
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1225
+#define	WT_STAT_CONN_CACHE_WRITE			1230
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1226
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1231
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1227
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1232
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1228
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1233
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1229
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1234
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1230
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1235
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1231
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1236
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1232
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1237
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1233
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1238
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1234
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1239
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1235
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1240
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1236
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1241
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1237
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1242
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1238
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1243
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1239
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1244
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1240
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1245
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1241
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1246
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1242
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1247
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1243
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1248
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1244
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1249
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1245
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1250
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1246
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1251
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1247
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1252
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1248
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1253
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1249
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1254
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1250
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1255
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1251
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1256
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1252
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1257
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1253
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1258
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1254
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1259
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1255
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1260
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1256
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1261
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1257
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1262
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1258
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1263
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1259
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1264
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1260
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1265
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1261
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1266
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1262
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1267
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1263
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1268
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1264
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1269
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1265
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1270
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1266
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1271
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1267
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1272
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1268
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1273
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1269
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1274
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1270
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1275
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1271
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1276
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1272
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1277
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1273
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1278
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1274
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1279
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1275
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1280
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1276
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1281
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1277
+#define	WT_STAT_CONN_CHECKPOINTS_API			1282
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1278
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1283
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1279
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1284
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1280
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1285
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1281
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1286
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1282
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1287
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1283
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1288
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1284
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1289
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1285
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1290
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1286
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1291
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1287
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1292
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1288
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1293
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1289
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1294
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1290
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1295
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1291
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1296
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1292
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1297
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1293
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1298
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1294
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1299
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1295
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1300
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1296
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1301
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1297
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1302
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1298
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1303
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1299
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1304
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1300
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1305
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1301
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1306
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1302
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1307
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1303
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1308
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1304
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1309
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1305
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1310
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1306
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1311
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1307
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1312
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1308
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1313
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1309
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1314
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1310
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1315
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1311
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1316
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1312
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1317
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1313
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1318
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1314
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1319
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1315
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1320
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1316
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1321
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1317
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1322
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1318
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1323
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1319
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1324
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1320
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1325
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1321
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1326
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1322
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1327
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1323
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1328
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1324
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1329
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1325
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1330
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1326
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1331
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1327
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1332
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1328
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1333
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1329
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1334
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1330
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1335
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1331
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1336
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1332
+#define	WT_STAT_CONN_TIME_TRAVEL			1337
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1333
+#define	WT_STAT_CONN_FILE_OPEN				1338
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1334
+#define	WT_STAT_CONN_BUCKETS_DH				1339
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1335
+#define	WT_STAT_CONN_BUCKETS				1340
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1336
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1341
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1337
+#define	WT_STAT_CONN_MEMORY_FREE			1342
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1338
+#define	WT_STAT_CONN_MEMORY_GROW			1343
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1339
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1344
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1340
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1345
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1341
+#define	WT_STAT_CONN_COND_WAIT				1346
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1342
+#define	WT_STAT_CONN_RWLOCK_READ			1347
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1343
+#define	WT_STAT_CONN_RWLOCK_WRITE			1348
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1344
+#define	WT_STAT_CONN_FSYNC_IO				1349
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1345
+#define	WT_STAT_CONN_READ_IO				1350
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1346
+#define	WT_STAT_CONN_WRITE_IO				1351
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1347
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1352
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1348
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1353
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1349
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1354
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1350
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1355
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1351
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1356
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1352
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1357
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1353
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1358
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1354
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1359
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1355
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1360
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1356
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1361
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1357
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1362
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1358
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1363
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1359
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1364
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1360
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1365
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1361
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1366
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1362
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1367
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1363
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1368
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1364
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1369
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1365
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1370
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1366
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1371
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1367
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1372
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1368
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1373
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1369
+#define	WT_STAT_CONN_CURSOR_CACHE			1374
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1370
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1375
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1371
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1376
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1372
+#define	WT_STAT_CONN_CURSOR_CREATE			1377
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1373
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1378
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1374
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1379
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1375
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1380
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1376
+#define	WT_STAT_CONN_CURSOR_INSERT			1381
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1377
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1382
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1378
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1383
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1379
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1384
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1380
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1385
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1381
+#define	WT_STAT_CONN_CURSOR_MODIFY			1386
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1382
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1387
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1383
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1388
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1384
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1389
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1385
+#define	WT_STAT_CONN_CURSOR_NEXT			1390
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1386
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1391
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1387
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1392
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1388
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1393
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1389
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1394
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1390
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1395
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1391
+#define	WT_STAT_CONN_CURSOR_RESTART			1396
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1392
+#define	WT_STAT_CONN_CURSOR_PREV			1397
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1393
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1398
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1394
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1399
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1395
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1400
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1396
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1401
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1397
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1402
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1398
+#define	WT_STAT_CONN_CURSOR_REMOVE			1403
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1399
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1404
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1400
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1405
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1401
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1406
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1402
+#define	WT_STAT_CONN_CURSOR_RESERVE			1407
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1403
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1408
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1404
+#define	WT_STAT_CONN_CURSOR_RESET			1409
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1405
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1410
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1406
+#define	WT_STAT_CONN_CURSOR_SEARCH			1411
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1407
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1412
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1408
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1413
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1409
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1414
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1410
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1415
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1411
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1416
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1412
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1417
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1413
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1418
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1414
+#define	WT_STAT_CONN_CURSOR_SWEEP			1419
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1415
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1420
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1416
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1421
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1417
+#define	WT_STAT_CONN_CURSOR_UPDATE			1422
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1418
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1423
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1419
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1424
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1420
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1425
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1421
+#define	WT_STAT_CONN_CURSOR_REOPEN			1426
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1422
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1427
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1423
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1428
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1424
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1429
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1425
+#define	WT_STAT_CONN_DH_SWEEP_REF			1430
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1426
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1431
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1427
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1432
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1428
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1433
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1429
+#define	WT_STAT_CONN_DH_SWEEPS				1434
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1430
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1435
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1431
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1436
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1432
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1437
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1433
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1438
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1434
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1439
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1435
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1440
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1436
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1441
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1437
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1442
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1438
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1443
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1439
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1444
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1440
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1445
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1441
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1446
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1442
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1447
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1443
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1448
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1444
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1449
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1445
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1450
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1446
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1451
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1447
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1452
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1448
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1453
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1449
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1454
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1450
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1455
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1451
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1456
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1452
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1457
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1453
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1458
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1454
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1459
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1455
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1460
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1456
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1461
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1457
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1462
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1458
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1463
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1459
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1464
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1460
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1465
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1461
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1466
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1462
+#define	WT_STAT_CONN_LOG_FLUSH				1467
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1463
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1468
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1464
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1469
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1465
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1470
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1466
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1471
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1467
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1472
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1468
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1473
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1469
+#define	WT_STAT_CONN_LOG_SCANS				1474
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1470
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1475
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1471
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1476
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1472
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1477
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1473
+#define	WT_STAT_CONN_LOG_SYNC				1478
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1474
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1479
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1475
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1480
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1476
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1481
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1477
+#define	WT_STAT_CONN_LOG_WRITES				1482
+/*! log: log write time (msec) */
+#define	WT_STAT_CONN_LOG_WRITES_TIME			1483
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1478
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1484
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1479
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1485
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1480
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1486
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1481
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1487
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1482
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1488
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1483
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1489
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1484
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1490
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1485
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1491
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1486
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1492
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1487
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1493
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1488
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1494
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1489
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1495
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1490
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1496
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1491
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1497
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1492
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1498
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1493
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1499
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1494
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1500
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1495
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1501
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1496
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1502
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1497
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1503
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1498
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1504
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1499
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1505
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1500
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1506
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1501
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1507
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1502
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1508
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1503
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1509
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1504
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1510
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1505
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1511
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1506
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1512
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1507
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1513
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1508
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1514
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1509
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1515
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1510
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1516
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1511
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1517
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1512
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1518
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1513
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1519
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1514
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1520
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1515
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1521
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1516
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1522
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1517
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1523
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1518
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1524
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1519
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1525
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1520
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1526
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1521
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1527
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1522
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1528
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1523
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1529
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1524
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1530
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1525
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1531
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1526
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1532
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1527
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1533
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1528
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1534
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1529
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1535
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1530
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1536
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1531
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1537
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1532
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1538
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1533
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1539
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1534
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1540
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1535
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1541
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1536
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1542
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1537
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1543
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1538
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1544
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1539
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1545
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1540
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1546
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1541
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1547
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1542
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1548
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1543
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1549
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1544
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1550
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1545
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1551
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1546
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1552
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1547
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1553
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1548
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1554
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1549
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1555
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1550
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1556
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1551
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1557
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1552
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1558
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1553
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1559
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1554
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1560
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1555
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1561
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1556
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1562
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1557
+#define	WT_STAT_CONN_REC_PAGES				1563
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1558
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1564
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1559
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1565
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1560
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1566
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1561
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1567
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1562
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1568
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1563
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1569
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1564
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1570
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1565
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1571
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1566
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1572
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1567
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1573
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1568
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1574
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1569
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1575
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1570
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1576
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1571
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1577
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1572
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1578
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1573
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1579
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1574
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1580
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1575
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1581
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1576
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1582
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1577
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1583
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1578
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1584
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1579
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1585
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1580
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1586
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1581
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1587
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1582
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1588
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1583
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1589
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1584
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1590
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1585
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1591
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1586
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1592
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1587
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1593
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1588
+#define	WT_STAT_CONN_FLUSH_TIER				1594
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1589
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1595
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1590
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1596
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1591
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1597
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1592
+#define	WT_STAT_CONN_SESSION_OPEN			1598
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1593
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1599
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1594
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1600
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1595
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1601
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1596
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1602
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1597
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1603
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1598
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1604
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1599
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1605
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1600
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1606
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1601
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1607
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1602
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1608
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1603
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1609
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1604
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1610
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1605
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1611
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1606
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1612
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1607
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1613
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1608
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1614
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1609
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1615
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1610
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1616
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1611
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1617
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1612
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1618
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1613
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1619
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1614
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1620
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1615
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1621
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1616
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1622
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1617
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1623
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1618
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1624
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1619
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1625
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1620
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1626
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1621
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1627
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1622
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1628
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1623
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1629
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1624
+#define	WT_STAT_CONN_TIERED_RETENTION			1630
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1625
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1631
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1626
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1632
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1627
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1633
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1628
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1634
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1629
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1635
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1630
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1636
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1631
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1637
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1632
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1638
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1633
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1639
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1634
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1640
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1635
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1641
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1636
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1642
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1637
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1643
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1638
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1644
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1639
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1645
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1640
+#define	WT_STAT_CONN_PAGE_SLEEP				1646
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1641
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1647
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1642
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1648
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1643
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1649
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1644
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1650
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1645
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1651
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1646
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1652
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1647
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1653
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1648
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1654
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1649
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1655
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1650
+#define	WT_STAT_CONN_TXN_PREPARE			1656
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1651
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1657
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1652
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1658
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1653
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1659
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1654
+#define	WT_STAT_CONN_TXN_QUERY_TS			1660
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1655
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1661
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1656
+#define	WT_STAT_CONN_TXN_RTS				1662
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1657
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1663
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1658
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1664
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1659
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1665
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1660
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1666
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1661
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1667
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1662
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1668
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1663
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1669
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1664
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1670
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1665
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1671
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1666
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1672
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1667
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1673
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1668
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1674
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1669
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1675
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1670
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1676
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1671
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1677
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1672
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1678
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1673
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1679
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1674
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1680
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1675
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1681
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1676
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1682
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1677
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1683
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1678
+#define	WT_STAT_CONN_TXN_SET_TS				1684
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1679
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1685
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1680
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1686
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1681
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1687
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1682
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1688
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1683
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1689
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1684
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1690
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1685
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1691
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1686
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1692
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1687
+#define	WT_STAT_CONN_TXN_BEGIN				1693
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1688
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1694
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1689
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1695
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1690
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1696
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1691
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1697
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1692
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1698
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1693
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1699
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1694
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1700
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1695
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1701
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1696
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1702
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1697
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1703
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1698
+#define	WT_STAT_CONN_TXN_COMMIT				1704
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1699
+#define	WT_STAT_CONN_TXN_ROLLBACK			1705
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1700
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1706
 
 /*!
  * @}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -8097,18 +8097,40 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_SESSION_BYTES_READ			4000
 /*! session: bytes written from cache */
 #define	WT_STAT_SESSION_BYTES_WRITE			4001
+/*! session: cursor read time (usecs) */
+#define	WT_STAT_SESSION_CURSOR_READ_TIME		4002
+/*! session: cursor write time (usecs) */
+#define	WT_STAT_SESSION_CURSOR_WRITE_TIME		4003
 /*! session: dhandle lock wait time (usecs) */
-#define	WT_STAT_SESSION_LOCK_DHANDLE_WAIT		4002
+#define	WT_STAT_SESSION_LOCK_DHANDLE_WAIT		4004
 /*! session: dirty bytes in this txn */
-#define	WT_STAT_SESSION_TXN_BYTES_DIRTY			4003
+#define	WT_STAT_SESSION_TXN_BYTES_DIRTY			4005
+/*! session: log write time (usecs) */
+#define	WT_STAT_SESSION_LOG_WRITE_TIME			4006
+/*! session: page insert wait pagelock time (usecs) */
+#define	WT_STAT_SESSION_PAGE_INSERT_WAIT_PAGELOCK_TIME	4007
 /*! session: page read from disk to cache time (usecs) */
-#define	WT_STAT_SESSION_READ_TIME			4004
+#define	WT_STAT_SESSION_READ_TIME			4008
+/*! session: page read time (usecs) */
+#define	WT_STAT_SESSION_PAGE_READ_TIME			4009
+/*! session: page split insert time (usecs) */
+#define	WT_STAT_SESSION_PAGE_SPLIT_INSERT_TIME		4010
+/*! session: page split multi time (usecs) */
+#define	WT_STAT_SESSION_PAGE_SPLIT_MULTI_TIME		4011
+/*! session: page split reverse time (usecs) */
+#define	WT_STAT_SESSION_PAGE_SPLIT_REVERSE_TIME		4012
+/*! session: page split rewrite time (usecs) */
+#define	WT_STAT_SESSION_PAGE_SPLIT_REWRITE_TIME		4013
 /*! session: page write from cache to disk time (usecs) */
-#define	WT_STAT_SESSION_WRITE_TIME			4005
+#define	WT_STAT_SESSION_WRITE_TIME			4014
+/*! session: reconcile time (usecs) */
+#define	WT_STAT_SESSION_RECONCILE_TIME			4015
+/*! session: ref locked and yiled time (usecs) */
+#define	WT_STAT_SESSION_REF_LOCKED_AND_YIELD_TIME	4016
 /*! session: schema lock wait time (usecs) */
-#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4006
+#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4017
 /*! session: time waiting for cache (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME			4007
+#define	WT_STAT_SESSION_CACHE_TIME			4018
 /*! @} */
 /*
  * Statistics section: END

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2506,9 +2506,11 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t
     WT_LOG *log;
     WT_LOG_RECORD *newlrp;
     size_t dst_len, len, new_size, result_len, src_len;
+    uint64_t time_start, time_stop;
     uint8_t *dst, *src;
     int compression_failed;
 
+    time_start = __wt_clock(session);
     conn = S2C(session);
     log = conn->log;
     /*
@@ -2595,7 +2597,8 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t
         WT_ASSERT(session, new_size < UINT32_MAX && ip->size < UINT32_MAX);
     }
     ret = __log_write_internal(session, ip, lsnp, flags);
-
+    time_stop = __wt_clock(session);
+    WT_STAT_SESSION_INCRV(session, log_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
 err:
     __wt_scr_free(session, &citem);
     __wt_scr_free(session, &eitem);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2598,7 +2598,8 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t
     }
     ret = __log_write_internal(session, ip, lsnp, flags);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, log_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, log_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_CONN_INCRV(session, log_writes_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 err:
     __wt_scr_free(session, &citem);
     __wt_scr_free(session, &eitem);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2598,7 +2598,7 @@ __wt_log_write(WT_SESSION_IMPL *session, WT_ITEM *record, WT_LSN *lsnp, uint32_t
     }
     ret = __log_write_internal(session, ip, lsnp, flags);
     time_stop = __wt_clock(session);
-    WT_STAT_SESSION_INCRV(session, log_write_time, WT_CLOCKDIFF_MS(time_stop, time_start));
+    WT_STAT_SESSION_INCRV(session, log_write_time, WT_CLOCKDIFF_US(time_stop, time_start));
     WT_STAT_CONN_INCRV(session, log_writes_time, WT_CLOCKDIFF_MS(time_stop, time_start));
 err:
     __wt_scr_free(session, &citem);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -377,7 +377,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
       conn->cache->reentry_hs_eviction_ms)
         conn->cache->reentry_hs_eviction_ms =
           session->reconcile_timeline.total_reentry_hs_eviction_time;
-
+    WT_STAT_SESSION_INCRV(session, reconcile_time, WT_CLOCKDIFF_US(rec_finish, rec_start));
 err:
     if (ret != 0)
         WT_RET_PANIC(session, ret, "reconciliation failed after building the disk image");

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1594,7 +1594,12 @@ static const char *const __stats_connection_desc[] = {
   "cache: overflow pages read into cache",
   "cache: page evict attempts by application threads",
   "cache: page evict failures by application threads",
+  "cache: page insert wait pagelock time (msecs)",
   "cache: page split during eviction deepened the tree",
+  "cache: page split insert time (msecs)",
+  "cache: page split multi time (msecs)",
+  "cache: page split reverse time (msecs)",
+  "cache: page split rewrite time (msecs)",
   "cache: page written requiring history store records",
   "cache: pages considered for eviction that were brought in by pre-fetch",
   "cache: pages currently held in the cache",
@@ -1875,6 +1880,7 @@ static const char *const __stats_connection_desc[] = {
   "log: log sync_dir operations",
   "log: log sync_dir time duration (usecs)",
   "log: log write operations",
+  "log: log write time (msec)",
   "log: logging bytes consolidated",
   "log: maximum log file size",
   "log: number of pre-allocated log files to create",
@@ -2347,7 +2353,12 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_read_overflow = 0;
     stats->cache_eviction_app_attempt = 0;
     stats->cache_eviction_app_fail = 0;
+    /* not clearing cache_page_insert_wait_pagelock_time */
     stats->cache_eviction_deepen = 0;
+    /* not clearing cache_page_split_insert_time */
+    /* not clearing cache_page_split_multi_time */
+    /* not clearing cache_page_split_reverse_time */
+    /* not clearing cache_page_split_rewrite_time */
     stats->cache_write_hs = 0;
     /* not clearing cache_eviction_consider_prefetch */
     /* not clearing cache_pages_inuse */
@@ -2624,6 +2635,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->log_sync_dir = 0;
     /* not clearing log_sync_dir_duration */
     stats->log_writes = 0;
+    stats->log_writes_time = 0;
     stats->log_slot_consolidated = 0;
     /* not clearing log_max_filesize */
     /* not clearing log_prealloc_max */
@@ -3121,7 +3133,13 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_read_overflow += WT_STAT_CONN_READ(from, cache_read_overflow);
     to->cache_eviction_app_attempt += WT_STAT_CONN_READ(from, cache_eviction_app_attempt);
     to->cache_eviction_app_fail += WT_STAT_CONN_READ(from, cache_eviction_app_fail);
+    to->cache_page_insert_wait_pagelock_time +=
+      WT_STAT_CONN_READ(from, cache_page_insert_wait_pagelock_time);
     to->cache_eviction_deepen += WT_STAT_CONN_READ(from, cache_eviction_deepen);
+    to->cache_page_split_insert_time += WT_STAT_CONN_READ(from, cache_page_split_insert_time);
+    to->cache_page_split_multi_time += WT_STAT_CONN_READ(from, cache_page_split_multi_time);
+    to->cache_page_split_reverse_time += WT_STAT_CONN_READ(from, cache_page_split_reverse_time);
+    to->cache_page_split_rewrite_time += WT_STAT_CONN_READ(from, cache_page_split_rewrite_time);
     to->cache_write_hs += WT_STAT_CONN_READ(from, cache_write_hs);
     to->cache_eviction_consider_prefetch +=
       WT_STAT_CONN_READ(from, cache_eviction_consider_prefetch);
@@ -3433,6 +3451,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->log_sync_dir += WT_STAT_CONN_READ(from, log_sync_dir);
     to->log_sync_dir_duration += WT_STAT_CONN_READ(from, log_sync_dir_duration);
     to->log_writes += WT_STAT_CONN_READ(from, log_writes);
+    to->log_writes_time += WT_STAT_CONN_READ(from, log_writes_time);
     to->log_slot_consolidated += WT_STAT_CONN_READ(from, log_slot_consolidated);
     to->log_max_filesize += WT_STAT_CONN_READ(from, log_max_filesize);
     to->log_prealloc_max += WT_STAT_CONN_READ(from, log_prealloc_max);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -3746,10 +3746,21 @@ __wt_stat_join_aggregate(WT_JOIN_STATS **from, WT_JOIN_STATS *to)
 static const char *const __stats_session_desc[] = {
   "session: bytes read into cache",
   "session: bytes written from cache",
+  "session: cursor read time (usecs)",
+  "session: cursor write time (usecs)",
   "session: dhandle lock wait time (usecs)",
   "session: dirty bytes in this txn",
+  "session: log write time (usecs)",
+  "session: page insert wait pagelock time (usecs)",
   "session: page read from disk to cache time (usecs)",
+  "session: page read time (usecs)",
+  "session: page split insert time (usecs)",
+  "session: page split multi time (usecs)",
+  "session: page split reverse time (usecs)",
+  "session: page split rewrite time (usecs)",
   "session: page write from cache to disk time (usecs)",
+  "session: reconcile time (usecs)",
+  "session: ref locked and yiled time (usecs)",
   "session: schema lock wait time (usecs)",
   "session: time waiting for cache (usecs)",
 };
@@ -3773,10 +3784,21 @@ __wt_stat_session_clear_single(WT_SESSION_STATS *stats)
 {
     stats->bytes_read = 0;
     stats->bytes_write = 0;
+    stats->cursor_read_time = 0;
+    stats->cursor_write_time = 0;
     stats->lock_dhandle_wait = 0;
     stats->txn_bytes_dirty = 0;
+    stats->log_write_time = 0;
+    stats->page_insert_wait_pagelock_time = 0;
     stats->read_time = 0;
+    stats->page_read_time = 0;
+    stats->page_split_insert_time = 0;
+    stats->page_split_multi_time = 0;
+    stats->page_split_reverse_time = 0;
+    stats->page_split_rewrite_time = 0;
     stats->write_time = 0;
+    stats->reconcile_time = 0;
+    stats->ref_locked_and_yield_time = 0;
     stats->lock_schema_wait = 0;
     stats->cache_time = 0;
 }


### PR DESCRIPTION
Optimized sesseion's Core time statistics, mongod.log direct locate time-consuming modules, Reduce the difficulty and time of problem analysis.

Finally, I will submit another PR to MongoDB to comply with the session statistics added by WT, so that we can see the corresponding mongod.log log as follows(The logs record the modules in which the user thread consumes more than 1ms during WT execution):
{"t":{"$date":"2024-06-01T15:15:36.782+08:00"},"s":"I"....................."storage":{"total write times": "1111ms"; Submodule time consuming：{"page lock wait":"100ms", "ref lock sleep":"50ms", "reconcile time":"11ms", "split multi time": "11ms", "bytesWrite":9451235,"read time":150592,......, "log write":"33"ms}};{"total read times": "1111ms"; Submodule time consuming: {"page lock wait":"100ms", "ref lock sleep":"50ms", "reconcile time":"11ms", "split multi time": "11ms", "bytesRead":9451235,"read time":150592,......}},"remote":"10.111.0.39:40870","protocol":"op_msg","durationMillis":10580}} 


Recently, I have applied this function to our company's MongoDB test environment (users will do pressure test and Functional test in the test environment before they really go online). Judging from the test experience of nearly two weeks, the effect is quite good. From the slow log, we can visually locate whether the problem is caused by mongo server or wt. if jitter caused by wt,  it Can visually locate the jitter caused by which small wt module.

 

At present, the sample number of our test environment is relatively small, and it is expected that more potential jitter problems of WT will be found in the future large-scale online use. We expect to find all module problems that may cause jitter through this function, and finally solve these jitter problems.

 

Sorry, this PR has not been evaluated by you yet. I am worried that I will forget my design ideas after too long, so I will submit the code first.

If you assess that the PR doesn't make sense to you, we can just shut it down.