### PR TITLE
WT-13322 Fix hs_cleanup test to pass checkpoint cleanup configuration and enable connection logs

### DIFF
--- a/test/cppsuite/configs/hs_cleanup_default.txt
+++ b/test/cppsuite/configs/hs_cleanup_default.txt
@@ -2,6 +2,7 @@
 # need to be defined.
 duration_seconds=60,
 cache_size_mb=200,
+enable_logging=true,
 statistics_config=
 (
     type=all,
@@ -11,7 +12,7 @@ metrics_monitor=
 (
     cache_hs_insert=
     (
-        max=10,
+        min=10,
         max=100000000,
         postrun=true,
         save=true,

--- a/test/cppsuite/configs/hs_cleanup_default.txt
+++ b/test/cppsuite/configs/hs_cleanup_default.txt
@@ -1,6 +1,6 @@
 # Configuration for hs_cleanup.
 # need to be defined.
-duration_seconds=60,
+duration_seconds=90,
 cache_size_mb=200,
 enable_logging=true,
 statistics_config=

--- a/test/cppsuite/configs/hs_cleanup_stress.txt
+++ b/test/cppsuite/configs/hs_cleanup_stress.txt
@@ -4,6 +4,7 @@ duration_seconds=3600,
 # to hold these values.
 # 1.5 GB
 cache_size_mb=1536,
+enable_logging=true,
 compression_enabled=true,
 statistics_config=
 (

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -47,31 +47,6 @@ public:
         init_operation_tracker();
     }
 
-    /*
-     * The checkpoint function has been overridden to accommodate the offloaded checkpoint cleanup
-     * thread, enabled by the debug=checkpoint_cleanup options, to accurately measure checkpoint
-     * cleanup pages removed.
-     */
-    void
-    checkpoint_operation(thread_worker *tw) override final
-    {
-        logger::log_msg(
-          LOG_INFO, type_string(tw->type) + " thread {" + std::to_string(tw->id) + "} commencing.");
-
-        while (tw->running()) {
-            tw->sleep();
-            /*
-             * This may seem like noise but it can prevent the test being killed by the evergreen
-             * timeout.
-             */
-            logger::log_msg(LOG_INFO,
-              type_string(tw->type) + " thread {" + std::to_string(tw->id) +
-                "} taking a checkpoint.");
-            testutil_check(
-              tw->session->checkpoint(tw->session.get(), "debug=(checkpoint_cleanup=true)"));
-        }
-    }
-
     void
     update_operation(thread_worker *tc) override final
     {

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2032,6 +2032,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "cppsuite perf test"
         vars:
+          test_config: checkpoint_cleanup=(wait=60)
           test_config_filename: configs/hs_cleanup_default.txt
           test_name: hs_cleanup
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2032,6 +2032,8 @@ tasks:
       - func: "fetch artifacts"
       - func: "cppsuite perf test"
         vars:
+          # Configure checkpoint cleanup to run more often as the test only runs for 90 seconds
+          # and checkpoint cleanup is triggered every 300 seconds by default.
           test_config: checkpoint_cleanup=(wait=60)
           test_config_filename: configs/hs_cleanup_default.txt
           test_name: hs_cleanup


### PR DESCRIPTION
This pull request has the following changes:
- Increase the test runtime duration to accommodate at least 1 checkpoint cleanup because the checkpoint_cleanup wait time minimum is 60 seconds.
- Enable connection log