### PR TITLE
WT-13479 __block_off_remove no longer sets el->last = nullptr

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -379,9 +379,10 @@ __block_off_remove(
     el->bytes -= (uint64_t)ext->size;
 
     /* Return the record if our caller wants it, otherwise free it. */
-    if (extp == NULL)
-        __wti_block_ext_free(session, &ext);
-    else
+    if (extp == NULL) {
+        WT_EXT *ext_to_free = ext;
+        __wti_block_ext_free(session, &ext_to_free);
+    } else
         *extp = ext;
 
     /* Update the cached end-of-list. */


### PR DESCRIPTION
__block_off_remove depends upon the pointer to the memory to be freed not changing.  Due to WT-13451 the pointer to the memory to be freed was zeroed. The fix is to free a copy of the pointer to the memory instead of the original pointer.