### PR TITLE
WT-13266 Fix decoding cell timestamps in wt_binary_decode

### DIFF
--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -317,13 +317,13 @@ class Cell(object):
             self.durable_stop_ts, self.size_durable_stop_ts = b.read_packed_uint64_with_size()
 
         if self.durable_start_ts is not None:
-            self.durable_start_ts += self.start_ts
+            self.durable_start_ts += self.start_ts if self.start_ts is not None else 0
         if self.stop_ts is not None:
-            self.stop_ts += self.start_ts
+            self.stop_ts += self.start_ts if self.start_ts is not None else 0
         if self.stop_txn is not None:
-            self.stop_txn += self.start_txn
+            self.stop_txn += self.start_txn if self.start_txn is not None else 0
         if self.durable_stop_ts is not None:
-            self.durable_stop_ts += self.stop_ts
+            self.durable_stop_ts += self.stop_ts if self.stop_ts is not None else 0
 
         if self.extra_descriptor & 0x80:
             raise ValueError('Junk in extra descriptor: ' + hex(self.extra_descriptor))

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -301,18 +301,30 @@ class Cell(object):
         '''
         if self.extra_descriptor == 0:
             return
-        if self.extra_descriptor & Cell.WT_CELL_TS_DURABLE_START != 0:
-            self.durable_start_ts, self.size_durable_start_ts = b.read_packed_uint64_with_size()
-        if self.extra_descriptor & Cell.WT_CELL_TS_DURABLE_STOP != 0:
-            self.durable_stop_ts, self.size_durable_stop_ts = b.read_packed_uint64_with_size()
+
         if self.extra_descriptor & Cell.WT_CELL_TS_START != 0:
             self.start_ts, self.size_start_ts = b.read_packed_uint64_with_size()
-        if self.extra_descriptor & Cell.WT_CELL_TS_STOP != 0:
-            self.stop_ts, self.size_stop_ts = b.read_packed_uint64_with_size()
         if self.extra_descriptor & Cell.WT_CELL_TXN_START != 0:
             self.start_txn, self.size_start_txn = b.read_packed_uint64_with_size()
+        if self.extra_descriptor & Cell.WT_CELL_TS_DURABLE_START != 0:
+            self.durable_start_ts, self.size_durable_start_ts = b.read_packed_uint64_with_size()
+
+        if self.extra_descriptor & Cell.WT_CELL_TS_STOP != 0:
+            self.stop_ts, self.size_stop_ts = b.read_packed_uint64_with_size()
         if self.extra_descriptor & Cell.WT_CELL_TXN_STOP != 0:
             self.stop_txn, self.size_stop_txn = b.read_packed_uint64_with_size()
+        if self.extra_descriptor & Cell.WT_CELL_TS_DURABLE_STOP != 0:
+            self.durable_stop_ts, self.size_durable_stop_ts = b.read_packed_uint64_with_size()
+
+        if self.durable_start_ts is not None:
+            self.durable_start_ts += self.start_ts
+        if self.stop_ts is not None:
+            self.stop_ts += self.start_ts
+        if self.stop_txn is not None:
+            self.stop_txn += self.start_txn
+        if self.durable_stop_ts is not None:
+            self.durable_stop_ts += self.stop_ts
+
         if self.extra_descriptor & 0x80:
             raise ValueError('Junk in extra descriptor: ' + hex(self.extra_descriptor))
 

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -329,30 +329,31 @@ def process_timestamps(p, cell: btree_format.Cell, pagestats: PageStats):
     if cell.prepared:
         p.rint_v(' prepared')
 
-    if cell.durable_start_ts is not None:
-        pagestats.d_start_ts_sz += cell.size_durable_start_ts
-        pagestats.num_d_start_ts += 1
-        p.rint_v(' durable start ts: ' + ts(cell.durable_start_ts))
-    if cell.durable_stop_ts is not None:
-        pagestats.d_stop_ts_sz += cell.size_durable_stop_ts
-        pagestats.num_d_stop_ts += 1
-        p.rint_v(' durable stop ts: ' + ts(cell.durable_stop_ts))
     if cell.start_ts is not None:
         pagestats.start_ts_sz += cell.size_start_ts
         pagestats.num_start_ts += 1
         p.rint_v(' start ts: ' + ts(cell.start_ts))
-    if cell.stop_ts is not None:
-        pagestats.stop_ts_sz += cell.size_stop_ts
-        pagestats.num_stop_ts += 1
-        p.rint_v(' stop ts: ' + ts(cell.stop_ts))
     if cell.start_txn is not None:
         pagestats.start_txn_sz += cell.size_start_txn
         pagestats.num_start_txn += 1
         p.rint_v(' start txn: ' + txn(cell.start_txn))
+    if cell.durable_start_ts is not None:
+        pagestats.d_start_ts_sz += cell.size_durable_start_ts
+        pagestats.num_d_start_ts += 1
+        p.rint_v(' durable start ts: ' + ts(cell.durable_start_ts))
+
+    if cell.stop_ts is not None:
+        pagestats.stop_ts_sz += cell.size_stop_ts
+        pagestats.num_stop_ts += 1
+        p.rint_v(' stop ts: ' + ts(cell.stop_ts))
     if cell.stop_txn is not None:
         pagestats.stop_txn_sz += cell.size_stop_txn
         pagestats.num_stop_txn += 1
         p.rint_v(' stop txn: ' + txn(cell.stop_txn))
+    if cell.durable_stop_ts is not None:
+        pagestats.d_stop_ts_sz += cell.size_durable_stop_ts
+        pagestats.num_d_stop_ts += 1
+        p.rint_v(' durable stop ts: ' + ts(cell.durable_stop_ts))
 
 def block_decode(p, b, opts):
     disk_pos = b.tell()


### PR DESCRIPTION
The PR fixes `btree_format.Cell._parse_timestamps` to match the order of operations in `__cell_pack_value_validity` and accounts for storing just the differences.