### PR TITLE
LABS-1100 Add verbose output for PALM.

### DIFF
--- a/ext/page_log/palm/CMakeLists.txt
+++ b/ext/page_log/palm/CMakeLists.txt
@@ -3,6 +3,7 @@ project(page_log C)
 set(sources
   "palm.c"
   "palm_kv.c"
+  "palm_verbose.c"
   "../../../third_party/openldap_liblmdb/mdb.c"
   "../../../third_party/openldap_liblmdb/midl.c"
 )

--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -39,6 +39,7 @@
 #include "queue.h"
 
 #include "palm_kv.h"
+#include "palm_verbose.h"
 
 #ifndef WT_THOUSAND
 #define WT_THOUSAND 1000
@@ -148,12 +149,6 @@ static int palm_kv_err(PALM *, WT_SESSION *, int, const char *, ...);
 static int palm_add_reference(WT_PAGE_LOG *);
 static int palm_terminate(WT_PAGE_LOG *, WT_SESSION *);
 
-#define VERBOSE_PRINT(palm, ...)          \
-    do {                                  \
-        if ((palm)->verbose > 0)          \
-            fprintf(stderr, __VA_ARGS__); \
-    } while (0);
-
 /*
  * palm_configure
  *     Parse the configuration for the keys we care about.
@@ -260,7 +255,7 @@ palm_delay(PALM *palm)
     if (palm->force_delay != 0 &&
       (palm->object_gets + palm->object_puts) % palm->force_delay == 0) {
         us = palm_compute_delay_us(palm, (uint64_t)palm->delay_ms * WT_THOUSAND);
-        VERBOSE_PRINT(palm,
+        PALM_VERBOSE_PRINT(palm,
           "Artificial delay %" PRIu64 " microseconds after %" PRIu64 " object reads, %" PRIu64
           " object writes\n",
           us, palm->object_gets, palm->object_puts);
@@ -269,7 +264,7 @@ palm_delay(PALM *palm)
     if (palm->force_error != 0 &&
       (palm->object_gets + palm->object_puts) % palm->force_error == 0) {
         us = palm_compute_delay_us(palm, (uint64_t)palm->error_ms * WT_THOUSAND);
-        VERBOSE_PRINT(palm,
+        PALM_VERBOSE_PRINT(palm,
           "Artificial error returned after %" PRIu64 " microseconds sleep, %" PRIu64
           " object reads, %" PRIu64 " object writes\n",
           us, palm->object_gets, palm->object_puts);
@@ -448,7 +443,7 @@ palm_get_package_part(WT_PAGE_LOG *page_log, WT_SESSION *session, WT_ITEM *packa
 
     palm = (PALM *)page_log;
 
-    VERBOSE_PRINT(palm, "palm_get_package_part\n");
+    PALM_VERBOSE_PRINT(palm, "palm_get_package_part\n");
 
     sizep = (size_t *)package_buffer->data;
     bytes_left = package_buffer->size;
@@ -471,6 +466,9 @@ palm_get_package_part(WT_PAGE_LOG *page_log, WT_SESSION *session, WT_ITEM *packa
         result->size = *sizep;
         result->data = ((uint8_t *)sizep) + sizeof(size_t);
     }
+    PALM_VERBOSE_PRINT(palm,
+      "palm_get_package_part(package=\n%s, delta=%d, result=\n%s) returns 0\n",
+      palm_verbose_item(package_buffer), delta_number, palm_verbose_item(result));
     return (0);
 }
 
@@ -488,7 +486,10 @@ palm_handle_put(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     palm = palm_handle->palm;
     palm_delay(palm);
 
-    VERBOSE_PRINT(palm_handle->palm, "palm_handle_put\n");
+    PALM_VERBOSE_PRINT(palm_handle->palm,
+      "palm_handle_put(plh=%p, page_id=%" PRIx64 ", checkpoint_id=%" PRIx64
+      ", is_delta=%d, buf=\n%s)\n",
+      plh, page_id, checkpoint_id, is_delta, palm_verbose_item(buf));
     PALM_KV_RET(palm, session, palm_kv_begin_transaction(&context, palm->kv_env, false));
     ret = palm_kv_get_global(&context, PALM_KV_GLOBAL_REVISION, &kv_revision);
     if (ret == MDB_NOTFOUND) {
@@ -526,7 +527,7 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     palm = palm_handle->palm;
     palm_delay(palm);
 
-    VERBOSE_PRINT(palm_handle->palm, "palm_handle_get\n");
+    PALM_VERBOSE_PRINT(palm_handle->palm, "palm_handle_get\n");
     PALM_KV_RET(palm, session, palm_kv_begin_transaction(&context, palm->kv_env, false));
     PALM_KV_ERR(palm, session,
       palm_kv_get_page_matches(&context, palm_handle->table_id, page_id, checkpoint_id, &matches));
@@ -544,6 +545,10 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     PALM_KV_ERR(palm, session, matches.error);
 
 err:
+    PALM_VERBOSE_PRINT(palm_handle->palm,
+      "palm_handle_get(plh=%p, page_id=%" PRIx64 ", checkpoint_id=%" PRIx64
+      ", buf=\n%s) returns %d\n",
+      plh, page_id, checkpoint_id, palm_verbose_item(package), ret);
     palm_kv_rollback_transaction(&context);
     return (ret);
 }

--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -489,7 +489,7 @@ palm_handle_put(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     PALM_VERBOSE_PRINT(palm_handle->palm,
       "palm_handle_put(plh=%p, page_id=%" PRIx64 ", checkpoint_id=%" PRIx64
       ", is_delta=%d, buf=\n%s)\n",
-      plh, page_id, checkpoint_id, is_delta, palm_verbose_item(buf));
+      (void *)plh, page_id, checkpoint_id, is_delta, palm_verbose_item(buf));
     PALM_KV_RET(palm, session, palm_kv_begin_transaction(&context, palm->kv_env, false));
     ret = palm_kv_get_global(&context, PALM_KV_GLOBAL_REVISION, &kv_revision);
     if (ret == MDB_NOTFOUND) {
@@ -528,8 +528,8 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     palm_delay(palm);
 
     PALM_VERBOSE_PRINT(palm_handle->palm,
-      "palm_handle_get(plh=%p, page_id=%" PRIx64 ", checkpoint_id=%" PRIx64 ")...\n", plh, page_id,
-      checkpoint_id);
+      "palm_handle_get(plh=%p, page_id=%" PRIx64 ", checkpoint_id=%" PRIx64 ")...\n", (void *)plh,
+      page_id, checkpoint_id);
     PALM_KV_RET(palm, session, palm_kv_begin_transaction(&context, palm->kv_env, false));
     PALM_KV_ERR(palm, session,
       palm_kv_get_page_matches(&context, palm_handle->table_id, page_id, checkpoint_id, &matches));
@@ -550,7 +550,7 @@ err:
     PALM_VERBOSE_PRINT(palm_handle->palm,
       "palm_handle_get(plh=%p, page_id=%" PRIx64 ", checkpoint_id=%" PRIx64
       ", buf=\n%s) returns %d\n",
-      plh, page_id, checkpoint_id, palm_verbose_item(package), ret);
+      (void *)plh, page_id, checkpoint_id, palm_verbose_item(package), ret);
     palm_kv_rollback_transaction(&context);
     return (ret);
 }

--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -527,7 +527,9 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     palm = palm_handle->palm;
     palm_delay(palm);
 
-    PALM_VERBOSE_PRINT(palm_handle->palm, "palm_handle_get\n");
+    PALM_VERBOSE_PRINT(palm_handle->palm,
+      "palm_handle_get(plh=%p, page_id=%" PRIx64 ", checkpoint_id=%" PRIx64 ")...\n", plh, page_id,
+      checkpoint_id);
     PALM_KV_RET(palm, session, palm_kv_begin_transaction(&context, palm->kv_env, false));
     PALM_KV_ERR(palm, session,
       palm_kv_get_page_matches(&context, palm_handle->table_id, page_id, checkpoint_id, &matches));

--- a/ext/page_log/palm/palm_verbose.c
+++ b/ext/page_log/palm/palm_verbose.c
@@ -41,9 +41,9 @@ static char
 verbose_hex_char(uint8_t x)
 {
     if (x < 10)
-        return '0' + x;
+        return ((char)('0' + x));
     else
-        return 'a' + (x - 10);
+        return ((char)('a' + (x - 10)));
 }
 
 /*

--- a/ext/page_log/palm/palm_verbose.c
+++ b/ext/page_log/palm/palm_verbose.c
@@ -31,14 +31,14 @@
 
 #include "palm_verbose.h"
 
-#define N_VERBOSE_SLOTS 16      /* must be a power of 2 */
+#define N_VERBOSE_SLOTS 16 /* must be a power of 2 */
 #define N_VERBOSE_MASK (N_VERBOSE_SLOTS - 1)
 
 /*
  * Return a single hex character.
  */
 static char
-verbose_hex_char(int x)
+verbose_hex_char(uint8_t x)
 {
     if (x < 10)
         return '0' + x;
@@ -47,8 +47,8 @@ verbose_hex_char(int x)
 }
 
 /*
- * Return a string for the buffer. Not strictly reentrant, but returns entries from a
- * circular buffer in a round-robin fashion.
+ * Return a string for the buffer. Not strictly reentrant, but returns entries from a circular
+ * buffer in a round-robin fashion.
  */
 const char *
 palm_verbose_item(const WT_ITEM *buf)
@@ -66,9 +66,8 @@ palm_verbose_item(const WT_ITEM *buf)
     slot = (__atomic_add_fetch(&slot_count, 1, __ATOMIC_SEQ_CST)) & N_VERBOSE_MASK;
 
     /*
-     * Get the beginning and end of the buffer.  Leave plenty of room
-     * at the end for the final entry plus the possibility of a space, newline,
-     * and a final "overflow" message.
+     * Get the beginning and end of the buffer. Leave plenty of room at the end for the final entry
+     * plus the possibility of a space, newline, and a final "overflow" message.
      */
     s = &return_slot[slot][0];
     end = &return_slot[slot][sizeof(return_slot[0])] - 30;

--- a/ext/page_log/palm/palm_verbose.c
+++ b/ext/page_log/palm/palm_verbose.c
@@ -1,0 +1,90 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <wiredtiger.h>
+
+#include "palm_verbose.h"
+
+#define N_VERBOSE_SLOTS 16      /* must be a power of 2 */
+#define N_VERBOSE_MASK (N_VERBOSE_SLOTS - 1)
+
+/*
+ * Return a single hex character.
+ */
+static char
+verbose_hex_char(int x)
+{
+    if (x < 10)
+        return '0' + x;
+    else
+        return 'a' + (x - 10);
+}
+
+/*
+ * Return a string for the buffer. Not strictly reentrant, but returns entries from a
+ * circular buffer in a round-robin fashion.
+ */
+const char *
+palm_verbose_item(const WT_ITEM *buf)
+{
+    static uint8_t slot_count = 0;
+    static char return_slot[N_VERBOSE_SLOTS][1024];
+    uint8_t slot;
+    const uint8_t *p;
+    size_t n;
+    char *end, *s;
+
+    /*
+     * Select the next slot in a circle of buffers.
+     */
+    slot = (__atomic_add_fetch(&slot_count, 1, __ATOMIC_SEQ_CST)) & N_VERBOSE_MASK;
+
+    /*
+     * Get the beginning and end of the buffer.  Leave plenty of room
+     * at the end for the final entry plus the possibility of a space, newline,
+     * and a final "overflow" message.
+     */
+    s = &return_slot[slot][0];
+    end = &return_slot[slot][sizeof(return_slot[0])] - 30;
+
+    for (n = 0, p = buf->data; n < buf->size && s < end; ++n, ++p) {
+        if (n != 0 && n % 32 == 0)
+            *s++ = '\n';
+        if (n % 4 == 0)
+            *s++ = ' ';
+        *s++ = verbose_hex_char((*p & 0xf0) >> 4);
+        *s++ = verbose_hex_char(*p & 0xf);
+    }
+    if (n < buf->size)
+        snprintf(s, 25, "...[%d total]", (int)buf->size);
+    else
+        *s = '\0';
+
+    return &return_slot[slot][0];
+}

--- a/ext/page_log/palm/palm_verbose.h
+++ b/ext/page_log/palm/palm_verbose.h
@@ -26,10 +26,10 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#define PALM_VERBOSE_PRINT(palm, ...)           \
-    do {                                        \
-        if ((palm)->verbose > 0)                \
-            fprintf(stderr, __VA_ARGS__);       \
+#define PALM_VERBOSE_PRINT(palm, ...)     \
+    do {                                  \
+        if ((palm)->verbose > 0)          \
+            fprintf(stderr, __VA_ARGS__); \
     } while (0);
 
 const char *palm_verbose_item(const WT_ITEM *buf);

--- a/ext/page_log/palm/palm_verbose.h
+++ b/ext/page_log/palm/palm_verbose.h
@@ -1,0 +1,35 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#define PALM_VERBOSE_PRINT(palm, ...)           \
+    do {                                        \
+        if ((palm)->verbose > 0)                \
+            fprintf(stderr, __VA_ARGS__);       \
+    } while (0);
+
+const char *palm_verbose_item(const WT_ITEM *buf);

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -99,7 +99,7 @@ class DisaggConfigMixin:
     # Some possible values to return: 'verbose=1'
     # or for palm: 'verbose=1,delay_ms=13,force_delay=30'
     def disaggregated_extension_config(self):
-        return ''
+        return 'verbose=1'
 
     # Load disaggregated storage extension.
     def disagg_conn_extensions(self, extlist):


### PR DESCRIPTION
This adds verbose output when the PALM extension is loaded with the "verbose=1" flag set.  The output looks like this:
```
palm_handle_put(plh=0xaaab09c9fa50, page_id=7a, checkpoint_id=0, is_delta=0, buf=
 00000000 00000000 16000000 00000000 3c000000 02000000 06200001 00000000
 00000000 4e2016fa 01000000 05003820 c09989c0 39c6eae4 278f7e47)
oligarch mgr clearing 2
palm_handle_put(plh=0xaaab09c9fa50, page_id=7b, checkpoint_id=0, is_delta=0, buf=
 00000000 00000000 17000000 00000000 3c000000 02000000 06200001 00000000
 00000000 e4d4785e 01000000 05003820 c09989c0 39c6eae4 278f7e47)
oligarch watcher started
[.] __wt_block_disagg_checkpoint_load(): 0xc027bce426759f9d
palm_handle_get
palm_handle_get(plh=0xaaab0bd23080, page_id=67, checkpoint_id=0, buf=
 fd060000 00000000 00000000 00000000 02000000 00000000 fd060000 c8000000
 07040001 00000000 00000000 e1f2657d 01000000 2148656c 6c6f2030 001b576f
 726c6400 2148656c 6c6f2031 001b576f 726c6400 2548656c 6c6f2031 30001b57
 6f726c64 00254865 6c6c6f20 3131001b 576f726c 64002548 656c6c6f 20313200
 1b576f72 6c640025 48656c6c 6f203133 001b576f 726c6400 2548656c 6c6f2031
 34001b57 6f726c64 00254865 6c6c6f20 3135001b 576f726c 64002548 656c6c6f
 20313600 1b576f72 6c640025 48656c6c 6f203137 001b576f 726c6400 2548656c
 6c6f2031 38001b57 6f726c64 00254865 6c6c6f20 3139001b 576f726c 64002148
 656c6c6f 2032001b 576f726c 64002548 656c6c6f 20323000 1b576f72 6c640025
 48656c6c 6f203231 001b576f 726c6400 2548656c 6c6f2032 32001b57 6f726c64
 00254865 6c6c6f20 3233001b 576f726c 64002548 656c6c6f 20323400 1b576f72
 6c640025 48656c6c 6f203235 001b576f 726c6400 2548656c 6c6f2032 36001b57
 6f726c64 00254865 6c6c6f20 3237001b 576f726c 64002548 656c6c6f 20323800
 1b576f72 6c640025 48656c6c 6f203239 001b576f...[1872 total]) returns 0
```