### PR TITLE
WT-13268 Fix parsing the timestamps

### DIFF
--- a/tools/hexfiend/Templates/WT/_wtpage.tcl-inc
+++ b/tools/hexfiend/Templates/WT/_wtpage.tcl-inc
@@ -76,12 +76,12 @@ proc __wt_cell {} {
           ssection extra {
             xentry extra { format_bits [set extra [uint8]] $WT_CELL_extra_b }
             if {$extra & $WT_CELL_PREPARE} { entry "prepared" "prepared" 1 [expr {[pos] - 1}] }
-            if {$extra & $WT_CELL_TS_DURABLE_START} { xentry "durable start ts" vuint }
-            if {$extra & $WT_CELL_TS_DURABLE_STOP} { xentry "durable stop ts" vuint }
             if {$extra & $WT_CELL_TS_START} { xentry "start ts" vuint }
-            if {$extra & $WT_CELL_TS_STOP} { xentry "stop ts" vuint }
             if {$extra & $WT_CELL_TXN_START} { xentry "start txn" vuint }
+            if {$extra & $WT_CELL_TS_DURABLE_START} { xentry "durable start ts" vuint }
+            if {$extra & $WT_CELL_TS_STOP} { xentry "stop ts" vuint }
             if {$extra & $WT_CELL_TXN_STOP} { xentry "stop txn" vuint }
+            if {$extra & $WT_CELL_TS_DURABLE_STOP} { xentry "durable stop ts" vuint }
           }
         }
 


### PR DESCRIPTION
Make it the same as [__wt_cell_unpack_safe()](https://github.com/wiredtiger/wiredtiger/blob/7461c8be5aef36f185b9b7074f605f0901000c18/src/include/cell_inline.h#L845-L884)