### PR TITLE
WT-13510 Fix WT_SESSION.strerror for SWIG, it shouldn't do "int checking" for its result

### DIFF
--- a/lang/python/setup_pip.py
+++ b/lang/python/setup_pip.py
@@ -33,7 +33,7 @@
 # are part of the package. To create the distribution, in this directory, run
 # "python setup_pip.py sdist", this creates a tar.gz file under ./dist .
 from __future__ import print_function
-import os, os.path, re, shutil, sys
+import os, os.path, platform, re, shutil, sys
 from setuptools import setup, Distribution, Extension
 import subprocess
 from subprocess import call
@@ -75,7 +75,9 @@ def get_compile_flags(inc_paths, lib_paths):
         cppflags.append('-DHAVE_CONFIG_H')
         ldflags = ['-L' + path for path in lib_paths]
         if sys.platform == 'darwin':
-            cflags.extend([ '-arch', 'x86_64' ])
+            # Figure out the machine architecture, e.g. arm64, x86_64.
+            arch = platform.machine()
+            cflags.extend(['-arch', f'{arch}'])
     return (cppflags, cflags, ldflags)
 
 # get_sources_curdir --

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -605,6 +605,7 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %exception __wt_connection::is_new;
 %exception __wt_connection::search_near;
 %exception __wt_session::get_rollback_reason;
+%exception __wt_session::strerror;
 %exception __wt_cursor::_set_key;
 %exception __wt_cursor::_set_key_str;
 %exception __wt_cursor::_set_value;


### PR DESCRIPTION
The change removes boilerplate checking for the strerror call.  The boilerplate checks assume the result is an int, which is not appropriate for this method.  Even moderate type checking will flag this error (I'm not sure why we've seen it up til now).

The wrapper file (one of the outputs of running SWIG), has this difference after the change:
```
$ diff lang/python/CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c{.ORIG,}
5808,5825c5808,5810
<     {
<       SWIG_PYTHON_THREAD_BEGIN_ALLOW;
<       result = (char *)(arg1)->strerror(arg2,arg3);
<       SWIG_PYTHON_THREAD_END_ALLOW;
<     }
<     if (result != 0)
<     /*@SWIG:/Users/dda/wt/git/wt-13510-swig-strerror/lang/python/wiredtiger.i,535,SWIG_ERROR_IF_NOT_SET@*/
<     do {
<       if (PyErr_Occurred() == NULL) {
<         /* We could use PyErr_SetObject for more complex reporting. */
<         if (PyErr_Occurred() == NULL && (intptr_t)result == WT_ROLLBACK)
<         SWIG_SetErrorMsg(wtRollbackError, wiredtiger_strerror(result));
<         else
<         SWIG_SetErrorMsg(wtError, wiredtiger_strerror(result));
<       }
<       SWIG_fail;
<     } while(0)
<     /*@SWIG@*/;
---
>     SWIG_PYTHON_THREAD_BEGIN_ALLOW;
>     result = (char *)(arg1)->strerror(arg2,arg3);
>     SWIG_PYTHON_THREAD_END_ALLOW;
```

