### PR TITLE
Revert "WT-13563 Modify dist/prototypes.py to split public and private functions into separate headers"

### DIFF
--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -1,43 +1,9 @@
 #!/usr/bin/env python3
 
-# This script parses the WiredTiger code base to find all function definitions and automatically 
-# generates their declarations. Declarations are added to src/include/extern.h by default, or to 
-# module-specific header files if the module is added to the SELF_CONTAINED_MODULES list
-
-# Attention! This script makes the following assumptions about the WiredTiger code directory:
-# - All module-related files should reside in a single src/module/ folder as a result of adding 
-#   a module to SELF_CONTAINED_MODULES
-# - Header files are named using the format {folder_name/module_name}.h or 
-#   {folder_name/module_name}_private.h.
-# - Header files that are modified by this script have also been automatically created by this 
-#   script as a result of adding a module to the SELF_CONTAINED_MODULES list.
-
 # Generate WiredTiger function prototypes.
 import fnmatch, re, os, sys
 from dist import compare_srcfile, format_srcfile, source_files
 from common_functions import filter_if_fast
-
-from collections import defaultdict
-
-# This is the list of modules that have their respective headers located in the src/module/ folder 
-# instead of in src/include/. As a result all relevant code is contained to a single folder. 
-# Adding modules to this list will automatically generate those headers, and we expect this list to 
-# grow as we modularise the code base.
-SELF_CONTAINED_MODULES = []
-
-DO_NOT_EDIT_BEGIN = "/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */\n"
-DO_NOT_EDIT_END = "/* DO NOT EDIT: automatically built by prototypes.py: END */\n"
-
-COPYRIGHT = """\
-/*-
- * Copyright (c) 2014-present MongoDB, Inc.
- * Copyright (c) 2008-2014 WiredTiger, Inc.
- * All rights reserved.
- *
- * See the file LICENSE for redistribution information.
- */
-
-"""
 
 if not [f for f in filter_if_fast(source_files(), prefix="../")]:
     sys.exit(0)
@@ -87,100 +53,42 @@ def extract_prototypes(filename, regexp):
     return ret
 
 # Build function prototypes from a list of files.
-def fn_prototypes(public_fns, private_fns, tests, name):
+def fn_prototypes(fns, tests, name):
     for sig in extract_prototypes(name, r'\n[A-Za-z_].*\n__wt_[^{]*'):
-        public_fns.append(sig)
+        fns.append(sig)
 
     for sig in extract_prototypes(name, r'\n[A-Za-z_].*\n__wti_[^{]*'):
-        private_fns.append(sig)
+        fns.append(sig)
 
     for sig in extract_prototypes(name, r'\n[A-Za-z_].*\n__ut_[^{]*'):
         tests.append(sig)
 
-# Create a new header file with function declarations.
-# As this is a new file also generate boilerplate like #pragma once
-def create_new_header(tmp_file, fns, tests, private_file=""):
+# Write results and compare to the current file.
+# Unit-testing functions are exposed separately in their own section to
+# allow them to be ifdef'd out.
+def output(fns, tests, f):
+    tmp_file = '__tmp_prototypes' + str(os.getpid())
     tfile = open(tmp_file, 'w')
-    tfile.write(COPYRIGHT)
     tfile.write("#pragma once\n\n")
-
-    if private_file:
-        tfile.write(f"#include \"{private_file}\"\n\n")
-
-    tfile.write(f"{DO_NOT_EDIT_BEGIN}\n")
-
     for e in sorted(list(set(fns))):
         tfile.write(e)
 
     tfile.write('\n#ifdef HAVE_UNITTEST\n')
     for e in sorted(list(set(tests))):
         tfile.write(e)
-
     tfile.write('\n#endif\n')
-    tfile.write(f"\n\n{DO_NOT_EDIT_END}")
+
     tfile.close()
-
-# Update an existing header file with function declarations.
-# As this file already exists only modify content between the DO NOT EDIT flags.
-def update_existing_header(tmp_file, fns, tests, f):
-    with open(f, 'r') as file:
-        lines = file.readlines()
-
-    if DO_NOT_EDIT_BEGIN not in lines or DO_NOT_EDIT_END not in lines:
-        print(f"Error: File {f} is missing the lines \n{DO_NOT_EDIT_BEGIN} and \
-              \n{DO_NOT_EDIT_END} required by prototypes.py. Both lines must \
-              be followed by a newline")
-        sys.exit(1)
-
-    start_line = lines.index(DO_NOT_EDIT_BEGIN)
-    end_line = lines.index(DO_NOT_EDIT_END)
-
-
-    # Content before the starting DO NOT EDIT is kept unchanged.
-    new_lines = lines[:start_line + 1]
-    new_lines.append("\n") # maintain the new line after START
-
-    # Replace the function prototypes between the DO NOT EDIT FLAGS
-    for e in sorted(list(set(fns))):
-        new_lines.append(e)
-
-    new_lines.append('\n#ifdef HAVE_UNITTEST\n')
-    for e in sorted(list(set(tests))):
-        new_lines.append(e)
-
-    new_lines.append('\n#endif\n')
-
-    # Finally, retain all content after the end DO NOT EDIT flag
-    new_lines.append("\n") # maintain the new line before END
-    new_lines.extend(lines[end_line:])
-
-    with open(tmp_file, 'w') as file:
-        file.writelines(new_lines)
-
-# Write results and compare to the current file.
-# Unit-testing functions are exposed separately in their own section to
-# allow them to be ifdef'd out.
-def output(fns, tests, f, private_file=""):
-    tmp_file = '__tmp_prototypes' + str(os.getpid())
-
-    if not os.path.isfile(f):
-        create_new_header(tmp_file, fns, tests, private_file)
-    else:
-        update_existing_header(tmp_file, fns, tests, f)
-
     format_srcfile(tmp_file)
     compare_srcfile(tmp_file, f)
 
-# Build a mapping from a module to its public functions, private functions, 
-# and HAVE_UNITTEST functions.
-def build_module_functions_dicts():
-    public_fns_dict = defaultdict(list)
-    private_fns_dict = defaultdict(list)
-    tests_dict = defaultdict(list)
-    
+# Update generic function prototypes.
+def prototypes_extern():
+    fns = []
+    tests = []
     for name in source_files():
         if not fnmatch.fnmatch(name, '*.c') + fnmatch.fnmatch(name, '*_inline.h'):
-            continue
+            continue;
         if fnmatch.fnmatch(name, '*/checksum/arm64/*'):
             continue
         if fnmatch.fnmatch(name, '*/checksum/loongarch64/*'):
@@ -196,42 +104,9 @@ def build_module_functions_dicts():
             continue
         if fnmatch.fnmatch(name, '*/ext/*'):
             continue
+        fn_prototypes(fns, tests, name)
 
-        if fnmatch.fnmatch(name, '../src/*'):
-            module_name = name.split("/")[2]
-            if module_name not in SELF_CONTAINED_MODULES:
-                # Non-self-contained modules put all their function prototypes in 
-                # src/include/extern.h This is indicated by belonging to the include folder.
-                fn_prototypes(public_fns_dict["include"], private_fns_dict["include"], 
-                    tests_dict["include"], name)
-            else:
-                fn_prototypes(public_fns_dict[module_name], private_fns_dict[module_name], 
-                    tests_dict[module_name], name)
-        else:
-            print(f"Unexpected filepath {name}")
-            sys.exit(1)
-
-    return (public_fns_dict, private_fns_dict, tests_dict)
-
-# Given a list of dicts that map a module to their public, private, and HAVE_UNITTEST functions, 
-# write their header files with function declarations.
-def write_header_files(public_fns_dict, private_fns_dict, tests_dict):
-    # Trust that the public functions dict lists all modules. 
-    # If a module doesn't have a public function then it can't be accessed and is dead code.
-    modules = public_fns_dict.keys()
-    for mod in modules:
-        if mod == "include":
-            # Functions defined in the include folder belong in extern.h
-            output(public_fns_dict[mod] + private_fns_dict[mod], tests_dict[mod], 
-                f"../src/include/extern.h")
-        else:
-            output(public_fns_dict[mod], tests_dict[mod], f"../src/{mod}/{mod}.h", 
-                private_file=f"{mod}_private.h")
-            if len(private_fns_dict[mod]) > 0:
-                # The second argument (tests_dict) is empty. These test functions are defined to
-                # expose module internals outside the module, so it doens't make sense for them 
-                # to be private.
-                output(private_fns_dict[mod], {}, f"../src/{mod}/{mod}_private.h")
+    output(fns, tests, "../src/include/extern.h")
 
 def prototypes_os():
     """
@@ -245,27 +120,10 @@ def prototypes_os():
         if m := re.match(r'^.*/os_(posix|win|linux|darwin)/.*', name):
             port = m.group(1)
             assert port in ports
-            # The operating system folders have special handling and write all functions 
-            # into a single extern_*.h file. Save all functions into the same fns list.
-            fn_prototypes(fns[port], fns[port], tests[port], name)
+            fn_prototypes(fns[port], tests[port], name)
 
     for p in ports:
         output(fns[p], tests[p], f"../src/include/extern_{p}.h")
 
-# Newly generated public headers need to be included from wt_internal.h.
-# Add a warning reminding developers to do so.
-def check_wt_internal_includes():
-    with open("../src/include/wt_internal.h", 'r') as file:
-        lines = file.readlines()
-
-        for mod in SELF_CONTAINED_MODULES:
-            include_line = f"#include \"../{mod}/{mod}.h\""
-            if f"{include_line}\n" not in lines:
-                print(f"The line '{include_line}' is missing from wt_internal.h. "
-                      "Please make sure to include it.")
-                exit(1)
-
-(pub_fns_dict, private_fns_dict, tests_dict) = build_module_functions_dicts()
-write_header_files(pub_fns_dict, private_fns_dict, tests_dict)
+prototypes_extern()
 prototypes_os()
-check_wt_internal_includes()

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
-
 extern WT_DATA_SOURCE *__wt_schema_get_source(WT_SESSION_IMPL *session, const char *name)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern WT_EXT *__wt_block_off_srch_inclusive(WT_EXTLIST *el, wt_off_t off)
@@ -2668,5 +2666,3 @@ extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack
 extern void __ut_chunkcache_bitmap_free(WT_SESSION_IMPL *session, size_t bit_index);
 
 #endif
-
-/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_darwin.h
+++ b/src/include/extern_darwin.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
-
 extern int __wt_futex_wait(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WORD expected, time_t usec,
   WT_FUTEX_WORD *wake_valp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_FUTEX_WORD wake_val)
@@ -10,5 +8,3 @@ extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_
 #ifdef HAVE_UNITTEST
 
 #endif
-
-/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_linux.h
+++ b/src/include/extern_linux.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
-
 extern int __wt_futex_wait(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WORD expected, time_t usec,
   WT_FUTEX_WORD *wake_valp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_FUTEX_WORD wake_val)
@@ -10,5 +8,3 @@ extern int __wt_futex_wake(volatile WT_FUTEX_WORD *addr, WT_FUTEX_WAKE wake, WT_
 #ifdef HAVE_UNITTEST
 
 #endif
-
-/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_posix.h
+++ b/src/include/extern_posix.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
-
 extern bool __wt_absolute_path(const char *path) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_has_priv(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern const char *__wt_path_separator(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -73,5 +71,3 @@ extern void __wti_posix_remap_resize_file(WT_FILE_HANDLE *file_handle, WT_SESSIO
 #ifdef HAVE_UNITTEST
 
 #endif
-
-/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/include/extern_win.h
+++ b/src/include/extern_win.h
@@ -1,7 +1,5 @@
 #pragma once
 
-/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
-
 extern DWORD __wt_getlasterror(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_absolute_path(const char *path) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_has_priv(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -71,5 +69,3 @@ extern void __wt_yield_no_barrier(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("
 #ifdef HAVE_UNITTEST
 
 #endif
-
-/* DO NOT EDIT: automatically built by prototypes.py: END */


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#11064

I found some more s_all scripts that will need updating to handle the case when this script move headers into a module. Reverting to re-deliver with all required s_all changes in one commit.