### PR TITLE
WT-13646 Fix link issue with catch2-unittest-assertions

### DIFF
--- a/test/unittest/tests/block/test_block_api_misc.cpp
+++ b/test/unittest/tests/block/test_block_api_misc.cpp
@@ -246,7 +246,7 @@ TEST_CASE("Block manager: size and stat", "[block_api_misc]")
         WT_ITEM buf;
         WT_CLEAR(buf);
         std::string test_string("test123");
-        create_write_buffer(&bm, session, test_string, &buf, 0);
+        create_write_buffer(&bm, session, test_string, &buf, 0, std::stoi(ALLOCATION_SIZE));
         uint8_t addr[WT_ADDR_MAX_COOKIE];
         size_t addr_size;
         wt_off_t bm_size, prev_size;

--- a/test/unittest/tests/block/test_block_api_write.cpp
+++ b/test/unittest/tests/block/test_block_api_write.cpp
@@ -33,7 +33,6 @@ struct addr_cookie {
     size_t size;
 };
 
-
 /*
  * Validate that the write buffer contents was correctly written to the file. We do this through
  * performing a bm->read and a file read and making sure that the read() matches the original write

--- a/test/unittest/tests/block/test_block_api_write.cpp
+++ b/test/unittest/tests/block/test_block_api_write.cpp
@@ -33,20 +33,6 @@ struct addr_cookie {
     size_t size;
 };
 
-/*
- * Test and validate the bm->write_size() function.
- */
-void
-test_and_validate_write_size(WT_BM *bm, const std::shared_ptr<mock_session> &session, size_t size)
-{
-    size_t ret_size = size;
-    // This function internally reads and changes the variable.
-    REQUIRE(bm->write_size(bm, session->get_wt_session_impl(), &ret_size) == 0);
-    // It is expected that the size is a modulo of the allocation size and is aligned to the nearest
-    // greater allocation size.
-    CHECK(ret_size % std::stoi(ALLOCATION_SIZE) == 0);
-    CHECK(ret_size == ((size / std::stoi(ALLOCATION_SIZE)) + 1) * std::stoi(ALLOCATION_SIZE));
-}
 
 /*
  * Validate that the write buffer contents was correctly written to the file. We do this through
@@ -148,6 +134,7 @@ TEST_CASE("Block manager: file operation read, write and write_size functions", 
 
     WT_BM bm;
     WT_CLEAR(bm);
+    size_t allocation_size = std::stoi(ALLOCATION_SIZE);
     auto path = std::filesystem::current_path();
     std::string file_path(path.string() + "/test.wt");
     setup_bm(session, &bm, file_path, ALLOCATION_SIZE, BLOCK_ALLOCATION, OS_CACHE_MAX,
@@ -155,12 +142,12 @@ TEST_CASE("Block manager: file operation read, write and write_size functions", 
 
     SECTION("Test write_size api")
     {
-        test_and_validate_write_size(&bm, session, 0);
-        test_and_validate_write_size(&bm, session, 800);
-        test_and_validate_write_size(&bm, session, 1234);
-        test_and_validate_write_size(&bm, session, 5000);
-        test_and_validate_write_size(&bm, session, 5120);
-        test_and_validate_write_size(&bm, session, 9999);
+        test_and_validate_write_size(&bm, session, 0, allocation_size);
+        test_and_validate_write_size(&bm, session, 800, allocation_size);
+        test_and_validate_write_size(&bm, session, 1234, allocation_size);
+        test_and_validate_write_size(&bm, session, 5000, allocation_size);
+        test_and_validate_write_size(&bm, session, 5120, allocation_size);
+        test_and_validate_write_size(&bm, session, 9999, allocation_size);
 
         // The write size function should fail, if the initial write size is too large.
         size_t init_size = UINT32_MAX - 1000;
@@ -172,7 +159,7 @@ TEST_CASE("Block manager: file operation read, write and write_size functions", 
         WT_ITEM buf;
         WT_CLEAR(buf);
         std::string test_string("hello");
-        create_write_buffer(&bm, session, test_string, &buf, 0);
+        create_write_buffer(&bm, session, test_string, &buf, 0, allocation_size);
 
         addr_cookie cookie;
         // Perform a write.
@@ -197,7 +184,7 @@ TEST_CASE("Block manager: file operation read, write and write_size functions", 
         for (const auto &str : test_strings) {
             WT_ITEM buf;
             WT_CLEAR(buf);
-            create_write_buffer(&bm, session, str, &buf, 0);
+            create_write_buffer(&bm, session, str, &buf, 0, allocation_size);
 
             addr_cookie cookie;
             REQUIRE(bm.write(&bm, session->get_wt_session_impl(), &buf, cookie.addr.data(),
@@ -220,8 +207,8 @@ TEST_CASE("Block manager: file operation read, write and write_size functions", 
         for (const auto &str : test_strings) {
             WT_ITEM buf;
             WT_CLEAR(buf);
-            test_and_validate_write_size(&bm, session, str.length());
-            create_write_buffer(&bm, session, str, &buf, str.length());
+            test_and_validate_write_size(&bm, session, str.length(), allocation_size);
+            create_write_buffer(&bm, session, str, &buf, str.length(), allocation_size);
 
             addr_cookie cookie;
             REQUIRE(bm.write(&bm, session->get_wt_session_impl(), &buf, cookie.addr.data(),
@@ -244,7 +231,7 @@ TEST_CASE("Block manager: file operation read, write and write_size functions", 
         std::string test_string(200, 'a');
         WT_ITEM buf;
         WT_CLEAR(buf);
-        create_write_buffer(&bm, session, test_string, &buf, 0);
+        create_write_buffer(&bm, session, test_string, &buf, 0, allocation_size);
 
         // The first block write should succeed.
         addr_cookie cookie;
@@ -260,7 +247,7 @@ TEST_CASE("Block manager: file operation read, write and write_size functions", 
         validate_write_block(&bm, session, &buf, cookie, test_string, false);
         REQUIRE(bm.block->fh->written == std::stoi(ALLOCATION_SIZE) * 2);
 
-        // Flag is now set, the block write should flushed with fsync.
+        // Flag is now set, the block write should be flushed with fsync.
         F_SET(session->get_wt_session_impl(), WT_SESSION_CAN_WAIT);
         REQUIRE(bm.write(&bm, session->get_wt_session_impl(), &buf, cookie.addr.data(),
                   &cookie.size, false, false) == 0);

--- a/test/unittest/tests/block/util_block.cpp
+++ b/test/unittest/tests/block/util_block.cpp
@@ -96,11 +96,11 @@ free_size_block(WT_SIZE *size)
  */
 void
 create_write_buffer(WT_BM *bm, std::shared_ptr<mock_session> session, std::string contents,
-  WT_ITEM *buf, size_t buf_memsize)
+  WT_ITEM *buf, size_t buf_memsize, size_t allocation_size)
 {
     // Fetch write buffer size from block manager.
     REQUIRE(bm->write_size(bm, session->get_wt_session_impl(), &buf_memsize) == 0);
-    test_and_validate_write_size(bm, session, buf_memsize);
+    test_and_validate_write_size(bm, session, buf_memsize, allocation_size);
 
     // Initialize the buffer with aligned size.
     F_SET(buf, WT_ITEM_ALIGNED);
@@ -151,4 +151,19 @@ setup_bm(std::shared_ptr<mock_session> &session, WT_BM *bm, const std::string &f
 
     // Initialize the extent lists inside the block handle.
     REQUIRE(__wti_block_ckpt_init(session->get_wt_session_impl(), &bm->block->live, nullptr) == 0);
+}
+
+/*
+ * Test and validate the bm->write_size() function.
+ */
+void
+test_and_validate_write_size(WT_BM *bm, const std::shared_ptr<mock_session> &session, size_t size, size_t allocation_size)
+{
+    size_t ret_size = size;
+    // This function internally reads and changes the variable.
+    REQUIRE(bm->write_size(bm, session->get_wt_session_impl(), &ret_size) == 0);
+    // It is expected that the size is a modulo of the allocation size and is aligned to the nearest
+    // greater allocation size.
+    CHECK(ret_size % allocation_size == 0);
+    CHECK(ret_size == ((size / allocation_size) + 1) * allocation_size);
 }

--- a/test/unittest/tests/block/util_block.cpp
+++ b/test/unittest/tests/block/util_block.cpp
@@ -157,7 +157,8 @@ setup_bm(std::shared_ptr<mock_session> &session, WT_BM *bm, const std::string &f
  * Test and validate the bm->write_size() function.
  */
 void
-test_and_validate_write_size(WT_BM *bm, const std::shared_ptr<mock_session> &session, size_t size, size_t allocation_size)
+test_and_validate_write_size(
+  WT_BM *bm, const std::shared_ptr<mock_session> &session, size_t size, size_t allocation_size)
 {
     size_t ret_size = size;
     // This function internally reads and changes the variable.

--- a/test/unittest/tests/block/util_block.h
+++ b/test/unittest/tests/block/util_block.h
@@ -27,10 +27,10 @@ void validate_size_block(WT_SIZE *size);
 
 /* Block Manager file API functions. */
 void create_write_buffer(WT_BM *bm, std::shared_ptr<mock_session> session, std::string contents,
-  WT_ITEM *buf, size_t buf_memsize);
+  WT_ITEM *buf, size_t buf_memsize, size_t allocation_size);
 void setup_bm(std::shared_ptr<mock_session> &session, WT_BM *bm, const std::string &file_path,
   const std::string &allocation_size, const std::string &block_allocation,
   const std::string &os_cache_max, const std::string &os_cache_dirty_max,
   const std::string &access_pattern);
 void test_and_validate_write_size(
-  WT_BM *bm, const std::shared_ptr<mock_session> &session, size_t size);
+  WT_BM *bm, const std::shared_ptr<mock_session> &session, size_t size, size_t allocation_size);


### PR DESCRIPTION
Moved test_and_validate_write_size() to util_block.cpp to fix link issues that occur when HAVE_UNITTEST_ASSERTS is set.

Note that it was necessary to add a parameter to test_and_validate_write_size() to pass in the allocation size rather than rely on a file-scope value.