### PR TITLE
WT-13547 hs_conn.c cleanup

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -951,7 +951,7 @@ restart:
         goto restart;
     }
 
-    /* Shut down the history store table after all eviction is complete. */
+    /* Indicate the history store file can no longer be used. */
     __wt_hs_close(session);
 
     /*

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -40,15 +40,16 @@ int
 __wt_hs_get_btree(WT_SESSION_IMPL *session, WT_BTREE **hs_btreep)
 {
     WT_CURSOR *hs_cursor;
-    WT_DECL_RET;
 
     *hs_btreep = NULL;
 
     WT_RET(__wt_curhs_open(session, NULL, &hs_cursor));
     *hs_btreep = __wt_curhs_get_btree(hs_cursor);
     WT_ASSERT(session, *hs_btreep != NULL);
-    WT_TRET(hs_cursor->close(hs_cursor));
-    return (ret);
+
+    WT_RET(hs_cursor->close(hs_cursor));
+
+    return (0);
 }
 
 /*

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -79,18 +79,14 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
 
     WT_ERR(__wt_open_internal_session(conn, "hs_access", true, 0, 0, &tmp_setup_session));
 
-    /*
-     * Retrieve the btree from the history store cursor.
-     */
+    /* Retrieve the btree from the history store cursor. */
     WT_ERR(__wt_hs_get_btree(tmp_setup_session, &btree));
 
     /* Track the history store file ID. */
     if (conn->cache->hs_fileid == 0)
         conn->cache->hs_fileid = btree->id;
 
-    /*
-     * We need to set file_max on the btree associated with one of the history store sessions.
-     */
+    /* We need to set file_max on the btree associated with one of the history store sessions. */
     btree->file_max = (uint64_t)cval.val;
     WT_STAT_CONN_SET(session, cache_hs_ondisk_max, btree->file_max);
 

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -9,16 +9,6 @@
 #include "wt_internal.h"
 
 /*
- * __hs_release_internal_session --
- *     Release the temporary internal session started to retrieve history store.
- */
-static int
-__hs_release_internal_session(WT_SESSION_IMPL *int_session)
-{
-    return (__wt_session_close_internal(int_session));
-}
-
-/*
  * __hs_cleanup_las --
  *     Drop the lookaside file if it exists.
  */
@@ -111,7 +101,7 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
 
 err:
     if (tmp_setup_session != NULL)
-        WT_TRET(__hs_release_internal_session(tmp_setup_session));
+        WT_TRET(__wt_session_close_internal(tmp_setup_session));
     return (ret);
 }
 

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -9,16 +9,6 @@
 #include "wt_internal.h"
 
 /*
- * __hs_start_internal_session --
- *     Create a temporary internal session to retrieve history store.
- */
-static int
-__hs_start_internal_session(WT_SESSION_IMPL *session, WT_SESSION_IMPL **int_sessionp)
-{
-    return (__wt_open_internal_session(S2C(session), "hs_access", true, 0, 0, int_sessionp));
-}
-
-/*
  * __hs_release_internal_session --
  *     Release the temporary internal session started to retrieve history store.
  */
@@ -96,7 +86,7 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
     if (F_ISSET(conn, WT_CONN_IN_MEMORY))
         return (0);
 
-    WT_ERR(__hs_start_internal_session(session, &tmp_setup_session));
+    WT_ERR(__wt_open_internal_session(conn, "hs_access", true, 0, 0, &tmp_setup_session));
 
     /*
      * Retrieve the btree from the history store cursor.

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -133,7 +133,7 @@ __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
 
 /*
  * __wt_hs_close --
- *     Destroy the database's history store.
+ *     Clear the connection's flag to make the history store unavailable.
  */
 void
 __wt_hs_close(WT_SESSION_IMPL *session)


### PR DESCRIPTION
The changes clean up the `hs_conn.c` file by:

- Removing unnecessary wrappers
- Using the right macros
- And formatting comments following our guidelines