### PR TITLE
WT-13512 Fix recognizing structs when merging configs

### DIFF
--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -106,7 +106,8 @@ __config_merge_scan(
     WT_DECL_ITEM(kb);
     WT_DECL_ITEM(vb);
     WT_DECL_RET;
-    size_t len;
+    bool is_struct;
+    size_t i, len;
 
     WT_ERR(__wt_scr_alloc(session, 1024, &kb));
     WT_ERR(__wt_scr_alloc(session, 1024, &vb));
@@ -154,9 +155,30 @@ __config_merge_scan(
          * WT_CONFIG_ITEM_STRUCT, so we check for a field name in the
          * value.
          */
-        if (v.type == WT_CONFIG_ITEM_STRUCT && strchr(vb->data, '=') != NULL) {
-            WT_ERR(__config_merge_scan(session, kb->data, vb->data, strip, cp));
-            continue;
+        if (v.type == WT_CONFIG_ITEM_STRUCT) {
+            /*
+             * A value is a struct if it has field names, which we can easily check by the presence
+             * of the '=' separator, or if the previous version of the key was a struct. We need to
+             * check the latter to handle cases such as "log=(enabled)", which does not contain '='
+             * in its value.
+             */
+            if (strchr(vb->data, '=') != NULL)
+                is_struct = true;
+            else {
+                is_struct = false;
+                for (i = 0; i < cp->entries_next; i++) {
+                    if (strncmp(cp->entries[i].k, kb->data, kb->size) == 0 &&
+                      strncmp(cp->entries[i].k + kb->size, SEP, strlen(SEP)) == 0) {
+                        is_struct = true;
+                        break;
+                    }
+                }
+            }
+
+            if (is_struct) {
+                WT_ERR(__config_merge_scan(session, kb->data, vb->data, strip, cp));
+                continue;
+            }
         }
 
         /* Insert the value into the array. */

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -106,8 +106,8 @@ __config_merge_scan(
     WT_DECL_ITEM(kb);
     WT_DECL_ITEM(vb);
     WT_DECL_RET;
-    bool is_struct;
     size_t i, len;
+    bool is_struct;
 
     WT_ERR(__wt_scr_alloc(session, 1024, &kb));
     WT_ERR(__wt_scr_alloc(session, 1024, &vb));

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -218,21 +218,16 @@ __wti_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
     conn = S2C(session);
 
     WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
-    enabled = cval.val != 0;
 
     /*
-     * If we're reconfiguring, enabled must match the already existing setting.
-     *
-     * If it is off and the user it turning it on, or it is on and the user is turning it off,
-     * return an error.
-     *
-     * See above: should never happen.
+     * If we're reconfiguring, do not evaluate the log=(enabled) setting, because it cannot be even
+     * specified (see the comment above). Get the value of "enabled" from the current state.
      */
-    if (reconfig &&
-      ((enabled && !FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED)) ||
-        (!enabled && FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))))
-        WT_RET_MSG(
-          session, EINVAL, "log manager reconfigure: enabled mismatch with existing setting");
+    if (reconfig) {
+        WT_ASSERT(session, cval.val == 0); /* log=(enabled) is not turned on in the config. */
+        enabled = FLD_ISSET(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED);
+    } else
+        enabled = cval.val != 0;
 
     /* Logging is incompatible with in-memory */
     if (enabled) {

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -217,16 +217,22 @@ __wti_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
 
     conn = S2C(session);
 
+    WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
+    enabled = cval.val != 0;
+
     /*
-     * If we're reconfiguring, do not evaluate the log=(enabled) setting, because it cannot be even
-     * specified (see the comment above). Get the value of "enabled" from the current state.
+     * If we're reconfiguring, enabled must match the already existing setting.
+     *
+     * If it is off and the user it turning it on, or it is on and the user is turning it off,
+     * return an error.
+     *
+     * See above: should never happen.
      */
-    if (reconfig)
-        enabled = FLD_ISSET(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED);
-    else {
-        WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
-        enabled = cval.val != 0;
-    }
+    if (reconfig &&
+      ((enabled && !FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED)) ||
+        (!enabled && FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))))
+        WT_RET_MSG(
+          session, EINVAL, "log manager reconfigure: enabled mismatch with existing setting");
 
     /* Logging is incompatible with in-memory */
     if (enabled) {

--- a/src/conn/conn_log.c
+++ b/src/conn/conn_log.c
@@ -217,17 +217,16 @@ __wti_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
 
     conn = S2C(session);
 
-    WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
-
     /*
      * If we're reconfiguring, do not evaluate the log=(enabled) setting, because it cannot be even
      * specified (see the comment above). Get the value of "enabled" from the current state.
      */
-    if (reconfig) {
-        WT_ASSERT(session, cval.val == 0); /* log=(enabled) is not turned on in the config. */
+    if (reconfig)
         enabled = FLD_ISSET(conn->log_flags, WT_CONN_LOG_CONFIG_ENABLED);
-    } else
+    else {
+        WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
         enabled = cval.val != 0;
+    }
 
     /* Logging is incompatible with in-memory */
     if (enabled) {

--- a/test/suite/test_reconfig05.py
+++ b/test/suite/test_reconfig05.py
@@ -35,12 +35,16 @@ import wttest
 # test_reconfig05.py
 #    Test WT_SESSION::reconfigure
 class test_reconfig05(wttest.WiredTigerTestCase):
+
+    # Test whether the reconfiguration can handle structs without the "=" separator.
     conn_config = 'log=(enabled)'
     create_session_config = 'key_format=S,value_format=S,'
     uri = "table:reconfig05"
 
     def test_reconfig05(self):
         self.session.create(self.uri, self.create_session_config)
+
+        # Check whether the following calls succeed.
         self.conn.reconfigure("cache_size=1GB")
         self.conn.reconfigure("cache_size=1GB,log=(os_cache_dirty_pct=30)")
         self.conn.reconfigure("log=(os_cache_dirty_pct=50)")

--- a/test/suite/test_reconfig05.py
+++ b/test/suite/test_reconfig05.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# session_api:reconfigure
+# [END_TAGS]
+
+import wttest
+
+# test_reconfig05.py
+#    Test WT_SESSION::reconfigure
+class test_reconfig05(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled)'
+    create_session_config = 'key_format=S,value_format=S,'
+    uri = "table:reconfig05"
+
+    def test_reconfig05(self):
+        self.session.create(self.uri, self.create_session_config)
+        self.conn.reconfigure("cache_size=1GB")
+        self.conn.reconfigure("cache_size=1GB,log=(os_cache_dirty_pct=30)")
+        self.conn.reconfigure("log=(os_cache_dirty_pct=50)")

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -40,7 +40,7 @@
 |Rollback To Stable||[test_checkpoint_snapshot03.py](../test/suite/test_checkpoint_snapshot03.py), [test_rollback_to_stable16.py](../test/suite/test_rollback_to_stable16.py), [test_rollback_to_stable18.py](../test/suite/test_rollback_to_stable18.py)
 |Salvage|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py)
 |Schema Api||[test_schema03.py](../test/suite/test_schema03.py)
-|Session Api|Reconfigure|[test_reconfig04.py](../test/suite/test_reconfig04.py)
+|Session Api|Reconfigure|[test_reconfig04.py](../test/suite/test_reconfig04.py), [test_reconfig05.py](../test/suite/test_reconfig05.py)
 |Session Api|Verify|[test_bug005.py](../test/suite/test_bug005.py)
 |Statistics||[test_stat_log02.py](../test/suite/test_stat_log02.py)
 |Tiered Storage|Checkpoint|[test_tiered08.py](../test/suite/test_tiered08.py)


### PR DESCRIPTION
This fixes an issue in `__config_merge_scan`, which did not recognize key/value pairs such as `log=(enabled)` to be recognized as structs. This had the unfortunate consequence of merging `log=(enabled=false)` and `log=(enabled)` to still result in `log=(enabled=false)`.

This could, for example, cause `WT_CONNECTION::reconfigure` to not work if the connection was opened with just `log=(enabled)`. In that case, the connection's own config string would still contain `enabled=false` but the connection flags would have `WT_CONN_LOG_ENABLED` set. This mismatch would then cause `__wti_logmgr_config` to fail.