### PR TITLE
WT-13679 Soft link ~/.cache to the /data folder in many-collections-test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -218,6 +218,14 @@ functions:
         source venv/bin/activate
         buildscripts/poetry_sync.sh
 
+        # FIXME-WT-13607 Bazel uses a substantial amount of space for cache when building
+        # mongo and we run out of disk space on the host. Temporarily soft link ~/.cache
+        # to point to /data - which has more space - until we fix this properly with
+        # bazel flag --user_output_root
+        rm -rf ~/.cache
+        mkdir -p /data/tmp_cache
+        ln -s /data/tmp_cache ~/.cache
+
         ./buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_gcc.vars --link-model=dynamic --ninja generate-ninja ICECC=icecc CCACHE=ccache
         ninja -j$(nproc --all) install-mongod
   "configure wiredtiger": &configure_wiredtiger
@@ -994,6 +1002,13 @@ functions:
       script: |
         rm -rf "wiredtiger"
         rm -rf "wiredtiger.tgz"
+        # FIXME-WT-13607 - Clean up the temporary symlink to /data created in "compile mongodb"
+        # This can be removed when we stop creating the symlink
+        if [ -L /data/tmp_cache ]; then
+          sudo rm -rf /data/tmp_cache
+          rm ~/.cache
+          mkdir ~/.cache
+        fi
 
   "run wt hang analyzer":
     command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -188,19 +188,13 @@ functions:
         # Find the equivalent mongodb branch that matches the same branch version to wiredtiger. In
         # the case of patch builds, it is possible that the developer has a branch name that doesn't
         # adhere to naming rules, therefore derive the base branch name from git.
-        echo "DBG A"
-        git branch --contains
-
-        branch=$(git branch --contains | grep -e "mongodb" -e "develop")
+        branch=$(git branch --contains | grep -e "mongodb" -e "develop" -e "evg-pr-test-")
         if [[ $branch =~ "mongodb-" ]]; then
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
           mongo_branch=master
         fi
         popd
-        echo "DBG B"
-        echo $mongo_repo
-        echo $mongo_branch
         git clone $mongo_repo -b $mongo_branch
   "import wiredtiger into mongo" :
     command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -188,6 +188,9 @@ functions:
         # Find the equivalent mongodb branch that matches the same branch version to wiredtiger. In
         # the case of patch builds, it is possible that the developer has a branch name that doesn't
         # adhere to naming rules, therefore derive the base branch name from git.
+        echo "DBG A"
+        git branch --contains
+
         branch=$(git branch --contains | grep -e "mongodb" -e "develop")
         if [[ $branch =~ "mongodb-" ]]; then
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
@@ -195,6 +198,9 @@ functions:
           mongo_branch=master
         fi
         popd
+        echo "DBG B"
+        echo $mongo_repo
+        echo $mongo_branch
         git clone $mongo_repo -b $mongo_branch
   "import wiredtiger into mongo" :
     command: shell.exec


### PR DESCRIPTION
The many-collections test is running out of space on evergreen due to storing bazel's cache in the home directory instead of the `/data` dir. This is an interim fix to resolve test failures while we pursue a proper fix in WT-13607.