### PR TITLE
WT-13456 Fix test function get_off_n. Assert in __block_append if not an append.

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1067,6 +1067,7 @@ noff
 nolock
 nonces
 nonliteral
+nonoverlapping
 nontransactionally
 noop
 nop

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -999,12 +999,12 @@ __block_append(
      * object in the skiplist, check for a simple extension, and otherwise append a new structure.
      */
     if ((ext = el->last) != NULL && ext->off + ext->size == off)
-        /* ext is adjacent to off/size. */
+        /* off/size is adjacent to and above ext. */
         ext->size += size;
     else {
         ext = __block_off_srch_last(el->off, astack);
         if (ext != NULL && ext->off + ext->size == off)
-            /* ext is adjacent to off/size. */
+            /* off/size is adjacent to and above ext. */
             ext->size += size;
         else if (ext == NULL) {
             WT_RET(__wti_block_ext_alloc(session, &ext));
@@ -1017,8 +1017,8 @@ __block_append(
 
             /* Update the cached end-of-list */
             el->last = ext;
-        } else if (ext->off >= (off + size)) {
-            /* ext is above off/size */
+        } else if (ext->off + ext->size < off) {
+            /* off/size is above and not adjacent to ext */
             WT_RET(__wti_block_ext_alloc(session, &ext));
             ext->off = off;
             ext->size = size;
@@ -1032,7 +1032,7 @@ __block_append(
             /* Update the cached end-of-list */
             el->last = ext;
         } else
-            /* ext intersects or is below off/size */
+            /* off/size intersects or is below ext */
             return (__block_merge(session, block, el, off, size));
     }
     el->bytes += (uint64_t)size;

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1019,7 +1019,7 @@ __block_append(
             /* Update the cached end-of-list */
             el->last = ext;
         } else
-            /* off/size intersects or is below ext */
+            /* off is not adjacent to the end of the last extent. */
             return (__block_merge(session, block, el, off, size));
     }
     el->bytes += (uint64_t)size;

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1033,7 +1033,7 @@ __block_append(
             el->last = ext;
         } else
             /* ext intersects or is below off/size */
-            return __block_merge(session, block, el, off, size);
+            return (__block_merge(session, block, el, off, size));
     }
     el->bytes += (uint64_t)size;
 

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1018,9 +1018,12 @@ __block_append(
 
             /* Update the cached end-of-list */
             el->last = ext;
-        } else
+        } else {
+            /* Assert that this is appending an extent after the last extent. */
+            WT_ASSERT(session, ext->off + ext->size < off);
             /* off is not adjacent to the end of the last extent. */
             return (__block_merge(session, block, el, off, size));
+        }
     }
     el->bytes += (uint64_t)size;
 

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -994,7 +994,7 @@ static int
 __block_append(
   WT_SESSION_IMPL *session, WT_BLOCK *block, WT_EXTLIST *el, wt_off_t off, wt_off_t size)
 {
-    WT_EXT **astack[WT_SKIP_MAXDEPTH], *ext;
+    WT_EXT **astack[WT_SKIP_MAXDEPTH], *last_ext;
     u_int i;
 
     WT_UNUSED(block);
@@ -1008,29 +1008,30 @@ __block_append(
      * The terminating element of the list is cached, check it; otherwise, get a stack for the last
      * object in the skiplist, check for a simple extension, and otherwise append a new structure.
      */
-    if ((ext = el->last) != NULL && ext->off + ext->size == off)
+    if ((last_ext = el->last) != NULL && last_ext->off + last_ext->size == off)
         /* Extend the last object on the list. off is adjacent to the end of the last extent.*/
-        ext->size += size;
+        last_ext->size += size;
     else {
-        ext = __block_off_srch_last(el->off, astack);
-        if (ext != NULL && ext->off + ext->size == off)
+        /* Update last_ext and, in case appending an extent, determine where to append an extent. */
+        last_ext = __block_off_srch_last(el->off, astack);
+        if (last_ext != NULL && last_ext->off + last_ext->size == off)
             /* Extend the last object on the list. off is adjacent to the end of the last extent.*/
-            ext->size += size;
+            last_ext->size += size;
         else {
-            if (ext != NULL)
+            if (last_ext != NULL)
                 /* Assert that this is appending an extent after the last extent. */
-                WT_ASSERT(session, ext->off + ext->size < off);
-            WT_RET(__wti_block_ext_alloc(session, &ext));
-            ext->off = off;
-            ext->size = size;
+                WT_ASSERT(session, last_ext->off + last_ext->size < off);
+            WT_RET(__wti_block_ext_alloc(session, &last_ext));
+            last_ext->off = off;
+            last_ext->size = size;
 
-            for (i = 0; i < ext->depth; ++i)
-                *astack[i] = ext;
+            for (i = 0; i < last_ext->depth; ++i)
+                *astack[i] = last_ext;
             ++el->entries;
         }
 
         /* Update the cached end-of-list */
-        el->last = ext;
+        el->last = last_ext;
     }
     el->bytes += (uint64_t)size;
 

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -988,11 +988,7 @@ static int
 __block_append(
   WT_SESSION_IMPL *session, WT_BLOCK *block, WT_EXTLIST *el, wt_off_t off, wt_off_t size)
 {
-#if 1
     WT_EXT **astack[WT_SKIP_MAXDEPTH], *ext, *new_ext;
-#else
-    WT_EXT **astack[WT_SKIP_MAXDEPTH], *ext;
-#endif
     u_int i;
 
     WT_UNUSED(block);

--- a/test/unittest/tests/block/test_extent_list_insert_block.cpp
+++ b/test/unittest/tests/block/test_extent_list_insert_block.cpp
@@ -227,39 +227,40 @@ TEST_CASE("Extent Lists: block_append", "[extent_list]")
     {
         BREAK;
         /* Tests and expected values. */
-        std::vector<off_size_expected> test_list{
-          {off_size(4096, 2048), // First half of First [4,096, 6,143].
-            {
-              off_size(4096, 2048), // First [4,096, 6,143].
-            }},
-          {off_size(4096 + 2048, 2048), // Adjacent: Second half of First [6,144, 8,191].
-            {
-              off_size(4096, 4096), // First [4,096, 8,191].
-            }},
-          {off_size(3 * 4096, 4096), // Not adjacent: Second [12,288, 16,383].
-            {
-              off_size(4096, 4096),     // First [4,096, 8,191].
-              off_size(3 * 4096, 4096), // Second [12,288, 16,383].
-            }},
-          {off_size(5 * 4096, 4096), // Not adjacent: Third [20,480, 24,575].
-            {
-              off_size(4096, 4096),     // First [4,096, 8,191].
-              off_size(3 * 4096, 4096), // Second [12,288, 16,383].
-              off_size(5 * 4096, 4096), // Third [20,480, 24,575].
-            }},
-#if 0                           // Tests that are not appends and should crash.
+        std::vector<off_size_expected> test_list
+        {
+            {off_size(4096, 2048), // First half of First [4,096, 6,143].
+              {
+                off_size(4096, 2048), // First [4,096, 6,143].
+              }},
+              {off_size(4096 + 2048, 2048), // Adjacent: Second half of First [6,144, 8,191].
+                {
+                  off_size(4096, 4096), // First [4,096, 8,191].
+                }},
+              {off_size(3 * 4096, 4096), // Not adjacent: Second [12,288, 16,383].
+                {
+                  off_size(4096, 4096),     // First [4,096, 8,191].
+                  off_size(3 * 4096, 4096), // Second [12,288, 16,383].
+                }},
+              {off_size(5 * 4096, 4096), // Not adjacent: Third [20,480, 24,575].
+                {
+                  off_size(4096, 4096),     // First [4,096, 8,191].
+                  off_size(3 * 4096, 4096), // Second [12,288, 16,383].
+                  off_size(5 * 4096, 4096), // Third [20,480, 24,575].
+                }},
+#if 0   // Tests that are not appends and should crash.
           {off_size(4 * 4096, 4096), // Below last extent, nonoverlapping
             {
               off_size(4096, 4096),     // First [4,096, 8,191].
               off_size(3 * 4096, 3*4096), // Second' [12,288, 24,575].
             }},
-#elif 0                         // Tests that are not appends and should crash.
-          {off_size(5 * 4096 + 1024, 4096), // Overlapping last extent
-            {
-              off_size(4096, 4096),     // First [4,096, 8,191].
-              off_size(3 * 4096, 4096), // Second [12,288, 16,383].
-              off_size(5 * 4096, 4096 + 1024), // Third' [20,480, 25,559].
-            }},
+#elif 0 // Tests that are not appends and should crash.
+              {off_size(5 * 4096 + 1024, 4096), // Overlapping last extent
+                {
+                  off_size(4096, 4096),            // First [4,096, 8,191].
+                  off_size(3 * 4096, 4096),        // Second [12,288, 16,383].
+                  off_size(5 * 4096, 4096 + 1024), // Third' [20,480, 25,559].
+                }},
 #endif
         };
 

--- a/test/unittest/tests/block/test_extent_list_insert_block.cpp
+++ b/test/unittest/tests/block/test_extent_list_insert_block.cpp
@@ -237,23 +237,17 @@ TEST_CASE("Extent Lists: block_append", "[extent_list]")
                 {
                   off_size(4096, 4096), // First [4,096, 8,191].
                 }},
-#if 0 // FAILED: REQUIRE( last == extlist.last ) with expansion: 0x0000000040319c10 ==.
-      // 0x0000000040334d60. When FIXME-WT-13456 is fixed, enable this test. It is a reproducer.
           {off_size(3 * 4096, 4096), // Not adjacent: Second [12,288, 16,383].
             {
               off_size(4096, 4096),     // First [4,096, 8,191].
               off_size(3 * 4096, 4096), // Second [12,288, 16,383].
             }},
-#endif
-#if 0 // Not run after previous failure. When FIXME-WT-13456 is fixed, enable this test. It is a
-      // reproducer.
           {off_size(5 * 4096, 4096), // Not adjacent: Third [20,480, 24,575].
             {
               off_size(4096, 4096),     // First [4,096, 8,191].
               off_size(3 * 4096, 4096), // Second [12,288, 16,383].
               off_size(5 * 4096, 4096), // Third [20,480, 24,575].
             }},
-#endif
         };
 
         /* Setup. */

--- a/test/unittest/tests/block/test_extent_list_insert_block.cpp
+++ b/test/unittest/tests/block/test_extent_list_insert_block.cpp
@@ -227,16 +227,15 @@ TEST_CASE("Extent Lists: block_append", "[extent_list]")
     {
         BREAK;
         /* Tests and expected values. */
-        std::vector<off_size_expected> test_list
-        {
-            {off_size(4096, 2048), // First half of First [4,096, 6,143].
-              {
-                off_size(4096, 2048), // First [4,096, 6,143].
-              }},
-              {off_size(4096 + 2048, 2048), // Adjacent: Second half of First [6,144, 8,191].
-                {
-                  off_size(4096, 4096), // First [4,096, 8,191].
-                }},
+        std::vector<off_size_expected> test_list{
+          {off_size(4096, 2048), // First half of First [4,096, 6,143].
+            {
+              off_size(4096, 2048), // First [4,096, 6,143].
+            }},
+          {off_size(4096 + 2048, 2048), // Adjacent: Second half of First [6,144, 8,191].
+            {
+              off_size(4096, 4096), // First [4,096, 8,191].
+            }},
           {off_size(3 * 4096, 4096), // Not adjacent: Second [12,288, 16,383].
             {
               off_size(4096, 4096),     // First [4,096, 8,191].

--- a/test/unittest/tests/block/test_extent_list_insert_block.cpp
+++ b/test/unittest/tests/block/test_extent_list_insert_block.cpp
@@ -247,6 +247,20 @@ TEST_CASE("Extent Lists: block_append", "[extent_list]")
               off_size(3 * 4096, 4096), // Second [12,288, 16,383].
               off_size(5 * 4096, 4096), // Third [20,480, 24,575].
             }},
+#if 0                           // Tests that are not appends and should crash.
+          {off_size(4 * 4096, 4096), // Below last extent, nonoverlapping
+            {
+              off_size(4096, 4096),     // First [4,096, 8,191].
+              off_size(3 * 4096, 3*4096), // Second' [12,288, 24,575].
+            }},
+#elif 0                         // Tests that are not appends and should crash.
+          {off_size(5 * 4096 + 1024, 4096), // Overlapping last extent
+            {
+              off_size(4096, 4096),     // First [4,096, 8,191].
+              off_size(3 * 4096, 4096), // Second [12,288, 16,383].
+              off_size(5 * 4096, 4096 + 1024), // Third' [20,480, 25,559].
+            }},
+#endif
         };
 
         /* Setup. */

--- a/test/unittest/tests/utils_extlist.cpp
+++ b/test/unittest/tests/utils_extlist.cpp
@@ -126,11 +126,10 @@ get_off_n(const WT_EXTLIST &extlist, uint32_t idx)
         REQUIRE(ext != NULL);
         ext = ext->next[0];
         ++ext_idx;
-    };
-
-    if (idx == (extlist.entries - 1)) {
-        REQUIRE(ext == extlist.last);
     }
+
+    if (idx == (extlist.entries - 1))
+        REQUIRE(ext == extlist.last);
     return ext;
 }
 

--- a/test/unittest/tests/utils_extlist.cpp
+++ b/test/unittest/tests/utils_extlist.cpp
@@ -119,14 +119,19 @@ alloc_new_ext(WT_SESSION_IMPL *session, const off_size &one)
 WT_EXT *
 get_off_n(const WT_EXTLIST &extlist, uint32_t idx)
 {
+    WT_EXT *ext = extlist.off[0];
+    uint32_t ext_idx = 0;
     REQUIRE(idx < extlist.entries);
-    if ((extlist.last != nullptr) && (idx == (extlist.entries - 1))) {
-        WT_EXT *last = extlist.off[idx];
-        if (last != nullptr)
-            REQUIRE(last == extlist.last);
-        return extlist.last;
+    while (ext_idx < idx) {
+        REQUIRE(ext != NULL);
+        ext = ext->next[0];
+        ++ext_idx;
+    };
+
+    if (idx == (extlist.entries - 1)) {
+        REQUIRE(ext == extlist.last);
     }
-    return extlist.off[idx];
+    return ext;
 }
 
 /*!

--- a/test/unittest/tests/utils_extlist.cpp
+++ b/test/unittest/tests/utils_extlist.cpp
@@ -247,6 +247,7 @@ verify_off_extent_list(
         ++idx;
         expected_bytes += ext->size;
     }
+    REQUIRE(idx == extlist.entries);
     if (!verify_bytes)
         return;
     REQUIRE(extlist.bytes == expected_bytes);


### PR DESCRIPTION
Fixed test function get_off_n. Assert in __block_append if not an append because it implements only appends. Added comments explaining stack returned by __block_off_srch_last, how __block_append uses it, and the lazy update of WT_EXTLIST.last.