### PR TITLE
WT-13344 Run stat.py in fast mode when stat_data.py is modified

### DIFF
--- a/dist/stat.py
+++ b/dist/stat.py
@@ -12,6 +12,7 @@ from common_functions import filter_if_fast
 
 if not [f for f in filter_if_fast([
             "../dist/dist.py",
+            "../dist/stat_data.py",
             "../src/include/stat.h",
             "../src/include/wiredtiger.in",
             "../src/support/stat.c",

--- a/dist/stat.py
+++ b/dist/stat.py
@@ -20,7 +20,7 @@ if not [f for f in filter_if_fast([
     sys.exit(0)
 
 # Read the source files.
-from stat_data import groups, dsrc_stats, conn_stats, conn_dsrc_stats, join_stats, \
+from stat_data import dsrc_stats, conn_stats, conn_dsrc_stats, join_stats, \
     session_stats
 
 ##########################################

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -159,37 +159,6 @@ class YieldStat(Stat):
         Stat.__init__(self, name, YieldStat.prefix, desc, flags)
 
 ##########################################
-# Groupings of useful statistics:
-# A pre-defined dictionary containing the group name as the key and the
-# list of prefix tags that comprise that group.
-##########################################
-groups = {}
-groups['cursor'] = [CursorStat.prefix, SessionOpStat.prefix]
-groups['evict'] = [
-    BlockCacheStat.prefix,
-    BlockStat.prefix,
-    CacheStat.prefix,
-    CacheWalkStat.prefix,
-    ChunkCacheStat.prefix,
-    ConnStat.prefix,
-    ThreadStat.prefix
-]
-groups['lsm'] = [LSMStat.prefix, TxnStat.prefix]
-groups['memory'] = [
-    CacheStat.prefix,
-    CacheWalkStat.prefix,
-    ConnStat.prefix,
-    RecStat.prefix]
-groups['system'] = [
-    CapacityStat.prefix,
-    ConnStat.prefix,
-    DhandleStat.prefix,
-    PerfHistStat.prefix,
-    SessionOpStat.prefix,
-    ThreadStat.prefix
-]
-
-##########################################
 # CONNECTION statistics
 ##########################################
 conn_stats = [


### PR DESCRIPTION
Add `stat_data.py` to the list of files that triggers `stat.py` in fast mode.
This change also removes some dead `group` code in `stat_data.py`