### PR TITLE
WT-13638 Set checkpoint most recent stats to 0

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -713,10 +713,10 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
         time_start = 0;
         if (WT_SESSION_IS_CHECKPOINT(session)) {
             time_start = __wt_clock(session);
-            conn->ckpt_apply = conn->ckpt_skip = conn->ckpt_drop = conn->ckpt_lock =
-              conn->ckpt_meta_check = 0;
-            conn->ckpt_apply_time = conn->ckpt_skip_time = conn->ckpt_drop_time =
-              conn->ckpt_lock_time = conn->ckpt_meta_check_time = 0;
+            conn->ckpt_apply = conn->ckpt_drop = conn->ckpt_lock = conn->ckpt_meta_check =
+              conn->ckpt_skip = 0;
+            conn->ckpt_apply_time = conn->ckpt_drop_time = conn->ckpt_lock_time =
+              conn->ckpt_meta_check_time = conn->ckpt_skip_time = 0;
             F_SET(conn, WT_CONN_CKPT_GATHER);
         }
         for (dhandle = NULL;;) {

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -713,8 +713,10 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
         time_start = 0;
         if (WT_SESSION_IS_CHECKPOINT(session)) {
             time_start = __wt_clock(session);
-            conn->ckpt_apply = conn->ckpt_skip = 0;
-            conn->ckpt_apply_time = conn->ckpt_skip_time = 0;
+            conn->ckpt_apply = conn->ckpt_skip = conn->ckpt_drop = conn->ckpt_lock =
+              conn->ckpt_meta_check = 0;
+            conn->ckpt_apply_time = conn->ckpt_skip_time = conn->ckpt_drop_time =
+              conn->ckpt_lock_time = conn->ckpt_meta_check_time = 0;
             F_SET(conn, WT_CONN_CKPT_GATHER);
         }
         for (dhandle = NULL;;) {


### PR DESCRIPTION
Currently only `ckpt_apply`, `ckpt_skip`, `ckpt_apply_time` and `ckpt_skip_time` are set to 0 during checkpoint prepare, and t2 is showing some of the most recent stats incrementally while others are not. We should set them to 0 as well so t2 can have a consistent view for all the `checkpoint most recent `stats.