### PR TITLE
WT-13300 Restore perf testing cadence to once daily

### DIFF
--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -6,7 +6,7 @@ include:
 variables:
 # Template for perf-tasks
 - &perf-tasks-template
-  batchtime: 360 # 6 hours
+  batchtime: 1440 # 1 day
   expansions: &ubuntu2004-perf-tests-expansions-template
     additional_env_vars: export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$WT_BUILDDIR/test/utility/"
     ENABLE_TCMALLOC: 1


### PR DESCRIPTION
We increased the rate of performance testing to 4 times per day during the 8.0 release period. Now the release period is finished restore our testing cadence to once a day.