### PR TITLE
WT-12492 Checkpoint target option: remove tests and examples

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -491,17 +491,6 @@ checkpoint_ops(WT_SESSION *session)
     /* Checkpoint of the database, creating a named snapshot. */
     error_check(session->checkpoint(session, "name=June01"));
 
-    /*
-     * Checkpoint a list of objects. JSON parsing requires quoting the list of target URIs.
-     */
-    error_check(session->checkpoint(session, "target=(\"table:table1\",\"table:table2\")"));
-
-    /*
-     * Checkpoint a list of objects, creating a named snapshot. JSON parsing requires quoting the
-     * list of target URIs.
-     */
-    error_check(session->checkpoint(session, "target=(\"table:mytable\"),name=midnight"));
-
     /* Checkpoint the database, discarding all previous snapshots. */
     error_check(session->checkpoint(session, "drop=(from=all)"));
 
@@ -517,21 +506,7 @@ checkpoint_ops(WT_SESSION *session)
      * Checkpoint the database, discarding all snapshots before and including "midnight".
      */
     error_check(session->checkpoint(session, "drop=(to=midnight)"));
-
-    /*
-     * Create a checkpoint of a table, creating the "July01" snapshot and discarding the "May01" and
-     * "June01" snapshots. JSON parsing requires quoting the list of target URIs.
-     */
-    error_check(
-      session->checkpoint(session, "target=(\"table:mytable\"),name=July01,drop=(May01,June01)"));
     /*! [Checkpoint examples] */
-
-    /*! [JSON quoting example] */
-    /*
-     * Checkpoint a list of objects. JSON parsing requires quoting the list of target URIs.
-     */
-    error_check(session->checkpoint(session, "target=(\"table:table1\",\"table:table2\")"));
-    /*! [JSON quoting example] */
 }
 
 static void
@@ -1163,8 +1138,13 @@ backup(WT_SESSION *session)
     /*! [backup log duplicate]*/
     /* Open the backup data source. */
     error_check(session->open_cursor(session, "backup:", NULL, NULL, &cursor));
+    /*! [JSON quoting example] */
     /* Open a duplicate cursor for additional log files. */
+    /*
+     * JSON parsing requires quoting a URI that contains a colon.
+     */
     error_check(session->open_cursor(session, NULL, cursor, "target=(\"log:\")", &dup_cursor));
+    /*! [JSON quoting example] */
     /*! [backup log duplicate]*/
 
     /*! [incremental backup]*/

--- a/src/docs/config-strings.dox
+++ b/src/docs/config-strings.dox
@@ -112,9 +112,9 @@ For example, in Python, code might look as follows:
 
 Because JSON compatibility allows colons to be used as key/value separators,
 WiredTiger URIs may require quoting.  For example, the following
-WT_SESSION::checkpoint call specifies a set of URIs as checkpoint targets,
-using double-quote characters to keep the parser from treating the colon
-characters as JSON name/value separators:
+WT_SESSION::open_cursor call specifies the URI "log:" using double-quote
+characters to keep the parser from treating the colon character as a JSON
+name/value separator:
 
 @snippet ex_all.c JSON quoting example
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2355,8 +2355,8 @@ tasks:
             done
 
   - name: csuite-long-running
-    # Set 5 hours timeout (60 * 60 * 5)
-    exec_timeout_secs: 18000
+    # Set 6 hours timeout (60 * 60 * 6 = 21600)
+    exec_timeout_secs: 21600
     commands:
       - func: "get project"
       - func: "compile wiredtiger"

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -219,42 +219,6 @@ class test_checkpoint_target(wttest.WiredTigerTestCase):
         self.assertEqual(cursor[ds.key(10)], value)
         cursor.close()
 
-    # FIXME-WT-10836
-    @wttest.skip_for_hook("tiered", "strange interaction with tiered and named checkpoints using target")
-    def test_checkpoint_target(self):
-        # Create 3 objects, change one record to an easily recognizable string.
-        uri = self.uri + '1'
-        ds1 = SimpleDataSet(self, uri, 100, key_format=self.fmt)
-        ds1.populate()
-        self.update(uri, ds1, 'ORIGINAL')
-
-        uri = self.uri + '2'
-        ds2 = SimpleDataSet(self, uri, 100, key_format=self.fmt)
-        ds2.populate()
-        self.update(uri, ds2, 'ORIGINAL')
-
-        uri = self.uri + '3'
-        ds3 = SimpleDataSet(self, uri, 100, key_format=self.fmt)
-        ds3.populate()
-        self.update(uri, ds3, 'ORIGINAL')
-
-        # Checkpoint all three objects.
-        self.session.checkpoint("name=checkpoint-1")
-
-        # Update all 3 objects, then checkpoint two of the objects with the
-        # same checkpoint name.
-        self.update(self.uri + '1', ds1, 'UPDATE')
-        self.update(self.uri + '2', ds2, 'UPDATE')
-        self.update(self.uri + '3', ds3, 'UPDATE')
-        target = 'target=("' + self.uri + '1"' + ',"' + self.uri + '2")'
-        self.session.checkpoint("name=checkpoint-1," + target)
-
-        # Confirm the checkpoint has the old value in objects that weren't
-        # checkpointed, and the new value in objects that were checkpointed.
-        self.check(self.uri + '1', ds1, 'UPDATE')
-        self.check(self.uri + '2', ds2, 'UPDATE')
-        self.check(self.uri + '3', ds3, 'ORIGINAL')
-
 # Check that you can't write checkpoint cursors.
 class test_checkpoint_cursor_update(wttest.WiredTigerTestCase):
     scenarios = make_scenarios([


### PR DESCRIPTION
This PR to branch develop has been replaced with PR #10932 to the project branch.  Close this PR after that is merged.

-   Delete checkpoint target examples (ex_all.c) and tests.
-    Replace [JSON quoting example] with a new example not using checkpoint target.

Status of Full patch build:
- One timed out task (csuite-long-running) now passes with a longer time out (6 hours instead of 5).
- One failed task (race-condition-stress-sanitizer-test-3) passed when I added logging of WT_ERR branching and WT_RET returning. The stack trace when it did fail without the added logging is below:

#0  0x00007f397e48600b in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f397e465859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f397ec0334d in __wt_abort (session=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/os_common/os_abort.c:30
#3  0x00007f397e808e8d in __wt_panic_func (session=0x7f3978542200, 
    error=<optimized out>, func=<optimized out>, line=<optimized out>, 
    category=<optimized out>, fmt=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/support/err.c:570
#4  0x00007f397ec7a48d in __reconcile (session=0x7f3978542200, 
    ref=<optimized out>, salvage=<optimized out>, flags=<optimized out>, 
    page_lockedp=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/reconcile/rec_write.c:383
383	        WT_RET_PANIC(session, ret, "reconciliation failed after building the disk image");
#5  0x00007f397ec783e4 in __wt_reconcile (session=0x7f3978542200, 
    ref=<optimized out>, salvage=<optimized out>, flags=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/reconcile/rec_write.c:95
#6  0x00007f397eb4880e in __evict_reconcile (session=0x7f3978542200, 
    ref=<optimized out>, evict_flags=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/evict/evict_page.c:1021
1021	        WT_WITH_TXN_ISOLATION(
#7  0x00007f397eb46c3e in __wt_evict (session=0x7f3978542200, 
    ref=<optimized out>, previous_state=<optimized out>, flags=4)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/evict/evict_page.c:275
275	        WT_ERR(__evict_reconcile(session, ref, flags));
#8  0x00007f397eb45c9a in __wt_page_release_evict (session=<optimized out>, 
    ref=<optimized out>, flags=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/evict/evict_page.c:91
91	    ret = __wt_evict(session, ref, previous_state, evict_flags);
#9  0x00007f397e894c0b in __cursor_reset (cbt=<optimized out>, 
    cbt@entry=0x61a000c82280)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/include/cursor_inline.h:306
306	        WT_TRET_BUSY_OK(__wt_page_release_evict(session, cbt->ref, 0));
#10 0x00007f397e89485c in __wt_btcur_reset (cbt=0x61a000c82280)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/btree/bt_cursor.c:629
629	    return (__cursor_reset(cbt));
#11 0x00007f397ea6854d in __curfile_reset (cursor=0x61a000c82280)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/src/cursor/cur_file.c:279
279	    ret = __wt_btcur_reset(cbt);
#12 0x00000000004eee02 in table_op (tinfo=<optimized out>, 
    tinfo@entry=0x6190012cd780, intxn=true, 
    iso_level=iso_level@entry=ISOLATION_SNAPSHOT, op=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/test/format/ops.c:916
916	    testutil_check(tinfo->cursor->reset(tinfo->cursor));
#13 0x00000000004e987b in ops (arg=<optimized out>)
    at /data/mci/42a4cc5c44e50a936fff0ac4d1499dc3/wiredtiger/test/format/ops.c:1302
1302	            ret = table_op(tinfo, intxn, iso_level, op);
#14 0x00007f397e66a609 in start_thread ()
