### PR TITLE
WT-13563 Modify dist/prototypes.py to split public and private functions into separate headers

### DIFF
--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -11,7 +11,7 @@ COPYRIGHT = """\
 /*-
  * Copyright (c) 2014-present MongoDB, Inc.
  * Copyright (c) 2008-2014 WiredTiger, Inc.
- *	All rights reserved.
+ * All rights reserved.
  *
  * See the file LICENSE for redistribution information.
  */
@@ -146,7 +146,8 @@ def output(fns, tests, f, private_file=""):
     format_srcfile(tmp_file)
     compare_srcfile(tmp_file, f)
 
-# Build a mapping from a component to its public functions, private functions, and HAVE_UNITTEST functions.
+# Build a mapping from a component to its public functions, private functions, 
+# and HAVE_UNITTEST functions.
 def build_component_functions_dicts():
     public_fns_dict = defaultdict(list)
     private_fns_dict = defaultdict(list)
@@ -178,11 +179,13 @@ def build_component_functions_dicts():
         if fnmatch.fnmatch(name, '../src/*'):
             component = name.split("/")[2]
             if component not in modularised_components:
-                # Non modularised components put all their function prototypes in src/include/extern.h
-                # This is indicated by belonging to the include folder.
-                fn_prototypes(public_fns_dict["include"], private_fns_dict["include"], tests_dict["include"], name)
+                # Non modularised components put all their function prototypes in 
+                # src/include/extern.h This is indicated by belonging to the include folder.
+                fn_prototypes(public_fns_dict["include"], private_fns_dict["include"], 
+                    tests_dict["include"], name)
             else:
-                fn_prototypes(public_fns_dict[component], private_fns_dict[component], tests_dict[component], name)
+                fn_prototypes(public_fns_dict[component], private_fns_dict[component], 
+                    tests_dict[component], name)
         else:
             print(f"Unexpected filepath {name}")
             exit(1)
@@ -198,12 +201,15 @@ def write_header_files(public_fns_dict, private_fns_dict, tests_dict):
     for comp in components:
         if comp == "include":
             # Functions defined in the include folder belong in extern.h
-            output(public_fns_dict[comp] + private_fns_dict[comp], tests_dict[comp], f"../src/include/extern.h")
+            output(public_fns_dict[comp] + private_fns_dict[comp], tests_dict[comp], 
+                f"../src/include/extern.h")
         else:
-            output(public_fns_dict[comp], tests_dict[comp], f"../src/{comp}/{comp}.h", private_file=f"{comp}_private.h")
+            output(public_fns_dict[comp], tests_dict[comp], f"../src/{comp}/{comp}.h", 
+                private_file=f"{comp}_private.h")
             if len(private_fns_dict[comp]) > 0:
-                # The second argument (tests_dict) is empty. These test functions are defined to expose module 
-                # internals outside the module, so it doens't make sense for them to be private.
+                # The second argument (tests_dict) is empty. These test functions are defined to
+                # expose module internals outside the module, so it doens't make sense for them 
+                # to be private.
                 output(private_fns_dict[comp], {}, f"../src/{comp}/{comp}_private.h")
 
 def prototypes_os():

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -7,6 +7,10 @@ from common_functions import filter_if_fast
 
 from collections import defaultdict
 
+# This is the list of components that have been modularised as part of Q3 and following work.
+# They place header files inside the src/foo folder rather than in src/include
+MODULARISED_COMPONENTS = []
+
 COPYRIGHT = """\
 /*-
  * Copyright (c) 2014-present MongoDB, Inc.
@@ -153,10 +157,6 @@ def build_component_functions_dicts():
     private_fns_dict = defaultdict(list)
     tests_dict = defaultdict(list)
     
-    # This is the list of components that have been modularised as part of Q3 and following work.
-    # They place header files inside the src/foo folder rather than in src/include
-    modularised_components = []
-
     for name in source_files():
         if not fnmatch.fnmatch(name, '*.c') + fnmatch.fnmatch(name, '*_inline.h'):
             continue
@@ -178,7 +178,7 @@ def build_component_functions_dicts():
 
         if fnmatch.fnmatch(name, '../src/*'):
             component = name.split("/")[2]
-            if component not in modularised_components:
+            if component not in MODULARISED_COMPONENTS:
                 # Non modularised components put all their function prototypes in 
                 # src/include/extern.h This is indicated by belonging to the include folder.
                 fn_prototypes(public_fns_dict["include"], private_fns_dict["include"], 

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -240,6 +240,20 @@ def prototypes_os():
     for p in ports:
         output(fns[p], tests[p], f"../src/include/extern_{p}.h")
 
+# Newly generated public headers need to be included from wt_internal.h.
+# Add a warning reminding developers to do so.
+def check_wt_internal_includes():
+    with open("../src/include/wt_internal.h", 'r') as file:
+        lines = file.readlines()
+
+        for mod in SELF_CONTAINED_MODULES:
+            include_line = f"#include \"../{mod}/{mod}.h\""
+            if f"{include_line}\n" not in lines:
+                print(f"The line '{include_line}' is missing from wt_internal.h. "
+                      "Please make sure to include it.")
+                exit(1)
+
 (pub_fns_dict, private_fns_dict, tests_dict) = build_module_functions_dicts()
 write_header_files(pub_fns_dict, private_fns_dict, tests_dict)
 prototypes_os()
+check_wt_internal_includes()

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -122,8 +122,6 @@ def update_existing_header(tmp_file, fns, tests, f):
     start_line = lines.index(DO_NOT_EDIT_BEGIN)
     end_line = lines.index(DO_NOT_EDIT_END)
 
-    # Safety check: We should always at least one function declaration in the file already
-    assert(start_line + 1 != end_line)
 
     # Content before the starting DO NOT EDIT is kept unchanged.
     new_lines = lines[:start_line + 1]

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 
+# This script parses the WiredTiger code base to find all function definitions and automatically 
+# generates their declarations. Declarations are added to src/include/extern.h by default, or to 
+# module-specific header files if the module is added to the SELF_CONTAINED_MODULES list
+
 # Attention! This script makes the following assumptions about the WiredTiger code directory:
 # - All module-related files should reside in a single src/module/ folder as a result of adding 
 #   a module to SELF_CONTAINED_MODULES
-# - Header files are named using the format {folder_name/module_name}.h or {folder_name/module_name}_private.h.
+# - Header files are named using the format {folder_name/module_name}.h or 
+#   {folder_name/module_name}_private.h.
 # - Header files that are modified by this script have also been automatically created by this 
 #   script as a result of adding a module to the SELF_CONTAINED_MODULES list.
 

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -116,7 +116,8 @@ def update_existing_header(tmp_file, fns, tests, f):
 
     if DO_NOT_EDIT_BEGIN not in lines or DO_NOT_EDIT_END not in lines:
         print(f"Error: File {f} is missing the lines \n{DO_NOT_EDIT_BEGIN} and \
-              \n{DO_NOT_EDIT_END} required by prototypes.py. Both lines must be followed by a newline")
+              \n{DO_NOT_EDIT_END} required by prototypes.py. Both lines must \
+              be followed by a newline")
         sys.exit(1)
 
     start_line = lines.index(DO_NOT_EDIT_BEGIN)

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -200,7 +200,7 @@ def build_module_functions_dicts():
         if fnmatch.fnmatch(name, '../src/*'):
             module_name = name.split("/")[2]
             if module_name not in SELF_CONTAINED_MODULES:
-                # Non-contained modules put all their function prototypes in 
+                # Non-self-contained modules put all their function prototypes in 
                 # src/include/extern.h This is indicated by belonging to the include folder.
                 fn_prototypes(public_fns_dict["include"], private_fns_dict["include"], 
                     tests_dict["include"], name)

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 
+# Attention! This script makes the following assumptions about the WiredTiger code directory:
+# - All module-related files should reside in a single src/module/ folder as a result of adding 
+#   a module to SELF_CONTAINED_MODULES
+# - Header files are named using the format {folder_name/module_name}.h or {folder_name/module_name}_private.h.
+# - Header files that are modified by this script have also been automatically created by this 
+#   script as a result of adding a module to the SELF_CONTAINED_MODULES list.
+
 # Generate WiredTiger function prototypes.
 import fnmatch, re, os, sys
 from dist import compare_srcfile, format_srcfile, source_files

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1,5 +1,7 @@
 #pragma once
 
+/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
+
 extern WT_DATA_SOURCE *__wt_schema_get_source(WT_SESSION_IMPL *session, const char *name)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern WT_EXT *__wt_block_off_srch_inclusive(WT_EXTLIST *el, wt_off_t off)
@@ -2662,3 +2664,5 @@ extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack
 extern void __ut_chunkcache_bitmap_free(WT_SESSION_IMPL *session, size_t bit_index);
 
 #endif
+
+/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_darwin.h
+++ b/src/include/extern_darwin.h
@@ -1,5 +1,7 @@
 #pragma once
 
+/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
+
 extern int __wt_futex_wait(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WORD expected, time_t usec,
   WT_FUTEX_WORD *wake_valp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_FUTEX_WORD wake_val)
@@ -8,3 +10,5 @@ extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_
 #ifdef HAVE_UNITTEST
 
 #endif
+
+/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_linux.h
+++ b/src/include/extern_linux.h
@@ -1,5 +1,7 @@
 #pragma once
 
+/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
+
 extern int __wt_futex_wait(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WORD expected, time_t usec,
   WT_FUTEX_WORD *wake_valp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_FUTEX_WORD wake_val)
@@ -8,3 +10,5 @@ extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_
 #ifdef HAVE_UNITTEST
 
 #endif
+
+/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_posix.h
+++ b/src/include/extern_posix.h
@@ -1,5 +1,7 @@
 #pragma once
 
+/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
+
 extern bool __wt_absolute_path(const char *path) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_has_priv(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_path_separator(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -71,3 +73,5 @@ extern void __wti_posix_remap_resize_file(WT_FILE_HANDLE *file_handle, WT_SESSIO
 #ifdef HAVE_UNITTEST
 
 #endif
+
+/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_win.h
+++ b/src/include/extern_win.h
@@ -1,5 +1,7 @@
 #pragma once
 
+/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
+
 extern DWORD __wt_getlasterror(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_absolute_path(const char *path) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_has_priv(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -69,3 +71,5 @@ extern void __wt_yield_no_barrier(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("
 #ifdef HAVE_UNITTEST
 
 #endif
+
+/* DO NOT EDIT: automatically built by prototypes.py: END */


### PR DESCRIPTION
Update the `prototypes.py` script to create dedicated `*.h` and `*_private.h` header files in each component folder.
Previously all function prototypes were defined in `extern.h`. This script allows modules to define all the functions owned by the module in headers inside that module.

The files also support adding content manually. Only code between the `DO NOT EDIT` flags will be automatically updated. this allows developers to place other items (macros, structs) inside the files.

This PR only introduces the changes to allow creation of these files on a per-module basis. Future tickets will enable it for modules by adding them to the `MODULARISED_COMPONENTS` field.