### PR TITLE
WT-13301 Remove the sanitizer_long flag from evergreen.yml

### DIFF
--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -37,7 +37,7 @@ define_c_test(
     DIR_NAME random
     DEPENDS "WT_POSIX"
     # This test takes over 20 minutes under ASan testing
-    LABEL "sanitizer_long"
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -132,7 +132,8 @@ define_c_test(
     DIR_NAME wt2403_lsm_workload
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2403_lsm_workload>/WT_HOME>
     DEPENDS "WT_POSIX"
-    LABEL "sanitizer_long"
+    # This test takes over 15 minutes under TSan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -140,7 +141,8 @@ define_c_test(
     SOURCES wt2246_col_append/main.c
     DIR_NAME wt2246_col_append
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2246_col_append>/WT_HOME>
-    LABEL "sanitizer_long"
+    # This test takes over 15 minutes under TSan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -149,7 +151,8 @@ define_c_test(
     DIR_NAME wt2323_join_visibility
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2323_join_visibility>/WT_HOME>
     DEPENDS "WT_POSIX"
-    LABEL "sanitizer_long"
+    # This test takes over 15 minutes under TSan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -159,7 +162,8 @@ define_c_test(
     EXEC_SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/wt2535_insert_race/smoke.sh
     ARGUMENTS $<TARGET_FILE:test_wt2535_insert_race>
     DEPENDS "WT_POSIX"
-    LABEL "sanitizer_long"
+    # This test takes over 15 minutes under TSan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -198,7 +202,8 @@ define_c_test(
     SOURCES wt2834_join_bloom_fix/main.c
     DIR_NAME wt2834_join_bloom_fix
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt2834_join_bloom_fix>/WT_HOME>
-    LABEL "sanitizer_long"
+    # This test takes over 15 minutes under TSan testing
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -253,7 +258,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt3338_partial_update>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over an hour under ASan testing
-    LABEL "sanitizer_long"
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -343,7 +348,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt7989_compact_checkpoint>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over 40 minutes under ASan testing
-    LABEL "sanitizer_long"
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -379,7 +384,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8659_reconstruct_database_from_logs>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over 20 minutes under ASan testing
-    LABEL "sanitizer_long"
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -389,7 +394,7 @@ define_c_test(
     ARGUMENTS -h $<SHELL_PATH:$<TARGET_FILE_DIR:test_wt8963_insert_stress>/WT_HOME>
     DEPENDS "WT_POSIX"
     # This test takes over an hour under ASan testing
-    LABEL "sanitizer_long"
+    LABEL "long_running"
 )
 
 define_c_test(
@@ -430,5 +435,6 @@ define_c_test(
     DIR_NAME wt12015_backup_corruption
     ARGUMENTS
     DEPENDS "WT_POSIX"
-    LABEL "sanitizer_long"
+    # This test takes over 15 minutes under TSan testing
+    LABEL "long_running"
 )

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5583,10 +5583,6 @@ buildvariants:
       export LSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/asan_leaks.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     # Exclude wt12015_backup_corruption for ASan builds. It creates false positives when it deliberately kills processes that invoke corruption.
-    # We also disable long tests to keep PR testing fast.
-    # FIXME-WT-XXXXX We're setting the -LE flag at the variant level since we can't set them on specific tasks below.
-    # They're only needed for csuite-tests-fast in the !.pull_request label and currently this is the only test in the variant that uses ctest_extra_args.
-    # If we add new tests they may unintentionally skip long tests.
     ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
     - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5584,10 +5584,10 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     # Exclude wt12015_backup_corruption for ASan builds. It creates false positives when it deliberately kills processes that invoke corruption.
     # We also disable long tests to keep PR testing fast.
-    # FIXME-WT-XXXXX We're setting the -LE flag at the variant level since we can't set them on specific tasks below. 
-    # They're only needed for csuite-tests-fast in the !.pull_request label and currently this is the only test in the variant that uses ctest_extra_args. 
+    # FIXME-WT-XXXXX We're setting the -LE flag at the variant level since we can't set them on specific tasks below.
+    # They're only needed for csuite-tests-fast in the !.pull_request label and currently this is the only test in the variant that uses ctest_extra_args.
     # If we add new tests they may unintentionally skip long tests.
-    ctest_extra_args: -E "wt12015_backup_corruption" -LE (long_running|sanitizer_long)
+    ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
     - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
     - name: examples-c-test
@@ -5628,7 +5628,7 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     # We don't run C++ memory sanitized testing as it creates false positives. TSan also significantly increases the runtime
     # of some csuite tests, so disable the already long tests as well as tests heavily impacted by TSan.
-    ctest_extra_args: -LE "cppsuite|long_running|sanitizer_long"
+    ctest_extra_args: -LE "cppsuite|long_running"
     # TSan slows down python testing enough that we start printing "operation took X seconds" warnings.
     # These don't impact functionality, but the python tests fail on detection of any content in stdout so ignore it instead.
     ignore_stdout: --ignore-stdout

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2080,24 +2080,14 @@ tasks:
   # End of cppsuite test tasks.
   # Start of csuite test tasks
   - name: csuite-tests-fast
-    tags: ["pull_request", "pull_request_no_sanitizer"]
+    tags: ["pull_request"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
           directory: test/csuite
-          ctest_extra_args: ${ctest_extra_args} -LE "long_running" -j ${num_jobs}
-
-  - name: csuite-tests-fast-sanitizer
-    tags: ["pull_request", "pull_request_sanitizer"]
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "make check directory"
-        vars:
-          directory: test/csuite
-          ctest_extra_args: ${ctest_extra_args} -E "wt12015_backup_corruption" -LE "long_running|sanitizer_long" -j ${num_jobs}
+          ctest_extra_args: -LE "long_running" ${ctest_extra_args} -j ${num_jobs}
 
   - name: csuite-timestamp-abort-test-s3
     commands:
@@ -5526,7 +5516,7 @@ buildvariants:
     data_validation_stress_test_args: -t r -m -W 3 -D -p -n 100000 -k 100000 -C cache_size=100MB
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.pull_request_sanitizer"
+    - name: ".pull_request !.pull_request_compilers"
     - name: ".lint"
     - name: ".unit_test_long"
       distros: ubuntu2004-large
@@ -5596,7 +5586,10 @@ buildvariants:
     # to deliberate killing of processes to invoke corruption.
     ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.pull_request_no_sanitizer !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
+    - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
+      vars:
+        # We want to keep pull request testing short. Disable tests that are slow under ASan
+        ctest_extra_args: -E "wt12015_backup_corruption" -LE sanitizer_long
     - name: examples-c-test
     - name: format-asan-smoke-test
 
@@ -5643,7 +5636,7 @@ buildvariants:
     validation_stress_num_runs: 20
   tasks:
     # Skip the azure/gcp tests as they don't compile under clang
-    - name: ".pull_request !.tiered_unittest !azure-gcp-tiered-test-small !.pull_request_compilers !.pull_request_no_sanitizer !.model_checking !csuite-wt12015-backup-corruption-test"
+    - name: ".pull_request !.tiered_unittest !azure-gcp-tiered-test-small !.pull_request_compilers !.model_checking !csuite-wt12015-backup-corruption-test"
     - name: compile
     - name: make-check-test
     - name: configure-combinations
@@ -6140,7 +6133,7 @@ buildvariants:
     NONSTANDALONE: -DWT_STANDALONE_BUILD=0
     unit_test_variant_args: "--hook nonstandalone"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.pull_request_sanitizer"
+    - name: ".pull_request !.pull_request_compilers"
     - name: compile
     - name: make-check-test
     - name: unit-test-extra-long

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5582,14 +5582,14 @@ buildvariants:
     additional_env_vars: |
       export LSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/asan_leaks.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
-    # Exclude this test for ASan builds, as it results in a false positives owing
-    # to deliberate killing of processes to invoke corruption.
-    ctest_extra_args: -E "wt12015_backup_corruption"
+    # Exclude wt12015_backup_corruption for ASan builds. It creates false positives when it deliberately kills processes that invoke corruption.
+    # We also disable long tests to keep PR testing fast.
+    # FIXME-WT-XXXXX We're setting the -LE flag at the variant level since we can't set them on specific tasks below. 
+    # They're only needed for csuite-tests-fast in the !.pull_request label and currently this is the only test in the variant that uses ctest_extra_args. 
+    # If we add new tests they may unintentionally skip long tests.
+    ctest_extra_args: -E "wt12015_backup_corruption" -LE (long_running|sanitizer_long)
   tasks:
     - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
-      vars:
-        # We want to keep pull request testing short. Disable tests that are slow under ASan
-        ctest_extra_args: -E "wt12015_backup_corruption" -LE sanitizer_long
     - name: examples-c-test
     - name: format-asan-smoke-test
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2080,14 +2080,24 @@ tasks:
   # End of cppsuite test tasks.
   # Start of csuite test tasks
   - name: csuite-tests-fast
-    tags: ["pull_request"]
+    tags: ["pull_request", "pull_request_no_sanitizer"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
           directory: test/csuite
-          ctest_extra_args: -LE "long_running" ${ctest_extra_args} -j ${num_jobs}
+          ctest_extra_args: ${ctest_extra_args} -LE "long_running" -j ${num_jobs}
+
+  - name: csuite-tests-fast-sanitizer
+    tags: ["pull_request", "pull_request_sanitizer"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "make check directory"
+        vars:
+          directory: test/csuite
+          ctest_extra_args: ${ctest_extra_args} -E "wt12015_backup_corruption" -LE "long_running|sanitizer_long" -j ${num_jobs}
 
   - name: csuite-timestamp-abort-test-s3
     commands:
@@ -5516,7 +5526,7 @@ buildvariants:
     data_validation_stress_test_args: -t r -m -W 3 -D -p -n 100000 -k 100000 -C cache_size=100MB
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
   tasks:
-    - name: ".pull_request !.pull_request_compilers"
+    - name: ".pull_request !.pull_request_compilers !.pull_request_sanitizer"
     - name: ".lint"
     - name: ".unit_test_long"
       distros: ubuntu2004-large
@@ -5586,10 +5596,7 @@ buildvariants:
     # to deliberate killing of processes to invoke corruption.
     ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
-      vars:
-        # We want to keep pull request testing short. Disable tests that are slow under ASan
-        ctest_extra_args: -E "wt12015_backup_corruption" -LE sanitizer_long
+    - name: ".pull_request !.pull_request_compilers !.pull_request_no_sanitizer !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
     - name: examples-c-test
     - name: format-asan-smoke-test
 
@@ -5636,7 +5643,7 @@ buildvariants:
     validation_stress_num_runs: 20
   tasks:
     # Skip the azure/gcp tests as they don't compile under clang
-    - name: ".pull_request !.tiered_unittest !azure-gcp-tiered-test-small !.pull_request_compilers !.model_checking !csuite-wt12015-backup-corruption-test"
+    - name: ".pull_request !.tiered_unittest !azure-gcp-tiered-test-small !.pull_request_compilers !.pull_request_no_sanitizer !.model_checking !csuite-wt12015-backup-corruption-test"
     - name: compile
     - name: make-check-test
     - name: configure-combinations
@@ -6133,7 +6140,7 @@ buildvariants:
     NONSTANDALONE: -DWT_STANDALONE_BUILD=0
     unit_test_variant_args: "--hook nonstandalone"
   tasks:
-    - name: ".pull_request !.pull_request_compilers"
+    - name: ".pull_request !.pull_request_compilers !.pull_request_sanitizer"
     - name: compile
     - name: make-check-test
     - name: unit-test-extra-long


### PR DESCRIPTION
Remove the `sanitizer_long` tag and use `long_running` instead. This means fewer csuite tests are run in `csuite-tests-fast` on our ubuntu variant, but guarantees we don't hit timeouts on our ASan and TSan variants.