### PR TITLE
WT-13546 Use internal session to create the history store table

### DIFF
--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -144,9 +144,8 @@ __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
         return (0);
 
     /*
-     * A new session is necessary to open the HS file rather than the default session. Connection
-     * API calls have the ability to change the default session for connections at any stage of
-     * recovery.
+     * It is necessary to create a new session to initialize the HS file because the default session
+     * can be used by other tasks concurrently during recovery.
      */
     WT_ERR(__wt_open_internal_session(conn, "hs-open", false, 0, 0, &hs_session));
 


### PR DESCRIPTION
The connection's default session is used to save/restore the connection state whenever a connection API is called. The same default session is also used for creating the history store table. After allowing the statistics cursor to be opened during recovery, it is possible that the stats collector thread can interact with the default session while it is creating the history store table.

To avoid these unnecessary interactions with the default session, use the internal history store session while creating the history store table.
