### PR TITLE
WT-13561 Refactor Eviction Public/Private API

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -256,7 +256,7 @@ __compact_walk_internal(WT_SESSION_IMPL *session, WT_REF *parent)
 
         WT_RET(__wt_session_compact_check_interrupted(session));
 
-        if (__wt_cache_stuck(session))
+        if (__wt_evict_cache_stuck(session))
             WT_RET(EBUSY);
 
         __wt_sleep(1, 0);
@@ -373,7 +373,7 @@ __wt_compact(WT_SESSION_IMPL *session)
                 bm->compact_progress(bm, session);
             WT_ERR(__wt_session_compact_check_interrupted(session));
 
-            if (__wt_cache_stuck(session))
+            if (__wt_evict_cache_stuck(session))
                 WT_ERR(EBUSY);
 
             first = false;
@@ -384,7 +384,7 @@ __wt_compact(WT_SESSION_IMPL *session)
          * Compact pulls pages into cache during the walk without checking whether the cache is
          * full. Check now to throttle compact to match eviction speed.
          */
-        WT_ERR(__wt_cache_eviction_check(session, false, false, &eviction_happened));
+        WT_ERR(__wt_evict_app_assist_worker_check(session, false, false, &eviction_happened));
         if (eviction_happened)
             WT_STAT_CONN_INCR(session, session_table_compact_eviction);
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -745,7 +745,7 @@ __wti_btcur_evict_reposition(WT_CURSOR_BTREE *cbt)
      * unlike read committed isolation level.
      */
     if (session->txn->isolation == WT_ISO_SNAPSHOT && F_ISSET(session->txn, WT_TXN_RUNNING) &&
-      (__wt_page_evict_soon_check(session, cbt->ref, NULL) ||
+      (__wt_evict_page_soon_check(session, cbt->ref, NULL) ||
         __cursor_reposition_timing_stress(session))) {
 
         WT_STAT_CONN_DSRC_INCR(session, cursor_reposition);

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -88,7 +88,7 @@ __random_skip_entries(WT_CURSOR_BTREE *cbt, WT_INSERT_HEAD *ins_head)
      * traversing the skip list each time accumulates to real time.
      */
     if (entries > WT_RANDOM_SKIP_EVICT_SOON)
-        __wt_page_evict_soon(session, cbt->ref);
+        __wt_evict_page_soon(session, cbt->ref);
 
     return (entries);
 }

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -85,6 +85,55 @@ __evict_force_check(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
+ * __wt_page_release_evict --
+ *     Release a reference to a page, and attempt to immediately evict it.
+ */
+int
+__wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
+{
+    WT_BTREE *btree;
+    WT_DECL_RET;
+    WT_REF_STATE previous_state;
+    uint32_t evict_flags;
+    bool locked;
+
+    btree = S2BT(session);
+
+    /*
+     * This function always releases the hazard pointer - ensure that's done regardless of whether
+     * we can get exclusive access. Take some care with order of operations: if we release the
+     * hazard pointer without first locking the page, it could be evicted in between.
+     */
+    previous_state = WT_REF_GET_STATE(ref);
+    locked =
+      previous_state == WT_REF_MEM && WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED);
+    if ((ret = __wt_hazard_clear(session, ref)) != 0 || !locked) {
+        if (locked)
+            WT_REF_SET_STATE(ref, previous_state);
+        return (ret == 0 ? EBUSY : ret);
+    }
+
+    evict_flags = LF_ISSET(WT_READ_NO_SPLIT) ? WT_EVICT_CALL_NO_SPLIT : 0;
+    FLD_SET(evict_flags, WT_EVICT_CALL_URGENT);
+
+    /*
+     * There is no need to cache a history store cursor if evicting a readonly page. That includes
+     * pages from a checkpoint. Note that opening a history store cursor on a checkpoint page from
+     * here will explode because the identity of the matching history store checkpoint isn't
+     * available.
+     */
+    if (ref->page != NULL && !__wt_page_evict_clean(ref->page)) {
+        WT_ASSERT(session, !WT_READING_CHECKPOINT(session));
+        WT_RET(__wt_curhs_cache(session));
+    }
+    (void)__wt_atomic_addv32(&btree->evict_busy, 1);
+    ret = __wt_evict(session, ref, previous_state, evict_flags);
+    (void)__wt_atomic_subv32(&btree->evict_busy, 1);
+
+    return (ret);
+}
+
+/*
  * __page_read --
  *     Read a page from the file.
  */

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -735,7 +735,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     if (result_entries == 0) {
         empty_parent = true;
         if (!__wt_ref_is_root(parent->pg_intl_parent_ref))
-            __wt_page_evict_soon(session, parent->pg_intl_parent_ref);
+            __wt_evict_page_soon(session, parent->pg_intl_parent_ref);
         goto err;
     }
 

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -52,7 +52,7 @@ __wt_btree_stat_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
       session, stats, compress_precomp_intl_max_page_size, btree->maxintlpage_precomp);
 
     if (F_ISSET(cst, WT_STAT_TYPE_CACHE_WALK))
-        __wt_curstat_cache_walk(session);
+        __wt_evict_stat_walk(session);
 
     if (F_ISSET(cst, WT_STAT_TYPE_TREE_WALK))
         WT_RET(__stat_tree_walk(session));

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -164,7 +164,7 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
         }
 
         /* Mark the obsolete page to evict soon. */
-        __wt_page_evict_soon(session, ref);
+        __wt_evict_page_soon(session, ref);
         WT_STAT_CONN_DSRC_INCR(session, checkpoint_cleanup_pages_evict);
     } else if (__sync_obsolete_tw_check(session, newest_ta)) {
 
@@ -416,8 +416,8 @@ __checkpoint_cleanup_page_skip(
      * and also it can dirty the already existing in-memory page in the cache, skip if eviction is
      * needed.
      */
-    if (__wt_eviction_needed(session, false, false, NULL) || __wt_cache_aggressive(session) ||
-      __wt_cache_full(session) || __wt_cache_stuck(session)) {
+    if (__wt_evict_needed(session, false, false, NULL) || __wt_evict_aggressive(session) ||
+      __wt_cache_full(session) || __wt_evict_cache_stuck(session)) {
         *skipp = true;
         return (0);
     }

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -380,7 +380,7 @@ restart:
              * deleted, mark it for eviction.
              */
             if (empty_internal) {
-                __wt_page_evict_soon(session, ref);
+                __wt_evict_page_soon(session, ref);
                 empty_internal = false;
             }
 

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -434,7 +434,7 @@ __wt_update_obsolete_check(
      */
     if (count > WT_THOUSAND) {
         WT_STAT_CONN_INCR(session, cache_eviction_force_long_update_list);
-        __wt_page_evict_soon(session, cbt->ref);
+        __wt_evict_page_soon(session, cbt->ref);
     }
 
     if (next != NULL)

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -658,7 +658,7 @@ __cache_pool_adjust(WT_SESSION_IMPL *session, uint64_t highest, uint64_t bump_th
          * the most active the more cache we should get assigned.
          */
         pressure = cache->cp_pass_pressure / highest_percentile;
-        busy = __wt_eviction_needed(entry->default_session, false, true, &pct_full);
+        busy = __wt_evict_needed(entry->default_session, false, true, &pct_full);
 
         __wt_verbose_debug2(session, WT_VERB_SHARED_CACHE,
           "\t%5" PRIu64 ", %3" PRIu64 ", %2" PRIu32 ", %d, %2.3f", entry->cache_size >> 20,

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -622,7 +622,7 @@ __background_compact_server(void *arg)
          * - The cache content is almost at the eviction_trigger threshold.
          */
         cache_pressure =
-          __wt_eviction_dirty_needed(session, NULL) || __wt_eviction_clean_needed(session, NULL);
+          __wt_evict_dirty_needed(session, NULL) || __wt_evict_clean_needed(session, NULL);
         if (cache_pressure)
             continue;
 
@@ -661,7 +661,7 @@ __background_compact_server(void *arg)
             WT_STAT_CONN_INCR(session, background_compact_fail);
             /* The following errors are always silenced. */
             if (ret == EBUSY || ret == ENOENT || ret == ETIMEDOUT || ret == WT_ROLLBACK) {
-                if (ret == EBUSY && __wt_cache_stuck(session))
+                if (ret == EBUSY && __wt_evict_cache_stuck(session))
                     WT_STAT_CONN_INCR(session, background_compact_fail_cache_pressure);
                 else if (ret == ETIMEDOUT)
                     WT_STAT_CONN_INCR(session, background_compact_timeout);

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -63,7 +63,7 @@ __prefetch_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
          * eligible pages (allowing pre-fetch to read into the cache), or we iterate through and
          * remove all the refs from the pre-fetch queue and pre-fetch becomes a no-op.
          */
-        if (__wt_eviction_clean_pressure(session)) {
+        if (__wt_evict_clean_pressure(session)) {
             F_CLR_ATOMIC_8(pe->ref, WT_REF_FLAG_PREFETCH);
             __wt_spin_unlock(session, &conn->prefetch_lock);
             __wt_free(session, pe);
@@ -178,7 +178,7 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
      * the queue. It should take a more conservative approach and stop as soon as it detects that we
      * are close to hitting the eviction clean trigger.
      */
-    if (__wt_eviction_clean_pressure(session))
+    if (__wt_evict_clean_pressure(session))
         return (EBUSY);
 
     WT_RET(__wt_calloc_one(session, &pe));

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -107,20 +107,6 @@ __wt_page_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
- * __wt_page_dirty_and_evict_soon --
- *     Mark a page dirty and set it to be evicted as soon as possible.
- */
-static WT_INLINE int
-__wt_page_dirty_and_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
-{
-    WT_RET(__wt_page_modify_init(session, ref->page));
-    __wt_page_modify_set(session, ref->page);
-    __wt_page_evict_soon(session, ref);
-
-    return (0);
-}
-
-/*
  * __wt_eviction_clean_pressure --
  *     Return true if clean cache is stressed and will soon require application threads to evict
  *     content.

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -219,36 +219,6 @@ __wti_eviction_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 }
 
 /*
- * __wti_btree_dominating_cache --
- *     Return if a single btree is occupying at least half of any of our target's cache usage.
- */
-static WT_INLINE bool
-__wti_btree_dominating_cache(WT_SESSION_IMPL *session, WT_BTREE *btree)
-{
-    WT_CACHE *cache;
-    uint64_t bytes_dirty;
-    uint64_t bytes_max;
-
-    cache = S2C(session)->cache;
-    bytes_max = S2C(session)->cache_size + 1;
-
-    if (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&btree->bytes_inmem)) >
-      (uint64_t)(0.5 * cache->eviction_target * bytes_max) / 100)
-        return (true);
-
-    bytes_dirty =
-      __wt_atomic_load64(&btree->bytes_dirty_intl) + __wt_atomic_load64(&btree->bytes_dirty_leaf);
-    if (__wt_cache_bytes_plus_overhead(cache, bytes_dirty) >
-      (uint64_t)(0.5 * cache->eviction_dirty_target * bytes_max) / 100)
-        return (true);
-    if (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&btree->bytes_updates)) >
-      (uint64_t)(0.5 * cache->eviction_updates_target * bytes_max) / 100)
-        return (true);
-
-    return (false);
-}
-
-/*
  * __wt_eviction_needed --
  *     Return if an application thread should do eviction, and the cache full percentage as a
  *     side-effect.

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -9,49 +9,49 @@
 #pragma once
 
 /*
- * __wt_cache_aggressive --
+ * __wt_evict_aggressive --
  *     Indicate if the cache is operating in aggressive mode.
  */
 static WT_INLINE bool
-__wt_cache_aggressive(WT_SESSION_IMPL *session)
+__wt_evict_aggressive(WT_SESSION_IMPL *session)
 {
     return (
       __wt_atomic_load32(&S2C(session)->cache->evict_aggressive_score) >= WT_EVICT_SCORE_CUTOFF);
 }
 
 /*
- * __cache_read_gen --
+ * __evict_read_gen --
  *     Get the current read generation number.
  */
 static WT_INLINE uint64_t
-__cache_read_gen(WT_SESSION_IMPL *session)
+__evict_read_gen(WT_SESSION_IMPL *session)
 {
     return (__wt_atomic_load64(&S2C(session)->cache->read_gen));
 }
 
 /*
- * __wti_cache_read_gen_incr --
+ * __wti_evict_read_gen_incr --
  *     Increment the current read generation number.
  */
 static WT_INLINE void
-__wti_cache_read_gen_incr(WT_SESSION_IMPL *session)
+__wti_evict_read_gen_incr(WT_SESSION_IMPL *session)
 {
     (void)__wt_atomic_add64(&S2C(session)->cache->read_gen, 1);
 }
 
 /*
- * __wt_cache_read_gen_bump --
+ * __wt_evict_read_gen_bump --
  *     Update the page's read generation.
  */
 static WT_INLINE void
-__wt_cache_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page)
+__wt_evict_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
     /* Ignore pages set for forcible eviction. */
     if (__wt_atomic_load64(&page->read_gen) == WT_READGEN_OLDEST)
         return;
 
     /* Ignore pages already in the future. */
-    if (__wt_atomic_load64(&page->read_gen) > __cache_read_gen(session))
+    if (__wt_atomic_load64(&page->read_gen) > __evict_read_gen(session))
         return;
 
     /*
@@ -61,28 +61,28 @@ __wt_cache_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page)
      * current global generation, we don't bother updating the page. In other words, the goal is to
      * avoid some number of updates immediately after each update we have to make.
      */
-    __wt_atomic_store64(&page->read_gen, __cache_read_gen(session) + WT_READGEN_STEP);
+    __wt_atomic_store64(&page->read_gen, __evict_read_gen(session) + WT_READGEN_STEP);
 }
 
 /*
- * __wt_cache_read_gen_new --
+ * __wt_evict_read_gen_new --
  *     Get the read generation for a new page in memory.
  */
 static WT_INLINE void
-__wt_cache_read_gen_new(WT_SESSION_IMPL *session, WT_PAGE *page)
+__wt_evict_read_gen_new(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
     WT_CACHE *cache;
 
     cache = S2C(session)->cache;
-    __wt_atomic_store64(&page->read_gen, (__cache_read_gen(session) + cache->read_gen_oldest) / 2);
+    __wt_atomic_store64(&page->read_gen, (__evict_read_gen(session) + cache->read_gen_oldest) / 2);
 }
 
 /*
- * __wt_cache_stuck --
+ * __wt_evict_cache_stuck --
  *     Indicate if the cache is stuck (i.e., not making progress).
  */
 static WT_INLINE bool
-__wt_cache_stuck(WT_SESSION_IMPL *session)
+__wt_evict_cache_stuck(WT_SESSION_IMPL *session)
 {
     WT_CACHE *cache;
     uint32_t tmp_evict_aggressive_score;
@@ -95,11 +95,11 @@ __wt_cache_stuck(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_page_evict_soon --
+ * __wt_evict_page_soon --
  *     Set a page to be evicted as soon as possible.
  */
 static WT_INLINE void
-__wt_page_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
+__wt_evict_page_soon(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_UNUSED(session);
 
@@ -107,12 +107,12 @@ __wt_page_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
- * __wt_eviction_clean_pressure --
+ * __wt_evict_clean_pressure --
  *     Return true if clean cache is stressed and will soon require application threads to evict
  *     content.
  */
 static WT_INLINE bool
-__wt_eviction_clean_pressure(WT_SESSION_IMPL *session)
+__wt_evict_clean_pressure(WT_SESSION_IMPL *session)
 {
     WT_CACHE *cache;
     double pct_full;
@@ -121,7 +121,7 @@ __wt_eviction_clean_pressure(WT_SESSION_IMPL *session)
     pct_full = 0;
 
     /* Eviction should be done if we hit the eviction clean trigger or come close to hitting it. */
-    if (__wt_eviction_clean_needed(session, &pct_full))
+    if (__wt_evict_clean_needed(session, &pct_full))
         return (true);
     if (pct_full > cache->eviction_target &&
       pct_full >= WT_EVICT_PRESSURE_THRESHOLD * cache->eviction_trigger)
@@ -130,11 +130,11 @@ __wt_eviction_clean_pressure(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_eviction_clean_needed --
+ * __wt_evict_clean_needed --
  *     Return if an application thread should do eviction due to the total volume of data in cache.
  */
 static WT_INLINE bool
-__wt_eviction_clean_needed(WT_SESSION_IMPL *session, double *pct_fullp)
+__wt_evict_clean_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 {
     WT_CACHE *cache;
     uint64_t bytes_inuse, bytes_max;
@@ -154,11 +154,11 @@ __wt_eviction_clean_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 }
 
 /*
- * __wti_eviction_dirty_target --
+ * __wti_evict_dirty_target --
  *     Return the effective dirty target (including checkpoint scrubbing).
  */
 static WT_INLINE double
-__wti_eviction_dirty_target(WT_CACHE *cache)
+__wti_evict_dirty_target(WT_CACHE *cache)
 {
     double dirty_target, scrub_target;
 
@@ -169,12 +169,12 @@ __wti_eviction_dirty_target(WT_CACHE *cache)
 }
 
 /*
- * __wt_eviction_dirty_needed --
+ * __wt_evict_dirty_needed --
  *     Return if an application thread should do eviction due to the total volume of dirty data in
  *     cache.
  */
 static WT_INLINE bool
-__wt_eviction_dirty_needed(WT_SESSION_IMPL *session, double *pct_fullp)
+__wt_evict_dirty_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 {
     WT_CACHE *cache;
     uint64_t bytes_dirty, bytes_max;
@@ -194,12 +194,12 @@ __wt_eviction_dirty_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 }
 
 /*
- * __wti_eviction_updates_needed --
+ * __wti_evict_updates_needed --
  *     Return if an application thread should do eviction due to the total volume of updates in
  *     cache.
  */
 static WT_INLINE bool
-__wti_eviction_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)
+__wti_evict_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 {
     WT_CACHE *cache;
     uint64_t bytes_max, bytes_updates;
@@ -219,12 +219,12 @@ __wti_eviction_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 }
 
 /*
- * __wt_eviction_needed --
+ * __wt_evict_needed --
  *     Return if an application thread should do eviction, and the cache full percentage as a
  *     side-effect.
  */
 static WT_INLINE bool
-__wt_eviction_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double *pct_fullp)
+__wt_evict_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double *pct_fullp)
 {
     WT_CACHE *cache;
     double pct_dirty, pct_full, pct_updates;
@@ -239,13 +239,13 @@ __wt_eviction_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double 
     if (F_ISSET(S2C(session), WT_CONN_CLOSING))
         return (false);
 
-    clean_needed = __wt_eviction_clean_needed(session, &pct_full);
+    clean_needed = __wt_evict_clean_needed(session, &pct_full);
     if (readonly) {
         dirty_needed = updates_needed = false;
         pct_dirty = pct_updates = 0.0;
     } else {
-        dirty_needed = __wt_eviction_dirty_needed(session, &pct_dirty);
-        updates_needed = __wti_eviction_updates_needed(session, &pct_updates);
+        dirty_needed = __wt_evict_dirty_needed(session, &pct_dirty);
+        updates_needed = __wti_evict_updates_needed(session, &pct_updates);
     }
 
     /*
@@ -270,11 +270,11 @@ __wt_eviction_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double 
 }
 
 /*
- * __wti_cache_hs_dirty --
+ * __wti_evict_hs_dirty --
  *     Return if a major portion of the cache is dirty due to history store content.
  */
 static WT_INLINE bool
-__wti_cache_hs_dirty(WT_SESSION_IMPL *session)
+__wti_evict_hs_dirty(WT_SESSION_IMPL *session)
 {
     WT_CACHE *cache;
     WT_CONNECTION_IMPL *conn;
@@ -288,11 +288,12 @@ __wti_cache_hs_dirty(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_cache_eviction_check --
+ * __wt_evict_app_assist_worker_check --
  *     Evict pages if the cache crosses its boundaries.
  */
 static WT_INLINE int
-__wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bool *didworkp)
+__wt_evict_app_assist_worker_check(
+  WT_SESSION_IMPL *session, bool busy, bool readonly, bool *didworkp)
 {
     WT_BTREE *btree;
     WT_TXN_GLOBAL *txn_global;
@@ -356,7 +357,7 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
         return (0);
 
     /* Check if eviction is needed. */
-    if (!__wt_eviction_needed(session, busy, readonly, &pct_full))
+    if (!__wt_evict_needed(session, busy, readonly, &pct_full))
         return (0);
 
     /*
@@ -366,5 +367,5 @@ __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly, bo
     if (didworkp != NULL)
         *didworkp = true;
 
-    return (__wti_cache_eviction_worker(session, busy, readonly, pct_full));
+    return (__wti_evict_app_assist_worker(session, busy, readonly, pct_full));
 }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1474,6 +1474,36 @@ __evict_walk_choose_dhandle(WT_SESSION_IMPL *session, WT_DATA_HANDLE **dhandle_p
 }
 
 /*
+ * __evict_btree_dominating_cache --
+ *     Return if a single btree is occupying at least half of any of our target's cache usage.
+ */
+static WT_INLINE bool
+__evict_btree_dominating_cache(WT_SESSION_IMPL *session, WT_BTREE *btree)
+{
+    WT_CACHE *cache;
+    uint64_t bytes_dirty;
+    uint64_t bytes_max;
+
+    cache = S2C(session)->cache;
+    bytes_max = S2C(session)->cache_size + 1;
+
+    if (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&btree->bytes_inmem)) >
+      (uint64_t)(0.5 * cache->eviction_target * bytes_max) / 100)
+        return (true);
+
+    bytes_dirty =
+      __wt_atomic_load64(&btree->bytes_dirty_intl) + __wt_atomic_load64(&btree->bytes_dirty_leaf);
+    if (__wt_cache_bytes_plus_overhead(cache, bytes_dirty) >
+      (uint64_t)(0.5 * cache->eviction_dirty_target * bytes_max) / 100)
+        return (true);
+    if (__wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&btree->bytes_updates)) >
+      (uint64_t)(0.5 * cache->eviction_updates_target * bytes_max) / 100)
+        return (true);
+
+    return (false);
+}
+
+/*
  * __evict_walk --
  *     Fill in the array by walking the next set of pages.
  */
@@ -1583,7 +1613,7 @@ retry:
          * its pages.
          */
         if (btree->evict_priority != 0 && !__wt_cache_aggressive(session) &&
-          !__wti_btree_dominating_cache(session, btree)) {
+          !__evict_btree_dominating_cache(session, btree)) {
             WT_STAT_CONN_INCR(session, cache_eviction_server_skip_trees_stick_in_cache);
             continue;
         }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -449,7 +449,7 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
     if (!F_ISSET(conn, WT_CONN_EVICTION_RUN) || __wt_atomic_loadv32(&cache->pass_intr) != 0)
         return (0);
 
-    if (!__wt_cache_stuck(session)) {
+    if (!__wt_evict_cache_stuck(session)) {
         /*
          * Try to get the handle list lock: if we give up, that indicates a session is waiting for
          * us to clear walks. Do that as part of a normal pass (without the handle list lock) to
@@ -640,7 +640,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
     conn = S2C(session);
     cache = conn->cache;
 
-    dirty_target = __wti_eviction_dirty_target(cache);
+    dirty_target = __wti_evict_dirty_target(cache);
     dirty_trigger = cache->eviction_dirty_trigger;
     target = cache->eviction_target;
     trigger = cache->eviction_trigger;
@@ -675,19 +675,19 @@ __evict_update_work(WT_SESSION_IMPL *session)
      */
     bytes_max = conn->cache_size + 1;
     bytes_inuse = __wt_cache_bytes_inuse(cache);
-    if (__wt_eviction_clean_needed(session, NULL))
+    if (__wt_evict_clean_needed(session, NULL))
         LF_SET(WT_CACHE_EVICT_CLEAN | WT_CACHE_EVICT_CLEAN_HARD);
     else if (bytes_inuse > (target * bytes_max) / 100)
         LF_SET(WT_CACHE_EVICT_CLEAN);
 
     bytes_dirty = __wt_cache_dirty_leaf_inuse(cache);
-    if (__wt_eviction_dirty_needed(session, NULL))
+    if (__wt_evict_dirty_needed(session, NULL))
         LF_SET(WT_CACHE_EVICT_DIRTY | WT_CACHE_EVICT_DIRTY_HARD);
     else if (bytes_dirty > (uint64_t)(dirty_target * bytes_max) / 100)
         LF_SET(WT_CACHE_EVICT_DIRTY);
 
     bytes_updates = __wt_cache_bytes_updates(cache);
-    if (__wti_eviction_updates_needed(session, NULL))
+    if (__wti_evict_updates_needed(session, NULL))
         LF_SET(WT_CACHE_EVICT_UPDATES | WT_CACHE_EVICT_UPDATES_HARD);
     else if (bytes_updates > (uint64_t)(updates_target * bytes_max) / 100)
         LF_SET(WT_CACHE_EVICT_UPDATES);
@@ -696,7 +696,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
      * If application threads are blocked by the total volume of data in cache, try dirty pages as
      * well.
      */
-    if (__wt_cache_aggressive(session) && LF_ISSET(WT_CACHE_EVICT_CLEAN_HARD))
+    if (__wt_evict_aggressive(session) && LF_ISSET(WT_CACHE_EVICT_CLEAN_HARD))
         LF_SET(WT_CACHE_EVICT_DIRTY);
 
     /*
@@ -767,7 +767,7 @@ __evict_pass(WT_SESSION_IMPL *session)
          * currently required, so that pages have some relative read generation when the eviction
          * server does need to do some work.
          */
-        __wti_cache_read_gen_incr(session);
+        __wti_evict_read_gen_incr(session);
         __wt_atomic_add64(&cache->evict_pass_gen, 1);
 
         /*
@@ -1351,7 +1351,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
     }
 
     /* Decide how many of the candidates we're going to try and evict. */
-    if (__wt_cache_aggressive(session))
+    if (__wt_evict_aggressive(session))
         queue->evict_candidates = entries;
     else {
         /*
@@ -1612,7 +1612,7 @@ retry:
          * If the file is contributing heavily to our cache usage then ignore the "stickiness" of
          * its pages.
          */
-        if (btree->evict_priority != 0 && !__wt_cache_aggressive(session) &&
+        if (btree->evict_priority != 0 && !__wt_evict_aggressive(session) &&
           !__evict_btree_dominating_cache(session, btree)) {
             WT_STAT_CONN_INCR(session, cache_eviction_server_skip_trees_stick_in_cache);
             continue;
@@ -1669,7 +1669,7 @@ retry:
              * If eviction is not in aggressive mode, sleep a bit to give the checkpoint thread a
              * chance to gather its handles.
              */
-            if (F_ISSET(conn, WT_CONN_CKPT_GATHER) && !__wt_cache_aggressive(session)) {
+            if (F_ISSET(conn, WT_CONN_CKPT_GATHER) && !__wt_evict_aggressive(session)) {
                 __wt_sleep(0, 10);
                 WT_STAT_CONN_INCR(session, cache_eviction_walk_sleeps);
             }
@@ -1907,7 +1907,7 @@ __evict_get_target_pages(WT_SESSION_IMPL *session, u_int max_entries, uint32_t s
      * can generate even more HS content and will not help with the cache pressure, and will
      * probably just amplify it further.
      */
-    if (!WT_IS_HS(btree->dhandle) && __wti_cache_hs_dirty(session)) {
+    if (!WT_IS_HS(btree->dhandle) && __wti_evict_hs_dirty(session)) {
         /* If target pages are less than 10, keep it like that. */
         if (target_pages >= 10) {
             target_pages = target_pages / 10;
@@ -2063,7 +2063,7 @@ __evict_should_give_up_walk(WT_SESSION_IMPL *session, uint64_t pages_seen, uint6
      * "deserts" in trees where no good eviction candidates can be found. Abandon the walk if we get
      * into that situation.
      */
-    give_up = !__wt_cache_aggressive(session) && !WT_IS_HS(btree->dhandle) &&
+    give_up = !__wt_evict_aggressive(session) && !WT_IS_HS(btree->dhandle) &&
       pages_seen > min_pages &&
       (pages_queued == 0 || (pages_seen / pages_queued) > (min_pages / target_pages));
     if (give_up) {
@@ -2134,14 +2134,14 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, WT_REF *
      * somehow leave a page without a read generation.
      */
     if (__wt_atomic_load64(&page->read_gen) == WT_READGEN_NOTSET)
-        __wt_cache_read_gen_new(session, page);
+        __wt_evict_read_gen_new(session, page);
 
     /* Pages being forcibly evicted go on the urgent queue. */
     if (modified &&
       (__wt_atomic_load64(&page->read_gen) == WT_READGEN_OLDEST ||
         __wt_atomic_loadsize(&page->memory_footprint) >= btree->splitmempage)) {
         WT_STAT_CONN_INCR(session, cache_eviction_pages_queued_oldest);
-        if (__wt_page_evict_urgent(session, ref))
+        if (__wt_evict_page_urgent(session, ref))
             *urgent_queuedp = true;
         return;
     }
@@ -2152,9 +2152,9 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, WT_REF *
      * configured cache size during checkpoints where reconciling non-HS pages can generate a
      * significant amount of HS dirty content very quickly.
      */
-    if (WT_IS_HS(btree->dhandle) && __wti_cache_hs_dirty(session)) {
+    if (WT_IS_HS(btree->dhandle) && __wti_evict_hs_dirty(session)) {
         WT_STAT_CONN_INCR(session, cache_eviction_pages_queued_urgent_hs_dirty);
-        if (__wt_page_evict_urgent(session, ref))
+        if (__wt_evict_page_urgent(session, ref))
             *urgent_queuedp = true;
         return;
     }
@@ -2198,12 +2198,12 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, WT_REF *
             WT_STAT_CONN_INCR(session, cache_eviction_server_skip_intl_page_with_active_child);
             return;
         }
-        if (__wt_atomic_load32(&btree->evict_walk_period) == 0 && !__wt_cache_aggressive(session))
+        if (__wt_atomic_load32(&btree->evict_walk_period) == 0 && !__wt_evict_aggressive(session))
             return;
     }
 
     /* Evaluate dirty page candidacy, when eviction is not aggressive. */
-    if (!__wt_cache_aggressive(session) && modified && __evict_skip_dirty_candidate(session, page))
+    if (!__wt_evict_aggressive(session) && modified && __evict_skip_dirty_candidate(session, page))
         return;
 
 fast:
@@ -2628,7 +2628,7 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
      * that point, eviction has already unlocked the page and some other thread may have evicted it
      * by the time we look at it.
      */
-    __wt_cache_read_gen_bump(session, ref->page);
+    __wt_evict_read_gen_bump(session, ref->page);
 
     WT_WITH_BTREE(session, btree, ret = __wt_evict(session, ref, previous_state, flags));
 
@@ -2657,12 +2657,12 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 }
 
 /*
- * __wti_cache_eviction_worker --
- *     Worker function for __wt_cache_eviction_check: evict pages if the cache crosses its
+ * __wti_evict_app_assist_worker --
+ *     Worker function for __wt_evict_app_assist_worker_check: evict pages if the cache crosses its
  *     boundaries.
  */
 int
-__wti_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, double pct_full)
+__wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, double pct_full)
 {
     WT_CACHE *cache;
     WT_CONNECTION_IMPL *conn;
@@ -2723,7 +2723,7 @@ __wti_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, 
          * If eviction is stuck, check if this thread is likely causing problems and should be
          * rolled back. Ignore if in recovery, those transactions can't be rolled back.
          */
-        if (!F_ISSET(conn, WT_CONN_RECOVERING) && __wt_cache_stuck(session)) {
+        if (!F_ISSET(conn, WT_CONN_RECOVERING) && __wt_evict_cache_stuck(session)) {
             ret = __wt_txn_is_blocking(session);
             if (ret == WT_ROLLBACK) {
                 if (__wt_atomic_load32(&cache->evict_aggressive_score) > 0)
@@ -2766,7 +2766,7 @@ __wti_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, 
         max_progress = busy ? 5 : 20;
 
         /* See if eviction is still needed. */
-        if (!__wt_eviction_needed(session, busy, readonly, &pct_full) ||
+        if (!__wt_evict_needed(session, busy, readonly, &pct_full) ||
           (pct_full < 100.0 &&
             (__wt_atomic_loadv64(&cache->eviction_progress) > initial_progress + max_progress)))
             break;
@@ -2818,11 +2818,11 @@ done:
 }
 
 /*
- * __wt_page_evict_urgent --
+ * __wt_evict_page_urgent --
  *     Set a page to be evicted as soon as possible.
  */
 bool
-__wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
+__wt_evict_page_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_CACHE *cache;
     WT_EVICT_ENTRY *evict;
@@ -3075,11 +3075,11 @@ __wt_verbose_dump_cache(WT_SESSION_IMPL *session)
     WT_RET(__wt_msg(session, "cache dump"));
 
     WT_RET(__wt_msg(session, "cache full: %s", __wt_cache_full(session) ? "yes" : "no"));
-    needed = __wt_eviction_clean_needed(session, &pct);
+    needed = __wt_evict_clean_needed(session, &pct);
     WT_RET(__wt_msg(session, "cache clean check: %s (%2.3f%%)", needed ? "yes" : "no", pct));
-    needed = __wt_eviction_dirty_needed(session, &pct);
+    needed = __wt_evict_dirty_needed(session, &pct);
     WT_RET(__wt_msg(session, "cache dirty check: %s (%2.3f%%)", needed ? "yes" : "no", pct));
-    needed = __wti_eviction_updates_needed(session, &pct);
+    needed = __wti_evict_updates_needed(session, &pct);
     WT_RET(__wt_msg(session, "cache updates check: %s (%2.3f%%)", needed ? "yes" : "no", pct));
 
     WT_WITH_HANDLE_LIST_READ_LOCK(session,

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -691,7 +691,7 @@ __evict_review_obsolete_time_window(WT_SESSION_IMPL *session, WT_REF *ref)
         return (0);
 
     /* Don't add more cache pressure. */
-    if (__wt_eviction_needed(session, false, false, NULL) || __wt_cache_stuck(session))
+    if (__wt_evict_needed(session, false, false, NULL) || __wt_evict_cache_stuck(session))
         return (0);
 
     /*
@@ -826,7 +826,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
      * the cache size limit.
      */
     if (conn->txn_global.checkpoint_running_hs && !WT_IS_HS(btree->dhandle) &&
-      __wti_cache_hs_dirty(session) && __wt_cache_full(session)) {
+      __wti_evict_hs_dirty(session) && __wt_cache_full(session)) {
         WT_STAT_CONN_INCR(session, cache_eviction_blocked_checkpoint_hs);
         return (__wt_set_return(session, EBUSY));
     }

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -45,55 +45,6 @@ __evict_exclusive(WT_SESSION_IMPL *session, WT_REF *ref)
     return (__wt_set_return(session, EBUSY));
 }
 
-/*
- * __wt_page_release_evict --
- *     Release a reference to a page, and attempt to immediately evict it.
- */
-int
-__wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
-{
-    WT_BTREE *btree;
-    WT_DECL_RET;
-    WT_REF_STATE previous_state;
-    uint32_t evict_flags;
-    bool locked;
-
-    btree = S2BT(session);
-
-    /*
-     * This function always releases the hazard pointer - ensure that's done regardless of whether
-     * we can get exclusive access. Take some care with order of operations: if we release the
-     * hazard pointer without first locking the page, it could be evicted in between.
-     */
-    previous_state = WT_REF_GET_STATE(ref);
-    locked =
-      previous_state == WT_REF_MEM && WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED);
-    if ((ret = __wt_hazard_clear(session, ref)) != 0 || !locked) {
-        if (locked)
-            WT_REF_SET_STATE(ref, previous_state);
-        return (ret == 0 ? EBUSY : ret);
-    }
-
-    evict_flags = LF_ISSET(WT_READ_NO_SPLIT) ? WT_EVICT_CALL_NO_SPLIT : 0;
-    FLD_SET(evict_flags, WT_EVICT_CALL_URGENT);
-
-    /*
-     * There is no need to cache a history store cursor if evicting a readonly page. That includes
-     * pages from a checkpoint. Note that opening a history store cursor on a checkpoint page from
-     * here will explode because the identity of the matching history store checkpoint isn't
-     * available.
-     */
-    if (ref->page != NULL && !__wt_page_evict_clean(ref->page)) {
-        WT_ASSERT(session, !WT_READING_CHECKPOINT(session));
-        WT_RET(__wt_curhs_cache(session));
-    }
-    (void)__wt_atomic_addv32(&btree->evict_busy, 1);
-    ret = __wt_evict(session, ref, previous_state, evict_flags);
-    (void)__wt_atomic_subv32(&btree->evict_busy, 1);
-
-    return (ret);
-}
-
 #define WT_EVICT_STATS_CLEAN 0x01
 #define WT_EVICT_STATS_FORCE_HS 0x02
 #define WT_EVICT_STATS_SUCCESS 0x04

--- a/src/evict/evict_stat.c
+++ b/src/evict/evict_stat.c
@@ -117,11 +117,11 @@ __evict_stat_walk(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_curstat_cache_walk --
+ * __wt_evict_stat_walk --
  *     Initialize the statistics for a cache cache_walk pass.
  */
 void
-__wt_curstat_cache_walk(WT_SESSION_IMPL *session)
+__wt_evict_stat_walk(WT_SESSION_IMPL *session)
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;

--- a/src/history/hs_rec.c
+++ b/src/history/hs_rec.c
@@ -45,8 +45,8 @@ __hs_verbose_cache_stats(WT_SESSION_IMPL *session, WT_BTREE *btree)
     if (WT_VERBOSE_ISSET(session, WT_VERB_HS) ||
       (ckpt_gen_current > ckpt_gen_last &&
         __wt_atomic_casv64(&cache->hs_verb_gen_write, ckpt_gen_last, ckpt_gen_current))) {
-        WT_IGNORE_RET(__wt_eviction_clean_needed(session, &pct_full));
-        WT_IGNORE_RET(__wt_eviction_dirty_needed(session, &pct_dirty));
+        WT_IGNORE_RET(__wt_evict_clean_needed(session, &pct_full));
+        WT_IGNORE_RET(__wt_evict_dirty_needed(session, &pct_dirty));
 
         __wt_verbose_multi(session,
           WT_DECL_VERBOSE_MULTI_CATEGORY(

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -102,6 +102,20 @@ __wt_page_evict_soon_check(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_sp
 }
 
 /*
+ * __wt_page_dirty_and_evict_soon --
+ *     Mark a page dirty and set it to be evicted as soon as possible.
+ */
+static WT_INLINE int
+__wt_page_dirty_and_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
+{
+    WT_RET(__wt_page_modify_init(session, ref->page));
+    __wt_page_modify_set(session, ref->page);
+    __wt_page_evict_soon(session, ref);
+
+    return (0);
+}
+
+/*
  * __wt_page_evict_clean --
  *     Return if the page can be evicted without dirtying the tree.
  */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -72,11 +72,11 @@ __wt_readgen_evict_soon(uint64_t *readgen)
 }
 
 /*
- * __wt_page_evict_soon_check --
+ * __wt_evict_page_soon_check --
  *     Check whether the page should be evicted urgently.
  */
 static WT_INLINE bool
-__wt_page_evict_soon_check(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_split)
+__wt_evict_page_soon_check(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_split)
 {
     WT_BTREE *btree;
     WT_PAGE *page;
@@ -110,7 +110,7 @@ __wt_page_dirty_and_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref)
 {
     WT_RET(__wt_page_modify_init(session, ref->page));
     __wt_page_modify_set(session, ref->page);
-    __wt_page_evict_soon(session, ref);
+    __wt_evict_page_soon(session, ref);
 
     return (0);
 }
@@ -726,7 +726,7 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
          * generation to avoid evicting a dirty page prematurely.
          */
         if (__wt_atomic_load64(&page->read_gen) == WT_READGEN_WONT_NEED)
-            __wt_cache_read_gen_new(session, page);
+            __wt_evict_read_gen_new(session, page);
 
         /*
          * We won the race to dirty the page, but another thread could have committed in the
@@ -1872,7 +1872,7 @@ __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
      * Retry if a reasonable amount of eviction time has passed, the choice of 5 eviction passes as
      * a reasonable amount of time is currently pretty arbitrary.
      */
-    if (__wt_cache_aggressive(session) ||
+    if (__wt_evict_aggressive(session) ||
       mod->last_evict_pass_gen + 5 < __wt_atomic_load64(&S2C(session)->cache->evict_pass_gen))
         return (true);
 
@@ -2040,7 +2040,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         return (0);
     }
 
-    if (__wt_page_evict_soon_check(session, ref, &inmem_split)) {
+    if (__wt_evict_page_soon_check(session, ref, &inmem_split)) {
         /*
          * If the operation has disabled eviction or splitting, or the session is preventing from
          * reconciling, then just queue the page for urgent eviction. Otherwise, attempt to release
@@ -2048,7 +2048,7 @@ __wt_page_release(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
          */
         if (LF_ISSET(WT_READ_NO_EVICT) ||
           (inmem_split ? LF_ISSET(WT_READ_NO_SPLIT) : F_ISSET(session, WT_SESSION_NO_RECONCILE)))
-            WT_IGNORE_RET(__wt_page_evict_urgent(session, ref));
+            WT_IGNORE_RET(__wt_evict_page_urgent(session, ref));
         else {
             WT_RET_BUSY_OK(__wt_page_release_evict(session, ref, flags));
             return (0);

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -227,7 +227,7 @@ __cursor_enter(WT_SESSION_IMPL *session)
      * If there are no other cursors positioned in the session, check whether the cache is full.
      */
     if (session->ncursors == 0)
-        WT_RET(__wt_cache_eviction_check(session, false, false, NULL));
+        WT_RET(__wt_evict_app_assist_worker_check(session, false, false, NULL));
     ++session->ncursors;
     return (0);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2173,8 +2173,6 @@ static WT_INLINE bool __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id
 static WT_INLINE bool __wt_txn_visible_id_snapshot(
   uint64_t id, uint64_t snap_min, uint64_t snap_max, uint64_t *snapshot, uint32_t snapshot_count)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wti_btree_dominating_cache(WT_SESSION_IMPL *session, WT_BTREE *btree)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wti_cache_hs_dirty(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wti_eviction_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -12,6 +12,8 @@ extern bool __wt_compact_check_eligibility(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_config_get_choice(const char **choices, WT_CONFIG_ITEM *item)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wt_evict_page_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_fsync_background_chk(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_gen_active(WT_SESSION_IMPL *session, int which, uint64_t generation)
@@ -22,8 +24,6 @@ extern bool __wt_hazard_check_assert(WT_SESSION_IMPL *session, void *ref, bool w
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_ispo2(uint32_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_modify_idempotent(const void *modify)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern bool __wt_page_evict_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_read_cell_time_window(WT_CURSOR_BTREE *cbt, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1422,8 +1422,6 @@ extern int __wti_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_cache_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly,
-  double pct_full) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_capacity_server_create(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_capacity_server_destroy(WT_SESSION_IMPL *session)
@@ -1541,6 +1539,8 @@ extern int __wti_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_desc_write(WT_SESSION_IMPL *session, WT_FH *fh, uint32_t allocsize)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly,
+  double pct_full) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_execute_handle_operation(WT_SESSION_IMPL *session, const char *uri,
   int (*file_func)(WT_SESSION_IMPL *, const char *[]), const char *cfg[], uint32_t open_flags)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1863,7 +1863,6 @@ extern void __wt_cursor_set_notsup(WT_CURSOR *cursor);
 extern void __wt_cursor_set_raw_key(WT_CURSOR *cursor, WT_ITEM *key);
 extern void __wt_cursor_set_raw_value(WT_CURSOR *cursor, WT_ITEM *value);
 extern void __wt_cursor_set_value(WT_CURSOR *cursor, ...);
-extern void __wt_curstat_cache_walk(WT_SESSION_IMPL *session);
 extern void __wt_curstat_dsrc_final(WT_CURSOR_STAT *cst);
 extern void __wt_encrypt_size(
   WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t incoming_size, size_t *sizep);
@@ -1880,6 +1879,7 @@ extern void __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session);
 extern void __wt_evict_priority_clear(WT_SESSION_IMPL *session);
 extern void __wt_evict_priority_set(WT_SESSION_IMPL *session, uint64_t v);
 extern void __wt_evict_server_wake(WT_SESSION_IMPL *session);
+extern void __wt_evict_stat_walk(WT_SESSION_IMPL *session);
 extern void __wt_evict_stats_update(WT_SESSION_IMPL *session);
 extern void __wt_ext_scr_free(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, void *p);
 extern void __wt_ext_spin_destroy(WT_EXTENSION_API *wt_api, WT_EXTENSION_SPINLOCK *ext_spinlock);
@@ -2064,11 +2064,7 @@ static WT_INLINE bool __wt_btree_lsm_over_size(WT_SESSION_IMPL *session, uint64_
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_btree_syncing_by_other_session(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_cache_aggressive(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_cache_full(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_cache_stuck(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_checksum_match(const void *chunk, size_t len, uint32_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2078,14 +2074,20 @@ static WT_INLINE bool __wt_conf_is_compiled(WT_CONNECTION_IMPL *conn, const char
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_cursor_has_cached_memory(WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_eviction_clean_needed(WT_SESSION_IMPL *session, double *pct_fullp)
+static WT_INLINE bool __wt_evict_aggressive(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_eviction_clean_pressure(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wt_evict_cache_stuck(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_eviction_dirty_needed(WT_SESSION_IMPL *session, double *pct_fullp)
+static WT_INLINE bool __wt_evict_clean_needed(WT_SESSION_IMPL *session, double *pct_fullp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_eviction_needed(WT_SESSION_IMPL *session, bool busy, bool readonly,
+static WT_INLINE bool __wt_evict_clean_pressure(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_evict_dirty_needed(WT_SESSION_IMPL *session, double *pct_fullp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_evict_needed(WT_SESSION_IMPL *session, bool busy, bool readonly,
   double *pct_fullp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_evict_page_soon_check(WT_SESSION_IMPL *session, WT_REF *ref,
+  bool *inmem_split) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_failpoint(WT_SESSION_IMPL *session, uint64_t conn_flag,
   u_int probability) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_isalnum(u_char c) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2114,8 +2116,6 @@ static WT_INLINE bool __wt_page_evict_clean(WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_page_evict_retry(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_page_evict_soon_check(WT_SESSION_IMPL *session, WT_REF *ref,
-  bool *inmem_split) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_page_is_empty(WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_page_is_modified(WT_PAGE *page)
@@ -2173,9 +2173,9 @@ static WT_INLINE bool __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id
 static WT_INLINE bool __wt_txn_visible_id_snapshot(
   uint64_t id, uint64_t snap_min, uint64_t snap_max, uint64_t *snapshot, uint32_t snapshot_count)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wti_cache_hs_dirty(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wti_evict_hs_dirty(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wti_eviction_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)
+static WT_INLINE bool __wti_evict_updates_needed(WT_SESSION_IMPL *session, double *pct_fullp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE const char *__wt_page_type_str(uint8_t val)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2185,7 +2185,7 @@ static WT_INLINE const char *__wt_update_type_str(uint8_t val)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE double __wt_read_shared_double(double *to_read)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE double __wti_eviction_dirty_target(WT_CACHE *cache)
+static WT_INLINE double __wti_evict_dirty_target(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_btcur_bounds_early_exit(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   bool next, bool *key_out_of_boundsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2207,8 +2207,6 @@ static WT_INLINE int __wt_buf_set_and_grow(WT_SESSION_IMPL *session, WT_ITEM *bu
   size_t size, size_t buf_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_buf_setstr(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *s)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_cache_eviction_check(WT_SESSION_IMPL *session, bool busy, bool readonly,
-  bool *didworkp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_cell_pack_value_match(WT_CELL *page_cell, WT_CELL *val_cell,
   const uint8_t *val_data, bool *matchp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_cell_unpack_safe(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,
@@ -2248,6 +2246,8 @@ static WT_INLINE int __wt_dsk_cell_data_ref_addr(WT_SESSION_IMPL *session, int p
   WT_CELL_UNPACK_ADDR *unpack, WT_ITEM *store) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_dsk_cell_data_ref_kv(WT_SESSION_IMPL *session, int page_type,
   WT_CELL_UNPACK_KV *unpack, WT_ITEM *store) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_evict_app_assist_worker_check(WT_SESSION_IMPL *session, bool busy,
+  bool readonly, bool *didworkp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_extlist_read_pair(const uint8_t **p, wt_off_t *offp, wt_off_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_extlist_write_pair(uint8_t **p, wt_off_t off, wt_off_t size)
@@ -2516,8 +2516,6 @@ static WT_INLINE void __wt_cache_page_inmem_decr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
 static WT_INLINE void __wt_cache_page_inmem_incr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
-static WT_INLINE void __wt_cache_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page);
-static WT_INLINE void __wt_cache_read_gen_new(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_cell_get_ta(WT_CELL_UNPACK_ADDR *unpack_addr, WT_TIME_AGGREGATE **tap);
 static WT_INLINE void __wt_cell_get_tw(WT_CELL_UNPACK_KV *unpack_value, WT_TIME_WINDOW **twp);
 static WT_INLINE void __wt_cell_type_reset(
@@ -2533,6 +2531,9 @@ static WT_INLINE void __wt_cursor_dhandle_decr_use(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_cursor_dhandle_incr_use(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_cursor_free_cached_memory(WT_CURSOR *cursor);
 static WT_INLINE void __wt_epoch(WT_SESSION_IMPL *session, struct timespec *tsp);
+static WT_INLINE void __wt_evict_page_soon(WT_SESSION_IMPL *session, WT_REF *ref);
+static WT_INLINE void __wt_evict_read_gen_bump(WT_SESSION_IMPL *session, WT_PAGE *page);
+static WT_INLINE void __wt_evict_read_gen_new(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_modifies_max_memsize(WT_UPDATE_VECTOR *modifies,
   const char *value_format, size_t base_value_size, size_t *max_memsize);
 static WT_INLINE void __wt_modify_max_memsize(
@@ -2543,7 +2544,6 @@ static WT_INLINE void __wt_modify_max_memsize_unpacked(WT_MODIFY *entries, int n
   const char *value_format, size_t base_value_size, size_t *max_memsize);
 static WT_INLINE void __wt_op_timer_start(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_op_timer_stop(WT_SESSION_IMPL *session);
-static WT_INLINE void __wt_page_evict_soon(WT_SESSION_IMPL *session, WT_REF *ref);
 static WT_INLINE void __wt_page_modify_clear(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page);
@@ -2602,7 +2602,7 @@ static WT_INLINE void __wt_txn_unmodify(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd);
 static WT_INLINE void __wt_upd_value_clear(WT_UPDATE_VALUE *upd_value);
 static WT_INLINE void __wt_usec_to_timespec(time_t usec, struct timespec *tsp);
-static WT_INLINE void __wti_cache_read_gen_incr(WT_SESSION_IMPL *session);
+static WT_INLINE void __wti_evict_read_gen_incr(WT_SESSION_IMPL *session);
 static inline bool __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *page,
   WT_TIME_AGGREGATE **ta) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -250,7 +250,7 @@ __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session)
      * totally full, return.
      */
     pct = 0.0;
-    if (__wt_eviction_needed(session, false, false, &pct))
+    if (__wt_evict_needed(session, false, false, &pct))
         max = 5;
     else
         max = 9;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1463,7 +1463,8 @@ __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
          * Stall here if the cache is completely full. Eviction check can return rollback, but the
          * WT_SESSION.begin_transaction API can't, continue on.
          */
-        WT_RET_ERROR_OK(__wt_cache_eviction_check(session, false, true, NULL), WT_ROLLBACK);
+        WT_RET_ERROR_OK(
+          __wt_evict_app_assist_worker_check(session, false, true, NULL), WT_ROLLBACK);
 
         __wt_txn_get_snapshot(session);
     }
@@ -1518,7 +1519,7 @@ __wt_txn_idle_cache_check(WT_SESSION_IMPL *session)
      */
     if (F_ISSET(txn, WT_TXN_RUNNING) && !F_ISSET(txn, WT_TXN_HAS_ID) &&
       __wt_atomic_loadv64(&txn_shared->pinned_id) == WT_TXN_NONE)
-        WT_RET(__wt_cache_eviction_check(session, false, true, NULL));
+        WT_RET(__wt_evict_app_assist_worker_check(session, false, true, NULL));
 
     return (0);
 }

--- a/src/lsm/lsm_tree.c
+++ b/src/lsm/lsm_tree.c
@@ -1224,7 +1224,7 @@ __wt_lsm_compact(WT_SESSION_IMPL *session, const char *name, bool *skipp)
          * we're making the problem worse.
          */
         WT_ERR(__wt_session_compact_check_interrupted(session));
-        if (__wt_cache_stuck(session))
+        if (__wt_evict_cache_stuck(session))
             WT_ERR(EBUSY);
         __wt_sleep(1, 0);
 

--- a/src/lsm/lsm_work_unit.c
+++ b/src/lsm/lsm_work_unit.c
@@ -379,7 +379,7 @@ __wti_lsm_checkpoint_chunk(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree, WT_L
          * If there is cache pressure consider making a chunk evictable to avoid the cache getting
          * stuck when history is required.
          */
-        if (__wt_eviction_needed(session, false, false, NULL))
+        if (__wt_evict_needed(session, false, false, NULL))
             WT_ERR(__wti_lsm_manager_push_entry(session, WT_LSM_WORK_ENABLE_EVICT, 0, lsm_tree));
 
         __wt_verbose_debug2(
@@ -493,7 +493,7 @@ __wti_lsm_work_enable_evict(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree)
     WT_CLEAR(cookie);
 
     /* Only do this if there is cache pressure */
-    if (!__wt_eviction_needed(session, false, false, NULL))
+    if (!__wt_evict_needed(session, false, false, NULL))
         return (0);
 
     WT_RET(__lsm_copy_chunks(session, lsm_tree, &cookie, false));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2040,7 +2040,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
      * Ignore error returns, the return must reflect the fate of the transaction.
      */
     if (!readonly)
-        WT_IGNORE_RET(__wt_cache_eviction_check(session, false, false, NULL));
+        WT_IGNORE_RET(__wt_evict_app_assist_worker_check(session, false, false, NULL));
 
     return (0);
 
@@ -2334,7 +2334,7 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
      * Ignore error returns, the return must reflect the fate of the transaction.
      */
     if (!readonly)
-        WT_IGNORE_RET(__wt_cache_eviction_check(session, false, false, NULL));
+        WT_IGNORE_RET(__wt_evict_app_assist_worker_check(session, false, false, NULL));
 
     return (ret);
 }


### PR DESCRIPTION
Now that all the eviction-related files are present in the evict/ folder and there is folder-module mapping, it becomes easier to use the current prefixes as they were originally intended. In this PR, I have done the following:

1. Removed functions (mainly public APIs) that were not part of eviction - 
    Functions that were irrelevant to eviction have been removed to clean up the API -  `__wt_page_release_evict` and 
    `__wt_page_dirty_and_evict_soon`
3. `__wti_btree_dominating_cache` function is only used in evict_lru.c, so it was relocated to improve modularity.
4. Renamed functions with prefixes starting with __wt_evict in the evict folder (except verbose functions) - After discussions with Etienne, we decided not to rename verbose-related functions yet, as a separate module will be created for verbose. Renaming them now would create unnecessary inconsistencies, so I have left them as-is.