### PR TITLE
LABS-1089 Fix SIGSEGV & page ID assert for non-disaggregated objects

### DIFF
--- a/src/block_disagg/block_disagg_mgr.c
+++ b/src/block_disagg/block_disagg_mgr.c
@@ -160,6 +160,8 @@ __wt_block_disagg_manager_owns_object(WT_SESSION_IMPL *session, const char *uri)
      * It's a janky check that should be made better, but assume any handle with a page log belongs
      * to this object-based block manager for now.
      */
+    if (session->dhandle == NULL || S2BT(session) == NULL)
+        return (false);
     if (WT_PREFIX_MATCH(uri, "file:") && (S2BT(session)->page_log != NULL))
         return (true);
     return (false);

--- a/src/block_pantry/block_mgr.c
+++ b/src/block_pantry/block_mgr.c
@@ -160,7 +160,9 @@ __wt_block_pantry_manager_owns_object(WT_SESSION_IMPL *session, const char *uri)
      * It's a janky check that should be made better, but assume any handle with a custom storage
      * source that isn't a tiered table belongs to this object-based block manager for now.
      */
-    if (WT_PREFIX_MATCH(uri, "file:") && ((WT_BTREE *)session->dhandle->handle)->bstorage != NULL)
+    if (session->dhandle == NULL || S2BT(session) == NULL)
+        return (false);
+    if (WT_PREFIX_MATCH(uri, "file:") && S2BT(session)->bstorage != NULL)
         return (true);
     return (false);
 }

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -506,6 +506,11 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     /* A page log service and a storage source cannot both be enabled. */
     WT_ASSERT(session, btree->page_log == NULL || btree->bstorage == NULL);
 
+    /* Detect if the btree is disaggregated. */
+    if (__wt_block_disagg_manager_owns_object(session, btree->dhandle->name) ||
+      __wt_block_pantry_manager_owns_object(session, btree->dhandle->name))
+        F_SET(btree, WT_BTREE_DISAGGREGATED);
+
     /* Get the last flush times for tiered storage, if applicable. */
     btree->flush_most_recent_secs = 0;
     ret = __wt_config_gets(session, cfg, "flush_time", &cval);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -28,6 +28,8 @@ __wt_page_block_meta_init(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
     btree = S2BT(session);
 
     memset(meta, 0, sizeof(*meta));
+    if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+        return;
 
     /*
      * Allocate an interim page ID. If the page is actually being loaded from disk, it's ok to waste

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -278,17 +278,18 @@ struct __wt_btree {
 #define WT_BTREE_ALTER 0x0001000u           /* Handle is for alter */
 #define WT_BTREE_BULK 0x0002000u            /* Bulk-load handle */
 #define WT_BTREE_CLOSED 0x0004000u          /* Handle closed */
-#define WT_BTREE_GARBAGE_COLLECT 0x0008000u /* Content becomes obsolete automatically */
-#define WT_BTREE_IGNORE_CACHE 0x0010000u    /* Cache-resident object */
-#define WT_BTREE_IN_MEMORY 0x0020000u       /* Cache-resident object */
-#define WT_BTREE_LOGGED 0x0040000u          /* Commit-level durability without timestamps */
-#define WT_BTREE_NO_CHECKPOINT 0x0080000u   /* Disable checkpoints */
-#define WT_BTREE_OBSOLETE_PAGES 0x0100000u  /* Handle has obsolete pages */
-#define WT_BTREE_READONLY 0x0200000u        /* Handle is readonly */
-#define WT_BTREE_SALVAGE 0x0400000u         /* Handle is for salvage */
-#define WT_BTREE_SKIP_CKPT 0x0800000u       /* Handle skipped checkpoint */
-#define WT_BTREE_UPGRADE 0x1000000u         /* Handle is for upgrade */
-#define WT_BTREE_VERIFY 0x2000000u          /* Handle is for verify */
+#define WT_BTREE_DISAGGREGATED 0x0008000u   /* In disaggregated storage */
+#define WT_BTREE_GARBAGE_COLLECT 0x0010000u /* Content becomes obsolete automatically */
+#define WT_BTREE_IGNORE_CACHE 0x0020000u    /* Cache-resident object */
+#define WT_BTREE_IN_MEMORY 0x0040000u       /* Cache-resident object */
+#define WT_BTREE_LOGGED 0x0080000u          /* Commit-level durability without timestamps */
+#define WT_BTREE_NO_CHECKPOINT 0x0100000u   /* Disable checkpoints */
+#define WT_BTREE_OBSOLETE_PAGES 0x0200000u  /* Handle has obsolete pages */
+#define WT_BTREE_READONLY 0x0400000u        /* Handle is readonly */
+#define WT_BTREE_SALVAGE 0x0800000u         /* Handle is for salvage */
+#define WT_BTREE_SKIP_CKPT 0x1000000u       /* Handle skipped checkpoint */
+#define WT_BTREE_UPGRADE 0x2000000u         /* Handle is for upgrade */
+#define WT_BTREE_VERIFY 0x4000000u          /* Handle is for verify */
                                             /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t flags;
 };


### PR DESCRIPTION
Using non-disaggregated objects can currently fail due to:
* The `btree` or the `btree` dhandle being NULL when detecting whether the object is disaggregated.
* The assertion that checks whether page IDs are set is triggered for non-disaggregated objects.