### PR TITLE
WT-13381 Improve startup logs

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3159,7 +3159,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     conn->page_size = __wt_get_vm_pagesize();
 
     /* Now that we know if verbose is configured, output the version. */
-    __wt_verbose_info(session, WT_VERB_VERSION, "%s", WIREDTIGER_VERSION_STRING);
+    __wt_verbose_info(session, WT_VERB_RECOVERY, "%s", "opening the WiredTiger library");
+    __wt_verbose(session, WT_VERB_VERSION, "%s", WIREDTIGER_VERSION_STRING);
 
     /*
      * Open the connection, then reset the local session as the real one was allocated in the open

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3159,7 +3159,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     conn->page_size = __wt_get_vm_pagesize();
 
     /* Now that we know if verbose is configured, output the version. */
-    __wt_verbose(session, WT_VERB_VERSION, "%s", WIREDTIGER_VERSION_STRING);
+    __wt_verbose_info(session, WT_VERB_VERSION, "%s", WIREDTIGER_VERSION_STRING);
 
     /*
      * Open the connection, then reset the local session as the real one was allocated in the open
@@ -3230,6 +3230,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      * Configuration completed; optionally write a base configuration file.
      */
     WT_ERR(__conn_write_base_config(session, cfg));
+    __wt_verbose_info(
+      session, WT_VERB_RECOVERY, "%s", "connection configuration string parsing completed");
 
     /*
      * Check on the turtle and metadata files, creating them if necessary (which avoids application
@@ -3245,6 +3247,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
 
     /* Verify the metadata file. */
     if (verify_meta) {
+        __wt_verbose_info(session, WT_VERB_RECOVERY, "%s", "performing metadata verify");
         wt_session = &session->iface;
         ret = wt_session->verify(wt_session, WT_METAFILE_URI, NULL);
         WT_ERR(ret);
@@ -3256,6 +3259,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      * overwrite any salvage we did if done before that call.
      */
     if (F_ISSET(conn, WT_CONN_SALVAGE)) {
+        __wt_verbose_info(session, WT_VERB_RECOVERY, "%s", "performing metadata salvage");
         wt_session = &session->iface;
         WT_ERR(__wt_copy_and_sync(wt_session, WT_METAFILE, WT_METAFILE_SLVG));
         WT_ERR(wt_session->salvage(wt_session, WT_METAFILE_URI, NULL));
@@ -3314,6 +3318,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     F_SET(conn, WT_CONN_READY);
     F_CLR(conn, WT_CONN_MINIMAL);
     *connectionp = &conn->iface;
+    __wt_verbose_info(
+      session, WT_VERB_RECOVERY, "%s", "the WiredTiger library has successfully opened");
 
 err:
     /* Discard the scratch buffers. */

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -216,6 +216,8 @@ __wti_connection_close(WT_CONNECTION_IMPL *conn)
 int
 __wti_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
 {
+    __wt_verbose_info(session, WT_VERB_RECOVERY, "%s", "starting WiredTiger utility threads");
+
     /*
      * Start the optional statistics thread. Start statistics first so that other optional threads
      * can know if statistics are enabled or not.
@@ -243,8 +245,6 @@ __wti_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
      * creating a new database.
      */
     WT_RET(__wt_hs_open(session, cfg));
-
-    __wt_verbose_info(session, WT_VERB_RECOVERY, "%s", "starting WiredTiger utility threads");
 
     /*
      * Start the optional logging/removal threads. NOTE: The log manager must be started before

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -244,6 +244,8 @@ __wti_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
      */
     WT_RET(__wt_hs_open(session, cfg));
 
+    __wt_verbose_info(session, WT_VERB_RECOVERY, "%s", "starting WiredTiger utility threads");
+
     /*
      * Start the optional logging/removal threads. NOTE: The log manager must be started before
      * checkpoints so that the checkpoint server knows if logging is enabled. It must also be
@@ -274,6 +276,9 @@ __wti_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Start the checkpoint cleanup thread. */
     WT_RET(__wt_checkpoint_cleanup_create(session, cfg));
+
+    __wt_verbose_info(
+      session, WT_VERB_RECOVERY, "%s", "WiredTiger utility threads are started successfully");
 
     return (0);
 }

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -278,7 +278,7 @@ __wti_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
     WT_RET(__wt_checkpoint_cleanup_create(session, cfg));
 
     __wt_verbose_info(
-      session, WT_VERB_RECOVERY, "%s", "WiredTiger utility threads are started successfully");
+      session, WT_VERB_RECOVERY, "%s", "WiredTiger utility threads started successfully");
 
     return (0);
 }

--- a/test/suite/test_verbose04.py
+++ b/test/suite/test_verbose04.py
@@ -118,9 +118,9 @@ class test_verbose04(test_verbose_base):
             session.compact(uri)
             session.close()
 
-        # At this time, no verbose messages should be generated with the following set of operations and the verbosity level
-        # WT_VERBOSE_INFO (0), hence we don't expect any output.
-        with self.expect_verbose(['all:0'], self.all_verbose_categories, self.is_json, False) as conn:
+        # At this time, only INFO verbose messages should be generated with the following set of
+        # operations and the verbosity level WT_VERBOSE_INFO (0).
+        with self.expect_verbose(['all:0'], self.all_verbose_categories, self.is_json) as conn:
             uri = 'table:test_verbose04_all'
             session = conn.open_session()
             session.create(uri, self.collection_cfg)

--- a/test/suite/test_verbose04.py
+++ b/test/suite/test_verbose04.py
@@ -148,15 +148,15 @@ class test_verbose04(test_verbose_base):
     # for specified categories.
     def test_verbose_multiple(self):
         self.close_conn()
-        # Test passing multiple verbose categories, being 'api' & 'all' & 'rts' with different dedicated
+        # Test passing multiple verbose categories, being 'api' & 'all' & 'version' with different dedicated
         # verbosity levels to each category. Ensuring the only verbose output generated is related
         # to those two categories.
-        cfgs = ['api:0,all:1,rts:0', 'rts:0,all,api:0']
+        cfgs = ['api:0,all:1,version:0', 'version:0,all,api:0']
 
-        #all_verbose_categories_except_api_and_version contains all verbose flags except WT_VERB_API and WT_VERB_RTS.
+        #all_verbose_categories_except_api_and_version contains all verbose flags except WT_VERB_API and WT_VERB_VERSION.
         all_verbose_categories_except_api_and_version = self.all_verbose_categories.copy()
         all_verbose_categories_except_api_and_version.remove('WT_VERB_API')
-        all_verbose_categories_except_api_and_version.remove('WT_VERB_RTS')
+        all_verbose_categories_except_api_and_version.remove('WT_VERB_VERSION')
 
         for cfg in cfgs:
             with self.expect_verbose([cfg], all_verbose_categories_except_api_and_version, self.is_json) as conn:

--- a/test/suite/test_verbose04.py
+++ b/test/suite/test_verbose04.py
@@ -148,15 +148,15 @@ class test_verbose04(test_verbose_base):
     # for specified categories.
     def test_verbose_multiple(self):
         self.close_conn()
-        # Test passing multiple verbose categories, being 'api' & 'all' & 'version' with different dedicated
+        # Test passing multiple verbose categories, being 'api' & 'all' & 'rts' with different dedicated
         # verbosity levels to each category. Ensuring the only verbose output generated is related
         # to those two categories.
-        cfgs = ['api:0,all:1,version:0', 'version:0,all,api:0']
+        cfgs = ['api:0,all:1,rts:0', 'rts:0,all,api:0']
 
-        #all_verbose_categories_except_api_and_version contains all verbose flags except WT_VERB_API and WT_VERB_VERSION.
+        #all_verbose_categories_except_api_and_version contains all verbose flags except WT_VERB_API and WT_VERB_RTS.
         all_verbose_categories_except_api_and_version = self.all_verbose_categories.copy()
         all_verbose_categories_except_api_and_version.remove('WT_VERB_API')
-        all_verbose_categories_except_api_and_version.remove('WT_VERB_VERSION')
+        all_verbose_categories_except_api_and_version.remove('WT_VERB_RTS')
 
         for cfg in cfgs:
             with self.expect_verbose([cfg], all_verbose_categories_except_api_and_version, self.is_json) as conn:

--- a/tools/rts_verifier/operation.py
+++ b/tools/rts_verifier/operation.py
@@ -59,7 +59,7 @@ class Operation:
         self.line = line
 
         # Extract the RTS message type, e.g. 'PAGE_ROLLBACK'.
-        matches = re.search('\[WT_VERB_RTS\]\[DEBUG_\d+\]: \[(\w+)\]', line)
+        matches = re.search('\[WT_VERB_RTS\]\[(?:INFO|DEBUG_\d+)\]: \[(\w+)\]', line)
         if matches is None or matches.group(1) is None:
             raise Exception("Checker got a verbose RTS message in a format it didn't understand: {}"
                             .format(line))


### PR DESCRIPTION
Add additional logs in the flow of WiredTiger recovery and also convert the existing logs into INFO logs to log them every time when WiredTiger is performing recovery.