### PR TITLE
WT-13521 Poc session to log weak dependency handling

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -2175,11 +2175,9 @@ __wt_btcur_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     WT_CURSOR_BTREE *start, *stop;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
-    bool logging;
 
     session = trunc_info->session;
     btree = CUR2BT(trunc_info->start);
-    logging = __wt_log_op(session);
     start = (WT_CURSOR_BTREE *)trunc_info->start;
     stop = (WT_CURSOR_BTREE *)trunc_info->stop;
 
@@ -2195,8 +2193,7 @@ __wt_btcur_range_truncate(WT_TRUNCATE_INFO *trunc_info)
      * We deal with this here by logging the truncate range first, then (in the logging code)
      * disabling writing of the in-memory remove records to disk.
      */
-    if (logging)
-        WT_RET(__wt_txn_truncate_log(trunc_info));
+    WT_RET(__wt_txn_truncate_log(trunc_info));
 
     switch (btree->type) {
     case BTREE_COL_FIX:

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -270,8 +270,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
-            WT_ERR(__wt_txn_log_op(session, cbt));
+        WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*
          * In case of append, the recno (key) for the value is assigned now. Set the key in the

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -292,8 +292,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
-            WT_ERR(__wt_txn_log_op(session, cbt));
+        WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*
          * Set the key in the transaction operation to be used in case this transaction is prepared

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -571,8 +571,7 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
     if (__txn_should_assign_timestamp(session, op))
         __txn_op_delete_commit_apply_page_del_timestamp(session, op->u.ref);
 
-    if (__wt_log_op(session))
-        WT_ERR(__wt_txn_log_op(session, NULL));
+    WT_ERR(__wt_txn_log_op(session, NULL));
     return (0);
 
 err:

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1586,7 +1586,7 @@ __wt_session_range_truncate(
     WT_TRUNCATE_INFO *trunc_info, _trunc_info;
     int cmp;
     const char *actual_uri;
-    bool local_start, local_stop, log_op, log_trunc, needs_next_prev;
+    bool local_start, local_stop, log_trunc, needs_next_prev;
 
     actual_uri = NULL;
     local_start = local_stop = log_trunc = false;
@@ -1749,12 +1749,9 @@ done:
         /* We have to have a dhandle from somewhere. */
         WT_ASSERT(session, dhandle != NULL);
         if (WT_DHANDLE_BTREE(dhandle)) {
-            WT_WITH_DHANDLE(session, dhandle, log_op = __wt_log_op(session));
-            if (log_op) {
-                WT_WITH_DHANDLE(session, dhandle, ret = __wt_txn_truncate_log(trunc_info));
-                WT_ERR(ret);
-                __wt_txn_truncate_end(session);
-            }
+            WT_WITH_DHANDLE(session, dhandle, ret = __wt_txn_truncate_log(trunc_info));
+            WT_ERR(ret);
+            __wt_txn_truncate_end(session);
         }
     }
 err:

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -267,6 +267,8 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
     op = txn->mod + txn->mod_count - 1;
     fileid = op->btree->id;
 
+    if (!__wt_log_op(session))
+        return (0);
     /*
      * If this operation is diagnostic only, set the ignore bit on the fileid so that recovery can
      * skip it.


### PR DESCRIPTION
Poc for removing the weak dependency between session module and log module for __wt_log_op.

The dependency on 

__wt_log_op

is of the form

       if (__wt_log_op(session))
          WT_ERR(__wt_txn_log_op(session, NULL)); 

__wt_log_op indicates whether the logging is needed or not, if needed transaction operation logging is performed.

I moved the check of whether logging is needed as part of performing the logging operation to reduce the dual dependency to single call dependency as I think, the user can call to log the operation and within the __wt_txn_log_op, if logging is needed, the operation will be logged else will become a no-op.