### PR TITLE
LABS-1096 Get most of the existing tiered tests working again

### DIFF
--- a/src/block_cache/block_tier.c
+++ b/src/block_cache/block_tier.c
@@ -92,8 +92,8 @@ __wt_blkcache_tiered_open(
         bstorage = tiered->bstorage;
         WT_WITH_BUCKET_STORAGE(bstorage, session,
           ret = __wt_block_open(session, tmp->mem, objectid, cfg, false, true, true, 0, &block));
-        block->remote = true;
         WT_ERR(ret);
+        block->remote = true;
     }
 
     *blockp = block;

--- a/test/suite/test_tiered16.py
+++ b/test/suite/test_tiered16.py
@@ -47,6 +47,10 @@ class test_tiered16(TieredConfigMixin, wttest.WiredTigerTestCase):
         expect = sorted(expect1)
         self.assertEquals(got, expect)
 
+    # Override the TieredConfigMixin function to ensure that the cache is enabled.
+    def tiered_extension_config(self):
+        return 'cache=1'
+
     def test_remove_shared(self):
         uri_a = "table:tiereda"
 

--- a/test/suite/test_tiered18.py
+++ b/test/suite/test_tiered18.py
@@ -83,7 +83,14 @@ class test_tiered18(wttest.WiredTigerTestCase, TieredConfigMixin):
         c = self.session.open_cursor('metadata:create')
         val = c[uri]
         c.close()
-        self.assertTrue(val_str in val)
+
+        # If the metadata string is something like 'log=(enabled=true)', also check for
+        # 'log=(enabled=true,'. We need this if 'log' in the table's metadata has other fields.
+        val_str_alt = val_str
+        if val_str_alt.endswith(')'):
+            val_str_alt = val_str_alt[:-1] + ','
+
+        self.assertTrue(val_str in val or val_str_alt in val)
 
     # Test calling the create API with shared enabled.
     def test_tiered_shared(self):


### PR DESCRIPTION
A collection of fixes to get most of our existing tiered tests working again. This PR fixes everything except `test_tiered13`, which doesn't work because we no longer print error messages.

Fixes included in the PR:
* Fixed a double-free if `dir_store_ckpt_load_internal` fails.
* Fixed a segfault if `__wt_block_open` fails.
* Don't load object checkpoints if the file is not an object directory (but rather a regular tiered storage object).
* Account for possible additional fields within the `log` configuration struct.
* Set the dir store `cache` setting explicitly if the test depends on it.