### PR TITLE
WT-13680 Improve error handling when Ruff is not found with the expected version

### DIFF
--- a/dist/ruff_check.py
+++ b/dist/ruff_check.py
@@ -10,7 +10,7 @@ import sys
 CURRENT_DIR = pathlib.Path(__file__).parent.resolve()
 
 
-def check_ruff_version(expected_version: str) -> bool:
+def __check_ruff_version(expected_version: str) -> bool:
     cmd = ["ruff", "--version"]
     try:
         output = subprocess.check_output(cmd, cwd=CURRENT_DIR).decode().strip()
@@ -26,19 +26,29 @@ def check_ruff_version(expected_version: str) -> bool:
     return True
 
 
-def get_expected_ruff_version(config_file: str) -> str:
+# Check Ruff is installed with the expected version.
+def check_ruff_installation(expected_version: str) -> bool:
+    if not which("ruff") or not __check_ruff_version(expected_version):
+        return False
+    return True
+
+
+# Retrieve the expected Ruff version from a toml file.
+def get_expected_ruff_version(ruff_toml_file: str) -> str:
     ruff_version = None
-    with open(config_file) as file:
+    with open(ruff_toml_file) as file:
         for line in file:
             m = re.search(r'required-version = "==(\d.\d.\d)"', line.strip())
             if m:
                 ruff_version = m.group(1)
                 break
-    assert ruff_version, f"No ruff version has been found in {config_file}"
+    assert ruff_version, f"No ruff version has been found in {ruff_toml_file}"
     return ruff_version
 
 
-def run_ruff_checks(cmd: list[str]) -> bool:
+# Execute the Ruff check command.
+def run_ruff_checks(ruff_toml_file: str) -> bool:
+    cmd = ["ruff", "check", "--fix", "../.", ".", "--config", ruff_toml_file]
     try:
         output = subprocess.check_output(cmd, cwd=CURRENT_DIR).decode().strip()
         if output == "All checks passed!":
@@ -53,6 +63,7 @@ def run_ruff_checks(cmd: list[str]) -> bool:
         return False
 
 
+# Show how to install Ruff.
 def show_ruff_installation_steps(expected_version: str) -> None:
     doc_link = "https://docs.astral.sh/ruff/installation/"
     print(f"Please install Ruff using the official documentation: {doc_link}\n")
@@ -66,15 +77,14 @@ def main():
     ruff_toml_file = f"{CURRENT_DIR}/ruff.toml"
     ruff_expected_version = get_expected_ruff_version(ruff_toml_file)
 
-    # Check the correct version of Ruff is installed.
-    if not which("ruff") or not check_ruff_version(ruff_expected_version):
+    # Check Ruff is present on the system.
+    if not check_ruff_installation(ruff_expected_version):
         print("Please check the right version of Ruff is installed.")
         show_ruff_installation_steps(ruff_expected_version)
         sys.exit(1)
 
-    cmd = ["ruff", "check", "--fix", "../.", ".", "--config", ruff_toml_file]
-
-    if not run_ruff_checks(cmd):
+    # Run Ruff checks.
+    if not run_ruff_checks(ruff_toml_file):
         sys.exit(1)
 
 

--- a/dist/ruff_check.py
+++ b/dist/ruff_check.py
@@ -8,7 +8,6 @@ import sys
 
 # Always use this script's folder as the working directory.
 CURRENT_DIR = pathlib.Path(__file__).parent.resolve()
-RUFF_TOML_FILE = f"{CURRENT_DIR}/ruff.toml"
 
 
 def check_ruff_version(expected_version: str) -> bool:
@@ -35,7 +34,7 @@ def get_expected_ruff_version(config_file: str) -> str:
             if m:
                 ruff_version = m.group(1)
                 break
-    assert ruff_version, f"No ruff version has been found in {RUFF_TOML_FILE}"
+    assert ruff_version, f"No ruff version has been found in {config_file}"
     return ruff_version
 
 
@@ -63,21 +62,21 @@ def show_ruff_installation_steps(expected_version: str) -> None:
     print(f"python3 -m pip install ruff=={expected_version}\n")
 
 
-ruff_expected_version = get_expected_ruff_version(RUFF_TOML_FILE)
+def main():
+    ruff_toml_file = f"{CURRENT_DIR}/ruff.toml"
+    ruff_expected_version = get_expected_ruff_version(ruff_toml_file)
 
-# If Ruff is not installed, show how to install it.
-if not which("ruff"):
-    print("Ruff is not installed!")
-    show_ruff_installation_steps(ruff_expected_version)
-    sys.exit(1)
-# Otherwise, check which version is installed.
-elif not check_ruff_version(ruff_expected_version):
-    print("Ruff version check failed.")
-    show_ruff_installation_steps(ruff_expected_version)
-    sys.exit(1)
+    # Check the correct version of Ruff is installed.
+    if not which("ruff") or not check_ruff_version(ruff_expected_version):
+        print("Please check the right version of Ruff is installed.")
+        show_ruff_installation_steps(ruff_expected_version)
+        sys.exit(1)
+
+    cmd = ["ruff", "check", "--fix", "../.", ".", "--config", ruff_toml_file]
+
+    if not run_ruff_checks(cmd):
+        sys.exit(1)
 
 
-cmd = ["ruff", "check", "--fix", "../.", ".", "--config", RUFF_TOML_FILE]
-
-if not run_ruff_checks(cmd):
-    sys.exit(1)
+if __name__ == "__main__":
+    main()

--- a/dist/ruff_check.py
+++ b/dist/ruff_check.py
@@ -1,48 +1,83 @@
 #!/usr/bin/env python3
 
+from shutil import which
 import pathlib
 import re
-from shutil import which
 import subprocess
 import sys
 
 # Always use this script's folder as the working directory.
-current_dir = pathlib.Path(__file__).parent.resolve()
-ruff_config = f"{current_dir}/ruff.toml"
+CURRENT_DIR = pathlib.Path(__file__).parent.resolve()
+RUFF_TOML_FILE = f"{CURRENT_DIR}/ruff.toml"
 
 
-def run(cmd):
+def check_ruff_version(expected_version: str) -> bool:
+    cmd = ["ruff", "--version"]
     try:
-        output = subprocess.check_output(cmd, cwd=current_dir).decode().strip()
+        output = subprocess.check_output(cmd, cwd=CURRENT_DIR).decode().strip()
+    except Exception as e:
+        print(e)
+        return False
+
+    if not output == f"ruff {expected_version}":
+        print(
+            f"Unexpected Ruff version detected: {output} instead of {expected_version}"
+        )
+        return False
+    return True
+
+
+def get_expected_ruff_version(config_file: str) -> str:
+    ruff_version = None
+    with open(config_file) as file:
+        for line in file:
+            m = re.search(r'required-version = "==(\d.\d.\d)"', line.strip())
+            if m:
+                ruff_version = m.group(1)
+                break
+    assert ruff_version, f"No ruff version has been found in {RUFF_TOML_FILE}"
+    return ruff_version
+
+
+def run_ruff_checks(cmd: list[str]) -> bool:
+    try:
+        output = subprocess.check_output(cmd, cwd=CURRENT_DIR).decode().strip()
         if output == "All checks passed!":
             return True
         else:
             print(output)
             return False
     except subprocess.CalledProcessError as cpe:
-        print("The command [%s] failed:\n%s" % (" ".join(cmd), cpe.output.decode("utf-8")))
+        print(
+            "The command [%s] failed:\n%s" % (" ".join(cmd), cpe.output.decode("utf-8"))
+        )
         return False
 
 
-if not which("ruff"):
+def show_ruff_installation_steps(expected_version: str) -> None:
     doc_link = "https://docs.astral.sh/ruff/installation/"
-    lines = []
-    ruff_version = None
-    with open(ruff_config) as file:
-        for line in file:
-            m = re.search(r'required-version = "==(\d.\d.\d)"', line.strip())
-            if m:
-                ruff_version = m.group(1)
-                break
-    print("Ruff is not installed!")
     print(f"Please install Ruff using the official documentation: {doc_link}\n")
     print("Suggested steps using a virtual environment:")
-    print(f"virtualenv -p python3 {current_dir.parent}/venv")
-    print(f"source {current_dir.parent}/venv/bin/activate")
-    print(f"python3 -m pip install ruff=={ruff_version}\n")
+    print(f"virtualenv -p python3 {CURRENT_DIR.parent}/venv")
+    print(f"source {CURRENT_DIR.parent}/venv/bin/activate")
+    print(f"python3 -m pip install ruff=={expected_version}\n")
+
+
+ruff_expected_version = get_expected_ruff_version(RUFF_TOML_FILE)
+
+# If Ruff is not installed, show how to install it.
+if not which("ruff"):
+    print("Ruff is not installed!")
+    show_ruff_installation_steps(ruff_expected_version)
+    sys.exit(1)
+# Otherwise, check which version is installed.
+elif not check_ruff_version(ruff_expected_version):
+    print("Ruff version check failed.")
+    show_ruff_installation_steps(ruff_expected_version)
     sys.exit(1)
 
-cmd = ["ruff", "check", "--fix", "../.", ".", "--config", ruff_config]
 
-if not run(cmd):
+cmd = ["ruff", "check", "--fix", "../.", ".", "--config", RUFF_TOML_FILE]
+
+if not run_ruff_checks(cmd):
     sys.exit(1)


### PR DESCRIPTION
The changes improve the error handling when a Ruff binary is found with a version that is not matching the expected one.