### PR TITLE
WT-13227 Remove directio adjacent buffer alignment code

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -297,7 +297,6 @@ __wti_desc_write(WT_SESSION_IMPL *session, WT_FH *fh, uint32_t allocsize)
     if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
         return (0);
 
-    /* Use a scratch buffer to get correct alignment for direct I/O. */
     WT_RET(__wt_scr_alloc(session, allocsize, &buf));
     memset(buf->mem, 0, allocsize);
 
@@ -379,7 +378,6 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
           block->name, block->size, allocsize);
     }
 
-    /* Use a scratch buffer to get correct alignment for direct I/O. */
     WT_RET(__wt_scr_alloc(session, allocsize, &buf));
 
     /* Read the first allocation-sized block and verify the file format. */

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -173,26 +173,13 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
     chunkcache_hit = full_checksum_mismatch = false;
     check_size = 0;
     failures = 0;
+    bufsize = WT_MAX(size, buf->memsize + 10);
     max_failures = F_ISSET(&S2C(session)->chunkcache, WT_CHUNKCACHE_CONFIGURED) ? 2 : 1;
     __wt_verbose_debug2(session, WT_VERB_READ,
       "off %" PRIuMAX ", size %" PRIu32 ", checksum %#" PRIx32, (uintmax_t)offset, size, checksum);
 
     WT_STAT_CONN_INCR(session, block_read);
     WT_STAT_CONN_INCRV(session, block_byte_read, size);
-
-    /*
-     * Grow the buffer as necessary and read the block. Buffers should be aligned for reading, but
-     * there are lots of buffers (for example, file cursors have two buffers each, key and value),
-     * and it's difficult to be sure we've found all of them. If the buffer isn't aligned, it's an
-     * easy fix: set the flag and guarantee we reallocate it. (Most of the time on reads, the buffer
-     * memory has not yet been allocated, so we're not adding any additional processing time.)
-     */
-    if (F_ISSET(buf, WT_ITEM_ALIGNED))
-        bufsize = size;
-    else {
-        F_SET(buf, WT_ITEM_ALIGNED);
-        bufsize = WT_MAX(size, buf->memsize + 10);
-    }
 
     /*
      * Ensure we don't read information that isn't there. It shouldn't ever happen, but it's a cheap

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -173,7 +173,7 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
     chunkcache_hit = full_checksum_mismatch = false;
     check_size = 0;
     failures = 0;
-    bufsize = WT_MAX(size, buf->memsize + 10);
+    bufsize = size;
     max_failures = F_ISSET(&S2C(session)->chunkcache, WT_CHUNKCACHE_CONFIGURED) ? 2 : 1;
     __wt_verbose_debug2(session, WT_VERB_READ,
       "off %" PRIuMAX ", size %" PRIu32 ", checksum %#" PRIx32, (uintmax_t)offset, size, checksum);

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -231,12 +231,6 @@ __block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_of
 
     fh = block->fh;
 
-    /* Buffers should be aligned for writing. */
-    if (!F_ISSET(buf, WT_ITEM_ALIGNED)) {
-        WT_ASSERT(session, F_ISSET(buf, WT_ITEM_ALIGNED));
-        WT_RET_MSG(session, EINVAL, "direct I/O check: write buffer incorrectly allocated");
-    }
-
     /*
      * File checkpoint/recovery magic: done before sizing the buffer as it may grow the buffer.
      */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -116,8 +116,7 @@ struct __wt_item {
 
     /*! Object flags (internal use). */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_ITEM_ALIGNED 0x1u
-#define WT_ITEM_INUSE   0x2u
+#define WT_ITEM_INUSE   0x1u
 /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t flags;
 #endif

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2279,7 +2279,7 @@ advance:
                 break;
             }
             /*
-             * We need to round up and read in the full padded record.
+             * We need to round up, and read in the full padded record.
              */
             WT_ERR(__wt_buf_grow(session, buf, rdup_len));
             WT_ERR(

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -784,8 +784,7 @@ __log_file_header(WT_SESSION_IMPL *session, WT_FH *fh, WT_LSN *end_lsn, bool pre
     log = conn->log;
 
     /*
-     * Set up the log descriptor record. Use a scratch buffer to get correct alignment for direct
-     * I/O.
+     * Set up the log descriptor record.
      */
     WT_ASSERT(session, sizeof(WT_LOG_DESC) < WT_LOG_ALIGN);
     WT_RET(__wt_scr_alloc(session, WT_LOG_ALIGN, &buf));
@@ -2280,7 +2279,7 @@ advance:
                 break;
             }
             /*
-             * We need to round up and read in the full padded record, especially for direct I/O.
+             * We need to round up and read in the full padded record.
              */
             WT_ERR(__wt_buf_grow(session, buf, rdup_len));
             WT_ERR(

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -456,7 +456,6 @@ __wt_log_slot_init(WT_SESSION_IMPL *session, bool alloc)
         log->slot_buf_size =
           (uint32_t)WT_MIN((size_t)conn->log_file_max / 10, WT_LOG_SLOT_BUF_SIZE);
         for (i = 0; i < WT_SLOT_POOL; i++) {
-            F_SET(&log->slot_pool[i].slot_buf, WT_ITEM_ALIGNED);
             WT_ERR(__wt_buf_init(session, &log->slot_pool[i].slot_buf, log->slot_buf_size));
             F_SET_ATOMIC_16(&log->slot_pool[i], WT_SLOT_INIT_FLAGS);
         }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -585,10 +585,6 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
         /* Connect pointers/buffers. */
         r->cur = &r->_cur;
         r->last = &r->_last;
-
-        /* Disk buffers need to be aligned for writing. */
-        F_SET(&r->chunk_A.image, WT_ITEM_ALIGNED);
-        F_SET(&r->chunk_B.image, WT_ITEM_ALIGNED);
     }
 
     /* Remember the configuration. */

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -329,9 +329,6 @@ __wt_scr_alloc_func(WT_SESSION_IMPL *session, size_t size, WT_ITEM **scratchp
         best = slot;
 
         WT_ERR(__wt_calloc_one(session, best));
-
-        /* Scratch buffers must be aligned. */
-        F_SET(*best, WT_ITEM_ALIGNED);
     }
 
     /* Grow the buffer as necessary and return. */


### PR DESCRIPTION
After investigating it seemed like a good idea to keep the usage of scratch buffers despite no longer needing it for alignment; scratch buffers are used in multiple places of our code, and is a convenient way for us to get a buffer in WT code. Instead we have removed alignment relating to direct io in the scratch buffer code itself, and made sure that no other functions using a scratch buffer are relying on this alignment.  We moved any other checks and alignment relating to scratch buffers + direct io here too. WT_ITEM_ALIGN was also removed. 