### PR TITLE
WT-13327 Cleanup code in log_slot.c

### DIFF
--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -531,7 +531,7 @@ __wti_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, W
     uint64_t time_start, time_stop, usecs;
     int64_t flag_state, new_state, old_state, released;
     int32_t join_offset, new_join, wait_cnt;
-    bool closed, diag_yield, raced, slept, unbuffered, yielded, force_unbuffered;
+    bool closed, diag_yield, force_unbuffered, raced, slept, unbuffered, yielded;
 
     conn = S2C(session);
     log = conn->log;
@@ -550,8 +550,7 @@ __wti_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, W
     diag_yield = (++log->write_calls % 7) == 0;
     force_unbuffered = (log->write_calls % WT_THOUSAND) == 0;
 #else
-    diag_yield = false;
-    force_unbuffered = false;
+    diag_yield = force_unbuffered = false;
 #endif
     if (force_unbuffered || mysize > WT_LOG_SLOT_BUF_MAX) {
         unbuffered = true;

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -548,12 +548,12 @@ __wti_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, W
     wait_cnt = 0;
 #ifdef HAVE_DIAGNOSTIC
     diag_yield = (++log->write_calls % 7) == 0;
-    force_unbuffered = (log->write_calls % WT_THOUSAND) == 0 || mysize > WT_LOG_SLOT_BUF_MAX;
+    force_unbuffered = (log->write_calls % WT_THOUSAND) == 0;
 #else
     diag_yield = false;
-    force_unbuffered = mysize > WT_LOG_SLOT_BUF_MAX;
+    force_unbuffered = false;
 #endif
-    if (force_unbuffered) {
+    if (force_unbuffered || mysize > WT_LOG_SLOT_BUF_MAX) {
         unbuffered = true;
         F_SET(myslot, WT_MYSLOT_UNBUFFERED);
     }

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -531,7 +531,7 @@ __wti_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, W
     uint64_t time_start, time_stop, usecs;
     int64_t flag_state, new_state, old_state, released;
     int32_t join_offset, new_join, wait_cnt;
-    bool closed, diag_yield, raced, slept, unbuffered, yielded;
+    bool closed, diag_yield, raced, slept, unbuffered, yielded, force_unbuffered;
 
     conn = S2C(session);
     log = conn->log;
@@ -548,11 +548,12 @@ __wti_log_slot_join(WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, W
     wait_cnt = 0;
 #ifdef HAVE_DIAGNOSTIC
     diag_yield = (++log->write_calls % 7) == 0;
-    if ((log->write_calls % WT_THOUSAND) == 0 || mysize > WT_LOG_SLOT_BUF_MAX) {
+    force_unbuffered = (log->write_calls % WT_THOUSAND) == 0 || mysize > WT_LOG_SLOT_BUF_MAX;
 #else
     diag_yield = false;
-    if (mysize > WT_LOG_SLOT_BUF_MAX) {
+    force_unbuffered = mysize > WT_LOG_SLOT_BUF_MAX;
 #endif
+    if (force_unbuffered) {
         unbuffered = true;
         F_SET(myslot, WT_MYSLOT_UNBUFFERED);
     }


### PR DESCRIPTION
The code coverage task complains about ```Non-matching opening bracket '{' detected``` which is caused by the preprocessor directives in log_slot.c. Rewrite it to avoid this warning.