### PR TITLE
WT-12902 Remove unused temporaries from IGNORE_RET macros

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -935,7 +935,7 @@ __verify_row_int_key_order(
 
     /* Update the largest key we've seen to the key just checked. */
     WT_RET(__wt_buf_set(session, vs->max_key, item.data, item.size));
-    WT_IGNORE_RET_PTR(__verify_addr_string(session, ref, vs->max_addr));
+    WT_IGNORE_RET(__verify_addr_string(session, ref, vs->max_addr));
 
     return (0);
 }
@@ -990,7 +990,7 @@ __verify_row_leaf_key_order(WT_SESSION_IMPL *session, WT_REF *ref, WT_VSTUFF *vs
 
     /* Update the largest key we've seen to the last key on this page. */
     WT_RET(__wt_row_leaf_key_copy(session, page, page->pg_row + (page->entries - 1), vs->max_key));
-    WT_IGNORE_RET_PTR(__verify_addr_string(session, ref, vs->max_addr));
+    WT_IGNORE_RET(__verify_addr_string(session, ref, vs->max_addr));
 
     return (0);
 }

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -91,7 +91,7 @@ __curdump_get_key(WT_CURSOR *cursor, ...)
             WT_ERR(child->get_key(child, &item));
 
             if (F_ISSET(cursor, WT_CURSTD_DUMP_PRETTY)) {
-                WT_IGNORE_RET_PTR(__wt_buf_set_printable_format(session, item.data, item.size,
+                WT_IGNORE_RET(__wt_buf_set_printable_format(session, item.data, item.size,
                   cursor->key_format, F_ISSET(cursor, WT_CURSTD_DUMP_HEX), &cursor->key));
             } else
                 WT_ERR(
@@ -241,7 +241,7 @@ __curdump_get_value(WT_CURSOR *cursor, ...)
         WT_ERR(child->get_value(child, &item));
 
         if (F_ISSET(cursor, WT_CURSTD_DUMP_PRETTY))
-            WT_IGNORE_RET_PTR(__wt_buf_set_printable_format(session, item.data, item.size,
+            WT_IGNORE_RET(__wt_buf_set_printable_format(session, item.data, item.size,
               cursor->value_format, F_ISSET(cursor, WT_CURSTD_DUMP_HEX), &cursor->value));
         else
             WT_ERR(

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -45,8 +45,8 @@ __hs_verbose_cache_stats(WT_SESSION_IMPL *session, WT_BTREE *btree)
     if (WT_VERBOSE_ISSET(session, WT_VERB_HS) ||
       (ckpt_gen_current > ckpt_gen_last &&
         __wt_atomic_casv64(&cache->hs_verb_gen_write, ckpt_gen_last, ckpt_gen_current))) {
-        WT_IGNORE_RET_BOOL(__wt_eviction_clean_needed(session, &pct_full));
-        WT_IGNORE_RET_BOOL(__wt_eviction_dirty_needed(session, &pct_dirty));
+        WT_IGNORE_RET(__wt_eviction_clean_needed(session, &pct_full));
+        WT_IGNORE_RET(__wt_eviction_dirty_needed(session, &pct_dirty));
 
         __wt_verbose_multi(session,
           WT_DECL_VERBOSE_MULTI_CATEGORY(

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2034,7 +2034,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
          */
         if (LF_ISSET(WT_READ_NO_EVICT) ||
           (inmem_split ? LF_ISSET(WT_READ_NO_SPLIT) : F_ISSET(session, WT_SESSION_NO_RECONCILE)))
-            WT_IGNORE_RET_BOOL(__wt_page_evict_urgent(session, ref));
+            WT_IGNORE_RET(__wt_page_evict_urgent(session, ref));
         else {
             WT_RET_BUSY_OK(__wt_page_release_evict(session, ref, flags));
             return (0);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -30,8 +30,7 @@
 #endif /* CODE_COVERAGE_MEASUREMENT */
 
 /*
- * Quiet compiler warnings about unused function parameters and variables, and unused function
- * return values.
+ * Explicitly suppress compiler warnings about unused variables, and function parameters.
  */
 #define WT_UNUSED(var) (void)(var)
 #define WT_NOT_READ(v, val) \
@@ -40,8 +39,11 @@
         (void)(v);          \
     } while (0);
 
-/* 
- * Explicitly suppress unused return value warning at function call sites. 
+/*
+ * Explicitly suppress: warning unused result.
+ *
+ * This is a different warning to unused variable warning suppressed by WT_UNUSED, and cannot be
+ * suppressed by only casting to void.
  */
 #define WT_IGNORE_RET(call) ((void)!(call))
 

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -42,8 +42,11 @@
 /*
  * Explicitly suppress: warning unused result.
  *
- * This is a different warning to unused variable warning suppressed by WT_UNUSED, and cannot be
- * suppressed by only casting to void.
+ * Simply casting to void as in WT_UNUSED will not suppress this warning on the current version of
+ * gcc (11.3.0) used for the server build.
+ *
+ * This workaround works with every supported toolchain, and does not employ unused temporary values
+ * that are then detected by Coverity.
  */
 #define WT_IGNORE_RET(call) ((void)!(call))
 

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -39,24 +39,13 @@
         (v) = (val);        \
         (void)(v);          \
     } while (0);
-#define WT_IGNORE_RET(call)                \
-    do {                                   \
-        uintmax_t __ignored_ret;           \
-        __ignored_ret = (uintmax_t)(call); \
-        WT_UNUSED(__ignored_ret);          \
-    } while (0)
-#define WT_IGNORE_RET_BOOL(call)  \
-    do {                          \
-        bool __ignored_ret;       \
-        __ignored_ret = (call);   \
-        WT_UNUSED(__ignored_ret); \
-    } while (0)
-#define WT_IGNORE_RET_PTR(call)    \
-    do {                           \
-        const void *__ignored_ret; \
-        __ignored_ret = (call);    \
-        WT_UNUSED(__ignored_ret);  \
-    } while (0)
+
+/* 
+ * Explicitly suppress unused return value warning at function call sites. 
+ */
+#define WT_IGNORE_RET(call) ((void)!(call))
+#define WT_IGNORE_RET_BOOL(call) ((void)!(call))
+#define WT_IGNORE_RET_PTR(call) ((void)!(call))
 
 #define WT_DIVIDER "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -44,8 +44,6 @@
  * Explicitly suppress unused return value warning at function call sites. 
  */
 #define WT_IGNORE_RET(call) ((void)!(call))
-#define WT_IGNORE_RET_BOOL(call) ((void)!(call))
-#define WT_IGNORE_RET_PTR(call) ((void)!(call))
 
 #define WT_DIVIDER "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 


### PR DESCRIPTION
Explicitly casting to void is not sufficient to suppress the warning. Inverting the value and then casting to void is works for all current mongodb v4 toolchains.