### PR TITLE
WT-13201 Create a TSan testing variant in evergreen that doesn't fail on error

### DIFF
--- a/lang/python/wiredtiger/init.py
+++ b/lang/python/wiredtiger/init.py
@@ -32,11 +32,6 @@
 # versions may be broken, see: https://github.com/swig/swig/issues/769 .
 # Importing indirectly seems to avoid these issues.
 
-# Restart this instance of python so it uses the most recent os.environ values
-def restart_python():
-    python = sys.executable
-    os.execl(python, python, *sys.argv)
-
 import os, sys
 fname = os.path.basename(__file__)
 if fname != '__init__.py' and fname != '__init__.pyc':
@@ -46,6 +41,11 @@ if fname != '__init__.py' and fname != '__init__.pyc':
 if sys.version_info[0] <= 2:
     print('WiredTiger requires Python version 3.0 or above')
     sys.exit(1)
+
+# Restart this instance of python so it uses the most recent os.environ values
+def restart_python():
+    python = sys.executable
+    os.execl(python, os.path.abspath(__file__), *sys.argv)
 
 # After importing the SWIG-generated file, copy all symbols from it
 # to this module so they will appear in the wiredtiger namespace.

--- a/lang/python/wiredtiger/init.py
+++ b/lang/python/wiredtiger/init.py
@@ -26,12 +26,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
 # init.py
 #      This is installed as __init__.py, and imports the file created by SWIG.
 # This is needed because SWIG's import helper code created by certain SWIG
 # versions may be broken, see: https://github.com/swig/swig/issues/769 .
 # Importing indirectly seems to avoid these issues.
+
+# Restart this instance of python so it uses the most recent os.environ values
+def restart_python():
+    python = sys.executable
+    os.execl(python, python, *sys.argv)
+
 import os, sys
 fname = os.path.basename(__file__)
 if fname != '__init__.py' and fname != '__init__.pyc':
@@ -46,6 +51,32 @@ if sys.version_info[0] <= 2:
 # to this module so they will appear in the wiredtiger namespace.
 me = sys.modules[__name__]
 sys.path.append(os.path.dirname(__file__))
+
+# Find the sanitizer environment variable.
+# FIXME-WT-13237: Rename these testutil flags
+if os.environ.get("TESTUTIL_TSAN") == "1":
+    import subprocess
+
+    # FIXME-WT-13143 We assume TSan is only compatible with clang here. This may change in the future.
+    command = "clang --print-file-name libtsan.so.0"
+    find_tsan_so = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    tsan_so_path = find_tsan_so.stdout.strip()
+    if not os.path.isfile(tsan_so_path):
+        print("Cannot find tsan lib")
+        exit(1)
+
+    ld_preload = os.environ.get("LD_PRELOAD")
+    if not ld_preload:
+        os.environ["LD_PRELOAD"] = tsan_so_path
+        restart_python()
+    elif tsan_so_path not in os.environ["LD_PRELOAD"]:
+        os.environ["LD_PRELOAD"] += f":{tsan_so_path}"
+        restart_python()
+    else:
+        # Python already has TSan linking, but if python calls ./wt in a subprocess this breaks ./wt
+        # Remove the TSan libs from LD_PRELOAD but *don't* restart python so we still have TSan linking in the current running process. 
+        paths = os.environ["LD_PRELOAD"].split(":")
+        os.environ["LD_PRELOAD"] = ":".join([p for p in paths if p != tsan_so_path])
 
 # explicitly importing _wiredtiger in advance of SWIG allows us to not
 # use relative importing, as SWIG does.  It doesn't work for us with Python2.

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -37,7 +37,7 @@ define_c_test(
     DIR_NAME random
     DEPENDS "WT_POSIX"
     # This test takes over 20 minutes under ASan testing
-    LABEL "long_running"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -132,6 +132,7 @@ define_c_test(
     DIR_NAME wt2403_lsm_workload
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2403_lsm_workload>/WT_HOME>
     DEPENDS "WT_POSIX"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -139,6 +140,7 @@ define_c_test(
     SOURCES wt2246_col_append/main.c
     DIR_NAME wt2246_col_append
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2246_col_append>/WT_HOME>
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -147,6 +149,7 @@ define_c_test(
     DIR_NAME wt2323_join_visibility
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2323_join_visibility>/WT_HOME>
     DEPENDS "WT_POSIX"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -156,6 +159,7 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2535_insert_race/smoke.sh
     ARGUMENTS $<TARGET_FILE:test_wt2535_insert_race>
     DEPENDS "WT_POSIX"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -194,6 +198,7 @@ define_c_test(
     SOURCES wt2834_join_bloom_fix/main.c
     DIR_NAME wt2834_join_bloom_fix
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2834_join_bloom_fix>/WT_HOME>
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -248,7 +253,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3338_partial_update>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over an hour under ASan testing
-    LABEL "long_running"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -338,7 +343,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt7989_compact_checkpoint>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over 40 minutes under ASan testing
-    LABEL "long_running"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -374,7 +379,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8659_reconstruct_database_from_logs>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over 20 minutes under ASan testing
-    LABEL "long_running"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -384,7 +389,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8963_insert_stress>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over an hour under ASan testing
-    LABEL "long_running"
+    LABEL "sanitizer_long"
 )
 
 define_c_test(
@@ -425,4 +430,5 @@ define_c_test(
     DIR_NAME wt12015_backup_corruption
     ARGUMENTS
     DEPENDS "WT_POSIX"
+    LABEL "sanitizer_long"
 )

--- a/test/csuite/wt4105_large_doc_small_upd/main.c
+++ b/test/csuite/wt4105_large_doc_small_upd/main.c
@@ -154,7 +154,8 @@ main(int argc, char *argv[])
              * Ignore this alarm for some sanitizer builds due to the typical slowdown they
              * introduce.
              */
-            if (!(testutil_is_flag_set("TESTUTIL_MSAN") || testutil_is_flag_set("TESTUTIL_UBSAN")))
+            if (!(testutil_is_flag_set("TESTUTIL_MSAN") || testutil_is_flag_set("TESTUTIL_UBSAN") ||
+                  testutil_is_flag_set("TESTUTIL_TSAN")))
                 (void)alarm(15);
             testutil_check(c->modify(c, &modify_entry, 1));
             (void)alarm(0);

--- a/test/csuite/wt4156_metadata_salvage/main.c
+++ b/test/csuite/wt4156_metadata_salvage/main.c
@@ -480,7 +480,7 @@ main(int argc, char *argv[])
     char copy_from[1024], save_path[1024];
 
     /* Bypass this test for ASAN builds */
-    if (testutil_is_flag_set("TESTUTIL_BYPASS_ASAN"))
+    if (testutil_is_flag_set("TESTUTIL_BYPASS_ASAN") || testutil_is_flag_set("TESTUTIL_TSAN"))
         return (EXIT_SUCCESS);
 
     opts = &_opts;

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5567,7 +5567,6 @@ buildvariants:
   display_name: "~ Ubuntu 20.04 TSAN (No throw)"
   patch_only: true
   run_on:
-  # Defaulting to ubuntu2004-large. We can move back to ubuntu2004-test as we ID which tests can fit on the smaller host
   - ubuntu2004-large
   expansions:
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5586,8 +5586,8 @@ buildvariants:
     # Reduce the number of test iterations in validation stressing as TSan increases runtime by a factor of roughly 10x
     validation_stress_num_runs: 20
   tasks:
-  # The pull request tag, which includes azure gcp, doesn't compile under clang
-  #  - name: ".pull_request"
+    # Skip the azure/gcp tests as they don't compile under clang
+    - name: ".pull_request !.azure-gcp-tiered-test-small"
     - name: ".unit_test_long"
     - name: compile
     - name: make-check-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5541,7 +5541,7 @@ buildvariants:
     - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
       vars:
         # We want to keep pull request testing short. Disable tests that are slow under ASan
-        extra_args: -E "wt12015_backup_corruption" -LE sanitizer_long
+        ctest_extra_args: -E "wt12015_backup_corruption" -LE sanitizer_long
     - name: examples-c-test
     - name: format-asan-smoke-test
 
@@ -5580,7 +5580,7 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     # We don't run C++ memory sanitized testing as it creates false positives. TSan also significantly increases the runtime 
     # of some csuite tests, so disable the already long tests as well as tests heavily impacted by TSan.
-    extra_args: -LE "cppsuite|long_running|sanitizer_long"
+    ctest_extra_args: -LE "cppsuite|long_running|sanitizer_long"
     # TSan slows down python testing enough that we start printing "operation took X seconds" warnings. 
     # These don't impact functionality, but the python tests fail on detection of any content in stdout so ignore it instead. 
     ignore_stdout: --ignore-stdout
@@ -5597,10 +5597,6 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: unit-test-zstd
     - name: unit-test-random-seed
-    # These cache stuck under TSan.
-    #- name: unit-test-hook-tiered
-    #- name: unit-test-hook-tiered-with-delays
-    #- name: unit-test-hook-tiered-timestamp
     - name: unit-test-hook-timestamp
     - name: test-prepare-hs03-hook-timestamp
     - name: spinlock-gcc-test
@@ -5608,27 +5604,13 @@ buildvariants:
     - name: static-wt-build-test
     - name: linux-directio
       distros: ubuntu2004-build
-    # Disabled as we have a naming conflict with the `extra_args` expansion. It's used both for args into ctest (as in this variant) and also as args into format test (this test)
-    # We need to split this into two (ctest_extra_args, format_extra_args) fields in a separate ticket.
-    # - name: format-mirror-test
     - name: format-smoke-test
-    # This gets OOM killed under TSan.
-    #- name: format-failure-configs-test
     - name: ".data-validation-stress-test"
     - name: catch2-unittest-test
     - name: s3-tiered-storage-extensions-test
     - name: bench-tiered-push-pull
     - name: catch2-unittest-assertions
-    # Azure gcp which falls under this label doesn't compile under clang.
-    #- name: ".tiered_unittest"
     - name: bench-tiered-push-pull-s3
-    # This is too slow under TSan.
-    #- name: csuite-timestamp-abort-test-s3
-    # This cache stucks under TSan.
-    # - name: unit-test-hook-tiered-s3
-    # Disabling as some tests take over 2.5 hours with TSan instrumented
-    # - name: csuite-long-running
-    #   batchtime: 1440 # once a day
 
 # Very minimal set without any extensions
 - name: ubuntu2004-minimal

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5559,6 +5559,7 @@ buildvariants:
   tasks:
     - name: examples-c-tsan
 
+# FIXME-WT-13256
 # This variant runs all possible tasks under TSan but instructs TSan to not report any issues it
 # encounters. This allows us to check whether a TSan change may cause other unexpected failures
 # while also not having to fix every TSan issue discovered. At the conclusion of the TSan work this

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -64,6 +64,7 @@ functions:
               export TESTUTIL_MSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ TSan ]]; then
               export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:verbosity=3"
+              export TESTUTIL_TSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ UBSan ]]; then
               export UBSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_stacktrace=1"
               export TESTUTIL_UBSAN=1
@@ -429,7 +430,7 @@ functions:
           set -o errexit
           set -o verbose
           ${PREPARE_TEST_ENV}
-          ../../../tools/run_parallel.sh 'nice ./recovery-test.sh "${data_validation_stress_test_args} ${run_test_checkpoint_args}" WT_TEST.$t test_checkpoint' 120
+          ../../../tools/run_parallel.sh 'nice ./recovery-test.sh "${data_validation_stress_test_args} ${run_test_checkpoint_args}" WT_TEST.$t test_checkpoint' ${validation_stress_num_runs|120}
   "run tiered storage test":
     - command: shell.exec
       params:
@@ -468,7 +469,7 @@ functions:
           pip3 install google-cloud-storage
 
           # Run Python testing for all tiered tests.
-          python3 ../test/suite/run.py -j $(nproc) ${tiered_storage_test_name}
+          python3 ../test/suite/run.py ${ignore_stdout|} -j $(nproc) ${tiered_storage_test_name}
   "compile wiredtiger docs":
     - command: shell.exec
       params:
@@ -784,9 +785,9 @@ functions:
           threads_command="-j ${num_jobs}"
         fi
         if [ ${check_coverage|false} = true ]; then
-            ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1 || echo "Ignoring failed test as we are checking test coverage"
+            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1 || echo "Ignoring failed test as we are checking test coverage"
         else
-            ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1
+            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1
         fi
 
   "code coverage analysis":
@@ -2104,6 +2105,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
+            ${PREPARE_TEST_ENV}
 
             ./test_timestamp_abort -PT -Po s3_store
 
@@ -2265,7 +2267,7 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-            ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} --hook tiered=tier_storage_source='s3_store' -j ${num_jobs} 2>&1
+            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} ${unit_test_args|-v 2} --hook tiered=tier_storage_source='s3_store' -j ${num_jobs} 2>&1
 
   - name: unit-test-hook-tiered-timestamp
     tags: ["python"]
@@ -2322,7 +2324,7 @@ tasks:
             do
               ((i=i+1))
               echo "Test count: $i"
-              ${python_binary|python3} ../test/suite/run.py -v 4 test_prepare_hs03.py --hook timestamp
+              ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} -v 4 test_prepare_hs03.py --hook timestamp
             done
 
   - name: csuite-long-running
@@ -2971,6 +2973,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
+            ${PREPARE_TEST_ENV}
             WT_BUILDDIR=$(pwd)/../../cmake_build LD_LIBRARY_PATH=$WT_BUILDDIR ${python_binary|python3} syscall.py --verbose --preserve
 
   - name: checkpoint-filetypes-test
@@ -5536,6 +5539,9 @@ buildvariants:
     ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
     - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
+      vars:
+        # We want to keep pull request testing short. Disable tests that are slow under ASan
+        extra_args: -E "wt12015_backup_corruption" -LE sanitizer_long
     - name: examples-c-test
     - name: format-asan-smoke-test
 
@@ -5552,6 +5558,77 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: examples-c-tsan
+
+# This variant runs all possible tasks under TSan but instructs TSan to not report any issues it
+# encounters. This allows us to check whether a TSan change may cause other unexpected failures
+# while also not having to fix every TSan issue discovered. At the conclusion of the TSan work this
+# variant will be deleted.
+- name: ubuntu2004-tsan-no-throw
+  display_name: "~ Ubuntu 20.04 TSAN (No throw)"
+  patch_only: true
+  run_on:
+  # Defaulting to ubuntu2004-large. We can move back to ubuntu2004-test as we ID which tests can fit on the smaller host
+  - ubuntu2004-large
+  expansions:
+    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake
+    CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=TSan
+    ENABLE_TCMALLOC: 0
+    data_validation_stress_test_args: -t r -m -W 3 -D -p -n 100000 -k 100000 -C cache_size=100MB
+    additional_env_vars: |
+      # We intentionally suppress all TSan warnings.
+      export TSAN_OPTIONS="detect_deadlocks=0:report_bugs=0:report_atomic_races=0:allocator_may_return_null=1"
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+    # We don't run C++ memory sanitized testing as it creates false positives. TSan also significantly increases the runtime 
+    # of some csuite tests, so disable the already long tests as well as tests heavily impacted by TSan.
+    extra_args: -LE "cppsuite|long_running|sanitizer_long"
+    # TSan slows down python testing enough that we start printing "operation took X seconds" warnings. 
+    # These don't impact functionality, but the python tests fail on detection of any content in stdout so ignore it instead. 
+    ignore_stdout: --ignore-stdout
+    # Reduce the number of test iterations in validation stressing as TSan increases runtime by a factor of roughly 10x
+    validation_stress_num_runs: 20
+  tasks:
+  # The pull request tag, which includes azure gcp, doesn't compile under clang
+  #  - name: ".pull_request"
+    - name: ".unit_test_long"
+    - name: compile
+    - name: make-check-test
+    - name: configure-combinations
+    - name: syscall-linux
+    - name: checkpoint-filetypes-test
+    - name: unit-test-zstd
+    - name: unit-test-random-seed
+    # These cache stuck under TSan.
+    #- name: unit-test-hook-tiered
+    #- name: unit-test-hook-tiered-with-delays
+    #- name: unit-test-hook-tiered-timestamp
+    - name: unit-test-hook-timestamp
+    - name: test-prepare-hs03-hook-timestamp
+    - name: spinlock-gcc-test
+    - name: spinlock-pthread-adaptive-test
+    - name: static-wt-build-test
+    - name: linux-directio
+      distros: ubuntu2004-build
+    # Disabled as we have a naming conflict with the `extra_args` expansion. It's used both for args into ctest (as in this variant) and also as args into format test (this test)
+    # We need to split this into two (ctest_extra_args, format_extra_args) fields in a separate ticket.
+    # - name: format-mirror-test
+    - name: format-smoke-test
+    # This gets OOM killed under TSan.
+    #- name: format-failure-configs-test
+    - name: ".data-validation-stress-test"
+    - name: catch2-unittest-test
+    - name: s3-tiered-storage-extensions-test
+    - name: bench-tiered-push-pull
+    - name: catch2-unittest-assertions
+    # Azure gcp which falls under this label doesn't compile under clang.
+    #- name: ".tiered_unittest"
+    - name: bench-tiered-push-pull-s3
+    # This is too slow under TSan.
+    #- name: csuite-timestamp-abort-test-s3
+    # This cache stucks under TSan.
+    # - name: unit-test-hook-tiered-s3
+    # Disabling as some tests take over 2.5 hours with TSan instrumented
+    # - name: csuite-long-running
+    #   batchtime: 1440 # once a day
 
 # Very minimal set without any extensions
 - name: ubuntu2004-minimal

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5578,11 +5578,11 @@ buildvariants:
       # We intentionally suppress all TSan warnings.
       export TSAN_OPTIONS="detect_deadlocks=0:report_bugs=0:report_atomic_races=0:allocator_may_return_null=1"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
-    # We don't run C++ memory sanitized testing as it creates false positives. TSan also significantly increases the runtime 
+    # We don't run C++ memory sanitized testing as it creates false positives. TSan also significantly increases the runtime
     # of some csuite tests, so disable the already long tests as well as tests heavily impacted by TSan.
     ctest_extra_args: -LE "cppsuite|long_running|sanitizer_long"
-    # TSan slows down python testing enough that we start printing "operation took X seconds" warnings. 
-    # These don't impact functionality, but the python tests fail on detection of any content in stdout so ignore it instead. 
+    # TSan slows down python testing enough that we start printing "operation took X seconds" warnings.
+    # These don't impact functionality, but the python tests fail on detection of any content in stdout so ignore it instead.
     ignore_stdout: --ignore-stdout
     # Reduce the number of test iterations in validation stressing as TSan increases runtime by a factor of roughly 10x
     validation_stress_num_runs: 20

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5588,8 +5588,7 @@ buildvariants:
     validation_stress_num_runs: 20
   tasks:
     # Skip the azure/gcp tests as they don't compile under clang
-    - name: ".pull_request !.azure-gcp-tiered-test-small"
-    - name: ".unit_test_long"
+    - name: ".pull_request !.tiered_unittest !.pull_request_compilers !.model_checking !csuite-wt12015-backup-corruption-test"
     - name: compile
     - name: make-check-test
     - name: configure-combinations

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -469,7 +469,7 @@ functions:
           pip3 install google-cloud-storage
 
           # Run Python testing for all tiered tests.
-          python3 ../test/suite/run.py ${ignore_stdout|} -j $(nproc) ${tiered_storage_test_name}
+          python3 ../test/suite/run.py ${ignore_stdout} -j $(nproc) ${tiered_storage_test_name}
   "compile wiredtiger docs":
     - command: shell.exec
       params:
@@ -785,9 +785,9 @@ functions:
           threads_command="-j ${num_jobs}"
         fi
         if [ ${check_coverage|false} = true ]; then
-            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1 || echo "Ignoring failed test as we are checking test coverage"
+            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1 || echo "Ignoring failed test as we are checking test coverage"
         else
-            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1
+            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1
         fi
 
   "code coverage analysis":
@@ -2267,7 +2267,7 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} ${unit_test_args|-v 2} --hook tiered=tier_storage_source='s3_store' -j ${num_jobs} 2>&1
+            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} ${unit_test_args|-v 2} --hook tiered=tier_storage_source='s3_store' -j ${num_jobs} 2>&1
 
   - name: unit-test-hook-tiered-timestamp
     tags: ["python"]
@@ -2324,7 +2324,7 @@ tasks:
             do
               ((i=i+1))
               echo "Test count: $i"
-              ${python_binary|python3} ../test/suite/run.py ${ignore_stdout|} -v 4 test_prepare_hs03.py --hook timestamp
+              ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} -v 4 test_prepare_hs03.py --hook timestamp
             done
 
   - name: csuite-long-running

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5588,7 +5588,7 @@ buildvariants:
     validation_stress_num_runs: 20
   tasks:
     # Skip the azure/gcp tests as they don't compile under clang
-    - name: ".pull_request !.tiered_unittest !.pull_request_compilers !.model_checking !csuite-wt12015-backup-corruption-test"
+    - name: ".pull_request !.tiered_unittest !azure-gcp-tiered-test-small !.pull_request_compilers !.model_checking !csuite-wt12015-backup-corruption-test"
     - name: compile
     - name: make-check-test
     - name: configure-combinations

--- a/test/fops/CMakeLists.txt
+++ b/test/fops/CMakeLists.txt
@@ -17,4 +17,4 @@ endif()
 
 
 # Run this during a "ctest check" smoke test.
-set_tests_properties(test_fops PROPERTIES LABELS "check")
+set_tests_properties(test_fops PROPERTIES LABELS "check;sanitizer_long")

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -112,12 +112,13 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
                 self.conn = None
 
     def test_bug018(self):
+        '''Test closing multiple tables'''
+
         # This test spawns another python instance but that circumvents the LD_PRELOAD logic in
         # init.py, which means that python instance crashes. We could fix that but it would require
         # some custom logic which is overkill for this single test.
         if os.environ.get("TESTUTIL_TSAN") == "1":
-            self.skipTest("Not compatibable with TSan")
-        '''Test closing multiple tables'''
+            self.skipTest("Not compatible with TSan")
 
         self.close_conn()
         subdir = 'SUBPROCESS'

--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -112,6 +112,11 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
                 self.conn = None
 
     def test_bug018(self):
+        # This test spawns another python instance but that circumvents the LD_PRELOAD logic in
+        # init.py, which means that python instance crashes. We could fix that but it would require
+        # some custom logic which is overkill for this single test.
+        if os.environ.get("TESTUTIL_TSAN") == "1":
+            self.skipTest("Not compatibable with TSan")
         '''Test closing multiple tables'''
 
         self.close_conn()

--- a/test/suite/test_checkpoint11.py
+++ b/test/suite/test_checkpoint11.py
@@ -42,6 +42,7 @@ from wtscenario import make_scenarios
 class test_checkpoint(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all),timing_stress_for_test=[checkpoint_slow]'
     session_config = 'isolation=snapshot'
+    rollbacks_allowed = 10
 
     format_values = [
         ('column-fix', dict(key_format='r', value_format='8t',

--- a/test/suite/test_rollback_to_stable38.py
+++ b/test/suite/test_rollback_to_stable38.py
@@ -70,7 +70,7 @@ class test_rollback_to_stable38(wttest.WiredTigerTestCase):
         cursor.close()
 
     def test_rollback_to_stable38(self):
-        # TSan slows this test down enough to reliably produce "Cache stuck for too long" 
+        # TSan slows this test down enough to reliably produce "Cache stuck for too long"
         # messages in stderr which fails the test.
         if os.environ.get("TESTUTIL_TSAN") == "1":
             self.skipTest("Not compatible with TSan")

--- a/test/suite/test_rollback_to_stable38.py
+++ b/test/suite/test_rollback_to_stable38.py
@@ -26,6 +26,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import os
+
 import wttest
 from helper import simulate_crash_restart
 from rollback_to_stable_util import verify_rts_logs
@@ -68,6 +70,11 @@ class test_rollback_to_stable38(wttest.WiredTigerTestCase):
         cursor.close()
 
     def test_rollback_to_stable38(self):
+        # TSan slows this test down enough to reliably produce "Cache stuck for too long" 
+        # messages in stderr which fails the test.
+        if os.environ.get("TESTUTIL_TSAN") == "1":
+            self.skipTest("Not compatible with TSan")
+
         nrows = 1000000
 
         # Create a table.


### PR DESCRIPTION
This PR adds a new buildvariant for running TSan tests, but ignoring all warnings raised by TSan. 
This is to catch any compilation or logic errors that might be introduced by changes that are behind an `#ifdef TSAN_BUILD`. 
As tests get added to the `ubuntu2004-tsan` variant we will remove them from this `no-throw` variant.