### PR TITLE
LABS-1090 Fix test_alter02 failures

### DIFF
--- a/test/suite/test_alter02.py
+++ b/test/suite/test_alter02.py
@@ -96,6 +96,13 @@ class test_alter02(TieredConfigMixin, wttest.WiredTigerTestCase):
         if metastr == '':
             return
         cursor = self.session.open_cursor('metadata:', None, None)
+
+        # If the metadata string is something like 'log=(enabled=true)', also check for
+        # 'log=(enabled=true,'. We need this if 'log' in the table's metadata has other fields.
+        metastr_alt = metastr
+        if metastr_alt.endswith(')'):
+            metastr_alt = metastr_alt[:-1] + ','
+
         #
         # Walk through all the metadata looking for the entries that are
         # the file URIs for components of the table.
@@ -111,7 +118,7 @@ class test_alter02(TieredConfigMixin, wttest.WiredTigerTestCase):
             if check_meta:
                 value = cursor[key]
                 found = True
-                self.assertTrue(value.find(metastr) != -1)
+                self.assertTrue(value.find(metastr) != -1 or value.find(metastr_alt) != -1)
         cursor.close()
         self.assertTrue(found == True)
 


### PR DESCRIPTION
Fix the `test_alter02` failures. This is an issue with the test, which assumes that table metadata would contain strings such as `log=(enabled=true)`, but since the introduction of `log.oligarch_constituent`, the table metadata instead contain strings such as `log=(enabled=true,oligarch_constituent=false)`.