### PR TITLE
WT-13525 Migrating to AWS-based MacOS hosts

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -271,7 +271,7 @@ functions:
           source venv/bin/activate
           pip3 install find_libpython==0.4.0
           # FIXME-WT-13704: installing swig to accommodate for macos14 not having swig by default, will be removed once swig
-          # is installed on this distro. See DEVPROD-12418.
+          # is installed on this distro.
           pip3 install swig
           SYSPYLIB=`find_libpython`
           SYSPYINCDEF=
@@ -365,7 +365,7 @@ functions:
           # Compiling with CMake generated Ninja file.
           cd cmake_build
           # FIXME-WT-13704: using virtual env to accommodate for macos14 not having swig by default, will be removed once swig
-          # is installed on this distro. See DEVPROD-12418.
+          # is installed on this distro.
           if [[ "${build_variant|}" =~ "macos-14-arm64" ]]; then
             source ../venv/bin/activate
           fi

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -272,7 +272,7 @@ functions:
           pip3 install find_libpython==0.4.0
           # FIXME-WT-13704: installing swig to accommodate for macos14 not having swig by default, will be removed once swig
           # is installed on this distro.
-          pip3 install swig
+          pip3 install swig==4.2.1
           SYSPYLIB=`find_libpython`
           SYSPYINCDEF=
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -270,7 +270,7 @@ functions:
           $SYSPY -mvenv venv
           source venv/bin/activate
           pip3 install find_libpython==0.4.0
-          # Fix-Me: installing swig to accommodate for macos14 not having swig by default, will be removed once swig
+          # FIXME-WT-13704: installing swig to accommodate for macos14 not having swig by default, will be removed once swig
           # is installed on this distro. See DEVPROD-12418.
           pip3 install swig
           SYSPYLIB=`find_libpython`
@@ -364,7 +364,7 @@ functions:
         else
           # Compiling with CMake generated Ninja file.
           cd cmake_build
-          # Fix-Me: using virtual env to accommodate for macos14 not having swig by default, will be removed once swig
+          # FIXME-WT-13704: using virtual env to accommodate for macos14 not having swig by default, will be removed once swig
           # is installed on this distro. See DEVPROD-12418.
           if [[ "${build_variant|}" =~ "macos-14-arm64" ]]; then
             source ../venv/bin/activate

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -262,7 +262,7 @@ functions:
           DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
         fi
 
-        if [[ "${build_variant|}" =~ "macos-13" ]]; then
+        if [[ "${build_variant|}" =~ "macos-14" ]]; then
           # For mac builds, we want explicitly tell cmake which python to use, as
           # well as the matching library directory and header files. The find_libpython
           # module gives us the library.
@@ -270,6 +270,9 @@ functions:
           $SYSPY -mvenv venv
           source venv/bin/activate
           pip3 install find_libpython==0.4.0
+          # Fix-Me: installing swig to accommodate for macos14 not having swig by default, will be removed once swig
+          # is installed on this distro. See DEVPROD-12418.
+          pip3 install swig
           SYSPYLIB=`find_libpython`
           SYSPYINCDEF=
 
@@ -288,7 +291,7 @@ functions:
              fi
           fi
 
-          if [ "${build_variant|}" = "macos-13-arm64" ]; then
+          if [ "${build_variant|}" = "macos-14-arm64" ]; then
             DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPython3_EXECUTABLE=$SYSPY -DPython3_LIBRARY=$SYSPYLIB -DPython3_INCLUDE_DIR=$SYSPYINCDEF"
           else
             DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPYTHON_EXECUTABLE:FILEPATH=$SYSPY -DPYTHON_LIBRARY=$SYSPYLIB -DPYTHON_INCLUDE_DIR=$SYSPYINCDEF"
@@ -361,6 +364,11 @@ functions:
         else
           # Compiling with CMake generated Ninja file.
           cd cmake_build
+          # Fix-Me: using virtual env to accommodate for macos14 not having swig by default, will be removed once swig
+          # is installed on this distro. See DEVPROD-12418.
+          if [[ "${build_variant|}" =~ "macos-14-arm64" ]]; then
+            source ../venv/bin/activate
+          fi
           if [ "${cmake_generator|Ninja}" = "Ninja" ]; then
             ninja -j ${num_jobs} 2>&1
           else
@@ -5633,10 +5641,10 @@ buildvariants:
     - name: catch2-unittest-test
 
 - <<: *mac_test_template
-  name: macos-13-arm64
-  display_name: "macOS 13 (ARM64)"
+  name: macos-14-arm64
+  display_name: "macOS 14 (ARM64)"
   run_on:
-    - macos-13-arm64
+    - macos-14-arm64
   batchtime: 120 # 2 hours
   expansions:
     python_binary: '/Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11'


### PR DESCRIPTION
DevProd are migrating our MacOS hosts from MscStadium to AWS so we are making changes in WT evergreen configuration to switch from macos-13-arm64 to macos-14-arm64. Our compilation requires the swig package, which is no longer installed in macos by default. Therefore I have modified the script for configure_wiredtiger and make_wiredtiger to install swig as a temporary workaround. A ticket has been filed to install siwg on our macos-14-arm64 distro and the temporary workaround will be removed after that ticket is completed. 