### PR TITLE
WT-13330 Disable cppsuite on Intel-based Macs as it only runs on linux. 

### DIFF
--- a/cmake/configs/x86/darwin/config.cmake
+++ b/cmake/configs/x86/darwin/config.cmake
@@ -8,3 +8,6 @@ if(has_x86intrin)
     add_cmake_flag(CMAKE_C_FLAGS -DHAVE_X86INTRIN_H)
 endif()
 unset(has_x86intrin CACHE)
+
+# Disable cppsuite as it only runs on linux.
+set(ENABLE_CPPSUITE 0)


### PR DESCRIPTION
After the changes in WT-13012, disable cppsuite on Intel-based Macs as it only runs on linux. WT-13012 had already disabled cppsuite on ARM-based Macs.
