### PR TITLE
WT-13352 Add recovery checkpoints that contain evicted prepared data to test/model

### DIFF
--- a/test/model/src/core/kv_table.cpp
+++ b/test/model/src/core/kv_table.cpp
@@ -282,14 +282,14 @@ kv_table::truncate(kv_transaction_ptr txn, const data_value &start, const data_v
         for (auto i = stop_iter; i != _data.end(); i++) {
             if (i->second.has_prepared())
                 throw known_issue_exception("WT-13232");
-            if (!i->second.exists() || i->second.implicit())
+            if (!i->second.exists(txn) || i->second.implicit())
                 continue;
             break;
         }
         for (auto i = std::reverse_iterator(start_iter); i != _data.rend(); i++) {
             if (i->second.has_prepared())
                 throw known_issue_exception("WT-13232");
-            if (!i->second.exists() || i->second.implicit())
+            if (!i->second.exists(txn) || i->second.implicit())
                 continue;
             break;
         }

--- a/test/model/src/driver/kv_workload.cpp
+++ b/test/model/src/driver/kv_workload.cpp
@@ -164,6 +164,10 @@ parse(const char *str)
         return insert(parse_uint64(args[0]), parse_uint64(args[1]),
           data_value(parse_uint64(args[2])), data_value(parse_uint64(args[3])));
     }
+    if (name == "nop") {
+        CHECK_NUM_ARGS(0);
+        return nop();
+    }
     if (name == "prepare_transaction") {
         CHECK_NUM_ARGS(2);
         return prepare_transaction(parse_uint64(args[0]), parse_uint64(args[1]));

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -387,7 +387,7 @@ kv_workload_generator::generate_transaction(size_t seq_no)
                     else {
                         txn << operation::prepare_transaction(txn_id, k_timestamp_none);
 
-                        /* Add a delay before finishing the transation. */
+                        /* Add a delay before finishing the transaction. */
                         size_t delay = _random.next_uint64(_spec.max_delay_after_prepare);
                         for (size_t i = 0; i < delay; i++)
                             txn << operation::nop();

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -70,6 +70,7 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     update_existing = 0.1;
 
     prepared_transaction = 0.25;
+    max_delay_after_prepare = 25; /* FIXME-WT-13232 This must be a small number until it's fixed. */
     use_set_commit_timestamp = 0.25;
     nonprepared_transaction_rollback = 0.1;
     prepared_transaction_rollback_after_prepare = 0.1;
@@ -385,6 +386,13 @@ kv_workload_generator::generate_transaction(size_t seq_no)
                         txn << operation::rollback_transaction(txn_id);
                     else {
                         txn << operation::prepare_transaction(txn_id, k_timestamp_none);
+
+                        /* Add a delay before finishing the transation. */
+                        size_t delay = _random.next_uint64(_spec.max_delay_after_prepare);
+                        for (size_t i = 0; i < delay; i++)
+                            txn << operation::nop();
+
+                        /* Finish the transaction. */
                         if (_random.next_float() <
                           _spec.prepared_transaction_rollback_after_prepare)
                             txn << operation::rollback_transaction(txn_id);
@@ -654,7 +662,8 @@ kv_workload_generator::run()
         if (s->next_operation_index >= s->sequence->size())
             throw model_exception("Internal error: No more operations left in a sequence");
         const operation::any &op = (*s->sequence)[s->next_operation_index++];
-        _workload << kv_workload_operation(op, s->sequence->seq_no());
+        if (!std::holds_alternative<operation::nop>(op))
+            _workload << kv_workload_operation(op, s->sequence->seq_no());
 
         /* If the operation resulted in a database crash or restart, stop all started sequences. */
         if (std::holds_alternative<operation::crash>(op) ||

--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -387,6 +387,17 @@ kv_workload_runner_wt::do_operation(const operation::insert &op)
  *     Execute the given workload operation in WiredTiger.
  */
 int
+kv_workload_runner_wt::do_operation(const operation::nop &op)
+{
+    (void)op;
+    return 0;
+}
+
+/*
+ * kv_workload_runner_wt::do_operation --
+ *     Execute the given workload operation in WiredTiger.
+ */
+int
 kv_workload_runner_wt::do_operation(const operation::prepare_transaction &op)
 {
     std::ostringstream config;

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -504,6 +504,50 @@ operator<<(std::ostream &out, const insert &op)
 }
 
 /*
+ * nop --
+ *     A representation of this workload operation.
+ */
+struct nop : public without_txn_id, public without_table_id {
+
+    /*
+     * nop::nop --
+     *     Create the operation.
+     */
+    inline nop() {}
+
+    /*
+     * nop::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const nop &other) const noexcept
+    {
+        return true;
+    }
+
+    /*
+     * nop::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const nop &other) const noexcept
+    {
+        return !(*this == other);
+    }
+};
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const nop &op)
+{
+    out << "nop()";
+    return out;
+}
+
+/*
  * prepare_transaction --
  *     A representation of this workload operation.
  */
@@ -930,8 +974,8 @@ operator<<(std::ostream &out, const truncate &op)
  *     Any workload operation.
  */
 using any = std::variant<begin_transaction, checkpoint, commit_transaction, crash, create_table,
-  evict, insert, prepare_transaction, remove, restart, rollback_to_stable, rollback_transaction,
-  set_commit_timestamp, set_oldest_timestamp, set_stable_timestamp, truncate>;
+  evict, insert, nop, prepare_transaction, remove, restart, rollback_to_stable,
+  rollback_transaction, set_commit_timestamp, set_oldest_timestamp, set_stable_timestamp, truncate>;
 
 /*
  * operator<< --

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -91,6 +91,9 @@ struct kv_workload_generator_spec {
     /* The probability of starting a prepared transaction. */
     float prepared_transaction;
 
+    /* The maximum delay after preparing a transaction (expressed as operation count). */
+    size_t max_delay_after_prepare;
+
     /* Probabilities of transaction rollback. */
     float nonprepared_transaction_rollback;
     float prepared_transaction_rollback_after_prepare;

--- a/test/model/src/include/model/driver/kv_workload_runner.h
+++ b/test/model/src/include/model/driver/kv_workload_runner.h
@@ -178,6 +178,17 @@ protected:
      *     Execute the given workload operation in the model.
      */
     int
+    do_operation(const operation::nop &op)
+    {
+        (void)op;
+        return 0;
+    }
+
+    /*
+     * kv_workload_runner::do_operation --
+     *     Execute the given workload operation in the model.
+     */
+    int
     do_operation(const operation::prepare_transaction &op)
     {
         transaction(op.txn_id)->prepare(op.prepare_timestamp);

--- a/test/model/src/include/model/driver/kv_workload_runner_wt.h
+++ b/test/model/src/include/model/driver/kv_workload_runner_wt.h
@@ -278,6 +278,12 @@ protected:
      * kv_workload_runner_wt::do_operation --
      *     Execute the given workload operation in WiredTiger.
      */
+    int do_operation(const operation::nop &op);
+
+    /*
+     * kv_workload_runner_wt::do_operation --
+     *     Execute the given workload operation in WiredTiger.
+     */
     int do_operation(const operation::prepare_transaction &op);
 
     /*

--- a/test/model/src/include/model/kv_table_item.h
+++ b/test/model/src/include/model/kv_table_item.h
@@ -97,6 +97,16 @@ public:
     bool exists(kv_checkpoint_ptr checkpoint) const;
 
     /*
+     * kv_table_item::exists --
+     *     Check whether the latest value exists for the given transaction snapshot.
+     */
+    inline bool
+    exists(kv_transaction_ptr txn) const
+    {
+        return get(std::move(txn)) != NONE;
+    }
+
+    /*
      * kv_table_item::exists_opt --
      *     Check whether the latest value exists, using the checkpoint if provided.
      */

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -293,6 +293,8 @@ test_workload_crash(void)
 static void
 test_workload_generator(void)
 {
+    int retries = 0;
+
     while (true) {
         try {
             std::shared_ptr<model::kv_workload> workload = model::kv_workload_generator::generate();
@@ -300,10 +302,14 @@ test_workload_generator(void)
             /* Run the workload in the model and in WiredTiger, then verify. */
             std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
             verify_workload(*workload, opts, test_home, ENV_CONFIG);
+
             break;
         } catch (model::known_issue_exception &) {
             /* Try again. */
         }
+
+        if (retries++ > 10)
+            throw model::model_exception("Too many retries for workload generation");
     }
 }
 

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -293,11 +293,18 @@ test_workload_crash(void)
 static void
 test_workload_generator(void)
 {
-    std::shared_ptr<model::kv_workload> workload = model::kv_workload_generator::generate();
+    while (true) {
+        try {
+            std::shared_ptr<model::kv_workload> workload = model::kv_workload_generator::generate();
 
-    /* Run the workload in the model and in WiredTiger, then verify. */
-    std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
-    verify_workload(*workload, opts, test_home, ENV_CONFIG);
+            /* Run the workload in the model and in WiredTiger, then verify. */
+            std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
+            verify_workload(*workload, opts, test_home, ENV_CONFIG);
+            break;
+        } catch (model::known_issue_exception &) {
+            /* Try again. */
+        }
+    }
 }
 
 /*

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -218,6 +218,7 @@ update_spec(model::kv_workload_generator_spec &spec, std::string &conn_config,
         UPDATE_SPEC(update_existing, float);
 
         UPDATE_SPEC(prepared_transaction, float);
+        UPDATE_SPEC(max_delay_after_prepare, uint64);
         UPDATE_SPEC(nonprepared_transaction_rollback, float);
         UPDATE_SPEC(prepared_transaction_rollback_after_prepare, float);
         UPDATE_SPEC(prepared_transaction_rollback_before_prepare, float);


### PR DESCRIPTION
This PR increases the probability that RTS in the test would see a checkpoint with evicted prepared data. It accomplishes this by adding a delay between when a transaction is prepared and when it is committed or rolled back. It implements this delay by modifying `kv_workload_generator::generate_transaction` to add a number of no-ops (`model::operation::nop`) after `prepare_transaction`, which ultimately causes the commit or rollback operation to come up later in the execution schedule. (The `nop` operation is not actually added to the final workload, but I still implemented it as an actual workload operation as that was more straightforward than doing something one-off).

After introducing these changes, the PR found a new way to reproduce WT-13232 for which `kv_table::truncate` didn't account, so the PR fixes that also. These changes also significantly increased the chances of reproducing WT-13232 in general, to the point that I added a `try`/`catch` statement for `model::known_issue_exception` to `test_workload_generator` to prevent spurious test failures.