### PR TITLE
WT-13403 Implement block manager file open unit tests

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -843,6 +843,7 @@ gte
 handleops
 handlep
 hardcoded
+hashmap
 hashsize
 hashtable
 hashval

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -817,6 +817,7 @@ gcc
 gcp
 gdb
 ge
+getWtSessionImpl
 getenv
 getlasterror
 getline

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -26,6 +26,7 @@ else()
         tests/block/test_bitstring.cpp
         tests/block/test_block_addr.cpp
         tests/block/test_block_ckpt.cpp
+        tests/block/test_block_file.cpp
         tests/block/test_block_other.cpp
         tests/block/test_block_session_ext.cpp
         tests/block/test_block_session_size.cpp

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -44,6 +44,7 @@ set(unittest_sources
     tests/utils.cpp
     tests/utils_extlist.cpp
     tests/wrappers/block_mods.cpp
+    tests/wrappers/config_parser.cpp
     tests/wrappers/connection_wrapper.cpp
     tests/wrappers/item_wrapper.cpp
     tests/wrappers/mock_connection.cpp

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -1,0 +1,229 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * [block_file]: block_open.c
+ * The block manager extent list consists of both extent blocks and size blocks. This unit test
+ * suite tests aims to test all of the allocation and frees of the extent and size block functions.
+ *
+ * The block session manages an internal caching mechanism for both block and size blocks that are
+ * created or discarded.
+ */
+#include "wt_internal.h"
+#include <catch2/catch.hpp>
+#include "../wrappers/mock_session.h"
+#include "../wrappers/config_parser.h"
+#include <iostream>
+
+const std::string ALLOCATION_SIZE = "512";
+const std::string BLOCK_ALLOCATION = "best";
+const std::string OS_CACHE_MAX = "0";
+const std::string OS_CACHE_DIRTY_MAX = "0";
+const std::string ACCESS_PATTERN = "random";
+const std::string DEFAULT_FILE_NAME = "test.txt";
+
+void
+free_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
+{
+    WT_IGNORE_RET(__wti_bm_close_block(session, block));
+}
+
+void
+validate_block_fh(WT_BLOCK *block, uint expected_ref, std::string name)
+{
+    REQUIRE(block->fh != nullptr);
+    REQUIRE(std::string(block->fh->name).compare(name) == 0);
+    REQUIRE(block->fh->file_type == WT_FS_OPEN_FILE_TYPE_DATA);
+    REQUIRE(block->fh->ref == 1);
+}
+
+void
+validate_block_config(WT_BLOCK *block, std::map<std::string, std::string> &config_map)
+{
+    auto it = config_map.find("allocation_size");
+    uint32_t expected_alloc_size =
+      it != config_map.end() ? std::stoi(it->second) : std::stoi(ALLOCATION_SIZE);
+    REQUIRE(block->allocsize == expected_alloc_size);
+    it = config_map.find("block_allocation");
+    uint32_t expected_block_allocation =
+      it != config_map.end() && it->second.compare(BLOCK_ALLOCATION) == 0 ? 0 : 1;
+    REQUIRE(block->allocfirst == expected_block_allocation);
+    REQUIRE(block->os_cache_max == std::stoi(config_map["os_cache_max"]));
+    REQUIRE(block->os_cache_dirty_max == std::stoi(config_map["os_cache_dirty_max"]));
+}
+
+void
+validate_block(WT_BLOCK *block, std::map<std::string, std::string> &config_map, uint expected_ref,
+  std::string name, bool readonly = false, bool created_during_backup = false)
+{
+    REQUIRE(block != nullptr);
+
+    // Test Block members.
+    INFO(block->name << name)
+    REQUIRE(std::string(block->name).compare(name) == 0);
+    REQUIRE(block->objectid == WT_TIERED_OBJECTID_NONE);
+    // REQUIRE(block->compact_session_id = WT_SESSION_ID_INVALID);
+    REQUIRE(block->ref == expected_ref);
+    REQUIRE(block->readonly == readonly);
+    REQUIRE(block->created_during_backup == created_during_backup);
+    REQUIRE(block->extend_len == 0);
+
+    // Test Block file handle members.
+    validate_block_fh(block, expected_ref, name);
+    REQUIRE(std::string(block->live_lock.name).compare("block manager") == 0);
+    REQUIRE(block->live_lock.initialized == true);
+
+    // Test Block configuration members.
+    validate_block_config(block, config_map);
+}
+
+void
+validate_and_free_block(WT_SESSION_IMPL *session, WT_BLOCK *block, config_parser &cp,
+  uint expected_ref, std::string name, bool readonly = false, bool created_during_backup = false)
+{
+    validate_block(block, cp.get_config_map(), expected_ref, name, readonly, created_during_backup);
+    free_block(session, block);
+}
+
+TEST_CASE("Block: __wt_block_open", "[block_file]")
+{
+    /* Build Mock session, this will automatically create a mock connection. */
+    std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
+    config_parser cp({{"allocation_size", ALLOCATION_SIZE}, {"block_allocation", BLOCK_ALLOCATION},
+      {"os_cache_max", OS_CACHE_MAX}, {"os_cache_dirty_max", OS_CACHE_DIRTY_MAX},
+      {"access_pattern_hint", ACCESS_PATTERN}});
+
+    REQUIRE((session->getMockConnection()->setupBlockManager(session->getWtSessionImpl())) == 0);
+
+    SECTION("Normal case")
+    {
+        WT_BLOCK *block;
+        std::cout << cp.get_config_array()[0] << std::endl;
+        REQUIRE(
+          (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+            WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
+        validate_block(block, cp.get_config_map(), 1, DEFAULT_FILE_NAME);
+
+        // Test already made item in hashmap.
+        WT_BLOCK *block2;
+        REQUIRE(
+          (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+            WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block2)) == 0);
+        validate_block(block2, cp.get_config_map(), 2, DEFAULT_FILE_NAME);
+
+        // Test already made item in hashmap but with different configuration.
+        // WT_BLOCK *block3;
+        // cp.get_config_map()["allocation_size"] = "1024";
+        // REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+        // WT_TIERED_OBJECTID_NONE,
+        //           cp.get_config_array(), false, false, false, 0, &block3)) == 0);
+        // validate_and_free_block(session->getWtSessionImpl(), block, cp, 3, DEFAULT_FILE_NAME);
+    }
+
+    SECTION("Test the configuration of allocation size")
+    {
+        // Test that argument allocation size should be priority over configuration string.
+        WT_BLOCK *block;
+        REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+                  WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 1024,
+                  &block)) == 0);
+        cp.get_config_map()["allocation_size"] = "1024";
+        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+
+        // Test that no allocation size in configuration should fail.
+        REQUIRE(cp.get_config_map().erase("allocation_size") == 1);
+        REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+                  WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0,
+                  &block)) == WT_NOTFOUND);
+        REQUIRE(block == nullptr);
+    }
+
+    SECTION("Test block_allocation configuration")
+    {
+        // Test that block allocation is configured to first.
+        cp.get_config_map()["block_allocation"] = "first";
+        WT_BLOCK *block;
+        REQUIRE(
+          (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+            WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
+        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+
+        // Test when block allocation is not configured.
+        REQUIRE(cp.get_config_map().erase("block_allocation") == 1);
+        REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+                  WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0,
+                  &block)) == WT_NOTFOUND);
+        REQUIRE(block == nullptr);
+
+        // cp.get_config_map()["block_allocation"] = "garbage";
+        // REQUIRE((__wt_block_open(session->getWtSessionImpl(), "test3.txt",
+        // WT_TIERED_OBJECTID_NONE, cfg, false, false, false, 512, &block)) == 0);
+        // validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, "test3.txt");
+    }
+
+    SECTION("Test os_cache_max and os_cache_dirty_max configuration")
+    {
+        // Test when os_cache_max is not configured.
+        WT_BLOCK *block;
+        REQUIRE(cp.get_config_map().erase("os_cache_max") == 1);
+        REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+                  WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0,
+                  &block)) == WT_NOTFOUND);
+        REQUIRE(block == nullptr);
+
+        // Test when os_cache_max is configured to 512.
+        cp.get_config_map()["os_cache_max"] = "512";
+        REQUIRE(
+          (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+            WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
+        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+
+        // Test when os_cache_dirty_max is not configured.
+        REQUIRE(cp.get_config_map().erase("os_cache_dirty_max") == 1);
+        REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+                  WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0,
+                  &block)) == WT_NOTFOUND);
+        REQUIRE(block == nullptr);
+
+        // Test when os_cache_dirty_max is configured to 512.
+        cp.get_config_map()["os_cache_dirty_max"] = "512";
+        REQUIRE(
+          (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+            WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
+        validate_and_free_block(
+          session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME.c_str());
+    }
+
+    SECTION("Test functional arguments")
+    {
+        // Test that read only is set.
+        WT_BLOCK *block;
+        REQUIRE(
+          (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+            WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, true, false, 0, &block)) == 0);
+        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME, true);
+
+        // char buf[512];
+        // WT_FILE_HANDLE* handle = block->fh->handle;
+        // REQUIRE(handle->fh_write(handle, (WT_SESSION *)session->getWtSessionImpl(), 0,
+        // std::stoi(ALLOCATION_SIZE), buf) == 0);
+        // F_SET(session->getMockConnection()->getWtConnectionImpl(), WT_CONN_INCR_BACKUP);
+        // REQUIRE((__wt_block_open(session->getWtSessionImpl(), "test2.txt",
+        // WT_TIERED_OBJECTID_NONE,
+        //     cp.get_config_array(), false, true, false, 0, &block)) == 0);
+        // REQUIRE(block->size == std::stoi(ALLOCATION_SIZE));
+        // validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, "test2.txt", false,
+        // true);
+    }
+}
+
+TEST_CASE("Block: __wt_block_close", "[block_file]") {}
+
+TEST_CASE("Block: __wti_bm_close_block", "[block_file]") {}
+
+TEST_CASE("Block: __bm_corrupt_dump", "[block_file]") {}

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -28,70 +28,86 @@ const std::string ACCESS_PATTERN = "random";
 const std::string DEFAULT_FILE_NAME = "test.txt";
 
 void
-free_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
-{
-    WT_IGNORE_RET(__wti_bm_close_block(session, block));
-}
-
-void
-validate_block_fh(WT_BLOCK *block, uint expected_ref, std::string name)
+validate_block_fh(WT_BLOCK *block, std::string const& name)
 {
     REQUIRE(block->fh != nullptr);
-    REQUIRE(std::string(block->fh->name).compare(name) == 0);
+    REQUIRE(std::string(block->fh->name) == name);
     REQUIRE(block->fh->file_type == WT_FS_OPEN_FILE_TYPE_DATA);
     REQUIRE(block->fh->ref == 1);
 }
 
 void
-validate_block_config(WT_BLOCK *block, std::map<std::string, std::string> &config_map)
+validate_block_config(WT_BLOCK *block, config_parser& cp)
 {
+    std::map<std::string, std::string> config_map = cp.get_config_map();
     auto it = config_map.find("allocation_size");
     uint32_t expected_alloc_size =
       it != config_map.end() ? std::stoi(it->second) : std::stoi(ALLOCATION_SIZE);
     REQUIRE(block->allocsize == expected_alloc_size);
-  
+
     it = config_map.find("block_allocation");
     uint32_t expected_block_allocation =
       it != config_map.end() && it->second.compare(BLOCK_ALLOCATION) == 0 ? 0 : 1;
-  
+
     REQUIRE(block->allocfirst == expected_block_allocation);
-    REQUIRE(block->os_cache_max == std::stoi(config_map["os_cache_max"]));
-    REQUIRE(block->os_cache_dirty_max == std::stoi(config_map["os_cache_dirty_max"]));
+    REQUIRE(block->os_cache_max == std::stoi(config_map.at("os_cache_max")));
+    REQUIRE(block->os_cache_dirty_max == std::stoi(config_map.at("os_cache_dirty_max")));
 }
 
 void
-validate_block(WT_BLOCK *block, std::map<std::string, std::string> &config_map, uint expected_ref,
-  std::string name, bool readonly = false, bool created_during_backup = false)
+validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser& cp,
+  uint expected_ref, std::string const& name, bool readonly = false)
 {
+
     REQUIRE(block != nullptr);
 
     // Test Block immediate members.
-    REQUIRE(std::string(block->name).compare(name) == 0);
+    REQUIRE(std::string(block->name) == name);
     REQUIRE(block->objectid == WT_TIERED_OBJECTID_NONE);
     // REQUIRE(block->compact_session_id = WT_SESSION_ID_INVALID);
     REQUIRE(block->ref == expected_ref);
     REQUIRE(block->readonly == readonly);
-    REQUIRE(block->created_during_backup == created_during_backup);
+    REQUIRE(block->created_during_backup == false);
     REQUIRE(block->extend_len == 0);
 
     // Test Block file handle members.
-    validate_block_fh(block, expected_ref, name);
-    REQUIRE(std::string(block->live_lock.name).compare("block manager") == 0);
+    validate_block_fh(block, name);
+    REQUIRE(std::string(block->live_lock.name) == std::string("block manager"));
     REQUIRE(block->live_lock.initialized == true);
 
     // Test Block configuration members.
-    validate_block_config(block, config_map);
+    validate_block_config(block, cp);
+
+    // Connection block lock should not be locked after the function completes.
+    WT_CONNECTION_IMPL *conn = session->getMockConnection()->getWtConnectionImpl();
+    REQUIRE(conn->block_lock.initialized == true);
+    REQUIRE(conn->block_lock.session_id != session->getWtSessionImpl()->id);
 }
 
 void
-validate_and_free_block(WT_SESSION_IMPL *session, WT_BLOCK *block, config_parser &cp,
-  uint expected_ref, std::string name, bool readonly = false, bool created_during_backup = false)
+validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser& cp,
+  uint expected_ref, std::string const& name, bool readonly = false)
 {
-    validate_block(block, cp.get_config_map(), expected_ref, name, readonly, created_during_backup);
-    free_block(session, block);
+    WT_CONNECTION_IMPL *conn = session->getMockConnection()->getWtConnectionImpl();
+    if (expected_ref == 0) {
+        //REQUIRE(block == nullptr);
+
+        uint64_t hash = __wt_hash_city64(name.c_str(), name.length());
+        uint64_t bucket = hash & (conn->hash_size - 1);
+        TAILQ_FOREACH (block, &conn->blockhash[bucket], hashq)
+            REQUIRE(std::string(block->name) != name);
+    } else {
+        REQUIRE(block != nullptr);
+        validate_block(session, block, cp, expected_ref, DEFAULT_FILE_NAME, readonly);
+        block->sync_on_checkpoint = false;
+    }
+
+    // Connection block lock should not be locked after the function completes.
+    REQUIRE(conn->block_lock.initialized == true);
+    REQUIRE(conn->block_lock.session_id != session->getWtSessionImpl()->id);
 }
 
-TEST_CASE("Block: __wt_block_open", "[block_file]")
+TEST_CASE("Block: __wt_block_open and __wti_bm_close_block", "[block_file]")
 {
     /* Build Mock session, this will automatically create a mock connection. */
     std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
@@ -101,21 +117,28 @@ TEST_CASE("Block: __wt_block_open", "[block_file]")
 
     REQUIRE((session->getMockConnection()->setupBlockManager(session->getWtSessionImpl())) == 0);
 
-    SECTION("Normal case")
+    SECTION("Test block open and block close with default configuration")
     {
-        WT_BLOCK *block;
+        WT_BLOCK *block = nullptr;
         REQUIRE(
           (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
             WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
-        validate_block(block, cp.get_config_map(), 1, DEFAULT_FILE_NAME);
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME);
 
         // Test already made item in hashmap.
-        WT_BLOCK *block2;
+        WT_BLOCK *block2 = nullptr;
         REQUIRE(
           (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
             WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block2)) == 0);
-        validate_and_free_block(session->getWtSessionImpl(), block2, cp, 2, DEFAULT_FILE_NAME);
-        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+        validate_block(session, block2, cp, 2, DEFAULT_FILE_NAME);
+
+        // Test block close, frees the block correctly.
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block2) == 0);
+        validate_free_block(session, block2, cp, 1, DEFAULT_FILE_NAME);
+
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
+
         /*
          * Test already made item in hashmap but with different configuration.
          * WT_BLOCK *block3;
@@ -130,13 +153,16 @@ TEST_CASE("Block: __wt_block_open", "[block_file]")
     SECTION("Test the configuration of allocation size")
     {
         // Test that argument allocation size should be priority over configuration string.
-        WT_BLOCK *block;
+        WT_BLOCK *block = nullptr;
         REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
                   WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 1024,
                   &block)) == 0);
         cp.get_config_map()["allocation_size"] = "1024";
-        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME);
 
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
+  
         // Test that no allocation size in configuration should fail.
         REQUIRE(cp.get_config_map().erase("allocation_size") == 1);
         REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
@@ -149,11 +175,14 @@ TEST_CASE("Block: __wt_block_open", "[block_file]")
     {
         // Test that block allocation is configured to first.
         cp.get_config_map()["block_allocation"] = "first";
-        WT_BLOCK *block;
+        WT_BLOCK *block = nullptr;
         REQUIRE(
           (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
             WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
-        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME);
+
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
 
         // Test when block allocation is not configured.
         REQUIRE(cp.get_config_map().erase("block_allocation") == 1);
@@ -164,16 +193,20 @@ TEST_CASE("Block: __wt_block_open", "[block_file]")
 
         // If block allocation is set to garbage, it should default back to "best".
         cp.get_config_map()["block_allocation"] = "garbage";
-        REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(), WT_TIERED_OBJECTID_NONE,
-                  cp.get_config_array(), false, false, false, 512, &block)) == 0);
+        REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+                  WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 512,
+                  &block)) == 0);
         cp.get_config_map()["block_allocation"] = "best";
-        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME);
+
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
     }
 
     SECTION("Test os_cache_max and os_cache_dirty_max configuration")
     {
         // Test when os_cache_max is not configured.
-        WT_BLOCK *block;
+        WT_BLOCK *block = nullptr;
         REQUIRE(cp.get_config_map().erase("os_cache_max") == 1);
         REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
                   WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0,
@@ -185,7 +218,10 @@ TEST_CASE("Block: __wt_block_open", "[block_file]")
         REQUIRE(
           (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
             WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
-        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME);
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME);
+
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
 
         // Test when os_cache_dirty_max is not configured.
         REQUIRE(cp.get_config_map().erase("os_cache_dirty_max") == 1);
@@ -199,16 +235,39 @@ TEST_CASE("Block: __wt_block_open", "[block_file]")
         REQUIRE(
           (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
             WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, false, false, 0, &block)) == 0);
-        validate_and_free_block(
-          session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME.c_str());
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME);
+
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
     }
 
-    SECTION("Test read only")
+    SECTION("Test block open with read only configuration")
     {
-        WT_BLOCK *block;
+        WT_BLOCK *block = nullptr;
         REQUIRE(
           (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
             WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, true, false, 0, &block)) == 0);
-        validate_and_free_block(session->getWtSessionImpl(), block, cp, 1, DEFAULT_FILE_NAME, true);
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME, true);
+
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
+    }
+
+    // SECTION("Test block close with nullptr")
+    // {
+    //     REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), nullptr) == 0);
+    // }
+
+    SECTION("Test block close with block sync")
+    {
+        WT_BLOCK *block = nullptr;
+        REQUIRE(
+          (__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
+            WT_TIERED_OBJECTID_NONE, cp.get_config_array(), false, true, false, 0, &block)) == 0);
+        validate_block(session, block, cp, 1, DEFAULT_FILE_NAME, true);
+        block->sync_on_checkpoint = true;
+
+        REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
+        validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
     }
 }

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -14,11 +14,11 @@
  * The block session manages an internal caching mechanism for both block and size blocks that are
  * created or discarded.
  */
-#include "wt_internal.h"
 #include <catch2/catch.hpp>
+#include <iostream>
 #include "../wrappers/mock_session.h"
 #include "../wrappers/config_parser.h"
-#include <iostream>
+#include "wt_internal.h"
 
 const std::string ALLOCATION_SIZE = "512";
 const std::string BLOCK_ALLOCATION = "best";

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -27,6 +27,14 @@ const std::string OS_CACHE_DIRTY_MAX = "0";
 const std::string ACCESS_PATTERN = "random";
 const std::string DEFAULT_FILE_NAME = "test.txt";
 
+// Added function declarations to allow default values to be set.
+void validate_block_fh(WT_BLOCK *block, std::string const &name);
+void validate_block_config(WT_BLOCK *block, config_parser const &cp);
+void validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser const &cp,
+  int expected_ref, std::string const &name, bool readonly = false);
+void validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block,
+  config_parser const &cp, int expected_ref, std::string const &name, bool readonly = false);
+
 void
 validate_block_fh(WT_BLOCK *block, std::string const &name)
 {
@@ -48,12 +56,12 @@ validate_block_config(WT_BLOCK *block, config_parser const &cp)
 
 void
 validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser const &cp,
-  uint expected_ref, std::string const &name, bool readonly = false)
+  int expected_ref, std::string const &name, bool readonly = false)
 {
 
     REQUIRE(block != nullptr);
 
-    // Test Block immediate members.
+    // Test block immediate members.
     CHECK(std::string(block->name) == name);
     CHECK(block->objectid == WT_TIERED_OBJECTID_NONE);
     CHECK(block->compact_session_id == WT_SESSION_ID_INVALID);
@@ -62,12 +70,12 @@ validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_par
     CHECK(block->created_during_backup == false);
     CHECK(block->extend_len == 0);
 
-    // Test Block file handle members.
+    // Test block file handle members.
     validate_block_fh(block, name);
     CHECK(std::string(block->live_lock.name) == std::string("block manager"));
     CHECK(block->live_lock.initialized == true);
 
-    // Test Block configuration members.
+    // Test block configuration members.
     validate_block_config(block, cp);
 
     // Connection block lock should not be locked after the function completes.

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -28,7 +28,7 @@ const std::string ACCESS_PATTERN = "random";
 const std::string DEFAULT_FILE_NAME = "test.txt";
 
 void
-validate_block_fh(WT_BLOCK *block, std::string const& name)
+validate_block_fh(WT_BLOCK *block, std::string const &name)
 {
     REQUIRE(block->fh != nullptr);
     REQUIRE(std::string(block->fh->name) == name);
@@ -37,7 +37,7 @@ validate_block_fh(WT_BLOCK *block, std::string const& name)
 }
 
 void
-validate_block_config(WT_BLOCK *block, config_parser& cp)
+validate_block_config(WT_BLOCK *block, config_parser &cp)
 {
     std::map<std::string, std::string> config_map = cp.get_config_map();
     auto it = config_map.find("allocation_size");
@@ -55,8 +55,8 @@ validate_block_config(WT_BLOCK *block, config_parser& cp)
 }
 
 void
-validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser& cp,
-  uint expected_ref, std::string const& name, bool readonly = false)
+validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser &cp,
+  uint expected_ref, std::string const &name, bool readonly = false)
 {
 
     REQUIRE(block != nullptr);
@@ -85,12 +85,12 @@ validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_par
 }
 
 void
-validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser& cp,
-  uint expected_ref, std::string const& name, bool readonly = false)
+validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser &cp,
+  uint expected_ref, std::string const &name, bool readonly = false)
 {
     WT_CONNECTION_IMPL *conn = session->getMockConnection()->getWtConnectionImpl();
     if (expected_ref == 0) {
-        //REQUIRE(block == nullptr);
+        // REQUIRE(block == nullptr);
 
         uint64_t hash = __wt_hash_city64(name.c_str(), name.length());
         uint64_t bucket = hash & (conn->hash_size - 1);
@@ -162,7 +162,7 @@ TEST_CASE("Block: __wt_block_open and __wti_bm_close_block", "[block_file]")
 
         REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
         validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
-  
+
         // Test that no allocation size in configuration should fail.
         REQUIRE(cp.get_config_map().erase("allocation_size") == 1);
         REQUIRE((__wt_block_open(session->getWtSessionImpl(), DEFAULT_FILE_NAME.c_str(),
@@ -252,11 +252,12 @@ TEST_CASE("Block: __wt_block_open and __wti_bm_close_block", "[block_file]")
         REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), block) == 0);
         validate_free_block(session, block, cp, 0, DEFAULT_FILE_NAME);
     }
-
-    // SECTION("Test block close with nullptr")
-    // {
-    //     REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), nullptr) == 0);
-    // }
+    /*
+     * SECTION("Test block close with nullptr")
+     * {
+     *     REQUIRE(__wti_bm_close_block(session->getWtSessionImpl(), nullptr) == 0);
+     * }
+     */
 
     SECTION("Test block close with block sync")
     {

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -16,9 +16,9 @@
  */
 #include <catch2/catch.hpp>
 #include <iostream>
+#include "wt_internal.h"
 #include "../wrappers/mock_session.h"
 #include "../wrappers/config_parser.h"
-#include "wt_internal.h"
 
 const std::string ALLOCATION_SIZE = "512";
 const std::string BLOCK_ALLOCATION = "best";

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -56,7 +56,7 @@ validate_block_config(WT_BLOCK *block, config_parser const &cp)
 
 void
 validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser const &cp,
-  int expected_ref, std::string const &name, bool readonly = false)
+  int expected_ref, std::string const &name, bool readonly)
 {
 
     REQUIRE(block != nullptr);
@@ -86,7 +86,7 @@ validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_par
 
 void
 validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser const &cp,
-  uint expected_ref, std::string const &name, bool readonly = false)
+  int expected_ref, std::string const &name, bool readonly)
 {
     WT_CONNECTION_IMPL *conn = session->getMockConnection()->getWtConnectionImpl();
     if (expected_ref == 0) {

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -28,7 +28,7 @@ const std::string ACCESS_PATTERN = "random";
 const std::string DEFAULT_FILE_NAME = "test.txt";
 
 void
-validate_block_fh(WT_BLOCK *block, std::string const &name)
+validate_block_fh(WT_BLOCK *block, std::string const& name)
 {
     REQUIRE(block->fh != nullptr);
     REQUIRE(std::string(block->fh->name) == name);
@@ -37,9 +37,9 @@ validate_block_fh(WT_BLOCK *block, std::string const &name)
 }
 
 void
-validate_block_config(WT_BLOCK *block, config_parser &cp)
+validate_block_config(WT_BLOCK *block, config_parser const& cp)
 {
-    std::map<std::string, std::string> config_map = cp.get_config_map();
+    std::map<std::string, std::string> const& config_map = cp.get_config_map();
     auto it = config_map.find("allocation_size");
     uint32_t expected_alloc_size =
       it != config_map.end() ? std::stoi(it->second) : std::stoi(ALLOCATION_SIZE);
@@ -55,8 +55,8 @@ validate_block_config(WT_BLOCK *block, config_parser &cp)
 }
 
 void
-validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser &cp,
-  uint expected_ref, std::string const &name, bool readonly = false)
+validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser const& cp,
+  uint expected_ref, std::string const& name, bool readonly = false)
 {
 
     REQUIRE(block != nullptr);
@@ -85,8 +85,8 @@ validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_par
 }
 
 void
-validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser &cp,
-  uint expected_ref, std::string const &name, bool readonly = false)
+validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_parser const& cp,
+  uint expected_ref, std::string const& name, bool readonly = false)
 {
     WT_CONNECTION_IMPL *conn = session->getMockConnection()->getWtConnectionImpl();
     if (expected_ref == 0) {

--- a/test/unittest/tests/block/test_block_file.cpp
+++ b/test/unittest/tests/block/test_block_file.cpp
@@ -73,14 +73,14 @@ validate_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, config_par
     // Test block file handle members.
     validate_block_fh(block, name);
     CHECK(std::string(block->live_lock.name) == std::string("block manager"));
-    CHECK(block->live_lock.initialized == true);
+    CHECK(static_cast<bool>(block->live_lock.initialized) == true);
 
     // Test block configuration members.
     validate_block_config(block, cp);
 
     // Connection block lock should not be locked after the function completes.
     WT_CONNECTION_IMPL *conn = session->getMockConnection()->getWtConnectionImpl();
-    CHECK(conn->block_lock.initialized == true);
+    CHECK(static_cast<bool>(conn->block_lock.initialized) == true);
     CHECK(conn->block_lock.session_id != session->getWtSessionImpl()->id);
 }
 
@@ -104,7 +104,7 @@ validate_free_block(std::shared_ptr<MockSession> session, WT_BLOCK *block, confi
     }
 
     // Connection block lock should not be locked after the function completes.
-    REQUIRE(conn->block_lock.initialized == true);
+    REQUIRE(static_cast<bool>(conn->block_lock.initialized) == true);
     REQUIRE(conn->block_lock.session_id != session->getWtSessionImpl()->id);
 }
 

--- a/test/unittest/tests/wrappers/config_parser.cpp
+++ b/test/unittest/tests/wrappers/config_parser.cpp
@@ -19,6 +19,12 @@ config_parser::get_config_map()
     return _config_map;
 }
 
+std::map<std::string, std::string> const&
+config_parser::get_config_map() const
+{
+    return _config_map;
+}
+
 void
 config_parser::construct_config_string()
 {

--- a/test/unittest/tests/wrappers/config_parser.cpp
+++ b/test/unittest/tests/wrappers/config_parser.cpp
@@ -8,14 +8,13 @@
 #include "config_parser.h"
 #include <string>
 
-config_parser::config_parser(const std::map<std::string, std::string>& map) :
-    _config_map(std::move(map)),
-    _cfg{nullptr, nullptr, nullptr}
+config_parser::config_parser(const std::map<std::string, std::string> &map)
+    : _config_map(std::move(map)), _cfg{nullptr, nullptr, nullptr}
 {
 }
 
-std::map<std::string, std::string>&
-config_parser::get_config_map()     
+std::map<std::string, std::string> &
+config_parser::get_config_map()
 {
     return _config_map;
 }

--- a/test/unittest/tests/wrappers/config_parser.cpp
+++ b/test/unittest/tests/wrappers/config_parser.cpp
@@ -5,8 +5,8 @@
  *
  * See the file LICENSE for redistribution information.
  */
-#include "config_parser.h"
 #include <string>
+#include "config_parser.h"
 
 config_parser::config_parser(const std::map<std::string, std::string> &map)
     : _config_map(std::move(map)), _cfg{nullptr, nullptr, nullptr}

--- a/test/unittest/tests/wrappers/config_parser.cpp
+++ b/test/unittest/tests/wrappers/config_parser.cpp
@@ -35,19 +35,13 @@ config_parser::erase_config(std::string config)
     return true;
 }
 
-void
-config_parser::construct_config_string()
+const char **
+config_parser::get_config_array()
 {
     std::string config_string;
     for (const auto &config : _config_map)
         config_string += config.first + "=" + config.second + ",";
     _config_string = config_string;
     _cfg[0] = _config_string.data();
-}
-
-const char **
-config_parser::get_config_array()
-{
-    construct_config_string();
     return const_cast<const char **>(_cfg);
 }

--- a/test/unittest/tests/wrappers/config_parser.cpp
+++ b/test/unittest/tests/wrappers/config_parser.cpp
@@ -13,16 +13,26 @@ config_parser::config_parser(const std::map<std::string, std::string> &map)
 {
 }
 
-std::map<std::string, std::string> &
-config_parser::get_config_map()
+const std::string &
+config_parser::get_config_value(std::string config) const
 {
-    return _config_map;
+    return _config_map.at(config);
 }
 
-std::map<std::string, std::string> const&
-config_parser::get_config_map() const
+void
+config_parser::insert_config(std::string config, std::string value)
 {
-    return _config_map;
+    _config_map[config] = value;
+}
+
+bool
+config_parser::erase_config(std::string config)
+{
+    auto it = _config_map.find(config);
+    if (it == _config_map.end())
+        return false;
+    _config_map.erase(it);
+    return true;
 }
 
 void

--- a/test/unittest/tests/wrappers/config_parser.cpp
+++ b/test/unittest/tests/wrappers/config_parser.cpp
@@ -1,0 +1,37 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+#include "config_parser.h"
+#include <string>
+
+config_parser::config_parser(std::map<std::string, std::string> map) : _config_map(map)
+{
+    _cfg[0] = _cfg[1] = _cfg[2] = nullptr;
+}
+
+std::map<std::string, std::string> &
+config_parser::get_config_map()
+{
+    return _config_map;
+}
+
+void
+config_parser::construct_config_string()
+{
+    std::string config_string;
+    for (const auto &config : this->_config_map)
+        config_string += config.first + "=" + config.second + ",";
+    _config_string = config_string;
+    _cfg[0] = _config_string.data();
+}
+
+const char **
+config_parser::get_config_array()
+{
+    construct_config_string();
+    return const_cast<const char **>(_cfg);
+}

--- a/test/unittest/tests/wrappers/config_parser.cpp
+++ b/test/unittest/tests/wrappers/config_parser.cpp
@@ -8,13 +8,14 @@
 #include "config_parser.h"
 #include <string>
 
-config_parser::config_parser(std::map<std::string, std::string> map) : _config_map(map)
+config_parser::config_parser(const std::map<std::string, std::string>& map) :
+    _config_map(std::move(map)),
+    _cfg{nullptr, nullptr, nullptr}
 {
-    _cfg[0] = _cfg[1] = _cfg[2] = nullptr;
 }
 
-std::map<std::string, std::string> &
-config_parser::get_config_map()
+std::map<std::string, std::string>&
+config_parser::get_config_map()     
 {
     return _config_map;
 }
@@ -23,7 +24,7 @@ void
 config_parser::construct_config_string()
 {
     std::string config_string;
-    for (const auto &config : this->_config_map)
+    for (const auto &config : _config_map)
         config_string += config.first + "=" + config.second + ",";
     _config_string = config_string;
     _cfg[0] = _config_string.data();

--- a/test/unittest/tests/wrappers/config_parser.h
+++ b/test/unittest/tests/wrappers/config_parser.h
@@ -1,0 +1,25 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+#include "wt_internal.h"
+#include <map>
+#include <string>
+
+class config_parser {
+public:
+    config_parser(std::map<std::string, std::string> map);
+    ~config_parser() = default;
+
+    std::map<std::string, std::string> &get_config_map();
+    void construct_config_string();
+    const char **get_config_array();
+
+private:
+    std::map<std::string, std::string> _config_map;
+    std::string _config_string;
+    char *_cfg[3];
+};

--- a/test/unittest/tests/wrappers/config_parser.h
+++ b/test/unittest/tests/wrappers/config_parser.h
@@ -10,18 +10,35 @@
 #include "wt_internal.h"
 #include <map>
 #include <string>
-
+/*
+ * WiredTiger requires a config string that is separated by "," to be passed into functions that
+ * configure the system. The class aims to create a config parser where the creation of the config
+ * string is controlled by a C++ map. The class should closely mimic the functionality of a map and
+ * at the end, users would call get_config_array to construct the config string to be passed into
+ * wiredtiger.
+ *
+ */
 class config_parser {
 public:
     explicit config_parser(const std::map<std::string, std::string> &map);
     ~config_parser() = default;
 
-    std::map<std::string, std::string> &get_config_map();
-    std::map<std::string, std::string> const &get_config_map() const;
-    void construct_config_string();
+    // Fetch the configuration value. If it does not exist an exception will be returned.
+    const std::string &get_config_value(std::string config) const;
+
+    // Insert the configuration and value into map.
+    void insert_config(std::string config, std::string value);
+
+    // Erase the configuration and value into map. Return true if the erase was successful.
+    bool erase_config(std::string config);
+
+    // Get the configuration array used to be passed into wiredtiger.
     const char **get_config_array();
 
 private:
+    // Construct the WiredTiger configuration string.
+    void construct_config_string();
+
     std::map<std::string, std::string> _config_map;
     std::string _config_string;
     char *_cfg[3];

--- a/test/unittest/tests/wrappers/config_parser.h
+++ b/test/unittest/tests/wrappers/config_parser.h
@@ -5,6 +5,8 @@
  *
  * See the file LICENSE for redistribution information.
  */
+#pragma once
+
 #include "wt_internal.h"
 #include <map>
 #include <string>

--- a/test/unittest/tests/wrappers/config_parser.h
+++ b/test/unittest/tests/wrappers/config_parser.h
@@ -7,9 +7,9 @@
  */
 #pragma once
 
-#include "wt_internal.h"
 #include <map>
 #include <string>
+#include "wt_internal.h"
 /*
  * WiredTiger requires a config string that is separated by "," to be passed into functions that
  * configure the system. The class aims to create a config parser where the creation of the config

--- a/test/unittest/tests/wrappers/config_parser.h
+++ b/test/unittest/tests/wrappers/config_parser.h
@@ -13,11 +13,11 @@
 
 class config_parser {
 public:
-    explicit config_parser(const std::map<std::string, std::string>& map);
+    explicit config_parser(const std::map<std::string, std::string> &map);
     ~config_parser() = default;
 
     std::map<std::string, std::string> &get_config_map();
-    std::map<std::string, std::string> const& get_config_map() const;
+    std::map<std::string, std::string> const &get_config_map() const;
     void construct_config_string();
     const char **get_config_array();
 

--- a/test/unittest/tests/wrappers/config_parser.h
+++ b/test/unittest/tests/wrappers/config_parser.h
@@ -13,10 +13,8 @@
 /*
  * WiredTiger requires a config string that is separated by "," to be passed into functions that
  * configure the system. The class aims to create a config parser where the creation of the config
- * string is controlled by a C++ map. The class should closely mimic the functionality of a map and
- * at the end, users would call get_config_array to construct the config string to be passed into
- * wiredtiger.
- *
+ * string is controlled by a C++ map. This class wraps a map. Once all required configuration items
+ * are added a valid WiredTiger config string can be generated using get_config_array.
  */
 class config_parser {
 public:
@@ -32,13 +30,10 @@ public:
     // Erase the configuration and value into map. Return true if the erase was successful.
     bool erase_config(std::string config);
 
-    // Get the configuration array used to be passed into wiredtiger.
+    // Construct the configuration array used to be passed into wiredtiger.
     const char **get_config_array();
 
 private:
-    // Construct the WiredTiger configuration string.
-    void construct_config_string();
-
     std::map<std::string, std::string> _config_map;
     std::string _config_string;
     char *_cfg[3];

--- a/test/unittest/tests/wrappers/config_parser.h
+++ b/test/unittest/tests/wrappers/config_parser.h
@@ -13,10 +13,11 @@
 
 class config_parser {
 public:
-    config_parser(std::map<std::string, std::string> map);
+    explicit config_parser(const std::map<std::string, std::string>& map);
     ~config_parser() = default;
 
     std::map<std::string, std::string> &get_config_map();
+    std::map<std::string, std::string> const& get_config_map() const;
     void construct_config_string();
     const char **get_config_array();
 

--- a/test/unittest/tests/wrappers/mock_connection.cpp
+++ b/test/unittest/tests/wrappers/mock_connection.cpp
@@ -15,6 +15,12 @@ MockConnection::MockConnection(WT_CONNECTION_IMPL *connectionImpl) : _connection
 
 MockConnection::~MockConnection()
 {
+    if (_connectionImpl->blockhash != nullptr)
+        __wt_free(nullptr, _connectionImpl->blockhash);
+    if (_connectionImpl->fhhash != nullptr)
+        __wt_free(nullptr, _connectionImpl->fhhash);
+    if (_connectionImpl->block_lock.initialized == 1)
+        __wt_spin_destroy(nullptr, &_connectionImpl->block_lock);
     __wt_free(nullptr, _connectionImpl->chunkcache.free_bitmap);
     __wt_free(nullptr, _connectionImpl);
 }

--- a/test/unittest/tests/wrappers/mock_connection.cpp
+++ b/test/unittest/tests/wrappers/mock_connection.cpp
@@ -44,20 +44,21 @@ MockConnection::setupChunkCache(
 }
 
 int
-MockConnection::setupBlockManager(WT_SESSION_IMPL *session) {
+MockConnection::setupBlockManager(WT_SESSION_IMPL *session)
+{
     F_SET(_connectionImpl, WT_CONN_IN_MEMORY);
     _connectionImpl->hash_size = 512;
     _connectionImpl->home = "";
     WT_RET(__wt_calloc_def(session, _connectionImpl->hash_size, &_connectionImpl->blockhash));
     WT_RET(__wt_calloc_def(session, _connectionImpl->hash_size, &_connectionImpl->fhhash));
     for (int i = 0; i < _connectionImpl->hash_size; ++i) {
-      TAILQ_INIT(&_connectionImpl->blockhash[i]);
-      TAILQ_INIT(&_connectionImpl->fhhash[i]);
+        TAILQ_INIT(&_connectionImpl->blockhash[i]);
+        TAILQ_INIT(&_connectionImpl->fhhash[i]);
     }
 
     WT_RET(__wt_spin_init(session, &_connectionImpl->block_lock, "block manager"));
     TAILQ_INIT(&_connectionImpl->blockqh); /* Block manager list */
-    TAILQ_INIT(&_connectionImpl->fhqh);                  /* File list */
+    TAILQ_INIT(&_connectionImpl->fhqh);    /* File list */
 
     WT_RET(__wt_os_inmemory(session));
     return 0;

--- a/test/unittest/tests/wrappers/mock_connection.cpp
+++ b/test/unittest/tests/wrappers/mock_connection.cpp
@@ -62,6 +62,7 @@ MockConnection::setupBlockManager(WT_SESSION_IMPL *session)
         TAILQ_INIT(&_connectionImpl->fhhash[i]);
     }
 
+    WT_RET(__wt_spin_init(session, &_connectionImpl->fh_lock, "file list"));
     WT_RET(__wt_spin_init(session, &_connectionImpl->block_lock, "block manager"));
     TAILQ_INIT(&_connectionImpl->blockqh); /* Block manager list */
     TAILQ_INIT(&_connectionImpl->fhqh);    /* File list */

--- a/test/unittest/tests/wrappers/mock_connection.h
+++ b/test/unittest/tests/wrappers/mock_connection.h
@@ -33,6 +33,8 @@ public:
 
     static std::shared_ptr<MockConnection> buildTestMockConnection();
     int setupChunkCache(WT_SESSION_IMPL *, uint64_t, size_t, WT_CHUNKCACHE *&);
+    // Initialize the data structures, in-memory file system and variables used for file handles and
+    // blocks. The block manager requires both to perform file type operations.
     int setupBlockManager(WT_SESSION_IMPL *);
 
 private:

--- a/test/unittest/tests/wrappers/mock_connection.h
+++ b/test/unittest/tests/wrappers/mock_connection.h
@@ -33,7 +33,7 @@ public:
 
     static std::shared_ptr<MockConnection> buildTestMockConnection();
     int setupChunkCache(WT_SESSION_IMPL *, uint64_t, size_t, WT_CHUNKCACHE *&);
-
+    int setupBlockManager(WT_SESSION_IMPL *);
 private:
     explicit MockConnection(WT_CONNECTION_IMPL *connectionImpl);
 

--- a/test/unittest/tests/wrappers/mock_connection.h
+++ b/test/unittest/tests/wrappers/mock_connection.h
@@ -34,6 +34,7 @@ public:
     static std::shared_ptr<MockConnection> buildTestMockConnection();
     int setupChunkCache(WT_SESSION_IMPL *, uint64_t, size_t, WT_CHUNKCACHE *&);
     int setupBlockManager(WT_SESSION_IMPL *);
+
 private:
     explicit MockConnection(WT_CONNECTION_IMPL *connectionImpl);
 

--- a/test/unittest/tests/wrappers/mock_session.cpp
+++ b/test/unittest/tests/wrappers/mock_session.cpp
@@ -25,8 +25,11 @@ MockSession::MockSession(WT_SESSION_IMPL *session, std::shared_ptr<MockConnectio
 
 MockSession::~MockSession()
 {
+    WT_CONNECTION_IMPL* connection_impl = _mockConnection->getWtConnectionImpl();
     if (_sessionImpl->block_manager != nullptr)
         __wt_free(nullptr, _sessionImpl->block_manager);
+    if (connection_impl->file_system != nullptr)
+        utils::throwIfNonZero(connection_impl->file_system->terminate(connection_impl->file_system, reinterpret_cast<WT_SESSION *>(_sessionImpl)));
     __wt_free(nullptr, _sessionImpl);
 }
 

--- a/test/unittest/tests/wrappers/mock_session.cpp
+++ b/test/unittest/tests/wrappers/mock_session.cpp
@@ -25,11 +25,12 @@ MockSession::MockSession(WT_SESSION_IMPL *session, std::shared_ptr<MockConnectio
 
 MockSession::~MockSession()
 {
-    WT_CONNECTION_IMPL* connection_impl = _mockConnection->getWtConnectionImpl();
+    WT_CONNECTION_IMPL *connection_impl = _mockConnection->getWtConnectionImpl();
     if (_sessionImpl->block_manager != nullptr)
         __wt_free(nullptr, _sessionImpl->block_manager);
     if (connection_impl->file_system != nullptr)
-        utils::throwIfNonZero(connection_impl->file_system->terminate(connection_impl->file_system, reinterpret_cast<WT_SESSION *>(_sessionImpl)));
+        utils::throwIfNonZero(connection_impl->file_system->terminate(
+          connection_impl->file_system, reinterpret_cast<WT_SESSION *>(_sessionImpl)));
     __wt_free(nullptr, _sessionImpl);
 }
 

--- a/test/unittest/tests/wrappers/mock_session.cpp
+++ b/test/unittest/tests/wrappers/mock_session.cpp
@@ -28,6 +28,7 @@ MockSession::~MockSession()
     WT_CONNECTION_IMPL *connection_impl = _mockConnection->getWtConnectionImpl();
     if (_sessionImpl->block_manager != nullptr)
         __wt_free(nullptr, _sessionImpl->block_manager);
+    // FIXME-WT-13505: Move terminate function to connection once circular dependency is fixed.
     if (connection_impl->file_system != nullptr)
         utils::throwIfNonZero(connection_impl->file_system->terminate(
           connection_impl->file_system, reinterpret_cast<WT_SESSION *>(_sessionImpl)));


### PR DESCRIPTION
This tickets aims to test the block manager flile open. There are a few technical changes I needed to make and would like to get reviews on:

- I have created a config parser that deals with configuring wiredtiger configurations. It would construct the config string and pass it into the first entry in the char ** array.
- I have tried to test all the possible scenarios in the file open.
- There are a few scenarios where it is not possible to test. For example, the function creates a local flag that is not persisted anywhere inside the block struct. I will create a new ticket to address the testability of this. Another case requires the file size to branch into the if statement. This was proven hard to test.
- I currently use `__wti_bm_close_block` to clear the block references.
- I created a setup in the mock connection and destruct it in the mock session and mock connection. I added a destruct in the mock session because it requires a reference to the session.
