### PR TITLE
WT-13250 Fix test_verify assert to be less strict

### DIFF
--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -176,7 +176,7 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
             outfilename='dump_corrupt.out', errfilename="dump_corrupt.err", failure=True)
         self.assertEqual(self.count_file_contains("dump_corrupt.out",
             "Read failure while accessing a page from the "), 1)
-        self.assertEqual(self.count_file_contains("stderr.txt", "read checksum error"), 1)
+        self.assertGreaterEqual(self.count_file_contains("stderr.txt", "read checksum error"), 1)
 
     def test_verify_api_read_corrupt_pages(self):
         """
@@ -262,7 +262,7 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(["-p", "verify", "-c", "table:" + self.tablename],
             errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
-        self.assertEqual(self.count_file_contains("verifyerr.out", "read checksum error"), 1)
+        self.assertGreaterEqual(self.count_file_contains("verifyerr.out", "read checksum error"), 1)
 
     def test_verify_process_25pct_junk(self):
         """
@@ -282,7 +282,7 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         self.runWt(["-p", "verify", "-c", "table:" + self.tablename],
             errfilename="verifyerr.out", failure=True)
         self.check_non_empty_file("verifyerr.out")
-        self.assertEqual(self.count_file_contains("verifyerr.out", "read checksum error"), 1)
+        self.assertGreaterEqual(self.count_file_contains("verifyerr.out", "read checksum error"), 1)
 
     def test_verify_process_read_corrupt_pages(self):
         """
@@ -316,7 +316,7 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         # not necessarily detect all three corruptions - e.g. we won't detect
         # a corruption if we overwrite free space or overwrite a page that is
         # a child of another page that we overwrite.
-        self.assertGreater(self.count_file_contains("verifyerr.out", "read checksum error"), 1)
+        self.assertGreaterEqual(self.count_file_contains("verifyerr.out", "read checksum error"), 1)
 
     def test_verify_process_truncated(self):
         """


### PR DESCRIPTION
There is a bug right now, where it is technically possible that we accidently corrupt the tail of a block. This would overlap into the next block causing two blocks to be corrupt. This PR aims to fix it by making the assert less strict.