### PR TITLE
WT-12736 Mark the page clean after re-instantiating the page with prepared updates.(v6.0 backport) (#10503)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -678,6 +678,7 @@ dsrc_stats = [
     # Btree statistics
     ##########################################
     BtreeStat('btree_checkpoint_generation', 'btree checkpoint generation', 'no_clear,no_scale'),
+    BtreeStat('btree_checkpoint_pages_reconciled', 'btree number of pages reconciled during checkpoint', 'no_clear,no_scale'),
     BtreeStat('btree_clean_checkpoint_timer', 'btree clean tree checkpoint expiration time', 'no_clear,no_scale'),
     BtreeStat('btree_column_deleted', 'column-store variable-size deleted values', 'no_scale,tree_walk'),
     BtreeStat('btree_column_fix', 'column-store fixed-size leaf pages', 'no_scale,tree_walk'),

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -316,6 +316,11 @@ __wt_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
 
+    /*
+     * The data is written to the disk so we can mark the page clean after re-instantiating prepared
+     * updates to avoid reconciling the page every time.
+     */
+    __wt_page_modify_clear(session, page);
     __wt_cache_page_inmem_incr(session, page, total_size);
 
     if (0) {

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -624,6 +624,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             }
             tried_eviction = false;
 
+            WT_STAT_INCR(session, btree->dhandle->stats, btree_checkpoint_pages_reconciled);
+
             WT_ERR(__wt_reconcile(session, walk, NULL, rec_flags));
 
             /*

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -917,6 +917,7 @@ struct __wt_dsrc_stats {
     int64_t btree_compact_pages_reviewed;
     int64_t btree_compact_pages_rewritten;
     int64_t btree_compact_pages_skipped;
+    int64_t btree_checkpoint_pages_reconciled;
     int64_t btree_compact_skipped;
     int64_t btree_column_fix;
     int64_t btree_column_tws;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6577,644 +6577,646 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN	2027
 /*! btree: btree compact pages skipped */
 #define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_SKIPPED	2028
+/*! btree: btree number of pages reconciled during checkpoint */
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2029
 /*! btree: btree skipped by compaction as process would not reduce size */
-#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2029
+#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2030
 /*!
  * btree: column-store fixed-size leaf pages, only reported if tree_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2030
+#define	WT_STAT_DSRC_BTREE_COLUMN_FIX			2031
 /*!
  * btree: column-store fixed-size time windows, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_TWS			2031
+#define	WT_STAT_DSRC_BTREE_COLUMN_TWS			2032
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2032
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2033
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2033
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2034
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2034
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2035
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2035
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2036
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2036
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2037
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2037
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2038
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2038
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2039
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2039
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2040
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2040
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2041
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2041
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2042
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2042
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2043
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2043
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2044
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2044
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2045
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2045
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2046
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2046
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2047
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2047
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2048
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2048
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2049
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2049
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2050
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2050
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2051
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2051
+#define	WT_STAT_DSRC_CACHE_EVICTION_CHECKPOINT		2052
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2052
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2053
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2053
+#define	WT_STAT_DSRC_CACHE_EVICTION_FAIL		2054
 /*!
  * cache: eviction gave up due to detecting an out of order on disk value
  * behind the last update on the chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_1	2054
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_1	2055
 /*!
  * cache: eviction gave up due to detecting an out of order tombstone
  * ahead of the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_2	2055
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_2	2056
 /*!
  * cache: eviction gave up due to detecting an out of order tombstone
  * ahead of the selected on disk update after validating the update chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_3	2056
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_3	2057
 /*!
  * cache: eviction gave up due to detecting out of order timestamps on
  * the update chain after the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_4	2057
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OOO_CHECKPOINT_RACE_4	2058
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2058
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2059
 /*! cache: eviction walk passes of a file */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2059
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_PASSES		2060
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2060
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2061
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2061
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2062
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2062
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2063
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2063
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2064
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2064
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2065
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2065
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2066
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2066
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ABANDONED	2067
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2067
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_STOPPED	2068
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2068
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	2069
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2069
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	2070
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	2070
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	2071
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2071
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALKS_ENDED		2072
 /*! cache: eviction walks restarted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_RESTART	2072
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_RESTART	2073
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2073
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_FROM_ROOT	2074
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2074
+#define	WT_STAT_DSRC_CACHE_EVICTION_WALK_SAVED_POS	2075
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2075
+#define	WT_STAT_DSRC_CACHE_EVICTION_HAZARD		2076
 /*! cache: history store table insert calls */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT			2076
+#define	WT_STAT_DSRC_CACHE_HS_INSERT			2077
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2077
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2078
 /*!
  * cache: history store table out-of-order resolved updates that lose
  * their durable timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2078
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2079
 /*!
  * cache: history store table out-of-order updates that were fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2079
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2080
 /*! cache: history store table reads */
-#define	WT_STAT_DSRC_CACHE_HS_READ			2080
+#define	WT_STAT_DSRC_CACHE_HS_READ			2081
 /*! cache: history store table reads missed */
-#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2081
+#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2082
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2082
+#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2083
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2083
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2084
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2084
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2085
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2085
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2086
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2086
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2087
 /*!
  * cache: history store table truncation to remove range of updates due
  * to out-of-order timestamp update on data page
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2087
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2088
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2088
+#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2089
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2089
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2090
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2090
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2091
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2091
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2092
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2092
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2093
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2093
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2094
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2094
+#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2095
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2095
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2096
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2096
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2097
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2097
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2098
 /*! cache: page written requiring history store records */
-#define	WT_STAT_DSRC_CACHE_WRITE_HS			2098
+#define	WT_STAT_DSRC_CACHE_WRITE_HS			2099
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2099
+#define	WT_STAT_DSRC_CACHE_READ				2100
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2100
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2101
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2101
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2102
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2102
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2103
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2103
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2104
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2104
+#define	WT_STAT_DSRC_CACHE_WRITE			2105
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2105
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2106
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2106
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2107
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2107
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2108
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2108
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2109
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2109
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2110
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2110
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2111
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2111
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2112
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2112
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2113
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2113
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2114
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2114
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2115
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2115
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2116
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2116
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2117
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2117
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2118
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2118
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2119
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2119
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2120
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2120
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2121
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2121
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2122
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2122
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2123
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2123
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2124
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2124
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2125
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2125
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2126
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2126
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2127
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2127
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2128
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2128
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2129
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2129
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2130
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2130
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2131
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_DSRC_CC_PAGES_EVICT			2131
+#define	WT_STAT_DSRC_CC_PAGES_EVICT			2132
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_DSRC_CC_PAGES_REMOVED			2132
+#define	WT_STAT_DSRC_CC_PAGES_REMOVED			2133
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_DSRC_CC_PAGES_WALK_SKIPPED		2133
+#define	WT_STAT_DSRC_CC_PAGES_WALK_SKIPPED		2134
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_DSRC_CC_PAGES_VISITED			2134
+#define	WT_STAT_DSRC_CC_PAGES_VISITED			2135
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2135
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2136
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2136
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2137
 /*! compression: compressed pages read */
-#define	WT_STAT_DSRC_COMPRESS_READ			2137
+#define	WT_STAT_DSRC_COMPRESS_READ			2138
 /*! compression: compressed pages written */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2138
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2139
 /*! compression: number of blocks with compress ratio greater than 64 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_MAX		2139
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_MAX		2140
 /*! compression: number of blocks with compress ratio smaller than 16 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_16		2140
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_16		2141
 /*! compression: number of blocks with compress ratio smaller than 2 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_2		2141
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_2		2142
 /*! compression: number of blocks with compress ratio smaller than 32 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_32		2142
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_32		2143
 /*! compression: number of blocks with compress ratio smaller than 4 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_4		2143
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_4		2144
 /*! compression: number of blocks with compress ratio smaller than 64 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_64		2144
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_64		2145
 /*! compression: number of blocks with compress ratio smaller than 8 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_8		2145
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_8		2146
 /*! compression: page written failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2146
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2147
 /*! compression: page written was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2147
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2148
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2148
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2149
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2149
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2150
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2150
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2151
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2151
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2152
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2152
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2153
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2153
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2154
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2154
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2155
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2155
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2156
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2156
+#define	WT_STAT_DSRC_CURSOR_CACHE			2157
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2157
+#define	WT_STAT_DSRC_CURSOR_CREATE			2158
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2158
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2159
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2159
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2160
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2160
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2161
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2161
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2162
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2162
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2163
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2163
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2164
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2164
+#define	WT_STAT_DSRC_CURSOR_INSERT			2165
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2165
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2166
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2166
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2167
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2167
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2168
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2168
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2169
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2169
+#define	WT_STAT_DSRC_CURSOR_NEXT			2170
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2170
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2171
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2171
+#define	WT_STAT_DSRC_CURSOR_RESTART			2172
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2172
+#define	WT_STAT_DSRC_CURSOR_PREV			2173
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2173
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2174
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2174
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2175
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2175
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2176
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2176
+#define	WT_STAT_DSRC_CURSOR_RESET			2177
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2177
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2178
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2178
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2179
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2179
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2180
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2180
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2181
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2181
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2182
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2182
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2183
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2183
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2184
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2184
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2185
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2185
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2186
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2186
+#define	WT_STAT_DSRC_REC_DICTIONARY			2187
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2187
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2188
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2188
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2189
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2189
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2190
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2190
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2191
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2191
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2192
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2192
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2193
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2193
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2194
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2194
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2195
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2195
+#define	WT_STAT_DSRC_REC_PAGES				2196
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2196
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2197
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2197
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2198
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2198
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2199
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2199
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2200
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2200
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2201
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2201
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2202
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2202
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2203
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2203
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2204
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2204
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2205
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2205
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2206
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2206
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2207
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2207
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2208
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2208
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2209
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2209
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2210
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2210
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2211
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2211
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2212
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2212
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2213
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2213
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2214
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2214
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2215
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2215
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2216
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2216
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2217
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2217
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2218
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2218
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2219
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2219
+#define	WT_STAT_DSRC_SESSION_COMPACT			2220
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_DSRC_TIERED_WORK_UNITS_DEQUEUED		2220
+#define	WT_STAT_DSRC_TIERED_WORK_UNITS_DEQUEUED		2221
 /*! session: tiered operations scheduled */
-#define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2221
+#define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2222
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_DSRC_TIERED_RETENTION			2222
+#define	WT_STAT_DSRC_TIERED_RETENTION			2223
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2223
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2224
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2224
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2225
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2225
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2226
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2226
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2227
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2227
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2228
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2228
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2229
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2229
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2230
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2230
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2231
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2231
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2232
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2232
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2233
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2233
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2234
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2234
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2235
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2235
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2236
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2236
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2237
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2237
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2238
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -32,6 +32,7 @@ static const char *const __stats_dsrc_desc[] = {
   "btree: btree compact pages reviewed",
   "btree: btree compact pages rewritten",
   "btree: btree compact pages skipped",
+  "btree: btree number of pages reconciled during checkpoint",
   "btree: btree skipped by compaction as process would not reduce size",
   "btree: column-store fixed-size leaf pages",
   "btree: column-store fixed-size time windows",
@@ -321,6 +322,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     /* not clearing btree_compact_pages_reviewed */
     /* not clearing btree_compact_pages_rewritten */
     /* not clearing btree_compact_pages_skipped */
+    /* not clearing btree_checkpoint_pages_reconciled */
     /* not clearing btree_compact_skipped */
     stats->btree_column_fix = 0;
     stats->btree_column_tws = 0;
@@ -578,6 +580,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->btree_compact_pages_reviewed += from->btree_compact_pages_reviewed;
     to->btree_compact_pages_rewritten += from->btree_compact_pages_rewritten;
     to->btree_compact_pages_skipped += from->btree_compact_pages_skipped;
+    to->btree_checkpoint_pages_reconciled += from->btree_checkpoint_pages_reconciled;
     to->btree_compact_skipped += from->btree_compact_skipped;
     to->btree_column_fix += from->btree_column_fix;
     to->btree_column_tws += from->btree_column_tws;
@@ -841,6 +844,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->btree_compact_pages_reviewed += WT_STAT_READ(from, btree_compact_pages_reviewed);
     to->btree_compact_pages_rewritten += WT_STAT_READ(from, btree_compact_pages_rewritten);
     to->btree_compact_pages_skipped += WT_STAT_READ(from, btree_compact_pages_skipped);
+    to->btree_checkpoint_pages_reconciled += WT_STAT_READ(from, btree_checkpoint_pages_reconciled);
     to->btree_compact_skipped += WT_STAT_READ(from, btree_compact_skipped);
     to->btree_column_fix += WT_STAT_READ(from, btree_column_fix);
     to->btree_column_tws += WT_STAT_READ(from, btree_column_tws);

--- a/test/suite/test_scrub_eviction_prepare.py
+++ b/test/suite/test_scrub_eviction_prepare.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wiredtiger import stat, WiredTigerError
+
+# test_scrub_eviction_prepare.py
+#
+# Test to do the following steps.
+# 1. Prepare an update with one key (key-2)
+# 2. Commit an update with another key(key-1)
+# 3, Make sure both the keys are on the same page.
+# 4. Set the key to full update and evict the page with release_evict
+# 5. Read the page back in memory
+# 6. Checkpoint
+# 7. Repeat steps 5,6 and validate that the page read back into memory should
+#    not be reconciled everytime with the help of btree stat.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - fails on tiered")
+class test_scrub_eviction_prepare(wttest.WiredTigerTestCase):
+
+    def conn_config(self):
+        config = 'cache_size=100MB,statistics=(all),statistics_log=(json,on_close,wait=1)'
+        return config
+
+    def get_stats(self, uri):
+        stat_cursor = self.session.open_cursor('statistics:' + uri)
+        btree_ckpt_pages_rec = stat_cursor[stat.dsrc.btree_checkpoint_pages_reconciled][2]
+        stat_cursor.close()
+        return btree_ckpt_pages_rec
+
+    def read_key(self, uri):
+        cur2 = self.session.open_cursor(uri)
+        cur2.set_key(2)
+        self.assertEqual(cur2.search(), 0)
+        cur2.close()
+
+    def test_scrub_eviction_prepare(self):
+        uri = 'table:test_scrub_eviction_prepare'
+
+        # Create a table.
+        self.session.create(uri, 'key_format=i,value_format=S')
+        session2 = self.conn.open_session()
+        session3 = self.conn.open_session()
+        cursor2 = session2.open_cursor(uri)
+
+        # Insert a key 2 and commit the transaction.
+        session2.begin_transaction()
+        cursor2[2] = '20'
+        session2.commit_transaction()
+
+        # Insert a key 1 and prepare the transaction.
+        session3.begin_transaction()
+        cursor2[1] = '10'
+        session3.prepare_transaction('prepare_timestamp=10')
+
+        # Set the key to 2(to avoid prepare conflict if the key is set to 1) in the evict
+        # cursor and evict the page which has both the keys 1 and 2.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        evict_cursor.set_key(2)
+        self.assertEqual(evict_cursor.search(), 0)
+        self.assertEqual(evict_cursor.reset(), 0)
+        evict_cursor.close()
+
+        self.session.checkpoint()
+        self.assertEqual(1, self.get_stats(uri))
+
+        # Read the key 2 to avoid prepared conflict, this will bring back the page
+        # that has both the keys 1 & 2 into the memory.
+        self.read_key(uri)
+        self.session.checkpoint()
+        # The page with prepared update should not be reconciled again.
+        self.assertEqual(1, self.get_stats(uri))
+
+        # Read the key 2 to avoid prepared conflict, this will bring back the page
+        # that has both the keys 1 & 2 into the memory.
+        self.read_key(uri)
+        self.session.checkpoint()
+        # The page with prepared update should not be reconciled again.
+        self.assertEqual(1, self.get_stats(uri))
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_scrub_eviction_prepare.py
+++ b/test/suite/test_scrub_eviction_prepare.py
@@ -40,7 +40,6 @@ from wiredtiger import stat, WiredTigerError
 # 6. Checkpoint
 # 7. Repeat steps 5,6 and validate that the page read back into memory should
 #    not be reconciled everytime with the help of btree stat.
-@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - fails on tiered")
 class test_scrub_eviction_prepare(wttest.WiredTigerTestCase):
 
     def conn_config(self):


### PR DESCRIPTION
This pull request has the following changes:

- Mark the page clean after instantiating it with prepared updates.
- A new Btree stat that tracks the number of pages reconciled during reconciliation.
- Python test to verify the fix
- Skip the new test for hook tiered tests

(cherry picked from commit f24f80110212792c006718503b8517714bcaed3a)