### PR TITLE
WT-12096 Don't validate timestamp against the on-page value if the update is globally visible

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1513,6 +1513,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
             for (; tmp != NULL && tmp != supd->onpage_upd; tmp = tmp->next)
                 WT_ASSERT(session, tmp == supd->onpage_tombstone || tmp->txnid == WT_TXN_ABORTED);
 #endif
+            /* Discard updates/tombstone after prev_onpage. */
             prev_onpage->next = NULL;
         }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -480,18 +480,28 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *s
      * reconciliations ondisk value that we will be comparing against.
      */
     if (vpack != NULL && !vpack->tw.prepare) {
-        WT_ASSERT_ALWAYS(session,
-          prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
-            prev_upd->start_ts == prev_upd->durable_ts ||
-            prev_upd->durable_ts >= vpack->tw.durable_start_ts,
-          "Durable timestamps cannot be out of order for prepared updates");
-        WT_ASSERT_ALWAYS(session,
-          prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
-            prev_upd->start_ts == prev_upd->durable_ts || !WT_TIME_WINDOW_HAS_STOP(&vpack->tw) ||
-            prev_upd->durable_ts >= vpack->tw.durable_stop_ts,
-          "Durable timestamps cannot be out of order for prepared updates");
-        if (prev_upd->start_ts < vpack->tw.start_ts ||
-          (WT_TIME_WINDOW_HAS_STOP(&vpack->tw) && prev_upd->start_ts < vpack->tw.stop_ts)) {
+        if (WT_TIME_WINDOW_HAS_STOP(&vpack->tw))
+            WT_ASSERT_ALWAYS(session,
+              prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
+                prev_upd->start_ts == prev_upd->durable_ts ||
+                prev_upd->durable_ts >= vpack->tw.durable_stop_ts,
+              "Stop: Durable timestamps cannot be out of order for prepared updates");
+        else
+            WT_ASSERT_ALWAYS(session,
+              prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
+                prev_upd->start_ts == prev_upd->durable_ts ||
+                prev_upd->durable_ts >= vpack->tw.durable_start_ts,
+              "Start: Durable timestamps cannot be out of order for prepared updates");
+        /*
+         * Rollback to stable may recover updates from the history store that is out of order to the
+         * on-disk value. Normally these updates have the WT_UPDATE_RESTORED_FROM_HS flag on them.
+         * However, in rare cases, if the newer update becomes globally visible, the restored update
+         * may be removed by the obsolete check. This may lead to an out of order edge case but it
+         * is benign. Check the global visibility of the update and ignore this case.
+         */
+        if (!__wt_txn_upd_visible_all(session, prev_upd) &&
+          (prev_upd->start_ts < vpack->tw.start_ts ||
+            (WT_TIME_WINDOW_HAS_STOP(&vpack->tw) && prev_upd->start_ts < vpack->tw.stop_ts))) {
             WT_ASSERT(session, prev_upd->start_ts == WT_TS_NONE);
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_1);
             return (EBUSY);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -499,13 +499,18 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *s
          * may be removed by the obsolete check. This may lead to an out of order edge case but it
          * is benign. Check the global visibility of the update and ignore this case.
          */
-        if (!__wt_txn_upd_visible_all(session, prev_upd) &&
-          (prev_upd->start_ts < vpack->tw.start_ts ||
-            (WT_TIME_WINDOW_HAS_STOP(&vpack->tw) && prev_upd->start_ts < vpack->tw.stop_ts))) {
-            WT_ASSERT(session, prev_upd->start_ts == WT_TS_NONE);
-            WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_1);
-            return (EBUSY);
-        }
+        if (prev_upd->start_ts == WT_TS_NONE) {
+            if (prev_upd->start_ts < vpack->tw.start_ts ||
+              (WT_TIME_WINDOW_HAS_STOP(&vpack->tw) && prev_upd->start_ts < vpack->tw.stop_ts)) {
+                WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_1);
+                return (EBUSY);
+            }
+        } else
+            WT_ASSERT(session,
+              __wt_txn_upd_visible_all(session, prev_upd) ||
+                (prev_upd->start_ts >= vpack->tw.start_ts &&
+                  (!WT_TIME_WINDOW_HAS_STOP(&vpack->tw) ||
+                    prev_upd->start_ts >= vpack->tw.stop_ts)));
     }
 
     return (0);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -494,8 +494,8 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_UPDATE *s
               "Start: Durable timestamps cannot be out of order for prepared updates");
 
         if (prev_upd->start_ts == WT_TS_NONE) {
-            if (prev_upd->start_ts < vpack->tw.start_ts ||
-              (WT_TIME_WINDOW_HAS_STOP(&vpack->tw) && prev_upd->start_ts < vpack->tw.stop_ts)) {
+            if (vpack->tw.start_ts != WT_TS_NONE ||
+              (WT_TIME_WINDOW_HAS_STOP(&vpack->tw) && vpack->tw.stop_ts != WT_TS_NONE)) {
                 WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_1);
                 return (EBUSY);
             }

--- a/test/suite/test_bug033.py
+++ b/test/suite/test_bug033.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest, threading, wtthread, time
+from wiredtiger import stat
+
+# test_bug033.py
+# Test for WT-12096 and BF-32981.
+# Test inserting obsolete updates on the update chain after rolling back to a stable timestamp.
+class test_bug033(wttest.WiredTigerTestCase):
+    uri = 'table:test_bug033'
+    conn_config = 'cache_size=100MB,statistics=(all),timing_stress_for_test=[checkpoint_slow]'
+
+    def evict(self, k):
+        evict_cursor = self.session.open_cursor(self.uri, None, "debug=(release_evict)")
+        self.session.begin_transaction()
+        evict_cursor.set_key(k)
+        evict_cursor.search()
+        evict_cursor.reset()
+        evict_cursor.close()
+        self.session.rollback_transaction()
+
+    def test_bug033(self):
+        # Note, the comments upd_chain: and disk: show what should be
+        # the upd_chain and disk at that point.
+        self.session.create(self.uri, f'key_format=i,value_format=S')
+
+        # Pin the oldest and stable timestamps to 1
+        self.conn.set_timestamp(f'oldest_timestamp={self.timestamp_str(1)},\
+                                stable_timestamp={self.timestamp_str(1)}')
+
+        # Create updates at timestamps 2 and 4 that should get blown away by rollback to stable.
+        self.session.begin_transaction()
+        c = self.session.open_cursor(self.uri, None)
+        c[0] = 'b'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(2)}')
+        c.close()
+        # upd_chain: 2
+        # disk: None
+        self.session.begin_transaction()
+        c = self.session.open_cursor(self.uri, None)
+        c[0] = 'c'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(4)}')
+        c.close()
+        # upd_chain: 2 -> 4
+        # disk: None
+
+        # Evict.
+        self.evict(0)
+        # upd_chain: Empty
+        # disk: 4
+        self.conn.rollback_to_stable()
+        # upd_chain: tombstone
+        # disk: 4
+
+        # Insert another update at timestamp 2.
+        self.session.begin_transaction()
+        c = self.session.open_cursor(self.uri, None)
+        c[0] = 'd'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(2)}')
+        c.close()
+        # upd_chain: tombstone -> 2
+        # disk: 4
+
+        # Move oldest and stable to 3.
+        self.conn.set_timestamp(f'oldest_timestamp={self.timestamp_str(3)},\
+                                stable_timestamp={self.timestamp_str(3)}')
+        # upd_chain: tombstone (obsolete) -> 2 (obsolete)
+        # disk: 4
+
+        # Give time for the oldest id to update. This ensures the obsolete check removes the
+        # obsolete tombstone.
+        time.sleep(1)
+
+        # Insert update at timestamp 4.
+        self.session.begin_transaction()
+        c = self.session.open_cursor(self.uri, None)
+        c[0] = 'e'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(4)}')
+        c.close()
+        # upd_chain: 2 (obsolete)
+        # disk: 4
+
+        # Create a checkpoint in parallel with the eviction below.
+        done = threading.Event()
+        ckpt = wtthread.checkpoint_thread(self.conn, done)
+        try:
+            ckpt.start()
+
+            # Wait for checkpoint to start before evicting.
+            ckpt_started = 0
+            while not ckpt_started:
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_started = stat_cursor[stat.conn.checkpoint_state][2] != 0
+                stat_cursor.close()
+                time.sleep(1)
+
+            self.evict(0)
+        finally:
+            done.set()          # Signal checkpoint to exit.
+            ckpt.join()

--- a/test/suite/test_bug033.py
+++ b/test/suite/test_bug033.py
@@ -30,7 +30,7 @@ import wiredtiger, wttest, threading, wtthread, time
 from wiredtiger import stat
 
 # test_bug033.py
-# Test for WT-12096 and BF-32981.
+# Test for WT-12096.
 # Test inserting obsolete updates on the update chain after rolling back to a stable timestamp.
 class test_bug033(wttest.WiredTigerTestCase):
     uri = 'table:test_bug033'


### PR DESCRIPTION
If an update is globally visible it can be evicted and EBUSY should not be returned. Thus the check for EBUSY should be skipped if an update is globally visible. The bug is the check for EBUSY was not skipped if an update is globally visible.

This was backed out since it made the occurrence of WT-12602 more frequent. Now it is no longer necessary to wait for WT-12602 and some BFs need this. So it is time to put this back.  The original PR was #10595.

There is bug fixing and code readability improvements included beyond the original PR.