### PR TITLE
WT-12492 WT-12492 Checkpoint target option: remove tests and examples

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -490,17 +490,6 @@ checkpoint_ops(WT_SESSION *session)
     /* Checkpoint of the database, creating a named snapshot. */
     error_check(session->checkpoint(session, "name=June01"));
 
-    /*
-     * Checkpoint a list of objects. JSON parsing requires quoting the list of target URIs.
-     */
-    error_check(session->checkpoint(session, "target=(\"table:table1\",\"table:table2\")"));
-
-    /*
-     * Checkpoint a list of objects, creating a named snapshot. JSON parsing requires quoting the
-     * list of target URIs.
-     */
-    error_check(session->checkpoint(session, "target=(\"table:mytable\"),name=midnight"));
-
     /* Checkpoint the database, discarding all previous snapshots. */
     error_check(session->checkpoint(session, "drop=(from=all)"));
 
@@ -516,21 +505,7 @@ checkpoint_ops(WT_SESSION *session)
      * Checkpoint the database, discarding all snapshots before and including "midnight".
      */
     error_check(session->checkpoint(session, "drop=(to=midnight)"));
-
-    /*
-     * Create a checkpoint of a table, creating the "July01" snapshot and discarding the "May01" and
-     * "June01" snapshots. JSON parsing requires quoting the list of target URIs.
-     */
-    error_check(
-      session->checkpoint(session, "target=(\"table:mytable\"),name=July01,drop=(May01,June01)"));
     /*! [Checkpoint examples] */
-
-    /*! [JSON quoting example] */
-    /*
-     * Checkpoint a list of objects. JSON parsing requires quoting the list of target URIs.
-     */
-    error_check(session->checkpoint(session, "target=(\"table:table1\",\"table:table2\")"));
-    /*! [JSON quoting example] */
 }
 
 static void
@@ -1130,8 +1105,13 @@ backup(WT_SESSION *session)
     /*! [backup log duplicate]*/
     /* Open the backup data source. */
     error_check(session->open_cursor(session, "backup:", NULL, NULL, &cursor));
+    /*! [JSON quoting example] */
     /* Open a duplicate cursor for additional log files. */
+    /*
+     * JSON parsing requires quoting a URI that contains a colon.
+     */
     error_check(session->open_cursor(session, NULL, cursor, "target=(\"log:\")", &dup_cursor));
+    /*! [JSON quoting example] */
     /*! [backup log duplicate]*/
 
     /*! [incremental block backup]*/

--- a/src/docs/config-strings.dox
+++ b/src/docs/config-strings.dox
@@ -112,9 +112,9 @@ For example, in Python, code might look as follows:
 
 Because JSON compatibility allows colons to be used as key/value separators,
 WiredTiger URIs may require quoting.  For example, the following
-WT_SESSION::checkpoint call specifies a set of URIs as checkpoint targets,
-using double-quote characters to keep the parser from treating the colon
-characters as JSON name/value separators:
+WT_SESSION::open_cursor call specifies the URI "log:" using double-quote
+characters to keep the parser from treating the colon character as a JSON
+name/value separator:
 
 @snippet ex_all.c JSON quoting example
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2326,8 +2326,8 @@ tasks:
             done
 
   - name: csuite-long-running
-    # Set 5 hours timeout (60 * 60 * 5)
-    exec_timeout_secs: 18000
+    # Set 6 hours timeout (60 * 60 * 6 = 21600)
+    exec_timeout_secs: 21600
     commands:
       - func: "get project"
       - func: "compile wiredtiger"

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -219,42 +219,6 @@ class test_checkpoint_target(wttest.WiredTigerTestCase):
         self.assertEqual(cursor[ds.key(10)], value)
         cursor.close()
 
-    # FIXME-WT-10836
-    @wttest.skip_for_hook("tiered", "strange interaction with tiered and named checkpoints using target")
-    def test_checkpoint_target(self):
-        # Create 3 objects, change one record to an easily recognizable string.
-        uri = self.uri + '1'
-        ds1 = SimpleDataSet(self, uri, 100, key_format=self.fmt)
-        ds1.populate()
-        self.update(uri, ds1, 'ORIGINAL')
-
-        uri = self.uri + '2'
-        ds2 = SimpleDataSet(self, uri, 100, key_format=self.fmt)
-        ds2.populate()
-        self.update(uri, ds2, 'ORIGINAL')
-
-        uri = self.uri + '3'
-        ds3 = SimpleDataSet(self, uri, 100, key_format=self.fmt)
-        ds3.populate()
-        self.update(uri, ds3, 'ORIGINAL')
-
-        # Checkpoint all three objects.
-        self.session.checkpoint("name=checkpoint-1")
-
-        # Update all 3 objects, then checkpoint two of the objects with the
-        # same checkpoint name.
-        self.update(self.uri + '1', ds1, 'UPDATE')
-        self.update(self.uri + '2', ds2, 'UPDATE')
-        self.update(self.uri + '3', ds3, 'UPDATE')
-        target = 'target=("' + self.uri + '1"' + ',"' + self.uri + '2")'
-        self.session.checkpoint("name=checkpoint-1," + target)
-
-        # Confirm the checkpoint has the old value in objects that weren't
-        # checkpointed, and the new value in objects that were checkpointed.
-        self.check(self.uri + '1', ds1, 'UPDATE')
-        self.check(self.uri + '2', ds2, 'UPDATE')
-        self.check(self.uri + '3', ds3, 'ORIGINAL')
-
 # Check that you can't write checkpoint cursors.
 class test_checkpoint_cursor_update(wttest.WiredTigerTestCase):
     scenarios = make_scenarios([


### PR DESCRIPTION
* Delete checkpoint target examples (ex_all.c) and tests.
* Replace [JSON quoting example] with a new example not using checkpoint target.
* Change timeout of csuite-long-running from 5 hours to 6 hours.
* Respond to code review on branch off develop.