### PR TITLE
WT-13521 POC-weaken-session-log-dependency-2

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -2184,7 +2184,7 @@ __wt_btcur_range_truncate(WT_TRUNCATE_INFO *trunc_info)
 
     session = trunc_info->session;
     btree = CUR2BT(trunc_info->start);
-    logging = __wt_log_op(session);
+    logging = __wt_txn_log_op_check(session);
     start = (WT_CURSOR_BTREE *)trunc_info->start;
     stop = (WT_CURSOR_BTREE *)trunc_info->stop;
 

--- a/src/btree/col_modify.c
+++ b/src/btree/col_modify.c
@@ -269,7 +269,7 @@ __wt_col_modify(WT_CURSOR_BTREE *cbt, uint64_t recno, const WT_ITEM *value, WT_U
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
+        if (__wt_txn_log_op_check(session))
             WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -291,7 +291,7 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
      * function can safely free the updates if it receives an error return.
      */
     if (added_to_txn && modify_type != WT_UPDATE_RESERVE) {
-        if (__wt_log_op(session))
+        if (__wt_txn_log_op_check(session))
             WT_ERR(__wt_txn_log_op(session, cbt));
 
         /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2096,8 +2096,6 @@ static WT_INLINE bool __wt_isprint(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_un
 static WT_INLINE bool __wt_isspace(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_leaf_page_can_split(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_log_op(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_off_page(WT_PAGE *page, const void *p)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_op_timer_fired(WT_SESSION_IMPL *session)
@@ -2144,6 +2142,8 @@ static WT_INLINE bool __wt_split_descent_race(WT_SESSION_IMPL *session, WT_REF *
   WT_PAGE_INDEX *saved_pindex) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_has_newest_and_visible_all(WT_SESSION_IMPL *session, uint64_t id,
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_txn_log_op_check(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/log_inline.h
+++ b/src/include/log_inline.h
@@ -36,36 +36,3 @@ __wt_lsn_offset(WT_LSN *lsn)
 {
     return (__wt_atomic_load32(&lsn->l.offset));
 }
-
-/*
- * __wt_log_op --
- *     Return if an operation should be logged.
- */
-static WT_INLINE bool
-__wt_log_op(WT_SESSION_IMPL *session)
-{
-    WT_CONNECTION_IMPL *conn;
-
-    conn = S2C(session);
-
-    /*
-     * Objects with checkpoint durability don't need logging unless we're in debug mode. That rules
-     * out almost all log records, check it first.
-     */
-    if (!F_ISSET(S2BT(session), WT_BTREE_LOGGED) &&
-      !FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING))
-        return (false);
-
-    /*
-     * Correct the above check for logging being configured. Files are configured for logging to
-     * turn off timestamps, so stop here if there aren't actually any log files.
-     */
-    if (!FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
-        return (false);
-
-    /* No logging during recovery. */
-    if (F_ISSET(conn, WT_CONN_RECOVERING))
-        return (false);
-
-    return (true);
-}

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1770,7 +1770,7 @@ done:
         /* We have to have a dhandle from somewhere. */
         WT_ASSERT(session, dhandle != NULL);
         if (WT_DHANDLE_BTREE(dhandle)) {
-            WT_WITH_DHANDLE(session, dhandle, log_op = __wt_log_op(session));
+            WT_WITH_DHANDLE(session, dhandle, log_op = __wt_txn_log_op_check(session));
             if (log_op) {
                 WT_WITH_DHANDLE(session, dhandle, ret = __wt_txn_truncate_log(trunc_info));
                 WT_ERR(ret);


### PR DESCRIPTION
This is an option to reduce the dependency between the session module and the log module.

session invokes __wt_log_op before logging the transaction operation. The usage is as :

```
   if (__wt_log_op(session))
      WT_ERR(__wt_txn_log_op(session, NULL)); 
```

All the other callers of __wt_log_op have the same above usage pattern.

__wt_log_op indicates whether a transaction operation needs to be logged or not. 
__wt_log_op is an inline function.

For performance reasons, it is better to have the check (__wt_log_op) as inline, and based on the check result, a relatively heavy function __wt_txn_log_op will be invoked.

The thought behind this change suggestion is to, the conditional check to determine whether an operation is required and whether the operation itself, should belong to the same module. 
In this case, the transaction module should be responsible for abstracting the functionality to determine whether transaction operation logging is needed or not. 
log module is the transaction log module, my view is that if the transaction module doesn't exist, then the log module also doesn't exist. i.e. the transaction module is composed of the log module.
In this case, I prefer the dependency of other modules like the session module can be on the transaction module, rather than directly on the log module which is part of the transaction module.

This change, I am not anticipating any performance regressions, it is just about a module dependency on two different modules 1) transaction and 2) log, the dependency is reduced to only one module 1) transaction.

Before this PR, the dependency is :

```
Session --> Transaction
Session --> Log
Transaction --> Log
```

With this PR, the dependency becomes :

```
Session --> Transaction
Transaction --> Log
```

