### PR TITLE
WT-13377 Fix session->reconfigure with respect to cache_max_wait_ms, accept 0

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2612,7 +2612,7 @@ extern int __ut_ovfl_discard_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_ovfl_track_init(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __ut_session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
+extern int __ut_session_config_int(WT_SESSION_IMPL *session, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bool skip_off);
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2612,6 +2612,8 @@ extern int __ut_ovfl_discard_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_ovfl_track_init(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bool skip_off);
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);
 extern void __ut_chunkcache_bitmap_free(WT_SESSION_IMPL *session, size_t bit_index);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -528,10 +528,6 @@ __session_config_int(WT_SESSION_IMPL *session, const char *config)
     }
     WT_RET_NOTFOUND_OK(ret);
 
-    if ((ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval)) == 0)
-        session->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
-    WT_RET_NOTFOUND_OK(ret);
-
     /*
      * There is a session debug configuration which can be set to evict pages as they are released
      * and no longer needed.
@@ -542,6 +538,10 @@ __session_config_int(WT_SESSION_IMPL *session, const char *config)
         else
             F_CLR(session, WT_SESSION_DEBUG_RELEASE_EVICT);
     }
+    WT_RET_NOTFOUND_OK(ret);
+
+    if ((ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval)) == 0)
+        session->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
     WT_RET_NOTFOUND_OK(ret);
 
     return (0);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -454,22 +454,97 @@ __wt_session_close_internal(WT_SESSION_IMPL *session)
 }
 
 /*
- * __session_config_cache_max_wait_ms --
- *     Configure the cache wait time on a session.
+ * __session_config_prefetch --
+ *     Configure pre-fetch flags on the session.
  */
 static int
-__session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
+__session_config_prefetch(WT_SESSION_IMPL *session, const char **cfg)
+{
+    WT_CONFIG_ITEM cval;
+
+    if (S2C(session)->prefetch_auto_on)
+        F_SET(session, WT_SESSION_PREFETCH_ENABLED);
+    else
+        F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
+
+    /*
+     * Override any connection-level pre-fetch settings if a specific session-level setting was
+     * provided.
+     */
+    if (__wt_config_gets(session, cfg + 1, "prefetch.enabled", &cval) == 0) {
+        if (cval.val) {
+            if (!S2C(session)->prefetch_available) {
+                F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
+                WT_RET_MSG(session, EINVAL,
+                  "pre-fetching cannot be enabled for the session if pre-fetching is configured as "
+                  "unavailable");
+            } else
+                F_SET(session, WT_SESSION_PREFETCH_ENABLED);
+        } else
+            F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
+    }
+
+    return (0);
+}
+
+/*
+ * __session_config_int --
+ *     Configure basic flags and values on the session. Tested via a unit test.
+ */
+static int
+__session_config_int(WT_SESSION_IMPL *session, const char *config)
 {
     WT_CONFIG_ITEM cval;
     WT_DECL_RET;
 
+    if ((ret = __wt_config_getones(session, config, "ignore_cache_size", &cval)) == 0) {
+        if (cval.val)
+            F_SET(session, WT_SESSION_IGNORE_CACHE_SIZE);
+        else
+            F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
+    }
+    WT_RET_NOTFOUND_OK(ret);
+
+    if ((ret = __wt_config_getones(session, config, "cache_cursors", &cval)) == 0) {
+        if (cval.val)
+            F_SET(session, WT_SESSION_CACHE_CURSORS);
+        else {
+            F_CLR(session, WT_SESSION_CACHE_CURSORS);
+            WT_RET(__session_close_cached_cursors(session));
+        }
+    }
+    WT_RET_NOTFOUND_OK(ret);
+
+    /*
+     * FIXME-WT-12021 Replace this debug option with the corresponding failpoint once this project
+     * is completed.
+     */
+    if ((ret = __wt_config_getones(
+           session, config, "debug.checkpoint_fail_before_turtle_update", &cval)) == 0) {
+        if (cval.val)
+            F_SET(session, WT_SESSION_DEBUG_CHECKPOINT_FAIL_BEFORE_TURTLE_UPDATE);
+        else
+            F_CLR(session, WT_SESSION_DEBUG_CHECKPOINT_FAIL_BEFORE_TURTLE_UPDATE);
+    }
+    WT_RET_NOTFOUND_OK(ret);
+
     if ((ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval)) == 0)
         session->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
+    WT_RET_NOTFOUND_OK(ret);
 
-    if (ret == WT_NOTFOUND)
-        ret = 0;
+    /*
+     * There is a session debug configuration which can be set to evict pages as they are released
+     * and no longer needed.
+     */
+    if ((ret = __wt_config_getones(session, config, "debug.release_evict_page", &cval)) == 0) {
+        if (cval.val)
+            F_SET(session, WT_SESSION_DEBUG_RELEASE_EVICT);
+        else
+            F_CLR(session, WT_SESSION_DEBUG_RELEASE_EVICT);
+    }
+    WT_RET_NOTFOUND_OK(ret);
 
-    return (ret);
+    return (0);
 }
 
 /*
@@ -479,7 +554,6 @@ __session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
 static int
 __session_reconfigure(WT_SESSION *wt_session, const char *config)
 {
-    WT_CONFIG_ITEM cval;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
@@ -497,77 +571,9 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
      */
     WT_ERR(__wt_txn_reconfigure(session, config));
 
-    ret = __wt_config_getones(session, config, "ignore_cache_size", &cval);
-    if (ret == 0) {
-        if (cval.val)
-            F_SET(session, WT_SESSION_IGNORE_CACHE_SIZE);
-        else
-            F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
-    }
-    WT_ERR_NOTFOUND_OK(ret, false);
+    WT_ERR(__session_config_int(session, config));
 
-    ret = __wt_config_getones(session, config, "cache_cursors", &cval);
-    if (ret == 0) {
-        if (cval.val)
-            F_SET(session, WT_SESSION_CACHE_CURSORS);
-        else {
-            F_CLR(session, WT_SESSION_CACHE_CURSORS);
-            WT_ERR(__session_close_cached_cursors(session));
-        }
-    }
-    WT_ERR_NOTFOUND_OK(ret, false);
-
-    /*
-     * FIXME-WT-12021 Replace this debug option with the corresponding failpoint once this project
-     * is completed.
-     */
-    if ((ret = __wt_config_getones(
-           session, config, "debug.checkpoint_fail_before_turtle_update", &cval)) == 0) {
-        if (cval.val)
-            F_SET(session, WT_SESSION_DEBUG_CHECKPOINT_FAIL_BEFORE_TURTLE_UPDATE);
-        else
-            F_CLR(session, WT_SESSION_DEBUG_CHECKPOINT_FAIL_BEFORE_TURTLE_UPDATE);
-    }
-    WT_ERR_NOTFOUND_OK(ret, false);
-
-    /*
-     * There is a session debug configuration which can be set to evict pages as they are released
-     * and no longer needed.
-     */
-    if ((ret = __wt_config_getones(session, config, "debug.release_evict_page", &cval)) == 0) {
-        if (cval.val)
-            F_SET(session, WT_SESSION_DEBUG_RELEASE_EVICT);
-        else
-            F_CLR(session, WT_SESSION_DEBUG_RELEASE_EVICT);
-    }
-
-    WT_ERR_NOTFOUND_OK(ret, false);
-
-    WT_ERR(__session_config_cache_max_wait_ms(session, config));
-
-    if (S2C(session)->prefetch_auto_on)
-        F_SET(session, WT_SESSION_PREFETCH_ENABLED);
-    else
-        F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
-
-    /*
-     * Override any connection-level pre-fetch settings if a specific session-level setting was
-     * provided.
-     */
-    if (__wt_config_gets(session, cfg + 1, "prefetch.enabled", &cval) == 0) {
-        if (cval.val) {
-            if (!S2C(session)->prefetch_available) {
-                F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
-                WT_ERR_MSG(session, EINVAL,
-                  "pre-fetching cannot be enabled for the session if pre-fetching is configured as "
-                  "unavailable");
-            } else
-                F_SET(session, WT_SESSION_PREFETCH_ENABLED);
-        } else
-            F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
-    }
-
-    WT_ERR_NOTFOUND_OK(ret, false);
+    WT_ERR(__session_config_prefetch(session, cfg));
 err:
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
@@ -2754,8 +2760,8 @@ __wt_open_internal_session(WT_CONNECTION_IMPL *conn, const char *name, bool open
 
 #ifdef HAVE_UNITTEST
 int
-__ut_session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
+__ut_session_config_int(WT_SESSION_IMPL *session, const char *config)
 {
-    return (__session_config_cache_max_wait_ms(session, config));
+    return (__session_config_int(session, config));
 }
 #endif

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -524,8 +524,7 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
 
     WT_ERR_NOTFOUND_OK(ret, false);
 
-    ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval);
-    if (ret == 0 && cval.val)
+    if ((ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval)) == 0)
         session->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
     WT_ERR_NOTFOUND_OK(ret, false);
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -472,14 +472,6 @@ __session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
     return (ret);
 }
 
-#ifdef HAVE_UNITTEST
-int
-__ut_session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
-{
-    return (__session_config_cache_max_wait_ms(session, config));
-}
-#endif
-
 /*
  * __session_reconfigure --
  *     WT_SESSION->reconfigure method.
@@ -2759,3 +2751,11 @@ __wt_open_internal_session(WT_CONNECTION_IMPL *conn, const char *name, bool open
     *sessionp = session;
     return (0);
 }
+
+#ifdef HAVE_UNITTEST
+int
+__ut_session_config_cache_max_wait_ms(WT_SESSION_IMPL *session, const char *config)
+{
+    return (__session_config_cache_max_wait_ms(session, config));
+}
+#endif

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
         tests/test_pow.cpp
         tests/test_prepare_mod_sort.cpp
         tests/test_reconciliation_tracking.cpp
+        tests/test_session_config.cpp
         tests/test_string_match.cpp
         tests/test_tailq.cpp
         tests/backup/test_incremental_blkmods.cpp

--- a/test/unittest/tests/test_session_config.cpp
+++ b/test/unittest/tests/test_session_config.cpp
@@ -1,0 +1,44 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "wrappers/mock_session.h"
+
+
+TEST_CASE("Set cache_max_wait_ms", "[session_config]")
+{
+    /* Build Mock session, this will automatically create a mock connection. */
+    std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
+
+    WT_SESSION_IMPL *session_impl = session->getWtSessionImpl();
+
+    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "cache_max_wait_ms=2000") == 0);
+    REQUIRE(session_impl->cache_max_wait_us == 2000 * WT_THOUSAND);
+
+    /* Test that setting to zero works correctly. */
+    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "cache_max_wait_ms=0") == 0);
+    REQUIRE(session_impl->cache_max_wait_us == 0);
+
+    /*
+     * This call should not error out or return WT_NOTFOUND with invalid strings. We should depend
+     * __wt_config_getones unit tests for correctness. Currently that test does not exist.
+     */
+    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, NULL) == 0);
+    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "") == 0);
+    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "foo=10000") == 0);
+    REQUIRE(session_impl->cache_max_wait_us == 0);
+
+    /*
+     * WiredTiger config strings accept negative values, but the session variable is a uint64_t.
+     * Overflow is allowed.
+     */
+    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "cache_max_wait_ms=-1") == 0);
+    REQUIRE(session_impl->cache_max_wait_us == 0xfffffffffffffc18);
+}

--- a/test/unittest/tests/test_session_config.cpp
+++ b/test/unittest/tests/test_session_config.cpp
@@ -11,34 +11,56 @@
 #include "wt_internal.h"
 #include "wrappers/mock_session.h"
 
+/*
+ * Check a basic configuration that sets and clears a flag.
+ */
+#define FLAG_TEST(config_param, flag)                                                    \
+    TEST_CASE(config_param, "[session_config]")                                          \
+    {                                                                                    \
+        std::shared_ptr<MockSession> session_mock = MockSession::buildTestMockSession(); \
+        WT_SESSION_IMPL *session = session_mock->getWtSessionImpl();                     \
+        session->flags = 0;                                                              \
+        REQUIRE(__ut_session_config_int(session, config_param "=true") == 0);            \
+        REQUIRE(F_ISSET(session, flag));                                                 \
+        REQUIRE(__ut_session_config_int(session, config_param "=false") == 0);           \
+        REQUIRE(!F_ISSET(session, flag));                                                \
+        REQUIRE(__ut_session_config_int(session, config_param "=true") == 0);            \
+        REQUIRE(__ut_session_config_int(session, "") == 0);                              \
+        REQUIRE(F_ISSET(session, flag));                                                 \
+    }
 
-TEST_CASE("Set cache_max_wait_ms", "[session_config]")
+FLAG_TEST("ignore_cache_size", WT_SESSION_IGNORE_CACHE_SIZE);
+FLAG_TEST("cache_cursors", WT_SESSION_CACHE_CURSORS);
+FLAG_TEST("debug.checkpoint_fail_before_turtle_update",
+  WT_SESSION_DEBUG_CHECKPOINT_FAIL_BEFORE_TURTLE_UPDATE);
+FLAG_TEST("debug.release_evict_page", WT_SESSION_DEBUG_RELEASE_EVICT);
+
+TEST_CASE("cache_max_wait_ms", "[session_config]")
 {
     /* Build Mock session, this will automatically create a mock connection. */
-    std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
+    std::shared_ptr<MockSession> session_mock = MockSession::buildTestMockSession();
+    WT_SESSION_IMPL *session = session_mock->getWtSessionImpl();
 
-    WT_SESSION_IMPL *session_impl = session->getWtSessionImpl();
-
-    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "cache_max_wait_ms=2000") == 0);
-    REQUIRE(session_impl->cache_max_wait_us == 2000 * WT_THOUSAND);
+    REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=2000") == 0);
+    REQUIRE(session->cache_max_wait_us == 2000 * WT_THOUSAND);
 
     /* Test that setting to zero works correctly. */
-    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "cache_max_wait_ms=0") == 0);
-    REQUIRE(session_impl->cache_max_wait_us == 0);
+    REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=0") == 0);
+    REQUIRE(session->cache_max_wait_us == 0);
 
     /*
      * This call should not error out or return WT_NOTFOUND with invalid strings. We should depend
      * __wt_config_getones unit tests for correctness. Currently that test does not exist.
      */
-    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, NULL) == 0);
-    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "") == 0);
-    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "foo=10000") == 0);
-    REQUIRE(session_impl->cache_max_wait_us == 0);
+    REQUIRE(__ut_session_config_int(session, NULL) == 0);
+    REQUIRE(__ut_session_config_int(session, "") == 0);
+    REQUIRE(__ut_session_config_int(session, "foo=10000") == 0);
+    REQUIRE(session->cache_max_wait_us == 0);
 
     /*
      * WiredTiger config strings accept negative values, but the session variable is a uint64_t.
      * Overflow is allowed.
      */
-    REQUIRE(__ut_session_config_cache_max_wait_ms(session_impl, "cache_max_wait_ms=-1") == 0);
-    REQUIRE(session_impl->cache_max_wait_us == 0xfffffffffffffc18);
+    REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=-1") == 0);
+    REQUIRE(session->cache_max_wait_us == 0xfffffffffffffc18);
 }


### PR DESCRIPTION
1. Fixed a bug that meant callers could not set cache_max_wait_ms to 0.
2. Implemented a unit test for this functionality.
3. Extended it to all but the prefetch configuration logic which is too special for easy unit testing.