### PR TITLE
WT-13521 POC-weaken-session-log-dependency-1

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -2180,11 +2180,9 @@ __wt_btcur_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     WT_CURSOR_BTREE *start, *stop;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
-    bool logging;
 
     session = trunc_info->session;
     btree = CUR2BT(trunc_info->start);
-    logging = __wt_log_op(session);
     start = (WT_CURSOR_BTREE *)trunc_info->start;
     stop = (WT_CURSOR_BTREE *)trunc_info->stop;
 
@@ -2200,8 +2198,7 @@ __wt_btcur_range_truncate(WT_TRUNCATE_INFO *trunc_info)
      * We deal with this here by logging the truncate range first, then (in the logging code)
      * disabling writing of the in-memory remove records to disk.
      */
-    if (logging)
-        WT_RET(__wt_txn_truncate_log(trunc_info));
+    WT_RET(__wt_txn_truncate_log(trunc_info));
 
     switch (btree->type) {
     case BTREE_COL_FIX:
@@ -2225,8 +2222,7 @@ __wt_btcur_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     }
 
 err:
-    if (logging)
-        __wt_txn_truncate_end(session);
+    __wt_txn_truncate_end(session);
     return (ret);
 }
 

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -269,8 +269,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
-            WT_ERR(__wt_txn_log_op(session, cbt));
+        WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*
          * In case of append, the recno (key) for the value is assigned now. Set the key in the

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -291,8 +291,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
-            WT_ERR(__wt_txn_log_op(session, cbt));
+        WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*
          * Set the key in the transaction operation to be used in case this transaction is prepared

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -571,8 +571,7 @@ __wt_txn_modify_page_delete(WT_SESSION_IMPL *session, WT_REF *ref)
     if (__txn_should_assign_timestamp(session, op))
         __txn_op_delete_commit_apply_page_del_timestamp(session, op->u.ref);
 
-    if (__wt_log_op(session))
-        WT_ERR(__wt_txn_log_op(session, NULL));
+    WT_ERR(__wt_txn_log_op(session, NULL));
     return (0);
 
 err:

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1607,7 +1607,7 @@ __wt_session_range_truncate(
     WT_TRUNCATE_INFO *trunc_info, _trunc_info;
     int cmp;
     const char *actual_uri;
-    bool local_start, local_stop, log_op, log_trunc, needs_next_prev;
+    bool local_start, local_stop, log_trunc, needs_next_prev;
 
     actual_uri = NULL;
     local_start = local_stop = log_trunc = false;
@@ -1770,12 +1770,9 @@ done:
         /* We have to have a dhandle from somewhere. */
         WT_ASSERT(session, dhandle != NULL);
         if (WT_DHANDLE_BTREE(dhandle)) {
-            WT_WITH_DHANDLE(session, dhandle, log_op = __wt_log_op(session));
-            if (log_op) {
-                WT_WITH_DHANDLE(session, dhandle, ret = __wt_txn_truncate_log(trunc_info));
-                WT_ERR(ret);
-                __wt_txn_truncate_end(session);
-            }
+            WT_WITH_DHANDLE(session, dhandle, ret = __wt_txn_truncate_log(trunc_info));
+            WT_ERR(ret);
+            __wt_txn_truncate_end(session);
         }
     }
 err:

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -266,6 +266,9 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
     op = txn->mod + txn->mod_count - 1;
     fileid = op->btree->id;
 
+    if (!__wt_log_op(session))
+        return (0);
+
     /*
      * If this operation is diagnostic only, set the ignore bit on the fileid so that recovery can
      * skip it.


### PR DESCRIPTION
This is an option to reduce the dependency between the session module and the log module.

session invokes __wt_log_op before logging the transaction operation. The usage is as :

       if (__wt_log_op(session))
          WT_ERR(__wt_txn_log_op(session, NULL)); 

All the other callers of __wt_log_op have the same above usage pattern.

__wt_log_op indicates whether a transaction operation needs to be logged or not.

The change suggested in this PR is to give the responsibility of checking whether a transaction operation is to be logged or not as well to __wt_txn_log_op. Modularity-wise, the function (__wt_txn_log_op) responsible for logging the transaction operation could check whether the logging is required or not. Logically, this change is fine in my opinion.

The difference is in performance, as __wt_log_op is an inline function, the callers can avoid the function call when the logging is not required. 

In the case of MongoDB, most of the operations performed on collections need not be logged. In such cases, this change probably introduces a performance regression. 

Before this PR, the usage is : 
------------------
       if (__wt_log_op(session))              <-------------------- Inline function
          WT_ERR(__wt_txn_log_op(session, NULL));  <------- Normal function 

With this PR, the usage becomes : 
------------------
       WT_ERR(__wt_txn_log_op(session, NULL));   <-------- Normal function

