### PR TITLE
WT-13643 Upgrade rhel81-power-8 host to rhel8-power

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5690,7 +5690,7 @@ buildvariants:
 - name: rhel8-ppc
   display_name: "~ RHEL8 PPC"
   run_on:
-  - rhel81-power8-small
+  - rhel8-power-small
   batchtime: 120 # 2 hours
   expansions:
     format_test_setting: ulimit -c unlimited


### PR DESCRIPTION
The `rhel81-power-8` hosts are being replaced with `rhel8-power` at the end of November. Update evergreen to use the new hosts ahead of time.