### PR TITLE
WT-13238 investigate and optimize code coverage

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3012,12 +3012,19 @@ tasks:
 
             # Record the end time, in seconds
             date +%s >> time.txt
-
-            rm -rf build_*
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
           working_dir: "wiredtiger"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            rm -rf build_*
       - func: "upload artifact"
         vars:
           upload_source_dir: "wiredtiger"
@@ -3048,12 +3055,19 @@ tasks:
 
             # Record the end time, in seconds
             date +%s >> time.txt
-
-            rm -rf build_*
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
           working_dir: "wiredtiger"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            rm -rf build_*
       - func: "upload artifact"
         vars:
           upload_source_dir: "wiredtiger"
@@ -3089,7 +3103,6 @@ tasks:
             pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
             mkdir -p full_coverage_report
             gcovr -r coverage_report_csuite --add-tracefile coverage_report_csuite/coverage_report/full_coverage_report.json --add-tracefile coverage_report_python/coverage_report/full_coverage_report.json -j 4 --html-self-contained --html-details full_coverage_report/2_coverage_report.html --json-summary-pretty --json-summary full_coverage_report/1_coverage_report_summary.json
-            ${python_binary|python3} coverage_report_csuite/test/evergreen/code_coverage_analysis.py -s full_coverage_report/1_coverage_report_summary.json -t time.txt
       - func: "upload stats to atlas"
         vars:
           stats_dir: ./full_coverage_report

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -802,9 +802,7 @@ functions:
         source venv/bin/activate
         pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
         mkdir -p coverage_report
-        output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html" \
-            "--json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json" \
-            "--json coverage_report/full_coverage_report.json"
+        output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json"
         if [ ! -z ${combine_coverage_report} ]; then
           gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} ${output_flags}
         else

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -619,7 +619,7 @@ functions:
         . test/evergreen/find_cmake.sh
         cd cmake_build
         echo "Using number of parallel processes '-j ${num_jobs}' for 'make check all'"
-        $CTEST -L check -j ${num_jobs} ${extra_args} --output-on-failure ${extra_args|} 2>&1
+        $CTEST -L check -j ${num_jobs} --output-on-failure ${extra_args|} 2>&1
 
   # The following cppsuite tasks define a greater overall task.
   "cppsuite test run": &cppsuite_test_run
@@ -841,7 +841,7 @@ functions:
     params:
       aws_secret: ${aws_secret}
       aws_key: ${aws_key}
-      local_files_include_filter: ${coverage_dir|wiredtiger/coverage_report}/*
+      local_files_include_filter: wiredtiger/coverage_report/*
       bucket: build_external
       permissions: public-read
       content_type: text/html
@@ -853,7 +853,7 @@ functions:
     params:
       aws_secret: ${aws_secret}
       aws_key: ${aws_key}
-      local_file: ${coverage_dir|wiredtiger/coverage_report}/2_coverage_report.html
+      local_file: wiredtiger/coverage_report/2_coverage_report.html
       bucket: build_external
       permissions: public-read
       content_type: text/html
@@ -3036,12 +3036,12 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
+            # Remove all build directories before uploading the artifacts.
             rm -rf build_*
       - func: "upload artifact"
         vars:
-          upload_source_dir: "wiredtiger"
+          upload_source_dir: "wiredtiger/coverage_report"
           upload_filename: coverage-report-python.tgz
-      - func: "cleanup"
       
 
   - name: coverage-report-csuite
@@ -3062,12 +3062,12 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
+            # Remove all build directories before uploading the artifacts.
             rm -rf build_*
       - func: "upload artifact"
         vars:
-          upload_source_dir: "wiredtiger"
+          upload_source_dir: "wiredtiger/coverage_report"
           upload_filename: coverage-report-csuite.tgz
-      - func: "cleanup"
   
   - name: generate-coverage-report
     tags: ["pull_request_code_statistics"]
@@ -3086,8 +3086,8 @@ tasks:
           destination: wiredtiger/coverage_report_csuite
       - func: "code coverage analysis"
         vars:
-          first_coverage_file_path: coverage_report_csuite/coverage_report/full_coverage_report.json
-          second_coverage_file_path: coverage_report_python/coverage_report/full_coverage_report.json
+          first_coverage_file_path: coverage_report_csuite/full_coverage_report.json
+          second_coverage_file_path: coverage_report_python/full_coverage_report.json
           combine_coverage_report: true
           generate_atlas_format: true
           working_dir: "wiredtiger"      
@@ -3120,6 +3120,7 @@ tasks:
               test/evergreen/code_coverage/coverage-report-per-test.sh false ${num_jobs|1}
             fi
       - func: "code coverage publish report"
+
   - name: coverage-report-catch2
     # This task measures code coverage achieved by only the Catch2-based unit tests.
     tags: ["pull_request_code_statistics"]
@@ -3211,6 +3212,7 @@ tasks:
               pr_args+="--github_pr_number ${github_pr_number} "
               pr_args+="--github_token ${github_app_token} "
             fi
+
             ######################################################
             # Obtain the complexity metrics for the 'current' code
             ######################################################

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -802,13 +802,38 @@ functions:
         source venv/bin/activate
         pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
         mkdir -p coverage_report
-        GCOV=/opt/mongodbtoolchain/v4/bin/gcov gcovr -f ${coverage_filter|src} -j 4 --html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/${coverage_report_name|full_coverage_report.json}
-        ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
+        if [ ! -z ${combine_coverage_report} ]; then
+          gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} --html-self-contained \
+            --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json \
+            --json coverage_report/full_coverage_report.json
+        else
+          gcovr -f ${coverage_filter|src} -j ${num_jobs|4} --html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty \
+            --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json
+          ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
+        fi    
 
         # Generate Atlas compatible format report.
         if [ ! -z ${generate_atlas_format} ]; then
-            ${python_binary|python3} test/evergreen/code_coverage_analysis.py -c component_coverage -o coverage_report/atlas_out_code_coverage.json -s coverage_report/1_coverage_report_summary.json -t time.txt
+            ${python_binary|python3} test/evergreen/code_coverage_analysis.py -c component_coverage -o coverage_report/atlas_out_code_coverage.json -s coverage_report/1_coverage_report_summary.json
         fi
+  "run code coverage tests":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        ${PREPARE_TEST_ENV}
+        test/evergreen/find_cmake.sh
+
+        # Record the start time, in seconds
+        date +%s > time.txt
+
+        ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -c ${code_coverage_test_file|test/evergreen/code_coverage/code_coverage_config.json} -b $(pwd)/build_ -j ${num_jobs} -s ${extra_args}
+
+        # Record the end time, in seconds
+        date +%s >> time.txt
 
   "code coverage publish report":
     command: s3.put
@@ -1312,10 +1337,12 @@ functions:
         silent: true
         script: |
           set -o errexit
+          set -o verbose
           ${PREPARE_PATH}
           virtualenv -p ${python_binary|python3} venv
           source venv/bin/activate
           pip3 install pymongo[srv]==3.12.2 pygit2==1.10.1
+          set -o verbose
           EVERGREEN_TASK_INFO='{ "evergreen_task_info": { "is_patch": "'${is_patch}'", "task_id": "'${task_id}'", "distro_id": "'${distro_id}'", "execution": "'${execution}'", "task_name": "'${task_name}'", "version_id": "'${version_id}'", "branch_name": "'${branch_name}'" } }'
           echo "EVERGREEN_TASK_INFO: $EVERGREEN_TASK_INFO"
           ${python_binary|python3} automation-scripts/evergreen/upload_stats_atlas.py -u ${atlas_perf_test_username} -p ${atlas_perf_test_password} -c ${collection|} -d ${database|} -f ${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/atlas_out_${test-name}.json -t ${created_at} -i "$EVERGREEN_TASK_INFO" -g "./wiredtiger"
@@ -2990,28 +3017,13 @@ tasks:
           checkpoint_args: -t r -n 1000000 -k 5000000 -C cache_size=100MB
 
   - name: coverage-report-python
-    # This task will measure code coverage across a range of tests, including, but not limited to,
-    # the Catch2-based unit tests. The tests are run in parallel.
+    # This task will measure code coverage across a range of python tests. The tests are run in parallel.
     tags: ["pull_request_code_statistics"]
     commands:
       - func: "get project"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            test/evergreen/find_cmake.sh
-
-            # Record the start time, in seconds
-            date +%s > time.txt
-
-            ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -v -c test/evergreen/code_coverage/code_coverage_config.json -b $(pwd)/build_ -j ${num_jobs} -s -p
-
-            # Record the end time, in seconds
-            date +%s >> time.txt
+      - func: "run code coverage tests"
+        vars:
+          extra_args: -p
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
@@ -3033,28 +3045,11 @@ tasks:
       
 
   - name: coverage-report-csuite
-    # This task will measure code coverage across a range of tests, including, but not limited to,
-    # the Catch2-based unit tests. The tests are run in parallel.
+    # This task will measure code coverage across a range of tests, not including python tests. The tests are run in parallel.
     tags: ["pull_request_code_statistics"]
     commands:
       - func: "get project"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            test/evergreen/find_cmake.sh
-
-            # Record the start time, in seconds
-            date +%s > time.txt
-
-            ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -v -c test/evergreen/code_coverage/code_coverage_config.json -b $(pwd)/build_ -j ${num_jobs} -s
-
-            # Record the end time, in seconds
-            date +%s >> time.txt
+      - func: "run code coverage tests"
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
@@ -3075,46 +3070,35 @@ tasks:
       - func: "cleanup"
   
   - name: generate-coverage-report
-    # This task will measure code coverage across a range of tests, including, but not limited to,
-    # the Catch2-based unit tests. The tests are run in parallel.
     tags: ["pull_request_code_statistics"]
     depends_on:
       - name: "coverage-report-csuite"
       - name: "coverage-report-python"
     commands:
+      - func: "get project"
       - func: "fetch artifacts"
         vars:
           dependent_task: coverage-report-python
-          destination: coverage_report_python
+          destination: wiredtiger/coverage_report_python
       - func: "fetch artifacts"
         vars:
           dependent_task: coverage-report-csuite
-          destination: coverage_report_csuite
-      - command: shell.exec
-        params:
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            echo "Performing code coverage analysis"
-            ${PREPARE_PATH}
-            virtualenv -p python3 venv
-            source venv/bin/activate
-            pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
-            mkdir -p full_coverage_report
-            gcovr -r coverage_report_csuite --add-tracefile coverage_report_csuite/coverage_report/full_coverage_report.json --add-tracefile coverage_report_python/coverage_report/full_coverage_report.json -j 4 --html-self-contained --html-details full_coverage_report/2_coverage_report.html --json-summary-pretty --json-summary full_coverage_report/1_coverage_report_summary.json
+          destination: wiredtiger/coverage_report_csuite
+      - func: "code coverage analysis"
+        vars:
+          first_coverage_file_path: coverage_report_csuite/coverage_report/full_coverage_report.json
+          second_coverage_file_path: coverage_report_python/coverage_report/full_coverage_report.json
+          combine_coverage_report: true
+          generate_atlas_format: true
+          working_dir: "wiredtiger"      
       - func: "upload stats to atlas"
         vars:
-          stats_dir: ./full_coverage_report
+          stats_dir: ./wiredtiger/coverage_report
           test-name: code_coverage
           collection: CodeCoverage
         # Publish the main page before the report so that it appears top of the list of files in the patch build.
       - func: "code coverage publish main page"
-        vars:
-          coverage_dir: full_coverage_report
       - func: "code coverage publish report"
-        vars:
-          coverage_dir: full_coverage_report
 
   - name: coverage-report-per-test
     # This task will measure code coverage across a range of tests, including, but not limited to,
@@ -3141,23 +3125,10 @@ tasks:
     tags: ["pull_request_code_statistics"]
     commands:
       - func: "get project"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            test/evergreen/find_cmake.sh
-
-            # Record the start time, in seconds
-            date +%s > time.txt
-
-            ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -v -c test/evergreen/code_coverage/code_coverage_config_catch2.json -b $(pwd)/build_ -j 1 -s
-
-            # Record the end time, in seconds
-            date +%s >> time.txt
+      - func: "run code coverage tests"
+        vars:
+          num_jobs: 1
+          code_coverage_test_file: test/evergreen/code_coverage/code_coverage_config_catch2.json 
       - func: "code coverage analysis"
         vars:
           working_dir: "wiredtiger"
@@ -3173,7 +3144,7 @@ tasks:
       - func: "get project"
       - command: shell.exec
         vars:
-          dependent_task: coverage-report
+          dependent_task: "generate-coverage-report"
         params:
           working_dir: "wiredtiger"
           shell: bash
@@ -3194,7 +3165,7 @@ tasks:
             mkdir -p coverage_report
       - command: s3.get
         vars:
-          dependent_task: coverage-report
+          dependent_task: "generate-coverage-report"
         params:
           aws_key: ${aws_key}
           aws_secret: ${aws_secret}
@@ -3203,7 +3174,7 @@ tasks:
           local_file: wiredtiger/coverage_report/full_coverage_report.json
       - command: shell.exec
         vars:
-          dependent_task: coverage-report
+          dependent_task: "generate-coverage-report"
         params:
           working_dir: "wiredtiger"
           shell: bash
@@ -3240,7 +3211,6 @@ tasks:
               pr_args+="--github_pr_number ${github_pr_number} "
               pr_args+="--github_token ${github_app_token} "
             fi
-
             ######################################################
             # Obtain the complexity metrics for the 'current' code
             ######################################################

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1337,12 +1337,10 @@ functions:
         silent: true
         script: |
           set -o errexit
-          set -o verbose
           ${PREPARE_PATH}
           virtualenv -p ${python_binary|python3} venv
           source venv/bin/activate
           pip3 install pymongo[srv]==3.12.2 pygit2==1.10.1
-          set -o verbose
           EVERGREEN_TASK_INFO='{ "evergreen_task_info": { "is_patch": "'${is_patch}'", "task_id": "'${task_id}'", "distro_id": "'${distro_id}'", "execution": "'${execution}'", "task_name": "'${task_name}'", "version_id": "'${version_id}'", "branch_name": "'${branch_name}'" } }'
           echo "EVERGREEN_TASK_INFO: $EVERGREEN_TASK_INFO"
           ${python_binary|python3} automation-scripts/evergreen/upload_stats_atlas.py -u ${atlas_perf_test_username} -p ${atlas_perf_test_password} -c ${collection|} -d ${database|} -f ${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/atlas_out_${test-name}.json -t ${created_at} -i "$EVERGREEN_TASK_INFO" -g "./wiredtiger"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6,7 +6,6 @@
 #######################################
 #            Project Settings         #
 #######################################
-
 stepback: true
 pre:
   - func: "cleanup"
@@ -620,7 +619,7 @@ functions:
         . test/evergreen/find_cmake.sh
         cd cmake_build
         echo "Using number of parallel processes '-j ${num_jobs}' for 'make check all'"
-        $CTEST -L check -j ${num_jobs} --output-on-failure ${extra_args|} 2>&1
+        $CTEST -L check -j ${num_jobs} ${extra_args} --output-on-failure ${extra_args|} 2>&1
 
   # The following cppsuite tasks define a greater overall task.
   "cppsuite test run": &cppsuite_test_run
@@ -803,7 +802,7 @@ functions:
         source venv/bin/activate
         pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
         mkdir -p coverage_report
-        GCOV=/opt/mongodbtoolchain/v4/bin/gcov gcovr -f ${coverage_filter|src} -j 4 --html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json
+        GCOV=/opt/mongodbtoolchain/v4/bin/gcov gcovr -f ${coverage_filter|src} -j 4 --html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/${coverage_report_name|full_coverage_report.json}
         ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
 
         # Generate Atlas compatible format report.
@@ -817,7 +816,7 @@ functions:
     params:
       aws_secret: ${aws_secret}
       aws_key: ${aws_key}
-      local_files_include_filter: wiredtiger/coverage_report/*
+      local_files_include_filter: ${coverage_dir|wiredtiger/coverage_report}/*
       bucket: build_external
       permissions: public-read
       content_type: text/html
@@ -829,7 +828,7 @@ functions:
     params:
       aws_secret: ${aws_secret}
       aws_key: ${aws_key}
-      local_file: wiredtiger/coverage_report/2_coverage_report.html
+      local_file: ${coverage_dir|wiredtiger/coverage_report}/2_coverage_report.html
       bucket: build_external
       permissions: public-read
       content_type: text/html
@@ -2990,7 +2989,7 @@ tasks:
         vars:
           checkpoint_args: -t r -n 1000000 -k 5000000 -C cache_size=100MB
 
-  - name: coverage-report
+  - name: coverage-report-python
     # This task will measure code coverage across a range of tests, including, but not limited to,
     # the Catch2-based unit tests. The tests are run in parallel.
     tags: ["pull_request_code_statistics"]
@@ -3006,8 +3005,39 @@ tasks:
             ${PREPARE_TEST_ENV}
             test/evergreen/find_cmake.sh
 
-            # Create directories for 8 builds
-            mkdir build_0 build_1 build_2 build_3 build_4 build_5 build_6 build_7
+            # Record the start time, in seconds
+            date +%s > time.txt
+
+            ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -v -c test/evergreen/code_coverage/code_coverage_config.json -b $(pwd)/build_ -j ${num_jobs} -s -p
+
+            # Record the end time, in seconds
+            date +%s >> time.txt
+      - func: "code coverage analysis"
+        vars:
+          generate_atlas_format: true
+          working_dir: "wiredtiger"
+      - func: "upload artifact"
+        vars:
+          upload_source_dir: "wiredtiger/coverage_report"
+          upload_filename: coverage-report-python.tgz
+      - func: "cleanup"
+      
+
+  - name: coverage-report-csuite
+    # This task will measure code coverage across a range of tests, including, but not limited to,
+    # the Catch2-based unit tests. The tests are run in parallel.
+    tags: ["pull_request_code_statistics"]
+    commands:
+      - func: "get project"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            test/evergreen/find_cmake.sh
 
             # Record the start time, in seconds
             date +%s > time.txt
@@ -3020,14 +3050,55 @@ tasks:
         vars:
           generate_atlas_format: true
           working_dir: "wiredtiger"
+      - func: "upload artifact"
+        vars:
+          upload_source_dir: "wiredtiger/coverage_report"
+          upload_filename: coverage-report-csuite.tgz
+      - func: "cleanup"
+  
+  - name: generate-coverage-report
+    # This task will measure code coverage across a range of tests, including, but not limited to,
+    # the Catch2-based unit tests. The tests are run in parallel.
+    tags: ["pull_request_code_statistics"]
+    depends_on:
+      - name: "coverage-report-csuite"
+      - name: "coverage-report-python"
+    commands:
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: coverage-report-python
+          destination: coverage_report_python
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: coverage-report-csuite
+          destination: coverage_report_csuite
+      - command: shell.exec
+        working_dir: wiredtiger
+        params:
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            echo "Performing code coverage analysis"
+            ${PREPARE_PATH}
+            virtualenv -p python3 venv
+            source venv/bin/activate
+            pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
+            mkdir -p full_coverage_report
+            GCOV=/opt//mongodbtoolchain/v4/bin/gcov gcovr --add-tracefile coverage_report_csuite/full_coverage_report.json --add-tracefile coverage_report_python/full_coverage_report.json -j 4 --html-self-contained --html-details full_coverage_report/2_coverage_report.html --json-summary-pretty --json-summary full_coverage_report/1_coverage_report_summary.json
+            ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s full_coverage_report/1_coverage_report_summary.json -t time.txt
       - func: "upload stats to atlas"
         vars:
-          stats_dir: ./wiredtiger/coverage_report
+          stats_dir: ./full_coverage_report
           test-name: code_coverage
           collection: CodeCoverage
         # Publish the main page before the report so that it appears top of the list of files in the patch build.
       - func: "code coverage publish main page"
+        vars:
+          coverage_dir: full_coverage_report
       - func: "code coverage publish report"
+        vars:
+          coverage_dir: full_coverage_report
 
   - name: coverage-report-per-test
     # This task will measure code coverage across a range of tests, including, but not limited to,
@@ -3042,6 +3113,7 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
+            
             if [ ${is_patch|false} = true ]; then
               test/evergreen/code_coverage/coverage-report-per-test.sh true ${num_jobs|1}
             else
@@ -3063,9 +3135,6 @@ tasks:
             ${PREPARE_TEST_ENV}
             test/evergreen/find_cmake.sh
 
-            # Create directories for 1 builds, as only one test will be run at once
-            mkdir build_0
-
             # Record the start time, in seconds
             date +%s > time.txt
 
@@ -3083,7 +3152,7 @@ tasks:
   - name: code-change-report
     tags: ["pull_request_code_statistics"]
     depends_on:
-      - name: "coverage-report"
+      - name: "generate-coverage-report"
     commands:
       - func: "get project"
       - command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -802,9 +802,9 @@ functions:
         source venv/bin/activate
         pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
         mkdir -p coverage_report
-        output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html
-            --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json
-            --json coverage_report/full_coverage_report.json
+        output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html" \
+            "--json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json" \
+            "--json coverage_report/full_coverage_report.json" \
         if [ ! -z ${combine_coverage_report} ]; then
           gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} ${output_flags}
         else

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -810,7 +810,7 @@ functions:
           gcovr -f ${coverage_filter|src} -j ${num_jobs|4} --html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty \
             --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json
           ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
-        fi    
+        fi
 
         # Generate Atlas compatible format report.
         if [ ! -z ${generate_atlas_format} ]; then
@@ -3040,7 +3040,6 @@ tasks:
         vars:
           upload_source_dir: "wiredtiger/coverage_report"
           upload_filename: coverage-report-python.tgz
-      
 
   - name: coverage-report-csuite
     # This task will measure code coverage across a range of tests, not including python tests. The tests are run in parallel.
@@ -3066,7 +3065,7 @@ tasks:
         vars:
           upload_source_dir: "wiredtiger/coverage_report"
           upload_filename: coverage-report-csuite.tgz
-  
+
   - name: generate-coverage-report
     tags: ["pull_request_code_statistics"]
     depends_on:
@@ -3088,7 +3087,7 @@ tasks:
           second_coverage_file_path: coverage_report_python/full_coverage_report.json
           combine_coverage_report: true
           generate_atlas_format: true
-          working_dir: "wiredtiger"      
+          working_dir: "wiredtiger"
       - func: "upload stats to atlas"
         vars:
           stats_dir: ./wiredtiger/coverage_report
@@ -3111,7 +3110,7 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-            
+
             if [ ${is_patch|false} = true ]; then
               test/evergreen/code_coverage/coverage-report-per-test.sh true ${num_jobs|1}
             else
@@ -3127,7 +3126,7 @@ tasks:
       - func: "run code coverage tests"
         vars:
           num_jobs: 1
-          code_coverage_test_file: test/evergreen/code_coverage/code_coverage_config_catch2.json 
+          code_coverage_test_file: test/evergreen/code_coverage/code_coverage_config_catch2.json
       - func: "code coverage analysis"
         vars:
           working_dir: "wiredtiger"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -804,9 +804,9 @@ functions:
         mkdir -p coverage_report
         output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json"
         if [ ! -z ${combine_coverage_report} ]; then
-          gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} ${output_flags}
+          gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} $output_flags
         else
-          gcovr -f ${coverage_filter|src} -j ${num_jobs|4} ${output_flags}
+          gcovr -f ${coverage_filter|src} -j ${num_jobs|4} $output_flags
           ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
         fi
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3012,13 +3012,15 @@ tasks:
 
             # Record the end time, in seconds
             date +%s >> time.txt
+
+            rm -rf build_*
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
           working_dir: "wiredtiger"
       - func: "upload artifact"
         vars:
-          upload_source_dir: "wiredtiger/coverage_report"
+          upload_source_dir: "wiredtiger"
           upload_filename: coverage-report-python.tgz
       - func: "cleanup"
       
@@ -3046,13 +3048,15 @@ tasks:
 
             # Record the end time, in seconds
             date +%s >> time.txt
+
+            rm -rf build_*
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
           working_dir: "wiredtiger"
       - func: "upload artifact"
         vars:
-          upload_source_dir: "wiredtiger/coverage_report"
+          upload_source_dir: "wiredtiger"
           upload_filename: coverage-report-csuite.tgz
       - func: "cleanup"
   
@@ -3073,7 +3077,6 @@ tasks:
           dependent_task: coverage-report-csuite
           destination: coverage_report_csuite
       - command: shell.exec
-        working_dir: wiredtiger
         params:
           shell: bash
           script: |
@@ -3085,8 +3088,8 @@ tasks:
             source venv/bin/activate
             pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
             mkdir -p full_coverage_report
-            GCOV=/opt//mongodbtoolchain/v4/bin/gcov gcovr --add-tracefile coverage_report_csuite/full_coverage_report.json --add-tracefile coverage_report_python/full_coverage_report.json -j 4 --html-self-contained --html-details full_coverage_report/2_coverage_report.html --json-summary-pretty --json-summary full_coverage_report/1_coverage_report_summary.json
-            ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s full_coverage_report/1_coverage_report_summary.json -t time.txt
+            gcovr -r coverage_report_csuite --add-tracefile coverage_report_csuite/coverage_report/full_coverage_report.json --add-tracefile coverage_report_python/coverage_report/full_coverage_report.json -j 4 --html-self-contained --html-details full_coverage_report/2_coverage_report.html --json-summary-pretty --json-summary full_coverage_report/1_coverage_report_summary.json
+            ${python_binary|python3} coverage_report_csuite/test/evergreen/code_coverage_analysis.py -s full_coverage_report/1_coverage_report_summary.json -t time.txt
       - func: "upload stats to atlas"
         vars:
           stats_dir: ./full_coverage_report

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -804,7 +804,7 @@ functions:
         mkdir -p coverage_report
         output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html" \
             "--json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json" \
-            "--json coverage_report/full_coverage_report.json" \
+            "--json coverage_report/full_coverage_report.json"
         if [ ! -z ${combine_coverage_report} ]; then
           gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} ${output_flags}
         else

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -802,8 +802,8 @@ functions:
         source venv/bin/activate
         pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
         mkdir -p coverage_report
-        output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html 
-            --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json 
+        output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html
+            --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json
             --json coverage_report/full_coverage_report.json
         if [ ! -z ${combine_coverage_report} ]; then
           gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} ${output_flags}

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -802,13 +802,13 @@ functions:
         source venv/bin/activate
         pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
         mkdir -p coverage_report
-        if [ ! -z ${combine_coverage_report} ]; then
-          gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} --html-self-contained \
-            --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json \
+        output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html 
+            --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json 
             --json coverage_report/full_coverage_report.json
+        if [ ! -z ${combine_coverage_report} ]; then
+          gcovr -f ${coverage_filter|src} --add-tracefile ${first_coverage_file_path} --add-tracefile ${second_coverage_file_path} -j ${num_jobs|4} ${output_flags}
         else
-          gcovr -f ${coverage_filter|src} -j ${num_jobs|4} --html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty \
-            --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json
+          gcovr -f ${coverage_filter|src} -j ${num_jobs|4} ${output_flags}
           ${python_binary|python3} test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
         fi
 
@@ -830,7 +830,7 @@ functions:
         # Record the start time, in seconds
         date +%s > time.txt
 
-        ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -c ${code_coverage_test_file|test/evergreen/code_coverage/code_coverage_config.json} -b $(pwd)/build_ -j ${num_jobs} -s ${extra_args}
+        ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -c ${code_coverage_test_file|test/evergreen/code_coverage/code_coverage_config.json} -b $(pwd)/build_ -j ${num_jobs} -s ${code_cov_extra_args}
 
         # Record the end time, in seconds
         date +%s >> time.txt
@@ -3015,13 +3015,15 @@ tasks:
           checkpoint_args: -t r -n 1000000 -k 5000000 -C cache_size=100MB
 
   - name: coverage-report-python
-    # This task will measure code coverage across a range of python tests. The tests are run in parallel.
+    # The coverage report tests are split into the two buckets, python and any other tests. The concept
+    # is to reduce compute time on the overall code coverage report. This task will measure code
+    # coverage across a range of python tests and run in parallel.
     tags: ["pull_request_code_statistics"]
     commands:
       - func: "get project"
       - func: "run code coverage tests"
         vars:
-          extra_args: -p
+          code_cov_extra_args: -p
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
@@ -3041,8 +3043,10 @@ tasks:
           upload_source_dir: "wiredtiger/coverage_report"
           upload_filename: coverage-report-python.tgz
 
-  - name: coverage-report-csuite
-    # This task will measure code coverage across a range of tests, not including python tests. The tests are run in parallel.
+  - name: coverage-report-other
+    # The coverage report tests are split into the two buckets, python and any other tests. The concept
+    # is to reduce compute time on the overall code coverage report. This task will measure code
+    # coverage tests such as wt tool and the csuite test, and run in parallel.
     tags: ["pull_request_code_statistics"]
     commands:
       - func: "get project"
@@ -3064,12 +3068,12 @@ tasks:
       - func: "upload artifact"
         vars:
           upload_source_dir: "wiredtiger/coverage_report"
-          upload_filename: coverage-report-csuite.tgz
+          upload_filename: coverage-report-other.tgz
 
   - name: generate-coverage-report
     tags: ["pull_request_code_statistics"]
     depends_on:
-      - name: "coverage-report-csuite"
+      - name: "coverage-report-other"
       - name: "coverage-report-python"
     commands:
       - func: "get project"
@@ -3079,11 +3083,11 @@ tasks:
           destination: wiredtiger/coverage_report_python
       - func: "fetch artifacts"
         vars:
-          dependent_task: coverage-report-csuite
-          destination: wiredtiger/coverage_report_csuite
+          dependent_task: coverage-report-other
+          destination: wiredtiger/coverage_report_other
       - func: "code coverage analysis"
         vars:
-          first_coverage_file_path: coverage_report_csuite/full_coverage_report.json
+          first_coverage_file_path: coverage_report_other/full_coverage_report.json
           second_coverage_file_path: coverage_report_python/full_coverage_report.json
           combine_coverage_report: true
           generate_atlas_format: true

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3021,7 +3021,7 @@ tasks:
       - func: "get project"
       - func: "run code coverage tests"
         vars:
-          code_cov_extra_args: -p
+          code_cov_extra_args: --bucket python
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true
@@ -3049,6 +3049,8 @@ tasks:
     commands:
       - func: "get project"
       - func: "run code coverage tests"
+        vars:
+          code_cov_extra_args: --bucket other
       - func: "code coverage analysis"
         vars:
           generate_atlas_format: true

--- a/test/evergreen/code_coverage/code_coverage_config.json
+++ b/test/evergreen/code_coverage/code_coverage_config.json
@@ -18,7 +18,7 @@
   ],
   "setup_actions" : [
     "cmake -DHAVE_UNITTEST=1 -DHAVE_DIAGNOSTIC=0 -DCODE_COVERAGE_MEASUREMENT=1 -DINLINE_FUNCTIONS_INSTEAD_OF_MACROS=1 -DCMAKE_BUILD_TYPE=Coverage -G Ninja ../.",
-    "ninja -j 2",
+    "ninja -j 16",
     "mkdir WT_HOME_COVERAGE",
     "examples/c/ex_hello/ex_hello",
     "./wt -h WT_HOME_COVERAGE load -j -f ../test/evergreen/code_coverage/test_table.json"

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -56,7 +56,7 @@ def run_task_lists_in_parallel(label, task_bucket_info, run_func):
     task_diff = task_end_time - task_start_time
     logging.debug("Time taken to perform {}: {} seconds".format(label, task_diff.total_seconds()))
 
-# Check the relevant build directories exist and have the correct status  if we are not setting up
+# Check the relevant build directories exist and have the correct status if we are not setting up
 def check_build_dirs(build_dir_base, parallel):
     task_bucket_info = list()
 

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -95,7 +95,7 @@ def setup_build_dirs(build_dir_base, parallel, setup_task_list):
     base_build_dir = "{}{}".format(build_dir_base, 0)
     if os.path.exists(base_build_dir):
         sys.exit('build directory exists within {}.'.format(base_build_dir))
-    
+
     logging.debug('Creating build directory {}.'.format(base_build_dir))
     os.mkdir(base_build_dir)
 

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -34,6 +34,15 @@ import subprocess
 import sys
 from datetime import datetime
 
+class PushWorkingDirectory:
+    def __init__(self, new_working_directory: str) -> None:
+        self.original_working_directory = os.getcwd()
+        self.new_working_directory = new_working_directory
+        os.chdir(self.new_working_directory)
+
+    def pop(self):
+        os.chdir(self.original_working_directory)
+
 # Execute each list of tasks in parallel
 def run_task_lists_in_parallel(label, task_bucket_info, run_func):
     parallel = len(task_bucket_info)
@@ -99,9 +108,10 @@ def setup_build_dirs(build_dir_base, parallel, setup_task_list):
     logging.debug("Compiling base build directory: {}".format(base_build_dir))
     for task in setup_task_list:
         try:
-            os.chdir(base_build_dir)
+            p = PushWorkingDirectory(base_build_dir)
             split_command = task.split()
             subprocess.run(split_command, check=True, capture_output=True)
+            p.pop()
         except subprocess.CalledProcessError as exception:
             logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
 

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -29,70 +29,37 @@
 import concurrent.futures
 import logging
 import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime
 
-
-def run_task_list(task_list_info):
-    build_dir = task_list_info["build_dir"]
-    task_list = task_list_info["task_bucket"]
-    list_start_time = datetime.now()
-    for task in task_list:
-        logging.debug("Running task {} in {}".format(task, build_dir))
-
-        start_time = datetime.now()
-        try:
-            os.chdir(build_dir)
-            split_command = task.split()
-            subprocess.run(split_command, check=True)
-        except subprocess.CalledProcessError as exception:
-            logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
-        end_time = datetime.now()
-        diff = end_time - start_time
-
-        logging.debug("Finished task {} in {} : took {} seconds".format(task, build_dir, diff.total_seconds()))
-
-    list_end_time = datetime.now()
-    diff = list_end_time - list_start_time
-
-    return_value = "Completed task list in {} : took {} seconds".format(build_dir, diff.total_seconds())
-    logging.debug(return_value)
-
-    return return_value
-
-
 # Execute each list of tasks in parallel
-def run_task_lists_in_parallel(label, task_bucket_info):
+def run_task_lists_in_parallel(label, task_bucket_info, run_func):
     parallel = len(task_bucket_info)
     task_start_time = datetime.now()
 
     with concurrent.futures.ProcessPoolExecutor(max_workers=parallel) as executor:
-        for e in executor.map(run_task_list, task_bucket_info):
+        for e in executor.map(run_func, task_bucket_info):
              logging.debug(e)
 
     task_end_time = datetime.now()
     task_diff = task_end_time - task_start_time
     logging.debug("Time taken to perform {}: {} seconds".format(label, task_diff.total_seconds()))
 
-
-# Check the relevant build directories exist and have the correct status
-def check_build_dirs(build_dir_base, parallel, setup):
-    build_dirs = list()
+# Check the relevant build directories exist and have the correct status  if we are not setting up
+def check_build_dirs(build_dir_base, parallel):
+    task_bucket_info = list()
 
     for build_num in range(parallel):
         this_build_dir = "{}{}".format(build_dir_base, build_num)
 
-        if not os.path.exists(this_build_dir):
-            sys.exit("Build directory {} doesn't exist".format(this_build_dir))
+        task_bucket_info.append({'build_dir': this_build_dir, 'task_bucket': []})
 
-        build_dirs.append(this_build_dir)
-
+        # Check build dir for coverage files.
         found_compile_time_coverage_files = False
         found_run_time_coverage_files = False
-
-        # Check build dir for coverage files
-        for root, dirs, files in os.walk(this_build_dir):
+        for _, _, files in os.walk(this_build_dir):
             for filename in files:
                 if filename.endswith('.gcno'):
                     found_compile_time_coverage_files = True
@@ -100,16 +67,48 @@ def check_build_dirs(build_dir_base, parallel, setup):
                     found_run_time_coverage_files = True
 
         logging.debug('Found compile time coverage files in {} = {}'.
-              format(this_build_dir, found_compile_time_coverage_files))
+            format(this_build_dir, found_compile_time_coverage_files))
         logging.debug('Found run time coverage files in {}     = {}'.
-              format(this_build_dir, found_run_time_coverage_files))
+            format(this_build_dir, found_run_time_coverage_files))
 
-        if not setup and not found_compile_time_coverage_files:
+        if not found_compile_time_coverage_files:
             sys.exit('No compile time coverage files found within {}. Please build for code coverage.'
-                     .format(this_build_dir))
+                    .format(this_build_dir))
 
-    logging.debug("Build dirs: {}".format(build_dirs))
+    logging.debug("Build dirs: {}".format(task_bucket_info))
 
-    return build_dirs
+    return task_bucket_info
+
+# Create the relevant build directories to run tasks.
+def setup_build_dirs(build_dir_base, parallel, setup_task_list):
+    task_bucket_info = list()
+
+    base_build_dir = "{}{}".format(build_dir_base, 0)
+    if os.path.exists(base_build_dir):
+        sys.exit('build directory exists within {}.'.format(base_build_dir))
+    
+    logging.debug('Creating build directory {}.', base_build_dir)
+    os.mkdir(base_build_dir)
+
+    for build_num in range(parallel):
+        this_build_dir = "{}{}".format(build_dir_base, build_num)
+        task_bucket_info.append({'build_dir': this_build_dir, 'task_bucket': []})
+
+    logging.debug("Build dirs: {}".format(task_bucket_info))
+
+    logging.debug("Compiling base build directory: {}".format(base_build_dir))
+    for task in setup_task_list:
+        try:
+            os.chdir(base_build_dir)
+            split_command = task.split()
+            subprocess.run(split_command, check=True, capture_output=True)
+        except subprocess.CalledProcessError as exception:
+            logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
+
+    # Copy compiled base build directory into the other build directores.
+    logging.debug("Copying base build directory {} into the other build directories.".format(base_build_dir))
+    for task_bucket in task_bucket_info[1:]:
+        shutil.copytree(base_build_dir, task_bucket['build_dir'])
+    return task_bucket_info
 
 

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -96,7 +96,7 @@ def setup_build_dirs(build_dir_base, parallel, setup_task_list):
     if os.path.exists(base_build_dir):
         sys.exit('build directory exists within {}.'.format(base_build_dir))
     
-    logging.debug('Creating build directory {}.', base_build_dir)
+    logging.debug('Creating build directory {}.'.format(base_build_dir))
     os.mkdir(base_build_dir)
 
     for build_num in range(parallel):
@@ -106,6 +106,7 @@ def setup_build_dirs(build_dir_base, parallel, setup_task_list):
     logging.debug("Build dirs: {}".format(task_bucket_info))
 
     logging.debug("Compiling base build directory: {}".format(base_build_dir))
+    start_time = datetime.now()
     for task in setup_task_list:
         try:
             p = PushWorkingDirectory(base_build_dir)
@@ -114,7 +115,10 @@ def setup_build_dirs(build_dir_base, parallel, setup_task_list):
             p.pop()
         except subprocess.CalledProcessError as exception:
             logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
+    end_time = datetime.now()
+    diff = end_time - start_time
 
+    logging.debug("Finished setup and took {} seconds".format(diff.total_seconds()))
     # Copy compiled base build directory into the other build directores.
     logging.debug("Copying base build directory {} into the other build directories.".format(base_build_dir))
     for task_bucket in task_bucket_info[1:]:

--- a/test/evergreen/code_coverage/coverage-report-per-test.sh
+++ b/test/evergreen/code_coverage/coverage-report-per-test.sh
@@ -18,7 +18,7 @@ test/evergreen/find_cmake.sh
 echo "Disk usage and free space for the current drive (pre-test):"
 df -h .
 
-# Create directories for 8 builds and the output data
+# Create the output data directory.
 mkdir -p coverage_data
 mkdir -p coverage_report
 

--- a/test/evergreen/code_coverage/coverage-report-per-test.sh
+++ b/test/evergreen/code_coverage/coverage-report-per-test.sh
@@ -19,7 +19,6 @@ echo "Disk usage and free space for the current drive (pre-test):"
 df -h .
 
 # Create directories for 8 builds and the output data
-mkdir build_0 build_1 build_2 build_3 build_4 build_5 build_6 build_7
 mkdir -p coverage_data
 mkdir -p coverage_report
 

--- a/test/evergreen/code_coverage/coverage-report-per-test.sh
+++ b/test/evergreen/code_coverage/coverage-report-per-test.sh
@@ -60,7 +60,7 @@ if [ "${is_patch}" = true ]; then
   ls -l coverage_report
   echo "cat coverage_report/diff.txt"
   cat coverage_report/diff.txt
-  python3 test/evergreen/code_change_report/per_test_code_coverage_report.py -v -c coverage_data -d coverage_report/diff.txt -m coverage_report/metrixpp.csv
+  python3 test/evergreen/code_change_report/per_test_code_coverage_report.py -c coverage_data -d coverage_report/diff.txt -m coverage_report/metrixpp.csv
 fi
 
 tar -czf coverage_report/coverage_data.tar.gz coverage_data

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -45,7 +45,7 @@ def run_task_list(task_list_info):
     # GCOV doesn't like it that we have copied the base build directory to construct the other
     # build directories. GCOV supports cross profiling for reference:
     # https://gcc.gnu.org/onlinedocs/gcc/Cross-profiling.html
-    # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away 
+    # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away
     # from the absolute path, and the GCOV_PREFIX prepends the directory path. In this case,
     # we are stripping away /data/mci/wiredtiger/build and then applying the correct build path.
     path_depth = build_dir.count("/")

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -126,7 +126,7 @@ def main():
             continue
         elif (not res and python):
             continue
-                
+
         build_dir_number = test_num % parallel_tests
         logging.debug("Prepping test [{}] as build number {}: {} ".format(test_num, build_dir_number, test))
         task_bucket_info[build_dir_number]['task_bucket'].append(test)

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -48,7 +48,8 @@ def run_task_list(task_list_info):
     # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away 
     # from the absolute path, and the GCOV_PREFIX prepends the directory path. In this case,
     # we are stripping away /data/mci/wiredtiger/build and then applying the correct build path.
-    env["GCOV_PREFIX_STRIP"] = "4"
+    path_depth = build_dir.count("/")
+    env["GCOV_PREFIX_STRIP"] = str(path_depth)
     for task in task_list:
         logging.debug("Running task {} in {}".format(task, build_dir))
         env["GCOV_PREFIX"] = build_dir
@@ -99,7 +100,7 @@ def main():
     logging.debug('  Number of parallel tests:        {}'.format(parallel_tests))
     logging.debug('  Perform setup actions:           {}'.format(setup))
 
-    if (bucket != "python" and bucket != "other"):
+    if (bucket and bucket != "python" and bucket != "other"):
         sys.exit("Only buckets options \"python\" and \"other\" are allowed")
 
     if parallel_tests < 1:

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -50,7 +50,7 @@ def run_task_list(task_list_info):
         try:
             os.chdir(build_dir)
             split_command = task.split()
-            subprocess.run(split_command, check=True, env=env)
+            subprocess.run(split_command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
         except subprocess.CalledProcessError as exception:
             logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
         end_time = datetime.now()

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -80,8 +80,7 @@ def main():
     parser.add_argument('-s', '--setup', action="store_true",
                         help='Perform setup actions from the config in each build directory')
     parser.add_argument('-v', '--verbose', action="store_true", help='Be verbose')
-    parser.add_argument('-p', '--python', action="store_true", help='Run on only python tests in code coverage')
-    parser.add_argument('-o', '--other', action="store_true", help='Run any other tests that are not python in code coverage')
+    parser.add_argument('-u', '--bucket', type=str, help='Run on only python tests in code coverage')
     args = parser.parse_args()
 
     verbose = args.verbose
@@ -89,8 +88,7 @@ def main():
     config_path = args.config_path
     build_dir_base = args.build_dir_base
     parallel_tests = args.parallel
-    python = args.python
-    other = args.other
+    bucket = args.bucket
     setup = args.setup
 
     logging.debug('Code Coverage')
@@ -100,6 +98,9 @@ def main():
     logging.debug('  Base name for build directories: {}'.format(build_dir_base))
     logging.debug('  Number of parallel tests:        {}'.format(parallel_tests))
     logging.debug('  Perform setup actions:           {}'.format(setup))
+
+    if (bucket != "python" and bucket != "other"):
+        sys.exit("Only buckets options \"python\" and \"other\" are allowed")
 
     if parallel_tests < 1:
         sys.exit("Number of parallel tests must be >= 1")
@@ -132,11 +133,11 @@ def main():
         # We currently have two machines that runs a subset of tests to reduce code coverage time.
         # To do this we divide the tests into two buckets into either only python tests or
         # non-python tests. If python is set, only include python tests in the task list.
-        res = re.search("python", test)
-        if (not res and python):
+        is_python_test = re.search("python", test)
+        if (not is_python_test and bucket == "python"):
             continue
-        # Else if other is set, only include non-python tests in the task lsit.
-        elif (res and other):
+        # Else if other is set, only include non-python tests in the task list.
+        elif (is_python_test and bucket == "other"):
             continue
         build_dir_number = test_num % parallel_tests
         logging.debug("Prepping test [{}] as build number {}: {} ".format(test_num, build_dir_number, test))

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -45,8 +45,9 @@ def run_task_list(task_list_info):
     # GCOV doesn't like it that we have copied the base build directory to construct the other
     # build directories. GCOV supports cross profiling for reference:
     # https://gcc.gnu.org/onlinedocs/gcc/Cross-profiling.html
-    # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away from the
-    # absolute path, and the GCOV_PREFIX prepends the directory path.
+    # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away 
+    # from the absolute path, and the GCOV_PREFIX prepends the directory path. In this case,
+    # we are stripping away /data/mci/wiredtiger/build and then applying the correct build path.
     env["GCOV_PREFIX_STRIP"] = "4"
     for task in task_list:
         logging.debug("Running task {} in {}".format(task, build_dir))

--- a/test/evergreen/code_coverage/per_test_code_coverage.py
+++ b/test/evergreen/code_coverage/per_test_code_coverage.py
@@ -43,7 +43,6 @@ def delete_runtime_coverage_files(build_dir_base: str) -> None:
         for filename in files:
             if filename.endswith('.gcda'):
                 file_path = os.path.join(root, filename)
-                logging.debug(f"Deleting: {file_path}")
                 os.remove(file_path)
                 logging.debug(f"Deleted: {file_path}")
 
@@ -61,8 +60,10 @@ def run_coverage_task_list(task_list_info):
     # https://gcc.gnu.org/onlinedocs/gcc/Cross-profiling.html
     # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away 
     # from the absolute path, and the GCOV_PREFIX prepends the directory path. In this case,
-    # we are stripping away /data/mci/wiredtiger/build and then applying the correct build path.
-    env["GCOV_PREFIX_STRIP"] = "4"
+    # we are stripping away /data/mci/commit_hash/wiredtiger/build and then applying the correct
+    # build path.
+    path_depth = build_dir.count("/")
+    env["GCOV_PREFIX_STRIP"] = str(path_depth)
     for index in range(len(task_list)):
         task = task_list[index]
         logging.debug("Running task {} in {}".format(task, build_dir))

--- a/test/evergreen/code_coverage/per_test_code_coverage.py
+++ b/test/evergreen/code_coverage/per_test_code_coverage.py
@@ -58,7 +58,7 @@ def run_coverage_task_list(task_list_info):
     # GCOV doesn't like it that we have copied the base build directory to construct the other
     # build directories. GCOV supports cross profiling for reference:
     # https://gcc.gnu.org/onlinedocs/gcc/Cross-profiling.html
-    # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away 
+    # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away
     # from the absolute path, and the GCOV_PREFIX prepends the directory path. In this case,
     # we are stripping away /data/mci/commit_hash/wiredtiger/build and then applying the correct
     # build path.

--- a/test/evergreen/code_coverage/per_test_code_coverage.py
+++ b/test/evergreen/code_coverage/per_test_code_coverage.py
@@ -56,6 +56,12 @@ def run_coverage_task_list(task_list_info):
     list_start_time = datetime.now()
 
     env = os.environ.copy()
+    # GCOV doesn't like it that we have copied the base build directory to construct the other
+    # build directories. GCOV supports cross profiling for reference:
+    # https://gcc.gnu.org/onlinedocs/gcc/Cross-profiling.html
+    # The basic idea is that GCOV_PREFIX_STRIP, indicates how many directory path to strip away 
+    # from the absolute path, and the GCOV_PREFIX prepends the directory path. In this case,
+    # we are stripping away /data/mci/wiredtiger/build and then applying the correct build path.
     env["GCOV_PREFIX_STRIP"] = "4"
     for index in range(len(task_list)):
         task = task_list[index]

--- a/test/evergreen/code_coverage/per_test_code_coverage.py
+++ b/test/evergreen/code_coverage/per_test_code_coverage.py
@@ -109,7 +109,7 @@ def run_gcovr(build_dir_base: str, gcovr_dir: str):
                 f"build_copy_name = {build_copy_name}, build_copy_path = {build_copy_path}, "
                 f"task_info_path = {task_info_path}, coverage_output_dir = {coverage_output_dir}")
             os.mkdir(coverage_output_dir)
-            shutil.copy(src=task_info_path, dst=coverage_output_dir)      
+            shutil.copy(src=task_info_path, dst=coverage_output_dir)
             gcovr_command = (f"gcovr {build_copy_name} -f src -j 16 --html-self-contained --html-details "
                              f"{coverage_output_dir}/2_coverage_report.html --json-summary-pretty "
                              f"--json-summary {coverage_output_dir}/1_coverage_report_summary.json "

--- a/test/evergreen/code_coverage_analysis.py
+++ b/test/evergreen/code_coverage_analysis.py
@@ -102,7 +102,7 @@ def main():
     parser.add_argument('-o', '--outfile', help='Path of the file to write test output to')
     parser.add_argument('-c', '--coverage_type',
                         help='Type of the coverage report to generate, component_coverage to generate component level coverage(by default the coverage type is overall)')
-    parser.add_argument('-t', '--time', required=True, help='Path to the timing data file')
+    parser.add_argument('-t', '--time', help='Path to the timing data file')
     parser.add_argument('-v', '--verbose', action="store_true", help='be verbose')
     args = parser.parse_args()
 
@@ -128,12 +128,13 @@ def main():
 
     print("Branch coverage = {}%".format(branch_coverage))
 
-    delta_secs = read_timing_data(args.time)
-    delta_mins = delta_secs / 60.0
-    code_coverage_per_min = branch_coverage / delta_mins
-    print("Time taken: {} seconds".format(delta_secs))
+    if (args.time):
+        delta_secs = read_timing_data(args.time)
+        delta_mins = delta_secs / 60.0
+        code_coverage_per_min = branch_coverage / delta_mins
+        print("Time taken: {} seconds".format(delta_secs))
 
-    print("Code coverage rate = {:.2f}%/min".format(code_coverage_per_min))
+        print("Code coverage rate = {:.2f}%/min".format(code_coverage_per_min))
 
 
 if __name__ == '__main__':

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -82,14 +82,17 @@ buildvariants:
   expansions:
     ENABLE_TCMALLOC: 0
     database: WTCodeStatisticsDB
-    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` / 2" | bc)
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
-    - name: coverage-report
+    - name: coverage-report-python
+      distros: ubuntu2004-arm64-large
+    - name: coverage-report-csuite
       distros: ubuntu2004-arm64-large
     - name: coverage-report-per-test
       distros: ubuntu2004-arm64-large
       activate: false # Launch only manually for now
     - name: coverage-report-catch2
+    - name: generate-coverage-report
     - name: cyclomatic-complexity
     - name: code-change-report
 

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -86,7 +86,7 @@ buildvariants:
   tasks:
     - name: coverage-report-python
       distros: ubuntu2004-arm64-large
-    - name: coverage-report-csuite
+    - name: coverage-report-other
       distros: ubuntu2004-arm64-large
     - name: coverage-report-per-test
       distros: ubuntu2004-arm64-large


### PR DESCRIPTION
I have optimized all the code coverage task time. The biggest improvements come from two major changes within the script and on Evergreen. 
1. There is a method to merge multiple code coverage reports and combine them into one. To utilise this advantage I have added parallel machines running a subset of the code coverage, and then I merge the code coverage report.
2. We now have the capability on building one directory and copying over the build directory. This allows us to use 16 threads to build WT and now we can just copy it over. 

In making the above two changes, I needed to refactor the python tests to accommodate for the change. The tasks now take 5-8 minutes down from 15 minutes. I will create another ticket to increase the coverage to 15 minutes. I have created a patch build to showcase the changes.