### PR TITLE
WT-13332 Prep for C++

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -338,7 +338,8 @@ __ckpt_extlist_read(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt, bo
 
     ci = (WT_BLOCK_CKPT *)ckpt->bpriv;
     WT_RET(__wti_block_ckpt_init(session, ci, ckpt->name));
-    WT_RET(__wti_block_ckpt_unpack(session, block, (const uint8_t*)ckpt->raw.data, ckpt->raw.size, ci));
+    WT_RET(
+      __wti_block_ckpt_unpack(session, block, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, ci));
 
     /* Extent lists from non-local objects aren't useful, we're going to skip them. */
     if (ci->root_objectid != block->objectid) {
@@ -448,7 +449,7 @@ __ckpt_add_blkmod_entry(
     WT_ASSERT(session, blk_mod->bitstring.size >= __bitstr_size((uint32_t)blk_mod->nbits));
     WT_ASSERT(session, end_bit < blk_mod->nbits);
     /* Set all the bits needed to record this offset/length pair. */
-    __bit_nset((uint8_t*)blk_mod->bitstring.mem, start_bit, end_bit);
+    __bit_nset((uint8_t *)blk_mod->bitstring.mem, start_bit, end_bit);
     return (0);
 }
 
@@ -694,9 +695,8 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
             continue;
 
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
-            __wti_ckpt_verbose(
-              session, block, "delete", ckpt->name, (const uint8_t *)ckpt->raw.data,
-              ckpt->raw.size);
+            __wti_ckpt_verbose(session, block, "delete", ckpt->name,
+              (const uint8_t *)ckpt->raw.data, ckpt->raw.size);
 
         /*
          * Find the checkpoint into which we'll roll this checkpoint's blocks: it's the next real
@@ -969,7 +969,8 @@ __ckpt_update(
     ckpt->raw.size = WT_PTRDIFF(endp, ckpt->raw.mem);
 
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
-        __wti_ckpt_verbose(session, block, "create", ckpt->name, (const uint8_t *)ckpt->raw.data, ckpt->raw.size);
+        __wti_ckpt_verbose(
+          session, block, "create", ckpt->name, (const uint8_t *)ckpt->raw.data, ckpt->raw.size);
 
     return (0);
 }

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -336,9 +336,9 @@ __ckpt_extlist_read(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt, bo
      */
     WT_RET(__wt_calloc(session, 1, sizeof(WT_BLOCK_CKPT), &ckpt->bpriv));
 
-    ci = ckpt->bpriv;
+    ci = (WT_BLOCK_CKPT *)ckpt->bpriv;
     WT_RET(__wti_block_ckpt_init(session, ci, ckpt->name));
-    WT_RET(__wti_block_ckpt_unpack(session, block, ckpt->raw.data, ckpt->raw.size, ci));
+    WT_RET(__wti_block_ckpt_unpack(session, block, (const uint8_t*)ckpt->raw.data, ckpt->raw.size, ci));
 
     /* Extent lists from non-local objects aren't useful, we're going to skip them. */
     if (ci->root_objectid != block->objectid) {
@@ -448,7 +448,7 @@ __ckpt_add_blkmod_entry(
     WT_ASSERT(session, blk_mod->bitstring.size >= __bitstr_size((uint32_t)blk_mod->nbits));
     WT_ASSERT(session, end_bit < blk_mod->nbits);
     /* Set all the bits needed to record this offset/length pair. */
-    __bit_nset(blk_mod->bitstring.mem, start_bit, end_bit);
+    __bit_nset((uint8_t*)blk_mod->bitstring.mem, start_bit, end_bit);
     return (0);
 }
 
@@ -689,13 +689,14 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
          * Set the "from" checkpoint structure. If it applies to a previous object, there's nothing
          * more to do.
          */
-        a = ckpt->bpriv;
+        a = (WT_BLOCK_CKPT *)ckpt->bpriv;
         if (a->root_objectid != block->objectid)
             continue;
 
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
             __wti_ckpt_verbose(
-              session, block, "delete", ckpt->name, ckpt->raw.data, ckpt->raw.size);
+              session, block, "delete", ckpt->name, (const uint8_t *)ckpt->raw.data,
+              ckpt->raw.size);
 
         /*
          * Find the checkpoint into which we'll roll this checkpoint's blocks: it's the next real
@@ -711,7 +712,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
         if (F_ISSET(next_ckpt, WT_CKPT_ADD))
             b = &block->live;
         else
-            b = next_ckpt->bpriv;
+            b = (WT_BLOCK_CKPT *)next_ckpt->bpriv;
 
         /*
          * Free the root page: there's nothing special about this free, the root page is allocated
@@ -776,7 +777,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
     /* Update checkpoints marked for update. */
     WT_CKPT_FOREACH (ckptbase, ckpt)
         if (F_ISSET(ckpt, WT_CKPT_UPDATE))
-            WT_ERR(__ckpt_update(session, block, ckptbase, ckpt, ckpt->bpriv));
+            WT_ERR(__ckpt_update(session, block, ckptbase, ckpt, (WT_BLOCK_CKPT *)ckpt->bpriv));
 
 live_update:
     /* Truncate the file if that's possible. */
@@ -832,7 +833,7 @@ live_update:
     WT_CKPT_FOREACH (ckptbase, ckpt)
         if (!F_ISSET(ckpt, WT_CKPT_DELETE))
             break;
-    if ((a = ckpt->bpriv) == NULL)
+    if ((a = (WT_BLOCK_CKPT *)ckpt->bpriv) == NULL)
         a = &block->live;
     if (a->discard.entries != 0)
         WT_ERR_MSG(
@@ -849,7 +850,7 @@ err:
 
     /* Discard any checkpoint information we loaded. */
     WT_CKPT_FOREACH (ckptbase, ckpt)
-        if ((ci = ckpt->bpriv) != NULL)
+        if ((ci = (WT_BLOCK_CKPT *)ckpt->bpriv) != NULL)
             __wti_block_ckpt_destroy(session, ci);
 
     return (ret);
@@ -894,7 +895,7 @@ __ckpt_update(
          * Copy the INCOMPLETE checkpoint information into the checkpoint.
          */
         WT_RET(__wt_buf_init(session, &ckpt->raw, WT_BLOCK_CHECKPOINT_BUFFER));
-        endp = ckpt->raw.mem;
+        endp = (uint8_t *)ckpt->raw.mem;
         WT_RET(__wti_block_ckpt_pack(session, block, &endp, ci, true));
         ckpt->raw.size = WT_PTRDIFF(endp, ckpt->raw.mem);
 
@@ -963,12 +964,12 @@ __ckpt_update(
 
     /* Copy the COMPLETE checkpoint information into the checkpoint. */
     WT_RET(__wt_buf_init(session, &ckpt->raw, WT_BLOCK_CHECKPOINT_BUFFER));
-    endp = ckpt->raw.mem;
+    endp = (uint8_t *)ckpt->raw.mem;
     WT_RET(__wti_block_ckpt_pack(session, block, &endp, ci, false));
     ckpt->raw.size = WT_PTRDIFF(endp, ckpt->raw.mem);
 
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
-        __wti_ckpt_verbose(session, block, "create", ckpt->name, ckpt->raw.data, ckpt->raw.size);
+        __wti_ckpt_verbose(session, block, "create", ckpt->name, (const uint8_t *)ckpt->raw.data, ckpt->raw.size);
 
     return (0);
 }

--- a/src/block/block_ckpt_scan.c
+++ b/src/block/block_ckpt_scan.c
@@ -176,15 +176,15 @@ __block_checkpoint_update(WT_SESSION_IMPL *session, WT_BLOCK *block, struct save
     checkpoint = info->checkpoint;
 
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
-        __wti_ckpt_verbose(
-          session, block, "import original", NULL, (const uint8_t *)checkpoint->mem,
-          checkpoint->size);
+        __wti_ckpt_verbose(session, block, "import original", NULL,
+          (const uint8_t *)checkpoint->mem, checkpoint->size);
 
     /*
      * Convert the final checkpoint data blob to a WT_BLOCK_CKPT structure, update it with the avail
      * list information, and convert it back to a data blob.
      */
-    WT_RET(__wti_block_ckpt_unpack(session, block, (const uint8_t *)checkpoint->data, checkpoint->size, &ci));
+    WT_RET(__wti_block_ckpt_unpack(
+      session, block, (const uint8_t *)checkpoint->data, checkpoint->size, &ci));
     ci.avail.offset = info->offset;
     ci.avail.size = info->size;
     ci.avail.checksum = info->checksum;
@@ -195,8 +195,7 @@ __block_checkpoint_update(WT_SESSION_IMPL *session, WT_BLOCK *block, struct save
     checkpoint->size = WT_PTRDIFF(endp, checkpoint->mem);
 
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
-        __wti_ckpt_verbose(
-          session, block, "import replace", NULL, (const uint8_t *)checkpoint->mem,
+        __wti_ckpt_verbose(session, block, "import replace", NULL, (const uint8_t *)checkpoint->mem,
           checkpoint->size);
 
     return (0);
@@ -291,11 +290,11 @@ __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **met
             continue;
         }
 
-        dsk = (const WT_PAGE_HEADER*)tmp->mem;
+        dsk = (const WT_PAGE_HEADER *)tmp->mem;
         if (dsk->type != WT_PAGE_BLOCK_MANAGER)
             continue;
 
-        p = (const uint8_t*)WT_BLOCK_HEADER_BYTE(tmp->mem);
+        p = (const uint8_t *)WT_BLOCK_HEADER_BYTE(tmp->mem);
         WT_BLOCK_SKIP(__wt_extlist_read_pair(&p, &ext_off, &ext_size));
         if (ext_off != WT_BLOCK_EXTLIST_MAGIC || ext_size != 0)
             continue;

--- a/src/block/block_ckpt_scan.c
+++ b/src/block/block_ckpt_scan.c
@@ -177,25 +177,27 @@ __block_checkpoint_update(WT_SESSION_IMPL *session, WT_BLOCK *block, struct save
 
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
         __wti_ckpt_verbose(
-          session, block, "import original", NULL, checkpoint->mem, checkpoint->size);
+          session, block, "import original", NULL, (const uint8_t *)checkpoint->mem,
+          checkpoint->size);
 
     /*
      * Convert the final checkpoint data blob to a WT_BLOCK_CKPT structure, update it with the avail
      * list information, and convert it back to a data blob.
      */
-    WT_RET(__wti_block_ckpt_unpack(session, block, checkpoint->data, checkpoint->size, &ci));
+    WT_RET(__wti_block_ckpt_unpack(session, block, (const uint8_t *)checkpoint->data, checkpoint->size, &ci));
     ci.avail.offset = info->offset;
     ci.avail.size = info->size;
     ci.avail.checksum = info->checksum;
     ci.file_size = (wt_off_t)info->file_size;
     WT_RET(__wt_buf_extend(session, checkpoint, WT_BLOCK_CHECKPOINT_BUFFER));
-    endp = checkpoint->mem;
+    endp = (uint8_t *)checkpoint->mem;
     WT_RET(__wti_block_ckpt_pack(session, block, &endp, &ci, false));
     checkpoint->size = WT_PTRDIFF(endp, checkpoint->mem);
 
     if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_2))
         __wti_ckpt_verbose(
-          session, block, "import replace", NULL, checkpoint->mem, checkpoint->size);
+          session, block, "import replace", NULL, (const uint8_t *)checkpoint->mem,
+          checkpoint->size);
 
     return (0);
 }
@@ -272,7 +274,7 @@ __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **met
          */
         if (__wt_read(session, fh, offset, (size_t)WT_BTREE_MIN_ALLOC_SIZE, tmp->mem) != 0)
             break;
-        blk = WT_BLOCK_HEADER_REF(tmp->mem);
+        blk = (WT_BLOCK_HEADER *)WT_BLOCK_HEADER_REF(tmp->mem);
         __wt_block_header_byteswap(blk);
         size = blk->disk_size;
         checksum = blk->checksum;
@@ -289,11 +291,11 @@ __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **met
             continue;
         }
 
-        dsk = tmp->mem;
+        dsk = (const WT_PAGE_HEADER*)tmp->mem;
         if (dsk->type != WT_PAGE_BLOCK_MANAGER)
             continue;
 
-        p = WT_BLOCK_HEADER_BYTE(tmp->mem);
+        p = (const uint8_t*)WT_BLOCK_HEADER_BYTE(tmp->mem);
         WT_BLOCK_SKIP(__wt_extlist_read_pair(&p, &ext_off, &ext_size));
         if (ext_off != WT_BLOCK_EXTLIST_MAGIC || ext_size != 0)
             continue;

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1182,7 +1182,7 @@ __wti_block_extlist_read(
     WT_ERR(
       __wti_block_read_off(session, block, tmp, el->objectid, el->offset, el->size, el->checksum));
 
-    p = WT_BLOCK_HEADER_BYTE(tmp->mem);
+    p = (const uint8_t *)WT_BLOCK_HEADER_BYTE(tmp->mem);
     WT_ERR(__wt_extlist_read_pair(&p, &off, &size));
     if (off != WT_BLOCK_EXTLIST_MAGIC || size != 0)
         goto corrupted;
@@ -1266,13 +1266,13 @@ __wti_block_extlist_write(
     size = ((size_t)entries + 2) * 2 * WT_INTPACK64_MAXSIZE;
     WT_RET(__wt_block_write_size(session, block, &size));
     WT_RET(__wt_scr_alloc(session, size, &tmp));
-    dsk = tmp->mem;
+    dsk = (WT_PAGE_HEADER *)tmp->mem;
     memset(dsk, 0, WT_BLOCK_HEADER_BYTE_SIZE);
     dsk->type = WT_PAGE_BLOCK_MANAGER;
     dsk->version = WT_PAGE_VERSION_TS;
 
     /* Fill the page's data. */
-    p = WT_BLOCK_HEADER_BYTE(dsk);
+    p = (uint8_t *)WT_BLOCK_HEADER_BYTE(dsk);
     /* Extent list starts */
     WT_ERR(__wt_extlist_write_pair(&p, WT_BLOCK_EXTLIST_MAGIC, 0));
     WT_EXT_FOREACH (ext, el->off) /* Free ranges */

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -44,7 +44,7 @@ __wt_block_manager_drop_object(
      */
     WT_WITH_BUCKET_STORAGE(bstorage, session,
       ret = bstorage->file_system->fs_remove(
-        bstorage->file_system, (WT_SESSION *)session, tmp->data, 0));
+        bstorage->file_system, (WT_SESSION *)session, (const char*)tmp->data, 0));
     WT_ERR(ret);
 
 err:
@@ -82,9 +82,9 @@ __wt_block_manager_create(WT_SESSION_IMPL *session, const char *filename, uint32
 
         for (suffix = 1;; ++suffix) {
             WT_ERR(__wt_buf_fmt(session, tmp, "%s.%d", filename, suffix));
-            WT_ERR(__wt_fs_exist(session, tmp->data, &exists));
+            WT_ERR(__wt_fs_exist(session, (const char*)tmp->data, &exists));
             if (!exists) {
-                WT_ERR(__wt_fs_rename(session, filename, tmp->data, false));
+                WT_ERR(__wt_fs_rename(session, filename, (const char*)tmp->data, false));
                 __wt_verbose_notice(session, WT_VERB_BLOCK,
                   "unexpected file %s found, renamed to %s", filename, (const char *)tmp->data);
                 break;
@@ -312,7 +312,7 @@ __wti_desc_write(WT_SESSION_IMPL *session, WT_FH *fh, uint32_t allocsize)
      * The checksum is (potentially) returned in a big-endian format, swap it into place in a
      * separate step.
      */
-    desc = buf->mem;
+    desc = (WT_BLOCK_DESC *)buf->mem;
     desc->magic = WT_BLOCK_MAGIC;
     desc->majorv = WT_BLOCK_MAJOR_VERSION;
     desc->minorv = WT_BLOCK_MINOR_VERSION;
@@ -397,7 +397,7 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
      * restore the header's checksum, and byte-swap the whole thing as necessary, leaving us with a
      * calculated checksum that should match the checksum in the header.
      */
-    desc = buf->mem;
+    desc = (WT_BLOCK_DESC *)buf->mem;
     checksum_saved = checksum_tmp = desc->checksum;
 #ifdef WORDS_BIGENDIAN
     checksum_tmp = __wt_bswap32(checksum_tmp);

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -44,7 +44,7 @@ __wt_block_manager_drop_object(
      */
     WT_WITH_BUCKET_STORAGE(bstorage, session,
       ret = bstorage->file_system->fs_remove(
-        bstorage->file_system, (WT_SESSION *)session, (const char*)tmp->data, 0));
+        bstorage->file_system, (WT_SESSION *)session, (const char *)tmp->data, 0));
     WT_ERR(ret);
 
 err:
@@ -82,9 +82,9 @@ __wt_block_manager_create(WT_SESSION_IMPL *session, const char *filename, uint32
 
         for (suffix = 1;; ++suffix) {
             WT_ERR(__wt_buf_fmt(session, tmp, "%s.%d", filename, suffix));
-            WT_ERR(__wt_fs_exist(session, (const char*)tmp->data, &exists));
+            WT_ERR(__wt_fs_exist(session, (const char *)tmp->data, &exists));
             if (!exists) {
-                WT_ERR(__wt_fs_rename(session, filename, (const char*)tmp->data, false));
+                WT_ERR(__wt_fs_rename(session, filename, (const char *)tmp->data, false));
                 __wt_verbose_notice(session, WT_VERB_BLOCK,
                   "unexpected file %s found, renamed to %s", filename, (const char *)tmp->data);
                 break;

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -145,7 +145,7 @@ __wt_block_read_off_blind(
      */
     WT_RET(__wt_scr_alloc(session, block->allocsize, &tmp));
     WT_ERR(__wt_read(session, block->fh, offset, (size_t)block->allocsize, tmp->mem));
-    blk = WT_BLOCK_HEADER_REF(tmp->mem);
+    blk = (WT_BLOCK_HEADER *)WT_BLOCK_HEADER_REF(tmp->mem);
     __wt_block_header_byteswap(blk);
 
     *sizep = blk->disk_size;
@@ -232,7 +232,7 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
          * big-endian handling early on, and then select from the original or swapped structure as
          * needed.
          */
-        blk = WT_BLOCK_HEADER_REF(buf->mem);
+        blk = (WT_BLOCK_HEADER *)WT_BLOCK_HEADER_REF(buf->mem);
         __wt_block_header_byteswap_copy(blk, &swap);
         check_size = F_ISSET(&swap, WT_BLOCK_DATA_CKSUM) ? size : WT_BLOCK_COMPRESS_SKIP;
         if (swap.checksum == checksum) {
@@ -242,7 +242,7 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
                  * Swap the page-header as needed; this doesn't belong here, but it's the best place
                  * to catch all callers.
                  */
-                __wt_page_header_byteswap(buf->mem);
+                __wt_page_header_byteswap((WT_PAGE_HEADER *)buf->mem);
                 return (0);
             }
             full_checksum_mismatch = true;

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -49,7 +49,7 @@ __wti_block_ext_alloc(WT_SESSION_IMPL *session, WT_EXT **extp)
     WT_EXT *ext;
     u_int i;
 
-    bms = session->block_manager;
+    bms = (WT_BLOCK_MGR_SESSION *)session->block_manager;
 
     /* Return a WT_EXT structure for use from a cached list. */
     if (bms != NULL && bms->ext_cache != NULL) {
@@ -83,7 +83,7 @@ __block_ext_prealloc(WT_SESSION_IMPL *session, u_int max)
     WT_BLOCK_MGR_SESSION *bms;
     WT_EXT *ext;
 
-    bms = session->block_manager;
+    bms = (WT_BLOCK_MGR_SESSION *)session->block_manager;
 
     for (; bms->ext_cache_cnt < max; ++bms->ext_cache_cnt) {
         WT_RET(__block_ext_alloc(session, &ext));
@@ -103,7 +103,7 @@ __wti_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext)
 {
     WT_BLOCK_MGR_SESSION *bms;
 
-    if ((bms = session->block_manager) == NULL)
+    if ((bms = (WT_BLOCK_MGR_SESSION *)session->block_manager) == NULL)
         __wt_free(session, ext);
     else {
         ext->next[0] = bms->ext_cache;
@@ -123,7 +123,7 @@ __block_ext_discard(WT_SESSION_IMPL *session, u_int max)
     WT_BLOCK_MGR_SESSION *bms;
     WT_EXT *ext, *next;
 
-    bms = session->block_manager;
+    bms = (WT_BLOCK_MGR_SESSION *)session->block_manager;
     if (max != 0 && bms->ext_cache_cnt <= max)
         return (0);
 
@@ -162,7 +162,7 @@ __wti_block_size_alloc(WT_SESSION_IMPL *session, WT_SIZE **szp)
 {
     WT_BLOCK_MGR_SESSION *bms;
 
-    bms = session->block_manager;
+    bms = (WT_BLOCK_MGR_SESSION *)session->block_manager;
 
     /* Return a WT_SIZE structure for use from a cached list. */
     if (bms != NULL && bms->sz_cache != NULL) {
@@ -190,7 +190,7 @@ __block_size_prealloc(WT_SESSION_IMPL *session, u_int max)
     WT_BLOCK_MGR_SESSION *bms;
     WT_SIZE *sz;
 
-    bms = session->block_manager;
+    bms = (WT_BLOCK_MGR_SESSION *)session->block_manager;
 
     for (; bms->sz_cache_cnt < max; ++bms->sz_cache_cnt) {
         WT_RET(__block_size_alloc(session, &sz));
@@ -210,7 +210,7 @@ __wti_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz)
 {
     WT_BLOCK_MGR_SESSION *bms;
 
-    if ((bms = session->block_manager) == NULL)
+    if ((bms = (WT_BLOCK_MGR_SESSION *)session->block_manager) == NULL)
         __wt_free(session, sz);
     else {
         sz->next[0] = bms->sz_cache;
@@ -230,7 +230,7 @@ __block_size_discard(WT_SESSION_IMPL *session, u_int max)
     WT_BLOCK_MGR_SESSION *bms;
     WT_SIZE *nsz, *sz;
 
-    bms = session->block_manager;
+    bms = (WT_BLOCK_MGR_SESSION *)session->block_manager;
     if (max != 0 && bms->sz_cache_cnt <= max)
         return (0);
 

--- a/src/block/block_slvg.c
+++ b/src/block/block_slvg.c
@@ -129,7 +129,7 @@ __wt_block_salvage_next(
          * it. Move to the next allocation sized boundary, we'll never consider this one again.
          */
         WT_ERR(__wt_read(session, fh, offset, (size_t)allocsize, tmp->mem));
-        blk = WT_BLOCK_HEADER_REF(tmp->mem);
+        blk = (WT_BLOCK_HEADER *)WT_BLOCK_HEADER_REF(tmp->mem);
         __wt_block_header_byteswap(blk);
         size = blk->disk_size;
         checksum = blk->checksum;

--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -119,7 +119,8 @@ __verify_last_avail(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt)
 
     ci = &_ci;
     WT_RET(__wti_block_ckpt_init(session, ci, ckpt->name));
-    WT_ERR(__wti_block_ckpt_unpack(session, block, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, ci));
+    WT_ERR(
+      __wti_block_ckpt_unpack(session, block, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, ci));
 
     el = &ci->avail;
     if (el->offset != WT_BLOCK_INVALID_OFFSET) {
@@ -148,7 +149,8 @@ __verify_set_file_size(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt)
 
     ci = &_ci;
     WT_RET(__wti_block_ckpt_init(session, ci, ckpt->name));
-    WT_ERR(__wti_block_ckpt_unpack(session, block, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, ci));
+    WT_ERR(
+      __wti_block_ckpt_unpack(session, block, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, ci));
 
     if (block->verify_layout) {
         WT_ERR(__wt_scr_alloc(session, 0, &tmp));

--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -119,7 +119,7 @@ __verify_last_avail(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt)
 
     ci = &_ci;
     WT_RET(__wti_block_ckpt_init(session, ci, ckpt->name));
-    WT_ERR(__wti_block_ckpt_unpack(session, block, ckpt->raw.data, ckpt->raw.size, ci));
+    WT_ERR(__wti_block_ckpt_unpack(session, block, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, ci));
 
     el = &ci->avail;
     if (el->offset != WT_BLOCK_INVALID_OFFSET) {
@@ -148,7 +148,7 @@ __verify_set_file_size(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckpt)
 
     ci = &_ci;
     WT_RET(__wti_block_ckpt_init(session, ci, ckpt->name));
-    WT_ERR(__wti_block_ckpt_unpack(session, block, ckpt->raw.data, ckpt->raw.size, ci));
+    WT_ERR(__wti_block_ckpt_unpack(session, block, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, ci));
 
     if (block->verify_layout) {
         WT_ERR(__wt_scr_alloc(session, 0, &tmp));

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -293,7 +293,7 @@ __block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_of
     /*
      * Clear the block header to ensure all of it is initialized, even the unused fields.
      */
-    blk = WT_BLOCK_HEADER_REF(buf->mem);
+    blk = (WT_BLOCK_HEADER *)WT_BLOCK_HEADER_REF(buf->mem);
     memset(blk, 0, sizeof(*blk));
 
     /*
@@ -389,9 +389,9 @@ __wti_block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, w
      * place to catch all callers. After the write, swap values back to native order so callers
      * never see anything other than their original content.
      */
-    __wt_page_header_byteswap(buf->mem);
+    __wt_page_header_byteswap((WT_PAGE_HEADER *)buf->mem);
     ret = __block_write_off(
       session, block, buf, offsetp, sizep, checksump, data_checksum, checkpoint_io, caller_locked);
-    __wt_page_header_byteswap(buf->mem);
+    __wt_page_header_byteswap((WT_PAGE_HEADER *)buf->mem);
     return (ret);
 }

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -216,7 +216,7 @@ verify:
         if (tmp == NULL)
             WT_ERR(__wt_scr_alloc(session, 4 * 1024, &tmp));
         WT_ERR(bm->addr_string(bm, session, tmp, addr, addr_size));
-        WT_ERR(__wt_verify_dsk(session, (const char*)tmp->data, buf));
+        WT_ERR(__wt_verify_dsk(session, (const char *)tmp->data, buf));
     }
 
 err:

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -120,7 +120,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
             WT_STAT_SESSION_INCRV(session, read_time, time_diff);
         }
 
-        dsk = ip->data;
+        dsk = (const WT_PAGE_HEADER *)ip->data;
         WT_STAT_CONN_DSRC_INCR(session, cache_read);
         if (WT_SESSION_IS_CHECKPOINT(session))
             WT_STAT_CONN_DSRC_INCR(session, cache_read_checkpoint);
@@ -135,7 +135,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
      * If the block is encrypted, copy the skipped bytes of the image into place, then decrypt. DRAM
      * block-cache blocks are never encrypted.
      */
-    dsk = ip->data;
+    dsk = (const WT_PAGE_HEADER *)ip->data;
     if (!blkcache_found || blkcache->type != WT_BLKCACHE_DRAM) {
         if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
             if (encryptor == NULL || encryptor->decrypt == NULL)
@@ -161,7 +161,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
     if (!skip_cache_put)
         WT_ERR(__wti_blkcache_put(session, ip, addr, addr_size, false));
 
-    dsk = ip->data;
+    dsk = (const WT_PAGE_HEADER *)ip->data;
     if (F_ISSET(dsk, WT_PAGE_COMPRESSED)) {
         if (compressor == NULL || compressor->decompress == NULL) {
             ret = __blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
@@ -216,7 +216,7 @@ verify:
         if (tmp == NULL)
             WT_ERR(__wt_scr_alloc(session, 4 * 1024, &tmp));
         WT_ERR(bm->addr_string(bm, session, tmp, addr, addr_size));
-        WT_ERR(__wt_verify_dsk(session, tmp->data, buf));
+        WT_ERR(__wt_verify_dsk(session, (const char*)tmp->data, buf));
     }
 
 err:
@@ -323,7 +323,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_
             ip = ctmp;
 
             /* Set the disk header flags. */
-            dsk = ip->mem;
+            dsk = (WT_PAGE_HEADER *)ip->mem;
             F_SET(dsk, WT_PAGE_COMPRESSED);
 
             /* Optionally return the compressed size. */
@@ -350,7 +350,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_
         ip = etmp;
 
         /* Set the disk header flags. */
-        dsk = ip->mem;
+        dsk = (WT_PAGE_HEADER *)ip->mem;
         if (compressed)
             F_SET(dsk, WT_PAGE_COMPRESSED);
         F_SET(dsk, WT_PAGE_ENCRYPTED);
@@ -391,7 +391,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_
      * images that are created during recovery may have the write generation number less than the
      * btree base write generation number, so don't verify it.
      */
-    dsk = ip->mem;
+    dsk = (WT_PAGE_HEADER *)ip->mem;
     WT_ASSERT(session, dsk->write_gen != 0);
 
     WT_STAT_CONN_DSRC_INCR(session, cache_write);

--- a/src/block_cache/block_tier.c
+++ b/src/block_cache/block_tier.c
@@ -91,7 +91,7 @@ __wti_blkcache_tiered_open(
 
         bstorage = tiered->bstorage;
         WT_WITH_BUCKET_STORAGE(bstorage, session,
-          ret = __wt_block_open(session, tmp->mem, objectid, cfg, false, true, true, 0, &block));
+          ret = __wt_block_open(session, (const char*)tmp->mem, objectid, cfg, false, true, true, 0, &block));
         block->remote = true;
         WT_ERR(ret);
     }

--- a/src/block_cache/block_tier.c
+++ b/src/block_cache/block_tier.c
@@ -91,7 +91,8 @@ __wti_blkcache_tiered_open(
 
         bstorage = tiered->bstorage;
         WT_WITH_BUCKET_STORAGE(bstorage, session,
-          ret = __wt_block_open(session, (const char*)tmp->mem, objectid, cfg, false, true, true, 0, &block));
+          ret = __wt_block_open(
+            session, (const char *)tmp->mem, objectid, cfg, false, true, true, 0, &block));
         block->remote = true;
         WT_ERR(ret);
     }

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -109,7 +109,7 @@ __compact_page_replace_addr(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY 
      * If there's no address at all (the page has never been written), allocate a new WT_ADDR
      * structure, otherwise, the address has already been instantiated, replace the cookie.
      */
-    addr = ref->addr;
+    addr = (WT_ADDR *)ref->addr;
     WT_ASSERT(session, addr != NULL);
 
     if (__wt_off_page(ref->home, addr))

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -301,7 +301,7 @@ restart_read:
         }
 
         /* Unpack the cell and build the return information. */
-        cell = WT_COL_PTR(page, cip);
+        cell = (WT_CELL *)WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
         rle = __wt_cell_rle(&unpack);
         if (unpack.type == WT_CELL_DEL) {

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -474,7 +474,7 @@ restart_read:
         }
 
         /* Unpack the cell and build the return information. */
-        cell = WT_COL_PTR(page, cip);
+        cell = (WT_CELL *)WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
         rle = __wt_cell_rle(&unpack);
         if (unpack.type == WT_CELL_DEL) {

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -466,7 +466,7 @@ __cursor_valid_col(WT_CURSOR_BTREE *cbt, bool *valid, bool check_bounds)
          * when read.
          */
         cip = &page->pg_var[cbt->slot];
-        cell = WT_COL_PTR(page, cip);
+        cell = (WT_CELL *)WT_COL_PTR(page, cip);
         if (__wt_cell_type(cell) == WT_CELL_DEL)
             return (0);
 
@@ -1798,7 +1798,7 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     WT_DECL_ITEM(modify);
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
-    size_t new, orig;
+    size_t new_size, orig_size;
     bool overwrite;
 
     cursor = &cbt->iface;
@@ -1836,13 +1836,13 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
 
     WT_ERR(__wt_modify_pack(cursor, entries, nentries, &modify));
 
-    orig = cursor->value.size;
+    orig_size = cursor->value.size;
     WT_ERR(__wt_modify_apply_item(session, cursor->value_format, &cursor->value, modify->data));
-    new = cursor->value.size;
+    new_size = cursor->value.size;
     WT_ERR(__cursor_size_chk(session, &cursor->value));
 
     WT_STAT_CONN_DSRC_INCRV(
-      session, cursor_update_bytes_changed, new > orig ? new - orig : orig - new);
+      session, cursor_update_bytes_changed, new_size > orig_size ? new_size - orig_size : orig_size - new_size);
 
     /*
      * WT_CURSOR.modify is update-without-overwrite.

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1841,8 +1841,8 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     new_size = cursor->value.size;
     WT_ERR(__cursor_size_chk(session, &cursor->value));
 
-    WT_STAT_CONN_DSRC_INCRV(
-      session, cursor_update_bytes_changed, new_size > orig_size ? new_size - orig_size : orig_size - new_size);
+    WT_STAT_CONN_DSRC_INCRV(session, cursor_update_bytes_changed,
+      new_size > orig_size ? new_size - orig_size : orig_size - new_size);
 
     /*
      * WT_CURSOR.modify is update-without-overwrite.

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -576,7 +576,8 @@ __debug_cell_int(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_ADDR *unp
             WT_RET(ds->f(ds, " | %s", __wt_time_aggregate_to_string(&unpack->ta, time_string)));
 
         WT_RET(__wt_scr_alloc(session, 128, &buf));
-        ret = ds->f(ds, " | addr: %s", __wt_addr_string(session, (const uint8_t *)unpack->data, unpack->size, buf));
+        ret = ds->f(ds, " | addr: %s",
+          __wt_addr_string(session, (const uint8_t *)unpack->data, unpack->size, buf));
         __wt_scr_free(session, &buf);
         WT_RET(ret);
         break;
@@ -681,8 +682,8 @@ __debug_cell_kv(
     switch (unpack->raw) {
     case WT_CELL_KEY_OVFL:
     case WT_CELL_VALUE_OVFL:
-        WT_RET(
-          ds->f(ds, " | addr: %s", __wt_addr_string(session, (const uint8_t *)unpack->data, unpack->size, ds->t1)));
+        WT_RET(ds->f(ds, " | addr: %s",
+          __wt_addr_string(session, (const uint8_t *)unpack->data, unpack->size, ds->t1)));
         break;
     }
     WT_RET(ds->f(ds, "\n"));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -101,7 +101,7 @@ __debug_bytes(WT_DBG *ds, const void *data_arg, size_t size)
     const uint8_t *data;
     u_char ch;
 
-    for (data = data_arg, i = 0; i < size; ++i, ++data) {
+    for (data = (const uint8_t *)data_arg, i = 0; i < size; ++i, ++data) {
         ch = data[0];
         if (__wt_isprint(ch))
             WT_RET(ds->f(ds, "%c", (int)ch));
@@ -384,7 +384,7 @@ __wt_debug_addr(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size,
 
     WT_RET(__wt_scr_alloc(session, 1024, &buf));
     WT_ERR(__wt_blkcache_read(session, buf, addr, addr_size));
-    ret = __wti_debug_disk(session, buf->mem, ofile, false, false);
+    ret = __wti_debug_disk(session, (const WT_PAGE_HEADER *)buf->mem, ofile, false, false);
 
 err:
     __wt_scr_free(session, &buf);
@@ -443,7 +443,7 @@ __wt_debug_offset(
      */
     WT_RET(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(__wt_blkcache_read(session, buf, addr, WT_PTRDIFF(endp, addr)));
-    ret = __wti_debug_disk(session, buf->mem, ofile, false, false);
+    ret = __wti_debug_disk(session, (const WT_PAGE_HEADER *)buf->mem, ofile, false, false);
 
 err:
     __wt_scr_free(session, &buf);
@@ -480,7 +480,7 @@ __debug_hs_cursor(WT_DBG *ds, WT_CURSOR *hs_cursor)
             WT_RET(ds->f(ds,
               "\t"
               "hs_modify: "));
-            WT_RET(__debug_modify(ds, ds->hs_value->data));
+            WT_RET(__debug_modify(ds, (const uint8_t *)ds->hs_value->data));
             WT_RET(ds->f(ds, "\n"));
         } else
             WT_RET(ds->f(ds,
@@ -576,7 +576,7 @@ __debug_cell_int(WT_DBG *ds, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_ADDR *unp
             WT_RET(ds->f(ds, " | %s", __wt_time_aggregate_to_string(&unpack->ta, time_string)));
 
         WT_RET(__wt_scr_alloc(session, 128, &buf));
-        ret = ds->f(ds, " | addr: %s", __wt_addr_string(session, unpack->data, unpack->size, buf));
+        ret = ds->f(ds, " | addr: %s", __wt_addr_string(session, (const uint8_t *)unpack->data, unpack->size, buf));
         __wt_scr_free(session, &buf);
         WT_RET(ret);
         break;
@@ -682,7 +682,7 @@ __debug_cell_kv(
     case WT_CELL_KEY_OVFL:
     case WT_CELL_VALUE_OVFL:
         WT_RET(
-          ds->f(ds, " | addr: %s", __wt_addr_string(session, unpack->data, unpack->size, ds->t1)));
+          ds->f(ds, " | addr: %s", __wt_addr_string(session, (const uint8_t *)unpack->data, unpack->size, ds->t1)));
         break;
     }
     WT_RET(ds->f(ds, "\n"));
@@ -1060,7 +1060,7 @@ __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
     WT_SESSION_IMPL *session;
     bool did_hs_checkpoint;
 
-    cbt = cursor_arg;
+    cbt = (WT_CURSOR_BTREE *)cursor_arg;
     session = CUR2S(cursor_arg);
     did_hs_checkpoint = false;
 
@@ -1418,14 +1418,14 @@ __debug_page_col_var(WT_DBG *ds, WT_REF *ref)
     recno = ref->ref_recno;
 
     WT_COL_FOREACH (page, cip, i) {
-        cell = WT_COL_PTR(page, cip);
+        cell = (WT_CELL *)WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(ds->session, page->dsk, cell, unpack);
         rle = __wt_cell_rle(unpack);
         WT_RET(ds->f(ds, "\trecno: {%" PRIu64 "}\n", recno));
         WT_RET(__debug_cell_kv(ds, page, WT_PAGE_COL_VAR, "V", unpack));
 
         if (!WT_IS_HS(session->dhandle) && ds->hs_cursor != NULL) {
-            p = ds->key->mem;
+            p = (uint8_t *)ds->key->mem;
             WT_RET(__wt_vpack_uint(&p, 0, recno));
             ds->key->size = WT_PTRDIFF(p, ds->key->mem);
             WT_RET(__debug_hs_key(ds));
@@ -1543,7 +1543,7 @@ __debug_col_skip(
         WT_RET(__debug_update(ds, ins->upd, hexbyte));
 
         if (!WT_IS_HS(session->dhandle) && hs_cursor != NULL) {
-            p = ds->key->mem;
+            p = (uint8_t *)ds->key->mem;
             WT_RET(__wt_vpack_uint(&p, 0, WT_INSERT_RECNO(ins)));
             ds->key->size = WT_PTRDIFF(p, ds->key->mem);
             WT_RET(__debug_hs_key(ds));

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -520,7 +520,7 @@ __instantiate_col_var(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_DELETED *pa
     recno = ref->ref_recno;
     WT_COL_FOREACH (page, cip, i) {
         /* Retrieve the stop time point from the page. */
-        __wt_cell_unpack_kv(session, page->dsk, WT_COL_PTR(page, cip), &unpack);
+        __wt_cell_unpack_kv(session, page->dsk, (WT_CELL *)WT_COL_PTR(page, cip), &unpack);
         rle = __wt_cell_rle(&unpack);
 
         /* If it's already deleted, it doesn't need another tombstone. */

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -138,7 +138,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
          * checkpoint (the file is being created), or the load call returns no root page (the
          * checkpoint is for an empty file).
          */
-        WT_ERR(bm->checkpoint_load(bm, session, ckpt.raw.data, ckpt.raw.size, root_addr,
+        WT_ERR(bm->checkpoint_load(bm, session, (const uint8_t*)ckpt.raw.data, ckpt.raw.size, root_addr,
           &root_addr_size, F_ISSET(btree, WT_BTREE_READONLY)));
         if (creation || root_addr_size == 0)
             WT_ERR(__btree_tree_open_empty(session, creation));
@@ -647,7 +647,7 @@ __wti_btree_tree_open(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
 
     F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
     if ((ret = __wt_blkcache_read(session, &dsk, addr, addr_size)) == 0)
-        ret = __wt_verify_dsk(session, tmp->data, &dsk);
+        ret = __wt_verify_dsk(session, (const char*)tmp->data, &dsk);
     /*
      * Flag any failed read or verification: if we're in startup, it may be fatal.
      */

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -138,8 +138,8 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
          * checkpoint (the file is being created), or the load call returns no root page (the
          * checkpoint is for an empty file).
          */
-        WT_ERR(bm->checkpoint_load(bm, session, (const uint8_t*)ckpt.raw.data, ckpt.raw.size, root_addr,
-          &root_addr_size, F_ISSET(btree, WT_BTREE_READONLY)));
+        WT_ERR(bm->checkpoint_load(bm, session, (const uint8_t *)ckpt.raw.data, ckpt.raw.size,
+          root_addr, &root_addr_size, F_ISSET(btree, WT_BTREE_READONLY)));
         if (creation || root_addr_size == 0)
             WT_ERR(__btree_tree_open_empty(session, creation));
         else {
@@ -647,7 +647,7 @@ __wti_btree_tree_open(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
 
     F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
     if ((ret = __wt_blkcache_read(session, &dsk, addr, addr_size)) == 0)
-        ret = __wt_verify_dsk(session, (const char*)tmp->data, &dsk);
+        ret = __wt_verify_dsk(session, (const char *)tmp->data, &dsk);
     /*
      * Flag any failed read or verification: if we're in startup, it may be fatal.
      */

--- a/src/btree/bt_import.c
+++ b/src/btree/bt_import.c
@@ -92,7 +92,7 @@ __wt_import_repair(WT_SESSION_IMPL *session, const char *uri, char **configp)
      * imported file has not been part of backup. Strip out the checkpoint LSN, an imported file
      * isn't associated with any log files. Assign a unique file ID.
      */
-    cfg[1] = (const char*)a->data;
+    cfg[1] = (const char *)a->data;
     cfg[2] = checkpoint_list;
     WT_ERR(__wt_reset_blkmod(session, (const char *)a->data, buf));
     cfg[3] = (const char *)buf->mem;

--- a/src/btree/bt_import.c
+++ b/src/btree/bt_import.c
@@ -92,10 +92,10 @@ __wt_import_repair(WT_SESSION_IMPL *session, const char *uri, char **configp)
      * imported file has not been part of backup. Strip out the checkpoint LSN, an imported file
      * isn't associated with any log files. Assign a unique file ID.
      */
-    cfg[1] = a->data;
+    cfg[1] = (const char*)a->data;
     cfg[2] = checkpoint_list;
-    WT_ERR(__wt_reset_blkmod(session, a->data, buf));
-    cfg[3] = buf->mem;
+    WT_ERR(__wt_reset_blkmod(session, (const char *)a->data, buf));
+    cfg[3] = (const char *)buf->mem;
     cfg[4] = "checkpoint_lsn=";
     WT_WITH_SCHEMA_LOCK(session,
       ret = __wt_snprintf(fileid, sizeof(fileid), "id=%" PRIu32, ++S2C(session)->next_file_id));

--- a/src/btree/bt_misc.c
+++ b/src/btree/bt_misc.c
@@ -30,7 +30,7 @@ __wt_addr_string(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size
         buf->data = WT_ERR_STRING;
         buf->size = strlen(WT_ERR_STRING);
     }
-    return (buf->data);
+    return ((const char *)buf->data);
 }
 
 /*

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -28,7 +28,7 @@ __ovfl_read(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size, WT_
      * page sizes, overflow items should be rare.
      */
     WT_RET(__wt_blkcache_read(session, store, addr, addr_size));
-    dsk = store->data;
+    dsk = (const WT_PAGE_HEADER *)store->data;
     store->data = WT_PAGE_HEADER_BYTE(btree, dsk);
     store->size = dsk->u.datalen;
 
@@ -54,7 +54,7 @@ __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_COMMON *u
      * about WT_CELL_VALUE_OVFL_RM cells.
      */
     if (page == NULL)
-        return (__ovfl_read(session, unpack->data, unpack->size, store));
+        return (__ovfl_read(session, (const uint8_t *)unpack->data, unpack->size, store));
 
     /*
      * WT_CELL_VALUE_OVFL_RM cells: if reconciliation deletes an overflow value, the on-page cell
@@ -67,7 +67,7 @@ __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_COMMON *u
         ret = __wt_buf_setstr(session, store, "WT_CELL_VALUE_OVFL_RM");
         *decoded = true;
     } else
-        ret = __ovfl_read(session, unpack->data, unpack->size, store);
+        ret = __ovfl_read(session, (const uint8_t *)unpack->data, unpack->size, store);
     __wt_readunlock(session, &S2BT(session)->ovfl_lock);
 
     return (ret);
@@ -152,5 +152,5 @@ __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
     __wt_writeunlock(session, &btree->ovfl_lock);
 
     /* Free the backing disk blocks. */
-    return (bm->free(bm, session, unpack->data, unpack->size));
+    return (bm->free(bm, session, (const uint8_t *)unpack->data, unpack->size));
 }

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -79,7 +79,7 @@ __wt_page_alloc(
         WT_ERR(
           __wt_calloc(session, 1, sizeof(WT_PAGE_INDEX) + alloc_entries * sizeof(WT_REF *), &p));
         size += sizeof(WT_PAGE_INDEX) + alloc_entries * sizeof(WT_REF *);
-        pindex = p;
+        pindex = (WT_PAGE_INDEX *)p;
         pindex->index = (WT_REF **)((WT_PAGE_INDEX *)p + 1);
         pindex->entries = alloc_entries;
         WT_INTL_INDEX_SET(page, pindex);
@@ -247,7 +247,7 @@ __wti_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
         recno = ref->ref_recno;
         WT_COL_FOREACH (page, cip, i) {
             /* Search for prepare records. */
-            cell = WT_COL_PTR(page, cip);
+            cell = (WT_CELL *)WT_COL_PTR(page, cip);
             __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
             rle = __wt_cell_rle(&unpack);
             if (!unpack.tw.prepare) {
@@ -352,7 +352,7 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     if (preparedp != NULL)
         *preparedp = false;
 
-    dsk = image;
+    dsk = (const WT_PAGE_HEADER *)image;
     alloc_entries = 0;
 
     /*
@@ -556,7 +556,7 @@ __inmem_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, bool *preparedp, size_t
     tmp = 0;
     prepare = false;
 
-    page->pg_fix_bitf = WT_PAGE_HEADER_BYTE(btree, dsk);
+    page->pg_fix_bitf = (uint8_t *)WT_PAGE_HEADER_BYTE(btree, dsk);
 
     WT_RET(__wti_col_fix_read_auxheader(session, dsk, &auxhdr));
     WT_ASSERT(session, auxhdr.dataoffset <= dsk->mem_size);
@@ -577,7 +577,7 @@ __inmem_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, bool *preparedp, size_t
         entry_num = 0;
         WT_CELL_FOREACH_FIX_TIMESTAMPS (session, dsk, &auxhdr, unpack) {
             if (unpack.type == WT_CELL_KEY) {
-                p8 = unpack.data;
+                p8 = (const uint8_t *)unpack.data;
                 /* The array is attached to the page, so we don't need to free it on error here. */
                 WT_RET(__wt_vunpack_uint(&p8, unpack.size, &tmp));
                 /* For now at least, check that the entries are in ascending order. */
@@ -592,7 +592,7 @@ __inmem_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, bool *preparedp, size_t
                       (auxhdr.entries - skipped) * sizeof(WT_COL_FIX_TW_ENTRY);
                     WT_RET(__wt_calloc(session, 1, size, &pv));
                     *sizep += size;
-                    page->u.col_fix.fix_tw = pv;
+                    page->u.col_fix.fix_tw = (WT_COL_FIX_TW *)pv;
                 }
                 page->pg_fix_tws[entry_num].recno_offset = recno_offset;
                 page->pg_fix_tws[entry_num].cell_offset = WT_PAGE_DISK_OFFSET(page, unpack.cell);
@@ -795,7 +795,7 @@ __inmem_col_var(
                 WT_RET(__wt_calloc(session, 1, size, &p));
                 *sizep += size;
 
-                page->u.col_var.repeats = p;
+                page->u.col_var.repeats = (WT_COL_VAR_REPEAT *)p;
                 page->pg_var_nrepeats = n;
                 repeats = page->pg_var_repeats;
             }

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -181,7 +181,8 @@ __wt_read_cell_time_window(WT_CURSOR_BTREE *cbt, WT_TIME_WINDOW *tw)
          */
         if (page->pg_var == NULL || (cbt->ins != NULL && !F_ISSET(cbt, WT_CBT_VAR_ONPAGE_MATCH)))
             return (false);
-        __read_col_time_window(session, page, (WT_CELL *)WT_COL_PTR(page, &page->pg_var[cbt->slot]), tw);
+        __read_col_time_window(
+          session, page, (WT_CELL *)WT_COL_PTR(page, &page->pg_var[cbt->slot]), tw);
         break;
     case WT_PAGE_COL_FIX:
         return (__col_fix_get_time_window(session, cbt->ref, cbt->recno, tw));

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -181,7 +181,7 @@ __wt_read_cell_time_window(WT_CURSOR_BTREE *cbt, WT_TIME_WINDOW *tw)
          */
         if (page->pg_var == NULL || (cbt->ins != NULL && !F_ISSET(cbt, WT_CBT_VAR_ONPAGE_MATCH)))
             return (false);
-        __read_col_time_window(session, page, WT_COL_PTR(page, &page->pg_var[cbt->slot]), tw);
+        __read_col_time_window(session, page, (WT_CELL *)WT_COL_PTR(page, &page->pg_var[cbt->slot]), tw);
         break;
     case WT_PAGE_COL_FIX:
         return (__col_fix_get_time_window(session, cbt->ref, cbt->recno, tw));
@@ -253,7 +253,7 @@ __wt_value_return_buf(WT_CURSOR_BTREE *cbt, WT_REF *ref, WT_ITEM *buf, WT_TIME_W
 
     case WT_PAGE_COL_VAR:
         /* Take the value from the original page cell. */
-        cell = WT_COL_PTR(page, &page->pg_var[cbt->slot]);
+        cell = (WT_CELL *)WT_COL_PTR(page, &page->pg_var[cbt->slot]);
         __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
         return (__read_page_cell_data_ref_kv(session, page, &unpack, buf, tw));
 

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -477,7 +477,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
          * file to grow as little as possible, or shrink, and future salvage calls don't need them
          * either.
          */
-        dsk = (const WT_PAGE_HEADER*)buf->data;
+        dsk = (const WT_PAGE_HEADER *)buf->data;
         switch (dsk->type) {
         case WT_PAGE_BLOCK_MANAGER:
         case WT_PAGE_COL_INT:
@@ -495,7 +495,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
          * the end of the file or overflow references to non-existent pages, might as well discard
          * these pages now.
          */
-        if (__wt_verify_dsk(session, (const char*)as->data, buf) != 0) {
+        if (__wt_verify_dsk(session, (const char *)as->data, buf) != 0) {
             __wt_verbose(session, WT_VERB_SALVAGE, "%s page failed verify %s",
               __wt_page_type_string(dsk->type), (const char *)as->data);
             WT_ERR(bm->free(bm, session, addr, addr_size));
@@ -2203,8 +2203,8 @@ __slvg_ovfl_reconcile(WT_SESSION_IMPL *session, WT_STUFF *ss)
              * there were no overflow items at all.
              */
             searchp = (WT_TRACK **)(ss->ovfl == NULL ?
-              NULL :
-              bsearch(addr, ss->ovfl, ss->ovfl_next, sizeof(WT_TRACK *), __slvg_ovfl_compare));
+                NULL :
+                bsearch(addr, ss->ovfl, ss->ovfl_next, sizeof(WT_TRACK *), __slvg_ovfl_compare));
 
             /*
              * If the overflow page doesn't exist or if another page has already claimed it, this

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -477,7 +477,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
          * file to grow as little as possible, or shrink, and future salvage calls don't need them
          * either.
          */
-        dsk = buf->data;
+        dsk = (const WT_PAGE_HEADER*)buf->data;
         switch (dsk->type) {
         case WT_PAGE_BLOCK_MANAGER:
         case WT_PAGE_COL_INT:
@@ -495,7 +495,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
          * the end of the file or overflow references to non-existent pages, might as well discard
          * these pages now.
          */
-        if (__wt_verify_dsk(session, as->data, buf) != 0) {
+        if (__wt_verify_dsk(session, (const char*)as->data, buf) != 0) {
             __wt_verbose(session, WT_VERB_SALVAGE, "%s page failed verify %s",
               __wt_page_type_string(dsk->type), (const char *)as->data);
             WT_ERR(bm->free(bm, session, addr, addr_size));
@@ -773,7 +773,7 @@ __slvg_trk_leaf_ovfl(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_TRA
 
             __wt_verbose(session, WT_VERB_SALVAGE, "%s overflow reference %s",
               __wt_addr_string(session, trk->trk_addr, trk->trk_addr_size, trk->ss->tmp1),
-              __wt_addr_string(session, unpack.data, unpack.size, trk->ss->tmp2));
+              __wt_addr_string(session, (const uint8_t *)unpack.data, unpack.size, trk->ss->tmp2));
 
             if (++ovfl_cnt == trk->trk_ovfl_cnt)
                 break;
@@ -925,7 +925,7 @@ static int
 __slvg_col_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_slot, WT_STUFF *ss)
 {
     WT_DECL_RET;
-    WT_TRACK *a_trk, *b_trk, *new;
+    WT_TRACK *a_trk, *b_trk, *new_trk;
     uint32_t i;
 
     /*
@@ -1060,10 +1060,10 @@ delete_b:
      *
      * Allocate a new WT_TRACK object, and extend the array of pages as necessary.
      */
-    WT_RET(__wt_calloc_one(session, &new));
+    WT_RET(__wt_calloc_one(session, &new_trk));
     if ((ret = __wt_realloc_def(session, &ss->pages_allocated, ss->pages_next + 1, &ss->pages)) !=
       0) {
-        __wt_free(session, new);
+        __wt_free(session, new_trk);
         return (ret);
     }
 
@@ -1071,9 +1071,9 @@ delete_b:
      * First, set up the track share (we do this after the allocation to ensure the shared reference
      * count is never incorrect).
      */
-    new->shared = a_trk->shared;
-    new->ss = a_trk->ss;
-    ++new->shared->ref;
+    new_trk->shared = a_trk->shared;
+    new_trk->ss = a_trk->ss;
+    ++new_trk->shared->ref;
 
     /*
      * Second, insert the new element into the array after the existing element (that's probably
@@ -1081,7 +1081,7 @@ delete_b:
      */
     memmove(
       ss->pages + a_slot + 1, ss->pages + a_slot, (ss->pages_next - a_slot) * sizeof(*ss->pages));
-    ss->pages[a_slot + 1] = new;
+    ss->pages[a_slot + 1] = new_trk;
     ++ss->pages_next;
 
     /*
@@ -1090,8 +1090,8 @@ delete_b:
      * __slvg_col_trk_update_start. That function will re-sort the WT_TRACK array as necessary to
      * move our new entry into the right sorted location.
      */
-    new->col_start = b_trk->col_stop + 1;
-    new->col_stop = a_trk->col_stop;
+    new_trk->col_start = b_trk->col_stop + 1;
+    new_trk->col_stop = a_trk->col_stop;
     __slvg_col_trk_update_start(a_slot + 1, ss);
 
     /*
@@ -1100,7 +1100,7 @@ delete_b:
      */
     a_trk->col_stop = b_trk->col_start - 1;
 
-    F_SET(new, WT_TRACK_MERGE);
+    F_SET(new_trk, WT_TRACK_MERGE);
     F_SET(a_trk, WT_TRACK_MERGE);
 
 merge:
@@ -1415,7 +1415,7 @@ __slvg_col_ovfl(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_PAGE *page)
      * that tracking succeeds.
      */
     WT_COL_FOREACH (page, cip, i) {
-        cell = WT_COL_PTR(page, cip);
+        cell = (WT_CELL *)WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
         if (unpack.type != WT_CELL_VALUE_OVFL)
             continue;
@@ -1506,7 +1506,7 @@ __slvg_row_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_s
 {
     WT_BTREE *btree;
     WT_DECL_RET;
-    WT_TRACK *a_trk, *b_trk, *new;
+    WT_TRACK *a_trk, *b_trk, *new_trk;
     uint32_t i;
     int start_cmp, stop_cmp;
 
@@ -1649,10 +1649,10 @@ delete_b:
      *
      * Allocate a new WT_TRACK object, and extend the array of pages as necessary.
      */
-    WT_RET(__wt_calloc_one(session, &new));
+    WT_RET(__wt_calloc_one(session, &new_trk));
     if ((ret = __wt_realloc_def(session, &ss->pages_allocated, ss->pages_next + 1, &ss->pages)) !=
       0) {
-        __wt_free(session, new);
+        __wt_free(session, new_trk);
         return (ret);
     }
 
@@ -1660,9 +1660,9 @@ delete_b:
      * First, set up the track share (we do this after the allocation to ensure the shared reference
      * count is never incorrect).
      */
-    new->shared = a_trk->shared;
-    new->ss = a_trk->ss;
-    ++new->shared->ref;
+    new_trk->shared = a_trk->shared;
+    new_trk->ss = a_trk->ss;
+    ++new_trk->shared->ref;
 
     /*
      * Second, insert the new element into the array after the existing element (that's probably
@@ -1670,7 +1670,7 @@ delete_b:
      */
     memmove(
       ss->pages + a_slot + 1, ss->pages + a_slot, (ss->pages_next - a_slot) * sizeof(*ss->pages));
-    ss->pages[a_slot + 1] = new;
+    ss->pages[a_slot + 1] = new_trk;
     ++ss->pages_next;
 
     /*
@@ -1679,7 +1679,7 @@ delete_b:
      * after the stop key of the middle chunk (that's b_trk), and re-sort the WT_TRACK array as
      * necessary to move our new entry into the right sorted location.
      */
-    WT_RET(__slvg_key_copy(session, &new->row_stop, A_TRK_STOP));
+    WT_RET(__slvg_key_copy(session, &new_trk->row_stop, A_TRK_STOP));
     WT_RET(__slvg_row_trk_update_start(session, B_TRK_STOP, a_slot + 1, ss));
 
     /*
@@ -1687,10 +1687,10 @@ delete_b:
      * page, that is, everything up to the starting key of the middle chunk (that's b_trk).
      */
     WT_RET(__slvg_key_copy(session, A_TRK_STOP, B_TRK_START));
-    F_SET(new, WT_TRACK_CHECK_START);
+    F_SET(new_trk, WT_TRACK_CHECK_START);
     F_SET(a_trk, WT_TRACK_CHECK_STOP);
 
-    F_SET(new, WT_TRACK_MERGE);
+    F_SET(new_trk, WT_TRACK_MERGE);
     F_SET(a_trk, WT_TRACK_MERGE);
 
 merge:
@@ -2093,7 +2093,7 @@ __slvg_reconcile_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, 
     uint32_t i;
 
     WT_UNUSED(bm);
-    trk = session->salvage_track;
+    trk = (WT_TRACK *)session->salvage_track;
 
     /*
      * Search the list of overflow records for this page -- we should find exactly one referenced
@@ -2202,9 +2202,9 @@ __slvg_ovfl_reconcile(WT_SESSION_IMPL *session, WT_STUFF *ss)
              * It is possible that salvage found a leaf page that points to an overflow item, but
              * there were no overflow items at all.
              */
-            searchp = ss->ovfl == NULL ?
+            searchp = (WT_TRACK **)(ss->ovfl == NULL ?
               NULL :
-              bsearch(addr, ss->ovfl, ss->ovfl_next, sizeof(WT_TRACK *), __slvg_ovfl_compare);
+              bsearch(addr, ss->ovfl, ss->ovfl_next, sizeof(WT_TRACK *), __slvg_ovfl_compare));
 
             /*
              * If the overflow page doesn't exist or if another page has already claimed it, this

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1706,7 +1706,8 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_R
     /* Verify any disk image we have. */
     WT_ASSERT_OPTIONAL(session, WT_DIAGNOSTIC_DISK_VALIDATE,
       multi->disk_image == NULL ||
-        __wt_verify_dsk_image(session, "[page instantiate]", (const WT_PAGE_HEADER *)multi->disk_image, 0, &multi->addr,
+        __wt_verify_dsk_image(session, "[page instantiate]",
+          (const WT_PAGE_HEADER *)multi->disk_image, 0, &multi->addr,
           WT_VRFY_DISK_EMPTY_PAGE_OK) == 0,
       "Failed to verify a disk image");
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -179,7 +179,7 @@ __split_ovfl_key_cleanup(WT_SESSION_IMPL *session, WT_PAGE *page, WT_REF *ref)
     /* Leak blocks rather than try this twice. */
     ikey->cell_offset = 0;
 
-    cell = WT_PAGE_REF_OFFSET(page, cell_offset);
+    cell = (WT_CELL *)WT_PAGE_REF_OFFSET(page, cell_offset);
     __wt_cell_unpack_kv(session, page->dsk, cell, &kpack);
     if (FLD_ISSET(kpack.flags, WT_CELL_UNPACK_OVERFLOW) && kpack.raw != WT_CELL_KEY_OVFL_RM)
         WT_RET(__wt_ovfl_discard(session, page, cell));
@@ -228,7 +228,7 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home, WT_REF **from_ref
         if ((ikey = __wt_ref_key_instantiated(ref)) == NULL) {
             __wt_ref_key(from_home, ref, &key, &size);
             WT_RET(__wti_row_ikey(session, 0, key, size, ref));
-            ikey = ref->ref_ikey;
+            ikey = (WT_IKEY *)ref->ref_ikey;
         } else {
             WT_RET(__split_ovfl_key_cleanup(session, from_home, ref));
             *decrp += sizeof(WT_IKEY) + ikey->size;
@@ -717,7 +717,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
                 if (scr == NULL)
                     WT_ERR(__wt_scr_alloc(session, 10 * sizeof(uint32_t), &scr));
                 WT_ERR(__wt_buf_grow(session, scr, (deleted_entries + 1) * sizeof(uint32_t)));
-                deleted_refs = scr->mem;
+                deleted_refs = (uint32_t *)scr->mem;
                 deleted_refs[deleted_entries++] = i;
             }
         }
@@ -1706,7 +1706,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_MULTI *multi, WT_R
     /* Verify any disk image we have. */
     WT_ASSERT_OPTIONAL(session, WT_DIAGNOSTIC_DISK_VALIDATE,
       multi->disk_image == NULL ||
-        __wt_verify_dsk_image(session, "[page instantiate]", multi->disk_image, 0, &multi->addr,
+        __wt_verify_dsk_image(session, "[page instantiate]", (const WT_PAGE_HEADER *)multi->disk_image, 0, &multi->addr,
           WT_VRFY_DISK_EMPTY_PAGE_OK) == 0,
       "Failed to verify a disk image");
 
@@ -2266,7 +2266,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
 {
     WT_DECL_RET;
     WT_PAGE *page;
-    WT_REF *new;
+    WT_REF *new_ref;
 
     page = ref->page;
 
@@ -2284,10 +2284,10 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
      * Allocate a WT_REF, the error path calls routines that free memory. The only field we need to
      * set is the record number, as it's used by the search routines.
      */
-    WT_RET(__wt_calloc_one(session, &new));
-    new->ref_recno = ref->ref_recno;
+    WT_RET(__wt_calloc_one(session, &new_ref));
+    new_ref->ref_recno = ref->ref_recno;
 
-    WT_ERR(__split_multi_inmem(session, page, multi, new));
+    WT_ERR(__split_multi_inmem(session, page, multi, new_ref));
 
     /*
      * The rewrite succeeded, we can no longer fail.
@@ -2311,14 +2311,14 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi)
     __wt_ref_out(session, ref);
 
     /* Swap the new page into place. */
-    ref->page = new->page;
+    ref->page = new_ref->page;
 
     WT_REF_SET_STATE(ref, WT_REF_MEM);
 
-    __wt_free(session, new);
+    __wt_free(session, new_ref);
     return (0);
 
 err:
-    __split_multi_inmem_fail(session, page, multi, new);
+    __split_multi_inmem_fail(session, page, multi, new_ref);
     return (ret);
 }

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -206,7 +206,7 @@ __stat_page_col_var(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
      * do our best, and simply count every overflow item (or RLE set of items) we see.
      */
     WT_COL_FOREACH (page, cip, i) {
-        cell = WT_COL_PTR(page, cip);
+        cell = (WT_CELL*)WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(session, page->dsk, cell, unpack);
         if (unpack->type == WT_CELL_DEL) {
             orig_deleted = true;

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -206,7 +206,7 @@ __stat_page_col_var(WT_SESSION_IMPL *session, WT_PAGE *page, WT_DSRC_STATS **sta
      * do our best, and simply count every overflow item (or RLE set of items) we see.
      */
     WT_COL_FOREACH (page, cip, i) {
-        cell = (WT_CELL*)WT_COL_PTR(page, cip);
+        cell = (WT_CELL *)WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(session, page->dsk, cell, unpack);
         if (unpack->type == WT_CELL_DEL) {
             orig_deleted = true;

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -440,12 +440,12 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
      */
     WT_WITHOUT_DHANDLE(session,
       WT_WITH_HANDLE_LIST_READ_LOCK(
-        session, (ret = __wt_conn_dhandle_find(session, uri->data, NULL))));
+        session, (ret = __wt_conn_dhandle_find(session, (const char *)uri->data, NULL))));
     if (ret == WT_NOTFOUND)
         return (0);
 
     /* Open a handle for processing. */
-    ret = __wt_session_get_dhandle(session, uri->data, NULL, NULL, 0);
+    ret = __wt_session_get_dhandle(session, (const char *)uri->data, NULL, NULL, 0);
     if (ret != 0) {
         __wt_verbose_debug1(session, WT_VERB_CHECKPOINT_CLEANUP, "%s: unable to open handle%s",
           (char *)uri->data,
@@ -679,7 +679,7 @@ __checkpoint_cleanup(void *arg)
     uint64_t last, now;
     bool cv_signalled;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
 
     __wt_seconds(session, &last);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -267,7 +267,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
 
         /* Load the checkpoint. */
         WT_ERR(bm->checkpoint_load(
-          bm, session, ckpt->raw.data, ckpt->raw.size, root_addr, &root_addr_size, true));
+          bm, session, (const uint8_t*)ckpt->raw.data, ckpt->raw.size, root_addr, &root_addr_size, true));
 
         /* Skip trees with no root page. */
         if (root_addr_size != 0) {
@@ -406,7 +406,7 @@ __verify_addr_string(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *buf)
 err:
     __wt_scr_free(session, &tmp);
     WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);
-    return (buf->data);
+    return ((const char *)buf->data);
 }
 
 /*
@@ -657,7 +657,7 @@ celltype_err:
             }
 
             /* Unpack the address block and check timestamps */
-            __wt_cell_unpack_addr(session, child_ref->home->dsk, child_ref->addr, unpack);
+            __wt_cell_unpack_addr(session, child_ref->home->dsk, (WT_CELL *)child_ref->addr, unpack);
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
 
             /* Verify the subtree. */
@@ -685,7 +685,7 @@ celltype_err:
             --vs->depth;
             WT_RET(ret);
 
-            WT_RET(bm->verify_addr(bm, session, unpack->data, unpack->size));
+            WT_RET(bm->verify_addr(bm, session, (const uint8_t *)unpack->data, unpack->size));
         }
         WT_INTL_FOREACH_END;
         break;
@@ -704,7 +704,7 @@ celltype_err:
                 WT_RET(__verify_row_int_key_order(session, page, child_ref, entry, vs));
 
             /* Unpack the address block and check timestamps */
-            __wt_cell_unpack_addr(session, child_ref->home->dsk, child_ref->addr, unpack);
+            __wt_cell_unpack_addr(session, child_ref->home->dsk, (WT_CELL*)child_ref->addr, unpack);
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
 
             /* Verify the subtree. */
@@ -732,7 +732,7 @@ celltype_err:
             --vs->depth;
             WT_RET(ret);
 
-            WT_RET(bm->verify_addr(bm, session, unpack->data, unpack->size));
+            WT_RET(bm->verify_addr(bm, session, (const uint8_t *)unpack->data, unpack->size));
         }
         WT_INTL_FOREACH_END;
         break;
@@ -863,7 +863,7 @@ __verify_overflow(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_siz
      * The physical page has already been verified, but we haven't confirmed it was an overflow
      * page, only that it was a valid page. Confirm it's the type of page we expected.
      */
-    dsk = vs->tmp1->data;
+    dsk = (const WT_PAGE_HEADER *)vs->tmp1->data;
     if (dsk->type != WT_PAGE_OVFL)
         WT_RET_MSG(session, WT_ERROR, "overflow referenced page at %s is not an overflow page",
           __wt_addr_string(session, addr, addr_size, vs->tmp1));
@@ -1022,12 +1022,12 @@ __verify_page_content_int(
 
         switch (unpack.type) {
         case WT_CELL_KEY_OVFL:
-            if ((ret = __verify_overflow(session, unpack.data, unpack.size, vs)) != 0)
+            if ((ret = __verify_overflow(session, (const uint8_t *)unpack.data, unpack.size, vs)) != 0)
                 WT_RET_MSG(session, ret,
                   "cell %" PRIu32
                   " on page at %s references an overflow item at %s that failed verification",
                   cell_num - 1, __verify_addr_string(session, ref, vs->tmp1),
-                  __wt_addr_string(session, unpack.data, unpack.size, vs->tmp2));
+                  __wt_addr_string(session, (const uint8_t *)unpack.data, unpack.size, vs->tmp2));
             break;
         }
 
@@ -1122,7 +1122,7 @@ __verify_page_content_fix(
          * history store entries, such pages can also be written by newer builds; so we should
          * always validate the history entries.
          */
-        p = vs->tmp1->mem;
+        p = (uint8_t *)vs->tmp1->mem;
         WT_RET(__wt_vpack_uint(&p, 0, ref->ref_recno + recno_offset));
         vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
         WT_RET(__verify_key_hs(session, vs->tmp1, start_ts, vs));
@@ -1175,12 +1175,12 @@ __verify_page_content_leaf(
         case WT_CELL_KEY_OVFL:
         case WT_CELL_VALUE_OVFL:
             found_ovfl = true;
-            if ((ret = __verify_overflow(session, unpack.data, unpack.size, vs)) != 0)
+            if ((ret = __verify_overflow(session, (const uint8_t *)unpack.data, unpack.size, vs)) != 0)
                 WT_RET_MSG(session, ret,
                   "cell %" PRIu32
                   " on page at %s references an overflow item at %s that failed verification",
                   cell_num - 1, __verify_addr_string(session, ref, vs->tmp1),
-                  __wt_addr_string(session, unpack.data, unpack.size, vs->tmp2));
+                  __wt_addr_string(session, (const uint8_t *)unpack.data, unpack.size, vs->tmp2));
             break;
         }
 
@@ -1211,7 +1211,7 @@ __verify_page_content_leaf(
             WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
-            p = vs->tmp1->mem;
+            p = (uint8_t *)vs->tmp1->mem;
             WT_RET(__wt_vpack_uint(&p, 0, recno));
             vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
             WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -266,8 +266,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
         }
 
         /* Load the checkpoint. */
-        WT_ERR(bm->checkpoint_load(
-          bm, session, (const uint8_t*)ckpt->raw.data, ckpt->raw.size, root_addr, &root_addr_size, true));
+        WT_ERR(bm->checkpoint_load(bm, session, (const uint8_t *)ckpt->raw.data, ckpt->raw.size,
+          root_addr, &root_addr_size, true));
 
         /* Skip trees with no root page. */
         if (root_addr_size != 0) {
@@ -657,7 +657,8 @@ celltype_err:
             }
 
             /* Unpack the address block and check timestamps */
-            __wt_cell_unpack_addr(session, child_ref->home->dsk, (WT_CELL *)child_ref->addr, unpack);
+            __wt_cell_unpack_addr(
+              session, child_ref->home->dsk, (WT_CELL *)child_ref->addr, unpack);
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
 
             /* Verify the subtree. */
@@ -704,7 +705,8 @@ celltype_err:
                 WT_RET(__verify_row_int_key_order(session, page, child_ref, entry, vs));
 
             /* Unpack the address block and check timestamps */
-            __wt_cell_unpack_addr(session, child_ref->home->dsk, (WT_CELL*)child_ref->addr, unpack);
+            __wt_cell_unpack_addr(
+              session, child_ref->home->dsk, (WT_CELL *)child_ref->addr, unpack);
             WT_RET(__verify_addr_ts(session, child_ref, unpack, vs));
 
             /* Verify the subtree. */
@@ -1022,7 +1024,8 @@ __verify_page_content_int(
 
         switch (unpack.type) {
         case WT_CELL_KEY_OVFL:
-            if ((ret = __verify_overflow(session, (const uint8_t *)unpack.data, unpack.size, vs)) != 0)
+            if ((ret = __verify_overflow(session, (const uint8_t *)unpack.data, unpack.size, vs)) !=
+              0)
                 WT_RET_MSG(session, ret,
                   "cell %" PRIu32
                   " on page at %s references an overflow item at %s that failed verification",
@@ -1175,7 +1178,8 @@ __verify_page_content_leaf(
         case WT_CELL_KEY_OVFL:
         case WT_CELL_VALUE_OVFL:
             found_ovfl = true;
-            if ((ret = __verify_overflow(session, (const uint8_t *)unpack.data, unpack.size, vs)) != 0)
+            if ((ret = __verify_overflow(session, (const uint8_t *)unpack.data, unpack.size, vs)) !=
+              0)
                 WT_RET_MSG(session, ret,
                   "cell %" PRIu32
                   " on page at %s references an overflow item at %s that failed verification",

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -52,9 +52,9 @@ static int __verify_dsk_row_leaf(WT_VERIFY_INFO *);
  * WT_CELL_FOREACH macro, created because the loop can't simply unpack cells,
  * verify has to do additional work to ensure that unpack is safe.
  */
-#define WT_CELL_FOREACH_VRFY(session, dsk, cell, unpack, i)                                 \
-    for ((cell) = (WT_CELL *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), (i) = (dsk)->u.entries; (i) > 0; \
-         (cell) = (WT_CELL *)((uint8_t *)(cell) + (unpack)->__len), --(i))
+#define WT_CELL_FOREACH_VRFY(session, dsk, cell, unpack, i)                                   \
+    for ((cell) = (WT_CELL *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), (i) = (dsk)->u.entries; \
+         (i) > 0; (cell) = (WT_CELL *)((uint8_t *)(cell) + (unpack)->__len), --(i))
 
 #define WT_CELL_FOREACH_FIX_TIMESTAMPS_VRFY(session, dsk, aux, cell, unpack, i)                \
     for ((cell) = (WT_CELL *)((uint8_t *)(dsk) + (aux)->dataoffset), (i) = (aux)->entries * 2; \
@@ -210,8 +210,8 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag, const WT_PAGE_H
 int
 __wt_verify_dsk(WT_SESSION_IMPL *session, const char *tag, WT_ITEM *buf)
 {
-    return (__wt_verify_dsk_image(
-      session, tag, (const WT_PAGE_HEADER *)buf->data, buf->size, NULL, WT_VRFY_DISK_CONTINUE_ON_FAILURE));
+    return (__wt_verify_dsk_image(session, tag, (const WT_PAGE_HEADER *)buf->data, buf->size, NULL,
+      WT_VRFY_DISK_CONTINUE_ON_FAILURE));
 }
 
 /*
@@ -486,7 +486,8 @@ __verify_dsk_row_int(WT_VERIFY_INFO *vi)
         case WT_CELL_ADDR_LEAF:
         case WT_CELL_ADDR_LEAF_NO:
         case WT_CELL_KEY_OVFL:
-            if ((ret = bm->addr_invalid(bm, vi->session, (const uint8_t *)unpack->data, unpack->size)) == EINVAL)
+            if ((ret = bm->addr_invalid(
+                   bm, vi->session, (const uint8_t *)unpack->data, unpack->size)) == EINVAL)
                 (void)__err_cell_corrupt_or_eof(ret, vi);
             WT_ERR(ret);
             break;
@@ -650,7 +651,8 @@ __verify_dsk_row_leaf(WT_VERIFY_INFO *vi)
         switch (cell_type) {
         case WT_CELL_KEY_OVFL:
         case WT_CELL_VALUE_OVFL:
-            if ((ret = bm->addr_invalid(bm, vi->session, (const uint8_t *)unpack->data, unpack->size)) == EINVAL)
+            if ((ret = bm->addr_invalid(
+                   bm, vi->session, (const uint8_t *)unpack->data, unpack->size)) == EINVAL)
                 (void)__err_cell_corrupt_or_eof(ret, vi);
             WT_ERR(ret);
             break;

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -53,7 +53,7 @@ static int __verify_dsk_row_leaf(WT_VERIFY_INFO *);
  * verify has to do additional work to ensure that unpack is safe.
  */
 #define WT_CELL_FOREACH_VRFY(session, dsk, cell, unpack, i)                                 \
-    for ((cell) = WT_PAGE_HEADER_BYTE(S2BT(session), dsk), (i) = (dsk)->u.entries; (i) > 0; \
+    for ((cell) = (WT_CELL *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), (i) = (dsk)->u.entries; (i) > 0; \
          (cell) = (WT_CELL *)((uint8_t *)(cell) + (unpack)->__len), --(i))
 
 #define WT_CELL_FOREACH_FIX_TIMESTAMPS_VRFY(session, dsk, aux, cell, unpack, i)                \
@@ -211,7 +211,7 @@ int
 __wt_verify_dsk(WT_SESSION_IMPL *session, const char *tag, WT_ITEM *buf)
 {
     return (__wt_verify_dsk_image(
-      session, tag, buf->data, buf->size, NULL, WT_VRFY_DISK_CONTINUE_ON_FAILURE));
+      session, tag, (const WT_PAGE_HEADER *)buf->data, buf->size, NULL, WT_VRFY_DISK_CONTINUE_ON_FAILURE));
 }
 
 /*
@@ -486,7 +486,7 @@ __verify_dsk_row_int(WT_VERIFY_INFO *vi)
         case WT_CELL_ADDR_LEAF:
         case WT_CELL_ADDR_LEAF_NO:
         case WT_CELL_KEY_OVFL:
-            if ((ret = bm->addr_invalid(bm, vi->session, unpack->data, unpack->size)) == EINVAL)
+            if ((ret = bm->addr_invalid(bm, vi->session, (const uint8_t *)unpack->data, unpack->size)) == EINVAL)
                 (void)__err_cell_corrupt_or_eof(ret, vi);
             WT_ERR(ret);
             break;
@@ -650,7 +650,7 @@ __verify_dsk_row_leaf(WT_VERIFY_INFO *vi)
         switch (cell_type) {
         case WT_CELL_KEY_OVFL:
         case WT_CELL_VALUE_OVFL:
-            if ((ret = bm->addr_invalid(bm, vi->session, unpack->data, unpack->size)) == EINVAL)
+            if ((ret = bm->addr_invalid(bm, vi->session, (const uint8_t *)unpack->data, unpack->size)) == EINVAL)
                 (void)__err_cell_corrupt_or_eof(ret, vi);
             WT_ERR(ret);
             break;
@@ -791,7 +791,7 @@ __verify_dsk_col_int(WT_VERIFY_INFO *vi)
         WT_RET(__verify_dsk_addr_validity(unpack, vi));
 
         /* Check if any referenced item is entirely in the file. */
-        ret = bm->addr_invalid(bm, vi->session, unpack->data, unpack->size);
+        ret = bm->addr_invalid(bm, vi->session, (const uint8_t *)unpack->data, unpack->size);
         WT_RET_ERROR_OK(ret, EINVAL);
         if (ret == EINVAL)
             return (__err_cell_corrupt_or_eof(ret, vi));
@@ -901,7 +901,7 @@ __verify_dsk_col_fix(WT_VERIFY_INFO *vi)
                   __wt_page_type_string(vi->dsk->type), vi->tag, cell_num - 1,
                   __wti_cell_type_string(unpack->type));
             /* Unpack the key and make sure it's in range. It's a recno offset. */
-            p = unpack->data;
+            p = (const uint8_t *)unpack->data;
             /* Note that unpack->size does not reach past the end of the page. */
             ret = __wt_vunpack_uint(&p, unpack->size, &recno_offset);
             if (ret != 0)
@@ -1000,7 +1000,7 @@ __verify_dsk_col_var(WT_VERIFY_INFO *vi)
 
         /* Check if any referenced item is entirely in the file. */
         if (cell_type == WT_CELL_VALUE_OVFL) {
-            ret = bm->addr_invalid(bm, vi->session, unpack->data, unpack->size);
+            ret = bm->addr_invalid(bm, vi->session, (const uint8_t *)unpack->data, unpack->size);
             WT_RET_ERROR_OK(ret, EINVAL);
             if (ret == EINVAL)
                 return (__err_cell_corrupt_or_eof(ret, vi));
@@ -1087,7 +1087,7 @@ __verify_dsk_chunk(WT_VERIFY_INFO *vi)
      * Fixed-length column-store and overflow pages are simple chunks of data-> Verify the data
      * doesn't overflow the end of the page.
      */
-    p = WT_PAGE_HEADER_BYTE(btree, vi->dsk);
+    p = (uint8_t *)WT_PAGE_HEADER_BYTE(btree, vi->dsk);
     if (p + datalen > end)
         WT_RET_VRFY(vi->session, "data on page at %s extends past the end of the page", vi->tag);
 

--- a/src/checksum/software/checksum.c
+++ b/src/checksum/software/checksum.c
@@ -584,7 +584,8 @@ __wt_checksum_with_seed_sw(uint32_t seed, const void *chunk, size_t len)
     crc = ~seed;
 
     /* Checksum one byte at a time to the first 4B boundary. */
-    for (p = (const uint8_t *)chunk; ((uintptr_t)p & (sizeof(uint32_t) - 1)) != 0 && len > 0; ++p, --len)
+    for (p = (const uint8_t *)chunk; ((uintptr_t)p & (sizeof(uint32_t) - 1)) != 0 && len > 0;
+         ++p, --len)
 #ifdef WORDS_BIGENDIAN
         crc = g_crc_slicing[0][((crc >> 24) ^ *p) & 0xFF] ^ (crc << 8);
 #else

--- a/src/checksum/software/checksum.c
+++ b/src/checksum/software/checksum.c
@@ -584,7 +584,7 @@ __wt_checksum_with_seed_sw(uint32_t seed, const void *chunk, size_t len)
     crc = ~seed;
 
     /* Checksum one byte at a time to the first 4B boundary. */
-    for (p = chunk; ((uintptr_t)p & (sizeof(uint32_t) - 1)) != 0 && len > 0; ++p, --len)
+    for (p = (const uint8_t *)chunk; ((uintptr_t)p & (sizeof(uint32_t) - 1)) != 0 && len > 0; ++p, --len)
 #ifdef WORDS_BIGENDIAN
         crc = g_crc_slicing[0][((crc >> 24) ^ *p) & 0xFF] ^ (crc << 8);
 #else

--- a/src/checksum/x86/crc32-x86.c
+++ b/src/checksum/x86/crc32-x86.c
@@ -51,7 +51,7 @@ __checksum_with_seed_hw(uint32_t seed, const void *chunk, size_t len)
     crc = ~seed;
 
     /* Checksum one byte at a time to the first 8B boundary. */
-    for (p = chunk; ((uintptr_t)p & (sizeof(uint64_t) - 1)) != 0 && len > 0; ++p, --len) {
+    for (p = (const uint8_t *)chunk; ((uintptr_t)p & (sizeof(uint64_t) - 1)) != 0 && len > 0; ++p, --len) {
         __asm__ __volatile__(".byte 0xF2, 0x0F, 0x38, 0xF0, 0xF1" : "=S"(crc) : "0"(crc), "c"(*p));
     }
 

--- a/src/checksum/x86/crc32-x86.c
+++ b/src/checksum/x86/crc32-x86.c
@@ -51,7 +51,8 @@ __checksum_with_seed_hw(uint32_t seed, const void *chunk, size_t len)
     crc = ~seed;
 
     /* Checksum one byte at a time to the first 8B boundary. */
-    for (p = (const uint8_t *)chunk; ((uintptr_t)p & (sizeof(uint64_t) - 1)) != 0 && len > 0; ++p, --len) {
+    for (p = (const uint8_t *)chunk; ((uintptr_t)p & (sizeof(uint64_t) - 1)) != 0 && len > 0;
+         ++p, --len) {
         __asm__ __volatile__(".byte 0xF2, 0x0F, 0x38, 0xF0, 0xF1" : "=S"(crc) : "0"(crc), "c"(*p));
     }
 

--- a/src/conf/conf_compile.c
+++ b/src/conf/conf_compile.c
@@ -137,7 +137,7 @@ __conf_check_compare(const void *keyvoid, const void *check)
 {
     const WT_CONFIG_ITEM *key;
 
-    key = keyvoid;
+    key = (const WT_CONFIG_ITEM *)keyvoid;
     return (strncmp(key->str, ((WT_CONFIG_CHECK *)check)->name, key->len));
 }
 
@@ -344,7 +344,7 @@ __wt_conf_compile(
     cfgs[0] = centry->base;
     cfgs[1] = format_copy;
     WT_ERR(__wt_calloc(session, centry->conf_total_size, 1, &buf));
-    conf = buf;
+    conf = (WT_CONF *)buf;
     conf->source_config = format_copy;
     conf->default_config = cfgs[0];
 
@@ -419,7 +419,7 @@ __wt_conf_compile_api_call(WT_SESSION_IMPL *session, const WT_CONFIG_ENTRY *cent
     WT_ASSERT(session, preconf != NULL);
 
     memcpy(compile_buf, preconf, compile_buf_size);
-    conf = compile_buf;
+    conf = (WT_CONF *)compile_buf;
 
     /* Save the config string from the API call, it can be helpful for debugging. */
     conf->api_config = config;

--- a/src/config/config_check.c
+++ b/src/config/config_check.c
@@ -41,8 +41,8 @@ __config_check_compare(const void *keyvoid, const void *checkvoid)
     const WT_CONFIG_ITEM *key;
     int cmp;
 
-    key = keyvoid;
-    check = checkvoid;
+    key = (const WT_CONFIG_ITEM *)keyvoid;
+    check = (const WT_CONFIG_CHECK *)checkvoid;
     cmp = strncmp(key->str, check->name, key->len);
     if (cmp == 0) {
         if (check->name[key->len] == '\0')

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -154,8 +154,8 @@ __config_merge_scan(
          * WT_CONFIG_ITEM_STRUCT, so we check for a field name in the
          * value.
          */
-        if (v.type == WT_CONFIG_ITEM_STRUCT && strchr(vb->data, '=') != NULL) {
-            WT_ERR(__config_merge_scan(session, kb->data, vb->data, strip, cp));
+        if (v.type == WT_CONFIG_ITEM_STRUCT && strchr((const char *)vb->data, '=') != NULL) {
+            WT_ERR(__config_merge_scan(session, (const char *)kb->data, (const char *)vb->data, strip, cp));
             continue;
         }
 
@@ -246,7 +246,7 @@ __config_merge_format_next(WT_SESSION_IMPL *session, const char *prefix, size_t 
             /*
              * It's possible the level contained nothing, check and discard empty levels.
              */
-            p = build->data;
+            p = (const char *)build->data;
             if (p[build->size - 3] == '(')
                 build->size = saved_len;
 

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -155,7 +155,8 @@ __config_merge_scan(
          * value.
          */
         if (v.type == WT_CONFIG_ITEM_STRUCT && strchr((const char *)vb->data, '=') != NULL) {
-            WT_ERR(__config_merge_scan(session, (const char *)kb->data, (const char *)vb->data, strip, cp));
+            WT_ERR(__config_merge_scan(
+              session, (const char *)kb->data, (const char *)vb->data, strip, cp));
             continue;
         }
 

--- a/src/conn/api_calc_modify.c
+++ b/src/conn/api_calc_modify.c
@@ -124,9 +124,9 @@ __wt_calc_modify(WT_SESSION_IMPL *wt_session, const WT_ITEM *oldv, const WT_ITEM
 
     cms.session = (WT_SESSION_IMPL *)wt_session;
 
-    cms.s1 = cms.used1 = oldv->data;
+    cms.s1 = cms.used1 = (const uint8_t *)oldv->data;
     cms.e1 = cms.s1 + oldv->size;
-    cms.s2 = cms.used2 = newv->data;
+    cms.s2 = cms.used2 = (const uint8_t *)newv->data;
     cms.e2 = cms.s2 + newv->size;
     cms.maxdiff = maxdiff;
     cms.maxentries = *nentriesp;

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1042,8 +1042,8 @@ __conn_load_extensions(WT_SESSION_IMPL *session, const char *cfg[], bool early_l
                 WT_ERR(__wt_scr_alloc(session, 0, &exconfig));
             WT_ERR(__wt_buf_fmt(session, exconfig, "%.*s", (int)sval.len, sval.str));
         }
-        sub_cfg[1] = sval.len > 0 ? exconfig->data : NULL;
-        WT_ERR(__conn_load_extension_int(session, expath->data, sub_cfg, early_load));
+        sub_cfg[1] = sval.len > 0 ? (const char *)exconfig->data : NULL;
+        WT_ERR(__conn_load_extension_int(session, (const char *)expath->data, sub_cfg, early_load));
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 
@@ -1576,7 +1576,7 @@ __conn_config_file(
      * unless the newline is quoted or backslash escaped. Comment lines (an unescaped newline where
      * the next non- white-space character is a hash), are discarded.
      */
-    for (quoted = false, p = t = cbuf->mem; len > 0;) {
+    for (quoted = false, p = t = (char *)cbuf->mem; len > 0;) {
         /*
          * Backslash pairs pass through untouched, unless immediately preceding a newline, in which
          * case both the backslash and the newline are discarded. Backslash characters escape quoted
@@ -1635,16 +1635,16 @@ __conn_config_file(
     cbuf->size = WT_PTRDIFF(t, cbuf->data);
 
     /* Check any version. */
-    WT_ERR(__conn_config_check_version(session, cbuf->data));
+    WT_ERR(__conn_config_check_version(session, (const char *)cbuf->data));
 
     /* Check the configuration information. */
     WT_ERR(__wt_config_check(session,
       is_user ? WT_CONFIG_REF(session, wiredtiger_open_usercfg) :
                 WT_CONFIG_REF(session, wiredtiger_open_basecfg),
-      cbuf->data, 0));
+      (const char *)cbuf->data, 0));
 
     /* Append it to the stack. */
-    __conn_config_append(cfg, cbuf->data);
+    __conn_config_append(cfg, (const char *)cbuf->data);
 
 err:
     WT_TRET(__wt_close(session, &fh));
@@ -1731,7 +1731,7 @@ __conn_config_env(WT_SESSION_IMPL *session, const char *cfg[], WT_ITEM *cbuf)
     WT_ERR(__wt_config_check(session, WT_CONFIG_REF(session, wiredtiger_open), env_config, 0));
 
     /* Append it to the stack. */
-    __conn_config_append(cfg, cbuf->data);
+    __conn_config_append(cfg, (const char *)cbuf->data);
 
 err:
     __wt_free(session, env_config);
@@ -3209,7 +3209,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     WT_ERR(__wt_scr_alloc(session, 0, &encbuf));
     WT_ERR(__wt_buf_fmt(session, encbuf, "(name=%.*s,keyid=%.*s,secretkey=%.*s)", (int)cval.len,
       cval.str, (int)keyid.len, keyid.str, (int)secretkey.len, secretkey.str));
-    enc_cfg[0] = encbuf->data;
+    enc_cfg[0] = (const char *)encbuf->data;
     WT_ERR(
       __wt_encryptor_config(session, &cval, &keyid, (WT_CONFIG_ARG *)enc_cfg, &conn->kencryptor));
 

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -115,7 +115,7 @@ __capacity_server(void *arg)
     WT_SESSION_IMPL *session;
     uint64_t start, stop, time_ms;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
     cap = &conn->capacity;
     for (;;) {

--- a/src/conn/conn_chunkcache.c
+++ b/src/conn/conn_chunkcache.c
@@ -222,7 +222,7 @@ __chunkcache_metadata_server(void *arg)
     uint64_t cond_time_us;
     bool signalled;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
     cond_time_us = WT_MILLION;
 

--- a/src/conn/conn_ckpt.c
+++ b/src/conn/conn_ckpt.c
@@ -81,7 +81,7 @@ __ckpt_server(void *arg)
     WT_SESSION_IMPL *session;
     uint64_t checkpoint_gen;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
     wt_session = (WT_SESSION *)session;
 

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -527,7 +527,7 @@ __background_compact_server(void *arg)
     WT_SESSION_IMPL *session;
     bool cache_pressure, full_iteration, running;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
     wt_session = (WT_SESSION *)session;
     cache_pressure = full_iteration = running = false;

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -310,7 +310,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
      * it should be NULL.
      */
     is_btree = WT_DHANDLE_BTREE(dhandle);
-    btree = is_btree ? dhandle->handle : NULL;
+    btree = is_btree ? (WT_BTREE *)dhandle->handle : NULL;
 
     if (is_btree) {
         /*
@@ -516,7 +516,7 @@ __wt_conn_dhandle_open(WT_SESSION_IMPL *session, const char *cfg[], uint32_t fla
     WT_DECL_RET;
 
     dhandle = session->dhandle;
-    btree = dhandle->handle;
+    btree = (WT_BTREE *)dhandle->handle;
 
     WT_ASSERT(session, F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE) && !LF_ISSET(WT_DHANDLE_LOCK_ONLY));
 

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -599,7 +599,7 @@ __log_file_server(void *arg)
     WT_SESSION_IMPL *session;
     uint32_t filenum;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
     log = conn->log;
     while (FLD_ISSET(conn->server_flags, WT_CONN_SERVER_LOG)) {
@@ -824,7 +824,7 @@ __log_wrlsn_server(void *arg)
     int yield;
     bool did_work;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
     log = conn->log;
     yield = 0;
@@ -879,7 +879,7 @@ __log_server(void *arg)
     uint64_t time_start, time_stop, timediff;
     bool did_work, signalled;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
     log = conn->log;
     force_write_timediff = 0;

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -357,7 +357,8 @@ __statlog_dump(WT_SESSION_IMPL *session, const char *name, bool conn_stats)
             endprefix = strchr(desc, ':');
             prefixlen = WT_PTRDIFF(endprefix, desc);
             WT_ASSERT(session, endprefix != NULL);
-            if (first || tmp->size != prefixlen || strncmp(desc, (const char *)tmp->data, tmp->size) != 0) {
+            if (first || tmp->size != prefixlen ||
+              strncmp(desc, (const char *)tmp->data, tmp->size) != 0) {
                 WT_ERR(__wt_buf_set(session, tmp, desc, prefixlen));
                 WT_ERR(__wt_fprintf(
                   session, conn->stat_fs, "%s\"%.*s\":{", first ? "" : "},", (int)prefixlen, desc));
@@ -485,10 +486,11 @@ __statlog_log_one(WT_SESSION_IMPL *session, WT_ITEM *path, WT_ITEM *tmp)
         WT_RET_MSG(session, ENOMEM, "strftime path conversion");
 
     /* If the path has changed, cycle the log file. */
-    if (conn->stat_fs == NULL || path == NULL || strcmp((const char *)tmp->mem, (const char *)path->mem) != 0) {
+    if (conn->stat_fs == NULL || path == NULL ||
+      strcmp((const char *)tmp->mem, (const char *)path->mem) != 0) {
         WT_RET(__wt_fclose(session, &conn->stat_fs));
-        WT_RET(__wt_fopen(session, (const char *)tmp->mem, WT_FS_OPEN_CREATE | WT_FS_OPEN_FIXED, WT_STREAM_APPEND,
-          &conn->stat_fs));
+        WT_RET(__wt_fopen(session, (const char *)tmp->mem, WT_FS_OPEN_CREATE | WT_FS_OPEN_FIXED,
+          WT_STREAM_APPEND, &conn->stat_fs));
 
         if (path != NULL)
             WT_RET(__wt_buf_setstr(session, path, (const char *)tmp->mem));

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -156,7 +156,7 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
     WT_RET(__wt_config_gets(session, cfg, "statistics_log.path", &cval));
     WT_ERR(__wt_scr_alloc(session, 0, &tmp));
     WT_ERR(__wt_buf_fmt(session, tmp, "%.*s/%s", (int)cval.len, cval.str, WT_STATLOG_FILENAME));
-    WT_ERR(__wt_filename(session, tmp->data, &conn->stat_path));
+    WT_ERR(__wt_filename(session, (const char *)tmp->data, &conn->stat_path));
 
     WT_ERR(__wt_config_gets(session, cfg, "statistics_log.sources", &cval));
     __wt_config_subinit(session, &objectconf, &cval);
@@ -334,7 +334,7 @@ __statlog_dump(WT_SESSION_IMPL *session, const char *name, bool conn_stats)
         uri = "statistics:";
     else {
         WT_ERR(__wt_buf_fmt(session, tmp, "statistics:%s", name));
-        uri = tmp->data;
+        uri = (const char *)tmp->data;
     }
 
     /*
@@ -357,7 +357,7 @@ __statlog_dump(WT_SESSION_IMPL *session, const char *name, bool conn_stats)
             endprefix = strchr(desc, ':');
             prefixlen = WT_PTRDIFF(endprefix, desc);
             WT_ASSERT(session, endprefix != NULL);
-            if (first || tmp->size != prefixlen || strncmp(desc, tmp->data, tmp->size) != 0) {
+            if (first || tmp->size != prefixlen || strncmp(desc, (const char *)tmp->data, tmp->size) != 0) {
                 WT_ERR(__wt_buf_set(session, tmp, desc, prefixlen));
                 WT_ERR(__wt_fprintf(
                   session, conn->stat_fs, "%s\"%.*s\":{", first ? "" : "},", (int)prefixlen, desc));
@@ -481,23 +481,23 @@ __statlog_log_one(WT_SESSION_IMPL *session, WT_ITEM *path, WT_ITEM *tmp)
     WT_RET(__wt_localtime(session, &ts.tv_sec, &localt));
 
     /* Create the logging path name for this time of day. */
-    if (strftime(tmp->mem, tmp->memsize, conn->stat_path, &localt) == 0)
+    if (strftime((char *)tmp->mem, tmp->memsize, conn->stat_path, &localt) == 0)
         WT_RET_MSG(session, ENOMEM, "strftime path conversion");
 
     /* If the path has changed, cycle the log file. */
-    if (conn->stat_fs == NULL || path == NULL || strcmp(tmp->mem, path->mem) != 0) {
+    if (conn->stat_fs == NULL || path == NULL || strcmp((const char *)tmp->mem, (const char *)path->mem) != 0) {
         WT_RET(__wt_fclose(session, &conn->stat_fs));
-        WT_RET(__wt_fopen(session, tmp->mem, WT_FS_OPEN_CREATE | WT_FS_OPEN_FIXED, WT_STREAM_APPEND,
+        WT_RET(__wt_fopen(session, (const char *)tmp->mem, WT_FS_OPEN_CREATE | WT_FS_OPEN_FIXED, WT_STREAM_APPEND,
           &conn->stat_fs));
 
         if (path != NULL)
-            WT_RET(__wt_buf_setstr(session, path, tmp->mem));
+            WT_RET(__wt_buf_setstr(session, path, (const char *)tmp->mem));
     }
 
     /* Create the entry prefix for this time of day. */
-    if (strftime(tmp->mem, tmp->memsize, conn->stat_format, &localt) == 0)
+    if (strftime((char *)tmp->mem, tmp->memsize, conn->stat_format, &localt) == 0)
         WT_RET_MSG(session, ENOMEM, "strftime timestamp conversion");
-    conn->stat_stamp = tmp->mem;
+    conn->stat_stamp = (const char *)tmp->mem;
     WT_RET(__statlog_print_header(session));
 
     /* Dump the connection statistics. */
@@ -575,7 +575,7 @@ __statlog_server(void *arg)
     WT_ITEM path, tmp;
     WT_SESSION_IMPL *session;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
 
     WT_CLEAR(path);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -68,7 +68,7 @@ __sweep_close_dhandle_locked(WT_SESSION_IMPL *session)
     WT_DATA_HANDLE *dhandle;
 
     dhandle = session->dhandle;
-    btree = WT_DHANDLE_BTREE(dhandle) ? dhandle->handle : NULL;
+    btree = WT_DHANDLE_BTREE(dhandle) ? (WT_BTREE *)dhandle->handle : NULL;
 
     /* This method expects dhandle write lock. */
     WT_ASSERT(session, FLD_ISSET(dhandle->lock_flags, WT_DHANDLE_LOCK_WRITE));
@@ -364,7 +364,7 @@ __sweep_server(void *arg)
     u_int dead_handles;
     bool cv_signalled;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
 
     /*

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -129,7 +129,7 @@ __tier_flush_meta(
      * timestamp from the btree handle, which is the last timestamp when this tree was flushed.
      */
     WT_ASSERT_ALWAYS(session, WT_DHANDLE_BTREE(dhandle), "Expected a btree handle");
-    btree = dhandle->handle;
+    btree = (WT_BTREE *)dhandle->handle;
     __wt_timestamp_to_hex_string(btree->flush_most_recent_ts, hex_timestamp);
     WT_ERR(__wt_metadata_remove(session, local_uri));
     WT_ERR(__wt_metadata_search(session, obj_uri, &obj_value));
@@ -137,7 +137,7 @@ __tier_flush_meta(
     WT_ERR(__wt_buf_fmt(
       session, buf, "flush_time=%" PRIu64 ",flush_timestamp=\"%s\"", now, hex_timestamp));
     cfg[0] = obj_value;
-    cfg[1] = buf->mem;
+    cfg[1] = (const char *)buf->mem;
     WT_ERR(__wt_config_collapse(session, cfg, &newconfig));
     WT_ERR(__wt_metadata_update(session, obj_uri, newconfig));
     WT_ERR(__wt_meta_track_off(session, true, ret != 0));
@@ -435,7 +435,7 @@ __tiered_server(void *arg)
     const char *msg;
     bool signalled;
 
-    session = arg;
+    session = (WT_SESSION_IMPL *)arg;
     conn = S2C(session);
 
     WT_CLEAR(path);

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -650,7 +650,7 @@ __backup_config(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, const char *cfg[
         }
 
         WT_ERR(__wt_buf_fmt(session, tmp, "%.*s", (int)k.len, k.str));
-        uri = tmp->data;
+        uri = (const char *)tmp->data;
         if (v.len != 0)
             WT_ERR_MSG(session, EINVAL, "%s: invalid backup target: URIs may need quoting", uri);
 

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -323,7 +323,8 @@ __wti_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
          */
         session_cache_flags = F_ISSET(session, WT_SESSION_CACHE_CURSORS);
         F_CLR(session, WT_SESSION_CACHE_CURSORS);
-        WT_ERR(__wt_curfile_open(session, (const char *)open_uri->data, NULL, cfg, &cb->incr_cursor));
+        WT_ERR(
+          __wt_curfile_open(session, (const char *)open_uri->data, NULL, cfg, &cb->incr_cursor));
         F_SET(session, session_cache_flags);
     }
     WT_ERR(__wt_cursor_init(cursor, uri, NULL, cfg, cursorp));

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -145,7 +145,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
         if (WT_PREFIX_MATCH(file, WT_LOG_FILENAME)) {
             WT_ERR(__wt_scr_alloc(session, 0, &buf));
             WT_ERR(__wt_log_filename(session, UINT32_MAX, file, buf));
-            file = buf->data;
+            file = (const char *)buf->data;
         }
         WT_ERR(__wt_fs_size(session, file, &size));
 
@@ -202,7 +202,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
         WT_ASSERT(session, cb->bit_offset <= cb->nbits);
         /* Look for the next chunk that had modifications. */
         while (cb->bit_offset < cb->nbits)
-            if (__bit_test(cb->bitstring.mem, cb->bit_offset)) {
+            if (__bit_test((const uint8_t *)cb->bitstring.mem, cb->bit_offset)) {
                 found = true;
                 WT_STAT_CONN_INCR(session, backup_blocks);
                 if (F_ISSET(cb, WT_CURBACKUP_COMPRESSED))
@@ -218,7 +218,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
                 start_bitoff = cb->bit_offset++;
                 if (F_ISSET(cb, WT_CURBACKUP_CONSOLIDATE)) {
                     while (cb->bit_offset < cb->nbits &&
-                      __bit_test(cb->bitstring.mem, cb->bit_offset++)) {
+                      __bit_test((const uint8_t *)cb->bitstring.mem, cb->bit_offset++)) {
                         total_len += cb->granularity;
                         /* Count all the blocks even if we return them consolidated. */
                         WT_STAT_CONN_INCR(session, backup_blocks);
@@ -323,7 +323,7 @@ __wti_curbackup_open_incr(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
          */
         session_cache_flags = F_ISSET(session, WT_SESSION_CACHE_CURSORS);
         F_CLR(session, WT_SESSION_CACHE_CURSORS);
-        WT_ERR(__wt_curfile_open(session, open_uri->data, NULL, cfg, &cb->incr_cursor));
+        WT_ERR(__wt_curfile_open(session, (const char *)open_uri->data, NULL, cfg, &cb->incr_cursor));
         F_SET(session, session_cache_flags);
     }
     WT_ERR(__wt_cursor_init(cursor, uri, NULL, cfg, cursorp));

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -16,9 +16,9 @@ static int
 __raw_to_dump(WT_SESSION_IMPL *session, WT_ITEM *from, WT_ITEM *to, bool hexonly)
 {
     if (hexonly)
-        WT_RET(__wt_raw_to_hex(session, from->data, from->size, to));
+        WT_RET(__wt_raw_to_hex(session, (const uint8_t *)from->data, from->size, to));
     else
-        WT_RET(__wt_raw_to_esc_hex(session, from->data, from->size, to));
+        WT_RET(__wt_raw_to_esc_hex(session, (const uint8_t *)from->data, from->size, to));
 
     return (0);
 }
@@ -104,7 +104,7 @@ __curdump_get_key(WT_CURSOR *cursor, ...)
             itemp->data = cursor->key.data;
             itemp->size = cursor->key.size;
         } else
-            *va_arg(ap, const char **) = cursor->key.data;
+            *va_arg(ap, const char **) = (const char *)cursor->key.data;
         va_end(ap);
     }
 
@@ -162,7 +162,7 @@ __curdump_set_keyv(WT_CURSOR *cursor, va_list ap)
     CURSOR_API_CALL(cursor, session, ret, set_key, NULL);
 
     if (F_ISSET(cursor, WT_CURSTD_RAW))
-        p = va_arg(ap, WT_ITEM *)->data;
+        p = (const char *)va_arg(ap, WT_ITEM *)->data;
     else
         p = va_arg(ap, const char *);
 
@@ -253,7 +253,7 @@ __curdump_get_value(WT_CURSOR *cursor, ...)
             itemp->data = cursor->value.data;
             itemp->size = cursor->value.size;
         } else
-            *va_arg(ap, const char **) = cursor->value.data;
+            *va_arg(ap, const char **) = (const char *)cursor->value.data;
         va_end(ap);
     }
 
@@ -279,7 +279,7 @@ __curdump_set_valuev(WT_CURSOR *cursor, va_list ap)
     CURSOR_API_CALL(cursor, session, ret, set_value, NULL);
 
     if (F_ISSET(cursor, WT_CURSTD_RAW))
-        p = va_arg(ap, WT_ITEM *)->data;
+        p = (const char *)va_arg(ap, WT_ITEM *)->data;
     else
         p = va_arg(ap, const char *);
 

--- a/src/cursor/cur_join.c
+++ b/src/cursor/cur_join.c
@@ -765,7 +765,7 @@ __curjoin_init_bloom(
         size = strlen(cjoin->table->iface.name) + 3;
         WT_ERR(__wt_scr_alloc(session, size, &uribuf));
         WT_ERR(__wt_buf_fmt(session, uribuf, "%s()", cjoin->table->iface.name));
-        uri = uribuf->data;
+        uri = (const char *)uribuf->data;
     }
     WT_ERR(__wt_open_cursor(session, uri, &cjoin->iface, raw_cfg, &c));
 

--- a/src/cursor/cur_json.c
+++ b/src/cursor/cur_json.c
@@ -238,7 +238,7 @@ __json_struct_size(WT_SESSION_IMPL *session, const void *buffer, size_t size, co
     const uint8_t *end, *p;
     bool needcr;
 
-    p = buffer;
+    p = (const uint8_t *)buffer;
     end = p + size;
     result = 0;
     needcr = false;
@@ -279,7 +279,7 @@ __json_struct_unpackv(WT_SESSION_IMPL *session, const void *buffer, size_t size,
     const uint8_t *end, *p;
     bool needcr;
 
-    p = buffer;
+    p = (const uint8_t *)buffer;
     end = p + size;
     needcr = false;
 
@@ -729,7 +729,7 @@ __json_pack_struct(
     const char *tokstart;
     bool multi;
 
-    p = buffer;
+    p = (uint8_t *)buffer;
     end = p + size;
     multi = false;
 

--- a/src/cursor/cur_log.c
+++ b/src/cursor/cur_log.c
@@ -18,7 +18,7 @@ __curlog_logrec(WT_SESSION_IMPL *session, WT_ITEM *logrec, WT_LSN *lsnp, WT_LSN 
 {
     WT_CURSOR_LOG *cl;
 
-    cl = cookie;
+    cl = (WT_CURSOR_LOG *)cookie;
     WT_UNUSED(firstrecord);
 
     /* Set up the LSNs and take a copy of the log record for the cursor. */

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -167,7 +167,7 @@ __curmetadata_setkv(WT_CURSOR_METADATA *mdc, WT_CURSOR *fc)
     c->key.data = fc->key.data;
     c->key.size = fc->key.size;
     if (F_ISSET(mdc, WT_MDC_CREATEONLY)) {
-        WT_ERR(__schema_create_collapse(session, mdc, fc->key.data, fc->value.data, &value));
+        WT_ERR(__schema_create_collapse(session, mdc, (const char *)fc->key.data, (const char *)fc->value.data, &value));
         WT_ERR(__wt_buf_set(session, &c->value, value, strlen(value) + 1));
     } else {
         c->value.data = fc->value.data;
@@ -189,8 +189,8 @@ err:
  */
 #define WT_KEY_IS_METADATA(key)                                              \
     ((key)->size > 0 &&                                                      \
-      (WT_STRING_LIT_MATCH(WT_METADATA_URI, (key)->data, (key)->size - 1) || \
-        WT_STRING_LIT_MATCH(WT_METAFILE_URI, (key)->data, (key)->size - 1)))
+      (WT_STRING_LIT_MATCH(WT_METADATA_URI, (const char *)(key)->data, (key)->size - 1) || \
+        WT_STRING_LIT_MATCH(WT_METAFILE_URI, (const char *)(key)->data, (key)->size - 1)))
 
 /*
  * __curmetadata_metadata_search --
@@ -480,7 +480,7 @@ __curmetadata_insert(WT_CURSOR *cursor)
     /*
      * Since the key/value formats are 's' the WT_ITEMs must contain a NULL terminated string.
      */
-    ret = __wt_metadata_insert(session, cursor->key.data, cursor->value.data);
+    ret = __wt_metadata_insert(session, (const char *)cursor->key.data, (const char *)cursor->value.data);
 
 err:
     API_END_RET(session, ret);
@@ -508,7 +508,7 @@ __curmetadata_update(WT_CURSOR *cursor)
     /*
      * Since the key/value formats are 's' the WT_ITEMs must contain a NULL terminated string.
      */
-    ret = __wt_metadata_update(session, cursor->key.data, cursor->value.data);
+    ret = __wt_metadata_update(session, (const char *)cursor->key.data, (const char *)cursor->value.data);
 
 err:
     API_END_RET(session, ret);
@@ -535,7 +535,7 @@ __curmetadata_remove(WT_CURSOR *cursor)
     /*
      * Since the key format is 's' the WT_ITEM must contain a NULL terminated string.
      */
-    ret = __wt_metadata_remove(session, cursor->key.data);
+    ret = __wt_metadata_remove(session, (const char *)cursor->key.data);
 
 err:
     API_END_RET(session, ret);

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -167,7 +167,8 @@ __curmetadata_setkv(WT_CURSOR_METADATA *mdc, WT_CURSOR *fc)
     c->key.data = fc->key.data;
     c->key.size = fc->key.size;
     if (F_ISSET(mdc, WT_MDC_CREATEONLY)) {
-        WT_ERR(__schema_create_collapse(session, mdc, (const char *)fc->key.data, (const char *)fc->value.data, &value));
+        WT_ERR(__schema_create_collapse(
+          session, mdc, (const char *)fc->key.data, (const char *)fc->value.data, &value));
         WT_ERR(__wt_buf_set(session, &c->value, value, strlen(value) + 1));
     } else {
         c->value.data = fc->value.data;
@@ -187,8 +188,8 @@ err:
  * Check if a key matches the metadata. The public value is "metadata:", but also check for the
  * internal version of the URI.
  */
-#define WT_KEY_IS_METADATA(key)                                              \
-    ((key)->size > 0 &&                                                      \
+#define WT_KEY_IS_METADATA(key)                                                            \
+    ((key)->size > 0 &&                                                                    \
       (WT_STRING_LIT_MATCH(WT_METADATA_URI, (const char *)(key)->data, (key)->size - 1) || \
         WT_STRING_LIT_MATCH(WT_METAFILE_URI, (const char *)(key)->data, (key)->size - 1)))
 
@@ -480,7 +481,8 @@ __curmetadata_insert(WT_CURSOR *cursor)
     /*
      * Since the key/value formats are 's' the WT_ITEMs must contain a NULL terminated string.
      */
-    ret = __wt_metadata_insert(session, (const char *)cursor->key.data, (const char *)cursor->value.data);
+    ret = __wt_metadata_insert(
+      session, (const char *)cursor->key.data, (const char *)cursor->value.data);
 
 err:
     API_END_RET(session, ret);
@@ -508,7 +510,8 @@ __curmetadata_update(WT_CURSOR *cursor)
     /*
      * Since the key/value formats are 's' the WT_ITEMs must contain a NULL terminated string.
      */
-    ret = __wt_metadata_update(session, (const char *)cursor->key.data, (const char *)cursor->value.data);
+    ret = __wt_metadata_update(
+      session, (const char *)cursor->key.data, (const char *)cursor->value.data);
 
 err:
     API_END_RET(session, ret);

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -118,7 +118,7 @@ __curstat_get_value(WT_CURSOR *cursor, ...)
         if ((p = va_arg(ap, const char **)) != NULL) {
             /* Create the printed value only when needed. */
             WT_ERR(__curstat_print_value(session, cst->v, &cst->pv));
-            *p = cst->pv.data;
+            *p = (const char *)cst->pv.data;
         }
         if ((v = va_arg(ap, uint64_t *)) != NULL)
             *v = cst->v;

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -421,7 +421,7 @@ __wti_cursor_get_keyv(WT_CURSOR *cursor, uint64_t flags, va_list ap)
             key->data = cursor->key.data;
             key->size = cursor->key.size;
         } else if (WT_STREQ(fmt, "S"))
-            *va_arg(ap, const char **) = cursor->key.data;
+            *va_arg(ap, const char **) = (const char *)cursor->key.data;
         else
             ret = __wt_struct_unpackv(session, cursor->key.data, cursor->key.size, fmt, ap);
     }
@@ -566,7 +566,7 @@ __wti_cursor_get_valuev(WT_CURSOR *cursor, va_list ap)
         value->data = cursor->value.data;
         value->size = cursor->value.size;
     } else if (WT_STREQ(fmt, "S"))
-        *va_arg(ap, const char **) = cursor->value.data;
+        *va_arg(ap, const char **) = (const char *)cursor->value.data;
     else if (WT_STREQ(fmt, "t") || (__wt_isdigit((u_char)fmt[0]) && WT_STREQ(fmt + 1, "t")))
         *va_arg(ap, uint8_t *) = *(uint8_t *)cursor->value.data;
     else

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -1176,7 +1176,7 @@ __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     for (cfg_cnt = 1; cfg[cfg_cnt] != NULL; ++cfg_cnt)
         WT_ERR(__wt_buf_catfmt(session, tmp, "%s,", cfg[cfg_cnt]));
     WT_ERR(__wt_buf_catfmt(session, tmp, "dump=\"\",readonly=0"));
-    WT_ERR(__wt_strdup(session, tmp->data, &ctable->cfg[1]));
+    WT_ERR(__wt_strdup(session, (const char *)tmp->data, &ctable->cfg[1]));
 
     if (0) {
 err:

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -362,7 +362,7 @@ __curversion_next_int(WT_CURSOR *cursor)
                 /* Ensure enough room for a column-store key without checking. */
                 WT_ERR(__wt_scr_alloc(session, WT_INTPACK64_MAXSIZE, &key));
 
-                p = key->mem;
+                p = (unsigned char *)key->mem;
                 WT_ERR(__wt_vpack_uint(&p, 0, cbt->recno));
                 key->size = WT_PTRDIFF(p, key->data);
                 hs_cursor->set_key(hs_cursor, 4, S2BT(session)->id, key, WT_TS_MAX, UINT64_MAX);

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -23,7 +23,7 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
     uint32_t rec_flags, walk_flags;
 
     dhandle = session->dhandle;
-    btree = dhandle->handle;
+    btree = (WT_BTREE *)dhandle->handle;
 
     /*
      * We need exclusive access to the file, we're about to discard the root page. Assert eviction

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -114,8 +114,8 @@ __evict_lru_cmp_debug(const void *a_arg, const void *b_arg)
     const WT_EVICT_ENTRY *a, *b;
     uint64_t a_score, b_score;
 
-    a = a_arg;
-    b = b_arg;
+    a = (const WT_EVICT_ENTRY *)a_arg;
+    b = (const WT_EVICT_ENTRY *)b_arg;
     a_score = (a->ref == NULL ? UINT64_MAX : 0);
     b_score = (b->ref == NULL ? UINT64_MAX : 0);
 
@@ -132,8 +132,8 @@ __evict_lru_cmp(const void *a_arg, const void *b_arg)
     const WT_EVICT_ENTRY *a, *b;
     uint64_t a_score, b_score;
 
-    a = a_arg;
-    b = b_arg;
+    a = (const WT_EVICT_ENTRY *)a_arg;
+    b = (const WT_EVICT_ENTRY *)b_arg;
     a_score = (a->ref == NULL ? UINT64_MAX : a->score);
     b_score = (b->ref == NULL ? UINT64_MAX : b->score);
 
@@ -152,7 +152,7 @@ __evict_list_clear(WT_SESSION_IMPL *session, WT_EVICT_ENTRY *e)
         F_CLR_ATOMIC_16(e->ref->page, WT_PAGE_EVICT_LRU | WT_PAGE_EVICT_LRU_URGENT);
     }
     e->ref = NULL;
-    e->btree = WT_DEBUG_POINT;
+    e->btree = (WT_BTREE *)WT_DEBUG_POINT;
 }
 
 /*
@@ -1528,7 +1528,7 @@ retry:
             continue;
 
         /* Skip files that don't allow eviction. */
-        btree = dhandle->handle;
+        btree = (WT_BTREE *)dhandle->handle;
         if (btree->evict_disabled > 0) {
             WT_STAT_CONN_INCR(session, cache_eviction_server_skip_trees_eviction_disabled);
             continue;
@@ -2792,7 +2792,7 @@ __verbose_dump_cache_single(WT_SESSION_IMPL *session, uint64_t *total_bytesp,
     updates_bytes = 0;
 
     dhandle = session->dhandle;
-    btree = dhandle->handle;
+    btree = (WT_BTREE *)dhandle->handle;
     WT_RET(__wt_msg(session, "%s(%s%s)%s%s:", dhandle->name,
       WT_DHANDLE_IS_CHECKPOINT(dhandle) ? "checkpoint=" : "",
       WT_DHANDLE_IS_CHECKPOINT(dhandle) ? dhandle->checkpoint : "<live>",

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -297,7 +297,7 @@ __hs_pack_key(WT_SESSION_IMPL *session, WT_BTREE *btree, WT_RECONCILE *r, WT_INS
     switch (r->page->type) {
     case WT_PAGE_COL_FIX:
     case WT_PAGE_COL_VAR:
-        p = key->mem;
+        p = (uint8_t *)key->mem;
         WT_RET(__wt_vpack_uint(&p, 0, WT_INSERT_RECNO(ins)));
         key->size = WT_PTRDIFF(p, key->data);
         break;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1704,11 +1704,11 @@ struct __wt_insert_head {
 #define WT_COL_FIX_FOREACH_BITS(btree, dsk, v, i)                            \
     for ((i) = 0,                                                            \
         (v) = (i) < (dsk)->u.entries ?                                       \
-           __bit_getv(WT_PAGE_HEADER_BYTE(btree, dsk), 0, (btree)->bitcnt) : \
+           __bit_getv((const uint8_t *)WT_PAGE_HEADER_BYTE(btree, dsk), 0, (btree)->bitcnt) : \
            0;                                                                \
          (i) < (dsk)->u.entries; ++(i),                                      \
         (v) = (i) < (dsk)->u.entries ?                                       \
-           __bit_getv(WT_PAGE_HEADER_BYTE(btree, dsk), i, (btree)->bitcnt) : \
+           __bit_getv((const uint8_t *)WT_PAGE_HEADER_BYTE(btree, dsk), i, (btree)->bitcnt) : \
            0)
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1701,13 +1701,13 @@ struct __wt_insert_head {
         (page)->modify->mod_col_append[0])
 
 /* WT_COL_FIX_FOREACH_BITS walks fixed-length bit-fields on a disk page. */
-#define WT_COL_FIX_FOREACH_BITS(btree, dsk, v, i)                            \
-    for ((i) = 0,                                                            \
-        (v) = (i) < (dsk)->u.entries ?                                       \
+#define WT_COL_FIX_FOREACH_BITS(btree, dsk, v, i)                                             \
+    for ((i) = 0,                                                                             \
+        (v) = (i) < (dsk)->u.entries ?                                                        \
            __bit_getv((const uint8_t *)WT_PAGE_HEADER_BYTE(btree, dsk), 0, (btree)->bitcnt) : \
-           0;                                                                \
-         (i) < (dsk)->u.entries; ++(i),                                      \
-        (v) = (i) < (dsk)->u.entries ?                                       \
+           0;                                                                                 \
+         (i) < (dsk)->u.entries; ++(i),                                                       \
+        (v) = (i) < (dsk)->u.entries ?                                                        \
            __bit_getv((const uint8_t *)WT_PAGE_HEADER_BYTE(btree, dsk), i, (btree)->bitcnt) : \
            0)
 

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1347,7 +1347,7 @@ __wt_page_cell_data_ref_kv(
     do {                                                                                        \
         uint32_t __i;                                                                           \
         uint8_t *__cell;                                                                        \
-        for (__cell = WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; __i > 0; \
+        for (__cell = (uint8_t *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; __i > 0; \
              __cell += (unpack).__len, --__i) {                                                 \
             __wt_cell_unpack_addr(session, dsk, (WT_CELL *)__cell, &(unpack));
 
@@ -1355,7 +1355,7 @@ __wt_page_cell_data_ref_kv(
     do {                                                                                        \
         uint32_t __i;                                                                           \
         uint8_t *__cell;                                                                        \
-        for (__cell = WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; __i > 0; \
+        for (__cell = (uint8_t *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; __i > 0; \
              __cell += (unpack).__len, --__i) {                                                 \
             __wt_cell_unpack_kv(session, dsk, (WT_CELL *)__cell, &(unpack));
 

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1343,20 +1343,20 @@ __wt_page_cell_data_ref_kv(
  * WT_CELL_FOREACH --
  *	Walk the cells on a page.
  */
-#define WT_CELL_FOREACH_ADDR(session, dsk, unpack)                                              \
-    do {                                                                                        \
-        uint32_t __i;                                                                           \
-        uint8_t *__cell;                                                                        \
-        for (__cell = (uint8_t *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; __i > 0; \
-             __cell += (unpack).__len, --__i) {                                                 \
+#define WT_CELL_FOREACH_ADDR(session, dsk, unpack)                                                \
+    do {                                                                                          \
+        uint32_t __i;                                                                             \
+        uint8_t *__cell;                                                                          \
+        for (__cell = (uint8_t *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; \
+             __i > 0; __cell += (unpack).__len, --__i) {                                          \
             __wt_cell_unpack_addr(session, dsk, (WT_CELL *)__cell, &(unpack));
 
-#define WT_CELL_FOREACH_KV(session, dsk, unpack)                                                \
-    do {                                                                                        \
-        uint32_t __i;                                                                           \
-        uint8_t *__cell;                                                                        \
-        for (__cell = (uint8_t *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; __i > 0; \
-             __cell += (unpack).__len, --__i) {                                                 \
+#define WT_CELL_FOREACH_KV(session, dsk, unpack)                                                  \
+    do {                                                                                          \
+        uint32_t __i;                                                                             \
+        uint8_t *__cell;                                                                          \
+        for (__cell = (uint8_t *)WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; \
+             __i > 0; __cell += (unpack).__len, --__i) {                                          \
             __wt_cell_unpack_kv(session, dsk, (WT_CELL *)__cell, &(unpack));
 
 #define WT_CELL_FOREACH_FIX_TIMESTAMPS(session, dsk, aux, unpack)                              \

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -466,7 +466,7 @@ union __wt_rand_state {
             (buf)->size = 0;                                                    \
         for (;;) {                                                              \
             WT_ASSERT(session, (buf)->memsize >= (buf)->size);                  \
-            if ((__p = (buf)->mem) != NULL)                                     \
+            if ((__p = (char *)(buf)->mem) != NULL)                             \
                 __p += (buf)->size;                                             \
             __space = (buf)->memsize - (buf)->size;                             \
                                                                                 \

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -47,7 +47,7 @@ __log_checksum_match(WT_ITEM *buf, uint32_t reclen)
     uint32_t checksum_saved, checksum_tmp;
     bool checksum_matched;
 
-    logrec = buf->mem;
+    logrec = (WT_LOG_RECORD *)buf->mem;
     checksum_saved = checksum_tmp = logrec->checksum;
 #ifdef WORDS_BIGENDIAN
     checksum_tmp = __wt_bswap32(checksum_tmp);
@@ -871,7 +871,7 @@ __log_openfile(WT_SESSION_IMPL *session, uint32_t id, uint32_t flags, WT_FH **fh
     __wt_verbose(session, WT_VERB_LOG, "opening log %s", (const char *)buf->data);
     if (FLD_ISSET(conn->direct_io, WT_DIRECT_IO_LOG))
         FLD_SET(wtopen_flags, WT_FS_OPEN_DIRECTIO);
-    WT_ERR(__wt_open(session, buf->data, WT_FS_OPEN_FILE_TYPE_LOG, wtopen_flags, fhp));
+    WT_ERR(__wt_open(session, (const char *)buf->data, WT_FS_OPEN_FILE_TYPE_LOG, wtopen_flags, fhp));
 err:
     __wt_scr_free(session, &buf);
     return (ret);
@@ -1118,7 +1118,7 @@ __log_alloc_prealloc(WT_SESSION_IMPL *session, uint32_t to_num)
      * All file setup, writing the header and pre-allocation was done before. We only need to rename
      * it.
      */
-    WT_ERR(__wt_fs_rename(session, from_path->data, to_path->data, false));
+    WT_ERR(__wt_fs_rename(session, (const char *)from_path->data, (const char *)to_path->data, false));
 
 err:
     __wt_scr_free(session, &from_path);
@@ -1565,7 +1565,7 @@ __wt_log_allocfile(WT_SESSION_IMPL *session, uint32_t lognum, const char *dest)
     /*
      * Rename it into place and make it available.
      */
-    WT_ERR(__wt_fs_rename(session, from_path->data, to_path->data, false));
+    WT_ERR(__wt_fs_rename(session, (const char *)from_path->data, (const char *)to_path->data, false));
 
 err:
     __wt_scr_free(session, &from_path);
@@ -1588,7 +1588,7 @@ __wt_log_remove(WT_SESSION_IMPL *session, const char *file_prefix, uint32_t logn
     WT_RET(__wt_scr_alloc(session, 0, &path));
     WT_ERR(__wt_log_filename(session, lognum, file_prefix, path));
     __wt_verbose(session, WT_VERB_LOG, "log_remove: remove log %s", (const char *)path->data);
-    WT_ERR(__wt_fs_remove(session, path->data, false, false));
+    WT_ERR(__wt_fs_remove(session, (const char *)path->data, false, false));
 err:
     __wt_scr_free(session, &path);
     return (ret);
@@ -1892,7 +1892,7 @@ __log_check_partial_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint32_t recle
      * to last byte is non-zero and the last byte is zero, that could still technically be the
      * result of a partial write, however unlikely it may be.
      */
-    rec = buf->mem;
+    rec = (uint8_t *)buf->mem;
     return (reclen > 0 && rec[reclen - 1] == 0);
 }
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -871,7 +871,8 @@ __log_openfile(WT_SESSION_IMPL *session, uint32_t id, uint32_t flags, WT_FH **fh
     __wt_verbose(session, WT_VERB_LOG, "opening log %s", (const char *)buf->data);
     if (FLD_ISSET(conn->direct_io, WT_DIRECT_IO_LOG))
         FLD_SET(wtopen_flags, WT_FS_OPEN_DIRECTIO);
-    WT_ERR(__wt_open(session, (const char *)buf->data, WT_FS_OPEN_FILE_TYPE_LOG, wtopen_flags, fhp));
+    WT_ERR(
+      __wt_open(session, (const char *)buf->data, WT_FS_OPEN_FILE_TYPE_LOG, wtopen_flags, fhp));
 err:
     __wt_scr_free(session, &buf);
     return (ret);
@@ -1118,7 +1119,8 @@ __log_alloc_prealloc(WT_SESSION_IMPL *session, uint32_t to_num)
      * All file setup, writing the header and pre-allocation was done before. We only need to rename
      * it.
      */
-    WT_ERR(__wt_fs_rename(session, (const char *)from_path->data, (const char *)to_path->data, false));
+    WT_ERR(
+      __wt_fs_rename(session, (const char *)from_path->data, (const char *)to_path->data, false));
 
 err:
     __wt_scr_free(session, &from_path);
@@ -1565,7 +1567,8 @@ __wt_log_allocfile(WT_SESSION_IMPL *session, uint32_t lognum, const char *dest)
     /*
      * Rename it into place and make it available.
      */
-    WT_ERR(__wt_fs_rename(session, (const char *)from_path->data, (const char *)to_path->data, false));
+    WT_ERR(
+      __wt_fs_rename(session, (const char *)from_path->data, (const char *)to_path->data, false));
 
 err:
     __wt_scr_free(session, &from_path);

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -224,7 +224,7 @@ __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *it
     else
         WT_RET(__wt_buf_grow(session, *escapedp, needed));
     WT_IGNORE_RET(
-      __wt_json_unpack_str((u_char *)(*escapedp)->mem, (*escapedp)->memsize, (u_char *)item->data, item->size));
+      __wt_json_unpack_str((*escapedp)->mem, (*escapedp)->memsize, item->data, item->size));
     return (0);
 }
 
@@ -243,7 +243,7 @@ __logrec_make_hex_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *ite
         WT_RET(__wt_scr_alloc(session, needed, escapedp));
     else
         WT_RET(__wt_buf_grow(session, *escapedp, needed));
-    __wt_fill_hex((const uint8_t *)item->data, item->size, (unsigned char *)(*escapedp)->mem, (*escapedp)->memsize, NULL);
+    __wt_fill_hex(item->data, item->size, (*escapedp)->mem, (*escapedp)->memsize, NULL);
     return (0);
 }
 

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -224,7 +224,7 @@ __logrec_make_json_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *it
     else
         WT_RET(__wt_buf_grow(session, *escapedp, needed));
     WT_IGNORE_RET(
-      __wt_json_unpack_str((*escapedp)->mem, (*escapedp)->memsize, item->data, item->size));
+      __wt_json_unpack_str((u_char *)(*escapedp)->mem, (*escapedp)->memsize, (u_char *)item->data, item->size));
     return (0);
 }
 
@@ -243,7 +243,7 @@ __logrec_make_hex_str(WT_SESSION_IMPL *session, WT_ITEM **escapedp, WT_ITEM *ite
         WT_RET(__wt_scr_alloc(session, needed, escapedp));
     else
         WT_RET(__wt_buf_grow(session, *escapedp, needed));
-    __wt_fill_hex(item->data, item->size, (*escapedp)->mem, (*escapedp)->memsize, NULL);
+    __wt_fill_hex((const uint8_t *)item->data, item->size, (unsigned char *)(*escapedp)->mem, (*escapedp)->memsize, NULL);
     return (0);
 }
 

--- a/src/lsm/lsm_meta.c
+++ b/src/lsm/lsm_meta.c
@@ -297,7 +297,7 @@ __lsm_meta_read_v1(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, const char *
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(__wt_buf_fmt(session, buf, "key_format=u,value_format=u,memory_page_max=%" PRIu64,
       2 * lsm_tree->chunk_size));
-    file_cfg[2] = buf->data;
+    file_cfg[2] = (const char *)buf->data;
     WT_ERR(__wt_config_collapse(session, file_cfg, &fileconf));
     lsm_tree->file_config = fileconf;
 
@@ -355,7 +355,7 @@ __lsm_meta_upgrade_v1(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
 
     WT_ERR(__wt_buf_catfmt(session, buf, ")"));
 
-    new_cfg[2] = buf->data;
+    new_cfg[2] = (const char *)buf->data;
     WT_ERR(__wt_config_merge(session, new_cfg, NULL, &lsm_tree->config));
 
 err:
@@ -459,7 +459,7 @@ __wti_lsm_meta_write(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, const char
     /* Update the existing configuration with the new values. */
     new_cfg[0] = WT_CONFIG_BASE(session, lsm_meta);
     new_cfg[1] = lsm_tree->config;
-    new_cfg[2] = buf->data;
+    new_cfg[2] = (const char *)buf->data;
     new_cfg[3] = newconfig;
     WT_ERR(__wt_config_collapse(session, new_cfg, &new_metadata));
     ret = __wt_metadata_update(session, lsm_tree->name, new_metadata);

--- a/src/lsm/lsm_stat.c
+++ b/src/lsm/lsm_stat.c
@@ -101,10 +101,10 @@ __curstat_lsm_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT *cs
          * filter's information, then aggregate into the top-level.
          */
         new_stats = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
-        WT_STAT_WRITE(
-          session, new_stats, bloom_size, (int64_t)((chunk->count * lsm_tree->bloom_bit_count) / 8));
-        WT_STAT_WRITE(
-          session, new_stats, bloom_page_evict, new_stats->cache_eviction_clean + new_stats->cache_eviction_dirty);
+        WT_STAT_WRITE(session, new_stats, bloom_size,
+          (int64_t)((chunk->count * lsm_tree->bloom_bit_count) / 8));
+        WT_STAT_WRITE(session, new_stats, bloom_page_evict,
+          new_stats->cache_eviction_clean + new_stats->cache_eviction_dirty);
         WT_STAT_WRITE(session, new_stats, bloom_page_read, new_stats->cache_read);
 
         __wt_stat_dsrc_aggregate_single(new_stats, stats);

--- a/src/lsm/lsm_stat.c
+++ b/src/lsm/lsm_stat.c
@@ -18,7 +18,7 @@ __curstat_lsm_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT *cs
     WT_CURSOR *stat_cursor;
     WT_DECL_ITEM(uribuf);
     WT_DECL_RET;
-    WT_DSRC_STATS *new, *stats;
+    WT_DSRC_STATS *new_stats, *stats;
     WT_LSM_CHUNK *chunk;
     WT_LSM_TREE *lsm_tree;
     int64_t bloom_count;
@@ -69,21 +69,21 @@ __curstat_lsm_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT *cs
          * open the ordinary handle on that chunk instead.
          */
         WT_ERR(__wt_buf_fmt(session, uribuf, "statistics:%s", chunk->uri));
-        ret = __wt_curstat_open(session, uribuf->data, NULL,
+        ret = __wt_curstat_open(session, (const char *)uribuf->data, NULL,
           F_ISSET(chunk, WT_LSM_CHUNK_ONDISK) ? disk_cfg : cfg, &stat_cursor);
         if (ret == WT_NOTFOUND && F_ISSET(chunk, WT_LSM_CHUNK_ONDISK))
-            ret = __wt_curstat_open(session, uribuf->data, NULL, cfg, &stat_cursor);
+            ret = __wt_curstat_open(session, (const char *)uribuf->data, NULL, cfg, &stat_cursor);
         WT_ERR(ret);
 
         /*
          * The underlying statistics have now been initialized; fill in values from the chunk's
          * information, then aggregate into the top-level.
          */
-        new = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
-        WT_STAT_WRITE(session, new, lsm_generation_max, chunk->generation);
+        new_stats = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
+        WT_STAT_WRITE(session, new_stats, lsm_generation_max, chunk->generation);
 
         /* Aggregate statistics from each new chunk. */
-        __wt_stat_dsrc_aggregate_single(new, stats);
+        __wt_stat_dsrc_aggregate_single(new_stats, stats);
         WT_ERR(stat_cursor->close(stat_cursor));
 
         if (!F_ISSET(chunk, WT_LSM_CHUNK_BLOOM))
@@ -94,20 +94,20 @@ __curstat_lsm_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT *cs
 
         /* Get the bloom filter's underlying object. */
         WT_ERR(__wt_buf_fmt(session, uribuf, "statistics:%s", chunk->bloom_uri));
-        WT_ERR(__wt_curstat_open(session, uribuf->data, NULL, cfg, &stat_cursor));
+        WT_ERR(__wt_curstat_open(session, (const char *)uribuf->data, NULL, cfg, &stat_cursor));
 
         /*
          * The underlying statistics have now been initialized; fill in values from the bloom
          * filter's information, then aggregate into the top-level.
          */
-        new = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
+        new_stats = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
         WT_STAT_WRITE(
-          session, new, bloom_size, (int64_t)((chunk->count * lsm_tree->bloom_bit_count) / 8));
+          session, new_stats, bloom_size, (int64_t)((chunk->count * lsm_tree->bloom_bit_count) / 8));
         WT_STAT_WRITE(
-          session, new, bloom_page_evict, new->cache_eviction_clean + new->cache_eviction_dirty);
-        WT_STAT_WRITE(session, new, bloom_page_read, new->cache_read);
+          session, new_stats, bloom_page_evict, new_stats->cache_eviction_clean + new_stats->cache_eviction_dirty);
+        WT_STAT_WRITE(session, new_stats, bloom_page_read, new_stats->cache_read);
 
-        __wt_stat_dsrc_aggregate_single(new, stats);
+        __wt_stat_dsrc_aggregate_single(new_stats, stats);
         WT_ERR(stat_cursor->close(stat_cursor));
     }
 

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -170,7 +170,7 @@ __lsm_tree_set_name(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, const char 
     WT_RET(__wt_strdup(session, uri, &p));
 
     __wt_free(session, lsm_tree->name);
-    lsm_tree->name = p;
+    lsm_tree->name = (const char *)p;
     lsm_tree->filename = lsm_tree->name + strlen("lsm:");
     return (0);
 }

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -304,7 +304,7 @@ __lsm_set_chunk_evictable(WT_SESSION_IMPL *session, WT_LSM_CHUNK *chunk, bool ne
     if (__wt_atomic_cas32(&chunk->evict_enabled, 0, 1)) {
         if (need_handle)
             WT_RET(__wt_session_get_dhandle(session, chunk->uri, NULL, NULL, 0));
-        btree = session->dhandle->handle;
+        btree = (WT_BTREE *)session->dhandle->handle;
         if (btree->evict_disabled_open) {
             btree->evict_disabled_open = false;
             __wt_evict_file_exclusive_off(session);

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -312,7 +312,7 @@ __ckpt_set(WT_SESSION_IMPL *session, const char *fname, const char *v, bool use_
 
         /* Concatenate the metadata base string with the checkpoint string. */
         WT_ERR(__wt_buf_fmt(session, tmp, "%s,%s", meta_base, str));
-        WT_ERR(__wt_metadata_update(session, fname, tmp->mem));
+        WT_ERR(__wt_metadata_update(session, fname, (const char *)tmp->mem));
     } else {
         /* Retrieve the metadata for this file. */
         WT_ERR(__wt_metadata_search(session, fname, &config));
@@ -472,9 +472,9 @@ __wt_meta_block_metadata(WT_SESSION_IMPL *session, const char *config, WT_CKPT *
         WT_ERR(__wt_buf_grow(session, b, encrypt_size));
         WT_ERR(__wt_encrypt(session, kencryptor, 0, a, b));
         WT_ERR(__wt_buf_grow(session, a, b->size * 2 + 1));
-        __wt_fill_hex(b->mem, b->size, a->mem, a->memsize, &a->size);
+        __wt_fill_hex((const uint8_t *)b->mem, b->size, (uint8_t *)a->mem, a->memsize, &a->size);
 
-        metadata = a->data;
+        metadata = (const char *)a->data;
         metadata_len = a->size;
     }
 
@@ -1133,7 +1133,7 @@ __wt_meta_ckptlist_to_meta(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, WT_ITEM 
             if (ckpt->raw.size == 0)
                 ckpt->addr.size = 0;
             else
-                WT_RET(__wt_raw_to_hex(session, ckpt->raw.data, ckpt->raw.size, &ckpt->addr));
+                WT_RET(__wt_raw_to_hex(session, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, &ckpt->addr));
         }
 
         WT_RET(__wt_check_addr_validity(session, &ckpt->ta, false));
@@ -1205,7 +1205,7 @@ __ckpt_blkmod_to_meta(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_CKPT *ckpt)
           !F_ISSET(blk, WT_BLOCK_MODS_RENAME) && __wt_random(&session->rnd) % 10 == 0)
             skip_rename = true;
 
-        WT_RET(__wt_raw_to_hex(session, blk->bitstring.data, blk->bitstring.size, &bitstring));
+        WT_RET(__wt_raw_to_hex(session, (const uint8_t *)blk->bitstring.data, blk->bitstring.size, &bitstring));
         WT_RET(__wt_buf_catfmt(session, buf,
           "%s\"%s\"=(id=%" PRIu32 ",granularity=%" PRIu64 ",nbits=%" PRIu64 ",offset=%" PRIu64
           "%s,blocks=%.*s)",
@@ -1247,7 +1247,7 @@ __wt_meta_ckptlist_update_config(
 
     /* Replace the checkpoint entry. */
     cfg[0] = oldcfg;
-    cfg[1] = buf->mem;
+    cfg[1] = (const char *)buf->mem;
     cfg[2] = NULL;
     WT_ERR(__wt_config_collapse(session, cfg, &newcfg));
 
@@ -1491,7 +1491,7 @@ __wt_meta_ckptlist_set(
     if (__wt_atomic_load_enum(&dhandle->type) == WT_DHANDLE_TYPE_TIERED)
         WT_ERR(__wt_tiered_set_metadata(session, (WT_TIERED *)dhandle, buf));
 
-    WT_ERR(__ckpt_set(session, fname, buf->mem, has_lsn));
+    WT_ERR(__ckpt_set(session, fname, (const char *)buf->mem, has_lsn));
 
 err:
     __wt_scr_free(session, &buf);
@@ -1610,7 +1610,7 @@ __meta_sysinfo_update(WT_SESSION_IMPL *session, bool full, const char *name, siz
         WT_RET(__wt_metadata_update(session, uri, value));
     if (name != NULL) {
         WT_RET(__wt_buf_fmt(session, buf, "%s.%.*s", uri, (int)namelen, name));
-        WT_RET(__wt_metadata_update(session, buf->data, value));
+        WT_RET(__wt_metadata_update(session, (const char *)buf->data, value));
     }
     return (0);
 }
@@ -1627,7 +1627,7 @@ __meta_sysinfo_remove(WT_SESSION_IMPL *session, bool full, const char *name, siz
         WT_RET_NOTFOUND_OK(__wt_metadata_remove(session, uri));
     if (name != NULL) {
         WT_RET(__wt_buf_fmt(session, buf, "%s.%.*s", uri, (int)namelen, name));
-        WT_RET_NOTFOUND_OK(__wt_metadata_remove(session, buf->data));
+        WT_RET_NOTFOUND_OK(__wt_metadata_remove(session, (const char *)buf->data));
     }
     return (0);
 }
@@ -1705,7 +1705,7 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session, bool full, const char *name, siz
                             "=%" PRIu64,
           hex_timestamp, session->current_ckpt_sec, conn->base_write_gen));
         WT_ERR(__meta_sysinfo_update(
-          session, full, name, namelen, uribuf, WT_SYSTEM_CKPT_URI, valbuf->data));
+          session, full, name, namelen, uribuf, WT_SYSTEM_CKPT_URI, (const char *)valbuf->data));
     }
 
     /*
@@ -1728,14 +1728,14 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session, bool full, const char *name, siz
                               "=%" PRIu64,
           hex_timestamp, session->current_ckpt_sec, conn->base_write_gen));
         WT_ERR(__meta_sysinfo_update(
-          session, full, name, namelen, uribuf, WT_SYSTEM_OLDEST_URI, valbuf->data));
+          session, full, name, namelen, uribuf, WT_SYSTEM_OLDEST_URI, (const char *)valbuf->data));
     }
 
     /* Handle the snapshot information. */
 
     WT_ERR(__meta_print_snapshot(session, valbuf));
     WT_ERR(__meta_sysinfo_update(
-      session, full, name, namelen, uribuf, WT_SYSTEM_CKPT_SNAPSHOT_URI, valbuf->data));
+      session, full, name, namelen, uribuf, WT_SYSTEM_CKPT_SNAPSHOT_URI, (const char *)valbuf->data));
 
     /* Print what we did. */
 
@@ -1759,7 +1759,7 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session, bool full, const char *name, siz
     if (full) {
         WT_ERR(__wt_buf_fmt(
           session, valbuf, WT_SYSTEM_BASE_WRITE_GEN "=%" PRIu64, conn->base_write_gen));
-        WT_ERR(__wt_metadata_update(session, WT_SYSTEM_BASE_WRITE_GEN_URI, valbuf->data));
+        WT_ERR(__wt_metadata_update(session, WT_SYSTEM_BASE_WRITE_GEN_URI, (const char *)valbuf->data));
     }
 
 err:
@@ -1848,7 +1848,7 @@ __wt_meta_read_checkpoint_snapshot(WT_SESSION_IMPL *session, const char *ckpt_na
     else {
         WT_ERR(__wt_scr_alloc(session, 0, &tmp));
         WT_ERR(__wt_buf_fmt(session, tmp, "%s.%s", WT_SYSTEM_CKPT_SNAPSHOT_URI, ckpt_name));
-        WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, tmp->data, &sys_config), false);
+        WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, (const char *)tmp->data, &sys_config), false);
     }
 
     /* Extract the components of the metadata string. */
@@ -1975,7 +1975,7 @@ __meta_retrieve_checkpoint_timestamp(WT_SESSION_IMPL *session, const char *ckpt_
 
     WT_ERR(__wt_scr_alloc(session, 0, &tmp));
     WT_ERR(__wt_buf_fmt(session, tmp, "%s.%s", uri, ckpt_name));
-    WT_ERR(__meta_retrieve_timestamp(session, tmp->data, key, timestampp, ckpttime));
+    WT_ERR(__meta_retrieve_timestamp(session, (const char *)tmp->data, key, timestampp, ckpttime));
 err:
     __wt_scr_free(session, &tmp);
     return (ret);

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1133,7 +1133,8 @@ __wt_meta_ckptlist_to_meta(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, WT_ITEM 
             if (ckpt->raw.size == 0)
                 ckpt->addr.size = 0;
             else
-                WT_RET(__wt_raw_to_hex(session, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, &ckpt->addr));
+                WT_RET(__wt_raw_to_hex(
+                  session, (const uint8_t *)ckpt->raw.data, ckpt->raw.size, &ckpt->addr));
         }
 
         WT_RET(__wt_check_addr_validity(session, &ckpt->ta, false));
@@ -1205,7 +1206,8 @@ __ckpt_blkmod_to_meta(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_CKPT *ckpt)
           !F_ISSET(blk, WT_BLOCK_MODS_RENAME) && __wt_random(&session->rnd) % 10 == 0)
             skip_rename = true;
 
-        WT_RET(__wt_raw_to_hex(session, (const uint8_t *)blk->bitstring.data, blk->bitstring.size, &bitstring));
+        WT_RET(__wt_raw_to_hex(
+          session, (const uint8_t *)blk->bitstring.data, blk->bitstring.size, &bitstring));
         WT_RET(__wt_buf_catfmt(session, buf,
           "%s\"%s\"=(id=%" PRIu32 ",granularity=%" PRIu64 ",nbits=%" PRIu64 ",offset=%" PRIu64
           "%s,blocks=%.*s)",
@@ -1734,8 +1736,8 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session, bool full, const char *name, siz
     /* Handle the snapshot information. */
 
     WT_ERR(__meta_print_snapshot(session, valbuf));
-    WT_ERR(__meta_sysinfo_update(
-      session, full, name, namelen, uribuf, WT_SYSTEM_CKPT_SNAPSHOT_URI, (const char *)valbuf->data));
+    WT_ERR(__meta_sysinfo_update(session, full, name, namelen, uribuf, WT_SYSTEM_CKPT_SNAPSHOT_URI,
+      (const char *)valbuf->data));
 
     /* Print what we did. */
 
@@ -1759,7 +1761,8 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session, bool full, const char *name, siz
     if (full) {
         WT_ERR(__wt_buf_fmt(
           session, valbuf, WT_SYSTEM_BASE_WRITE_GEN "=%" PRIu64, conn->base_write_gen));
-        WT_ERR(__wt_metadata_update(session, WT_SYSTEM_BASE_WRITE_GEN_URI, (const char *)valbuf->data));
+        WT_ERR(
+          __wt_metadata_update(session, WT_SYSTEM_BASE_WRITE_GEN_URI, (const char *)valbuf->data));
     }
 
 err:
@@ -1848,7 +1851,8 @@ __wt_meta_read_checkpoint_snapshot(WT_SESSION_IMPL *session, const char *ckpt_na
     else {
         WT_ERR(__wt_scr_alloc(session, 0, &tmp));
         WT_ERR(__wt_buf_fmt(session, tmp, "%s.%s", WT_SYSTEM_CKPT_SNAPSHOT_URI, ckpt_name));
-        WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, (const char *)tmp->data, &sys_config), false);
+        WT_ERR_NOTFOUND_OK(
+          __wt_metadata_search(session, (const char *)tmp->data, &sys_config), false);
     }
 
     /* Extract the components of the metadata string. */

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -58,7 +58,7 @@ __meta_track_next(WT_SESSION_IMPL *session, WT_META_TRACK **trkp)
     WT_ASSERT(session, session->meta_track_next != NULL);
 
     if (trkp != NULL) {
-        *trkp = session->meta_track_next;
+        *trkp = (WT_META_TRACK *)session->meta_track_next;
         session->meta_track_next = *trkp + 1;
     }
 
@@ -86,7 +86,7 @@ __meta_track_err(WT_SESSION_IMPL *session)
 {
     WT_META_TRACK *trk;
 
-    trk = session->meta_track_next;
+    trk = (WT_META_TRACK *)session->meta_track_next;
     --trk;
     __meta_track_clear(session, trk);
 
@@ -141,7 +141,7 @@ __meta_track_apply(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
     case WT_ST_EMPTY: /* Unused slot */
         break;
     case WT_ST_CHECKPOINT: /* Checkpoint, see above */
-        btree = trk->dhandle->handle;
+        btree = (WT_BTREE *)trk->dhandle->handle;
         bm = btree->bm;
         WT_WITH_DHANDLE(session, trk->dhandle, ret = bm->checkpoint_resolve(bm, session, false));
         break;
@@ -181,7 +181,7 @@ __meta_track_unroll(WT_SESSION_IMPL *session, WT_META_TRACK *trk)
     case WT_ST_EMPTY: /* Unused slot */
         break;
     case WT_ST_CHECKPOINT: /* Checkpoint, see above */
-        btree = trk->dhandle->handle;
+        btree = (WT_BTREE *)trk->dhandle->handle;
         bm = btree->bm;
         WT_WITH_DHANDLE(session, trk->dhandle, ret = bm->checkpoint_resolve(bm, session, true));
         break;
@@ -244,8 +244,8 @@ __wt_meta_track_off(WT_SESSION_IMPL *session, bool need_sync, bool unroll)
 
     WT_ASSERT(session, WT_META_TRACKING(session) && session->meta_track_nest > 0);
 
-    trk_orig = session->meta_track;
-    trk = session->meta_track_next;
+    trk_orig = (WT_META_TRACK *)session->meta_track;
+    trk = (WT_META_TRACK *)session->meta_track_next;
 
     /* If it was a nested transaction, there is nothing to do. */
     if (--session->meta_track_nest != 0)
@@ -368,8 +368,8 @@ __wt_meta_track_sub_off(WT_SESSION_IMPL *session)
     if (!WT_META_TRACKING(session) || session->meta_track_sub == NULL)
         return (0);
 
-    trk_orig = session->meta_track_sub;
-    trk = session->meta_track_next;
+    trk_orig = (WT_META_TRACK *)session->meta_track_sub;
+    trk = (WT_META_TRACK *)session->meta_track_next;
 
     /* Turn off tracking for unroll. */
     session->meta_track_next = session->meta_track_sub = NULL;

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -39,7 +39,7 @@ __metadata_config(WT_SESSION_IMPL *session, char **metaconfp)
     WT_ERR(__wt_buf_fmt(session, buf,
       "key_format=S,value_format=S,id=%d,version=(major=%" PRIu16 ",minor=%" PRIu16 ")",
       WT_METAFILE_ID, WT_BTREE_VERSION_MAX.major, WT_BTREE_VERSION_MAX.minor));
-    cfg[1] = buf->data;
+    cfg[1] = (const char *)buf->data;
     ret = __wt_config_tiered_strip(session, cfg, (const char **)metaconfp);
 
 err:
@@ -188,7 +188,7 @@ __metadata_entry_worker(WT_SESSION_IMPL *session, WT_ITEM *key, WT_ITEM *value, 
      * In the case of partial backup restore, add the entry to the metadata even if the table entry
      * doesn't exist so that we can correctly drop all related entries via the schema code later.
      */
-    WT_RET(__wt_metadata_update(session, key->data, value->data));
+    WT_RET(__wt_metadata_update(session, (const char *)key->data, (const char *)value->data));
 
     return (0);
 }
@@ -644,7 +644,7 @@ __wti_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
         WT_ERR(__wt_getline(session, fs, buf));
         if (buf->size == 0)
             WT_ERR(WT_NOTFOUND);
-    } while (strcmp(key, buf->data) != 0);
+    } while (strcmp(key, (const char *)buf->data) != 0);
 
     /* Key matched: read the subsequent line for the value. */
     WT_ERR(__wt_getline(session, fs, buf));
@@ -652,7 +652,7 @@ __wti_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
         WT_ERR(WT_NOTFOUND);
 
     /* Copy the value for the caller. */
-    WT_ERR(__wt_strdup(session, buf->data, valuep));
+    WT_ERR(__wt_strdup(session, (const char *)buf->data, valuep));
 
 err:
     WT_TRET(__wt_fclose(session, &fs));

--- a/src/os_common/filename.c
+++ b/src/os_common/filename.c
@@ -124,7 +124,7 @@ __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const char *to)
 
     /* Open the from and temporary file handles. */
     WT_ERR(__wt_open(session, from, WT_FS_OPEN_FILE_TYPE_REGULAR, 0, &ffh));
-    WT_ERR(__wt_open(session,(const char *) tmp->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
+    WT_ERR(__wt_open(session, (const char *)tmp->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
       WT_FS_OPEN_CREATE | WT_FS_OPEN_EXCLUSIVE, &tfh));
 
 /*

--- a/src/os_common/filename.c
+++ b/src/os_common/filename.c
@@ -120,11 +120,11 @@ __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const char *to)
     WT_ERR(__wt_buf_fmt(session, tmp, "%s.copy", to));
 
     WT_ERR(__wt_remove_if_exists(session, to, false));
-    WT_ERR(__wt_remove_if_exists(session, tmp->data, false));
+    WT_ERR(__wt_remove_if_exists(session, (const char *)tmp->data, false));
 
     /* Open the from and temporary file handles. */
     WT_ERR(__wt_open(session, from, WT_FS_OPEN_FILE_TYPE_REGULAR, 0, &ffh));
-    WT_ERR(__wt_open(session, tmp->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
+    WT_ERR(__wt_open(session,(const char *) tmp->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
       WT_FS_OPEN_CREATE | WT_FS_OPEN_EXCLUSIVE, &tfh));
 
 /*
@@ -147,7 +147,7 @@ __wt_copy_and_sync(WT_SESSION *wt_session, const char *from, const char *to)
     WT_ERR(__wt_fsync(session, tfh, true));
     WT_ERR(__wt_close(session, &tfh));
 
-    ret = __wt_fs_rename(session, tmp->data, to, true);
+    ret = __wt_fs_rename(session, (const char *)tmp->data, to, true);
 
 err:
     WT_TRET(__wt_close(session, &ffh));

--- a/src/os_common/os_errno.c
+++ b/src/os_common/os_errno.c
@@ -53,7 +53,7 @@ __wt_strerror(WT_SESSION_IMPL *session, int error, char *errbuf, size_t errlen)
         return (errbuf);
     if (session != NULL && __wt_buf_fmt(session, &session->err, "error return: %d", error) == 0 &&
       session->err.data != NULL)
-        return (session->err.data);
+        return ((const char *)session->err.data);
 
     /* Defeated. */
     return ("Unable to return error string");

--- a/src/os_common/os_fstream.c
+++ b/src/os_common/os_fstream.c
@@ -87,7 +87,7 @@ __fstream_getline(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, WT_ITEM *buf)
             fstr->off += (wt_off_t)len;
         }
 
-        c = *(p = fstr->buf.data);
+        c = *(p = (const char *)fstr->buf.data);
         fstr->buf.data = ++p;
 
         /* Leave space for a trailing NUL. */
@@ -132,7 +132,7 @@ __fstream_printf(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, const char *fmt, va
 
     for (;;) {
         va_copy(ap_copy, ap);
-        if ((p = buf->mem) != NULL)
+        if ((p = (char *)buf->mem) != NULL)
             p += buf->size;
         space = buf->memsize - buf->size;
 

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -551,7 +551,7 @@ __posix_file_read(
 
     /* Break reads larger than 1GB into 1GB chunks. */
     nr = 0;
-    for (addr = buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
+    for (addr = (uint8_t *)buf; len > 0; addr += nr, len -= (size_t)nr, offset += nr) {
         chunk = WT_MIN(len, WT_GIGABYTE);
         /*
          * The WT_SYSCALL_RETRY macro expects 0 for success. pread returns > 0 when it successfully
@@ -723,7 +723,7 @@ __posix_file_write(
           len >= S2C(session)->buffer_alignment && len % S2C(session)->buffer_alignment == 0));
 
     /* Break writes larger than 1GB into 1GB chunks. */
-    for (addr = buf; len > 0; addr += nw, len -= (size_t)nw, offset += nw) {
+    for (addr = (uint8_t *)buf; len > 0; addr += nw, len -= (size_t)nw, offset += nw) {
         chunk = WT_MIN(len, WT_GIGABYTE);
         if ((nw = pwrite(pfh->fd, addr, chunk, offset)) < 0)
             WT_RET_MSG(session, __wt_errno(),

--- a/src/packing/pack_impl.c
+++ b/src/packing/pack_impl.c
@@ -119,7 +119,7 @@ __wt_struct_repack(WT_SESSION_IMPL *session, const char *infmt, const char *outf
     const void *start;
 
     start = NULL;
-    p = inbuf->data;
+    p = (const uint8_t *)inbuf->data;
     end = p + inbuf->size;
 
     WT_RET(__pack_init(session, &packout, outfmt));

--- a/src/packing/pack_stream.c
+++ b/src/packing/pack_stream.c
@@ -33,7 +33,7 @@ wiredtiger_pack_start(
     session = (WT_SESSION_IMPL *)wt_session;
     WT_RET(__wt_calloc_one(session, &ps));
     WT_ERR(__pack_init(session, &ps->pack, format));
-    ps->p = ps->start = buffer;
+    ps->p = ps->start = (uint8_t *)buffer;
     ps->end = ps->p + size;
     *psp = ps;
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -20,7 +20,7 @@ __rec_col_fix_bulk_insert_split_check(WT_CURSOR_BULK *cbulk)
     WT_SESSION_IMPL *session;
 
     session = CUR2S(cbulk);
-    r = cbulk->reconcile;
+    r = (WT_RECONCILE *)cbulk->reconcile;
     btree = S2BT(session);
 
     if (cbulk->entry == cbulk->nrecs) {
@@ -36,7 +36,7 @@ __rec_col_fix_bulk_insert_split_check(WT_CURSOR_BULK *cbulk)
             __wt_rec_incr(
               session, r, cbulk->entry, __bitstr_size((size_t)cbulk->entry * btree->bitcnt));
             __bit_clear_end(
-              WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
+              (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
             WT_RET(__wti_rec_split(session, r, 0));
         }
         cbulk->entry = 0;
@@ -57,7 +57,7 @@ __wt_bulk_insert_fix(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool delet
     WT_RECONCILE *r;
     WT_TIME_WINDOW tw;
 
-    r = cbulk->reconcile;
+    r = (WT_RECONCILE *)cbulk->reconcile;
     btree = S2BT(session);
     cursor = &cbulk->cbt.iface;
 
@@ -91,13 +91,13 @@ __wt_bulk_insert_fix_bitmap(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     uint32_t entries, offset, page_entries, page_size;
     const uint8_t *data;
 
-    r = cbulk->reconcile;
+    r = (WT_RECONCILE *)cbulk->reconcile;
     btree = S2BT(session);
     cursor = &cbulk->cbt.iface;
 
     if (((r->recno - 1) * btree->bitcnt) & 0x7)
         WT_RET_MSG(session, EINVAL, "Bulk bitmap load not aligned on a byte boundary");
-    for (data = cursor->value.data, entries = (uint32_t)cursor->value.size; entries > 0;
+    for (data = (const uint8_t *)cursor->value.data, entries = (uint32_t)cursor->value.size; entries > 0;
          entries -= page_entries, data += page_size) {
         WT_RET(__rec_col_fix_bulk_insert_split_check(cbulk));
 
@@ -127,7 +127,7 @@ __wt_bulk_insert_var(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool delet
     WT_REC_KV *val;
     WT_TIME_WINDOW tw;
 
-    r = cbulk->reconcile;
+    r = (WT_RECONCILE *)cbulk->reconcile;
     btree = S2BT(session);
     WT_TIME_WINDOW_INIT(&tw);
 
@@ -286,12 +286,12 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
          * build a new cell.
          */
         if (addr == NULL && __wt_off_page(page, ref->addr))
-            addr = ref->addr;
+            addr = (WT_ADDR *)ref->addr;
         if (addr != NULL) {
             __wt_rec_cell_build_addr(session, r, addr, NULL, ref->ref_recno, page_del);
             WT_TIME_AGGREGATE_COPY(&ta, &addr->ta);
         } else {
-            __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
+            __wt_cell_unpack_addr(session, page->dsk, (WT_CELL *)ref->addr, vpack);
             if (cms.state == WT_CHILD_PROXY || F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED)) {
                 /*
                  * Need to build a proxy (page-deleted) cell or rebuild the cell with updated time
@@ -953,7 +953,7 @@ __wti_rec_col_fix(
 
             /* Make sure the trailing bits in the bitmap get cleared. */
             __bit_clear_end(
-              WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
+              (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
 
             /* Now split. */
             WT_ERR(__wti_rec_split(session, r, 0));
@@ -986,7 +986,7 @@ __wti_rec_col_fix(
     }
 
     /* Make sure the trailing bits in the bitmap get cleared. */
-    __bit_clear_end(WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
+    __bit_clear_end((uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
 
     /* Write the remnant page. */
     WT_ERR(__wti_rec_split_finish(session, r));
@@ -1278,7 +1278,7 @@ __wti_rec_col_var(
     /* For each entry in the in-memory page... */
     WT_COL_FOREACH (page, cip, i) {
         ovfl_state = OVFL_IGNORE;
-        cell = WT_COL_PTR(page, cip);
+        cell = (WT_CELL *)WT_COL_PTR(page, cip);
         __wt_cell_unpack_kv(session, page->dsk, cell, vpack);
         nrepeat = __wt_cell_rle(vpack);
         ins = WT_SKIP_FIRST(WT_COL_UPDATE(page, cip));

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -35,8 +35,8 @@ __rec_col_fix_bulk_insert_split_check(WT_CURSOR_BULK *cbulk)
              */
             __wt_rec_incr(
               session, r, cbulk->entry, __bitstr_size((size_t)cbulk->entry * btree->bitcnt));
-            __bit_clear_end(
-              (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
+            __bit_clear_end((uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem),
+              cbulk->entry, btree->bitcnt);
             WT_RET(__wti_rec_split(session, r, 0));
         }
         cbulk->entry = 0;
@@ -97,8 +97,8 @@ __wt_bulk_insert_fix_bitmap(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
 
     if (((r->recno - 1) * btree->bitcnt) & 0x7)
         WT_RET_MSG(session, EINVAL, "Bulk bitmap load not aligned on a byte boundary");
-    for (data = (const uint8_t *)cursor->value.data, entries = (uint32_t)cursor->value.size; entries > 0;
-         entries -= page_entries, data += page_size) {
+    for (data = (const uint8_t *)cursor->value.data, entries = (uint32_t)cursor->value.size;
+         entries > 0; entries -= page_entries, data += page_size) {
         WT_RET(__rec_col_fix_bulk_insert_split_check(cbulk));
 
         page_entries = WT_MIN(entries, cbulk->nrecs - cbulk->entry);
@@ -952,8 +952,8 @@ __wti_rec_col_fix(
             }
 
             /* Make sure the trailing bits in the bitmap get cleared. */
-            __bit_clear_end(
-              (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
+            __bit_clear_end((uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem),
+              r->entries, btree->bitcnt);
 
             /* Now split. */
             WT_ERR(__wti_rec_split(session, r, 0));
@@ -986,7 +986,8 @@ __wti_rec_col_fix(
     }
 
     /* Make sure the trailing bits in the bitmap get cleared. */
-    __bit_clear_end((uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
+    __bit_clear_end(
+      (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), r->entries, btree->bitcnt);
 
     /* Write the remnant page. */
     WT_ERR(__wti_rec_split_finish(session, r));

--- a/src/reconcile/rec_dictionary.c
+++ b/src/reconcile/rec_dictionary.c
@@ -161,7 +161,7 @@ __wt_rec_dictionary_lookup(
          dp != NULL && dp->hash == hash; dp = dp->next[0]) {
         WT_RET(
           __wt_cell_pack_value_match((WT_CELL *)((uint8_t *)r->cur_ptr->image.mem + dp->offset),
-            &val->cell, val->buf.data, &match));
+            &val->cell, (const uint8_t *)val->buf.data, &match));
         if (match) {
             WT_STAT_DSRC_INCR(session, rec_dictionary);
             *dpp = dp;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -120,7 +120,7 @@ __rec_cell_build_leaf_key(
                 pfx_max = size;
             if (r->last->size < pfx_max)
                 pfx_max = r->last->size;
-            for (a = data, b = r->last->data; pfx < pfx_max; ++pfx)
+            for (a = (const uint8_t *)data, b = (const uint8_t *)r->last->data; pfx < pfx_max; ++pfx)
                 if (*a++ != *b++)
                     break;
 
@@ -182,7 +182,7 @@ __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     WT_TIME_WINDOW tw;
     bool ovfl_key;
 
-    r = cbulk->reconcile;
+    r = (WT_RECONCILE *)cbulk->reconcile;
     btree = S2BT(session);
     cursor = &cbulk->cbt.iface;
     WT_TIME_WINDOW_INIT(&tw);
@@ -338,7 +338,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
         cell = NULL;
         ikey = __wt_ref_key_instantiated(ref);
         if (ikey != NULL && ikey->cell_offset != 0) {
-            cell = WT_PAGE_REF_OFFSET(page, ikey->cell_offset);
+            cell = (WT_CELL *)WT_PAGE_REF_OFFSET(page, ikey->cell_offset);
             __wt_cell_unpack_addr(session, page->dsk, cell, kpack);
 
             /*
@@ -351,7 +351,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
         }
 
         WT_ERR(__wti_rec_child_modify(session, r, ref, &cms));
-        addr = ref->addr;
+        addr = (WT_ADDR *)ref->addr;
         child = ref->page;
 
         switch (cms.state) {
@@ -403,7 +403,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
             source_ta = &addr->ta;
         } else if (cms.state == WT_CHILD_PROXY) {
             /* Proxy cells require additional information in the address cell. */
-            __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
+            __wt_cell_unpack_addr(session, page->dsk, (WT_CELL *)ref->addr, vpack);
             page_del = &cms.del;
             __wt_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del);
             source_ta = &vpack->ta;
@@ -414,7 +414,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
              */
             WT_ASSERT_ALWAYS(session, cms.state == WT_CHILD_ORIGINAL,
               "Not propagating the original fast-truncate information");
-            __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
+            __wt_cell_unpack_addr(session, page->dsk, (WT_CELL *)ref->addr, vpack);
 
             /* The proxy cells of fast truncate pages must be handled in the above flows. */
             WT_ASSERT_ALWAYS(session, vpack->type != WT_CELL_ADDR_DEL,

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -120,7 +120,8 @@ __rec_cell_build_leaf_key(
                 pfx_max = size;
             if (r->last->size < pfx_max)
                 pfx_max = r->last->size;
-            for (a = (const uint8_t *)data, b = (const uint8_t *)r->last->data; pfx < pfx_max; ++pfx)
+            for (a = (const uint8_t *)data, b = (const uint8_t *)r->last->data; pfx < pfx_max;
+                 ++pfx)
                 if (*a++ != *b++)
                     break;
 

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -397,7 +397,8 @@ __ovfl_reuse_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
-        WT_TRET(bm->free(bm, session, (const uint8_t *)WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
+        WT_TRET(
+          bm->free(bm, session, (const uint8_t *)WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
         decr += WT_OVFL_SIZE(reuse, WT_OVFL_REUSE);
         __wt_free(session, reuse);
     }

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -45,7 +45,7 @@ __ovfl_discard_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell, c
 
     __wt_verbose_debug2(session, WT_VERB_OVERFLOW, "discard: %s%s%p %s", tag == NULL ? "" : tag,
       tag == NULL ? "" : ": ", (void *)page,
-      __wt_addr_string(session, unpack->data, unpack->size, tmp));
+      __wt_addr_string(session, (const uint8_t *)unpack->data, unpack->size, tmp));
 
     __wt_scr_free(session, &tmp);
     return (0);
@@ -168,7 +168,7 @@ __ovfl_reuse_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_OVFL_REUSE *reu
 
     __wt_verbose_debug2(session, WT_VERB_OVERFLOW, "reuse: %s%s%p %s (%s%s%s) {%.*s}",
       tag == NULL ? "" : tag, tag == NULL ? "" : ": ", (void *)page,
-      __wt_addr_string(session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size, tmp),
+      __wt_addr_string(session, (const uint8_t *)WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size, tmp),
       F_ISSET(reuse, WT_OVFL_REUSE_INUSE) ? "inuse" : "",
       F_ISSET(reuse, WT_OVFL_REUSE_INUSE) && F_ISSET(reuse, WT_OVFL_REUSE_JUST_ADDED) ? ", " : "",
       F_ISSET(reuse, WT_OVFL_REUSE_JUST_ADDED) ? "just-added" : "",
@@ -342,7 +342,7 @@ __ovfl_reuse_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
-        WT_RET(bm->free(bm, session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
+        WT_RET(bm->free(bm, session, (const uint8_t *)WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
         decr += WT_OVFL_SIZE(reuse, WT_OVFL_REUSE);
         __wt_free(session, reuse);
     }
@@ -397,7 +397,7 @@ __ovfl_reuse_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
-        WT_TRET(bm->free(bm, session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
+        WT_TRET(bm->free(bm, session, (const uint8_t *)WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
         decr += WT_OVFL_SIZE(reuse, WT_OVFL_REUSE);
         __wt_free(session, reuse);
     }
@@ -432,7 +432,7 @@ __wti_ovfl_reuse_search(WT_SESSION_IMPL *session, WT_PAGE *page, uint8_t **addrp
     if ((reuse = __ovfl_reuse_skip_search(head, value, value_size)) == NULL)
         return (0);
 
-    *addrp = WT_OVFL_REUSE_ADDR(reuse);
+    *addrp = (uint8_t *)WT_OVFL_REUSE_ADDR(reuse);
     *addr_sizep = reuse->addr_size;
     F_SET(reuse, WT_OVFL_REUSE_INUSE);
 
@@ -512,7 +512,7 @@ __wt_ovfl_reuse_free(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (mod == NULL || mod->ovfl_track == NULL)
         return;
 
-    for (reuse = mod->ovfl_track->ovfl_reuse[0]; reuse != NULL; reuse = next) {
+    for (reuse = mod->ovfl_track->ovfl_reuse[0]; reuse != NULL; reuse = (WT_OVFL_REUSE *)next) {
         next = reuse->next[0];
         __wt_free(session, reuse);
     }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2177,7 +2177,8 @@ copy_image:
      */
     WT_ASSERT(session,
       verify_image == false ||
-        __wt_verify_dsk_image(session, "[reconcile-image]", (const WT_PAGE_HEADER *)chunk->image.data, 0, &multi->addr,
+        __wt_verify_dsk_image(session, "[reconcile-image]",
+          (const WT_PAGE_HEADER *)chunk->image.data, 0, &multi->addr,
           WT_VRFY_DISK_EMPTY_PAGE_OK) == 0);
 #endif
     /*
@@ -2252,8 +2253,8 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
         if (cbulk->entry != 0) {
             __wt_rec_incr(
               session, r, cbulk->entry, __bitstr_size((size_t)cbulk->entry * btree->bitcnt));
-            __bit_clear_end(
-              (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
+            __bit_clear_end((uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem),
+              cbulk->entry, btree->bitcnt);
         }
         break;
     case BTREE_COL_VAR:

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -242,7 +242,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     WT_CLEAR(session->reconcile_timeline);
     session->reconcile_timeline.reconcile_start = rec_start;
 
-    r = session->reconcile;
+    r = (WT_RECONCILE *)session->reconcile;
 
     /* Only update if we are in the first entry into eviction. */
     if (!session->evict_timeline.reentry_hs_eviction)
@@ -887,7 +887,7 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, uint8_t *addr, size_t *addr_
          * We're passed a table's disk image. Decompress if necessary and verify the image. Always
          * check the in-memory length for accuracy.
          */
-        dsk = buf->mem;
+        dsk = (WT_PAGE_HEADER *)buf->mem;
         if (compressed) {
             WT_ASSERT_ALWAYS(session, __wt_scr_alloc(session, dsk->mem_size, &ctmp),
               "Failed to allocate scratch buffer");
@@ -1188,7 +1188,7 @@ __wti_rec_split_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page, u
     /* Starting record number, entries, first free byte. */
     r->recno = recno;
     r->entries = 0;
-    r->first_free = WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem);
+    r->first_free = (unsigned char *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem);
 
     if (page->type == WT_PAGE_COL_FIX) {
         r->aux_start_offset = (uint32_t)(primary_size + WT_COL_FIX_AUXHEADER_RESERVATION);
@@ -1328,8 +1328,8 @@ __rec_split_row_promote(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_ITEM *key,
      * larger byte value in the current key, or the current key will be a longer key, and the
      * interesting byte is one past the length of the shorter key.
      */
-    pa = max->data;
-    pb = r->cur->data;
+    pa = (const uint8_t *)max->data;
+    pb = (const uint8_t *)r->cur->data;
     len = WT_MIN(max->size, r->cur->size);
     size = len + 1;
     for (cnt = 1; len > 0; ++cnt, --len, ++pa, ++pb)
@@ -1531,7 +1531,7 @@ __wti_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
 
     /* Reset tracking information. */
     r->entries = 0;
-    r->first_free = WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem);
+    r->first_free = (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem);
 
     if (r->page->type == WT_PAGE_COL_FIX) {
         /*
@@ -1659,7 +1659,7 @@ __rec_split_finish_process_prev(WT_SESSION_IMPL *session, WT_RECONCILE *r)
          */
         prev_ptr->entries += cur_ptr->entries;
         WT_TIME_AGGREGATE_MERGE(session, &prev_ptr->ta, &cur_ptr->ta);
-        dsk = r->cur_ptr->image.mem;
+        dsk = (WT_PAGE_HEADER *)r->cur_ptr->image.mem;
         memcpy((uint8_t *)r->prev_ptr->image.mem + prev_ptr->image.size,
           WT_PAGE_HEADER_BYTE(btree, dsk), cur_ptr->image.size - WT_PAGE_HEADER_BYTE_SIZE(btree));
         prev_ptr->image.size = combined_size;
@@ -1687,7 +1687,7 @@ __rec_split_finish_process_prev(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         len_to_move = prev_ptr->image.size - prev_ptr->min_offset;
         if (r->space_avail < len_to_move)
             WT_RET(__wti_rec_split_grow(session, r, len_to_move));
-        cur_dsk_start = WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem);
+        cur_dsk_start = (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem);
 
         /*
          * Shift the contents of the current buffer to make space for the data that will be
@@ -1963,7 +1963,7 @@ __rec_compression_adjust(WT_SESSION_IMPL *session, uint32_t max, size_t compress
   bool last_block, uint64_t *adjustp)
 {
     WT_BTREE *btree;
-    uint64_t adjust, current, new;
+    uint64_t adjust, current, new_value;
     u_int ten_percent;
 
     btree = S2BT(session);
@@ -1998,9 +1998,9 @@ __rec_compression_adjust(WT_SESSION_IMPL *session, uint32_t max, size_t compress
          */
         adjust = current - max;
         if (adjust > ten_percent)
-            new = current - ten_percent;
+            new_value = current - ten_percent;
         else if (adjust != 0)
-            new = max;
+            new_value = max;
         else
             return;
     } else {
@@ -2019,13 +2019,13 @@ __rec_compression_adjust(WT_SESSION_IMPL *session, uint32_t max, size_t compress
 
         adjust = current + ten_percent;
         if (adjust < btree->maxmempage_image)
-            new = adjust;
+            new_value = adjust;
         else if (current != btree->maxmempage_image)
-            new = btree->maxmempage_image;
+            new_value = btree->maxmempage_image;
         else
             return;
     }
-    WT_WRITE_ONCE(*adjustp, new);
+    WT_WRITE_ONCE(*adjustp, new_value);
 }
 
 /*
@@ -2096,12 +2096,12 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         WT_RET(__rec_split_write_supd(session, r, chunk, multi, last_block));
 
     /* Initialize the page header(s). */
-    __rec_split_write_header(session, r, chunk, multi, chunk->image.mem);
+    __rec_split_write_header(session, r, chunk, multi, (WT_PAGE_HEADER *)chunk->image.mem);
     if (r->page->type == WT_PAGE_COL_FIX)
         __wti_rec_col_fix_write_auxheader(session, chunk->entries, chunk->aux_start_offset,
-          chunk->auxentries, chunk->image.mem, chunk->image.size);
+          chunk->auxentries, (uint8_t *)chunk->image.mem, chunk->image.size);
     if (compressed_image != NULL)
-        __rec_split_write_header(session, r, chunk, multi, compressed_image->mem);
+        __rec_split_write_header(session, r, chunk, multi, (WT_PAGE_HEADER *)compressed_image->mem);
 
     /*
      * If we are writing the whole page in our first/only attempt, it might be a checkpoint
@@ -2177,7 +2177,7 @@ copy_image:
      */
     WT_ASSERT(session,
       verify_image == false ||
-        __wt_verify_dsk_image(session, "[reconcile-image]", chunk->image.data, 0, &multi->addr,
+        __wt_verify_dsk_image(session, "[reconcile-image]", (const WT_PAGE_HEADER *)chunk->image.data, 0, &multi->addr,
           WT_VRFY_DISK_EMPTY_PAGE_OK) == 0);
 #endif
     /*
@@ -2223,7 +2223,7 @@ __wt_bulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     cbulk->leaf = cbulk->ref->page;
 
     WT_RET(__rec_init(session, cbulk->ref, 0, NULL, &cbulk->reconcile));
-    r = cbulk->reconcile;
+    r = (WT_RECONCILE *)cbulk->reconcile;
     r->is_bulk_load = true;
 
     recno = btree->type == BTREE_ROW ? WT_RECNO_OOB : 1;
@@ -2244,7 +2244,7 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     WT_RECONCILE *r;
 
     btree = S2BT(session);
-    if ((r = cbulk->reconcile) == NULL)
+    if ((r = (WT_RECONCILE *)cbulk->reconcile) == NULL)
         return (0);
 
     switch (btree->type) {
@@ -2253,7 +2253,7 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
             __wt_rec_incr(
               session, r, cbulk->entry, __bitstr_size((size_t)cbulk->entry * btree->bitcnt));
             __bit_clear_end(
-              WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
+              (uint8_t *)WT_PAGE_HEADER_BYTE(btree, r->cur_ptr->image.mem), cbulk->entry, btree->bitcnt);
         }
         break;
     case BTREE_COL_VAR:
@@ -2734,7 +2734,7 @@ __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *k
         WT_RET(__wt_scr_alloc(session, size, &tmp));
 
         /* Initialize the buffer: disk header and overflow record. */
-        dsk = tmp->mem;
+        dsk = (WT_PAGE_HEADER *)tmp->mem;
         memset(dsk, 0, WT_PAGE_HEADER_SIZE);
         dsk->type = WT_PAGE_OVFL;
         __rec_set_page_write_gen(btree, dsk);

--- a/src/rollback_to_stable/rts_visibility.c
+++ b/src/rollback_to_stable/rts_visibility.c
@@ -88,7 +88,7 @@ __wti_rts_visibility_page_needs_abort(
     const char *tag;
     bool prepared, result;
 
-    addr = ref->addr;
+    addr = (WT_ADDR *)ref->addr;
     mod = ref->page == NULL ? NULL : ref->page->modify;
     durable_ts = WT_TS_NONE;
     newest_txn = WT_TXN_NONE;

--- a/src/schema/schema_alter.c
+++ b/src/schema/schema_alter.c
@@ -309,7 +309,7 @@ __alter_tree(WT_SESSION_IMPL *session, const char *name, const char *newcfg[])
     WT_ERR(__wt_buf_fmt(session, data_source, "%.*s", (int)cval.len, cval.str));
 
     /* Alter the data source */
-    WT_ERR(__schema_alter(session, data_source->data, newcfg));
+    WT_ERR(__schema_alter(session, (const char *)data_source->data, newcfg));
 
     /* Alter the index or colgroup */
     if (is_colgroup)

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -422,8 +422,8 @@ __wt_find_import_metadata(WT_SESSION_IMPL *session, const char *uri, const char 
 
     entry.uri = uri;
     entry.config = NULL;
-    result = (WT_IMPORT_ENTRY *)bsearch(&entry, session->import_list->entries, session->import_list->entries_next,
-      sizeof(WT_IMPORT_ENTRY), __create_import_cmp_uri);
+    result = (WT_IMPORT_ENTRY *)bsearch(&entry, session->import_list->entries,
+      session->import_list->entries_next, sizeof(WT_IMPORT_ENTRY), __create_import_cmp_uri);
 
     if (result == NULL)
         WT_RET_MSG(session, WT_NOTFOUND, "failed to find metadata for %s", uri);

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -243,7 +243,7 @@ __create_file(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const c
                  * information as the imported file was not part of any backup.
                  */
                 WT_ERR(__wt_reset_blkmod(session, config, buf));
-                filecfg[3] = buf->mem;
+                filecfg[3] = (const char *)buf->mem;
             } else if (session->import_list == NULL) {
                 /*
                  * If there is no file metadata provided, the user should be specifying a "repair".
@@ -274,7 +274,7 @@ __create_file(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const c
               WT_BTREE_VERSION_MAX.minor));
             for (p = filecfg; *p != NULL; ++p)
                 ;
-            *p = val->data;
+            *p = (const char *)val->data;
             WT_ERR(__wt_config_collapse(session, filecfg, &fileconf));
         } else {
             /* Try to recreate the associated metadata from the imported data source. */
@@ -422,7 +422,7 @@ __wt_find_import_metadata(WT_SESSION_IMPL *session, const char *uri, const char 
 
     entry.uri = uri;
     entry.config = NULL;
-    result = bsearch(&entry, session->import_list->entries, session->import_list->entries_next,
+    result = (WT_IMPORT_ENTRY *)bsearch(&entry, session->import_list->entries, session->import_list->entries_next,
       sizeof(WT_IMPORT_ENTRY), __create_import_cmp_uri);
 
     if (result == NULL)
@@ -568,7 +568,7 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
         if (table->is_tiered_shared) {
             WT_ERR(__wt_schema_tiered_shared_colgroup_name(
               session, tablename, i == 0 ? true : false, buf));
-            name = buf->data;
+            name = (const char *)buf->data;
         }
 
         /* Check if the column group already exists. */
@@ -586,18 +586,18 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
         /* Add the source to the colgroup config before collapsing. */
         if (__wt_config_getones(session, config, "source", &cval) == 0 && cval.len != 0) {
             WT_ERR(__wt_buf_fmt(session, &namebuf, "%.*s", (int)cval.len, cval.str));
-            source = namebuf.data;
+            source = (const char *)namebuf.data;
         } else if (table->is_tiered_shared) {
             WT_ERR(__schema_tiered_shared_colgroup_source(
               session, table, i == 0 ? true : false, &namebuf));
-            source = namebuf.data;
+            source = (const char *)namebuf.data;
             WT_ERR(__wt_buf_fmt(session, &confbuf, "source=\"%s\"", source));
-            *cfgp++ = confbuf.data;
+            *cfgp++ = (const char *)confbuf.data;
         } else {
             WT_ERR(__wti_schema_colgroup_source(session, table, cgname, config, &namebuf));
-            source = namebuf.data;
+            source = (const char *)namebuf.data;
             WT_ERR(__wt_buf_fmt(session, &confbuf, "source=\"%s\"", source));
-            *cfgp++ = confbuf.data;
+            *cfgp++ = (const char *)confbuf.data;
         }
 
         if (session->import_list != NULL)
@@ -615,7 +615,7 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
                 WT_ERR(__wt_struct_reformat(session, table, cval.str, cval.len, NULL, true, &fmt));
             }
 
-            sourcecfg[1] = fmt.data;
+            sourcecfg[1] = (const char *)fmt.data;
         }
 
         WT_ERR(__wt_config_merge(session, sourcecfg, NULL, &sourceconf));
@@ -788,10 +788,10 @@ __create_index(WT_SESSION_IMPL *session, const char *name, bool exclusive, const
 
     if (__wt_config_getones(session, config, "source", &cval) == 0) {
         WT_ERR(__wt_buf_fmt(session, &namebuf, "%.*s", (int)cval.len, cval.str));
-        source = namebuf.data;
+        source = (const char *)namebuf.data;
     } else {
         WT_ERR(__wti_schema_index_source(session, table, idxname, config, &namebuf));
-        source = namebuf.data;
+        source = (const char *)namebuf.data;
 
         /* Add the source name to the index config before collapsing. */
         WT_ERR(__wt_buf_catfmt(session, &confbuf, ",source=\"%s\"", source));
@@ -867,20 +867,20 @@ __create_index(WT_SESSION_IMPL *session, const char *name, bool exclusive, const
       session, table, icols.str, icols.len, (const char *)extra_cols.data, false, &fmt));
 
     /* Check for a record number index key, which makes no sense. */
-    WT_ERR(__wt_config_getones(session, fmt.data, "key_format", &cval));
+    WT_ERR(__wt_config_getones(session, (const char *)fmt.data, "key_format", &cval));
     if (cval.len == 1 && cval.str[0] == 'r')
         WT_ERR_MSG(
           session, EINVAL, "column-store index may not use the record number as its index key");
 
     WT_ERR(__wt_buf_catfmt(session, &fmt, ",index_key_columns=%u", npublic_cols));
 
-    sourcecfg[1] = fmt.data;
+    sourcecfg[1] = (const char *)fmt.data;
     WT_ERR(__wt_config_merge(session, sourcecfg, NULL, &sourceconf));
 
     WT_ERR(__wt_schema_create(session, source, sourceconf));
 
     cfg[1] = sourceconf;
-    cfg[2] = confbuf.data;
+    cfg[2] = (const char *)confbuf.data;
     WT_ERR(__wt_config_collapse(session, cfg, &idxconf));
 
     if (!exists) {
@@ -991,7 +991,7 @@ __create_table(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const 
 
         /* Concatenate the metadata base string with the tiered storage shared string. */
         WT_ERR(__wt_buf_fmt(session, tmp, "%s,%s", tablecfg, "shared=true"));
-        WT_ERR(__wt_metadata_insert(session, uri, tmp->mem));
+        WT_ERR(__wt_metadata_insert(session, uri, (const char *)tmp->mem));
     } else
         WT_ERR(__wt_metadata_insert(session, uri, tablecfg));
 
@@ -1130,7 +1130,7 @@ __create_tiered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const
               ",id=%" PRIu32 ",version=(major=%" PRIu16 ",minor=%" PRIu16 "),checkpoint_lsn=",
               conn->bstorage->bucket, conn->bstorage->bucket_prefix, ++conn->next_file_id,
               WT_BTREE_VERSION_MAX.major, WT_BTREE_VERSION_MAX.minor));
-            cfg[1] = tmp->data;
+            cfg[1] = (const char *)tmp->data;
             cfg[2] = config;
             cfg[3] = "tiers=()";
             WT_ERR(__wt_config_tiered_strip(session, cfg, &metadata));

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -105,7 +105,7 @@ __wt_schema_get_table(WT_SESSION_IMPL *session, const char *name, size_t namelen
     WT_RET(__wt_scr_alloc(session, namelen + 1, &namebuf));
     WT_ERR(__wt_buf_fmt(session, namebuf, "table:%.*s", (int)namelen, name));
 
-    WT_ERR(__wt_schema_get_table_uri(session, namebuf->data, ok_incomplete, flags, tablep));
+    WT_ERR(__wt_schema_get_table_uri(session, (const char *)namebuf->data, ok_incomplete, flags, tablep));
 
 err:
     __wt_scr_free(session, &namebuf);

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -105,7 +105,8 @@ __wt_schema_get_table(WT_SESSION_IMPL *session, const char *name, size_t namelen
     WT_RET(__wt_scr_alloc(session, namelen + 1, &namebuf));
     WT_ERR(__wt_buf_fmt(session, namebuf, "table:%.*s", (int)namelen, name));
 
-    WT_ERR(__wt_schema_get_table_uri(session, (const char *)namebuf->data, ok_incomplete, flags, tablep));
+    WT_ERR(__wt_schema_get_table_uri(
+      session, (const char *)namebuf->data, ok_incomplete, flags, tablep));
 
 err:
     __wt_scr_free(session, &namebuf);

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -85,7 +85,7 @@ __wti_schema_open_colgroups(WT_SESSION_IMPL *session, WT_TABLE *table)
               session, table->iface.name, i == 0 ? true : false, buf));
         else
             WT_ERR(__schema_colgroup_name(session, table, ckey.str, ckey.len, buf));
-        if ((ret = __wt_metadata_search(session, buf->data, &cgconfig)) != 0) {
+        if ((ret = __wt_metadata_search(session, (const char *)buf->data, &cgconfig)) != 0) {
             /* It is okay if the table is incomplete. */
             if (ret == WT_NOTFOUND)
                 ret = 0;
@@ -217,7 +217,7 @@ __open_index(WT_SESSION_IMPL *session, WT_TABLE *table, WT_INDEX *idx)
         goto err;
 
     WT_ERR(__wt_scr_alloc(session, 0, &plan));
-    WT_ERR(__wt_struct_plan(session, table, buf->data, buf->size, false, plan));
+    WT_ERR(__wt_struct_plan(session, table, (const char *)buf->data, buf->size, false, plan));
     WT_ERR(__wt_strndup(session, plan->data, plan->size, &idx->key_plan));
 
     /* Set up the cursor key format (the visible columns). */
@@ -280,7 +280,7 @@ __schema_open_index(
         WT_ERR(cursor->get_key(cursor, &uri));
         name = uri;
 
-        if (!WT_PREFIX_SKIP(name, tmp->data)) {
+        if (!WT_PREFIX_SKIP(name, (const char *)tmp->data)) {
             /*
              * We reached the end of index list, remove the rest of in memory indices, they no
              * longer exist.

--- a/src/schema/schema_project.c
+++ b/src/schema/schema_project.c
@@ -223,7 +223,7 @@ __wt_schema_project_slice(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *
     p = end = NULL; /* -Wuninitialized */
 
     WT_RET(__pack_init(session, &vpack, vformat));
-    vp = value->data;
+    vp = (const uint8_t *)value->data;
     vend = vp + value->size;
 
     /* Reset any of the buffers we will be setting. */
@@ -405,7 +405,7 @@ __wt_schema_project_merge(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *
             } else
                 WT_RET(__pack_init(session, &pack, c->key_format));
             buf = &c->key;
-            p = buf->data;
+            p = (const uint8_t *)buf->data;
             end = p + buf->size;
             continue;
 
@@ -413,7 +413,7 @@ __wt_schema_project_merge(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *
             c = cp[arg];
             WT_RET(__pack_init(session, &pack, c->value_format));
             buf = &c->value;
-            p = buf->data;
+            p = (const uint8_t *)buf->data;
             end = p + buf->size;
             continue;
         }

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -162,7 +162,8 @@ __rename_tree(WT_SESSION_IMPL *session, WT_TABLE *table, const char *newuri, con
      * Do the rename before updating the metadata to avoid leaving the metadata inconsistent if the
      * rename fails.
      */
-    WT_ERR(__wt_schema_rename(session, (const char *)os->data, (const char *)ns->data, cfg, check_visibility));
+    WT_ERR(__wt_schema_rename(
+      session, (const char *)os->data, (const char *)ns->data, cfg, check_visibility));
 
     /*
      * Remove the old metadata entry. Insert the new metadata entry.

--- a/src/schema/schema_rename.c
+++ b/src/schema/schema_rename.c
@@ -66,7 +66,7 @@ __rename_file(WT_SESSION_IMPL *session, const char *uri, const char *newuri, boo
     filecfg[0] = oldvalue;
     if (F_ISSET(S2C(session), WT_CONN_INCR_BACKUP)) {
         WT_ERR(__wt_reset_blkmod(session, oldvalue, buf));
-        filecfg[1] = buf->mem;
+        filecfg[1] = (const char *)buf->mem;
     } else
         filecfg[1] = NULL;
     WT_ERR(__wt_config_collapse(session, filecfg, &newvalue));
@@ -162,13 +162,13 @@ __rename_tree(WT_SESSION_IMPL *session, WT_TABLE *table, const char *newuri, con
      * Do the rename before updating the metadata to avoid leaving the metadata inconsistent if the
      * rename fails.
      */
-    WT_ERR(__wt_schema_rename(session, os->data, ns->data, cfg, check_visibility));
+    WT_ERR(__wt_schema_rename(session, (const char *)os->data, (const char *)ns->data, cfg, check_visibility));
 
     /*
      * Remove the old metadata entry. Insert the new metadata entry.
      */
     WT_ERR(__wt_metadata_remove(session, name));
-    WT_ERR(__wt_metadata_insert(session, nn->data, nv->data));
+    WT_ERR(__wt_metadata_insert(session, (const char *)nn->data, (const char *)nv->data));
 
 err:
     __wt_scr_free(session, &nn);

--- a/src/schema/schema_stat.c
+++ b/src/schema/schema_stat.c
@@ -24,7 +24,7 @@ __wt_curstat_colgroup_init(
 
     WT_RET(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(__wt_buf_fmt(session, buf, "statistics:%s", colgroup->source));
-    ret = __wt_curstat_init(session, buf->data, NULL, cfg, cst);
+    ret = __wt_curstat_init(session, (const char *)buf->data, NULL, cfg, cst);
 
 err:
     __wt_scr_free(session, &buf);
@@ -47,7 +47,7 @@ __wt_curstat_index_init(
 
     WT_RET(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(__wt_buf_fmt(session, buf, "statistics:%s", idx->source));
-    ret = __wt_curstat_init(session, buf->data, NULL, cfg, cst);
+    ret = __wt_curstat_init(session, (const char *)buf->data, NULL, cfg, cst);
 
 err:
     __wt_scr_free(session, &buf);
@@ -96,9 +96,9 @@ __curstat_size_only(WT_SESSION_IMPL *session, const char *uri, bool *was_fast, W
      * drop). That is fine - failing here results in falling back to the slow path of opening the
      * handle.
      */
-    WT_ERR(__wt_fs_exist(session, namebuf.data, &exist));
+    WT_ERR(__wt_fs_exist(session, (const char *)namebuf.data, &exist));
     if (exist) {
-        WT_ERR(__wt_fs_size(session, namebuf.data, &filesize));
+        WT_ERR(__wt_fs_size(session, (const char *)namebuf.data, &filesize));
 
         /* Setup and populate the statistics structure */
         __wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
@@ -126,7 +126,7 @@ __wt_curstat_table_init(
     WT_CURSOR *stat_cursor;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
-    WT_DSRC_STATS *new, *stats;
+    WT_DSRC_STATS *new_stats, *stats;
     WT_TABLE *table;
     u_int i;
     const char *name;
@@ -158,7 +158,7 @@ __wt_curstat_table_init(
      */
     if (table->is_simple) {
         WT_ERR(__wt_buf_fmt(session, buf, "statistics:%s", table->cgroups[0]->name));
-        WT_ERR(__wt_curstat_init(session, buf->data, NULL, cfg, cst));
+        WT_ERR(__wt_curstat_init(session, (const char *)buf->data, NULL, cfg, cst));
         goto done;
     }
 
@@ -170,12 +170,12 @@ __wt_curstat_table_init(
      */
     for (i = 0; i < WT_COLGROUPS(table); i++) {
         WT_ERR(__wt_buf_fmt(session, buf, "statistics:%s", table->cgroups[i]->name));
-        WT_ERR(__wt_curstat_open(session, buf->data, NULL, cfg, &stat_cursor));
-        new = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
+        WT_ERR(__wt_curstat_open(session, (const char *)buf->data, NULL, cfg, &stat_cursor));
+        new_stats = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
         if (i == 0)
-            *stats = *new;
+            *stats = *new_stats;
         else
-            __wt_stat_dsrc_aggregate_single(new, stats);
+            __wt_stat_dsrc_aggregate_single(new_stats, stats);
         WT_ERR(stat_cursor->close(stat_cursor));
     }
 
@@ -183,9 +183,9 @@ __wt_curstat_table_init(
     WT_ERR(__wt_schema_open_indices(session, table));
     for (i = 0; i < table->nindices; i++) {
         WT_ERR(__wt_buf_fmt(session, buf, "statistics:%s", table->indices[i]->name));
-        WT_ERR(__wt_curstat_open(session, buf->data, NULL, cfg, &stat_cursor));
-        new = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
-        __wt_stat_dsrc_aggregate_single(new, stats);
+        WT_ERR(__wt_curstat_open(session, (const char *)buf->data, NULL, cfg, &stat_cursor));
+        new_stats = (WT_DSRC_STATS *)WT_CURSOR_STATS(stat_cursor);
+        __wt_stat_dsrc_aggregate_single(new_stats, stats);
         WT_ERR(stat_cursor->close(stat_cursor));
     }
 

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -174,8 +174,8 @@ __wt_name_check(WT_SESSION_IMPL *session, const char *str, size_t len, bool chec
     WT_ERR(__wt_buf_fmt(session, tmp, "%.*s", (int)len, str));
 
     /* If we want to skip the URI check call the internal function directly. */
-    ret = check_uri ? __wt_str_name_check(session, tmp->data) :
-                      __str_name_check(session, tmp->data, false);
+    ret = check_uri ? __wt_str_name_check(session, (const char *)tmp->data) :
+                      __str_name_check(session, (const char *)tmp->data, false);
 
 err:
     __wt_scr_free(session, &tmp);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -161,7 +161,7 @@ __wt_session_lock_dhandle(WT_SESSION_IMPL *session, uint32_t flags, bool *is_dea
     *is_deadp = false;
 
     dhandle = session->dhandle;
-    btree = dhandle->handle;
+    btree = (WT_BTREE *)dhandle->handle;
     lock_busy = false;
     want_exclusive = LF_ISSET(WT_DHANDLE_EXCLUSIVE);
 
@@ -282,7 +282,7 @@ __wt_session_release_dhandle_v2(WT_SESSION_IMPL *session, bool check_visibility)
     bool locked, write_locked;
 
     dhandle = session->dhandle;
-    btree = dhandle->handle;
+    btree = (WT_BTREE *)dhandle->handle;
     write_locked = F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE);
     locked = true;
 

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -347,8 +347,8 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
 
         /* Allocate a scratch buffer (known to be large enough), and JSON encode the message. */
         WT_ERR(__wt_scr_alloc(session, tmp->size * WT_MAX_JSON_ENCODE + 256, &json_msg));
-        json_msg->size =
-          __wt_json_unpack_str((uint8_t *)json_msg->mem, json_msg->memsize, (const u_char *)tmp->data, tmp->size);
+        json_msg->size = __wt_json_unpack_str(
+          (uint8_t *)json_msg->mem, json_msg->memsize, (const u_char *)tmp->data, tmp->size);
 
         /* Append the rest of the message to the JSON buffer (we allocated extra space for it). */
         p = (char *)json_msg->mem + json_msg->size;

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -328,7 +328,7 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
 
         /* Format the message into a scratch buffer, growing it if necessary. */
         WT_ERR(__wt_scr_alloc(session, 4 * 1024, &tmp));
-        WT_ERR(__wt_vsnprintf_len_set(tmp->mem, tmp->memsize, &len, fmt, ap));
+        WT_ERR(__wt_vsnprintf_len_set((char *)tmp->mem, tmp->memsize, &len, fmt, ap));
         tmp->size = len;
         if (len >= tmp->memsize) {
             WT_ERR(__wt_buf_grow(session, tmp, len + 1024));
@@ -339,7 +339,7 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
              * analyzer might figure it out).
              */
             no_stderr = true;
-            WT_ERR(__wt_vsnprintf_len_set(tmp->mem, tmp->memsize, &len, fmt, ap_copy));
+            WT_ERR(__wt_vsnprintf_len_set((char *)tmp->mem, tmp->memsize, &len, fmt, ap_copy));
             tmp->size = len;
             if (len >= tmp->memsize)
                 goto err;
@@ -348,7 +348,7 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
         /* Allocate a scratch buffer (known to be large enough), and JSON encode the message. */
         WT_ERR(__wt_scr_alloc(session, tmp->size * WT_MAX_JSON_ENCODE + 256, &json_msg));
         json_msg->size =
-          __wt_json_unpack_str((uint8_t *)json_msg->mem, json_msg->memsize, tmp->data, tmp->size);
+          __wt_json_unpack_str((uint8_t *)json_msg->mem, json_msg->memsize, (const u_char *)tmp->data, tmp->size);
 
         /* Append the rest of the message to the JSON buffer (we allocated extra space for it). */
         p = (char *)json_msg->mem + json_msg->size;
@@ -370,13 +370,13 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
          */
         len = WT_PTRDIFF(p, json_msg->mem);
         if (sizeof(msg) - prefix_len > len) {
-            strcpy(msg + prefix_len, json_msg->mem);
+            strcpy(msg + prefix_len, (const char *)json_msg->mem);
             final = msg;
         } else {
             WT_ERR(__wt_buf_grow(session, tmp, prefix_len + len + 1));
-            strcpy(tmp->mem, msg);
-            strcpy((char *)tmp->mem + prefix_len, json_msg->mem);
-            final = tmp->mem;
+            strcpy((char *)tmp->mem, msg);
+            strcpy((char *)tmp->mem + prefix_len, (const char *)json_msg->mem);
+            final = (char *)tmp->mem;
         }
     } else {
         /* Category and verbosity level. */
@@ -404,7 +404,7 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
         if (remain == 0) {
             WT_ERR(__wt_scr_alloc(session, prefix_len + len + 1024, &tmp));
             WT_ERR(__wt_buf_set(session, tmp, msg, prefix_len));
-            final = tmp->mem;
+            final = (char *)tmp->mem;
             p = (char *)tmp->mem + prefix_len;
             remain = tmp->memsize - prefix_len;
             /*
@@ -419,7 +419,7 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
                 remain -= len;
                 p += len;
                 if (err != NULL)
-                    __eventv_append_error(err, tmp->mem, p, &remain);
+                    __eventv_append_error(err, (char *)tmp->mem, p, &remain);
             } else
                 remain = 0;
 
@@ -660,7 +660,7 @@ __wt_msg(WT_SESSION_IMPL *session, const char *fmt, ...) WT_GCC_FUNC_ATTRIBUTE((
 
     wt_session = (WT_SESSION *)session;
     handler = session->event_handler;
-    ret = handler->handle_message(handler, wt_session, buf->data);
+    ret = handler->handle_message(handler, wt_session, (const char *)buf->data);
 
 err:
     __wt_scr_free(session, &buf);
@@ -689,7 +689,7 @@ __wt_ext_msg_printf(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char
 
     wt_session = (WT_SESSION *)session;
     handler = session->event_handler;
-    ret = handler->handle_message(handler, wt_session, buf->data);
+    ret = handler->handle_message(handler, wt_session, (const char *)buf->data);
 
 err:
     __wt_scr_free(session, &buf);

--- a/src/support/hash_city.c
+++ b/src/support/hash_city.c
@@ -352,5 +352,5 @@ static WT_INLINE uint64_t CityHash64(const char *s, size_t len) {
 uint64_t
 __wt_hash_city64(const void *s, size_t len)
 {
-	return (CityHash64(s, len));
+	return (CityHash64((const char *)s, len));
 }

--- a/src/support/hash_fnv.c
+++ b/src/support/hash_fnv.c
@@ -126,7 +126,7 @@
 static WT_INLINE uint64_t
 fnv_64a_buf(const void *buf, size_t len, uint64_t hval)
 {
-	const unsigned char *bp = buf;		/* start of buffer */
+	const unsigned char *bp = (const unsigned char *)buf;		/* start of buffer */
 	const unsigned char *be = bp + len;	/* beyond end of buffer */
 
 	/*

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -406,7 +406,7 @@ __wt_hazard_check_assert(WT_SESSION_IMPL *session, void *ref, bool waitfor)
 
     s = NULL;
     for (i = 0;;) {
-        if ((hp = __wt_hazard_check(session, ref, &s)) == NULL)
+        if ((hp = __wt_hazard_check(session, (WT_REF *)ref, &s)) == NULL)
             return (true);
         if (!waitfor || ++i > 100)
             break;

--- a/src/support/hex.c
+++ b/src/support/hex.c
@@ -54,7 +54,7 @@ __wt_raw_to_hex(WT_SESSION_IMPL *session, const uint8_t *from, size_t size, WT_I
     len = size * 2 + 1;
     WT_RET(__wt_buf_init(session, to, len));
 
-    __fill_hex(from, size, to->mem, len, &to->size);
+    __fill_hex(from, size, (uint8_t *)to->mem, len, &to->size);
     return (0);
 }
 
@@ -74,7 +74,7 @@ __wt_raw_to_esc_hex(WT_SESSION_IMPL *session, const uint8_t *from, size_t size, 
      */
     WT_RET(__wt_buf_init(session, to, size * 3 + 1));
 
-    for (p = from, t = to->mem, i = size; i > 0; --i, ++p)
+    for (p = from, t = (u_char *)to->mem, i = size; i > 0; --i, ++p)
         if (__wt_isprint((u_char)*p)) {
             if (*p == '\\')
                 *t++ = '\\';
@@ -277,7 +277,7 @@ __wt_nhex_to_raw(WT_SESSION_IMPL *session, const char *from, size_t size, WT_ITE
 
     WT_RET(__wt_buf_init(session, to, size / 2));
 
-    for (p = (u_char *)from, t = to->mem; size > 0; p += 2, size -= 2, ++t)
+    for (p = (u_char *)from, t = (u_char *)to->mem; size > 0; p += 2, size -= 2, ++t)
         if (__wt_hex2byte(p, t))
             return (__hex_fmterr(session));
 
@@ -297,7 +297,7 @@ __wt_esc_hex_to_raw(WT_SESSION_IMPL *session, const char *from, WT_ITEM *to)
 
     WT_RET(__wt_buf_init(session, to, strlen(from)));
 
-    for (p = (u_char *)from, t = to->mem; *p != '\0'; ++p, ++t) {
+    for (p = (u_char *)from, t = (u_char *)to->mem; *p != '\0'; ++p, ++t) {
         if ((*t = *p) != '\\')
             continue;
         ++p;

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -51,7 +51,7 @@ __wt_modify_idempotent(const void *modify)
     int nentries;
 
     /* Get the number of modify entries. */
-    p = modify;
+    p = (const size_t *)modify;
     memcpy(&tmp, p++, sizeof(size_t));
     nentries = (int)tmp;
 
@@ -99,7 +99,7 @@ __wt_modify_pack(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries, WT_ITEM **
     WT_RET(__wt_scr_alloc(session, len, &modify));
 
     data = (uint8_t *)modify->mem + sizeof(size_t) + ((size_t)nentries * 3 * sizeof(size_t));
-    p = modify->mem;
+    p = (size_t *)modify->mem;
     *p++ = (size_t)nentries;
     for (i = 0; i < nentries; ++i) {
         *p++ = entries[i].data.size;
@@ -133,7 +133,7 @@ __modify_apply_one(WT_SESSION_IMPL *session, WT_ITEM *value, WT_MODIFY *modify, 
     uint8_t *to;
     const uint8_t *data, *from;
 
-    data = modify->data.data;
+    data = (const uint8_t *)modify->data.data;
     data_size = modify->data.size;
     offset = modify->offset;
     size = modify->size;
@@ -364,7 +364,7 @@ __wt_modify_apply_item(
     /*
      * Get the number of modify entries and set a second pointer to reference the replacement data.
      */
-    p = modify;
+    p = (const size_t *)modify;
     memcpy(&tmp, p++, sizeof(size_t));
     nentries = (int)tmp;
 

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -210,7 +210,8 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
          * potential overflow, wait until we can get a valid ticket.
          */
         writers_active = old_lock.u.s.next - old_lock.u.s.current;
-        if (old_lock.u.s.readers_queued == UINT8_MAX || old_lock.u.s.readers_queued > writers_active) {
+        if (old_lock.u.s.readers_queued == UINT8_MAX ||
+          old_lock.u.s.readers_queued > writers_active) {
 stall:
             __wt_cond_wait(session, l->cond_readers, 10 * WT_THOUSAND, NULL);
             continue;

--- a/src/support/scratch.c
+++ b/src/support/scratch.c
@@ -132,15 +132,15 @@ __wt_buf_set_printable(
     WT_DECL_RET;
 
     if (hexonly)
-        ret = __wt_raw_to_hex(session, p, size, buf);
+        ret = __wt_raw_to_hex(session, (const uint8_t *)p, size, buf);
     else
-        ret = __wt_raw_to_esc_hex(session, p, size, buf);
+        ret = __wt_raw_to_esc_hex(session, (const uint8_t *)p, size, buf);
 
     if (ret != 0) {
         buf->data = "[Error]";
         buf->size = strlen("[Error]");
     }
-    return (buf->data);
+    return ((const char *)buf->data);
 }
 
 /*
@@ -254,7 +254,7 @@ __wt_buf_set_size(WT_SESSION_IMPL *session, uint64_t size, bool exact, WT_ITEM *
         buf->data = "[Error]";
         buf->size = strlen("[Error]");
     }
-    return (buf->data);
+    return ((const char *)buf->data);
 }
 
 /*

--- a/src/tiered/tiered_config.c
+++ b/src/tiered/tiered_config.c
@@ -59,7 +59,7 @@ int
 __wti_tiered_bucket_config(
   WT_SESSION_IMPL *session, const char *cfg[], WT_BUCKET_STORAGE **bstoragep)
 {
-    WT_BUCKET_STORAGE *bstorage, *new;
+    WT_BUCKET_STORAGE *bstorage, *new_storage;
     WT_CONFIG_ITEM auth, bucket, cachedir, name, prefix, shared;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_ITEM(buf);
@@ -72,7 +72,7 @@ __wti_tiered_bucket_config(
 
     WT_RET(__wt_config_gets(session, cfg, "tiered_storage.name", &name));
     WT_RET(__wt_scr_alloc(session, 0, &buf));
-    bstorage = new = NULL;
+    bstorage = new_storage = NULL;
     conn = S2C(session);
 
     __wt_spin_lock(session, &conn->storage_lock);
@@ -122,36 +122,36 @@ __wti_tiered_bucket_config(
         }
     }
 
-    WT_ERR(__wt_calloc_one(session, &new));
-    WT_ERR(__wt_strndup(session, auth.str, auth.len, &new->auth_token));
-    WT_ERR(__wt_strndup(session, bucket.str, bucket.len, &new->bucket));
-    WT_ERR(__wt_strndup(session, prefix.str, prefix.len, &new->bucket_prefix));
-    WT_ERR(__wt_strndup(session, cachedir.str, cachedir.len, &new->cache_directory));
+    WT_ERR(__wt_calloc_one(session, &new_storage));
+    WT_ERR(__wt_strndup(session, auth.str, auth.len, &new_storage->auth_token));
+    WT_ERR(__wt_strndup(session, bucket.str, bucket.len, &new_storage->bucket));
+    WT_ERR(__wt_strndup(session, prefix.str, prefix.len, &new_storage->bucket_prefix));
+    WT_ERR(__wt_strndup(session, cachedir.str, cachedir.len, &new_storage->cache_directory));
 
     storage = nstorage->storage_source;
     if (cachedir.len != 0)
-        WT_ERR(__wt_buf_fmt(session, buf, "cache_directory=%s", new->cache_directory));
+        WT_ERR(__wt_buf_fmt(session, buf, "cache_directory=%s", new_storage->cache_directory));
     WT_ERR(storage->ss_customize_file_system(
-      storage, &session->iface, new->bucket, new->auth_token, buf->data, &new->file_system));
-    new->storage_source = storage;
+      storage, &session->iface, new_storage->bucket, new_storage->auth_token, (const char *)buf->data, &new_storage->file_system));
+    new_storage->storage_source = storage;
     if (shared.val)
-        new->tiered_shared = true;
+        new_storage->tiered_shared = true;
 
     /* If we're creating a new bucket storage, parse the other settings into it. */
-    TAILQ_INSERT_HEAD(&nstorage->bucketqh, new, q);
-    TAILQ_INSERT_HEAD(&nstorage->buckethashqh[hash_bucket], new, hashq);
-    F_SET(new, WT_BUCKET_FREE);
-    WT_ERR(__tiered_common_config(session, cfg, new));
-    *bstoragep = new;
+    TAILQ_INSERT_HEAD(&nstorage->bucketqh, new_storage, q);
+    TAILQ_INSERT_HEAD(&nstorage->buckethashqh[hash_bucket], new_storage, hashq);
+    F_SET(new_storage, WT_BUCKET_FREE);
+    WT_ERR(__tiered_common_config(session, cfg, new_storage));
+    *bstoragep = new_storage;
 
 done:
     if (0) {
 err:
-        if (new != NULL) {
-            __wt_free(session, new->bucket);
-            __wt_free(session, new->bucket_prefix);
+        if (new_storage != NULL) {
+            __wt_free(session, new_storage->bucket);
+            __wt_free(session, new_storage->bucket_prefix);
         }
-        __wt_free(session, new);
+        __wt_free(session, new_storage);
     }
     __wt_spin_unlock(session, &conn->storage_lock);
     __wt_scr_free(session, &buf);

--- a/src/tiered/tiered_config.c
+++ b/src/tiered/tiered_config.c
@@ -131,8 +131,8 @@ __wti_tiered_bucket_config(
     storage = nstorage->storage_source;
     if (cachedir.len != 0)
         WT_ERR(__wt_buf_fmt(session, buf, "cache_directory=%s", new_storage->cache_directory));
-    WT_ERR(storage->ss_customize_file_system(
-      storage, &session->iface, new_storage->bucket, new_storage->auth_token, (const char *)buf->data, &new_storage->file_system));
+    WT_ERR(storage->ss_customize_file_system(storage, &session->iface, new_storage->bucket,
+      new_storage->auth_token, (const char *)buf->data, &new_storage->file_system));
     new_storage->storage_source = storage;
     if (shared.val)
         new_storage->tiered_shared = true;

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -386,7 +386,7 @@ __tiered_create_tier_tree(WT_SESSION_IMPL *session, WT_TIERED *tiered)
         WT_ERR(__wt_buf_fmt(session, tmp,
           ",readonly=true,tiered_object=true,tiered_storage=(bucket=%s,bucket_prefix=%s)",
           tiered->bstorage->bucket, tiered->bstorage->bucket_prefix));
-        cfg[1] = tmp->data;
+        cfg[1] = (const char *)tmp->data;
         WT_ERR(__wt_config_merge(session, cfg, NULL, &config));
         /* Set up a tier:example metadata for the first time. */
         __wt_verbose(
@@ -489,7 +489,7 @@ __wt_tiered_set_metadata(WT_SESSION_IMPL *session, WT_TIERED *tiered, WT_ITEM *b
 
     dhandle = &tiered->iface;
     WT_ASSERT_ALWAYS(session, WT_DHANDLE_BTREE(dhandle), "Expected a btree handle");
-    btree = dhandle->handle;
+    btree = (WT_BTREE *)dhandle->handle;
 
     __wt_timestamp_to_hex_string(btree->flush_most_recent_ts, hex_timestamp);
     WT_RET(__wt_buf_catfmt(session, buf,
@@ -529,7 +529,7 @@ __tiered_update_metadata(WT_SESSION_IMPL *session, WT_TIERED *tiered, const char
 
     cfg[0] = WT_CONFIG_BASE(session, tiered_meta);
     cfg[1] = orig_config;
-    cfg[2] = tmp->data;
+    cfg[2] = (const char *)tmp->data;
     strip = "tiered_storage=(shared=),";
     WT_ERR(__wt_config_merge(session, cfg, strip, &newconfig));
     __wt_verbose(

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -321,7 +321,7 @@ __checkpoint_apply_operation(
         if (op == NULL)
             continue;
         WT_ERR(__wt_buf_fmt(session, tmp, "%.*s", (int)k.len, k.str));
-        if ((ret = __wt_schema_worker(session, tmp->data, op, NULL, cfg, 0)) != 0)
+        if ((ret = __wt_schema_worker(session, (const char *)tmp->data, op, NULL, cfg, 0)) != 0)
             WT_ERR_MSG(session, ret, "%s", (const char *)tmp->data);
     }
     WT_ERR_NOTFOUND_OK(ret, false);
@@ -1681,7 +1681,7 @@ __drop_list_execute(WT_SESSION_IMPL *session, WT_ITEM *drop_list)
     WT_DECL_RET;
 
     /* The list has the form (name, name, ...,) so we can read it with the config parser. */
-    __wt_config_init(session, &dropconf, drop_list->data);
+    __wt_config_init(session, &dropconf, (const char *)drop_list->data);
     while ((ret = __wt_config_next(&dropconf, &k, &v)) == 0) {
         WT_RET(__wt_meta_sysinfo_clear(session, k.str, k.len));
     }
@@ -2299,7 +2299,7 @@ __checkpoint_save_ckptlist(WT_SESSION_IMPL *session, WT_CKPT *ckptbase)
         if (strcmp(ckpt->name, WT_CHECKPOINT) == 0) {
             WT_ERR(__wt_buf_fmt(session, tmp, "%s.%" PRId64, WT_CHECKPOINT, ckpt->order));
             __wt_free(session, ckpt->name);
-            WT_ERR(__wt_strdup(session, tmp->mem, &ckpt->name));
+            WT_ERR(__wt_strdup(session, (const char *)tmp->mem, &ckpt->name));
         }
 
         /* Reset the flags, and mark a checkpoint fake if there is no address. */

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -503,7 +503,7 @@ __wt_txn_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_
         txn->ckpt_nsnapshot = txn->snapshot_data.snapshot_count;
         recsize = (size_t)txn->ckpt_nsnapshot * WT_INTPACK64_MAXSIZE;
         WT_ERR(__wt_scr_alloc(session, recsize, &txn->ckpt_snapshot));
-        end = p = txn->ckpt_snapshot->mem;
+        end = p = (unsigned char *)txn->ckpt_snapshot->mem;
         /* There many not be any snapshot entries. */
         if (end != NULL) {
             end += recsize;
@@ -672,7 +672,7 @@ __txn_printlog(WT_SESSION_IMPL *session, WT_ITEM *rawrec, WT_LSN *lsnp, WT_LSN *
     bool compressed;
 
     WT_UNUSED(next_lsnp);
-    args = cookie;
+    args = (WT_TXN_PRINTLOG_ARGS *)cookie;
 
     p = WT_LOG_SKIP_HEADER(rawrec->data);
     end = (const uint8_t *)rawrec->data + rawrec->size;

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -473,7 +473,7 @@ __txn_log_recover(WT_SESSION_IMPL *session, WT_ITEM *logrec, WT_LSN *lsnp, WT_LS
     uint32_t rectype;
     const uint8_t *end, *p;
 
-    r = cookie;
+    r = (WT_RECOVERY *)cookie;
     p = WT_LOG_SKIP_HEADER(logrec->data);
     end = (const uint8_t *)logrec->data + logrec->size;
     WT_UNUSED(firstrecord);


### PR DESCRIPTION
This PR makes some simple, safe changes to WiredTiger that will prepare for being able to compile WT in C++.

Specifically, these changes make the code largely (but not entirely) C++ compatible while maintaining C compatibility. The changes in this ticket are:

- Rename any variables called new as new is a reserved word in C++
- Make all implicit casts from void * explicit, as implicit cases from void * are not supported in C++

Note these are not the only changes required to make WT C++ compatible, but the changes make up 80-90% of the lines of code that would need to change, and the changes are both simple, safe, and work in both C and C++.