### PR TITLE
WT-13234 Read pages with obsolete time window from disk (v8.0) (#10896)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1064,6 +1064,7 @@ conn_dsrc_stats = [
     ##########################################
     CheckpointStat('checkpoint_cleanup_pages_evict', 'pages added for eviction during checkpoint cleanup'),
     CheckpointStat('checkpoint_cleanup_pages_obsolete_tw', 'pages dirtied due to obsolete time window by checkpoint cleanup'),
+    CheckpointStat('checkpoint_cleanup_pages_read_obsolete_tw', 'pages read into cache during checkpoint cleanup due to obsolete time window'),
     CheckpointStat('checkpoint_cleanup_pages_read_reclaim_space', 'pages read into cache during checkpoint cleanup (reclaim_space)'),
     CheckpointStat('checkpoint_cleanup_pages_removed', 'pages removed during checkpoint cleanup'),
     CheckpointStat('checkpoint_cleanup_pages_visited', 'pages visited during checkpoint cleanup'),

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -12,6 +12,63 @@
 #define WT_URI_FILE_PREFIX "file:"
 
 /*
+ * __sync_obsolete_limit_reached --
+ *     This function checks whether checkpoint cleanup can continue operating on the obsolete time
+ *     window pages.
+ */
+static bool
+__sync_obsolete_limit_reached(WT_SESSION_IMPL *session)
+{
+    WT_BTREE *btree;
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+    btree = S2BT(session);
+
+    /* Check current progress against max. */
+    if (__wt_atomic_load32(&btree->checkpoint_cleanup_obsolete_tw_pages) >=
+      conn->heuristic_controls.checkpoint_cleanup_obsolete_tw_pages_dirty_max)
+        return (true);
+
+    /*
+     * If the current btree has not contributed to the cleanup yet, only process it if we can track
+     * another btree.
+     */
+    if (__wt_atomic_load32(&btree->eviction_obsolete_tw_pages) == 0 &&
+      __wt_atomic_load32(&btree->checkpoint_cleanup_obsolete_tw_pages) == 0 &&
+      __wt_atomic_load32(&conn->heuristic_controls.obsolete_tw_btree_count) >=
+        conn->heuristic_controls.obsolete_tw_btree_max)
+        return (true);
+
+    return (false);
+}
+
+/*
+ * __sync_obsolete_tw_check --
+ *     This function checks whether the given time aggregate refers to a globally visible time
+ *     window and if checkpoint cleanup can process it. Note that time aggregates corresponding to
+ *     fully deleted pages are not considered.
+ */
+static bool
+__sync_obsolete_tw_check(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE ta)
+{
+    /* Don't process fully deleted pages. */
+    if (WT_TIME_AGGREGATE_HAS_STOP(&ta))
+        return (false);
+
+    /* Limit the activity to reduce the load. */
+    if (__sync_obsolete_limit_reached(session))
+        return (false);
+
+    /* Ensure there is globally visible content. */
+    if (!__wt_txn_has_newest_and_visible_all(
+          session, ta.newest_txn, WT_MAX(ta.newest_start_durable_ts, ta.newest_stop_durable_ts)))
+        return (false);
+
+    return (true);
+}
+
+/*
  * __sync_obsolete_inmem_evict_or_mark_dirty --
  *     This function checks whether the in-memory ref contains obsolete information and takes
  *     necessary action.
@@ -109,46 +166,29 @@ __sync_obsolete_inmem_evict_or_mark_dirty(WT_SESSION_IMPL *session, WT_REF *ref)
         /* Mark the obsolete page to evict soon. */
         __wt_page_evict_soon(session, ref);
         WT_STAT_CONN_DATA_INCR(session, checkpoint_cleanup_pages_evict);
-    } else if (!has_stop) {
+    } else if (__sync_obsolete_tw_check(session, newest_ta)) {
+
         /*
-         * Limit the number of obsolete time window pages that are marked as dirty to reduce the
-         * load.
+         * Dirty the page with an obsolete time window to let the page reconciliation remove all the
+         * obsolete time window information.
          */
-        if (__wt_atomic_load32(&btree->checkpoint_cleanup_obsolete_tw_pages) >=
-          conn->heuristic_controls.checkpoint_cleanup_obsolete_tw_pages_dirty_max)
-            return (0);
+        __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
+          "%p in-memory page %s obsolete time window: time aggregate %s", (void *)ref, tag,
+          __wt_time_aggregate_to_string(&newest_ta, time_string));
 
-        /* Limit the number of btrees that can be cleaned up. */
+        WT_RET(__wt_page_modify_init(session, ref->page));
+        __wt_page_modify_set(session, ref->page);
+
+        /*
+         * Save that another tree has been processed if that's the first time it gets cleaned and
+         * update the number of pages made dirty for that tree.
+         */
         if (__wt_atomic_load32(&btree->eviction_obsolete_tw_pages) == 0 &&
-          __wt_atomic_load32(&btree->checkpoint_cleanup_obsolete_tw_pages) == 0 &&
-          __wt_atomic_load32(&conn->heuristic_controls.obsolete_tw_btree_count) >=
-            conn->heuristic_controls.obsolete_tw_btree_max)
-            return (0);
+          __wt_atomic_load32(&btree->checkpoint_cleanup_obsolete_tw_pages) == 0)
+            __wt_atomic_addv32(&conn->heuristic_controls.obsolete_tw_btree_count, 1);
 
-        if (__wt_txn_newest_visible_all(session, newest_ta.newest_txn,
-              WT_MAX(newest_ta.newest_start_durable_ts, newest_ta.newest_stop_durable_ts))) {
-            /*
-             * Dirty the page with an obsolete time window to let the page reconciliation remove all
-             * the obsolete time window information.
-             */
-            __wt_verbose(session, WT_VERB_CHECKPOINT_CLEANUP,
-              "%p in-memory page %s obsolete time window: time aggregate %s", (void *)ref, tag,
-              __wt_time_aggregate_to_string(&newest_ta, time_string));
-
-            WT_RET(__wt_page_modify_init(session, ref->page));
-            __wt_page_modify_set(session, ref->page);
-
-            /*
-             * Save that another tree has been processed if that's the first time it gets cleaned
-             * and update the number of pages made dirty for that tree.
-             */
-            if (__wt_atomic_load32(&btree->eviction_obsolete_tw_pages) == 0 &&
-              __wt_atomic_load32(&btree->checkpoint_cleanup_obsolete_tw_pages) == 0)
-                __wt_atomic_addv32(&conn->heuristic_controls.obsolete_tw_btree_count, 1);
-
-            __wt_atomic_addv32(&btree->checkpoint_cleanup_obsolete_tw_pages, 1);
-            WT_STAT_CONN_DATA_INCR(session, checkpoint_cleanup_pages_obsolete_tw);
-        }
+        __wt_atomic_addv32(&btree->checkpoint_cleanup_obsolete_tw_pages, 1);
+        WT_STAT_CONN_DATA_INCR(session, checkpoint_cleanup_pages_obsolete_tw);
     }
 
     return (0);
@@ -392,16 +432,17 @@ __checkpoint_cleanup_page_skip(
     }
 
     /*
-     * The checkpoint cleanup fast deletes the obsolete leaf page by marking it as deleted
-     * in the internal page. To achieve this,
+     * From this point, the page is on disk and checkpoint cleanup should NOT induce a read if at
+     * least of one of the following conditions is met:
      *
-     * 1. Checkpoint has to read all the internal pages that have obsolete leaf pages.
-     *    To limit the reading of number of internal pages, the aggregated stop durable timestamp
-     *    is checked except when the table is logged. Logged tables do not use timestamps.
+     * - The page is a leaf with no overflow items because obsolete leaf pages with overflow
+     * keys/values cannot be fast deleted to free the overflow blocks. The overflow blocks can be
+     * freed during reconciliation after being marked dirty.
      *
-     * 2. Obsolete leaf pages with overflow keys/values cannot be fast deleted to free
-     *    the overflow blocks. Read the page into cache and mark it dirty to remove the
-     *    overflow blocks during reconciliation.
+     * - The page does not have any deletes (checked using the aggregated stop durable timestamp)
+     * AND
+     *  - the checkpoint cleanup is not configured with the reclaim space method OR
+     *  - the table is not logged
      *
      * FIXME: Read internal pages from non-logged tables when the remove/truncate
      * operation is performed using no timestamp.
@@ -414,6 +455,15 @@ __checkpoint_cleanup_page_skip(
           !F_ISSET(S2BT(session), WT_BTREE_LOGGED);
         if (!*skipp)
             WT_STAT_CONN_DATA_INCR(session, checkpoint_cleanup_pages_read_reclaim_space);
+    }
+
+    /*
+     * While we may have decided to skip the page, check if there is obsolete content that can be
+     * cleaned up.
+     */
+    if (*skipp && __sync_obsolete_tw_check(session, addr.ta)) {
+        WT_STAT_CONN_DATA_INCR(session, checkpoint_cleanup_pages_read_obsolete_tw);
+        *skipp = false;
     }
 
     if (*skipp) {
@@ -508,11 +558,11 @@ __checkpoint_cleanup_eligibility(WT_SESSION_IMPL *session, const char *uri, cons
     WT_DECL_RET;
     wt_timestamp_t newest_start_durable_ts, newest_stop_durable_ts;
     size_t addr_size;
-    uint64_t newest_txn;
+    uint64_t newest_txn, write_gen;
 
     newest_start_durable_ts = newest_stop_durable_ts = WT_TS_NONE;
     newest_txn = WT_TXN_NONE;
-    addr_size = 0;
+    addr_size = write_gen = 0;
 
     /* Checkpoint cleanup cannot remove obsolete pages from tiered tables. */
     if (WT_SUFFIX_MATCH(uri, ".wtobj"))
@@ -538,21 +588,25 @@ __checkpoint_cleanup_eligibility(WT_SESSION_IMPL *session, const char *uri, cons
     WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
     __wt_config_subinit(session, &ckptconf, &cval);
     while ((ret = __wt_config_next(&ckptconf, &key, &cval)) == 0) {
-        ret = __wt_config_subgets(session, &cval, "newest_stop_durable_ts", &value);
+        ret = __wt_config_subgets(session, &cval, "addr", &value);
         if (ret == 0)
-            newest_stop_durable_ts = WT_MAX(newest_stop_durable_ts, (wt_timestamp_t)value.val);
+            addr_size = value.len;
         WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "newest_start_durable_ts", &value);
         if (ret == 0)
             newest_start_durable_ts = WT_MAX(newest_start_durable_ts, (wt_timestamp_t)value.val);
         WT_RET_NOTFOUND_OK(ret);
+        ret = __wt_config_subgets(session, &cval, "newest_stop_durable_ts", &value);
+        if (ret == 0)
+            newest_stop_durable_ts = WT_MAX(newest_stop_durable_ts, (wt_timestamp_t)value.val);
+        WT_RET_NOTFOUND_OK(ret);
         ret = __wt_config_subgets(session, &cval, "newest_txn", &value);
         if (ret == 0)
             newest_txn = WT_MAX(newest_txn, (uint64_t)value.val);
         WT_RET_NOTFOUND_OK(ret);
-        ret = __wt_config_subgets(session, &cval, "addr", &value);
+        ret = __wt_config_subgets(session, &cval, "write_gen", &value);
         if (ret == 0)
-            addr_size = value.len;
+            write_gen = WT_MAX(write_gen, (uint64_t)value.val);
         WT_RET_NOTFOUND_OK(ret);
     }
     WT_RET_NOTFOUND_OK(ret);
@@ -566,10 +620,23 @@ __checkpoint_cleanup_eligibility(WT_SESSION_IMPL *session, const char *uri, cons
         return (true);
 
     /*
-     * The checkpoint has some obsolete time window information that is no longer required to exist
-     * in the btree. Remove the obsolete data to reduce the checkpoint size.
+     * We don't want to rely on transaction IDs that come from a previous run because they will be
+     * very likely bigger than the current oldest one as WiredTiger restarts the transaction
+     * counters upon restart. Transaction IDs from a previous run can be detected using the write
+     * generation number.
      */
-    if (__wt_txn_newest_visible_all(
+    if (write_gen < S2C(session)->base_write_gen)
+        newest_txn = WT_TXN_NONE;
+
+    /*
+     * The checkpoint has some obsolete time window information that is no longer required to exist
+     * in the btree. Remove the obsolete data to reduce the checkpoint size. Note the visibility
+     * check is done later on at the page level when walking the tree to find the right page that
+     * has obsolete content.
+     *
+     * FIXME-WT-13321 Rely on the oldest_start_ts rather than the newest_*_ts.
+     */
+    if (__wt_txn_has_newest_and_visible_all(
           session, newest_txn, WT_MAX(newest_start_durable_ts, newest_stop_durable_ts)))
         return (true);
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -770,7 +770,7 @@ __evict_review_obsolete_time_window(WT_SESSION_IMPL *session, WT_REF *ref)
      * Mark the page as dirty to allow the page reconciliation to remove all information related to
      * an obsolete time window.
      */
-    if (__wt_txn_newest_visible_all(session, newest_ta.newest_txn,
+    if (__wt_txn_has_newest_and_visible_all(session, newest_ta.newest_txn,
           WT_MAX(newest_ta.newest_start_durable_ts, newest_ta.newest_stop_durable_ts))) {
         __wt_verbose(session, WT_VERB_EVICT,
           "%p in-memory page obsolete time window: time aggregate %s", (void *)ref,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2145,7 +2145,7 @@ static WT_INLINE bool __wt_spin_owned(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_split_descent_race(WT_SESSION_IMPL *session, WT_REF *ref,
   WT_PAGE_INDEX *saved_pindex) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_txn_newest_visible_all(WT_SESSION_IMPL *session, uint64_t id,
+static WT_INLINE bool __wt_txn_has_newest_and_visible_all(WT_SESSION_IMPL *session, uint64_t id,
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -651,6 +651,7 @@ struct __wt_connection_stats {
     int64_t checkpoint_cleanup_pages_evict;
     int64_t checkpoint_cleanup_pages_obsolete_tw;
     int64_t checkpoint_cleanup_pages_read_reclaim_space;
+    int64_t checkpoint_cleanup_pages_read_obsolete_tw;
     int64_t checkpoint_cleanup_pages_removed;
     int64_t checkpoint_cleanup_pages_walk_skipped;
     int64_t checkpoint_cleanup_pages_visited;
@@ -1225,6 +1226,7 @@ struct __wt_dsrc_stats {
     int64_t checkpoint_cleanup_pages_evict;
     int64_t checkpoint_cleanup_pages_obsolete_tw;
     int64_t checkpoint_cleanup_pages_read_reclaim_space;
+    int64_t checkpoint_cleanup_pages_read_obsolete_tw;
     int64_t checkpoint_cleanup_pages_removed;
     int64_t checkpoint_cleanup_pages_walk_skipped;
     int64_t checkpoint_cleanup_pages_visited;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -777,11 +777,12 @@ __wt_txn_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t times
 }
 
 /*
- * __wt_txn_newest_visible_all --
- *     Check whether a given newest time window is globally visible.
+ * __wt_txn_has_newest_and_visible_all --
+ *     Check whether a given time window is either globally visible or obsolete. Note that both the
+ *     id and the timestamp have to be greater than 0 to be considered.
  */
 static WT_INLINE bool
-__wt_txn_newest_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp)
+__wt_txn_has_newest_and_visible_all(WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp)
 {
     /* If there is no transaction or timestamp information available, there is nothing to do. */
     if (id == WT_TXN_NONE && timestamp == WT_TS_NONE)

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6220,986 +6220,991 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * (reclaim_space)
  */
 #define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1285
+/*!
+ * checkpoint: pages read into cache during checkpoint cleanup due to
+ * obsolete time window
+ */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1286
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1286
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1287
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1287
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1288
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1288
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1289
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1289
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1290
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1290
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1291
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1291
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1292
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1292
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1293
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1293
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1294
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1294
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1295
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1295
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1296
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1296
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1297
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1297
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1298
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1298
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1299
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1299
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1300
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1300
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1301
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1301
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1302
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1302
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1303
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1303
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1304
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1304
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1305
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1305
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1306
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1306
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1307
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1307
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1308
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1308
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1309
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1309
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1310
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1310
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1311
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1311
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1312
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1312
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1313
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1313
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1314
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1314
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1315
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1315
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1316
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1316
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1317
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1317
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1318
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1318
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1319
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1319
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1320
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1320
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1321
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1321
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1322
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1322
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1323
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1323
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1324
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1324
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1325
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1325
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1326
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1326
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1327
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1327
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1328
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1328
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1329
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1329
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1330
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1330
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1331
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1331
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1332
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1332
+#define	WT_STAT_CONN_TIME_TRAVEL			1333
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1333
+#define	WT_STAT_CONN_FILE_OPEN				1334
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1334
+#define	WT_STAT_CONN_BUCKETS_DH				1335
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1335
+#define	WT_STAT_CONN_BUCKETS				1336
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1336
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1337
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1337
+#define	WT_STAT_CONN_MEMORY_FREE			1338
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1338
+#define	WT_STAT_CONN_MEMORY_GROW			1339
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1339
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1340
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1340
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1341
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1341
+#define	WT_STAT_CONN_COND_WAIT				1342
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1342
+#define	WT_STAT_CONN_RWLOCK_READ			1343
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1343
+#define	WT_STAT_CONN_RWLOCK_WRITE			1344
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1344
+#define	WT_STAT_CONN_FSYNC_IO				1345
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1345
+#define	WT_STAT_CONN_READ_IO				1346
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1346
+#define	WT_STAT_CONN_WRITE_IO				1347
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1347
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1348
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1348
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1349
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1349
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1350
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1350
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1351
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1351
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1352
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1352
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1353
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1353
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1354
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1354
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1355
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1355
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1356
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1356
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1357
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1357
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1358
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1358
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1359
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1359
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1360
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1360
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1361
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1361
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1362
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1362
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1363
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1363
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1364
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1364
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1365
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1365
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1366
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1366
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1367
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1367
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1368
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1368
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1369
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1369
+#define	WT_STAT_CONN_CURSOR_CACHE			1370
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1370
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1371
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1371
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1372
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1372
+#define	WT_STAT_CONN_CURSOR_CREATE			1373
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1373
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1374
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1374
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1375
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1375
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1376
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1376
+#define	WT_STAT_CONN_CURSOR_INSERT			1377
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1377
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1378
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1378
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1379
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1379
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1380
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1380
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1381
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1381
+#define	WT_STAT_CONN_CURSOR_MODIFY			1382
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1382
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1383
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1383
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1384
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1384
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1385
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1385
+#define	WT_STAT_CONN_CURSOR_NEXT			1386
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1386
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1387
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1387
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1388
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1388
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1389
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1389
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1390
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1390
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1391
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1391
+#define	WT_STAT_CONN_CURSOR_RESTART			1392
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1392
+#define	WT_STAT_CONN_CURSOR_PREV			1393
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1393
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1394
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1394
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1395
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1395
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1396
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1396
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1397
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1397
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1398
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1398
+#define	WT_STAT_CONN_CURSOR_REMOVE			1399
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1399
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1400
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1400
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1401
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1401
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1402
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1402
+#define	WT_STAT_CONN_CURSOR_RESERVE			1403
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1403
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1404
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1404
+#define	WT_STAT_CONN_CURSOR_RESET			1405
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1405
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1406
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1406
+#define	WT_STAT_CONN_CURSOR_SEARCH			1407
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1407
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1408
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1408
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1409
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1409
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1410
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1410
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1411
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1411
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1412
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1412
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1413
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1413
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1414
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1414
+#define	WT_STAT_CONN_CURSOR_SWEEP			1415
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1415
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1416
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1416
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1417
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1417
+#define	WT_STAT_CONN_CURSOR_UPDATE			1418
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1418
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1419
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1419
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1420
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1420
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1421
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1421
+#define	WT_STAT_CONN_CURSOR_REOPEN			1422
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1422
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1423
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1423
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1424
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1424
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1425
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1425
+#define	WT_STAT_CONN_DH_SWEEP_REF			1426
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1426
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1427
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1427
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1428
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1428
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1429
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1429
+#define	WT_STAT_CONN_DH_SWEEPS				1430
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1430
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1431
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1431
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1432
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1432
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1433
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1433
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1434
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1434
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1435
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1435
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1436
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1436
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1437
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1437
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1438
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1438
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1439
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1439
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1440
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1440
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1441
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1441
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1442
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1442
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1443
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1443
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1444
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1444
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1445
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1445
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1446
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1446
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1447
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1447
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1448
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1448
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1449
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1449
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1450
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1450
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1451
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1451
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1452
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1452
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1453
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1453
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1454
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1454
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1455
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1455
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1456
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1456
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1457
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1457
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1458
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1458
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1459
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1459
+#define	WT_STAT_CONN_LOG_FLUSH				1460
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1460
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1461
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1461
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1462
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1462
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1463
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1463
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1464
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1464
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1465
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1465
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1466
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1466
+#define	WT_STAT_CONN_LOG_SCANS				1467
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1467
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1468
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1468
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1469
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1469
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1470
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1470
+#define	WT_STAT_CONN_LOG_SYNC				1471
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1471
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1472
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1472
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1473
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1473
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1474
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1474
+#define	WT_STAT_CONN_LOG_WRITES				1475
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1475
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1476
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1476
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1477
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1477
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1478
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1478
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1479
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1479
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1480
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1480
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1481
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1481
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1482
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1482
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1483
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1483
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1484
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1484
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1485
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1485
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1486
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1486
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1487
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1487
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1488
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1488
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1489
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1489
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1490
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1490
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1491
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1491
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1492
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1492
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1493
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1493
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1494
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1494
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1495
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1495
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1496
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1496
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1497
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1497
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1498
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1498
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1499
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1499
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1500
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1500
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1501
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1501
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1502
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1502
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1503
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1503
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1504
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1504
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1505
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1505
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1506
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1506
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1507
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1507
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1508
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1508
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1509
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1509
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1510
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1510
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1511
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1511
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1512
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1512
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1513
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1513
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1514
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1514
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1515
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1515
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1516
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1516
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1517
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1517
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1518
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1518
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1519
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1519
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1520
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1520
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1521
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1521
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1522
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1522
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1523
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1523
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1524
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1524
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1525
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1525
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1526
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1526
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1527
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1527
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1528
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1528
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1529
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1529
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1530
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1530
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1531
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1531
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1532
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1532
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1533
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1533
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1534
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1534
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1535
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1535
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1536
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1536
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1537
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1537
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1538
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1538
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1539
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1539
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1540
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1540
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1541
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1541
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1542
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1542
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1543
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1543
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1544
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1544
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1545
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1545
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1546
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1546
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1547
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1547
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1548
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1548
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1549
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1549
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1550
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1550
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1551
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1551
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1552
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1552
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1553
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1553
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1554
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1554
+#define	WT_STAT_CONN_REC_PAGES				1555
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1555
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1556
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1556
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1557
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1557
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1558
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1558
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1559
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1559
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1560
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1560
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1561
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1561
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1562
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1562
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1563
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1563
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1564
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1564
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1565
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1565
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1566
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1566
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1567
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1567
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1568
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1568
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1569
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1569
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1570
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1570
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1571
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1571
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1572
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1572
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1573
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1573
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1574
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1574
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1575
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1575
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1576
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1576
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1577
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1577
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1578
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1578
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1579
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1579
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1580
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1580
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1581
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1581
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1582
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1582
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1583
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1583
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1584
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1584
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1585
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1585
+#define	WT_STAT_CONN_FLUSH_TIER				1586
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1586
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1587
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1587
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1588
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1588
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1589
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1589
+#define	WT_STAT_CONN_SESSION_OPEN			1590
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1590
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1591
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1591
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1592
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1592
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1593
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1593
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1594
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1594
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1595
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1595
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1596
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1596
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1597
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1597
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1598
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1598
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1599
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1599
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1600
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1600
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1601
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1601
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1602
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1602
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1603
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1603
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1604
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1604
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1605
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1605
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1606
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1606
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1607
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1607
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1608
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1608
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1609
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1609
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1610
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1610
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1611
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1611
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1612
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1612
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1613
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1613
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1614
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1614
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1615
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1615
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1616
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1616
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1617
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1617
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1618
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1618
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1619
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1619
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1620
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1620
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1621
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1621
+#define	WT_STAT_CONN_TIERED_RETENTION			1622
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1622
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1623
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1623
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1624
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1624
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1625
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1625
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1626
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1626
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1627
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1627
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1628
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1628
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1629
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1629
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1630
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1630
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1631
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1631
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1632
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1632
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1633
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1633
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1634
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1634
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1635
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1635
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1636
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1636
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1637
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1637
+#define	WT_STAT_CONN_PAGE_SLEEP				1638
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1638
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1639
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1639
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1640
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1640
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1641
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1641
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1642
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1642
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1643
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1643
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1644
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1644
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1645
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1645
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1646
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1646
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1647
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1647
+#define	WT_STAT_CONN_TXN_PREPARE			1648
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1648
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1649
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1649
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1650
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1650
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1651
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1651
+#define	WT_STAT_CONN_TXN_QUERY_TS			1652
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1652
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1653
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1653
+#define	WT_STAT_CONN_TXN_RTS				1654
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1654
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1655
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1655
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1656
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1656
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1657
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1657
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1658
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1658
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1659
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1659
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1660
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1660
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1661
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1661
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1662
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1662
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1663
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1663
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1664
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1664
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1665
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1665
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1666
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1666
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1667
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1667
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1668
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1668
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1669
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1669
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1670
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1670
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1671
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1671
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1672
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1672
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1673
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1673
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1674
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1674
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1675
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1675
+#define	WT_STAT_CONN_TXN_SET_TS				1676
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1676
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1677
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1677
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1678
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1678
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1679
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1679
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1680
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1680
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1681
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1681
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1682
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1682
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1683
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1683
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1684
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1684
+#define	WT_STAT_CONN_TXN_BEGIN				1685
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1685
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1686
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1686
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1687
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1687
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1688
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1688
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1689
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1689
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1690
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1690
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1691
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1691
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1692
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1692
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1693
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1693
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1694
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1694
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1695
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1695
+#define	WT_STAT_CONN_TXN_COMMIT				1696
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1696
+#define	WT_STAT_CONN_TXN_ROLLBACK			1697
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1697
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1698
 
 /*!
  * @}
@@ -7696,444 +7701,449 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * (reclaim_space)
  */
 #define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2154
+/*!
+ * checkpoint: pages read into cache during checkpoint cleanup due to
+ * obsolete time window
+ */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2155
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2155
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2156
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2156
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2157
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2157
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2158
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_CHECKPOINT_OBSOLETE_APPLIED	2158
+#define	WT_STAT_DSRC_CHECKPOINT_OBSOLETE_APPLIED	2159
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2159
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2160
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2160
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2161
 /*! compression: page written to disk failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2161
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2162
 /*! compression: page written to disk was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2162
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2163
 /*! compression: pages read from disk */
-#define	WT_STAT_DSRC_COMPRESS_READ			2163
+#define	WT_STAT_DSRC_COMPRESS_READ			2164
 /*!
  * compression: pages read from disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2164
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2165
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2165
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2166
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2166
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2167
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2167
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2168
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2168
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2169
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2169
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2170
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2170
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2171
 /*! compression: pages written to disk */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2171
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2172
 /*!
  * compression: pages written to disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2172
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2173
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2173
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2174
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2174
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2175
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2175
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2176
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2176
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2177
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2177
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2178
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2178
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2179
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2179
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2180
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2180
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2181
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2181
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2182
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2182
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2183
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2183
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2184
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2184
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2185
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2185
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2186
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2186
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2187
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2187
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2188
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2188
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2189
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2189
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2190
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2190
+#define	WT_STAT_DSRC_CURSOR_CACHE			2191
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2191
+#define	WT_STAT_DSRC_CURSOR_CREATE			2192
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2192
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2193
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2193
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2194
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2194
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2195
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2195
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2196
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2196
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2197
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2197
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2198
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2198
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2199
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2199
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2200
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2200
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2201
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2201
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2202
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2202
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2203
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2203
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2204
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2204
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2205
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2205
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2206
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2206
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2207
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2207
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2208
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2208
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2209
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2209
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2210
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2210
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2211
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2211
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2212
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2212
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2213
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2213
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2214
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2214
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2215
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2215
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2216
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2216
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2217
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2217
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2218
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2218
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2219
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2219
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2220
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2220
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2221
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2221
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2222
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2222
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2223
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2223
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2224
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2224
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2225
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2225
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2226
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2226
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2227
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2227
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2228
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2228
+#define	WT_STAT_DSRC_CURSOR_INSERT			2229
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2229
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2230
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2230
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2231
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2231
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2232
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2232
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2233
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2233
+#define	WT_STAT_DSRC_CURSOR_NEXT			2234
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2234
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2235
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2235
+#define	WT_STAT_DSRC_CURSOR_RESTART			2236
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2236
+#define	WT_STAT_DSRC_CURSOR_PREV			2237
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2237
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2238
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2238
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2239
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2239
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2240
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2240
+#define	WT_STAT_DSRC_CURSOR_RESET			2241
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2241
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2242
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2242
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2243
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2243
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2244
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2244
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2245
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2245
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2246
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2246
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2247
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2247
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2248
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2248
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2249
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2249
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2250
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2250
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2251
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2251
+#define	WT_STAT_DSRC_REC_DICTIONARY			2252
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2252
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2253
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2253
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2254
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2254
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2255
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2255
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2256
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2256
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2257
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2257
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2258
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2258
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2259
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2259
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2260
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2260
+#define	WT_STAT_DSRC_REC_PAGES				2261
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2261
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2262
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2262
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2263
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2263
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2264
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2264
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2265
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2265
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2266
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2266
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2267
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2267
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2268
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2268
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2269
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2269
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2270
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2270
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2271
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2271
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2272
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2272
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2273
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2273
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2274
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2274
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2275
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2275
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2276
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2276
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2277
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2277
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2278
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2278
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2279
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2279
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2280
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2280
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2281
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2281
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2282
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2282
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2283
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2283
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2284
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2284
+#define	WT_STAT_DSRC_SESSION_COMPACT			2285
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2285
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2286
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2286
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2287
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2287
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2288
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2288
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2289
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2289
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2290
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2290
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2291
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2291
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2292
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2292
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2293
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2293
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2294
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2294
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2295
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2295
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2296
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2296
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2297
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2297
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2298
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2298
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2299
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2299
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2300
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2300
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2301
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2301
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2302
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2302
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2303
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2303
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2304
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2304
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2305
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -171,6 +171,7 @@ static const char *const __stats_dsrc_desc[] = {
   "checkpoint: pages added for eviction during checkpoint cleanup",
   "checkpoint: pages dirtied due to obsolete time window by checkpoint cleanup",
   "checkpoint: pages read into cache during checkpoint cleanup (reclaim_space)",
+  "checkpoint: pages read into cache during checkpoint cleanup due to obsolete time window",
   "checkpoint: pages removed during checkpoint cleanup",
   "checkpoint: pages skipped during checkpoint cleanup tree walk",
   "checkpoint: pages visited during checkpoint cleanup",
@@ -523,6 +524,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->checkpoint_cleanup_pages_evict = 0;
     stats->checkpoint_cleanup_pages_obsolete_tw = 0;
     stats->checkpoint_cleanup_pages_read_reclaim_space = 0;
+    stats->checkpoint_cleanup_pages_read_obsolete_tw = 0;
     stats->checkpoint_cleanup_pages_removed = 0;
     stats->checkpoint_cleanup_pages_walk_skipped = 0;
     stats->checkpoint_cleanup_pages_visited = 0;
@@ -864,6 +866,8 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->checkpoint_cleanup_pages_obsolete_tw += from->checkpoint_cleanup_pages_obsolete_tw;
     to->checkpoint_cleanup_pages_read_reclaim_space +=
       from->checkpoint_cleanup_pages_read_reclaim_space;
+    to->checkpoint_cleanup_pages_read_obsolete_tw +=
+      from->checkpoint_cleanup_pages_read_obsolete_tw;
     to->checkpoint_cleanup_pages_removed += from->checkpoint_cleanup_pages_removed;
     to->checkpoint_cleanup_pages_walk_skipped += from->checkpoint_cleanup_pages_walk_skipped;
     to->checkpoint_cleanup_pages_visited += from->checkpoint_cleanup_pages_visited;
@@ -1214,6 +1218,8 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
       WT_STAT_READ(from, checkpoint_cleanup_pages_obsolete_tw);
     to->checkpoint_cleanup_pages_read_reclaim_space +=
       WT_STAT_READ(from, checkpoint_cleanup_pages_read_reclaim_space);
+    to->checkpoint_cleanup_pages_read_obsolete_tw +=
+      WT_STAT_READ(from, checkpoint_cleanup_pages_read_obsolete_tw);
     to->checkpoint_cleanup_pages_removed += WT_STAT_READ(from, checkpoint_cleanup_pages_removed);
     to->checkpoint_cleanup_pages_walk_skipped +=
       WT_STAT_READ(from, checkpoint_cleanup_pages_walk_skipped);
@@ -1686,6 +1692,7 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint: pages added for eviction during checkpoint cleanup",
   "checkpoint: pages dirtied due to obsolete time window by checkpoint cleanup",
   "checkpoint: pages read into cache during checkpoint cleanup (reclaim_space)",
+  "checkpoint: pages read into cache during checkpoint cleanup due to obsolete time window",
   "checkpoint: pages removed during checkpoint cleanup",
   "checkpoint: pages skipped during checkpoint cleanup tree walk",
   "checkpoint: pages visited during checkpoint cleanup",
@@ -2434,6 +2441,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->checkpoint_cleanup_pages_evict = 0;
     stats->checkpoint_cleanup_pages_obsolete_tw = 0;
     stats->checkpoint_cleanup_pages_read_reclaim_space = 0;
+    stats->checkpoint_cleanup_pages_read_obsolete_tw = 0;
     stats->checkpoint_cleanup_pages_removed = 0;
     stats->checkpoint_cleanup_pages_walk_skipped = 0;
     stats->checkpoint_cleanup_pages_visited = 0;
@@ -3208,6 +3216,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
       WT_STAT_READ(from, checkpoint_cleanup_pages_obsolete_tw);
     to->checkpoint_cleanup_pages_read_reclaim_space +=
       WT_STAT_READ(from, checkpoint_cleanup_pages_read_reclaim_space);
+    to->checkpoint_cleanup_pages_read_obsolete_tw +=
+      WT_STAT_READ(from, checkpoint_cleanup_pages_read_obsolete_tw);
     to->checkpoint_cleanup_pages_removed += WT_STAT_READ(from, checkpoint_cleanup_pages_removed);
     to->checkpoint_cleanup_pages_walk_skipped +=
       WT_STAT_READ(from, checkpoint_cleanup_pages_walk_skipped);

--- a/test/suite/test_cc09.py
+++ b/test/suite/test_cc09.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from test_cc01 import test_cc_base
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# test_cc09.py
+# Verify checkpoint cleanup reads pages from the disk to remove any obsolete time window information
+# present on the page.
+@wttest.skip_for_hook("tiered", "FIXME-WT-9809 - Checkpoint cleanup does not support tiered tables")
+class test_cc09(test_cc_base):
+    conn_config_common = 'statistics=(all),statistics_log=(json,wait=1,on_close=true),verbose=(checkpoint_cleanup:0)'
+
+    # These settings set a limit to the number of btrees/pages that can be cleaned up per btree per
+    # checkpoint by the checkpoint cleanup thread.
+    conn_config_values = [
+        ('no_btrees', dict(expected_cleanup=False, cc_obsolete_tw_max=0, conn_config=f'{conn_config_common},heuristic_controls=[obsolete_tw_btree_max=0]')),
+        ('no_pages', dict(expected_cleanup=False, cc_obsolete_tw_max=0, conn_config=f'{conn_config_common},heuristic_controls=[checkpoint_cleanup_obsolete_tw_pages_dirty_max=0]')),
+        ('50_pages', dict(expected_cleanup=True, cc_obsolete_tw_max=50, conn_config=f'{conn_config_common},heuristic_controls=[checkpoint_cleanup_obsolete_tw_pages_dirty_max=50]')),
+        ('100_pages', dict(expected_cleanup=True, cc_obsolete_tw_max=100, conn_config=f'{conn_config_common},heuristic_controls=[checkpoint_cleanup_obsolete_tw_pages_dirty_max=100]')),
+        ('500_pages', dict(expected_cleanup=True, cc_obsolete_tw_max=500, conn_config=f'{conn_config_common},heuristic_controls=[checkpoint_cleanup_obsolete_tw_pages_dirty_max=500]')),
+    ]
+
+    # Necessary conditions for checkpoint cleanup to run.
+    cc_scenarios = [
+        ('newest_stop_durable_ts', dict(has_delete=True, bump_oldest_ts=False)),
+        ('obsolete_ts', dict(has_delete=False, bump_oldest_ts=True)),
+        ('none', dict(has_delete=False, bump_oldest_ts=False)),
+    ]
+
+    scenarios = make_scenarios(conn_config_values, cc_scenarios)
+
+    def test_cc09(self):
+        create_params = 'key_format=i,value_format=S'
+        nrows = 100000
+        uri = 'table:cc09'
+        value = 'k' * 1024
+
+        self.session.create(uri, create_params)
+        self.populate(uri, 0, nrows, value)
+
+        # Make all the inserted data stable and checkpoint to make everything clean.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(nrows))
+        self.session.checkpoint()
+
+        # Bump the oldest timestamp to make some of the previously inserted data globally
+        # visible. This makes any time window informaton associated with that data obsolete and
+        # eligible for cleanup.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(2 * nrows // 3))
+
+        # Restart to have everything on disk.
+        self.reopen_conn()
+
+        # Open the table as we need the dhandle to be open for checkpoint cleanup to process the
+        # table.
+        cursor = self.session.open_cursor(uri, None, None)
+
+        if self.has_delete:
+            self.session.begin_transaction()
+            cursor.set_key(1)
+            cursor.remove()
+            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(nrows + 1))
+            self.session.checkpoint()
+
+        if self.bump_oldest_ts:
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(nrows))
+
+        # Force checkpoint cleanup and wait for it to make progress. It should read pages from the
+        # disk to clear the obsolete content if allowed to.
+        self.wait_for_cc_to_run()
+
+        cc_read_stat = self.get_stat(stat.conn.checkpoint_cleanup_pages_read_obsolete_tw)
+        cc_dirty_stat = self.get_stat(stat.conn.checkpoint_cleanup_pages_obsolete_tw)
+
+        # We may be expecting cleanup but we have to be in one of the valid scenarios for checkpoint
+        # cleanup to do something.
+        if self.expected_cleanup and (self.has_delete or self.bump_oldest_ts):
+            assert cc_read_stat > 0, "Checkpoint cleanup did not read anything"
+            assert cc_dirty_stat > 0, "Checkpoint cleanup did not dirty anything"
+            assert cc_dirty_stat <= self.cc_obsolete_tw_max, f"Checkpoint cleanup dirtied too many pages {cc_dirty_stat} (max: {self.cc_obsolete_tw_max})"
+        else:
+            assert cc_read_stat == 0, f"Checkpoint cleanup is not expected to read anything ({cc_read_stat})"
+            assert cc_dirty_stat == 0, f"Checkpoint cleanup is not expected to dirty anything ({cc_dirty_stat})"


### PR DESCRIPTION
The checkpoint cleanup thread can now read pages from disk whenever they contain globally visible content.

(cherry picked from commit c31f5590c121f7991ac30a527dd8587beaea2f57)

