### PR TITLE
WT-13676 Fix typo. Extra char at end of config string.

### DIFF
--- a/test/format/import.c
+++ b/test/format/import.c
@@ -136,7 +136,7 @@ import(void *arg)
              * the latest checkpoint.
              */
             testutil_snprintf(buf, sizeof(buf),
-              "%s,import=(enabled,repair=false,panic_corrupt=false,file_metadata=(%s))t",
+              "%s,import=(enabled,repair=false,panic_corrupt=false,file_metadata=(%s))",
               table_config, file_config);
             ret = session->create(session, IMPORT_URI, buf);
             if (ret != 0) {


### PR DESCRIPTION
Trivial PR to fix a typo (that didn't cause the test to fail). 
