### PR TITLE
WT-13502 Add 'backup_checkpoint' to 'query_timestamp'.

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -2028,9 +2028,10 @@ methods = {
     Config('get', 'all_durable', r'''
         specify which timestamp to query: \c all_durable returns the largest timestamp such
         that all timestamps up to and including that value have been committed (possibly
-        bounded by the application-set \c durable timestamp); \c last_checkpoint returns the
-        timestamp of the most recent stable checkpoint; \c oldest_timestamp returns the most
-        recent \c oldest_timestamp set with WT_CONNECTION::set_timestamp; \c oldest_reader
+        bounded by the application-set \c durable timestamp); \c backup_checkpoint returns
+        the stable timestamp of the checkpoint pinned for an open backup cursor; \c last_checkpoint
+        return the timestamp of the most recent stable checkpoint; \c oldest_timestamp returns the
+        most recent \c oldest_timestamp set with WT_CONNECTION::set_timestamp; \c oldest_reader
         returns the minimum of the read timestamps of all active readers; \c pinned returns
         the minimum of the \c oldest_timestamp and the read timestamps of all active readers;
         \c recovery returns the timestamp of the most recent stable checkpoint taken prior to
@@ -2038,7 +2039,7 @@ methods = {
         WT_CONNECTION::set_timestamp. (The \c oldest and \c stable arguments are deprecated
         short-hand for \c oldest_timestamp and \c stable_timestamp, respectively.) See @ref
         timestamp_global_api''',
-        choices=['all_durable','last_checkpoint','oldest',
+        choices=['all_durable','backup_checkpoint','last_checkpoint','oldest',
             'oldest_reader','oldest_timestamp','pinned','recovery','stable','stable_timestamp']),
 ]),
 

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -116,6 +116,7 @@ static const uint8_t confchk_WT_CONNECTION_open_session_jump[WT_CONFIG_JUMP_TABL
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3,
   3, 3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6};
 const char __WT_CONFIG_CHOICE_all_durable[] = "all_durable";
+const char __WT_CONFIG_CHOICE_backup_checkpoint[] = "backup_checkpoint";
 const char __WT_CONFIG_CHOICE_last_checkpoint[] = "last_checkpoint";
 const char __WT_CONFIG_CHOICE_oldest[] = "oldest";
 const char __WT_CONFIG_CHOICE_oldest_reader[] = "oldest_reader";
@@ -126,15 +127,17 @@ const char __WT_CONFIG_CHOICE_stable[] = "stable";
 const char __WT_CONFIG_CHOICE_stable_timestamp[] = "stable_timestamp";
 
 static const char *confchk_get_choices[] = {__WT_CONFIG_CHOICE_all_durable,
-  __WT_CONFIG_CHOICE_last_checkpoint, __WT_CONFIG_CHOICE_oldest, __WT_CONFIG_CHOICE_oldest_reader,
-  __WT_CONFIG_CHOICE_oldest_timestamp, __WT_CONFIG_CHOICE_pinned, __WT_CONFIG_CHOICE_recovery,
-  __WT_CONFIG_CHOICE_stable, __WT_CONFIG_CHOICE_stable_timestamp, NULL};
+  __WT_CONFIG_CHOICE_backup_checkpoint, __WT_CONFIG_CHOICE_last_checkpoint,
+  __WT_CONFIG_CHOICE_oldest, __WT_CONFIG_CHOICE_oldest_reader, __WT_CONFIG_CHOICE_oldest_timestamp,
+  __WT_CONFIG_CHOICE_pinned, __WT_CONFIG_CHOICE_recovery, __WT_CONFIG_CHOICE_stable,
+  __WT_CONFIG_CHOICE_stable_timestamp, NULL};
 
 static const WT_CONFIG_CHECK confchk_WT_CONNECTION_query_timestamp[] = {
   {"get", "string", NULL,
-    "choices=[\"all_durable\",\"last_checkpoint\",\"oldest\","
-    "\"oldest_reader\",\"oldest_timestamp\",\"pinned\",\"recovery\","
-    "\"stable\",\"stable_timestamp\"]",
+    "choices=[\"all_durable\",\"backup_checkpoint\","
+    "\"last_checkpoint\",\"oldest\",\"oldest_reader\","
+    "\"oldest_timestamp\",\"pinned\",\"recovery\",\"stable\","
+    "\"stable_timestamp\"]",
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 142, INT64_MIN, INT64_MAX, confchk_get_choices},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -833,6 +833,7 @@ __backup_start(
          * backup file list until it is complete and valid.
          */
         WT_WITH_HOTBACKUP_WRITE_LOCK(session, WT_CONN_HOTBACKUP_START(conn));
+        conn->hot_backup_timestamp = conn->txn_global.last_ckpt_timestamp;
 
         /* We're the lock holder, we own cleanup. */
         F_SET(cb, WT_CURBACKUP_LOCKER);

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -173,6 +173,7 @@ extern const char __WT_CONFIG_CHOICE_always[];
 extern const char __WT_CONFIG_CHOICE_and[];
 extern const char __WT_CONFIG_CHOICE_api[];
 extern const char __WT_CONFIG_CHOICE_backup[];
+extern const char __WT_CONFIG_CHOICE_backup_checkpoint[];
 extern const char __WT_CONFIG_CHOICE_backup_rename[];
 extern const char __WT_CONFIG_CHOICE_best[];
 extern const char __WT_CONFIG_CHOICE_block[];

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -511,8 +511,9 @@ struct __wt_connection_impl {
 
     WT_RWLOCK hot_backup_lock; /* Hot backup serialization */
     wt_shared uint64_t
-      hot_backup_start;     /* Clock value of most recent checkpoint needed by hot backup */
-    char **hot_backup_list; /* Hot backup file list */
+      hot_backup_start;            /* Clock value of most recent checkpoint needed by hot backup */
+    uint64_t hot_backup_timestamp; /* Stable timestamp of checkpoint for the open backup */
+    char **hot_backup_list;        /* Hot backup file list */
     uint32_t *partial_backup_remove_ids; /* Remove btree id list for partial backup */
 
     WT_SESSION_IMPL *ckpt_session;       /* Checkpoint thread session */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2664,18 +2664,19 @@ struct __wt_connection {
      * @configstart{WT_CONNECTION.query_timestamp, see dist/api_data.py}
      * @config{get, specify which timestamp to query: \c all_durable returns the largest timestamp
      * such that all timestamps up to and including that value have been committed (possibly bounded
-     * by the application-set \c durable timestamp); \c last_checkpoint returns the timestamp of the
-     * most recent stable checkpoint; \c oldest_timestamp returns the most recent \c
-     * oldest_timestamp set with WT_CONNECTION::set_timestamp; \c oldest_reader returns the minimum
-     * of the read timestamps of all active readers; \c pinned returns the minimum of the \c
+     * by the application-set \c durable timestamp); \c backup_checkpoint returns the stable
+     * timestamp of the checkpoint pinned for an open backup cursor; \c last_checkpoint return the
+     * timestamp of the most recent stable checkpoint; \c oldest_timestamp returns the most recent
+     * \c oldest_timestamp set with WT_CONNECTION::set_timestamp; \c oldest_reader returns the
+     * minimum of the read timestamps of all active readers; \c pinned returns the minimum of the \c
      * oldest_timestamp and the read timestamps of all active readers; \c recovery returns the
      * timestamp of the most recent stable checkpoint taken prior to a shutdown; \c stable_timestamp
      * returns the most recent \c stable_timestamp set with WT_CONNECTION::set_timestamp.  (The \c
      * oldest and \c stable arguments are deprecated short-hand for \c oldest_timestamp and \c
      * stable_timestamp\, respectively.) See @ref timestamp_global_api., a string\, chosen from the
-     * following options: \c "all_durable"\, \c "last_checkpoint"\, \c "oldest"\, \c
-     * "oldest_reader"\, \c "oldest_timestamp"\, \c "pinned"\, \c "recovery"\, \c "stable"\, \c
-     * "stable_timestamp"; default \c all_durable.}
+     * following options: \c "all_durable"\, \c "backup_checkpoint"\, \c "last_checkpoint"\, \c
+     * "oldest"\, \c "oldest_reader"\, \c "oldest_timestamp"\, \c "pinned"\, \c "recovery"\, \c
+     * "stable"\, \c "stable_timestamp"; default \c all_durable.}
      * @configend
      *
      * A timestamp of 0 is returned if the timestamp is not available or has not been set.

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -187,6 +187,12 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
 
         WT_STAT_CONN_INCR(session, txn_walk_sessions);
         WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
+    } else if (WT_CONFIG_LIT_MATCH("backup_checkpoint", cval)) {
+        /* Read-only value forever. Make sure we don't used a cached version. */
+        ts = WT_TS_NONE;
+        /* Only return the value if a backup is in progress. */
+        if (__wt_atomic_load64(&conn->hot_backup_start) != 0)
+            ts = conn->hot_backup_timestamp;
     } else if (WT_CONFIG_LIT_MATCH("last_checkpoint", cval)) {
         /* Read-only value forever. Make sure we don't used a cached version. */
         WT_COMPILER_BARRIER();

--- a/test/suite/test_backup30.py
+++ b/test/suite/test_backup30.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, wiredtiger, wttest
+from wtbackup import backup_base
+from wtscenario import make_scenarios
+
+# test_backup30.py
+# Test querying the ceckpoint timestamp for a backup cursor.
+class test_backup30(backup_base):
+    dir='backup.dir'                    # Backup directory name
+    uri="table:table30"
+
+    def add_timestamp_data(self, uri, key, val, timestamp):
+        self.session.begin_transaction()
+        c = self.session.open_cursor(uri, None, None)
+        for i in range(0, 1000):
+            k = key + str(i)
+            v = val
+            c[k] = v
+        c.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(timestamp))
+
+    def test_backup30(self):
+        self.session.create(self.uri, "key_format=S,value_format=S")
+
+        self.add_timestamp_data(self.uri, "key", "val", 1)
+        self.add_timestamp_data(self.uri, "key", "val5", 5)
+        # Stable timestamp at 10.
+        stable = self.timestamp_str(10)
+        self.conn.set_timestamp('stable_timestamp=' + stable)
+        self.session.checkpoint()
+        # If a backup cursor isn't open the returned timestamp should be 0.
+        self.assertTimestampsEqual("0", self.conn.query_timestamp('get=backup_checkpoint'))
+        # Open a backup cursor.
+        bkup_c = self.session.open_cursor('backup:', None, None)
+        # If a backup cursor is open the returned timestamp should be the checkpoint stable.
+        self.assertTimestampsEqual(stable, self.conn.query_timestamp('get=backup_checkpoint'))
+
+        # Add more data and advance stable and take another checkpoint while the backup
+        # cursor is open. Make sure backup timestamp remains the same.
+        self.add_timestamp_data(self.uri, "key", "val11", 11)
+        self.add_timestamp_data(self.uri, "key", "val15", 15)
+        stable2 = self.timestamp_str(20)
+        self.conn.set_timestamp('stable_timestamp=' + stable2)
+        self.session.checkpoint()
+
+        self.assertTimestampsEqual(stable, self.conn.query_timestamp('get=backup_checkpoint'))
+
+        # Close and reopen the backup cursor and make sure it advances.
+        bkup_c.close()
+        self.assertTimestampsEqual("0", self.conn.query_timestamp('get=backup_checkpoint'))
+        bkup_c = self.session.open_cursor('backup:', None, None)
+        # If a backup cursor is open the returned timestamp should be the checkpoint stable.
+        self.assertTimestampsEqual(stable2, self.conn.query_timestamp('get=backup_checkpoint'))


### PR DESCRIPTION
Add a configuration setting to be able to query the timestamp that is the timestamp of the checkpoint pinned by an open backup cursor.

@luke-pearson and @keitharnoldsmith here is an implementation of what we discussed. It basically works but I didn't go into situations where timestamps aren't in use or checkpoints sometimes taken without the stable or weird cases like that. This is the basic functionality and plumbing. But I did make a test!
