### PR TITLE
WT-13442 Do not allow out of order truncate commit timestamp

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -423,7 +423,7 @@ __wt_debug_offset(WT_SESSION_IMPL *session, wt_off_t offset, uint32_t size, uint
     WT_BLOCK *block;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
-    uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE], *endp;
+    uint8_t addr[WT_ADDR_MAX_COOKIE], *endp;
 
     WT_ASSERT(session, S2BT_SAFE(session) != NULL);
 

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -62,7 +62,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     size_t root_addr_size;
-    uint8_t root_addr[WT_BTREE_MAX_ADDR_COOKIE];
+    uint8_t root_addr[WT_ADDR_MAX_COOKIE];
     bool creation, forced_salvage;
 
     btree = S2BT(session);
@@ -119,7 +119,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
      * !!!
      * As part of block-manager configuration, we need to return the maximum
      * sized address cookie that a block manager will ever return.  There's
-     * a limit of WT_BTREE_MAX_ADDR_COOKIE, but at 255B, it's too large for
+     * a limit of WT_ADDR_MAX_COOKIE, but at 255B, it's too large for
      * a Btree with 512B internal pages.  The default block manager packs
      * a wt_off_t and 2 uint32_t's into its cookie, so there's no problem
      * now, but when we create a block manager extension API, we need some

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -429,7 +429,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
     WT_DECL_RET;
     const WT_PAGE_HEADER *dsk;
     size_t addr_size;
-    uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
+    uint8_t addr[WT_ADDR_MAX_COOKIE];
     bool eof, valid;
 
     bm = S2BT(session)->bm;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -204,7 +204,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
     WT_DECL_RET;
     WT_VSTUFF *vs, _vstuff;
     size_t root_addr_size;
-    uint8_t root_addr[WT_BTREE_MAX_ADDR_COOKIE];
+    uint8_t root_addr[WT_ADDR_MAX_COOKIE];
     const char *name;
     bool bm_start, quit, skip_hs;
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1059,6 +1059,31 @@ struct __wt_page_deleted {
 };
 
 /*
+ * A location in a file is a variable-length cookie, but it has a maximum size so it's easy to
+ * create temporary space in which to store them. (Locations can't be much larger than this anyway,
+ * they must fit onto the minimum size page because a reference to an overflow page is itself a
+ * location.)
+ */
+#define WT_ADDR_MAX_COOKIE 255 /* Maximum address cookie */
+
+/*
+ * WT_ADDR_COPY --
+ *	We have to lock the WT_REF to look at a WT_ADDR: a structure we can use to quickly get a
+ * copy of the WT_REF address information.
+ */
+struct __wt_addr_copy {
+    uint8_t type;
+
+    uint8_t addr[WT_ADDR_MAX_COOKIE];
+    uint8_t size;
+
+    WT_TIME_AGGREGATE ta;
+
+    WT_PAGE_DELETED del; /* Fast-truncate page information */
+    bool del_set;
+};
+
+/*
  * WT_REF_HIST --
  *	State information of a ref at a single point in time.
  */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -94,6 +94,23 @@ typedef enum { /* Start position for eviction walk */
 #define WT_BTREE_ID_INVALID UINT32_MAX
 
 /*
+ * WT_ADDR_COPY --
+ *	We have to lock the WT_REF to look at a WT_ADDR: a structure we can use to quickly get a
+ * copy of the WT_REF address information.
+ */
+struct __wt_addr_copy {
+    uint8_t type;
+
+    uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
+    uint8_t size;
+
+    WT_TIME_AGGREGATE ta;
+
+    WT_PAGE_DELETED del; /* Fast-truncate page information */
+    bool del_set;
+};
+
+/*
  * WT_BTREE --
  *	A btree handle.
  */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -47,14 +47,6 @@
  */
 #define WT_BTREE_MAX_OBJECT_SIZE ((uint32_t)(UINT32_MAX - 1024))
 
-/*
- * A location in a file is a variable-length cookie, but it has a maximum size so it's easy to
- * create temporary space in which to store them. (Locations can't be much larger than this anyway,
- * they must fit onto the minimum size page because a reference to an overflow page is itself a
- * location.)
- */
-#define WT_BTREE_MAX_ADDR_COOKIE 255 /* Maximum address cookie */
-
 /* Evict pages if we see this many consecutive deleted records. */
 #define WT_BTREE_DELETE_THRESHOLD WT_THOUSAND
 
@@ -92,23 +84,6 @@ typedef enum { /* Start position for eviction walk */
 
 /* An invalid btree file ID value. ID 0 is reserved for the metadata file. */
 #define WT_BTREE_ID_INVALID UINT32_MAX
-
-/*
- * WT_ADDR_COPY --
- *	We have to lock the WT_REF to look at a WT_ADDR: a structure we can use to quickly get a
- * copy of the WT_REF address information.
- */
-struct __wt_addr_copy {
-    uint8_t type;
-
-    uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
-    uint8_t size;
-
-    WT_TIME_AGGREGATE ta;
-
-    WT_PAGE_DELETED del; /* Fast-truncate page information */
-    bool del_set;
-};
 
 /*
  * WT_BTREE --

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1489,23 +1489,6 @@ __wt_row_leaf_value_cell(
 }
 
 /*
- * WT_ADDR_COPY --
- *	We have to lock the WT_REF to look at a WT_ADDR: a structure we can use to quickly get a
- * copy of the WT_REF address information.
- */
-struct __wt_addr_copy {
-    uint8_t type;
-
-    uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
-    uint8_t size;
-
-    WT_TIME_AGGREGATE ta;
-
-    WT_PAGE_DELETED del; /* Fast-truncate page information */
-    bool del_set;
-};
-
-/*
  * __wt_ref_addr_copy --
  *     Return a copy of the WT_REF address information.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2372,7 +2372,11 @@ static WT_INLINE int __wt_txn_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_B
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_txn_op_delete_commit_apply_timestamps(
+  WT_SESSION_IMPL *session, WT_TXN_OP *op) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_op_set_key(WT_SESSION_IMPL *session, const WT_ITEM *key)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key,
   uint64_t recno, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2382,6 +2386,9 @@ static WT_INLINE int __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, W
   WT_UPDATE *upd, WT_UPDATE **prepare_updp, WT_UPDATE **restored_updp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_search_check(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_txn_timestamp_usage_check(
+  WT_SESSION_IMPL *session, WT_TXN_OP *op, wt_timestamp_t op_ts, wt_timestamp_t prev_op_durable_ts)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_upd_alloc(WT_SESSION_IMPL *session, const WT_ITEM *value,
   u_int modify_type, WT_UPDATE **updp, size_t *sizep)
@@ -2589,10 +2596,7 @@ static WT_INLINE void __wt_txn_cursor_op(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_txn_err_set(WT_SESSION_IMPL *session, int ret);
 static WT_INLINE void __wt_txn_op_delete_apply_prepare_state(
   WT_SESSION_IMPL *session, WT_REF *ref, bool commit);
-static WT_INLINE void __wt_txn_op_delete_commit_apply_timestamps(
-  WT_SESSION_IMPL *session, WT_REF *ref);
 static WT_INLINE void __wt_txn_op_set_recno(WT_SESSION_IMPL *session, uint64_t recno);
-static WT_INLINE void __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op);
 static WT_INLINE void __wt_txn_pinned_timestamp(
   WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp);
 static WT_INLINE void __wt_txn_read_last(WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2376,8 +2376,8 @@ static WT_INLINE int __wt_txn_op_delete_commit_apply_timestamps(
   WT_SESSION_IMPL *session, WT_TXN_OP *op) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_op_set_key(WT_SESSION_IMPL *session, const WT_ITEM *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op,
+  bool validate) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key,
   uint64_t recno, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_read_upd_list(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -384,9 +384,10 @@ __txn_op_delete_commit_apply_page_del_timestamp(WT_SESSION_IMPL *session, WT_TXN
         /* Validate the commit timestamp against the maximum durable timestamp on the page. */
         WT_ENTER_GENERATION(session, WT_GEN_SPLIT);
         WT_WITH_BTREE(session, op->btree, addr_found = __wt_ref_addr_copy(session, ref, &addr));
-        if (addr_found)
-            ret = __wt_txn_timestamp_usage_check(session, op, txn->commit_timestamp,
-              WT_MAX(addr.ta.newest_start_durable_ts, addr.ta.newest_stop_durable_ts));
+        WT_ASSERT_ALWAYS(
+          session, addr_found == true, "Found a fast truncated page without an address");
+        ret = __wt_txn_timestamp_usage_check(session, op, txn->commit_timestamp,
+          WT_MAX(addr.ta.newest_start_durable_ts, addr.ta.newest_stop_durable_ts));
         WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);
         WT_RET(ret);
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -371,6 +371,7 @@ __txn_op_delete_commit_apply_page_del_timestamp(WT_SESSION_IMPL *session, WT_TXN
     WT_PAGE_DELETED *page_del;
     WT_REF *ref;
     WT_TXN *txn;
+    bool addr_found;
 
     ref = op->u.ref;
     txn = session->txn;
@@ -382,7 +383,8 @@ __txn_op_delete_commit_apply_page_del_timestamp(WT_SESSION_IMPL *session, WT_TXN
 
         /* Validate the commit timestamp against the maximum durable timestamp on the page. */
         WT_ENTER_GENERATION(session, WT_GEN_SPLIT);
-        if (__wt_ref_addr_copy(session, ref, &addr))
+        WT_WITH_BTREE(session, op->btree, addr_found = __wt_ref_addr_copy(session, ref, &addr));
+        if (addr_found)
             ret = __wt_txn_timestamp_usage_check(session, op, txn->commit_timestamp,
               WT_MAX(addr.ta.newest_start_durable_ts, addr.ta.newest_stop_durable_ts));
         WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -676,7 +676,7 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
     ref->page_del->txnid = txn->id;
 
     if (__txn_should_assign_timestamp(session, op))
-        __txn_op_delete_commit_apply_page_del_timestamp(session, op);
+        WT_ERR(__txn_op_delete_commit_apply_page_del_timestamp(session, op));
 
     if (__wt_log_op(session))
         WT_ERR(__wt_txn_log_op(session, NULL));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2040,7 +2040,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
     WT_MULTI *multi;
     WT_PAGE *page;
     size_t addr_size, compressed_size;
-    uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
+    uint8_t addr[WT_ADDR_MAX_COOKIE];
 #ifdef HAVE_DIAGNOSTIC
     bool verify_image;
 #endif
@@ -2713,7 +2713,7 @@ __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *k
     WT_PAGE *page;
     WT_PAGE_HEADER *dsk;
     size_t size;
-    uint8_t *addr, buf[WT_BTREE_MAX_ADDR_COOKIE];
+    uint8_t *addr, buf[WT_ADDR_MAX_COOKIE];
 
     btree = S2BT(session);
     bm = btree->bm;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -938,89 +938,6 @@ err:
 }
 
 /*
- * __txn_timestamp_usage_check --
- *     Check if a commit will violate timestamp rules.
- */
-static WT_INLINE int
-__txn_timestamp_usage_check(WT_SESSION_IMPL *session, WT_TXN_OP *op, WT_UPDATE *upd)
-{
-    WT_BTREE *btree;
-    WT_TXN *txn;
-    wt_timestamp_t op_ts, prev_op_durable_ts;
-    uint16_t flags;
-    char ts_string[2][WT_TS_INT_STRING_SIZE];
-    const char *name;
-    bool no_ts_ok, txn_has_ts;
-
-    btree = op->btree;
-    txn = session->txn;
-    flags = btree->dhandle->ts_flags;
-    name = btree->dhandle->name;
-    txn_has_ts = F_ISSET(txn, WT_TXN_HAS_TS_COMMIT | WT_TXN_HAS_TS_DURABLE);
-
-    /* Timestamps are ignored on logged files. */
-    if (F_ISSET(btree, WT_BTREE_LOGGED))
-        return (0);
-
-    /*
-     * Do not check for timestamp usage in recovery. We don't expect recovery to be using timestamps
-     * when applying commits, and it is possible that timestamps may be out-of-order in log replay.
-     */
-    if (F_ISSET(S2C(session), WT_CONN_RECOVERING))
-        return (0);
-
-    op_ts = upd->start_ts != WT_TS_NONE ? upd->start_ts : txn->commit_timestamp;
-
-    /* Check for disallowed timestamps. */
-    if (LF_ISSET(WT_DHANDLE_TS_NEVER)) {
-        if (!txn_has_ts)
-            return (0);
-
-        __wt_err(session, EINVAL,
-          "%s: " WT_TS_VERBOSE_PREFIX "timestamp %s set when disallowed by table configuration",
-          name, __wt_timestamp_to_string(op_ts, ts_string[0]));
-#ifdef HAVE_DIAGNOSTIC
-        __wt_abort(session);
-#endif
-        return (EINVAL);
-    }
-
-    prev_op_durable_ts = upd->prev_durable_ts;
-
-    /*
-     * Ordered consistency requires all updates use timestamps, once they are first used, but this
-     * test can be turned off on a per-transaction basis.
-     */
-    no_ts_ok = F_ISSET(txn, WT_TXN_TS_NOT_SET);
-    if (!txn_has_ts && prev_op_durable_ts != WT_TS_NONE && !no_ts_ok) {
-        __wt_err(session, EINVAL,
-          "%s: " WT_TS_VERBOSE_PREFIX
-          "no timestamp provided for an update to a table configured to always use timestamps "
-          "once they are first used",
-          name);
-#ifdef HAVE_DIAGNOSTIC
-        __wt_abort(session);
-#endif
-        return (EINVAL);
-    }
-
-    /* Ordered consistency requires all updates be in timestamp order. */
-    if (txn_has_ts && prev_op_durable_ts > op_ts) {
-        __wt_err(session, EINVAL,
-          "%s: " WT_TS_VERBOSE_PREFIX
-          "updating a value with a timestamp %s before the previous update %s",
-          name, __wt_timestamp_to_string(op_ts, ts_string[0]),
-          __wt_timestamp_to_string(prev_op_durable_ts, ts_string[1]));
-#ifdef HAVE_DIAGNOSTIC
-        __wt_abort(session);
-#endif
-        return (EINVAL);
-    }
-
-    return (0);
-}
-
-/*
  * __txn_fixup_hs_update --
  *     Fix the history store update with the max stop time point if we commit the prepared update.
  */
@@ -1319,7 +1236,8 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
 
     /* A prepared operation that is rolled back will not have a timestamp worth asserting on. */
     if (commit)
-        WT_RET(__txn_timestamp_usage_check(session, op, upd));
+        WT_RET(
+          __wt_txn_timestamp_usage_check(session, op, txn->commit_timestamp, upd->prev_durable_ts));
 
     for (first_committed_upd = upd; first_committed_upd != NULL &&
          (first_committed_upd->txnid == WT_TXN_ABORTED ||
@@ -1865,8 +1783,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                 if (cache->hs_fileid != 0 && op->btree->id == cache->hs_fileid)
                     break;
 
-                __wt_txn_op_set_timestamp(session, op);
-                WT_ERR(__txn_timestamp_usage_check(session, op, upd));
+                WT_ERR(__wt_txn_op_set_timestamp(session, op));
             } else {
                 /*
                  * If an operation has the key repeated flag set, skip resolving prepared updates as
@@ -1891,7 +1808,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
             }
             break;
         case WT_TXN_OP_REF_DELETE:
-            __wt_txn_op_set_timestamp(session, op);
+            WT_ERR(__wt_txn_op_set_timestamp(session, op));
             break;
         case WT_TXN_OP_TRUNCATE_COL:
         case WT_TXN_OP_TRUNCATE_ROW:

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1783,7 +1783,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                 if (cache->hs_fileid != 0 && op->btree->id == cache->hs_fileid)
                     break;
 
-                WT_ERR(__wt_txn_op_set_timestamp(session, op));
+                WT_ERR(__wt_txn_op_set_timestamp(session, op, true));
             } else {
                 /*
                  * If an operation has the key repeated flag set, skip resolving prepared updates as
@@ -1808,7 +1808,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
             }
             break;
         case WT_TXN_OP_REF_DELETE:
-            WT_ERR(__wt_txn_op_set_timestamp(session, op));
+            WT_ERR(__wt_txn_op_set_timestamp(session, op, true));
             break;
         case WT_TXN_OP_TRUNCATE_COL:
         case WT_TXN_OP_TRUNCATE_ROW:

--- a/test/suite/test_truncate28.py
+++ b/test/suite/test_truncate28.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper import simulate_crash_restart
+
+# test_truncate28.py
+# Test that out of order truncate commit timestamp doesn't allowed.
+class test_truncate28(wttest.WiredTigerTestCase):
+    conn_config = 'cache_size=50MB,statistics=(all)'
+    def evict_cursor(self, uri, nrows):
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        self.session.begin_transaction("ignore_prepare=true")
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(i)
+            if i % 10 == 0:
+                evict_cursor.reset()
+        evict_cursor.close()
+        self.session.rollback_transaction()
+
+    def get_fast_truncated_pages(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        stat_cursor.close()
+        return pages
+
+    def test_truncate28(self):
+        if wiredtiger.diagnostic_build():
+            self.skipTest('requires a non-diagnostic build')
+
+        nrows = 10000
+        uri = 'table:test_truncate27'
+        self.session.create(uri, 'key_format=i,value_format=S')
+
+        value = 'a' * 100
+
+        # Pin oldest timestamp.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, nrows + 1):
+            # Insert some data.
+            self.session.begin_transaction()
+            cursor[i] = value
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(i))
+        cursor.close()
+
+        # Insert a prepared committed data.
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(uri)
+        cursor[nrows + 1] = value
+        cursor.close()
+        prepare_ts = nrows + 1
+        commit_ts = nrows + 1
+        durable_ts = nrows + 2
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(prepare_ts))
+        self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(durable_ts))
+        self.session.commit_transaction()
+
+        # Update stable timestamp and checkpoint.
+        stable_ts = (int) (nrows / 2)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable_ts))
+        self.session.checkpoint()
+
+        # Evict everything.
+        self.evict_cursor(uri, nrows + 1)
+        self.session.checkpoint()
+
+        # Do a fast truncate.
+        # The commit timestamp is less than the previous durable timestamp.
+        truncate_ts = nrows
+        truncate_session = self.conn.open_session()
+        truncate_session.begin_transaction()
+        cursor_start = truncate_session.open_cursor(uri)
+        cursor_start.set_key(nrows // 2)
+        truncate_session.truncate(None, cursor_start, None, None)
+
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: truncate_session.commit_transaction('commit_timestamp=' + self.timestamp_str(truncate_ts)),
+            '/unexpected timestamp usage/')
+        cursor_start.close()
+
+        # Make the fast truncate stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(durable_ts))
+        self.session.checkpoint()

--- a/test/suite/test_truncate28.py
+++ b/test/suite/test_truncate28.py
@@ -30,7 +30,7 @@ import wiredtiger, wttest
 from helper import simulate_crash_restart
 
 # test_truncate28.py
-# Test that out of order truncate commit timestamp doesn't allowed.
+# Test that out of order commit timestamps aren't allowed when performing truncate operations.
 class test_truncate28(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,statistics=(all)'
     def evict_cursor(self, uri, nrows):
@@ -87,7 +87,8 @@ class test_truncate28(wttest.WiredTigerTestCase):
         self.evict_cursor(uri, nrows + 1)
         self.session.checkpoint()
 
-        # Do a fast truncate with a commit timestamp is less than the previous durable timestamp on the page.
+        # Do a fast truncate with a commit timestamp that is less than the previous durable timestamp
+        # on the page.
         truncate_ts = nrows
         truncate_session = self.conn.open_session()
         truncate_session.begin_transaction()

--- a/test/unittest/tests/block/test_block_addr.cpp
+++ b/test/unittest/tests/block/test_block_addr.cpp
@@ -89,7 +89,7 @@ static void
 test_pack_and_unpack_addr_cookie(
   WT_BLOCK *block, wt_off_t pack_offset, uint32_t pack_size, uint32_t pack_checksum)
 {
-    uint8_t p[WT_BTREE_MAX_ADDR_COOKIE], *pp;
+    uint8_t p[WT_ADDR_MAX_COOKIE], *pp;
     pp = p;
 
     size_t addr_size;


### PR DESCRIPTION
WiredTiger doesn't allow out-of-order commit timestamps and it
return an error whenever an operation is trying to commit with
a timestamp less than the existing timestamp on an update.
However, it failed to verify the truncate commit timestamp.

The WiredTiger timestamp usage check is extended for the truncate
operations also doesn't allow an out-of-order commit timestamp
to be performed.
