### PR TITLE
WT-9939 Enter split generation on eviction to prevent split parent free too early (#8799)

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1461,17 +1461,9 @@ struct __wt_col_fix_auxiliary_header {
  * examining an index, we don't want the oldest split generation to move forward and potentially
  * free it.
  */
-#define WT_ENTER_PAGE_INDEX(session)                                         \
-    do {                                                                     \
-        uint64_t __prev_split_gen = __wt_session_gen(session, WT_GEN_SPLIT); \
-        if (__prev_split_gen == 0)                                           \
-            __wt_session_gen_enter(session, WT_GEN_SPLIT);
+#define WT_ENTER_PAGE_INDEX(session) WT_ENTER_GENERATION((session), WT_GEN_SPLIT);
 
-#define WT_LEAVE_PAGE_INDEX(session)                   \
-    if (__prev_split_gen == 0)                         \
-        __wt_session_gen_leave(session, WT_GEN_SPLIT); \
-    }                                                  \
-    while (0)
+#define WT_LEAVE_PAGE_INDEX(session) WT_LEAVE_GENERATION((session), WT_GEN_SPLIT);
 
 #define WT_WITH_PAGE_INDEX(session, e) \
     WT_ENTER_PAGE_INDEX(session);      \

--- a/src/txn/txn_rollback_to_stable.c
+++ b/src/txn/txn_rollback_to_stable.c
@@ -1360,10 +1360,10 @@ __rollback_to_stable_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollbac
               WT_READ_NO_EVICT | WT_READ_WONT_NEED | WT_READ_VISIBLE_ALL)) == 0 &&
       ref != NULL) {
         __rollback_progress_msg(session, rollback_timer, 0, 0, &rollback_msg_count, true);
-        if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
+        if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
             WT_WITH_PAGE_INDEX(
               session, ret = __rollback_abort_fast_truncate(session, ref, rollback_timestamp));
-        else
+        } else
             WT_RET(__rollback_abort_updates(session, ref, rollback_timestamp));
     }
 


### PR DESCRIPTION
WT-9939. Added entering split generation on eviction to prevent parent from being freed after split.

(cherry picked from commit 5c981e88d873ea0c670ee9f078ded60d4ad6ff2a)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
