### PR TITLE
WT-13438 Implement block_session bms function unit tests

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -305,6 +305,7 @@ Podir
 Posix
 PostgreSQL
 Pre
+Prealloc
 Precompiled
 Prefetch
 Preload
@@ -532,6 +533,7 @@ blkincr
 blkmod
 blkmods
 bm
+bms
 bnd
 bool
 boolean

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -329,9 +329,4 @@ __ut_block_size_discard(WT_SESSION_IMPL *session, u_int max)
 {
     return (__block_size_discard(session, max));
 }
-
-__ut_block_manager_session_cleanup(WT_SESSION_IMPL *session)
-{
-    return (__block_manager_session_cleanup(session));
-}
 #endif

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -329,4 +329,9 @@ __ut_block_size_discard(WT_SESSION_IMPL *session, u_int max)
 {
     return (__block_size_discard(session, max));
 }
+
+__ut_block_manager_session_cleanup(WT_SESSION_IMPL *session)
+{
+    return (__block_manager_session_cleanup(session));
+}
 #endif

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -28,6 +28,7 @@ else()
         tests/block/test_block_ckpt.cpp
         tests/block/test_block_file.cpp
         tests/block/test_block_other.cpp
+        tests/block/test_block_session_bms.cpp
         tests/block/test_block_session_ext.cpp
         tests/block/test_block_session_size.cpp
         tests/block/test_extent_list_insert_wo_block.cpp

--- a/test/unittest/tests/block/test_block_session_bms.cpp
+++ b/test/unittest/tests/block/test_block_session_bms.cpp
@@ -10,7 +10,7 @@
  * [block_session_bms]: block_session.c
  * The block manager extent list consists of both extent and size type blocks. This unit test
  * suite tests aims to test all of the allocation and frees of combined extent and size functions.
- * 
+ *
  * The file aims to test the management of the block manager session.
  */
 #include "wt_internal.h"
@@ -68,7 +68,7 @@ TEST_CASE("Block session: __block_manager_session_cleanup", "[block_session_bms]
     WT_SESSION_IMPL *session_impl = session->getWtSessionImpl();
 
     SECTION("Free with null session block manager ")
-    {   
+    {
         std::shared_ptr<MockSession> session_no_bms = MockSession::buildTestMockSession();
         REQUIRE(__ut_block_manager_session_cleanup(session_no_bms->getWtSessionImpl()) == 0);
         REQUIRE(session_no_bms->getWtSessionImpl()->block_manager == nullptr);

--- a/test/unittest/tests/block/test_block_session_bms.cpp
+++ b/test/unittest/tests/block/test_block_session_bms.cpp
@@ -37,6 +37,7 @@ TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session_bms]")
          */
         REQUIRE(session->getWtSessionImpl()->block_manager_cleanup != nullptr);
         REQUIRE(bms != nullptr);
+        __wt_free(nullptr, bms);
     }
 
     WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();

--- a/test/unittest/tests/block/test_block_session_bms.cpp
+++ b/test/unittest/tests/block/test_block_session_bms.cpp
@@ -1,0 +1,129 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * [block_session]: block_session.c
+ * The block manager extent list consists of both extent and size type blocks. This unit test
+ * suite tests aims to test all of the allocation and frees of the extent and size block functions.
+ *
+ * The block session manages an internal caching mechanism for both block and size blocks that are
+ * created or discarded.
+ */
+#include "wt_internal.h"
+#include <catch2/catch.hpp>
+#include "../wrappers/mock_session.h"
+#include "util_block.h"
+
+TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session]")
+{
+    std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
+
+    SECTION("Prealloc with null block manager")
+    {
+        WT_BLOCK_MGR_SESSION *bms = nullptr;
+
+        __wt_random_init(&session->getWtSessionImpl()->rnd);
+
+        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 0) == 0);
+        bms = static_cast<WT_BLOCK_MGR_SESSION *>(session->getWtSessionImpl()->block_manager);
+
+        /*
+         * Check that the session block manager clean up function is set. This is important for
+         * cleaning up the blocks that get allocated.
+         */
+        REQUIRE(session->getWtSessionImpl()->block_manager_cleanup != nullptr);
+        REQUIRE(bms != nullptr);
+    }
+
+    WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
+    SECTION("Prealloc with block manager")
+    {
+        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        REQUIRE(session->getWtSessionImpl()->block_manager == bms);
+        validate_and_free_ext_list(bms, 2);
+        // validate_and_free_size_list(bms, 2);
+    }
+
+    SECTION("Prealloc with existing cache")
+    {
+        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        REQUIRE(session->getWtSessionImpl()->block_manager == bms);
+        validate_ext_list(bms, 2);
+        // validate_size_list(bms, 2);
+
+        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 5) == 0);
+        validate_and_free_ext_list(bms, 5);
+        // validate_and_free_size_list(bms, 5);
+    }
+}
+
+TEST_CASE("Block session: __block_manager_session_cleanup", "[block_session]")
+{
+    std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
+
+    SECTION("Free with null session block manager ")
+    {
+        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == 0);
+        REQUIRE(session->getWtSessionImpl()->block_manager == nullptr);
+    }
+
+    SECTION("Calling free with session block manager")
+    {
+        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
+        REQUIRE(bms != nullptr);
+        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == 0);
+
+        REQUIRE(bms == nullptr);
+    }
+
+    SECTION("Calling free with session block manager and cache")
+    {
+        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
+        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        validate_ext_list(bms, 2);
+        // validate_size_list(bms, 2);
+
+        REQUIRE(bms != nullptr);
+        // REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == 0);
+        // validate_ext_list(bms, 0);
+        // validate_size_list(bms, 0);
+        // REQUIRE(bms == nullptr);
+    }
+
+    SECTION("Calling free with session block manager and fake extent cache")
+    {
+        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
+        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        validate_ext_list(bms, 2);
+        // validate_size_list(bms, 2);
+
+        bms->ext_cache_cnt = 3;
+
+        REQUIRE(bms != nullptr);
+        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == WT_ERROR);
+        // validate_ext_list(bms, 0);
+        // validate_size_list(bms, 0);
+        // REQUIRE(bms == nullptr);
+    }
+
+    SECTION("Calling free with session block manager and fake size cache")
+    {
+        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
+        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        validate_ext_list(bms, 2);
+        // validate_size_list(bms, 2);
+
+        bms->sz_cache_cnt = 3;
+
+        REQUIRE(bms != nullptr);
+        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == WT_ERROR);
+        // validate_ext_list(bms, 0);
+        // validate_size_list(bms, 0);
+        // REQUIRE(bms == nullptr);
+    }
+}

--- a/test/unittest/tests/block/test_block_session_bms.cpp
+++ b/test/unittest/tests/block/test_block_session_bms.cpp
@@ -20,43 +20,43 @@
 
 TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session_bms]")
 {
-    std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
+    std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
 
     SECTION("Prealloc with null block manager")
     {
         WT_BLOCK_MGR_SESSION *bms = nullptr;
 
-        __wt_random_init(&session->getWtSessionImpl()->rnd);
+        __wt_random_init(&session->get_wt_session_impl()->rnd);
 
-        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 0) == 0);
-        bms = static_cast<WT_BLOCK_MGR_SESSION *>(session->getWtSessionImpl()->block_manager);
+        REQUIRE(__wti_block_ext_prealloc(session->get_wt_session_impl(), 0) == 0);
+        bms = static_cast<WT_BLOCK_MGR_SESSION *>(session->get_wt_session_impl()->block_manager);
 
         /*
          * Check that the session block manager clean up function is set. This is important for
          * cleaning up the blocks that get allocated.
          */
-        REQUIRE(session->getWtSessionImpl()->block_manager_cleanup != nullptr);
+        REQUIRE(session->get_wt_session_impl()->block_manager_cleanup != nullptr);
         REQUIRE(bms != nullptr);
         __wt_free(nullptr, bms);
     }
 
-    WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
+    WT_BLOCK_MGR_SESSION *bms = session->setup_block_manager_session();
     SECTION("Prealloc with block manager")
     {
-        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
-        REQUIRE(session->getWtSessionImpl()->block_manager == bms);
+        REQUIRE(__wti_block_ext_prealloc(session->get_wt_session_impl(), 2) == 0);
+        REQUIRE(session->get_wt_session_impl()->block_manager == bms);
         validate_and_free_ext_list(bms, 2);
         validate_and_free_size_list(bms, 2);
     }
 
     SECTION("Prealloc with existing cache")
     {
-        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
-        REQUIRE(session->getWtSessionImpl()->block_manager == bms);
+        REQUIRE(__wti_block_ext_prealloc(session->get_wt_session_impl(), 2) == 0);
+        REQUIRE(session->get_wt_session_impl()->block_manager == bms);
         validate_ext_list(bms, 2);
         validate_size_list(bms, 2);
 
-        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 5) == 0);
+        REQUIRE(__wti_block_ext_prealloc(session->get_wt_session_impl(), 5) == 0);
         validate_and_free_ext_list(bms, 5);
         validate_and_free_size_list(bms, 5);
     }
@@ -64,15 +64,15 @@ TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session_bms]")
 
 TEST_CASE("Block session: __block_manager_session_cleanup", "[block_session_bms]")
 {
-    std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
-    WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
-    WT_SESSION_IMPL *session_impl = session->getWtSessionImpl();
+    std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
+    WT_BLOCK_MGR_SESSION *bms = session->setup_block_manager_session();
+    WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();
 
     SECTION("Free with null session block manager ")
     {
-        std::shared_ptr<MockSession> session_no_bms = MockSession::buildTestMockSession();
-        REQUIRE(__ut_block_manager_session_cleanup(session_no_bms->getWtSessionImpl()) == 0);
-        REQUIRE(session_no_bms->getWtSessionImpl()->block_manager == nullptr);
+        std::shared_ptr<mock_session> session_no_bms = mock_session::build_test_mock_session();
+        REQUIRE(__ut_block_manager_session_cleanup(session_no_bms->get_wt_session_impl()) == 0);
+        REQUIRE(session_no_bms->get_wt_session_impl()->block_manager == nullptr);
     }
 
     SECTION("Calling free with session block manager")

--- a/test/unittest/tests/block/test_block_session_bms.cpp
+++ b/test/unittest/tests/block/test_block_session_bms.cpp
@@ -7,19 +7,18 @@
  */
 
 /*
- * [block_session]: block_session.c
+ * [block_session_bms]: block_session.c
  * The block manager extent list consists of both extent and size type blocks. This unit test
- * suite tests aims to test all of the allocation and frees of the extent and size block functions.
- *
- * The block session manages an internal caching mechanism for both block and size blocks that are
- * created or discarded.
+ * suite tests aims to test all of the allocation and frees of combined extent and size functions.
+ * 
+ * The file aims to test the management of the block manager session.
  */
 #include "wt_internal.h"
 #include <catch2/catch.hpp>
 #include "../wrappers/mock_session.h"
 #include "util_block.h"
 
-TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session]")
+TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session_bms]")
 {
     std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
 
@@ -46,7 +45,7 @@ TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session]")
         REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
         REQUIRE(session->getWtSessionImpl()->block_manager == bms);
         validate_and_free_ext_list(bms, 2);
-        // validate_and_free_size_list(bms, 2);
+        validate_and_free_size_list(bms, 2);
     }
 
     SECTION("Prealloc with existing cache")
@@ -54,76 +53,68 @@ TEST_CASE("Block session: __wti_block_ext_prealloc", "[block_session]")
         REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
         REQUIRE(session->getWtSessionImpl()->block_manager == bms);
         validate_ext_list(bms, 2);
-        // validate_size_list(bms, 2);
+        validate_size_list(bms, 2);
 
         REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 5) == 0);
         validate_and_free_ext_list(bms, 5);
-        // validate_and_free_size_list(bms, 5);
+        validate_and_free_size_list(bms, 5);
     }
 }
 
-TEST_CASE("Block session: __block_manager_session_cleanup", "[block_session]")
+TEST_CASE("Block session: __block_manager_session_cleanup", "[block_session_bms]")
 {
     std::shared_ptr<MockSession> session = MockSession::buildTestMockSession();
+    WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
+    WT_SESSION_IMPL *session_impl = session->getWtSessionImpl();
 
     SECTION("Free with null session block manager ")
-    {
-        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == 0);
-        REQUIRE(session->getWtSessionImpl()->block_manager == nullptr);
+    {   
+        std::shared_ptr<MockSession> session_no_bms = MockSession::buildTestMockSession();
+        REQUIRE(__ut_block_manager_session_cleanup(session_no_bms->getWtSessionImpl()) == 0);
+        REQUIRE(session_no_bms->getWtSessionImpl()->block_manager == nullptr);
     }
 
     SECTION("Calling free with session block manager")
     {
-        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
-        REQUIRE(bms != nullptr);
-        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == 0);
-
-        REQUIRE(bms == nullptr);
+        REQUIRE(session_impl->block_manager != nullptr);
+        REQUIRE(__ut_block_manager_session_cleanup(session_impl) == 0);
+        REQUIRE(session_impl->block_manager == nullptr);
     }
 
     SECTION("Calling free with session block manager and cache")
     {
-        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
-        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        REQUIRE(__wti_block_ext_prealloc(session_impl, 2) == 0);
         validate_ext_list(bms, 2);
-        // validate_size_list(bms, 2);
+        validate_size_list(bms, 2);
 
-        REQUIRE(bms != nullptr);
-        // REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == 0);
-        // validate_ext_list(bms, 0);
-        // validate_size_list(bms, 0);
-        // REQUIRE(bms == nullptr);
+        REQUIRE(session_impl->block_manager != nullptr);
+        REQUIRE(__ut_block_manager_session_cleanup(session_impl) == 0);
+        REQUIRE(session_impl->block_manager == nullptr);
     }
 
     SECTION("Calling free with session block manager and fake extent cache")
     {
-        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
-        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        REQUIRE(__wti_block_ext_prealloc(session_impl, 2) == 0);
         validate_ext_list(bms, 2);
-        // validate_size_list(bms, 2);
+        validate_size_list(bms, 2);
 
         bms->ext_cache_cnt = 3;
 
-        REQUIRE(bms != nullptr);
-        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == WT_ERROR);
-        // validate_ext_list(bms, 0);
-        // validate_size_list(bms, 0);
-        // REQUIRE(bms == nullptr);
+        REQUIRE(session_impl->block_manager != nullptr);
+        REQUIRE(__ut_block_manager_session_cleanup(session_impl) == WT_ERROR);
+        REQUIRE(session_impl->block_manager == nullptr);
     }
 
     SECTION("Calling free with session block manager and fake size cache")
     {
-        WT_BLOCK_MGR_SESSION *bms = session->setupBlockManagerSession();
-        REQUIRE(__wti_block_ext_prealloc(session->getWtSessionImpl(), 2) == 0);
+        REQUIRE(__wti_block_ext_prealloc(session_impl, 2) == 0);
         validate_ext_list(bms, 2);
-        // validate_size_list(bms, 2);
+        validate_size_list(bms, 2);
 
         bms->sz_cache_cnt = 3;
 
-        REQUIRE(bms != nullptr);
-        REQUIRE(__ut_block_manager_session_cleanup(session->getWtSessionImpl()) == WT_ERROR);
-        // validate_ext_list(bms, 0);
-        // validate_size_list(bms, 0);
-        // REQUIRE(bms == nullptr);
+        REQUIRE(session_impl->block_manager != nullptr);
+        REQUIRE(__ut_block_manager_session_cleanup(session_impl) == WT_ERROR);
+        REQUIRE(session_impl->block_manager == nullptr);
     }
 }

--- a/test/unittest/tests/block/test_block_session_ext.cpp
+++ b/test/unittest/tests/block/test_block_session_ext.cpp
@@ -16,7 +16,7 @@
  */
 #include <catch2/catch.hpp>
 
-#include "wt_internal.h"
+#include "util_block.h"
 #include "../wrappers/mock_session.h"
 
 void

--- a/test/unittest/tests/block/test_block_session_ext.cpp
+++ b/test/unittest/tests/block/test_block_session_ext.cpp
@@ -42,10 +42,10 @@ void
 validate_ext_list(WT_BLOCK_MGR_SESSION *bms, int expected_items)
 {
     REQUIRE(bms != nullptr);
+    REQUIRE(bms->ext_cache_cnt == expected_items);
     if (bms->ext_cache_cnt == 0)
         REQUIRE(bms->ext_cache == nullptr);
 
-    REQUIRE(bms->ext_cache_cnt == expected_items);
     WT_EXT *curr = bms->ext_cache;
     for (int i = 0; i < expected_items; i++) {
         validate_ext_block(curr);

--- a/test/unittest/tests/block/util_block.h
+++ b/test/unittest/tests/block/util_block.h
@@ -5,9 +5,11 @@
  *
  * See the file LICENSE for redistribution information.
  */
+#pragma once
+
 #include "wt_internal.h"
 
-// Extent validation functions.
+/* Extent validation functions. */
 void validate_and_free_ext_list(WT_BLOCK_MGR_SESSION *bms, int);
 void free_ext_list(WT_BLOCK_MGR_SESSION *);
 void validate_and_free_ext_block(WT_EXT *);
@@ -15,7 +17,7 @@ void validate_ext_list(WT_BLOCK_MGR_SESSION *, int);
 void free_ext_block(WT_EXT *);
 void validate_ext_block(WT_EXT *);
 
-// Size validation functions.
+/* Size validation functions. */
 void validate_and_free_size_list(WT_BLOCK_MGR_SESSION *, int);
 void free_size_list(WT_BLOCK_MGR_SESSION *);
 void validate_and_free_size_block(WT_SIZE *);

--- a/test/unittest/tests/block/util_block.h
+++ b/test/unittest/tests/block/util_block.h
@@ -7,9 +7,18 @@
  */
 #include "wt_internal.h"
 
-void validate_and_free_ext_list(WT_BLOCK_MGR_SESSION *bms, int expected_items);
-void free_ext_list(WT_BLOCK_MGR_SESSION *bms);
-void validate_and_free_ext_block(WT_EXT *ext);
-void validate_ext_list(WT_BLOCK_MGR_SESSION *bms, int expected_items);
-void free_ext_block(WT_EXT *ext);
-void validate_ext_block(WT_EXT *ext);
+// Extent validation functions.
+void validate_and_free_ext_list(WT_BLOCK_MGR_SESSION *bms, int);
+void free_ext_list(WT_BLOCK_MGR_SESSION *);
+void validate_and_free_ext_block(WT_EXT *);
+void validate_ext_list(WT_BLOCK_MGR_SESSION *, int);
+void free_ext_block(WT_EXT *);
+void validate_ext_block(WT_EXT *);
+
+// Size validation functions.
+void validate_and_free_size_list(WT_BLOCK_MGR_SESSION *, int);
+void free_size_list(WT_BLOCK_MGR_SESSION *);
+void validate_and_free_size_block(WT_SIZE *);
+void validate_size_list(WT_BLOCK_MGR_SESSION *, int);
+void free_size_block(WT_SIZE *);
+void validate_size_block(WT_SIZE *);

--- a/test/unittest/tests/block/util_block.h
+++ b/test/unittest/tests/block/util_block.h
@@ -1,0 +1,15 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+#include "wt_internal.h"
+
+void validate_and_free_ext_list(WT_BLOCK_MGR_SESSION *bms, int expected_items);
+void free_ext_list(WT_BLOCK_MGR_SESSION *bms);
+void validate_and_free_ext_block(WT_EXT *ext);
+void validate_ext_list(WT_BLOCK_MGR_SESSION *bms, int expected_items);
+void free_ext_block(WT_EXT *ext);
+void validate_ext_block(WT_EXT *ext);


### PR DESCRIPTION
The ticket here deals with only the block manager session type unit tests. I have added a util_block.h file inside the folder so that I could use the validate function within the unit test file.