### PR TITLE
WT-13282 Add a mechanism to test/model to handle (and skip over) known bugs

### DIFF
--- a/test/model/src/core/kv_table.cpp
+++ b/test/model/src/core/kv_table.cpp
@@ -275,8 +275,8 @@ kv_table::truncate(kv_transaction_ptr txn, const data_value &start, const data_v
         /* FIXME-WT-13232 Disable this check or make it FLCS only (depending on the fix). */
         /*
          * WiredTiger's implementation of truncate returns a prepare conflict if the key following
-         * the truncate range belongs to a prepared transaction, or in some cases, the preceding
-         * key. In the case of FLCS, skip all implicitly created items following the truncation
+         * (or, in some cases, preceding) the truncate range belongs to a prepared transaction. In
+         * the case of FLCS, skip all implicitly created items before and after the truncation
          * range.
          */
         for (auto i = stop_iter; i != _data.end(); i++) {

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -56,11 +56,7 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     insert = 0.75;
     remove = 0.15;
     set_commit_timestamp = 0.05;
-    /*
-     * FIXME-WT-13232 Enable the eviction operator when we've determined how to handle prepare
-     * conflicts with keys adjacent to the truncation range. Set to 0.005.
-     */
-    truncate = 0.0;
+    truncate = 0.005;
 
     checkpoint = 0.02;
     crash = 0.002;
@@ -425,13 +421,15 @@ kv_workload_generator::generate_transaction(size_t seq_no)
                 table_context_ptr table = choose_table(txn_ptr);
 
                 /*
-                 * Don't use truncate on FLCS tables, because a truncate on an FLCS table can
-                 * conflict with operations adjacent to the truncation range's key range. For
-                 * example, if a user wants to truncate range 10-12 on a table with keys [10, 11,
-                 * 12, 13, 14], a concurrent update to key 13 would result in a conflict (while an
-                 * update to 14 would be able proceed). This does not happen with the other table
-                 * types, which are implemented using bounded cursors; FLCS does not support bounded
-                 * cursors, so it uses a different implementation.
+                 * FIXME-WT-13232 Don't use truncate on FLCS tables, because a truncate on an FLCS
+                 * table can conflict with operations adjacent to the truncation range's key range.
+                 * For example, if a user wants to truncate range 10-12 on a table with keys [10,
+                 * 11, 12, 13, 14], a concurrent update to key 13 would result in a conflict (while
+                 * an update to 14 would be able proceed).
+                 *
+                 * FIXME-WT-13350 Similarly, truncating an implicitly created range of keys in an
+                 * FLCS table conflicts with a concurrent insert operation that caused this range of
+                 * keys to be created.
                  *
                  * The workload generator cannot currently account for this, so don't use truncate
                  * with FLCS tables for now.

--- a/test/model/src/include/model/core.h
+++ b/test/model/src/include/model/core.h
@@ -246,4 +246,35 @@ public:
     inline wiredtiger_abort_exception() noexcept : std::runtime_error("WiredTiger would abort") {}
 };
 
+/*
+ * known_issue_exception --
+ *     An exception for known WiredTiger issues.
+ */
+class known_issue_exception : public std::runtime_error {
+
+public:
+    /*
+     * known_issue_exception::known_issue_exception --
+     *     Create a new instance of the exception.
+     */
+    inline known_issue_exception(const char *issue) noexcept
+        : std::runtime_error(std::string("Hit a known WiredTiger issue: ") + issue), _issue(issue)
+    {
+    }
+
+    /*
+     * known_issue_exception::issue --
+     *     Get the ticket number for the known issue as a C string. The lifetime of the pointer
+     *     corresponds to the lifetime of this exception.
+     */
+    inline const char *
+    issue() noexcept
+    {
+        return _issue.c_str();
+    }
+
+private:
+    std::string _issue;
+};
+
 } /* namespace model */

--- a/test/model/src/include/model/kv_table_item.h
+++ b/test/model/src/include/model/kv_table_item.h
@@ -176,7 +176,18 @@ public:
      * kv_table_item::has_prepared --
      *     Check whether the item has any prepared updates for the given timestamp.
      */
-    bool has_prepared(timestamp_t timestamp) const;
+    bool has_prepared(timestamp_t timestamp = k_timestamp_max) const;
+
+    /*
+     * kv_table_item::implicit --
+     *     Check if the item has been created implicitly and exists only implicitly.
+     */
+    inline bool
+    implicit() const
+    {
+        std::lock_guard lock_guard(_lock);
+        return _updates.size() == 1 && (*_updates.begin())->implicit();
+    }
 
     /*
      * kv_table_item::rollback_to_stable --

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -96,6 +96,10 @@ run_and_verify(std::shared_ptr<model::kv_workload> workload, const std::string &
 
         /* When we load the workload from WiredTiger, that would be after running recovery. */
         database.restart();
+    } catch (model::known_issue_exception &e) {
+        std::cerr << "Warning: Reproduced known WiredTiger issue " << e.issue()
+                  << " (skip the rest of the test)" << std::endl;
+        return;
     } catch (std::exception &e) {
         throw std::runtime_error(
           "Failed to run the workload in the model: " + std::string(e.what()));


### PR DESCRIPTION
Add a mechanism for ignoring known bugs and implemented it for WT-13232. The model can now throw an exception if it knows that it's going to trigger a known bug, which then results in the rest of that test being skipped.

This approach works well for the class of bugs that can be modeled during workload execution, such as WT-13232. I chose this approach as it provides a simple mechanism to unblock this project. In the future, we can create the alternative (but much more complicated) mechanism described in WT-13282, which would allow us to skip over bugs that are harder to model. We can come back to it in the future if it becomes necessary.