### PR TITLE
WT-13667 Support compiling WiredTiger with SWIG 4.3.0 version

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -666,7 +666,7 @@ OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, search_near, (self))
 		metadata = PyBytes_FromStringAndSize(*$1, *$2);
 		$result = metadata;
 		data = PyBytes_FromStringAndSize(*$3, *$4);
-		$result = SWIG_Python_AppendOutput($result, data);
+		$result = SWIG_AppendOutput($result, data);
 	} else {
 		SWIG_exception_fail(SWIG_AttributeError, "invalid pointer argument");
 	}
@@ -678,7 +678,7 @@ OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, search_near, (self))
 		key_data = PyBytes_FromStringAndSize(*$1, *$2);
 		$result = key_data;
 		value_data = PyBytes_FromStringAndSize(*$3, *$4);
-		$result = SWIG_Python_AppendOutput($result, value_data);
+		$result = SWIG_AppendOutput($result, value_data);
 	} else {
 		SWIG_exception_fail(SWIG_AttributeError, "invalid pointer argument");
 	}


### PR DESCRIPTION
SWIG 4.3.0 version has introduced a couple of incompatibilties and WiredTiger is affected with the SWIG_Python_AppendOutput API.

Change the code to use SWIG_AppendOutput API that internally calls the SWIG_Python_AppendOutput API with the required parameters.
