### PR TITLE
WT-13493 Review Checkpoint logging debug levels

### DIFF
--- a/src/btree/bt_import.c
+++ b/src/btree/bt_import.c
@@ -131,7 +131,7 @@ __wt_import_repair(WT_SESSION_IMPL *session, const char *uri, char **configp)
     F_SET(ckpt, WT_CKPT_UPDATE);
     WT_ERR(__wt_buf_set(session, &ckpt->raw, checkpoint->data, checkpoint->size));
     WT_ERR(__wt_meta_ckptlist_update_config(session, ckptbase, config_tmp, &config));
-    __wt_verbose(session, WT_VERB_CHECKPOINT, "import metadata: %s", config);
+    __wt_verbose_info(session, WT_VERB_CHECKPOINT, "import metadata: %s", config);
     *configp = config;
 
 err:

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -388,7 +388,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
     if (time_start != 0) {
         time_stop = __wt_clock(session);
-        __wt_verbose_info(session, WT_VERB_CHECKPOINT,
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT,
           "__sync_file WT_SYNC_%s wrote: %" PRIu64 " leaf pages (%" PRIu64 "B), %" PRIu64
           " internal pages (%" PRIu64 "B), and took %" PRIu64 "ms",
           syncop == WT_SYNC_WRITE_LEAVES ? "WRITE_LEAVES" : "CHECKPOINT", leaf_pages, leaf_bytes,

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -388,7 +388,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
     if (time_start != 0) {
         time_stop = __wt_clock(session);
-        __wt_verbose(session, WT_VERB_CHECKPOINT,
+        __wt_verbose_info(session, WT_VERB_CHECKPOINT,
           "__sync_file WT_SYNC_%s wrote: %" PRIu64 " leaf pages (%" PRIu64 "B), %" PRIu64
           " internal pages (%" PRIu64 "B), and took %" PRIu64 "ms",
           syncop == WT_SYNC_WRITE_LEAVES ? "WRITE_LEAVES" : "CHECKPOINT", leaf_pages, leaf_bytes,

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -150,7 +150,7 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
           session, newest_ta.newest_stop_txn, newest_ta.newest_stop_durable_ts);
 
     if (obsolete) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+        __wt_verbose_info(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p in-memory page with %s obsolete has a stop time aggregate %s", (void *)ref, tag,
           __wt_time_aggregate_to_string(&newest_ta, time_string));
 
@@ -172,7 +172,7 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
          * Dirty the page with an obsolete time window to let the page reconciliation remove all the
          * obsolete time window information.
          */
-        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+        __wt_verbose_info(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p in-memory page %s obsolete time window: time aggregate %s", (void *)ref, tag,
           __wt_time_aggregate_to_string(&newest_ta, time_string));
 
@@ -257,7 +257,7 @@ __sync_obsolete_disk_cleanup(WT_SESSION_IMPL *session, WT_REF *ref, bool *ref_de
           session, newest_ta.newest_stop_txn, newest_ta.newest_stop_durable_ts);
     }
 
-    __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+    __wt_verbose_info(session, WT_VERB_CHECKPOINT_CLEANUP,
       "%p on-disk page obsolete check: %s"
       "obsolete, stop time aggregate %s",
       (void *)ref, obsolete ? "" : "not ", __wt_time_aggregate_to_string(&newest_ta, time_string));

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -150,7 +150,7 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
           session, newest_ta.newest_stop_txn, newest_ta.newest_stop_durable_ts);
 
     if (obsolete) {
-        __wt_verbose_info(session, WT_VERB_CHECKPOINT_CLEANUP,
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p in-memory page with %s obsolete has a stop time aggregate %s", (void *)ref, tag,
           __wt_time_aggregate_to_string(&newest_ta, time_string));
 
@@ -172,7 +172,7 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
          * Dirty the page with an obsolete time window to let the page reconciliation remove all the
          * obsolete time window information.
          */
-        __wt_verbose_info(session, WT_VERB_CHECKPOINT_CLEANUP,
+        __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
           "%p in-memory page %s obsolete time window: time aggregate %s", (void *)ref, tag,
           __wt_time_aggregate_to_string(&newest_ta, time_string));
 
@@ -257,7 +257,7 @@ __sync_obsolete_disk_cleanup(WT_SESSION_IMPL *session, WT_REF *ref, bool *ref_de
           session, newest_ta.newest_stop_txn, newest_ta.newest_stop_durable_ts);
     }
 
-    __wt_verbose_info(session, WT_VERB_CHECKPOINT_CLEANUP,
+    __wt_verbose_debug2(session, WT_VERB_CHECKPOINT_CLEANUP,
       "%p on-disk page obsolete check: %s"
       "obsolete, stop time aggregate %s",
       (void *)ref, obsolete ? "" : "not ", __wt_time_aggregate_to_string(&newest_ta, time_string));

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1739,7 +1739,7 @@ __wt_meta_sysinfo_set(WT_SESSION_IMPL *session, bool full, const char *name, siz
 
     /* Print what we did. */
 
-    __wt_verbose(session, WT_VERB_CHECKPOINT_PROGRESS,
+    __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
       "saving checkpoint snapshot min: %" PRIu64 ", snapshot max: %" PRIu64
       " snapshot count: %" PRIu32
       ", oldest timestamp: %s , meta checkpoint timestamp: %s"

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -619,7 +619,7 @@ __checkpoint_prepare_progress(WT_SESSION_IMPL *session, bool final)
     time_diff = WT_TIMEDIFF_SEC(cur_time, conn->ckpt_timer_start);
 
     if (final || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt_progress_msg_count) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_PROGRESS,
+        __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
           "Checkpoint prepare %s for %" PRIu64 " seconds and it has gathered %" PRIu64
           " dhandles and skipped %" PRIu64 " dhandles",
           final ? "ran" : "has been running", time_diff, conn->ckpt_apply, conn->ckpt_skip);
@@ -645,7 +645,7 @@ __wt_checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
     time_diff = WT_TIMEDIFF_SEC(cur_time, conn->ckpt_timer_start);
 
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt_progress_msg_count) {
-        __wt_verbose(session, WT_VERB_CHECKPOINT_PROGRESS,
+        __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
           "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64 " MB)",
           closing ? "ran" : "has been running", time_diff, conn->ckpt_write_pages,
           conn->ckpt_write_bytes / WT_MEGABYTE);
@@ -721,7 +721,7 @@ __checkpoint_verbose_track(WT_SESSION_IMPL *session, const char *msg)
 
     /* Get time diff in milliseconds. */
     msec = WT_TIMEDIFF_MS(stop, conn->ckpt_timer_start);
-    __wt_verbose(session, WT_VERB_CHECKPOINT,
+    __wt_verbose_info(session, WT_VERB_CHECKPOINT,
       "time: %" PRIu64 " ms, gen: %" PRIu64 ": Full database checkpoint %s", msec,
       __wt_gen(session, WT_GEN_CHECKPOINT), msg);
 }

--- a/test/suite/test_cc09.py
+++ b/test/suite/test_cc09.py
@@ -96,6 +96,7 @@ class test_cc09(test_cc_base):
         # disk to clear the obsolete content if allowed to.
         self.wait_for_cc_to_run()
 
+        self.ignoreStdoutPatternIfExists('WT_VERB_CHECKPOINT_CLEANUP')
         cc_read_stat = self.get_stat(stat.conn.checkpoint_cleanup_pages_read_obsolete_tw)
         cc_dirty_stat = self.get_stat(stat.conn.checkpoint_cleanup_pages_obsolete_tw)
 

--- a/test/suite/test_cc09.py
+++ b/test/suite/test_cc09.py
@@ -96,7 +96,6 @@ class test_cc09(test_cc_base):
         # disk to clear the obsolete content if allowed to.
         self.wait_for_cc_to_run()
 
-        self.ignoreStdoutPatternIfExists('WT_VERB_CHECKPOINT_CLEANUP')
         cc_read_stat = self.get_stat(stat.conn.checkpoint_cleanup_pages_read_obsolete_tw)
         cc_dirty_stat = self.get_stat(stat.conn.checkpoint_cleanup_pages_obsolete_tw)
 


### PR DESCRIPTION
The Checkpoint verbose category messages `WT_VERB_CHECKPOINT`, `WT_VERB_CHECKPOINT_PROGRESS`, and `WT_VERB_CHECKPOINT_CLEANUP` are configured to log at either the `__wt_verbose_debug1`, `__wt_verbose_debug2`, `__wt_verbose_notice` or `__wt_verbose_info` levels. The `__wt_verbose_worker` function, responsible for handling verbose logging, is invoked from `__wti_ckpt_verbose` and is protected by the `WT_VERBOSE_DEBUG_2` level. All the checkpoint verbose category messages are set to the appropriate vebose levels.