### PR TITLE
WT-13507 Fix README.md for WT unit tests

### DIFF
--- a/test/unittest/README.md
+++ b/test/unittest/README.md
@@ -2,8 +2,9 @@
 
 ## Building/running
 
-These tests are built as part of the default build via CMake + Ninja. To run
-them, go to your build directory and execute tests/unittest/unittests.
+To build these tests, run CMake with -DHAVE_UNITTEST=1, then build as
+usual with Ninja.  To run them, go to your build directory and execute
+./test/unittest/catch2-unittests.
 
 To run tests for a specific tag (a.k.a. subsystem), put the tag in square
 brackets, e.g. `[extent_list]`. You can specify multiple tags using commas.

--- a/test/unittest/README.md
+++ b/test/unittest/README.md
@@ -2,9 +2,9 @@
 
 ## Building/running
 
-To build these tests, run CMake with -DHAVE_UNITTEST=1, then build as
+To build these tests, run CMake with `-DHAVE_UNITTEST=1`, then build as
 usual with Ninja.  To run them, go to your build directory and execute
-./test/unittest/catch2-unittests.
+`./test/unittest/catch2-unittests`.
 
 To run tests for a specific tag (a.k.a. subsystem), put the tag in square
 brackets, e.g. `[extent_list]`. You can specify multiple tags using commas.


### PR DESCRIPTION
This change fixes a couple inaccuracies in the README file for our unittest directory

- To build the tests you need to specify the `-DHAVE_UNITTEST=1` option to `cmake`
- The name of the executable to run the tests was incorrect

Image of the update text is attached.

<img width="1075" alt="Screenshot 2024-09-06 at 5 33 24 PM" src="https://github.com/user-attachments/assets/f281e90e-9559-4c52-b6b0-9c9703e64df2">

