### PR TITLE
Revert "WT-12462 Remove rename api docs and instances (#10355)" (#10719)

### DIFF
--- a/src/docs/arch-schema.dox
+++ b/src/docs/arch-schema.dox
@@ -99,6 +99,11 @@ WT_SESSION::drop operation drops the specified \c uri. The method will delete al
 and metadata entries. It is possible to keep the underlying files by specifying
 \c "remove_files=false" in the config string.
 
+@subsection schema_rename Rename
+
+WT_SESSION::rename schema operation renames the underlying data objects on the filesystem and
+updates the metadata accordingly.
+
 @subsection schema_alter Alter
 
 WT_SESSION::alter allows modification of some table settings after creation.

--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -412,6 +412,18 @@ The \c read command exits non-zero if a specified record is not found.
 The \c read command has no command-specific options.
 
 <hr>
+@section util_rename wt rename
+Rename a table.
+
+The \c rename command renames the specified table.
+
+@subsection util_rename_synopsis Synopsis
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] rename uri new-uri`
+
+@subsection util_rename_options Options
+The \c rename command has no command-specific options.
+
+<hr>
 @section util_salvage wt salvage
 Recover data from a corrupted table.
 

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -9,9 +9,9 @@ codes are WiredTiger-specific (for example, \c WT_ROLLBACK).
 @section error_ebusy EBUSY errors
 
 WiredTiger returns \c EBUSY for operations requiring exclusive access, when
-an object is not available for exclusive access. These operations include the
-WT_SESSION::alter, WT_SESSION::drop, WT_SESSION::salvage,
-WT_SESSION::upgrade and WT_SESSION::verify methods, all of which will return
+an object is not available for exclusive access. These operations include
+the WT_SESSION::alter, WT_SESSION::drop, WT_SESSION::rename,
+WT_SESSION::salvage and WT_SESSION::verify methods, all of which will return
 \c EBUSY and fail if there are open cursors on the target object. Internal
 WiredTiger threads may temporarily open cursors on objects (for example,
 threads performing operations like statistics logging), and in that case

--- a/src/docs/transactions_api.dox
+++ b/src/docs/transactions_api.dox
@@ -29,7 +29,7 @@ Schema changing operations are not generally transactional in WiredTiger, they
 can't be grouped together within the scope of a transaction and atomically
 committed or aborted. Think of them as one-shot transactions where the operation
 will either succeed or fail. Examples of schema changing operations are table
-create and drop.
+create, drop and rename.
 
 A data operation executed within a transaction can fail if it conflicts with an
 operation in another concurrently running transaction.  (A conflict occurs

--- a/test/evergreen/code_coverage/code_coverage_config.json
+++ b/test/evergreen/code_coverage/code_coverage_config.json
@@ -50,6 +50,8 @@
     "./wt -h WT_HOME_COVERAGE printlog -?",
     "./wt -h WT_HOME_COVERAGE read",
     "./wt -h WT_HOME_COVERAGE read -?",
+    "./wt -h WT_HOME_COVERAGE rename",
+    "./wt -h WT_HOME_COVERAGE rename -?",
     "./wt -h WT_HOME_COVERAGE salvage",
     "./wt -h WT_HOME_COVERAGE salvage -?",
     "./wt -h WT_HOME_COVERAGE stat",


### PR DESCRIPTION
This reverts commit 15e78573a6d3522cdd46ba050dd449f4718b5538.