### PR TITLE
WT-13092 Perform dirty eviction when the page has obsolete time window (4.4 backport)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -689,6 +689,16 @@ connection_runtime_config = [
             interval in seconds at which to check for files that are
             inactive and close them''', min=1, max=100000),
         ]),
+    Config('heuristic_controls', '', r'''
+        control the behavior of various optimizations. This is primarily used as a mechanism for
+        rolling out changes to internal heuristics while providing a mechanism for quickly
+        reverting to prior behavior in the field''',
+        type='category', subconfig=[
+            Config('obsolete_tw_pages_dirty', '100', r'''
+                eviction to mark the number of obsolete time window pages that are marked as dirty
+                per btree in a single checkpoint''',
+                min=0, max=100000),
+        ]),
     Config('io_capacity', '', r'''
         control how many bytes per second are written and read. Exceeding
         the capacity results in throttling.''',

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -785,6 +785,7 @@ conn_dsrc_stats = [
     CacheStat('cache_eviction_clean', 'unmodified pages evicted'),
     CacheStat('cache_eviction_deepen', 'page split during eviction deepened the tree'),
     CacheStat('cache_eviction_dirty', 'modified pages evicted'),
+    CacheStat('cache_eviction_dirty_obsolete_tw', 'pages dirtied due to obsolete time window'),
     CacheStat('cache_eviction_hazard', 'hazard pointer blocked page eviction'),
     CacheStat('cache_eviction_internal', 'internal pages evicted'),
     CacheStat('cache_eviction_pages_seen', 'pages seen by eviction walk'),

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -544,6 +544,12 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
         btree->syncing = WT_BTREE_SYNC_WAIT;
         __wt_gen_next_drain(session, WT_GEN_EVICT);
         btree->syncing = WT_BTREE_SYNC_RUNNING;
+
+        /*
+         * Reset the number of obsolete time window pages to let the eviction threads continue
+         * marking the clean obsolete time window pages as dirty once the checkpoint is finished.
+         */
+        btree->obsolete_tw_pages = 0;
         is_hs = WT_IS_HS(btree->dhandle);
 
         /* Add in history store reconciliation for standard files. */

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -61,6 +61,10 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_file_manager_subconfigs[] =
   {"close_scan_interval", "int", NULL, "min=1,max=100000", NULL, 0},
   {NULL, NULL, NULL, NULL, NULL, 0}};
 
+static const WT_CONFIG_CHECK confchk_wiredtiger_open_heuristic_controls_subconfigs[] = {
+  {"obsolete_tw_pages_dirty", "int", NULL, "min=0,max=100000", NULL, 0},
+  {NULL, NULL, NULL, NULL, NULL, 0}};
+
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_history_store_subconfigs[] = {
   {"file_max", "int", NULL, "min=0", NULL, 0}, {NULL, NULL, NULL, NULL, NULL, 0}};
 
@@ -117,6 +121,8 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_reconfigure[] = {
   {"eviction_updates_target", "int", NULL, "min=0,max=10TB", NULL, 0},
   {"eviction_updates_trigger", "int", NULL, "min=0,max=10TB", NULL, 0},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3},
+  {"heuristic_controls", "category", NULL, NULL,
+    confchk_wiredtiger_open_heuristic_controls_subconfigs, 1},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
   {"log", "category", NULL, NULL, confchk_WT_CONNECTION_reconfigure_log_subconfigs, 4},
@@ -841,6 +847,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2},
   {"hazard_max", "int", NULL, "min=15", NULL, 0},
+  {"heuristic_controls", "category", NULL, NULL,
+    confchk_wiredtiger_open_heuristic_controls_subconfigs, 1},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"in_memory", "boolean", NULL, NULL, NULL, 0},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
@@ -922,6 +930,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2},
   {"hazard_max", "int", NULL, "min=15", NULL, 0},
+  {"heuristic_controls", "category", NULL, NULL,
+    confchk_wiredtiger_open_heuristic_controls_subconfigs, 1},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"in_memory", "boolean", NULL, NULL, NULL, 0},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
@@ -1001,6 +1011,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2},
   {"hazard_max", "int", NULL, "min=15", NULL, 0},
+  {"heuristic_controls", "category", NULL, NULL,
+    confchk_wiredtiger_open_heuristic_controls_subconfigs, 1},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 10},
@@ -1077,6 +1089,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2},
   {"hazard_max", "int", NULL, "min=15", NULL, 0},
+  {"heuristic_controls", "category", NULL, NULL,
+    confchk_wiredtiger_open_heuristic_controls_subconfigs, 1},
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 1},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 10},
@@ -1154,18 +1168,19 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "eviction_dirty_trigger=20,eviction_target=80,eviction_trigger=95"
     ",eviction_updates_target=0,eviction_updates_trigger=0,"
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
-    "close_scan_interval=10),history_store=(file_max=0),"
-    "io_capacity=(total=0),log=(archive=true,os_cache_dirty_pct=0,"
-    "prealloc=true,zero_fill=false),lsm_manager=(merge=true,"
-    "worker_thread_max=4),operation_timeout_ms=0,"
-    "operation_tracking=(enabled=false,path=\".\"),"
-    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
-    "statistics=none,statistics_log=(json=false,on_close=false,"
-    "sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
+    "close_scan_interval=10),"
+    "heuristic_controls=(obsolete_tw_pages_dirty=100),"
+    "history_store=(file_max=0),io_capacity=(total=0),"
+    "log=(archive=true,os_cache_dirty_pct=0,prealloc=true,"
+    "zero_fill=false),lsm_manager=(merge=true,worker_thread_max=4),"
+    "operation_timeout_ms=0,operation_tracking=(enabled=false,"
+    "path=\".\"),shared_cache=(chunk=10MB,name=,quota=0,reserve=0,"
+    "size=500MB),statistics=none,statistics_log=(json=false,"
+    "on_close=false,sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
     "tiered_manager=(threads_max=8,threads_min=1,wait=0),"
     "tiered_storage=(local_retention=300),timing_stress_for_test=,"
     "verbose=[]",
-    confchk_WT_CONNECTION_reconfigure, 29},
+    confchk_WT_CONNECTION_reconfigure, 30},
   {"WT_CONNECTION.rollback_to_stable", "", NULL, 0}, {"WT_CONNECTION.set_file_system", "", NULL, 0},
   {"WT_CONNECTION.set_timestamp",
     "commit_timestamp=,durable_timestamp=,force=false,"
@@ -1425,7 +1440,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "exclusive=false,extensions=,file_close_sync=true,file_extend=,"
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
-    "hazard_max=1000,history_store=(file_max=0),in_memory=false,"
+    "hazard_max=1000,heuristic_controls=(obsolete_tw_pages_dirty=100)"
+    ",history_store=(file_max=0),in_memory=false,"
     "io_capacity=(total=0),log=(archive=true,compressor=,"
     "enabled=false,file_max=100MB,force_write_wait=0,"
     "os_cache_dirty_pct=0,path=\".\",prealloc=true,recover=on,"
@@ -1443,7 +1459,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "timing_stress_for_test=,transaction_sync=(enabled=false,"
     "method=fsync),use_environment=true,use_environment_priv=false,"
     "verbose=[],verify_metadata=false,write_through=",
-    confchk_wiredtiger_open, 57},
+    confchk_wiredtiger_open, 58},
   {"wiredtiger_open_all",
     "buffer_alignment=-1,builtin_extension_config=,cache_cursors=true"
     ",cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
@@ -1461,7 +1477,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "exclusive=false,extensions=,file_close_sync=true,file_extend=,"
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
-    "hazard_max=1000,history_store=(file_max=0),in_memory=false,"
+    "hazard_max=1000,heuristic_controls=(obsolete_tw_pages_dirty=100)"
+    ",history_store=(file_max=0),in_memory=false,"
     "io_capacity=(total=0),log=(archive=true,compressor=,"
     "enabled=false,file_max=100MB,force_write_wait=0,"
     "os_cache_dirty_pct=0,path=\".\",prealloc=true,recover=on,"
@@ -1480,7 +1497,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "method=fsync),use_environment=true,use_environment_priv=false,"
     "verbose=[],verify_metadata=false,version=(major=0,minor=0),"
     "write_through=",
-    confchk_wiredtiger_open_all, 58},
+    confchk_wiredtiger_open_all, 59},
   {"wiredtiger_open_basecfg",
     "buffer_alignment=-1,builtin_extension_config=,cache_cursors=true"
     ",cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
@@ -1498,8 +1515,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "extensions=,file_close_sync=true,file_extend=,"
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
-    "hazard_max=1000,history_store=(file_max=0),io_capacity=(total=0)"
-    ",log=(archive=true,compressor=,enabled=false,file_max=100MB,"
+    "hazard_max=1000,heuristic_controls=(obsolete_tw_pages_dirty=100)"
+    ",history_store=(file_max=0),io_capacity=(total=0),"
+    "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",recover=on,zero_fill=false),lsm_manager=(merge=true,"
     "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
@@ -1515,7 +1533,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "timing_stress_for_test=,transaction_sync=(enabled=false,"
     "method=fsync),verbose=[],verify_metadata=false,version=(major=0,"
     "minor=0),write_through=",
-    confchk_wiredtiger_open_basecfg, 52},
+    confchk_wiredtiger_open_basecfg, 53},
   {"wiredtiger_open_usercfg",
     "buffer_alignment=-1,builtin_extension_config=,cache_cursors=true"
     ",cache_max_wait_ms=0,cache_overhead=8,cache_size=100MB,"
@@ -1533,8 +1551,9 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "extensions=,file_close_sync=true,file_extend=,"
     "file_manager=(close_handle_minimum=250,close_idle_time=30,"
     "close_scan_interval=10),hash=(buckets=512,dhandle_buckets=512),"
-    "hazard_max=1000,history_store=(file_max=0),io_capacity=(total=0)"
-    ",log=(archive=true,compressor=,enabled=false,file_max=100MB,"
+    "hazard_max=1000,heuristic_controls=(obsolete_tw_pages_dirty=100)"
+    ",history_store=(file_max=0),io_capacity=(total=0),"
+    "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",recover=on,zero_fill=false),lsm_manager=(merge=true,"
     "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
@@ -1549,7 +1568,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {{"WT_CONNECTION.add_collator", 
     "cache_directory=,local_retention=300,name=),"
     "timing_stress_for_test=,transaction_sync=(enabled=false,"
     "method=fsync),verbose=[],verify_metadata=false,write_through=",
-    confchk_wiredtiger_open_usercfg, 51},
+    confchk_wiredtiger_open_usercfg, 52},
   {NULL, NULL, NULL, 0}};
 
 int

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1983,6 +1983,24 @@ __wt_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
+ * __wt_heuristic_controls_config --
+ *     Set heuristic_controls configuration.
+ */
+int
+__wt_heuristic_controls_config(WT_SESSION_IMPL *session, const char *cfg[])
+{
+    WT_CONFIG_ITEM cval;
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+
+    WT_RET(__wt_config_gets(session, cfg, "heuristic_controls.obsolete_tw_pages_dirty", &cval));
+    conn->heuristic_controls.obsolete_tw_pages_dirty = (uint32_t)cval.val;
+
+    return (0);
+}
+
+/*
  * __wt_verbose_config --
  *     Set verbose configuration.
  */
@@ -2833,6 +2851,9 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      * is set up.
      */
     WT_ERR(__wt_debug_mode_config(session, cfg));
+
+    /* Parse the heuristic_controls configuration. */
+    WT_ERR(__wt_heuristic_controls_config(session, cfg));
 
     /*
      * Load the extensions after initialization completes; extensions expect everything else to be

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -422,6 +422,7 @@ __wt_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
     WT_ERR(__wt_capacity_server_create(session, cfg));
     WT_ERR(__wt_checkpoint_server_create(session, cfg));
     WT_ERR(__wt_debug_mode_config(session, cfg));
+    WT_ERR(__wt_heuristic_controls_config(session, cfg));
     WT_ERR(__wt_hs_config(session, cfg));
     WT_ERR(__wt_logmgr_reconfig(session, cfg));
     WT_ERR(__wt_lsm_manager_reconfig(session, cfg));

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -228,6 +228,12 @@ struct __wt_btree {
     uint64_t clean_ckpt_timer;
 
     /*
+     * Track the number of obsolete time window pages that are changed into dirty page
+     * reconciliation by the eviction.
+     */
+    uint32_t obsolete_tw_pages;
+
+    /*
      * We flush pages from the tree (in order to make checkpoint faster), without a high-level lock.
      * To avoid multiple threads flushing at the same time, lock the tree.
      */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -64,6 +64,14 @@ struct __wt_bucket_storage {
     } while (0)
 
 /*
+ * WT_HEURISTIC_CONTROLS --
+ *  Heuristic controls configuration.
+ */
+struct __wt_heuristic_controls {
+    uint32_t obsolete_tw_pages_dirty;
+};
+
+/*
  * WT_KEYED_ENCRYPTOR --
  *	A list entry for an encryptor with a unique (name, keyid).
  */
@@ -265,6 +273,8 @@ struct __wt_connection_impl {
 
     /* Configuration */
     const WT_CONFIG_ENTRY **config_entries;
+
+    WT_HEURISTIC_CONTROLS heuristic_controls; /* Heuristic controls configuration */
 
     uint64_t operation_timeout_us; /* Maximum operation period before rollback */
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -771,6 +771,8 @@ extern int __wt_hazard_set_func(WT_SESSION_IMPL *session, WT_REF *ref, bool *bus
   const char *func, int line
 #endif
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_heuristic_controls_config(WT_SESSION_IMPL *session, const char *cfg[])
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hex2byte(const u_char *from, u_char *to)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *to)

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -445,6 +445,7 @@ struct __wt_connection_stats {
     int64_t cache_eviction_deepen;
     int64_t cache_write_hs;
     int64_t cache_pages_inuse;
+    int64_t cache_eviction_dirty_obsolete_tw;
     int64_t cache_eviction_app;
     int64_t cache_eviction_pages_in_parallel_with_checkpoint;
     int64_t cache_eviction_pages_queued;
@@ -918,6 +919,7 @@ struct __wt_dsrc_stats {
     int64_t cache_read_overflow;
     int64_t cache_eviction_deepen;
     int64_t cache_write_hs;
+    int64_t cache_eviction_dirty_obsolete_tw;
     int64_t cache_read;
     int64_t cache_read_deleted;
     int64_t cache_read_deleted_prepared;

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -162,3 +162,7 @@
         if ((source)->prepare != 0)                                                           \
             (dest)->prepare = 1;                                                              \
     } while (0)
+
+/* Check if the stop time aggregate is set. */
+#define WT_TIME_AGGREGATE_HAS_STOP(ta) \
+    ((ta)->newest_stop_txn != WT_TXN_MAX || (ta)->newest_stop_ts != WT_TS_MAX)

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2170,6 +2170,15 @@ struct __wt_connection {
 	 * check for files that are inactive and close them., an integer between 1 and 100000;
 	 * default \c 10.}
 	 * @config{ ),,}
+	 * @config{heuristic_controls = (, control the behavior of various optimizations.  This is
+	 * primarily used as a mechanism for rolling out changes to internal heuristics while
+	 * providing a mechanism for quickly reverting to prior behavior in the field., a set of
+	 * related configuration options defined below.}
+	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+	 * obsolete_tw_pages_dirty, eviction to mark the number of obsolete time window pages that
+	 * are marked as dirty per btree in a single checkpoint., an integer between 0 and 100000;
+	 * default \c 100.}
+	 * @config{ ),,}
 	 * @config{history_store = (, history store configuration options., a set of related
 	 * configuration options defined below.}
 	 * @config{&nbsp;&nbsp;&nbsp;&nbsp;file_max, The
@@ -2892,6 +2901,14 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;dhandle_buckets, configure the number of
  * hash buckets for hash arrays relating to data handles., an integer between 64 and 65536; default
  * \c 512.}
+ * @config{ ),,}
+ * @config{heuristic_controls = (, control the behavior of various optimizations.  This is primarily
+ * used as a mechanism for rolling out changes to internal heuristics while providing a mechanism
+ * for quickly reverting to prior behavior in the field., a set of related configuration options
+ * defined below.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;obsolete_tw_pages_dirty, eviction to mark the
+ * number of obsolete time window pages that are marked as dirty per btree in a single checkpoint.,
+ * an integer between 0 and 100000; default \c 100.}
  * @config{ ),,}
  * @config{history_store = (, history store configuration options., a set of related configuration
  * options defined below.}
@@ -5365,904 +5382,906 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_WRITE_HS			1130
 /*! cache: pages currently held in the cache */
 #define	WT_STAT_CONN_CACHE_PAGES_INUSE			1131
+/*! cache: pages dirtied due to obsolete time window */
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1132
 /*! cache: pages evicted by application threads */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP			1132
+#define	WT_STAT_CONN_CACHE_EVICTION_APP			1133
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1133
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1134
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1134
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1135
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1135
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1136
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1136
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1137
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1137
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1138
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1138
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1139
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1139
+#define	WT_STAT_CONN_CACHE_READ				1140
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1140
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1141
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1141
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1142
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1142
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1143
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1143
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1144
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1144
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1145
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1145
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1146
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1146
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1147
 /*!
  * cache: pages selected for eviction unable to be evicted as the parent
  * page has overflow items
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_PARENT_HAS_OVERFLOW_ITEMS	1147
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_PARENT_HAS_OVERFLOW_ITEMS	1148
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1148
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1149
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1149
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1150
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and out of order timestamps handling
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_OUT_OF_ORDER_TS	1150
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_OUT_OF_ORDER_TS	1151
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1151
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1152
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1152
+#define	WT_STAT_CONN_CACHE_WRITE			1153
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1153
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1154
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1154
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1155
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1155
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1156
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1156
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1157
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1157
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1158
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1158
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1159
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1159
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1160
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1160
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1161
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1161
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1162
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1162
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1163
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1163
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1164
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1164
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1165
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1165
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1166
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1166
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1167
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1167
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1168
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1168
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1169
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1169
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1170
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1170
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1171
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1171
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1172
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1172
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1173
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1173
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1174
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1174
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1175
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1175
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1176
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1176
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1177
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1177
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1178
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1178
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1179
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1179
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1180
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1180
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1181
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1181
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1182
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1182
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1183
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1183
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1184
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1184
+#define	WT_STAT_CONN_TIME_TRAVEL			1185
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1185
+#define	WT_STAT_CONN_FILE_OPEN				1186
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1186
+#define	WT_STAT_CONN_BUCKETS_DH				1187
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1187
+#define	WT_STAT_CONN_BUCKETS				1188
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1188
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1189
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1189
+#define	WT_STAT_CONN_MEMORY_FREE			1190
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1190
+#define	WT_STAT_CONN_MEMORY_GROW			1191
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1191
+#define	WT_STAT_CONN_COND_WAIT				1192
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1192
+#define	WT_STAT_CONN_RWLOCK_READ			1193
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1193
+#define	WT_STAT_CONN_RWLOCK_WRITE			1194
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1194
+#define	WT_STAT_CONN_FSYNC_IO				1195
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1195
+#define	WT_STAT_CONN_READ_IO				1196
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1196
+#define	WT_STAT_CONN_WRITE_IO				1197
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1197
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1198
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1198
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1199
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1199
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1200
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1200
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1201
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1201
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1202
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1202
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1203
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1203
+#define	WT_STAT_CONN_CURSOR_CACHE			1204
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1204
+#define	WT_STAT_CONN_CURSOR_CREATE			1205
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1205
+#define	WT_STAT_CONN_CURSOR_INSERT			1206
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1206
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1207
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1207
+#define	WT_STAT_CONN_CURSOR_MODIFY			1208
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1208
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1209
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1209
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1210
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1210
+#define	WT_STAT_CONN_CURSOR_NEXT			1211
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1211
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1212
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1212
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1213
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1213
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1214
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1214
+#define	WT_STAT_CONN_CURSOR_RESTART			1215
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1215
+#define	WT_STAT_CONN_CURSOR_PREV			1216
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1216
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1217
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1217
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1218
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1218
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1219
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1219
+#define	WT_STAT_CONN_CURSOR_REMOVE			1220
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1220
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1221
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1221
+#define	WT_STAT_CONN_CURSOR_RESERVE			1222
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1222
+#define	WT_STAT_CONN_CURSOR_RESET			1223
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1223
+#define	WT_STAT_CONN_CURSOR_SEARCH			1224
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1224
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1225
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1225
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1226
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1226
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1227
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1227
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1228
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1228
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1229
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1229
+#define	WT_STAT_CONN_CURSOR_SWEEP			1230
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1230
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1231
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1231
+#define	WT_STAT_CONN_CURSOR_UPDATE			1232
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1232
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1233
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1233
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1234
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1234
+#define	WT_STAT_CONN_CURSOR_REOPEN			1235
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1235
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1236
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1236
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1237
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1237
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1238
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1238
+#define	WT_STAT_CONN_DH_SWEEP_REF			1239
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1239
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1240
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1240
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1241
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1241
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1242
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1242
+#define	WT_STAT_CONN_DH_SWEEPS				1243
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1243
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1244
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1244
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1245
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1245
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1246
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1246
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1247
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1247
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1248
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1248
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1249
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1249
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1250
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1250
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1251
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1251
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1252
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1252
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1253
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1253
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1254
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1254
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1255
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1255
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1256
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1256
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1257
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1257
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1258
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1258
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1259
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1259
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1260
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1260
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1261
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1261
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1262
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1262
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1263
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1263
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1264
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1264
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1265
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1265
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1266
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1266
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1267
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1267
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1268
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1268
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1269
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1269
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1270
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1270
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1271
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1271
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1272
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1272
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1273
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1273
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1274
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1274
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1275
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1275
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1276
 /*! log: force archive time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1276
+#define	WT_STAT_CONN_LOG_FORCE_ARCHIVE_SLEEP		1277
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1277
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1278
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1278
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1279
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1279
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1280
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1280
+#define	WT_STAT_CONN_LOG_FLUSH				1281
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1281
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1282
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1282
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1283
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1283
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1284
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1284
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1285
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1285
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1286
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1286
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1287
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1287
+#define	WT_STAT_CONN_LOG_SCANS				1288
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1288
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1289
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1289
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1290
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1290
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1291
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1291
+#define	WT_STAT_CONN_LOG_SYNC				1292
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1292
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1293
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1293
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1294
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1294
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1295
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1295
+#define	WT_STAT_CONN_LOG_WRITES				1296
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1296
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1297
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1297
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1298
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1298
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1299
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1299
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1300
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1300
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1301
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1301
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1302
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1302
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1303
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1303
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1304
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1304
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1305
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1305
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1306
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1306
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1307
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1307
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1308
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1308
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1309
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1309
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1310
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1310
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1311
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1311
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1312
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1312
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1313
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1313
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1314
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1314
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1315
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1315
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1316
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1316
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1317
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1317
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1318
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1318
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1319
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1319
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1320
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1320
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1321
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1321
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1322
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1322
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1323
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1323
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1324
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1324
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1325
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1325
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1326
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1326
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1327
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1327
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1328
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1328
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1329
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1329
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1330
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1330
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1331
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1331
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1332
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1332
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1333
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1333
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1334
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1334
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1335
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1335
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1336
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1336
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1337
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1337
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1338
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1338
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1339
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1339
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1340
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1340
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1341
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1341
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1342
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1342
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1343
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1343
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1344
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1344
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1345
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1345
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1346
 /*! reconciliation: internal-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_INTERNAL		1346
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_INTERNAL		1347
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1347
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1348
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1348
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1349
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1349
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1350
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1350
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1351
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1351
+#define	WT_STAT_CONN_REC_PAGES				1352
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1352
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1353
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1353
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1354
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1354
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1355
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1355
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1356
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1356
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1357
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1357
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1358
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1358
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1359
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1359
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1360
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1360
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1361
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1361
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1362
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1362
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1363
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1363
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1364
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1364
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1365
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1365
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1366
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1366
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1367
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1367
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1368
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1368
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1369
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1369
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1370
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1370
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1371
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1371
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1372
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1372
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1373
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1373
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1374
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1374
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1375
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1375
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1376
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1376
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1377
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1377
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1378
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1378
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1379
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1379
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1380
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1380
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1381
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1381
+#define	WT_STAT_CONN_FLUSH_TIER				1382
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1382
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1383
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1383
+#define	WT_STAT_CONN_SESSION_OPEN			1384
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1384
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1385
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1385
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1386
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1386
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1387
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1387
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1388
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1388
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1389
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1389
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1390
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1390
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1391
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1391
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1392
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1392
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1393
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1393
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1394
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1394
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1395
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1395
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1396
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1396
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1397
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1397
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1398
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1398
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1399
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1399
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1400
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1400
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1401
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1401
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1402
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1402
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1403
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1403
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1404
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1404
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1405
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1405
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1406
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1406
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1407
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1407
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1408
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1408
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1409
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1409
+#define	WT_STAT_CONN_TIERED_RETENTION			1410
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1410
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1411
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1411
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1412
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1412
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1413
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1413
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1414
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1414
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1415
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1415
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1416
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1416
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1417
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1417
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1418
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1418
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1419
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1419
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1420
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1420
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1421
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1421
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1422
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1422
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1423
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1423
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1424
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1424
+#define	WT_STAT_CONN_PAGE_SLEEP				1425
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1425
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1426
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1426
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1427
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1427
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1428
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1428
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1429
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1429
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1430
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1430
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1431
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1431
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1432
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1432
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1433
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1433
+#define	WT_STAT_CONN_TXN_PREPARE			1434
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1434
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1435
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1435
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1436
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1436
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1437
 /*!
  * transaction: prepared transactions rolled back and do not remove the
  * history store entry
  */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_DO_NOT_REMOVE_HS_UPDATE	1437
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_DO_NOT_REMOVE_HS_UPDATE	1438
 /*!
  * transaction: prepared transactions rolled back and fix the history
  * store entry with checkpoint reserved transaction id
  */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_FIX_HS_UPDATE_WITH_CKPT_RESERVED_TXNID	1438
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK_FIX_HS_UPDATE_WITH_CKPT_RESERVED_TXNID	1439
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1439
+#define	WT_STAT_CONN_TXN_QUERY_TS			1440
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1440
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1441
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1441
+#define	WT_STAT_CONN_TXN_RTS				1442
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1442
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1443
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1443
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1444
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1444
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1445
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1445
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1446
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1446
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1447
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1447
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1448
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1448
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1449
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1449
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1450
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1450
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1451
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1451
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1452
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1452
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1453
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1453
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1454
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1454
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1455
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1455
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1456
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1456
+#define	WT_STAT_CONN_TXN_SET_TS				1457
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1457
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1458
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1458
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1459
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1459
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1460
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1460
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1461
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1461
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1462
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1462
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1463
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1463
+#define	WT_STAT_CONN_TXN_BEGIN				1464
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1464
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1465
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1465
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1466
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1466
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1467
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1467
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1468
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1468
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1469
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1469
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1470
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1470
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1471
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1471
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1472
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1472
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1473
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1473
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1474
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1474
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1475
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1475
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1476
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1476
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1477
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1477
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1478
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1478
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1479
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1479
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1480
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1480
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1481
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1481
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1482
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1482
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1483
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1483
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1484
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1484
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1485
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1485
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1486
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1486
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1487
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1487
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1488
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1488
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1489
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1489
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1490
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1490
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1491
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1491
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1492
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1492
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1493
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1493
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1494
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1494
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1495
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1495
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1496
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1496
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1497
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1497
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1498
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1498
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1499
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1499
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1500
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1500
+#define	WT_STAT_CONN_TXN_COMMIT				1501
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1501
+#define	WT_STAT_CONN_TXN_ROLLBACK			1502
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1502
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1503
 
 /*!
  * @}
@@ -6535,396 +6554,398 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2093
 /*! cache: page written requiring history store records */
 #define	WT_STAT_DSRC_CACHE_WRITE_HS			2094
+/*! cache: pages dirtied due to obsolete time window */
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY_OBSOLETE_TW	2095
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2095
+#define	WT_STAT_DSRC_CACHE_READ				2096
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2096
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2097
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2097
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2098
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2098
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2099
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2099
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2100
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2100
+#define	WT_STAT_DSRC_CACHE_WRITE			2101
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2101
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2102
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2102
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2103
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2103
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2104
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2104
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2105
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2105
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2106
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2106
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2107
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2107
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2108
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2108
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2109
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2109
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2110
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2110
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2111
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2111
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2112
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2112
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2113
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2113
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2114
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2114
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2115
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2115
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2116
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2116
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2117
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2117
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2118
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2118
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2119
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2119
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2120
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2120
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2121
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2121
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2122
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2122
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2123
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2123
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2124
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2124
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2125
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2125
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2126
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2126
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2127
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_DSRC_CC_PAGES_EVICT			2127
+#define	WT_STAT_DSRC_CC_PAGES_EVICT			2128
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_DSRC_CC_PAGES_REMOVED			2128
+#define	WT_STAT_DSRC_CC_PAGES_REMOVED			2129
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_DSRC_CC_PAGES_WALK_SKIPPED		2129
+#define	WT_STAT_DSRC_CC_PAGES_WALK_SKIPPED		2130
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_DSRC_CC_PAGES_VISITED			2130
+#define	WT_STAT_DSRC_CC_PAGES_VISITED			2131
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2131
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2132
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2132
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2133
 /*! compression: compressed pages read */
-#define	WT_STAT_DSRC_COMPRESS_READ			2133
+#define	WT_STAT_DSRC_COMPRESS_READ			2134
 /*! compression: compressed pages written */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2134
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2135
 /*! compression: page written failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2135
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2136
 /*! compression: page written was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2136
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2137
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2137
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2138
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2138
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2139
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2139
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2140
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2140
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2141
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2141
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2142
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2142
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2143
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2143
+#define	WT_STAT_DSRC_CURSOR_CACHE			2144
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2144
+#define	WT_STAT_DSRC_CURSOR_CREATE			2145
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2145
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2146
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2146
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2147
 /*! cursor: cursor next calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2147
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2148
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2148
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2149
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2149
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2150
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2150
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2151
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2151
+#define	WT_STAT_DSRC_CURSOR_INSERT			2152
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2152
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2153
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2153
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2154
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2154
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2155
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2155
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2156
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2156
+#define	WT_STAT_DSRC_CURSOR_NEXT			2157
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2157
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2158
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2158
+#define	WT_STAT_DSRC_CURSOR_RESTART			2159
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2159
+#define	WT_STAT_DSRC_CURSOR_PREV			2160
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2160
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2161
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2161
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2162
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2162
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2163
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2163
+#define	WT_STAT_DSRC_CURSOR_RESET			2164
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2164
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2165
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2165
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2166
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2166
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2167
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2167
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2168
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2168
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2169
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2169
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2170
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2170
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2171
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2171
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2172
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2172
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2173
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2173
+#define	WT_STAT_DSRC_REC_DICTIONARY			2174
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2174
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2175
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2175
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2176
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2176
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2177
 /*! reconciliation: internal-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2177
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_INTERNAL		2178
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2178
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2179
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2179
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2180
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2180
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2181
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2181
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2182
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2182
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2183
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2183
+#define	WT_STAT_DSRC_REC_PAGES				2184
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2184
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2185
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2185
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2186
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2186
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2187
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2187
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2188
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2188
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2189
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2189
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2190
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2190
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2191
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2191
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2192
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2192
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2193
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2193
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2194
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2194
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2195
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2195
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2196
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2196
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2197
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2197
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2198
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2198
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2199
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2199
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2200
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2200
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2201
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2201
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2202
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2202
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2203
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2203
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2204
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2204
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2205
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2205
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2206
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2206
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2207
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2207
+#define	WT_STAT_DSRC_SESSION_COMPACT			2208
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_DSRC_TIERED_WORK_UNITS_DEQUEUED		2208
+#define	WT_STAT_DSRC_TIERED_WORK_UNITS_DEQUEUED		2209
 /*! session: tiered operations scheduled */
-#define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2209
+#define	WT_STAT_DSRC_TIERED_WORK_UNITS_CREATED		2210
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_DSRC_TIERED_RETENTION			2210
+#define	WT_STAT_DSRC_TIERED_RETENTION			2211
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2211
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2212
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2212
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2213
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2213
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2214
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2214
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2215
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2215
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2216
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2216
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2217
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2217
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2218
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2218
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2219
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2219
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2220
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2220
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2221
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2221
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2222
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2222
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2223
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2223
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2224
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2224
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2225
 
 /*!
  * @}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -199,6 +199,8 @@ struct __wt_fstream;
 typedef struct __wt_fstream WT_FSTREAM;
 struct __wt_hazard;
 typedef struct __wt_hazard WT_HAZARD;
+struct __wt_heuristic_controls;
+typedef struct __wt_heuristic_controls WT_HEURISTIC_CONTROLS;
 struct __wt_ikey;
 typedef struct __wt_ikey WT_IKEY;
 struct __wt_index;

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -105,6 +105,7 @@ static const char *const __stats_dsrc_desc[] = {
   "cache: overflow pages read into cache",
   "cache: page split during eviction deepened the tree",
   "cache: page written requiring history store records",
+  "cache: pages dirtied due to obsolete time window",
   "cache: pages read into cache",
   "cache: pages read into cache after truncate",
   "cache: pages read into cache after truncate in prepare state",
@@ -373,6 +374,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->cache_read_overflow = 0;
     stats->cache_eviction_deepen = 0;
     stats->cache_write_hs = 0;
+    stats->cache_eviction_dirty_obsolete_tw = 0;
     stats->cache_read = 0;
     stats->cache_read_deleted = 0;
     stats->cache_read_deleted_prepared = 0;
@@ -628,6 +630,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->cache_read_overflow += from->cache_read_overflow;
     to->cache_eviction_deepen += from->cache_eviction_deepen;
     to->cache_write_hs += from->cache_write_hs;
+    to->cache_eviction_dirty_obsolete_tw += from->cache_eviction_dirty_obsolete_tw;
     to->cache_read += from->cache_read;
     to->cache_read_deleted += from->cache_read_deleted;
     to->cache_read_deleted_prepared += from->cache_read_deleted_prepared;
@@ -885,6 +888,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->cache_read_overflow += WT_STAT_READ(from, cache_read_overflow);
     to->cache_eviction_deepen += WT_STAT_READ(from, cache_eviction_deepen);
     to->cache_write_hs += WT_STAT_READ(from, cache_write_hs);
+    to->cache_eviction_dirty_obsolete_tw += WT_STAT_READ(from, cache_eviction_dirty_obsolete_tw);
     to->cache_read += WT_STAT_READ(from, cache_read);
     to->cache_read_deleted += WT_STAT_READ(from, cache_read_deleted);
     to->cache_read_deleted_prepared += WT_STAT_READ(from, cache_read_deleted_prepared);
@@ -1170,6 +1174,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: page split during eviction deepened the tree",
   "cache: page written requiring history store records",
   "cache: pages currently held in the cache",
+  "cache: pages dirtied due to obsolete time window",
   "cache: pages evicted by application threads",
   "cache: pages evicted in parallel with checkpoint",
   "cache: pages queued for eviction",
@@ -1720,6 +1725,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_eviction_deepen = 0;
     stats->cache_write_hs = 0;
     /* not clearing cache_pages_inuse */
+    stats->cache_eviction_dirty_obsolete_tw = 0;
     stats->cache_eviction_app = 0;
     stats->cache_eviction_pages_in_parallel_with_checkpoint = 0;
     stats->cache_eviction_pages_queued = 0;
@@ -2260,6 +2266,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_deepen += WT_STAT_READ(from, cache_eviction_deepen);
     to->cache_write_hs += WT_STAT_READ(from, cache_write_hs);
     to->cache_pages_inuse += WT_STAT_READ(from, cache_pages_inuse);
+    to->cache_eviction_dirty_obsolete_tw += WT_STAT_READ(from, cache_eviction_dirty_obsolete_tw);
     to->cache_eviction_app += WT_STAT_READ(from, cache_eviction_app);
     to->cache_eviction_pages_in_parallel_with_checkpoint +=
       WT_STAT_READ(from, cache_eviction_pages_in_parallel_with_checkpoint);

--- a/test/suite/test_eviction02.py
+++ b/test/suite/test_eviction02.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from wiredtiger import stat
+from wtscenario import make_scenarios
+import wttest
+
+# test_eviction02.py
+# Verify evicting a clean page removes any obsolete time window information
+# present on the page.
+class test_eviction02(wttest.WiredTigerTestCase):
+    conn_config_common = 'cache_size=10MB,statistics=(all),statistics_log=(json,wait=1,on_close=true)'
+
+    # These values set a limit to the number of pages that can be cleaned up per btree per
+    # checkpoint.
+    conn_config_values = [
+        ('50', dict(obsolete_tw_max=50, conn_config=f'{conn_config_common},heuristic_controls=[obsolete_tw_pages_dirty=50]')),
+        ('100', dict(obsolete_tw_max=100, conn_config=f'{conn_config_common},heuristic_controls=[obsolete_tw_pages_dirty=100]')),
+        ('500', dict(obsolete_tw_max=500, conn_config=f'{conn_config_common},heuristic_controls=[obsolete_tw_pages_dirty=500]')),
+    ]
+
+    scenarios = make_scenarios(conn_config_values)
+
+    def check_stat(self, prev_value, current_value):
+        # Stats may have a stale value, allow some buffer.
+        error_margin = 2
+        threshold = self.obsolete_tw_max * error_margin
+        diff = current_value - prev_value
+        assert diff <= threshold, f"Unexpected number of pages with obsolete tw cleaned: {diff} (max {threshold})"
+
+    def get_stat(self, stat, uri = ""):
+        stat_cursor = self.session.open_cursor(f'statistics:{uri}')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def populate(self, uri, start_key, num_keys, value):
+        c = self.session.open_cursor(uri, None)
+        for k in range(start_key, num_keys):
+            self.session.begin_transaction()
+            c[k] = value
+            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(k + 1))
+        c.close()
+
+    def evict_cursor(self, uri, nrows):
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        self.session.begin_transaction("ignore_prepare=true")
+        for i in range (1, nrows + 1):
+            evict_cursor.set_key(i)
+            evict_cursor.search()
+            if i % 10 == 0:
+                evict_cursor.reset()
+        evict_cursor.close()
+        self.session.rollback_transaction()
+
+    def test_evict(self):
+        create_params = 'key_format=i,value_format=S'
+        nrows = 10000
+        uri = 'table:eviction02'
+        value = 'k' * 1024
+
+        self.session.create(uri, create_params)
+
+        prev_obsolete_tw_value = 0
+        for i in range(10):
+            # Append some data.
+            self.populate(uri, nrows * i, nrows * (i + 1), value)
+
+            # Checkpoint with cleanup.
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(nrows * (i + 1)))
+            self.session.checkpoint()
+
+            # Check statistics.
+            current_obsolete_tw_value = self.get_stat(stat.dsrc.cache_eviction_dirty_obsolete_tw, uri)
+            if i > 0:
+                self.check_stat(prev_obsolete_tw_value, current_obsolete_tw_value)
+            prev_obsolete_tw_value = current_obsolete_tw_value
+
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(nrows * (i + 1)))
+
+        self.session.checkpoint()
+        self.evict_cursor(uri, nrows * 10)
+
+        # Check statistics.
+        current_obsolete_tw_value = self.get_stat(stat.dsrc.cache_eviction_dirty_obsolete_tw, uri)
+        self.check_stat(prev_obsolete_tw_value, current_obsolete_tw_value)
+        # Check also the connection level stat.
+        self.assertGreater(self.get_stat(stat.conn.cache_eviction_dirty_obsolete_tw), 0)


### PR DESCRIPTION
Before evicting a clean page, mark the page dirty to perform a dirty eviction instead of clean page eviction when the page has obsolete time window.

---------

Co-authored-by: Hari Babu Kommi <haribabu.kommi@mongodb.com>
(cherry picked from commit 7a4dbfa352a895fdaf35f17d65575d833b4003f3)