### PR TITLE
LABS-1226 Increase PALM cache size, making it configurable, enable new block manager in more Python tests

### DIFF
--- a/ext/page_log/palm/palm_kv.c
+++ b/ext/page_log/palm/palm_kv.c
@@ -41,15 +41,13 @@
 
 #include "palm_kv.h"
 
-/*
- * Set the size of the LMDB cache. Ideally, this should be a parameter of some kind.
- */
-static const size_t PALM_LMDB_CACHE_SIZE = 100 * 1024 * 1024;
+static const size_t MEGABYTE = 1024 * 1024;
+
 /*
  * LMDB requires the number of tables to be known at startup. If we add any more tables, we need to
  * increment this.
  */
-#define PALM_MAX_DBI 3
+static const u_int PALM_MAX_DBI = 3;
 
 /*
  * The PAGE_KEY is the on disk format for the key of the pages table. The value is a set of bytes,
@@ -117,7 +115,7 @@ palm_kv_timestamp_us(void)
 }
 
 int
-palm_kv_env_create(PALM_KV_ENV **envp)
+palm_kv_env_create(PALM_KV_ENV **envp, uint32_t cache_size_mb)
 {
     PALM_KV_ENV *env;
     int ret;
@@ -133,7 +131,7 @@ palm_kv_env_create(PALM_KV_ENV **envp)
         free(env);
         return (ret);
     }
-    if ((ret = mdb_env_set_mapsize(env->lmdb_env, PALM_LMDB_CACHE_SIZE)) != 0) {
+    if ((ret = mdb_env_set_mapsize(env->lmdb_env, cache_size_mb * MEGABYTE)) != 0) {
         free(env);
         return (ret);
     }

--- a/ext/page_log/palm/palm_kv.h
+++ b/ext/page_log/palm/palm_kv.h
@@ -72,7 +72,7 @@ typedef struct PALM_KV_PAGE_MATCHES {
     uint32_t flags;
 } PALM_KV_PAGE_MATCHES;
 
-int palm_kv_env_create(PALM_KV_ENV **env);
+int palm_kv_env_create(PALM_KV_ENV **env, uint32_t cache_size_mb);
 int palm_kv_env_open(PALM_KV_ENV *env, const char *homedir);
 void palm_kv_env_close(PALM_KV_ENV *env);
 

--- a/src/oligarch_log/oligarch_log.c
+++ b/src/oligarch_log/oligarch_log.c
@@ -877,13 +877,12 @@ __oligarch_log_openfile(WT_SESSION_IMPL *session, uint32_t id, uint32_t flags, W
         FLD_SET(wtopen_flags, WT_FS_OPEN_DIRECTIO);
 
     /*
-     * XXX
-     * Open failures of log files may occur in disaggregated storage.  Suppress the errors for now.
-     * Eventually we expect the oligarch log to not use files anyway.
-     * Once we do that, remove the new session flag to quiet open file failures.
+     * XXX Open failures of log files may occur in disaggregated storage. Suppress the errors for
+     * now. Eventually we expect the oligarch log to not use files anyway. Once we do that, remove
+     * the new session flag to quiet open file failures.
      */
     F_SET(session, WT_SESSION_QUIET_OPEN_FILE);
-    ret =__wt_open(session, buf->data, WT_FS_OPEN_FILE_TYPE_OLIGARCH_LOG, wtopen_flags, fhp);
+    ret = __wt_open(session, buf->data, WT_FS_OPEN_FILE_TYPE_OLIGARCH_LOG, wtopen_flags, fhp);
     F_CLR(session, WT_SESSION_QUIET_OPEN_FILE);
     WT_ERR(ret);
 err:

--- a/test/suite/test_oligarch02.py
+++ b/test/suite/test_oligarch02.py
@@ -28,29 +28,21 @@
 
 import os, wiredtiger, wttest
 
-StorageSource = wiredtiger.StorageSource  # easy access to constants
-
 # test_oligarch02.py
 #    Basic oligarch tree cursor creation
 class test_oligarch02(wttest.WiredTigerTestCase):
 
     uri_base = "test_oligarch02"
     conn_config = 'oligarch_log=(enabled),verbose=[oligarch],oligarch=(role="leader"),' \
-                + 'disaggregated=(stable_prefix=.,storage_source=dir_store),'
+                + 'disaggregated=(stable_prefix=.,page_log=palm),'
 
     uri = "oligarch:" + uri_base
 
-    # Load the directory store extension, which has object storage support
+    # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):
         if os.name == 'nt':
             extlist.skip_if_missing = True
-        extlist.extension('storage_sources', 'dir_store')
-
-    # Custom test case setup
-    def early_setup(self):
-        # FIXME: This shouldn't take an absolute path
-        os.mkdir('foo') # Hard coded to match library for now.
-        os.mkdir('bar') # Hard coded to match library for now.
+        extlist.extension('page_log', 'palm')
 
     # Test inserting a record into an oligarch tree
     def test_oligarch02(self):

--- a/test/suite/test_oligarch03.py
+++ b/test/suite/test_oligarch03.py
@@ -36,21 +36,15 @@ class test_oligarch03(wttest.WiredTigerTestCase):
 
     uri_base = "test_oligarch03"
     conn_config = 'oligarch_log=(enabled),verbose=[oligarch],oligarch=(role="leader"),' \
-                + 'disaggregated=(stable_prefix=.,storage_source=dir_store),'
+                + 'disaggregated=(stable_prefix=.,page_log=palm),'
 
     uri = "oligarch:" + uri_base
 
-    # Load the directory store extension, which has object storage support
+    # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):
         if os.name == 'nt':
             extlist.skip_if_missing = True
-        extlist.extension('storage_sources', 'dir_store')
-
-    # Custom test case setup
-    def early_setup(self):
-        # FIXME: This shouldn't take an absolute path
-        os.mkdir('foo') # Hard coded to match library for now.
-        os.mkdir('bar') # Hard coded to match library for now.
+        extlist.extension('page_log', 'palm')
 
     # Test inserting a record into an oligarch tree
     def test_oligarch03(self):

--- a/test/suite/test_oligarch05.py
+++ b/test/suite/test_oligarch05.py
@@ -47,12 +47,6 @@ class test_oligarch05(wttest.WiredTigerTestCase):
             extlist.skip_if_missing = True
         extlist.extension('page_log', 'palm')
 
-    # Custom test case setup
-    def early_setup(self):
-        # FIXME: This shouldn't take an absolute path
-        os.mkdir('foo') # Hard coded to match library for now.
-        os.mkdir('bar') # Hard coded to match library for now.
-
     # Test records into an oligarch tree and restarting
     def test_oligarch05(self):
         self.skipTest('disaggregated storage no longer uses dir store')

--- a/test/suite/test_oligarch05.py
+++ b/test/suite/test_oligarch05.py
@@ -36,16 +36,16 @@ class test_oligarch05(wttest.WiredTigerTestCase):
     nitems = 100000
     uri_base = "test_oligarch05"
     base_conn_config = 'oligarch_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
-                + 'disaggregated=(stable_prefix=.,storage_source=dir_store),'
+                + 'disaggregated=(stable_prefix=.,page_log=palm),'
     conn_config = base_conn_config + 'oligarch=(role="leader"),'
 
     uri = "oligarch:" + uri_base
 
-    # Load the directory store extension, which has object storage support
+    # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):
         if os.name == 'nt':
             extlist.skip_if_missing = True
-        extlist.extension('storage_sources', 'dir_store')
+        extlist.extension('page_log', 'palm')
 
     # Custom test case setup
     def early_setup(self):

--- a/test/suite/test_oligarch06.py
+++ b/test/suite/test_oligarch06.py
@@ -52,17 +52,11 @@ class test_oligarch06(wttest.WiredTigerTestCase):
 
     # Custom test case setup
     def early_setup(self):
-        # FIXME: This shouldn't take an absolute path
-        os.mkdir('foo') # Hard coded to match library for now.
-        os.mkdir('bar') # Hard coded to match library for now.
         os.mkdir('follower')
-        os.mkdir('follower/foo')
-        os.mkdir('follower/bar')
-
-        # TODO shouldn't need these - work around code in __wt_open_fs that handles
-        # non fixed-location files
-        os.mkdir('follower/foo/follower')
-        os.mkdir('follower/bar/follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+        os.system('echo setup; ls -l . ./follower')
 
     # Test records into an oligarch tree and restarting
     def test_oligarch06(self):

--- a/test/suite/test_oligarch06.py
+++ b/test/suite/test_oligarch06.py
@@ -37,17 +37,17 @@ class test_oligarch06(wttest.WiredTigerTestCase):
 
     # conn_config = 'log=(enabled),verbose=[oligarch:5]'
     conn_base_config = 'oligarch_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
-                     + 'disaggregated=(stable_prefix=.,storage_source=dir_store),'
+                     + 'disaggregated=(stable_prefix=.,page_log=palm),'
     conn_config = conn_base_config + 'oligarch=(role="leader")'
 
     # TODO do Python tests expect a field named uri?
     uri = "oligarch:test_oligarch06"
 
-    # Load the directory store extension, which has object storage support
+    # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):
         if os.name == 'nt':
             extlist.skip_if_missing = True
-        extlist.extension('storage_sources', 'dir_store')
+        extlist.extension('page_log', 'palm')
         self.pr(f"{extlist=}")
 
     # Custom test case setup
@@ -176,7 +176,7 @@ class test_oligarch06(wttest.WiredTigerTestCase):
         conn_follow.close()
         self.pr("reopen the follower")
         # TODO figure out self.extensionsConfig()
-        conn_follow = self.wiredtiger_open('follower', 'extensions=["../../ext/storage_sources/dir_store/libwiredtiger_dir_store.so"],create,' + self.conn_config)
+        conn_follow = self.wiredtiger_open('follower', 'extensions=["../../ext/page_log/palm/libwiredtiger_palm.so"],create,' + self.conn_config)
         session_follow = conn_follow.open_session('')
 
         cursor_follow = session_follow.open_cursor(self.uri, None, None)

--- a/test/suite/test_oligarch07.py
+++ b/test/suite/test_oligarch07.py
@@ -36,18 +36,18 @@ class test_oligarch07(wttest.WiredTigerTestCase):
     nitems = 500
 
     conn_base_config = 'oligarch_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
-                     + 'disaggregated=(stable_prefix=.,storage_source=dir_store),'
+                     + 'disaggregated=(stable_prefix=.,page_log=palm),'
     conn_config = conn_base_config + 'oligarch=(role="leader")'
 
     create_session_config = 'key_format=S,value_format=S'
 
     uri = "oligarch:test_oligarch07"
 
-    # Load the directory store extension, which has object storage support
+    # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):
         if os.name == 'nt':
             extlist.skip_if_missing = True
-        extlist.extension('storage_sources', 'dir_store')
+        extlist.extension('page_log', 'palm')
         self.pr(f"{extlist=}")
 
     # Custom test case setup

--- a/test/suite/test_oligarch07.py
+++ b/test/suite/test_oligarch07.py
@@ -52,17 +52,11 @@ class test_oligarch07(wttest.WiredTigerTestCase):
 
     # Custom test case setup
     def early_setup(self):
-        # FIXME: This shouldn't take an absolute path
-        os.mkdir('foo') # Hard coded to match library for now.
-        os.mkdir('bar') # Hard coded to match library for now.
         os.mkdir('follower')
-        os.mkdir('follower/foo')
-        os.mkdir('follower/bar')
-
-        # TODO shouldn't need these - work around code in __wt_open_fs that handles
-        # non fixed-location files
-        os.mkdir('follower/foo/follower')
-        os.mkdir('follower/bar/follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+        os.system('echo setup; ls -l . ./follower')
 
     # Test inserting records into a follower that turned into a leader
     def test_oligarch07(self):

--- a/test/suite/test_oligarch11.py
+++ b/test/suite/test_oligarch11.py
@@ -40,7 +40,7 @@ class test_oligarch11(wttest.WiredTigerTestCase):
 
     uri = "oligarch:" + uri_base
 
-    # Load the directory store extension, which has object storage support
+    # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):
         if os.name == 'nt':
             extlist.skip_if_missing = True


### PR DESCRIPTION
This uses the new block manager in all oligarch tests except for 04, 10.  Those pretty consistently crash w/ the new block manager - and while they more occasionally crash with the pantry block manager, I want to understand and chase those failures separately.
