### PR TITLE
LABS-1171 Start table, checkpoint, and page IDs at 1

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -41,7 +41,7 @@ __bmd_checkpoint_pack_raw(WT_BLOCK_DISAGG *block_disagg, WT_SESSION_IMPL *sessio
      * which will be written into the block manager checkpoint cookie.
      */
     WT_RET(__wt_block_disagg_write_internal(
-      session, block_disagg, root_image, block_meta, &size, &checksum, true, true));
+      session, block_disagg, root_image, block_meta, block_meta, &size, &checksum, true, true));
 
     WT_RET(__wt_block_disagg_ckpt_pack(block_disagg, &endp, block_meta->page_id,
       block_meta->checkpoint_id, block_meta->reconciliation_id, size, checksum));
@@ -124,7 +124,7 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
     WT_ERR(__wt_scr_alloc(session, len, &buf));
     memcpy(buf->mem, entry, len);
     buf->size = len - 1;
-    WT_ERR(__wt_disagg_put_meta(session, 0, 0, buf));
+    WT_ERR(__wt_disagg_put_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, 1, buf));
 
 err:
     __wt_scr_free(session, &buf);

--- a/src/block_pantry/block_ckpt.c
+++ b/src/block_pantry/block_ckpt.c
@@ -128,7 +128,7 @@ __wt_bmp_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool failed)
     WT_ERR(__wt_scr_alloc(session, len, &buf));
     memcpy(buf->mem, entry, len);
     buf->size = len - 1;
-    WT_ERR(__wt_disagg_put_meta(session, 0, 0, buf));
+    WT_ERR(__wt_disagg_put_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, 1, buf));
 
 err:
     __wt_scr_free(session, &buf);

--- a/src/conn/conn_oligarch.c
+++ b/src/conn/conn_oligarch.c
@@ -40,7 +40,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t checkpoint_id)
         WT_ERR(EINVAL);
 
     /* Read the checkpoint metadata from the special metadata page. */
-    WT_ERR(__wt_disagg_get_meta(session, 0, checkpoint_id, item));
+    WT_ERR(__wt_disagg_get_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, checkpoint_id, item));
 
     if (item->size >= sizeof(buf))
         WT_ERR(ENOMEM);
@@ -891,8 +891,8 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
 
     /* Set up a handle for accessing shared metadata. */
     if (npage_log != NULL) {
-        WT_ERR(npage_log->page_log->pl_open_handle(
-          npage_log->page_log, &session->iface, 0, &conn->disaggregated_storage.page_log_meta));
+        WT_ERR(npage_log->page_log->pl_open_handle(npage_log->page_log, &session->iface,
+          WT_DISAGG_METADATA_TABLE_ID, &conn->disaggregated_storage.page_log_meta));
     }
     if (bstorage != NULL) {
         WT_WITH_BUCKET_STORAGE(bstorage, session, {

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -247,8 +247,9 @@ extern int __wt_block_disagg_write(WT_SESSION_IMPL *session, WT_BLOCK *block, WT
   WT_PAGE_BLOCK_META *block_meta, uint8_t *addr, size_t *addr_sizep, bool data_checksum,
   bool checkpoint_io) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_disagg,
-  WT_ITEM *buf, WT_PAGE_BLOCK_META *block_meta, uint32_t *sizep, uint32_t *checksump,
-  bool data_checksum, bool checkpoint_io) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_ITEM *buf, const WT_PAGE_BLOCK_META *block_meta, WT_PAGE_BLOCK_META *new_block_meta,
+  uint32_t *sizep, uint32_t *checksump, bool data_checksum, bool checkpoint_io)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_write_size(size_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_free(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr,

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -39,6 +39,9 @@
 #define WT_CC_METAFILE "WiredTigerCC.wt"          /* Chunk cache metadata table */
 #define WT_CC_METAFILE_URI "file:WiredTigerCC.wt" /* Chunk cache metadata table URI */
 
+#define WT_DISAGG_METADATA_TABLE_ID 1     /* The table ID for metadata */
+#define WT_DISAGG_METADATA_MAIN_PAGE_ID 1 /* The page ID for the main system metadata */
+
 #define WT_SYSTEM_PREFIX "system:"                               /* System URI prefix */
 #define WT_SYSTEM_CKPT_TS "checkpoint_timestamp"                 /* Checkpoint timestamp name */
 #define WT_SYSTEM_CKPT_URI "system:checkpoint"                   /* Checkpoint timestamp URI */

--- a/test/suite/test_oligarch06.py
+++ b/test/suite/test_oligarch06.py
@@ -107,7 +107,7 @@ class test_oligarch06(wttest.WiredTigerTestCase):
 
         # Ensure that all data makes it to the follower before we check.
         self.session.checkpoint()
-        conn_follow.reconfigure('disaggregated=(checkpoint_id=0)') # TODO Use a real checkpoint ID
+        conn_follow.reconfigure('disaggregated=(checkpoint_id=1)') # TODO Use a real checkpoint ID
 
         cursor_follow2 = session_follow.open_cursor(self.uri, None, None)
         item_count = 0
@@ -135,7 +135,7 @@ class test_oligarch06(wttest.WiredTigerTestCase):
 
         # Ensure that all data makes it to the follower before we check.
         self.session.checkpoint()
-        conn_follow.reconfigure('disaggregated=(checkpoint_id=0)') # TODO Use a real checkpoint ID
+        conn_follow.reconfigure('disaggregated=(checkpoint_id=1)') # TODO Use a real checkpoint ID
 
         cursor_follow3 = session_follow.open_cursor(self.uri, None, None)
         item_count = 0
@@ -168,7 +168,7 @@ class test_oligarch06(wttest.WiredTigerTestCase):
 
         # Checkpoint to ensure that we don't miss any items after we reopen the connection below.
         self.session.checkpoint()
-        conn_follow.reconfigure('disaggregated=(checkpoint_id=0)') # TODO Use a real checkpoint ID
+        conn_follow.reconfigure('disaggregated=(checkpoint_id=1)') # TODO Use a real checkpoint ID
 
         # Reopen the follower connection.
         session_follow.close()

--- a/test/suite/test_oligarch07.py
+++ b/test/suite/test_oligarch07.py
@@ -93,7 +93,7 @@ class test_oligarch07(wttest.WiredTigerTestCase):
         time.sleep(1)
         self.session.checkpoint()
         time.sleep(1)
-        conn_follow.reconfigure('disaggregated=(checkpoint_id=0)') # TODO Use a real checkpoint ID
+        conn_follow.reconfigure('disaggregated=(checkpoint_id=1)') # TODO Use a real checkpoint ID
 
         #
         # Part 2: The big switcheroo
@@ -117,7 +117,7 @@ class test_oligarch07(wttest.WiredTigerTestCase):
         cursor.close()
         time.sleep(1)
         session_follow.checkpoint()
-        self.conn.reconfigure('disaggregated=(checkpoint_id=0)') # TODO Use a real checkpoint ID
+        self.conn.reconfigure('disaggregated=(checkpoint_id=1)') # TODO Use a real checkpoint ID
 
         #
         # Part 4: Ensure that all data is in both leader and follower.


### PR DESCRIPTION
The PR makes a few changes:
* Use checkpoint ID 1 instead of 0 (until we implement checkpoint IDs for real)
* Use table ID 1 instead of 0 for the metadata
* Use page ID 1 instead of 0 for the main metadata page
* Update the tests accordingly

The PR also starts passing in the current and new block meta arguments to the write as we discussed, albeit currently only still internally within the new BM.