### PR TITLE
WT-13560 Deprecate SSH Cloning of Git repositories

### DIFF
--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -21,7 +21,7 @@ We also suggest <a href="https://ninja-build.org/">Ninja</a> and
 First, clone the repository:
 
 @code
-git clone git://github.com/wiredtiger/wiredtiger.git
+git clone https://github.com/wiredtiger/wiredtiger.git
 @endcode
 
 Now proceed with @ref posix_building.

--- a/test/compatibility/common/compatibility_common.py
+++ b/test/compatibility/common/compatibility_common.py
@@ -121,7 +121,7 @@ def prepare_branch(branch, config):
             print(f'Branch {branch} is already cloned')
             system(f'git -C "{path}" pull')
         else:
-            source = 'git@github.com:wiredtiger/wiredtiger.git'
+            source = 'https://github.com:wiredtiger/wiredtiger.git'
             print(f'Cloning branch {branch}')
             system(f'git clone "{source}" "{path}" -b {branch}')
 

--- a/test/compatibility/common/compatibility_common.py
+++ b/test/compatibility/common/compatibility_common.py
@@ -121,7 +121,7 @@ def prepare_branch(branch, config):
             print(f'Branch {branch} is already cloned')
             system(f'git -C "{path}" pull')
         else:
-            source = 'https://github.com:wiredtiger/wiredtiger.git'
+            source = 'https://github.com/wiredtiger/wiredtiger.git'
             print(f'Cloning branch {branch}')
             system(f'git clone "{source}" "{path}" -b {branch}')
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2782,6 +2782,7 @@ tasks:
       - func: "compile wiredtiger docs"
 
   - name: doc-update
+    patchable: false
     stepback: false
     commands:
       - func: "get project"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -145,7 +145,6 @@ functions:
       script: |
         set -o errexit
         set -o verbose
-        echo "generated_token: ${generated_token}"
         if ! [ -d "./automation-scripts" ]; then
           git clone https://x-access-token:${generated_token}@github.com/wiredtiger/automation-scripts.git
         fi

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -128,6 +128,15 @@ functions:
     type: setup
     params:
       directory: wiredtiger
+  "generate github token": &gen_github_token
+    command: github.generate_token
+    params:
+      owner: wiredtiger
+      repo: automation-scripts
+      expansion_name: generated_token
+      permissions:
+          metadata: read
+          contents: read
   "get automation-scripts": &get_automation_scripts
     command: shell.exec
     type: setup
@@ -136,8 +145,9 @@ functions:
       script: |
         set -o errexit
         set -o verbose
+        echo "generated_token: ${generated_token}"
         if ! [ -d "./automation-scripts" ]; then
-          git clone git@github.com:wiredtiger/automation-scripts.git
+          git clone https://x-access-token:${generated_token}@github.com:wiredtiger/automation-scripts.git
         fi
   "fetch artifacts": &fetch_artifacts
     command: s3.get
@@ -369,6 +379,7 @@ functions:
         fi
         echo "Ending 'make wiredtiger' step"
   "compile wiredtiger":
+    - *gen_github_token
     - *get_automation_scripts
     - *configure_wiredtiger
     - *make_wiredtiger
@@ -1127,6 +1138,7 @@ functions:
           ${python_binary|python3} wiredtiger/bench/perf_run_py/perf_json_converter_for_atlas_evergreen.py -i ${input_file} -n ${test_name} -o ${output_path}
 
   "upload stats to atlas":
+    - *gen_github_token
     - *get_automation_scripts
     - command: shell.exec
       params:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -147,7 +147,7 @@ functions:
         set -o verbose
         echo "generated_token: ${generated_token}"
         if ! [ -d "./automation-scripts" ]; then
-          git clone https://x-access-token:${generated_token}@github.com:wiredtiger/automation-scripts.git
+          git clone https://x-access-token:${generated_token}@github.com/wiredtiger/automation-scripts.git
         fi
   "fetch artifacts": &fetch_artifacts
     command: s3.get
@@ -555,7 +555,7 @@ functions:
             exit 0
           fi
 
-          git clone git@github.com:wiredtiger/wiredtiger.github.com.git
+          git clone https://github.com/wiredtiger/wiredtiger.github.com.git
           cd wiredtiger.github.com
 
           # Branches to update are defined through an expansion variable.
@@ -2731,6 +2731,7 @@ tasks:
   - name: configure-combinations
     commands:
       - func: "get project"
+      - func: "generate github token"
       - func: "get automation-scripts"
       - command: shell.exec
         params:
@@ -2781,7 +2782,6 @@ tasks:
       - func: "compile wiredtiger docs"
 
   - name: doc-update
-    patchable: false
     stepback: false
     commands:
       - func: "get project"
@@ -3209,6 +3209,7 @@ tasks:
   - name: long-test
     commands:
       - func: "get project"
+      - func: "generate github token"
       - func: "get automation-scripts"
       - func: "configure wiredtiger"
       - func: "make wiredtiger"

--- a/test/multiversion/wt_multiversion.sh
+++ b/test/multiversion/wt_multiversion.sh
@@ -5,7 +5,7 @@ last_stable_dir=wiredtiger_${last_stable}/
 last_stable_branch=mongodb-${last_stable}
 
 function setup_last_stable {
-    git clone https://github.com:wiredtiger/wiredtiger.git ${last_stable_dir}
+    git clone https://github.com/wiredtiger/wiredtiger.git ${last_stable_dir}
     cd ${last_stable_dir}/build_posix/ || exit
     git checkout $last_stable_branch || exit 1
     bash reconf

--- a/test/multiversion/wt_multiversion.sh
+++ b/test/multiversion/wt_multiversion.sh
@@ -5,7 +5,7 @@ last_stable_dir=wiredtiger_${last_stable}/
 last_stable_branch=mongodb-${last_stable}
 
 function setup_last_stable {
-    git clone git@github.com:wiredtiger/wiredtiger.git ${last_stable_dir}
+    git clone https://github.com:wiredtiger/wiredtiger.git ${last_stable_dir}
     cd ${last_stable_dir}/build_posix/ || exit
     git checkout $last_stable_branch || exit 1
     bash reconf


### PR DESCRIPTION
Replace the existing SSH clones (i.e. git clone git@//github.com/<org>/<repo>) with either HTTP clones or the `github.generate_token` Evergreen project command, to support the deprecation of SSH cloning in Evergreen.

Please note the change will need to be backported to all supported release branches.