### PR TITLE
WT-13521-poc-session-log-dependency-alternative

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -2179,7 +2179,7 @@ __wt_btcur_range_truncate(WT_TRUNCATE_INFO *trunc_info)
 
     session = trunc_info->session;
     btree = CUR2BT(trunc_info->start);
-    logging = __wt_log_op(session);
+    logging = __wt_txn_log_op_check(session);
     start = (WT_CURSOR_BTREE *)trunc_info->start;
     stop = (WT_CURSOR_BTREE *)trunc_info->stop;
 

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -270,7 +270,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
+        if (__wt_txn_log_op_check(session))
             WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -292,7 +292,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
+        if (__wt_log_txn_op(session))
             WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -60,7 +60,7 @@ static WT_INLINE bool __wt_isprint(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_un
 static WT_INLINE bool __wt_isspace(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_log_op(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wt_txn_log_op_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_off_page(WT_PAGE *page, const void *p)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/log_inline.h
+++ b/src/include/log_inline.h
@@ -36,36 +36,3 @@ __wt_lsn_offset(WT_LSN *lsn)
 {
     return (__wt_atomic_load32(&lsn->l.offset));
 }
-
-/*
- * __wt_log_op --
- *     Return if an operation should be logged.
- */
-static WT_INLINE bool
-__wt_log_op(WT_SESSION_IMPL *session)
-{
-    WT_CONNECTION_IMPL *conn;
-
-    conn = S2C(session);
-
-    /*
-     * Objects with checkpoint durability don't need logging unless we're in debug mode. That rules
-     * out almost all log records, check it first.
-     */
-    if (!F_ISSET(S2BT(session), WT_BTREE_LOGGED) &&
-      !FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING))
-        return (false);
-
-    /*
-     * Correct the above check for logging being configured. Files are configured for logging to
-     * turn off timestamps, so stop here if there aren't actually any log files.
-     */
-    if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
-        return (false);
-
-    /* No logging during recovery. */
-    if (F_ISSET(conn, WT_CONN_RECOVERING))
-        return (false);
-
-    return (true);
-}

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -37,6 +37,39 @@ __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
 }
 
 /*
+ * __wt_txn_log_op_check --
+ *     Return if a transaction operation should be logged.
+ */
+static WT_INLINE bool
+__wt_txn_log_op_check(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+
+    /*
+     * Objects with checkpoint durability don't need transaction logging unless we're in debug mode.
+     * That rules out almost all log records, check it first.
+     */
+    if (!F_ISSET(S2BT(session), WT_BTREE_LOGGED) &&
+      !FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING))
+        return (false);
+
+    /*
+     * Correct the above check for logging being configured. Files are configured for logging to
+     * turn off timestamps, so stop here if there aren't actually any log files.
+     */
+    if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
+        return (false);
+
+    /* No transaction logging during recovery. */
+    if (F_ISSET(conn, WT_CONN_RECOVERING))
+        return (false);
+
+    return (true);
+}
+
+/*
  * __wt_txn_err_set --
  *     Set an error in the current transaction.
  */
@@ -571,7 +604,7 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
     if (__txn_should_assign_timestamp(session, op))
         __txn_op_delete_commit_apply_page_del_timestamp(session, op->u.ref);
 
-    if (__wt_log_op(session))
+    if (__wt_txn_log_op_check(session))
         WT_ERR(__wt_txn_log_op(session, NULL));
     return (0);
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1749,7 +1749,7 @@ done:
         /* We have to have a dhandle from somewhere. */
         WT_ASSERT(session, dhandle != NULL);
         if (WT_DHANDLE_BTREE(dhandle)) {
-            WT_WITH_DHANDLE(session, dhandle, log_op = __wt_log_op(session));
+            WT_WITH_DHANDLE(session, dhandle, log_op = __wt_txn_log_op_check(session));
             if (log_op) {
                 WT_WITH_DHANDLE(session, dhandle, ret = __wt_txn_truncate_log(trunc_info));
                 WT_ERR(ret);


### PR DESCRIPTION
This is an alternative approach for reducing the dependency between session and log.

__wt_log_op is whether to log the transaction operation or not, based on the result the transaction logging will be performed.

Transaction logging call is _wt txn_log_op.
Basically to keep the inline nature of the check,
__wt_log_op is moved from log_inline.h to txn_inline.h and the function name is changed.

The other approach is https://github.com/wiredtiger/wiredtiger/pull/11020
