### PR TITLE
WT-13607 Save bazel cache into evergreen workdir instead of home folder

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -218,13 +218,11 @@ functions:
         source venv/bin/activate
         buildscripts/poetry_sync.sh
 
-        # FIXME-WT-13607 Bazel uses a substantial amount of space for cache when building
-        # mongo and we run out of disk space on the host. Temporarily soft link ~/.cache
-        # to point to /data - which has more space - until we fix this properly with
-        # bazel flag --user_output_root
-        rm -rf ~/.cache
-        mkdir -p /data/tmp_cache
-        ln -s /data/tmp_cache ~/.cache
+        # The bazel cache uses a substantial (>30GB) amount of data which causes our evergreen hosts
+        # to run out of disk space. By default it's saved into ~/.cache, but we want it saved into
+        # our evergreen workspace which has more backing storage
+        echo "startup --output_user_root=${workdir}/bazel-output-root" >> ~/.bazelrc
+        echo "BAZELISK_HOME=${workdir}/bazelisk_home" >> ~/.bazeliskrc
 
         ./buildscripts/scons.py --variables-files=etc/scons/mongodbtoolchain_stable_gcc.vars --link-model=dynamic --ninja generate-ninja ICECC=icecc CCACHE=ccache
         ninja -j$(nproc --all) install-mongod
@@ -1002,13 +1000,6 @@ functions:
       script: |
         rm -rf "wiredtiger"
         rm -rf "wiredtiger.tgz"
-        # FIXME-WT-13607 - Clean up the temporary symlink to /data created in "compile mongodb"
-        # This can be removed when we stop creating the symlink
-        if [ -L /data/tmp_cache ]; then
-          sudo rm -rf /data/tmp_cache
-          rm ~/.cache
-          mkdir ~/.cache
-        fi
 
   "run wt hang analyzer":
     command: shell.exec


### PR DESCRIPTION
Bazel stores its cache in the home folder, but our evergreen spawn hosts don't have enough storage space to handle a mongo compilation. Update `compile mongodb` to instead store bazel output in the evergreen working dir which has a larger backing storage.

This PR removes the temporary fix from WT-13679 and replaces it with a proper .bazelrc solution