### PR TITLE
WT-13451 Update free block functions to pass in double pointers and make it consistent with wiredtigers free pattern

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -816,7 +816,6 @@ gcc
 gcp
 gdb
 ge
-getWtSessionImpl
 getenv
 getlasterror
 getline
@@ -1410,7 +1409,6 @@ userbad
 usercfg
 usleep
 usr
-ut
 utf
 util
 utils

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -252,7 +252,6 @@ Marsaglia
 Marsaglia's
 Mellor
 Mitzenmacher
-MockSession
 MongoDB
 MoveFileExW
 MultiByteToWideChar
@@ -551,7 +550,6 @@ btree's
 btrees
 buf
 bufsz
-buildTestMockSession
 builddir
 builtins
 bursty

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -362,7 +362,7 @@ __block_off_remove(
         if (szp->off[0] == NULL) {
             for (i = 0; i < szp->depth; ++i)
                 *sstack[i] = szp->next[i];
-            __wti_block_size_free(session, szp);
+            __wti_block_size_free(session, &szp);
         }
     }
 #ifdef HAVE_DIAGNOSTIC
@@ -380,7 +380,7 @@ __block_off_remove(
 
     /* Return the record if our caller wants it, otherwise free it. */
     if (extp == NULL)
-        __wti_block_ext_free(session, ext);
+        __wti_block_ext_free(session, &ext);
     else
         *extp = ext;
 
@@ -480,7 +480,7 @@ __wti_block_off_remove_overlap(
         }
     }
     if (ext != NULL)
-        __wti_block_ext_free(session, ext);
+        __wti_block_ext_free(session, &ext);
     return (0);
 }
 
@@ -597,7 +597,7 @@ append:
         __wt_verbose(session, WT_VERB_BLOCK, "%s: allocate range %" PRIdMAX "-%" PRIdMAX,
           block->live.avail.name, (intmax_t)ext->off, (intmax_t)(ext->off + ext->size));
 
-        __wti_block_ext_free(session, ext);
+        __wti_block_ext_free(session, &ext);
     }
 
     /* Add the newly allocated extent to the list of allocations. */

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -88,15 +88,15 @@ __block_ext_prealloc(WT_SESSION_IMPL *session, u_int max)
  *     Add a WT_EXT structure to the cached list.
  */
 void
-__wti_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext)
+__wti_block_ext_free(WT_SESSION_IMPL *session, WT_EXT **ext)
 {
     WT_BLOCK_MGR_SESSION *bms;
 
     if ((bms = session->block_manager) == NULL)
-        __wt_free(session, ext);
+        __wt_free(session, *ext);
     else {
-        ext->next[0] = bms->ext_cache;
-        bms->ext_cache = ext;
+        (*ext)->next[0] = bms->ext_cache;
+        bms->ext_cache = *ext;
 
         ++bms->ext_cache_cnt;
     }
@@ -195,15 +195,15 @@ __block_size_prealloc(WT_SESSION_IMPL *session, u_int max)
  *     Add a WT_SIZE structure to the cached list.
  */
 void
-__wti_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz)
+__wti_block_size_free(WT_SESSION_IMPL *session, WT_SIZE **sz)
 {
     WT_BLOCK_MGR_SESSION *bms;
 
     if ((bms = session->block_manager) == NULL)
-        __wt_free(session, sz);
+        __wt_free(session, *sz);
     else {
-        sz->next[0] = bms->sz_cache;
-        bms->sz_cache = sz;
+        (*sz)->next[0] = bms->sz_cache;
+        bms->sz_cache = *sz;
 
         ++bms->sz_cache_cnt;
     }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1995,9 +1995,9 @@ extern void __wti_blkcache_get_read_handle(WT_BLOCK *block);
 extern void __wti_blkcache_remove(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size);
 extern void __wti_block_ckpt_destroy(WT_SESSION_IMPL *session, WT_BLOCK_CKPT *ci);
 extern void __wti_block_configure_first_fit(WT_BLOCK *block, bool on);
-extern void __wti_block_ext_free(WT_SESSION_IMPL *session, WT_EXT *ext);
+extern void __wti_block_ext_free(WT_SESSION_IMPL *session, WT_EXT **ext);
 extern void __wti_block_extlist_free(WT_SESSION_IMPL *session, WT_EXTLIST *el);
-extern void __wti_block_size_free(WT_SESSION_IMPL *session, WT_SIZE *sz);
+extern void __wti_block_size_free(WT_SESSION_IMPL *session, WT_SIZE **sz);
 extern void __wti_btcur_iterate_setup(WT_CURSOR_BTREE *cbt);
 extern void __wti_cache_stats_update(WT_SESSION_IMPL *session);
 extern void __wti_ckpt_verbose(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *tag,

--- a/test/unittest/tests/block/test_block_session_ext.cpp
+++ b/test/unittest/tests/block/test_block_session_ext.cpp
@@ -202,27 +202,25 @@ TEST_CASE("Block session: __wti_block_ext_free", "[block_session_ext]")
     std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
     WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
 
-    /*
-     * FIXME-WT-13451: Update __wti_block_ext_free function to test that block is set to null
-     * SECTION("Free with null block manager session")
-     * {
-     *    std::shared_ptr<MockSession> session_no_bm = MockSession::buildTestMockSession();
-     *    WT_EXT *ext;
-     *
-     *    REQUIRE(__ut_block_ext_alloc(session_no_bm->getWtSessionImpl(), &ext) == 0);
-     *    REQUIRE(ext != nullptr);
-     *
-     *    __wti_block_ext_free(session_no_bm->getWtSessionImpl(), ext);
-     *    REQUIRE(ext == nullptr);
-     * }
-     */
+    
+    SECTION("Free with null block manager session")
+    {
+        std::shared_ptr<MockSession> session_no_bm = MockSession::buildTestMockSession();
+        WT_EXT *ext;
+
+        REQUIRE(__ut_block_ext_alloc(session_no_bm->getWtSessionImpl(), &ext) == 0);
+        REQUIRE(ext != nullptr);
+    
+        __wti_block_ext_free(session_no_bm->getWtSessionImpl(), &ext);
+        REQUIRE(ext == nullptr);
+    }
 
     SECTION("Calling free with cache")
     {
         WT_EXT *ext;
         REQUIRE(__ut_block_ext_alloc(session->getWtSessionImpl(), &ext) == 0);
 
-        __wti_block_ext_free(session->getWtSessionImpl(), ext);
+        __wti_block_ext_free(session->getWtSessionImpl(), &ext);
 
         REQUIRE(ext != nullptr);
         REQUIRE(bms->ext_cache == ext);
@@ -230,7 +228,7 @@ TEST_CASE("Block session: __wti_block_ext_free", "[block_session_ext]")
 
         WT_EXT *ext2;
         REQUIRE(__ut_block_ext_alloc(session->getWtSessionImpl(), &ext2) == 0);
-        __wti_block_ext_free(session->getWtSessionImpl(), ext2);
+        __wti_block_ext_free(session->getWtSessionImpl(), &ext2);
 
         REQUIRE(ext != nullptr);
         REQUIRE(bms->ext_cache == ext2);

--- a/test/unittest/tests/block/test_block_session_ext.cpp
+++ b/test/unittest/tests/block/test_block_session_ext.cpp
@@ -202,7 +202,6 @@ TEST_CASE("Block session: __wti_block_ext_free", "[block_session_ext]")
     std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
     WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
 
-    
     SECTION("Free with null block manager session")
     {
         std::shared_ptr<MockSession> session_no_bm = MockSession::buildTestMockSession();
@@ -210,7 +209,7 @@ TEST_CASE("Block session: __wti_block_ext_free", "[block_session_ext]")
 
         REQUIRE(__ut_block_ext_alloc(session_no_bm->getWtSessionImpl(), &ext) == 0);
         REQUIRE(ext != nullptr);
-    
+
         __wti_block_ext_free(session_no_bm->getWtSessionImpl(), &ext);
         REQUIRE(ext == nullptr);
     }

--- a/test/unittest/tests/block/test_block_session_size.cpp
+++ b/test/unittest/tests/block/test_block_session_size.cpp
@@ -206,28 +206,26 @@ TEST_CASE("Block session: __wti_block_size_free", "[block_session_size]")
     std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
     WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
 
-    /*
-     * FIXME-WT-13451: Update __wti_block_size_free function to test that block is set to null
-     * SECTION("Free with null block manager session -- needs discussion")
-     * {
-     *   std::shared_ptr<MockSession> session_no_bm = MockSession::buildTestMockSession();
-     *   WT_SIZE *sz;
-     *
-     *   REQUIRE(__ut_block_size_alloc(session_no_bm->getWtSessionImpl(), &sz) == 0);
-     *   REQUIRE(sz != nullptr);
-     *
-     *   __wti_block_size_free(session_no_bm->getWtSessionImpl(), sz);
-     *
-     *   REQUIRE(sz == nullptr);
-     * }
-     */
+    SECTION("Free with null block manager session")
+    {
+        std::shared_ptr<MockSession> session_no_bm = MockSession::buildTestMockSession();
+        WT_SIZE *sz;
+    
+        REQUIRE(__ut_block_size_alloc(session_no_bm->getWtSessionImpl(), &sz) == 0);
+        REQUIRE(sz != nullptr);
+    
+        __wti_block_size_free(session_no_bm->getWtSessionImpl(), &sz);
+    
+        REQUIRE(sz == nullptr);
+    }
+     
 
     SECTION("Calling free with cache")
     {
         WT_SIZE *sz = nullptr;
         REQUIRE(__ut_block_size_alloc(session->getWtSessionImpl(), &sz) == 0);
 
-        __wti_block_size_free(session->getWtSessionImpl(), sz);
+        __wti_block_size_free(session->getWtSessionImpl(), &sz);
 
         REQUIRE(sz != nullptr);
         REQUIRE(bms->sz_cache == sz);
@@ -235,7 +233,7 @@ TEST_CASE("Block session: __wti_block_size_free", "[block_session_size]")
 
         WT_SIZE *sz2 = nullptr;
         REQUIRE(__ut_block_size_alloc(session->getWtSessionImpl(), &sz2) == 0);
-        __wti_block_size_free(session->getWtSessionImpl(), sz2);
+        __wti_block_size_free(session->getWtSessionImpl(), &sz2);
 
         REQUIRE(sz != nullptr);
         REQUIRE(bms->sz_cache == sz2);

--- a/test/unittest/tests/block/test_block_session_size.cpp
+++ b/test/unittest/tests/block/test_block_session_size.cpp
@@ -210,15 +210,14 @@ TEST_CASE("Block session: __wti_block_size_free", "[block_session_size]")
     {
         std::shared_ptr<MockSession> session_no_bm = MockSession::buildTestMockSession();
         WT_SIZE *sz;
-    
+
         REQUIRE(__ut_block_size_alloc(session_no_bm->getWtSessionImpl(), &sz) == 0);
         REQUIRE(sz != nullptr);
-    
+
         __wti_block_size_free(session_no_bm->getWtSessionImpl(), &sz);
-    
+
         REQUIRE(sz == nullptr);
     }
-     
 
     SECTION("Calling free with cache")
     {

--- a/test/unittest/tests/utils_extlist.cpp
+++ b/test/unittest/tests/utils_extlist.cpp
@@ -178,7 +178,7 @@ size_free_list(WT_SESSION_IMPL *session, WT_SIZE **head)
     while (sizep != nullptr) {
         WT_SIZE *next_sizep = sizep->next[0];
         sizep->next[0] = nullptr;
-        __wti_block_size_free(session, sizep);
+        __wti_block_size_free(session, &sizep);
         sizep = next_sizep;
     }
 }

--- a/test/unittest/tests/utils_extlist.cpp
+++ b/test/unittest/tests/utils_extlist.cpp
@@ -153,7 +153,7 @@ ext_free_list(WT_SESSION_IMPL *session, WT_EXT **head, WT_EXT *last)
             last_found = true;
         WT_EXT *next_extp = extp->next[0];
         extp->next[0] = nullptr;
-        __wti_block_ext_free(session, extp);
+        __wti_block_ext_free(session, &extp);
         extp = next_extp;
     }
     return last_found;
@@ -194,7 +194,7 @@ void
 extlist_free(WT_SESSION_IMPL *session, WT_EXTLIST &extlist)
 {
     if (!ext_free_list(session, extlist.off, extlist.last) && extlist.last != nullptr) {
-        __wti_block_ext_free(session, extlist.last);
+        __wti_block_ext_free(session, &extlist.last);
         extlist.last = nullptr;
     }
     size_free_list(session, extlist.sz);


### PR DESCRIPTION
The ticket changes the free functions to pass in double pointers instead. The reason behind this change is for testing purposes.  When we pass in a single pointer reference that is going to be freed, C does a copy-by-value of the pointer and does not clear the original pointer reference. Therefore if we pass in the pointer to the pointer, we can properly clear the original pointer to NULL.