### PR TITLE
LABS-927 Fix resource leak in checkpoint_resolve

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -99,14 +99,19 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
 
     block_disagg = (WT_BLOCK_DISAGG *)bm->block;
 
+    buf = NULL;
+    entry = NULL;
+    md_cursor = NULL;
+    tablename = NULL;
+
     if (failed)
         return (0);
 
     /* Get a metadata cursor pointing to this table */
-    WT_RET(__wt_metadata_cursor(session, &md_cursor));
+    WT_ERR(__wt_metadata_cursor(session, &md_cursor));
     /* TODO less hacky way to get URI */
     len = strlen("file:") + strlen(block_disagg->name) + 1;
-    WT_RET(__wt_calloc_def(session, len, &tablename));
+    WT_ERR(__wt_calloc_def(session, len, &tablename));
     WT_ERR(__wt_snprintf(tablename, len, "file:%s", block_disagg->name));
     md_cursor->set_key(md_cursor, tablename);
     WT_ERR(md_cursor->search(md_cursor));
@@ -130,6 +135,8 @@ err:
     __wt_scr_free(session, &buf);
     __wt_free(session, tablename);
     __wt_free(session, entry); /* TODO may not have been allocated */
+    if (md_cursor != NULL)
+        WT_TRET(__wt_metadata_cursor_release(session, &md_cursor));
 
     return (0);
 }


### PR DESCRIPTION
Close the metadata cursor in the block manager's `checkpoint_resolve`. This causes calling `WT_SESSION::checkpoint` to result in having an active transaction, which would in turn cause the server's `WiredTigerSessionCache::releaseSession` to fail.