### PR TITLE
WT-13146 In timing stress sleep randomly on every 100th iteration when history store search is enabled.

### DIFF
--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1383,6 +1383,7 @@ retry:
 
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
     if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
+        /* Sleep randomly on every 100th iteration when history store search is enabled. */
         if (__wt_random(&session->rnd) % 100 == 0)
             __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
         WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1387,8 +1387,10 @@ retry:
          * Stressing this code path may slow down the system too much. To minimize the impact, sleep
          * on every random 100th iteration when this is enabled.
          */
-        if (__wt_random(&session->rnd) % 100 == 0)
+        if (FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_HS_SEARCH) &&
+          __wt_random(&session->rnd) % 100 == 0)
             __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
+
         WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,
           cbt->upd_value, &cbt->upd_value->buf));
     }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1383,7 +1383,8 @@ retry:
 
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
     if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
-        __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
+        if (__wt_random(&session->rnd) % 100 == 0)
+            __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
         WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,
           cbt->upd_value, &cbt->upd_value->buf));
     }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1383,7 +1383,10 @@ retry:
 
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
     if (F_ISSET(S2C(session), WT_CONN_HS_OPEN) && !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
-        /* Sleep randomly on every 100th iteration when history store search is enabled. */
+        /*
+         * Stressing this code path may slow down the system too much. To minimize the impact, sleep
+         * on every random 100th iteration when this is enabled.
+         */
         if (__wt_random(&session->rnd) % 100 == 0)
             __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
         WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,


### PR DESCRIPTION
If the stress history store search is enabled, then sleep on every random 100th iteration.