### PR TITLE
WT-13215 Backup:Compare checkpoint metadata while ignoring checkpoint flags. (#10811) (v8.0 Backport)

### DIFF
--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -764,8 +764,6 @@ __assert_ckpt_matches(WT_SESSION_IMPL *session, WT_CKPT *ckpt_a, WT_CKPT *ckpt_b
       "Checkpoint data/size mismatch in __assert_ckpt_matches");
     WT_ASSERT_ALWAYS(session, ckpt_a->bpriv == NULL && ckpt_b->bpriv == NULL,
       "Checkpoint block manager mismatch in __assert_ckpt_matches");
-    WT_ASSERT_ALWAYS(session, ckpt_a->flags == ckpt_b->flags,
-      "Checkpoint flags mismatch in __assert_ckpt_matches");
 }
 
 /*


### PR DESCRIPTION

In backup, compare checkpoint's persisted data from metadata while ignoring checkpoint flags.

(cherry picked from commit fa5f9464eb4b89e89fc50aea5f4694883dcd2f4a)