### PR TITLE
LABS-1200 Fix retries in block manager and emulate materialization delays in PALM for disagg storage

### DIFF
--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -348,7 +348,7 @@ palm_init_context(PALM *palm, PALM_KV_CONTEXT *context)
      * So when setting PAGE_KEY.timestamp_materialized_us, we'd need to make each value set was
      * monotonically increasing.
      */
-    context->materialization_delay_us = palm->materialization_delay_ms;
+    context->materialization_delay_us = palm->materialization_delay_ms * WT_THOUSAND;
 }
 
 /*

--- a/ext/page_log/palm/palm_kv.c
+++ b/ext/page_log/palm/palm_kv.c
@@ -111,6 +111,7 @@ palm_kv_timestamp_us(void)
 
     ret = gettimeofday(&v, NULL);
     assert(ret == 0);
+    (void)ret; /* Assure that ret is "used" when assertions are not in effect. */
 
     return (uint64_t)(v.tv_sec * WT_MILLION + v.tv_usec);
 }

--- a/ext/page_log/palm/palm_kv.c
+++ b/ext/page_log/palm/palm_kv.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <sys/types.h>
 
 #include <wiredtiger.h>
@@ -44,7 +45,6 @@
  * Set the size of the LMDB cache. Ideally, this should be a parameter of some kind.
  */
 static const size_t PALM_LMDB_CACHE_SIZE = 100 * 1024 * 1024;
-
 /*
  * LMDB requires the number of tables to be known at startup. If we add any more tables, we need to
  * increment this.
@@ -69,7 +69,17 @@ typedef struct PAGE_KEY {
     uint64_t backlink;
     uint64_t base;
     uint32_t flags;
+
+    /* To simulate materialization delays, this is the timestamp this record becomes available. */
+    uint64_t timestamp_materialized_us;
 } PAGE_KEY;
+
+/*
+ * True if and only if the result matches the table and page and is materialized.
+ */
+#define RESULT_MATCH(result_key, _table_id, _page_id, _now)                          \
+    ((result_key)->table_id == (_table_id) && (result_key)->page_id == (_page_id) && \
+      _now > (result_key)->timestamp_materialized_us)
 
 #ifdef PALM_KV_DEBUG
 /* Show the contents of the PAGE_KEY to stderr.  This can be useful for debugging. */
@@ -92,6 +102,18 @@ ret_match_string(PALM_KV_PAGE_MATCHES *matches)
     return (return_string);
 }
 #endif
+
+static uint64_t
+palm_kv_timestamp_us(void)
+{
+    struct timeval v;
+    int ret;
+
+    ret = gettimeofday(&v, NULL);
+    assert(ret == 0);
+
+    return (uint64_t)(v.tv_sec * WT_MILLION + v.tv_usec);
+}
 
 int
 palm_kv_env_create(PALM_KV_ENV **envp)
@@ -252,6 +274,7 @@ palm_kv_put_page(PALM_KV_CONTEXT *context, uint64_t table_id, uint64_t page_id,
     page_key.backlink = backlink;
     page_key.base = base;
     page_key.flags = flags;
+    page_key.timestamp_materialized_us = palm_kv_timestamp_us() + context->materialization_delay_us;
     kval.mv_size = sizeof(page_key);
     kval.mv_data = &page_key;
     vval.mv_size = buf->size;
@@ -268,6 +291,7 @@ palm_kv_get_page_matches(PALM_KV_CONTEXT *context, uint64_t table_id, uint64_t p
     MDB_val vval;
     PAGE_KEY page_key;
     PAGE_KEY *result_key;
+    uint64_t now;
     int ret;
 
     memset(&kval, 0, sizeof(kval));
@@ -275,6 +299,7 @@ palm_kv_get_page_matches(PALM_KV_CONTEXT *context, uint64_t table_id, uint64_t p
     memset(matches, 0, sizeof(*matches));
     memset(&page_key, 0, sizeof(page_key));
     result_key = NULL;
+    now = palm_kv_timestamp_us();
 
     matches->table_id = table_id;
     matches->page_id = page_id;
@@ -302,14 +327,14 @@ palm_kv_get_page_matches(PALM_KV_CONTEXT *context, uint64_t table_id, uint64_t p
      * Now back up until we get a match. This will be the last valid record that matches the
      * table/page.
      */
-    while (ret == 0 && (result_key->table_id != table_id || result_key->page_id != page_id)) {
+    while (ret == 0 && !RESULT_MATCH(result_key, table_id, page_id, now)) {
         ret = mdb_cursor_get(matches->lmdb_cursor, &kval, &vval, MDB_PREV);
         result_key = (PAGE_KEY *)kval.mv_data;
     }
     /*
      * Now back up until we match table/page/checkpoint.
      */
-    while (ret == 0 && result_key->table_id == table_id && result_key->page_id == page_id &&
+    while (ret == 0 && RESULT_MATCH(result_key, table_id, page_id, now) &&
       result_key->checkpoint_id >= checkpoint_id) {
 
         /* If this is what we're looking for, we're done, and the cursor is positioned. */
@@ -339,10 +364,13 @@ palm_kv_next_page_match(PALM_KV_PAGE_MATCHES *matches)
     MDB_val kval;
     MDB_val vval;
     PAGE_KEY *page_key;
+    uint64_t now;
     int ret;
 
     if (matches->lmdb_cursor == NULL)
         return (false);
+
+    now = palm_kv_timestamp_us();
 
     memset(&kval, 0, sizeof(kval));
     memset(&vval, 0, sizeof(vval));
@@ -363,8 +391,8 @@ palm_kv_next_page_match(PALM_KV_PAGE_MATCHES *matches)
     } else
         page_key = NULL;
 
-    if (ret == 0 && page_key->table_id == matches->table_id &&
-      page_key->page_id == matches->page_id && page_key->checkpoint_id == matches->checkpoint_id) {
+    if (ret == 0 && RESULT_MATCH(page_key, matches->table_id, matches->page_id, now) &&
+      page_key->checkpoint_id == matches->checkpoint_id) {
         matches->size = vval.mv_size;
         matches->data = vval.mv_data;
         matches->revision = page_key->revision;

--- a/ext/page_log/palm/palm_kv.h
+++ b/ext/page_log/palm/palm_kv.h
@@ -29,6 +29,14 @@
 #include "../../../third_party/openldap_liblmdb/lmdb.h"
 
 /*
+ * Both PALM and PALM_KV need these, there's no other convenient place for them.
+ */
+#ifndef WT_THOUSAND
+#define WT_THOUSAND 1000
+#define WT_MILLION 1000000
+#endif
+
+/*
  * This include file creates a tiny bit of abstraction for the KV database used, in case we want to
  * ever change to a different implementation.
  *
@@ -44,6 +52,7 @@ typedef struct PALM_KV_ENV {
 typedef struct PALM_KV_CONTEXT {
     PALM_KV_ENV *env;
     MDB_txn *lmdb_txn;
+    uint32_t materialization_delay_us;
 } PALM_KV_CONTEXT;
 
 typedef struct PALM_KV_PAGE_MATCHES {

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -69,7 +69,7 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
     WT_DECL_RET;
     WT_ITEM *current;
     WT_PAGE_LOG_GET_ARGS get_args;
-    uint32_t retry;
+    uint32_t orig_count, retry;
     int32_t result, last;
     uint8_t expected_magic;
     bool is_delta;
@@ -85,12 +85,16 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
     if (block_meta != NULL)
         WT_CLEAR(*block_meta);
 
-    __wt_verbose(session, WT_VERB_READ, "off %" PRIuMAX ", size %" PRIu32 ", checksum %" PRIu32,
-      (uintmax_t)page_id, size, checksum);
+    __wt_verbose(session, WT_VERB_READ,
+      "page_id %" PRIu64 ", checkpoint_id %" PRIu64 ", reconciliation_id %" PRIu64 ", size %" PRIu32
+      ", checksum %" PRIu32,
+      page_id, checkpoint_id, reconciliation_id, size, checksum);
 
     WT_STAT_CONN_INCR(session, disagg_block_get);
     WT_STAT_CONN_INCR(session, block_read);
     WT_STAT_CONN_INCRV(session, block_byte_read, size);
+
+    orig_count = *results_count;
 
     if (0) {
 reread:
@@ -98,8 +102,13 @@ reread:
          * Retry a read again. This code may go away once we establish a way to ask for a particular
          * delta.
          */
-        __wt_sleep(0, 100 + retry * 100);
+        __wt_verbose_notice(session, WT_VERB_READ,
+          "retry #%" PRIu32 " for page_id %" PRIu64 ", checkpoint_id %" PRIu64
+          ", reconciliation_id %" PRIu64 ", size %" PRIu32 ", checksum %" PRIu32,
+          retry, page_id, checkpoint_id, reconciliation_id, size, checksum);
+        __wt_sleep(0, 10000 + retry * 5000);
         memset(results_array, 0, *results_count * sizeof(results_array[0]));
+        *results_count = orig_count;
         ++retry;
     }
     /*

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -98,7 +98,7 @@ class DisaggConfigMixin:
     #
     # Some possible values to return: 'verbose=1'
     # or for palm: 'verbose=1,delay_ms=13,force_delay=30'
-    # or 'materialization_delay_ms=1000000'
+    # or 'materialization_delay_ms=1000'
     def disaggregated_extension_config(self):
         return 'verbose=1'
 

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -98,6 +98,7 @@ class DisaggConfigMixin:
     #
     # Some possible values to return: 'verbose=1'
     # or for palm: 'verbose=1,delay_ms=13,force_delay=30'
+    # or 'materialization_delay_ms=1000000'
     def disaggregated_extension_config(self):
         return 'verbose=1'
 

--- a/test/suite/test_oligarch10.py
+++ b/test/suite/test_oligarch10.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+
+# test_oligarch10.py
+#    Create an artificial delay in materializing pages from the page service.
+class test_oligarch10(wttest.WiredTigerTestCase):
+    nitems = 50000
+    uri_base = "test_oligarch10"
+    # conn_config = 'log=(enabled),verbose=[oligarch:5]'
+    conn_config = 'oligarch_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+                + 'oligarch=(role="leader"),' \
+                + 'disaggregated=(stable_prefix=.,page_log=palm),'
+
+    uri = "oligarch:" + uri_base
+
+    # Load the directory store extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        config='materialization_delay_ms=1000000'
+        extlist.extension('page_log', 'palm', f'(config="({config})")')
+
+    # Test inserting a record into an oligarch tree
+    def test_oligarch10(self):
+        base_create = 'key_format=S,value_format=S'
+
+        self.pr("create oligarch tree")
+        self.session.create(self.uri, base_create)
+
+        with self.expectedStdoutPattern('retry', maxchars=100000):
+            self.pr('opening cursor')
+            cursor = self.session.open_cursor(self.uri, None, None)
+
+            for i in range(self.nitems):
+                cursor["Hello " + str(i)] = "World"
+                cursor["Hi " + str(i)] = "There"
+                cursor["OK " + str(i)] = "Go"
+                if i % 10000 == 0:
+                    time.sleep(1)
+
+            cursor.reset()
+
+            self.pr('opening cursor')
+            cursor.close()
+            time.sleep(1)
+
+            item_count = 0
+            cursor = self.session.open_cursor(self.uri, None, None)
+            while cursor.next() == 0:
+                item_count += 1
+
+            self.pr('read cursor saw: ' + str(item_count))
+            self.assertEqual(item_count, self.nitems * 3)
+            cursor.close()

--- a/test/suite/test_oligarch11.py
+++ b/test/suite/test_oligarch11.py
@@ -28,13 +28,13 @@
 
 import os, time, wiredtiger, wttest
 
-# test_oligarch10.py
+# test_oligarch11.py
 #    Create an artificial delay in materializing pages from the page service.
-class test_oligarch10(wttest.WiredTigerTestCase):
-    nitems = 50000
-    uri_base = "test_oligarch10"
+class test_oligarch11(wttest.WiredTigerTestCase):
+    nitems = 5000
+    uri_base = "test_oligarch11"
     # conn_config = 'log=(enabled),verbose=[oligarch:5]'
-    conn_config = 'oligarch_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_config = 'oligarch_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                 + 'oligarch=(role="leader"),' \
                 + 'disaggregated=(stable_prefix=.,page_log=palm),'
 
@@ -44,11 +44,11 @@ class test_oligarch10(wttest.WiredTigerTestCase):
     def conn_extensions(self, extlist):
         if os.name == 'nt':
             extlist.skip_if_missing = True
-        config='materialization_delay_ms=1000000'
+        config='materialization_delay_ms=3000'  # 3 seconds
         extlist.extension('page_log', 'palm', f'(config="({config})")')
 
     # Test inserting a record into an oligarch tree
-    def test_oligarch10(self):
+    def test_oligarch11(self):
         base_create = 'key_format=S,value_format=S'
 
         self.pr("create oligarch tree")


### PR DESCRIPTION
- Fixed retries in block manager, the result_count was not being reset.
- Added a way, with a palm config variable, to emulate materialization delays
- Added a test to confirm that it all works