### PR TITLE
WT-13678 Add breakpoint functionality to model workload replay

### DIFF
--- a/test/model/src/driver/kv_workload.cpp
+++ b/test/model/src/driver/kv_workload.cpp
@@ -136,6 +136,10 @@ parse(const char *str)
         CHECK_NUM_ARGS(1);
         return begin_transaction(parse_uint64(args[0]));
     }
+    if (name == "breakpoint") {
+        CHECK_NUM_ARGS(0);
+        return breakpoint();
+    }
     if (name == "checkpoint") {
         CHECK_NUM_ARGS_RANGE(0, 1);
         return checkpoint(args.size() == 0 ? nullptr : args[0].c_str());

--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -276,6 +276,7 @@ kv_workload_runner_wt::do_operation(const operation::breakpoint &op)
     int ret = _connection->open_session(_connection, nullptr, nullptr, &session);
     if (ret != 0)
         return ret;
+    wiredtiger_session_guard session_guard(session);
 
     return session->breakpoint(session);
 }

--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -269,6 +269,22 @@ kv_workload_runner_wt::do_operation(const operation::begin_transaction &op)
  *     Execute the given workload operation in WiredTiger.
  */
 int
+kv_workload_runner_wt::do_operation(const operation::breakpoint &op)
+{
+    std::shared_lock lock(_connection_lock);
+    WT_SESSION *session;
+    int ret = _connection->open_session(_connection, nullptr, nullptr, &session);
+    if (ret != 0)
+        return ret;
+
+    return session->breakpoint(session);
+}
+
+/*
+ * kv_workload_runner_wt::do_operation --
+ *     Execute the given workload operation in WiredTiger.
+ */
+int
 kv_workload_runner_wt::do_operation(const operation::checkpoint &op)
 {
     std::shared_lock lock(_connection_lock);

--- a/test/model/src/include/model/driver/kv_workload.h
+++ b/test/model/src/include/model/driver/kv_workload.h
@@ -213,6 +213,49 @@ operator<<(std::ostream &out, const begin_transaction &op)
 }
 
 /*
+ * breakpoint --
+ *     A representation of this workload operation.
+ */
+struct breakpoint : public without_txn_id, public without_table_id {
+    /*
+     * breakpoint::breakpoint --
+     *     Create the operation.
+     */
+    inline breakpoint() {}
+
+    /*
+     * breakpoint::operator== --
+     *     Compare for equality.
+     */
+    inline bool
+    operator==(const breakpoint &other) const noexcept
+    {
+        return true;
+    }
+
+    /*
+     * breakpoint::operator!= --
+     *     Compare for inequality.
+     */
+    inline bool
+    operator!=(const breakpoint &other) const noexcept
+    {
+        return !(*this == other);
+    }
+};
+
+/*
+ * operator<< --
+ *     Human-readable output.
+ */
+inline std::ostream &
+operator<<(std::ostream &out, const breakpoint &op)
+{
+    out << "breakpoint()";
+    return out;
+}
+
+/*
  * checkpoint --
  *     A representation of this workload operation.
  */
@@ -1026,10 +1069,10 @@ operator<<(std::ostream &out, const wt_config &op)
  * any --
  *     Any workload operation.
  */
-using any =
-  std::variant<begin_transaction, checkpoint, commit_transaction, crash, create_table, evict,
-    insert, nop, prepare_transaction, remove, restart, rollback_to_stable, rollback_transaction,
-    set_commit_timestamp, set_oldest_timestamp, set_stable_timestamp, truncate, wt_config>;
+using any = std::variant<begin_transaction, breakpoint, checkpoint, commit_transaction, crash,
+  create_table, evict, insert, nop, prepare_transaction, remove, restart, rollback_to_stable,
+  rollback_transaction, set_commit_timestamp, set_oldest_timestamp, set_stable_timestamp, truncate,
+  wt_config>;
 
 /*
  * operator<< --

--- a/test/model/src/include/model/driver/kv_workload_runner.h
+++ b/test/model/src/include/model/driver/kv_workload_runner.h
@@ -105,6 +105,16 @@ protected:
      *     Execute the given workload operation in the model.
      */
     int
+    do_operation(const operation::breakpoint &op)
+    {
+        return 0;
+    }
+
+    /*
+     * kv_workload_runner::do_operation --
+     *     Execute the given workload operation in the model.
+     */
+    int
     do_operation(const operation::checkpoint &op)
     {
         _database.create_checkpoint(op.name.empty() ? nullptr : op.name.c_str());

--- a/test/model/src/include/model/driver/kv_workload_runner_wt.h
+++ b/test/model/src/include/model/driver/kv_workload_runner_wt.h
@@ -253,6 +253,12 @@ protected:
      * kv_workload_runner_wt::do_operation --
      *     Execute the given workload operation in WiredTiger.
      */
+    int do_operation(const operation::breakpoint &op);
+
+    /*
+     * kv_workload_runner_wt::do_operation --
+     *     Execute the given workload operation in WiredTiger.
+     */
     int do_operation(const operation::checkpoint &op);
 
     /*


### PR DESCRIPTION
The model test replay functionality is incredibly useful to debug issues with deterministic reproducibility. It would be nice to be able to break inside of WiredTiger part way through replaying a workload. This exact functionality was used by me to solve WT-13612. 

This PR adds that functionality.