### PR TITLE
WT-13409 One ret in __txn_checkpoint is not handled (v8.0 backport) (#11022)

### DIFF
--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1215,8 +1215,10 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     WT_ERR(__checkpoint_apply_to_dhandles(session, cfg, __wt_checkpoint_sync));
 
     /* Sync the history store file. */
-    if (F_ISSET(hs_dhandle, WT_DHANDLE_OPEN))
+    if (F_ISSET(hs_dhandle, WT_DHANDLE_OPEN)) {
         WT_WITH_DHANDLE(session, hs_dhandle, ret = __wt_checkpoint_sync(session, NULL));
+        WT_ERR(ret);
+    }
 
     time_stop_fsync = __wt_clock(session);
     fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop_fsync, time_start_fsync);


### PR DESCRIPTION


1c8fa9c91

Co-authored-by: Chenhao Qu <chenhao.qu@mongodb.com>
(cherry picked from commit 25ae7562f345eef2c382ed356ffd1b929a044685)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
