### PR TITLE
LABS-926 Implement WT_CURSOR::largest_key for Oligarch tables

### DIFF
--- a/src/cursor/cur_oligarch.c
+++ b/src/cursor/cur_oligarch.c
@@ -523,22 +523,20 @@ err:
 }
 
 /*
- * __coligarch_prev --
- *     WT_CURSOR->prev method for the oligarch cursor type.
+ * __coligarch_prev_int --
+ *     WT_CURSOR->prev method for the oligarch cursor type (internal version).
  */
 static int
-__coligarch_prev(WT_CURSOR *cursor)
+__coligarch_prev_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 {
     WT_CURSOR *alternate_cursor, *c;
     WT_CURSOR_OLIGARCH *coligarch;
     WT_DECL_RET;
-    WT_SESSION_IMPL *session;
     int cmp;
     bool deleted;
 
     coligarch = (WT_CURSOR_OLIGARCH *)cursor;
 
-    CURSOR_API_CALL(cursor, session, ret, prev, coligarch->dhandle);
     __cursor_novalue(cursor);
     WT_ERR(__coligarch_enter(coligarch, false, false));
 
@@ -588,6 +586,23 @@ err:
     __coligarch_leave(coligarch);
     if (ret == 0)
         __coligarch_deleted_decode(&cursor->value);
+    return (ret);
+}
+
+/*
+ * __coligarch_prev --
+ *     WT_CURSOR->prev method for the oligarch cursor type.
+ */
+static int
+__coligarch_prev(WT_CURSOR *cursor)
+{
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+
+    CURSOR_API_CALL(cursor, session, ret, prev, ((WT_CURSOR_OLIGARCH *)cursor)->dhandle);
+    WT_ERR(__coligarch_prev_int(session, cursor));
+
+err:
     API_END_RET(session, ret);
 }
 
@@ -1145,6 +1160,51 @@ err:
 }
 
 /*
+ * __coligarch_largest_key --
+ *     WT_CURSOR->largest_key implementation for oligarch tables.
+ */
+static int
+__coligarch_largest_key(WT_CURSOR *cursor)
+{
+    WT_DECL_ITEM(key);
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    bool key_only;
+
+    key_only = F_ISSET(cursor, WT_CURSTD_KEY_ONLY);
+    CURSOR_API_CALL(cursor, session, ret, largest_key, ((WT_CURSOR_OLIGARCH *)cursor)->dhandle);
+
+    if (WT_CURSOR_BOUNDS_SET(cursor))
+        WT_ERR_MSG(session, EINVAL, "setting bounds is not compatible with cursor largest key");
+
+    WT_ERR(__wt_scr_alloc(session, 0, &key));
+
+    /* Reset the cursor to give up the cursor position. */
+    WT_ERR(cursor->reset(cursor));
+
+    /* Set the flag to bypass value read. */
+    F_SET(cursor, WT_CURSTD_KEY_ONLY);
+
+    /* Call cursor prev to get the largest key. */
+    WT_ERR(__coligarch_prev_int(session, cursor));
+
+    /* Copy the key as we will reset the cursor after that. */
+    WT_ERR(__wt_buf_set(session, key, cursor->key.data, cursor->key.size));
+    WT_ERR(cursor->reset(cursor));
+    WT_ERR(__wt_buf_set(session, &cursor->key, key->data, key->size));
+    /* Set the key as external. */
+    F_SET(cursor, WT_CURSTD_KEY_EXT);
+
+err:
+    if (!key_only)
+        F_CLR(cursor, WT_CURSTD_KEY_ONLY);
+    __wt_scr_free(session, &key);
+    if (ret != 0)
+        WT_TRET(cursor->reset(cursor));
+    API_END_RET_STAT(session, ret, cursor_largest_key);
+}
+
+/*
  * __coligarch_close_int --
  *     Close an oligarch cursor
  */
@@ -1228,7 +1288,7 @@ __wt_coligarch_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,
       __coligarch_remove,                             /* remove */
       __coligarch_reserve,                            /* reserve */
       __wt_cursor_reconfigure,                        /* reconfigure */
-      __wt_cursor_notsup,                             /* largest_key */
+      __coligarch_largest_key,                        /* largest_key */
       __wt_cursor_config_notsup,                      /* bound */
       __wt_cursor_notsup,                             /* cache */
       __wt_cursor_reopen_notsup,                      /* reopen */

--- a/test/suite/test_oligarch10.py
+++ b/test/suite/test_oligarch10.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+
+# test_oligarch10.py
+#    Additional oligarch table & cursor methods.
+class test_oligarch10(wttest.WiredTigerTestCase):
+    nitems = 100_000
+
+    conn_base_config = 'oligarch_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(stable_prefix=.,storage_source=dir_store),'
+    conn_config = conn_base_config + 'oligarch=(role="leader")'
+
+    uri = "oligarch:test_oligarch10"
+
+    # Load the directory store extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        extlist.extension('storage_sources', 'dir_store')
+        self.pr(f"{extlist=}")
+
+    # Custom test case setup
+    def early_setup(self):
+        # FIXME: This shouldn't take an absolute path
+        os.mkdir('foo') # Hard coded to match library for now.
+        os.mkdir('bar') # Hard coded to match library for now.
+        os.mkdir('follower')
+        os.mkdir('follower/foo')
+        os.mkdir('follower/bar')
+
+        # TODO shouldn't need these - work around code in __wt_open_fs that handles
+        # non fixed-location files
+        os.mkdir('follower/foo/follower')
+        os.mkdir('follower/bar/follower')
+
+    # Test additional oligarch table / cursor operations
+    def test_oligarch10(self):
+        session_config = 'key_format=i,value_format=S'
+
+        self.session.create(self.uri, session_config)
+
+        # TODO figure out self.extensionsConfig()
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + "oligarch=(role=\"follower\")")
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, session_config)
+
+        # Check the largest key before populating the data
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(cursor.largest_key(), wiredtiger.WT_NOTFOUND)
+
+        # Populate
+        for i in range(self.nitems):
+            cursor[i + 1] = f'Value {i}'
+
+        # Check the largest key
+        self.assertEqual(cursor.largest_key(), 0)
+        self.assertEqual(cursor.get_key(), self.nitems)
+
+        # Check the largest key again after a checkpoint and a bit of a wait
+        time.sleep(1)
+        self.session.checkpoint()
+        time.sleep(1)
+        self.assertEqual(cursor.largest_key(), 0)
+        self.assertEqual(cursor.get_key(), self.nitems)
+
+        # Ensure that all data makes it to the follower
+        conn_follow.reconfigure('disaggregated=(checkpoint_id=1)') # TODO Use a real checkpoint ID
+
+        # Check the largest key at the follower
+        cursor_follow = session_follow.open_cursor(self.uri, None, None)
+        self.assertEqual(cursor_follow.largest_key(), 0)
+        self.assertEqual(cursor_follow.get_key(), self.nitems)
+
+        # Cleanup
+        cursor.close()
+        cursor_follow.close()
+        session_follow.close()
+        conn_follow.close()


### PR DESCRIPTION
Implement WT_CURSOR::largest_key for Oligarch tables, because it is needed by the Server.

The implementation of `__coligarch_largest_key` is mostly a copy of `__wti_cursor_largest_key`.