### PR TITLE
WT-13351 Increase the length of test/model runs

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3939,8 +3939,8 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-            # Keep repeating the model test for 30 minutes
-            ./model_test -l 2000-3000 -t 1800
+            # Keep repeating the model test for 60 minutes
+            ./model_test -l 2000-3000 -t 3600
 
   - name: model-test-long-with-coverage
     tags: ["model_checking"]
@@ -3968,8 +3968,8 @@ tasks:
             # Record the start time, in seconds (needed by the code coverage analysis step below)
             date +%s > ../../../../time.txt
 
-            # Keep repeating the model test for 600 seconds
-            ./model_test -l 2000-3000 -t 600
+            # Keep repeating the model test for 60 minutes
+            ./model_test -l 2000-3000 -t 3600
 
             # Record the end time, in seconds
             date +%s >> ../../../../time.txt


### PR DESCRIPTION
Increase the length of test/model runs to better cover the parts of the code that we currently hit with a smaller probability. In particular, we need this to get a more accurate code coverage runs to see what parts of RTS we still do not cover.

This change brings up the code coverage report to 90% lines.