### PR TITLE
WT-13080 Pause background compaction in case of cache pressure

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -219,6 +219,7 @@ conn_stats = [
     BackgroundCompactStat('background_compact_interrupted', 'background compact interrupted', 'no_scale'),
     BackgroundCompactStat('background_compact_running', 'background compact running', 'no_scale'),
     BackgroundCompactStat('background_compact_skipped', 'background compact skipped file as not meeting requirements for compaction', 'no_scale'),
+    BackgroundCompactStat('background_compact_sleep_cache_pressure', 'background compact sleeps due to cache pressure', 'no_scale'),
     BackgroundCompactStat('background_compact_success', 'background compact successful calls', 'no_scale'),
     BackgroundCompactStat('background_compact_timeout', 'background compact timeout', 'no_scale'),
 

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -554,7 +554,7 @@ __background_compact_server(void *arg)
         }
 
         /*
-         * Take a break or wait until signalled in the following conditions:
+         * Take a break or wait until signalled in any of the following conditions:
          * - Background compaction is not enabled.
          * - The entire metadata has been parsed.
          * - There is cache pressure and we don't want compaction to potentially add more.
@@ -617,7 +617,7 @@ __background_compact_server(void *arg)
             continue;
 
         /*
-         * Throttle background compaction if one of the following conditions is met:
+         * Throttle background compaction if any of the following conditions is met:
          * - The dirty trigger threshold has been reached as compaction may generate more dirty
          * content.
          * - The cache is almost full.

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -619,7 +619,8 @@ __background_compact_server(void *arg)
         /*
          * Throttle background compaction if any of the following conditions is met:
          * - The dirty trigger threshold has been reached as compaction may generate more dirty
-         * content.
+         * content. Note that updates are not considered as compaction only marks pages dirty and
+         * does not generate additional updates.
          * - The cache is almost full.
          */
         cache_pressure = __wt_eviction_dirty_needed(session, NULL) ||

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -557,7 +557,7 @@ __background_compact_server(void *arg)
          * Take a break or wait until signalled in the following conditions:
          * - Background compaction is not enabled.
          * - The entire metadata has been parsed.
-         * - There is cache pressure.
+         * - There is cache pressure and we don't want compaction to potentially add more.
          */
         if (!running || full_iteration || cache_pressure) {
             /*
@@ -573,10 +573,6 @@ __background_compact_server(void *arg)
                 __background_compact_list_cleanup(session, BACKGROUND_COMPACT_CLEANUP_STALE_STAT);
             }
 
-            /*
-             * In case of cache pressure, the thread waits for some time to give the system some
-             * time to recover.
-             */
             if (cache_pressure) {
                 WT_STAT_CONN_INCR(session, background_compact_sleep_cache_pressure);
                 cache_pressure = false;

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -620,8 +620,14 @@ __background_compact_server(void *arg)
         if (!running)
             continue;
 
-        /* Check if there is cache pressure. */
-        cache_pressure = __wt_cache_bytes_inuse(cache) >= cache_pressure_limit;
+        /*
+         * Throttle background compaction if one of the following conditions is met:
+         * - The dirty trigger threshold has been reached as compaction may generate more dirty
+         * content.
+         * - The cache is almost full.
+         */
+        cache_pressure = __wt_eviction_dirty_needed(session, NULL) ||
+          __wt_cache_bytes_inuse(cache) >= cache_pressure_limit;
         if (cache_pressure)
             continue;
 

--- a/src/docs/arch-compact.dox
+++ b/src/docs/arch-compact.dox
@@ -81,7 +81,8 @@ Background compaction retrieves the files to compact by walking the metadata fil
 background compaction reduces the number of checkpoints by skipping the first one described in the
 section above. Furthermore, background compaction gathers statistics over time to keep track of tables
 where compaction is successful. Using those statistics, the service focuses on tables where compaction
-is likely to reclaim space and avoids unnecessary attempts.
+is likely to reclaim space and avoids unnecessary attempts. Finally, if \c eviction_dirty_trigger has been reached,
+the thread waits for the dirty content to be reduced to a lower value before continuing to the next table.
 
 Background compaction can be enabled, configured, and disabled through the same API \c WT_SESSION::compact.
 When disabled, background compaction turns off as soon as possible and when re-enabled, it starts

--- a/src/docs/arch-compact.dox
+++ b/src/docs/arch-compact.dox
@@ -81,8 +81,11 @@ Background compaction retrieves the files to compact by walking the metadata fil
 background compaction reduces the number of checkpoints by skipping the first one described in the
 section above. Furthermore, background compaction gathers statistics over time to keep track of tables
 where compaction is successful. Using those statistics, the service focuses on tables where compaction
-is likely to reclaim space and avoids unnecessary attempts. Finally, if \c eviction_dirty_trigger has been reached,
-the thread waits for the dirty content to be reduced to a lower value before continuing to the next table.
+is likely to reclaim space and avoids unnecessary attempts. Finally, the thread makes sure that the
+following conditions are met before processing the next table:
+
+- the dirty content in the cache is below the \c eviction_dirty_trigger threshold and,
+- the cache is not almost full.
 
 Background compaction can be enabled, configured, and disabled through the same API \c WT_SESSION::compact.
 When disabled, background compaction turns off as soon as possible and when re-enabled, it starts

--- a/src/docs/arch-compact.dox
+++ b/src/docs/arch-compact.dox
@@ -84,7 +84,7 @@ where compaction is successful. Using those statistics, the service focuses on t
 is likely to reclaim space and avoids unnecessary attempts. Finally, the thread makes sure that the
 following conditions are met before processing the next table:
 
-- the dirty content in the cache is below the \c eviction_dirty_trigger threshold and,
+- the dirty content in the cache (without considering updates) is below the \c eviction_dirty_trigger threshold and,
 - the cache is not almost full.
 
 Background compaction can be enabled, configured, and disabled through the same API \c WT_SESSION::compact.

--- a/src/docs/arch-compact.dox
+++ b/src/docs/arch-compact.dox
@@ -85,7 +85,7 @@ is likely to reclaim space and avoids unnecessary attempts. Finally, the thread 
 following conditions are met before processing the next table:
 
 - the dirty content in the cache (without considering updates) is below the \c eviction_dirty_trigger threshold and,
-- the cache is not almost full.
+- the overall cache content is less than the \c eviction_trigger threshold.
 
 Background compaction can be enabled, configured, and disabled through the same API \c WT_SESSION::compact.
 When disabled, background compaction turns off as soon as possible and when re-enabled, it starts

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -432,6 +432,7 @@ struct __wt_connection_stats {
     int64_t background_compact_running;
     int64_t background_compact_exclude;
     int64_t background_compact_skipped;
+    int64_t background_compact_sleep_cache_pressure;
     int64_t background_compact_success;
     int64_t background_compact_timeout;
     int64_t background_compact_files_tracked;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5496,1672 +5496,1674 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * requirements for compaction
  */
 #define	WT_STAT_CONN_BACKGROUND_COMPACT_SKIPPED		1019
+/*! background-compact: background compact sleeps due to cache pressure */
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_SLEEP_CACHE_PRESSURE	1020
 /*! background-compact: background compact successful calls */
-#define	WT_STAT_CONN_BACKGROUND_COMPACT_SUCCESS		1020
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_SUCCESS		1021
 /*! background-compact: background compact timeout */
-#define	WT_STAT_CONN_BACKGROUND_COMPACT_TIMEOUT		1021
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_TIMEOUT		1022
 /*! background-compact: number of files tracked by background compaction */
-#define	WT_STAT_CONN_BACKGROUND_COMPACT_FILES_TRACKED	1022
+#define	WT_STAT_CONN_BACKGROUND_COMPACT_FILES_TRACKED	1023
 /*! backup: backup cursor open */
-#define	WT_STAT_CONN_BACKUP_CURSOR_OPEN			1023
+#define	WT_STAT_CONN_BACKUP_CURSOR_OPEN			1024
 /*! backup: backup duplicate cursor open */
-#define	WT_STAT_CONN_BACKUP_DUP_OPEN			1024
+#define	WT_STAT_CONN_BACKUP_DUP_OPEN			1025
 /*! backup: backup granularity size */
-#define	WT_STAT_CONN_BACKUP_GRANULARITY			1025
+#define	WT_STAT_CONN_BACKUP_GRANULARITY			1026
 /*! backup: incremental backup enabled */
-#define	WT_STAT_CONN_BACKUP_INCREMENTAL			1026
+#define	WT_STAT_CONN_BACKUP_INCREMENTAL			1027
 /*! backup: opening the backup cursor in progress */
-#define	WT_STAT_CONN_BACKUP_START			1027
+#define	WT_STAT_CONN_BACKUP_START			1028
 /*! backup: total modified incremental blocks */
-#define	WT_STAT_CONN_BACKUP_BLOCKS			1028
+#define	WT_STAT_CONN_BACKUP_BLOCKS			1029
 /*! backup: total modified incremental blocks with compressed data */
-#define	WT_STAT_CONN_BACKUP_BLOCKS_COMPRESSED		1029
+#define	WT_STAT_CONN_BACKUP_BLOCKS_COMPRESSED		1030
 /*! backup: total modified incremental blocks without compressed data */
-#define	WT_STAT_CONN_BACKUP_BLOCKS_UNCOMPRESSED		1030
+#define	WT_STAT_CONN_BACKUP_BLOCKS_UNCOMPRESSED		1031
 /*! block-cache: cached blocks updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1031
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1032
 /*! block-cache: cached bytes updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1032
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1033
 /*! block-cache: evicted blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1033
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1034
 /*! block-cache: file size causing bypass */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1034
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1035
 /*! block-cache: lookups */
-#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1035
+#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1036
 /*! block-cache: number of blocks not evicted due to overhead */
-#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1036
+#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1037
 /*!
  * block-cache: number of bypasses because no-write-allocate setting was
  * on
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1037
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1038
 /*! block-cache: number of bypasses due to overhead on put */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1038
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1039
 /*! block-cache: number of bypasses on get */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1039
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1040
 /*! block-cache: number of bypasses on put because file is too small */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1040
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1041
 /*! block-cache: number of eviction passes */
-#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1041
+#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1042
 /*! block-cache: number of hits */
-#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1042
+#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1043
 /*! block-cache: number of misses */
-#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1043
+#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1044
 /*! block-cache: number of put bypasses on checkpoint I/O */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1044
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1045
 /*! block-cache: removed blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1045
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1046
 /*! block-cache: time sleeping to remove block (usecs) */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1046
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1047
 /*! block-cache: total blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1047
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1048
 /*! block-cache: total blocks inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1048
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1049
 /*! block-cache: total blocks inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1049
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1050
 /*! block-cache: total bytes */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1050
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1051
 /*! block-cache: total bytes inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1051
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1052
 /*! block-cache: total bytes inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1052
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1053
 /*! block-manager: blocks pre-loaded */
-#define	WT_STAT_CONN_BLOCK_PRELOAD			1053
+#define	WT_STAT_CONN_BLOCK_PRELOAD			1054
 /*! block-manager: blocks read */
-#define	WT_STAT_CONN_BLOCK_READ				1054
+#define	WT_STAT_CONN_BLOCK_READ				1055
 /*! block-manager: blocks written */
-#define	WT_STAT_CONN_BLOCK_WRITE			1055
+#define	WT_STAT_CONN_BLOCK_WRITE			1056
 /*! block-manager: bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ			1056
+#define	WT_STAT_CONN_BLOCK_BYTE_READ			1057
 /*! block-manager: bytes read via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1057
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1058
 /*! block-manager: bytes read via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1058
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1059
 /*! block-manager: bytes written */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1059
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1060
 /*! block-manager: bytes written by compaction */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1060
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1061
 /*! block-manager: bytes written for checkpoint */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1061
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1062
 /*! block-manager: bytes written via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1062
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1063
 /*! block-manager: bytes written via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1063
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1064
 /*! block-manager: mapped blocks read */
-#define	WT_STAT_CONN_BLOCK_MAP_READ			1064
+#define	WT_STAT_CONN_BLOCK_MAP_READ			1065
 /*! block-manager: mapped bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1065
+#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1066
 /*!
  * block-manager: number of times the file was remapped because it
  * changed size via fallocate or truncate
  */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1066
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1067
 /*! block-manager: number of times the region was remapped via write */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1067
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1068
 /*! cache: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_TIME		1068
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_TIME		1069
 /*! cache: application threads page read from disk to cache count */
-#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1069
+#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1070
 /*! cache: application threads page read from disk to cache time (usecs) */
-#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1070
+#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1071
 /*! cache: application threads page write from cache to disk count */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1071
+#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1072
 /*! cache: application threads page write from cache to disk time (usecs) */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1072
+#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1073
 /*! cache: bytes allocated for updates */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1073
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1074
 /*! cache: bytes belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1074
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1075
 /*! cache: bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS			1075
+#define	WT_STAT_CONN_CACHE_BYTES_HS			1076
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1076
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1077
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1077
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1078
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1078
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1079
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1079
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1080
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1080
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1081
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1081
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1082
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1082
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1083
 /*! cache: evict page attempts by eviction server */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICT_ATTEMPT	1083
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICT_ATTEMPT	1084
 /*! cache: evict page attempts by eviction worker threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICT_ATTEMPT	1084
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICT_ATTEMPT	1085
 /*! cache: evict page failures by eviction server */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICT_FAIL	1085
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_EVICT_FAIL	1086
 /*! cache: evict page failures by eviction worker threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICT_FAIL	1086
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_EVICT_FAIL	1087
 /*! cache: eviction calls to get a page */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1087
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1088
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1088
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1089
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1089
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1090
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1090
+#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1091
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1091
+#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1092
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1092
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1093
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1093
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1094
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1094
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1095
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1095
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1096
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1096
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1097
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1097
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1098
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1098
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1099
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1099
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1100
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1100
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1101
 /*! cache: eviction server skips dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1101
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1102
 /*! cache: eviction server skips internal pages as it has an active child. */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1103
 /*! cache: eviction server skips metadata pages with history */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1104
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1104
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1105
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_RETRY	1105
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_RETRY	1106
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1106
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1107
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_TREE	1107
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_TREE	1108
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1108
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1109
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1109
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1110
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1110
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1111
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1111
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1112
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1112
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1113
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1113
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1114
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1114
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1115
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1115
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1116
 /*! cache: eviction state */
-#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1116
+#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1117
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1117
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1118
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1118
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1119
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1119
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1120
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1120
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1121
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1121
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1122
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1122
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1123
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1123
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1124
 /*! cache: eviction walk target strategy both clean and dirty pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1124
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1125
 /*! cache: eviction walk target strategy only clean pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1126
 /*! cache: eviction walk target strategy only dirty pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1126
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1127
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1127
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1128
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1128
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1129
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1129
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1130
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1130
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1131
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1131
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1132
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1132
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1133
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1133
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1134
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1134
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1135
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1135
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1136
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1136
+#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1137
 /*! cache: eviction worker thread created */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1137
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1138
 /*! cache: eviction worker thread removed */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1138
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1139
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1139
+#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1140
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1140
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1141
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1141
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1142
 /*! cache: force re-tuning of eviction workers once in a while */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1142
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1143
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1143
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1144
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1144
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1145
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1145
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1146
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1146
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1147
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1147
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1148
 /*! cache: forced eviction - pages evicted that were clean time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1148
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1149
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1149
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1150
 /*! cache: forced eviction - pages evicted that were dirty time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1150
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1151
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1151
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1152
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1152
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1153
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1153
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1154
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1154
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1155
 /*!
  * cache: forced eviction - pages selected unable to be evicted time
  * (usecs)
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1155
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1156
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1156
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1157
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1157
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1158
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1158
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1159
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1159
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1160
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1160
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1161
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1161
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1162
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1162
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1163
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1163
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1164
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1164
+#define	WT_STAT_CONN_CACHE_HS_READ			1165
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1165
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1166
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1166
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1167
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1167
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1168
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1168
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1169
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1169
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1170
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1170
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1171
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1171
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1172
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1172
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1173
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1173
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1174
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1174
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1175
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1175
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1176
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1176
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1177
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1177
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1178
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1178
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1179
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1179
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1180
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1180
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1181
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1181
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1182
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1182
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1183
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1183
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1184
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1184
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1185
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1185
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1186
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1186
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1187
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1187
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1188
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1188
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1189
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1189
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1190
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1190
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1191
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1191
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1192
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY_ATTEMPT	1192
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY_ATTEMPT	1193
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY_FAIL	1193
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_DIRTY_FAIL	1194
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1194
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1195
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	1195
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	1196
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1196
+#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1197
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1197
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1198
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1198
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1199
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_ATTEMPT		1199
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_ATTEMPT		1200
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_FAIL		1200
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_FAIL		1201
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1201
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1202
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1202
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1203
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1203
+#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1204
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1204
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1205
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1205
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1206
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1206
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1207
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1207
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1208
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1208
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1209
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1209
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1210
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1210
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1211
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1211
+#define	WT_STAT_CONN_CACHE_READ				1212
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1212
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1213
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1213
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1214
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1214
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1215
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1215
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1216
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1216
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1217
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1217
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1218
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1218
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1219
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1219
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1220
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1220
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1221
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1221
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1222
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1222
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1223
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1223
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1224
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1224
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1225
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1225
+#define	WT_STAT_CONN_CACHE_WRITE			1226
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1226
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1227
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1227
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1228
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1228
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1229
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1229
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1230
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1230
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1231
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1231
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1232
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1232
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1233
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1233
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1234
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1234
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1235
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1235
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1236
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1236
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1237
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1237
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1238
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1238
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1239
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1239
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1240
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1240
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1241
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1241
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1242
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1242
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1243
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1243
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1244
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1244
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1245
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1245
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1246
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1246
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1247
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1247
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1248
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1248
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1249
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1249
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1250
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1250
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1251
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1251
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1252
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1252
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1253
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1253
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1254
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1254
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1255
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1255
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1256
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1256
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1257
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1257
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1258
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1258
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1259
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1259
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1260
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1260
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1261
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1261
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1262
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1262
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1263
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1263
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1264
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1264
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1265
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1265
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1266
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1266
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1267
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1267
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1268
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1268
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1269
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1269
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1270
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1270
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1271
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1271
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1272
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1272
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1273
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1273
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1274
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1274
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1275
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1275
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1276
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1276
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1277
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1277
+#define	WT_STAT_CONN_CHECKPOINTS_API			1278
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1278
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1279
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1279
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1280
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1280
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1281
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1281
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1282
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1282
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1283
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1283
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1284
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1284
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1285
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1285
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1286
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1286
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1287
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1287
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1288
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1288
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1289
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1289
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1290
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1290
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1291
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1291
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1292
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1292
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1293
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1293
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1294
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1294
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1295
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1295
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1296
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1296
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1297
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1297
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1298
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1298
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1299
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1299
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1300
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1300
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1301
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1301
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1302
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1302
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1303
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1303
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1304
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1304
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1305
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1305
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1306
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1306
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1307
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1307
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1308
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1308
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1309
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1309
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1310
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1310
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1311
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1311
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1312
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1312
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1313
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1313
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1314
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1314
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1315
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1315
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1316
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1316
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1317
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1317
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1318
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1318
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1319
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1319
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1320
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1320
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1321
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1321
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1322
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1322
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1323
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1323
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1324
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1324
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1325
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1325
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1326
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1326
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1327
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1327
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1328
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1328
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1329
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1329
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1330
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1330
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1331
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1331
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1332
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1332
+#define	WT_STAT_CONN_TIME_TRAVEL			1333
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1333
+#define	WT_STAT_CONN_FILE_OPEN				1334
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1334
+#define	WT_STAT_CONN_BUCKETS_DH				1335
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1335
+#define	WT_STAT_CONN_BUCKETS				1336
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1336
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1337
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1337
+#define	WT_STAT_CONN_MEMORY_FREE			1338
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1338
+#define	WT_STAT_CONN_MEMORY_GROW			1339
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1339
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1340
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1340
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1341
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1341
+#define	WT_STAT_CONN_COND_WAIT				1342
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1342
+#define	WT_STAT_CONN_RWLOCK_READ			1343
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1343
+#define	WT_STAT_CONN_RWLOCK_WRITE			1344
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1344
+#define	WT_STAT_CONN_FSYNC_IO				1345
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1345
+#define	WT_STAT_CONN_READ_IO				1346
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1346
+#define	WT_STAT_CONN_WRITE_IO				1347
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1347
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1348
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1348
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1349
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1349
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1350
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1350
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1351
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1351
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1352
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1352
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1353
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1353
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1354
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1354
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1355
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1355
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1356
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1356
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1357
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1357
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1358
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1358
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1359
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1359
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1360
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1360
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1361
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1361
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1362
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1362
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1363
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1363
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1364
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1364
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1365
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1365
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1366
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1366
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1367
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1367
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1368
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1368
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1369
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1369
+#define	WT_STAT_CONN_CURSOR_CACHE			1370
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1370
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1371
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1371
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1372
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1372
+#define	WT_STAT_CONN_CURSOR_CREATE			1373
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1373
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1374
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1374
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1375
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1375
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1376
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1376
+#define	WT_STAT_CONN_CURSOR_INSERT			1377
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1377
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1378
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1378
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1379
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1379
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1380
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1380
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1381
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1381
+#define	WT_STAT_CONN_CURSOR_MODIFY			1382
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1382
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1383
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1383
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1384
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1384
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1385
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1385
+#define	WT_STAT_CONN_CURSOR_NEXT			1386
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1386
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1387
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1387
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1388
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1388
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1389
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1389
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1390
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1390
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1391
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1391
+#define	WT_STAT_CONN_CURSOR_RESTART			1392
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1392
+#define	WT_STAT_CONN_CURSOR_PREV			1393
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1393
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1394
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1394
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1395
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1395
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1396
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1396
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1397
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1397
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1398
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1398
+#define	WT_STAT_CONN_CURSOR_REMOVE			1399
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1399
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1400
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1400
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1401
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1401
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1402
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1402
+#define	WT_STAT_CONN_CURSOR_RESERVE			1403
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1403
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1404
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1404
+#define	WT_STAT_CONN_CURSOR_RESET			1405
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1405
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1406
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1406
+#define	WT_STAT_CONN_CURSOR_SEARCH			1407
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1407
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1408
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1408
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1409
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1409
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1410
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1410
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1411
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1411
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1412
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1412
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1413
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1413
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1414
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1414
+#define	WT_STAT_CONN_CURSOR_SWEEP			1415
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1415
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1416
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1416
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1417
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1417
+#define	WT_STAT_CONN_CURSOR_UPDATE			1418
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1418
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1419
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1419
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1420
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1420
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1421
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1421
+#define	WT_STAT_CONN_CURSOR_REOPEN			1422
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1422
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1423
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1423
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1424
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1424
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1425
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1425
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1426
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1426
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1427
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1427
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1428
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1428
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1429
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1429
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1430
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1430
+#define	WT_STAT_CONN_DH_SWEEP_REF			1431
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1431
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1432
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1432
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1433
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1433
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1434
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1434
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1435
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1435
+#define	WT_STAT_CONN_DH_SWEEPS				1436
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1436
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1437
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1437
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1438
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1438
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1439
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1439
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1440
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1440
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1441
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1441
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1442
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1442
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1443
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1443
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1444
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1444
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1445
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1445
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1446
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1446
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1447
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1447
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1448
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1448
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1449
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1449
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1450
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1450
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1451
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1451
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1452
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1452
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1453
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1453
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1454
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1454
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1455
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1455
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1456
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1456
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1457
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1457
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1458
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1458
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1459
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1459
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1460
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1460
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1461
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1461
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1462
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1462
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1463
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1463
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1464
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1464
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1465
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1465
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1466
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1466
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1467
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1467
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1468
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1468
+#define	WT_STAT_CONN_LOG_FLUSH				1469
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1469
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1470
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1470
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1471
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1471
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1472
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1472
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1473
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1473
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1474
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1474
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1475
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1475
+#define	WT_STAT_CONN_LOG_SCANS				1476
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1476
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1477
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1477
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1478
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1478
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1479
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1479
+#define	WT_STAT_CONN_LOG_SYNC				1480
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1480
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1481
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1481
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1482
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1482
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1483
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1483
+#define	WT_STAT_CONN_LOG_WRITES				1484
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1484
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1485
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1485
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1486
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1486
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1487
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1487
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1488
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1488
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1489
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1489
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1490
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1490
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1491
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1491
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1492
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1492
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1493
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1493
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1494
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1494
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1495
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1495
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1496
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1496
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1497
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1497
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1498
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1498
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1499
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1499
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1500
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1500
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1501
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1501
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1502
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1502
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1503
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1503
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1504
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1504
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1505
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1505
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1506
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1506
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1507
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1507
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1508
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1508
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1509
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1509
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1510
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1510
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1511
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1511
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1512
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1512
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1513
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1513
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1514
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1514
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1515
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1515
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1516
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1516
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1517
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1517
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1518
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1518
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1519
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1519
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1520
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1520
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1521
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1521
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1522
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1522
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1523
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1523
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1524
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1524
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1525
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1525
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1526
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1526
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1527
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1527
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1528
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1528
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1529
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1529
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1530
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1530
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1531
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1531
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1532
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1532
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1533
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1533
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1534
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1534
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1535
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1535
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1536
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1536
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1537
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1537
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1538
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1538
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1539
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1539
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1540
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1540
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1541
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1541
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1542
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1542
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1543
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1543
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1544
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1544
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1545
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1545
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1546
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1546
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1547
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1547
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1548
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1548
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1549
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1549
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1550
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1550
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1551
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1551
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1552
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1552
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1553
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1553
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1554
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1554
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1555
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1555
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1556
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1556
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1557
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1557
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1558
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1558
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1559
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1559
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1560
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1560
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1561
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1561
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1562
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1562
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1563
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1563
+#define	WT_STAT_CONN_REC_PAGES				1564
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1564
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1565
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1565
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1566
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1566
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1567
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1567
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1568
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1568
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1569
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1569
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1570
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1570
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1571
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1571
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1572
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1572
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1573
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1573
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1574
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1574
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1575
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1575
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1576
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1576
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1577
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1577
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1578
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1578
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1579
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1579
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1580
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1580
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1581
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1581
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1582
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1582
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1583
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1583
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1584
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1584
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1585
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1585
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1586
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1586
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1587
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1587
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1588
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1588
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1589
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1589
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1590
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1590
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1591
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1591
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1592
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1592
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1593
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1593
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1594
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1594
+#define	WT_STAT_CONN_FLUSH_TIER				1595
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1595
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1596
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1596
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1597
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1597
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1598
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1598
+#define	WT_STAT_CONN_SESSION_OPEN			1599
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1599
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1600
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1600
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1601
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1601
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1602
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1602
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1603
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1603
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1604
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1604
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1605
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1605
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1606
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1606
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1607
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1607
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1608
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1608
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1609
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1609
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1610
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1610
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1611
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1611
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1612
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1612
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1613
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1613
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1614
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1614
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1615
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1615
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1616
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1616
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1617
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1617
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1618
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1618
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1619
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1619
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1620
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1620
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1621
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1621
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1622
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1622
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1623
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1623
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1624
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1624
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1625
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1625
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1626
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1626
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1627
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1627
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1628
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1628
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1629
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1629
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1630
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1630
+#define	WT_STAT_CONN_TIERED_RETENTION			1631
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1631
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1632
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1632
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1633
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1633
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1634
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1634
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1635
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1635
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1636
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1636
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1637
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1637
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1638
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1638
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1639
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1639
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1640
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1640
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1641
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1641
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1642
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1642
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1643
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1643
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1644
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1644
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1645
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1645
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1646
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1646
+#define	WT_STAT_CONN_PAGE_SLEEP				1647
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1647
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1648
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1648
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1649
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1649
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1650
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1650
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1651
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1651
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1652
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1652
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1653
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1653
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1654
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1654
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1655
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1655
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1656
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1656
+#define	WT_STAT_CONN_TXN_PREPARE			1657
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1657
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1658
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1658
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1659
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1659
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1660
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1660
+#define	WT_STAT_CONN_TXN_QUERY_TS			1661
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1661
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1662
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1662
+#define	WT_STAT_CONN_TXN_RTS				1663
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1663
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1664
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1664
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1665
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1665
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1666
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1666
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1667
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1667
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1668
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1668
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1669
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1669
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1670
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1670
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1671
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1671
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1672
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1672
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1673
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1673
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1674
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1674
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1675
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1675
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1676
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1676
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1677
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1677
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1678
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1678
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1679
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1679
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1680
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1680
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1681
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1681
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1682
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1682
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1683
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1683
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1684
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1684
+#define	WT_STAT_CONN_TXN_SET_TS				1685
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1685
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1686
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1686
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1687
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1687
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1688
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1688
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1689
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1689
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1690
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1690
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1691
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1691
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1692
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1692
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1693
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1693
+#define	WT_STAT_CONN_TXN_BEGIN				1694
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1694
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1695
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1695
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1696
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1696
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1697
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1697
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1698
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1698
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1699
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1699
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1700
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1700
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1701
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1701
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1702
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1702
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1703
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1703
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1704
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1704
+#define	WT_STAT_CONN_TXN_COMMIT				1705
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1705
+#define	WT_STAT_CONN_TXN_ROLLBACK			1706
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1706
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1707
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1396,6 +1396,7 @@ static const char *const __stats_connection_desc[] = {
   "background-compact: background compact running",
   "background-compact: background compact skipped file as it is part of the exclude list",
   "background-compact: background compact skipped file as not meeting requirements for compaction",
+  "background-compact: background compact sleeps due to cache pressure",
   "background-compact: background compact successful calls",
   "background-compact: background compact timeout",
   "background-compact: number of files tracked by background compaction",
@@ -2172,6 +2173,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->background_compact_running = 0;
     stats->background_compact_exclude = 0;
     stats->background_compact_skipped = 0;
+    stats->background_compact_sleep_cache_pressure = 0;
     stats->background_compact_success = 0;
     stats->background_compact_timeout = 0;
     stats->background_compact_files_tracked = 0;
@@ -2897,6 +2899,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->background_compact_running += WT_STAT_CONN_READ(from, background_compact_running);
     to->background_compact_exclude += WT_STAT_CONN_READ(from, background_compact_exclude);
     to->background_compact_skipped += WT_STAT_CONN_READ(from, background_compact_skipped);
+    to->background_compact_sleep_cache_pressure +=
+      WT_STAT_CONN_READ(from, background_compact_sleep_cache_pressure);
     to->background_compact_success += WT_STAT_CONN_READ(from, background_compact_success);
     to->background_compact_timeout += WT_STAT_CONN_READ(from, background_compact_timeout);
     to->background_compact_files_tracked +=


### PR DESCRIPTION
Make the background compaction thread sleep if the cache has reached `eviction_trigger` or if dirty eviction is needed.