### PR TITLE
WT-13302: lost data bug fix by "wt pringlog"

### DIFF
--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -241,6 +241,8 @@ main(int argc, char *argv[])
         if (strcmp(command, "printlog") == 0) {
             func = util_printlog;
             rec_config = REC_LOGOFF;
+            if (!readonly)
+                readonly_config = READONLY;
         }
         break;
     case 'r':


### PR DESCRIPTION
The procedure for causing data loss is as follows: Mongod operation logic:
1. Write data to a single node
2. Stop writing data
3. View count
4. Kill the mongod process
5. Wt analyzes printlog
6. View count

![image](https://github.com/user-attachments/assets/808696b6-aef0-4c80-97a6-9bedc37abd2c)
After the restart, the total count is reduced from 141066 to 64516, 141066-64516=76500, and 76500 data is lost