### PR TITLE
WT-13340 Don't skip checkpoint if the file can be truncated

### DIFF
--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -56,6 +56,18 @@ __wti_block_ckpt_init(WT_SESSION_IMPL *session, WT_BLOCK_CKPT *ci, const char *n
 }
 
 /*
+ * __wt_block_checkpoint_can_truncate --
+ *     Return whether there is an available extent at the end of the file, indicating that the file
+ *     can be truncated at the end of the next checkpoint.
+ */
+bool
+__wt_block_checkpoint_can_truncate(WT_BM *bm, WT_SESSION_IMPL *session)
+{
+
+    return (__wti_block_extlist_can_truncate(session, bm->block, &bm->block->live.avail));
+}
+
+/*
  * __wt_block_checkpoint_load --
  *     Return the address cookie for the root page of a checkpoint. Also initialize its extent lists
  *     if loading the live checkpoint from a writeable file.

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1341,10 +1341,6 @@ __wti_block_extlist_can_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_E
 {
     WT_EXT **astack[WT_SKIP_MAXDEPTH], *ext;
 
-    /*
-     * Check if the last available extent is at the end of the file, and if so, truncate the file
-     * and discard the extent.
-     */
     if ((ext = __block_off_srch_last(el->off, astack)) == NULL)
         return (false);
     WT_ASSERT(session, ext->off + ext->size <= block->size);

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1334,7 +1334,7 @@ err:
 
 /*
  * __wti_block_extlist_can_truncate --
- *     Truncate the file based on the last available extent in the list.
+ *     Check if there is an available extent at the end of the file that can be truncated.
  */
 bool
 __wti_block_extlist_can_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_EXTLIST *el)

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1333,6 +1333,28 @@ err:
 }
 
 /*
+ * __wti_block_extlist_can_truncate --
+ *     Truncate the file based on the last available extent in the list.
+ */
+bool
+__wti_block_extlist_can_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_EXTLIST *el)
+{
+    WT_EXT **astack[WT_SKIP_MAXDEPTH], *ext;
+
+    /*
+     * Check if the last available extent is at the end of the file, and if so, truncate the file
+     * and discard the extent.
+     */
+    if ((ext = __block_off_srch_last(el->off, astack)) == NULL)
+        return (false);
+    WT_ASSERT(session, ext->off + ext->size <= block->size);
+    if (ext->off + ext->size < block->size)
+        return (false);
+
+    return (true);
+}
+
+/*
  * __wti_block_extlist_truncate --
  *     Truncate the file based on the last available extent in the list.
  */

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -891,7 +891,7 @@ __bm_write_size_readonly(WT_BM *bm, WT_SESSION_IMPL *session, size_t *sizep)
 
 /*
  * __bm_can_truncate --
- *     Determine if a file has available space at the end of the file.
+ *     Check if a file has available space at the end of the file.
  */
 static bool
 __bm_can_truncate(WT_BM *bm, WT_SESSION_IMPL *session)

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -890,6 +890,16 @@ __bm_write_size_readonly(WT_BM *bm, WT_SESSION_IMPL *session, size_t *sizep)
 }
 
 /*
+ * __bm_can_truncate --
+ *     Determine if a file has available space at the end of the file.
+ */
+static bool
+__bm_can_truncate(WT_BM *bm, WT_SESSION_IMPL *session)
+{
+    return (__wt_block_checkpoint_can_truncate(bm, session));
+}
+
+/*
  * __wti_bm_method_set --
  *     Set up the legal methods.
  */
@@ -899,6 +909,7 @@ __wti_bm_method_set(WT_BM *bm, bool readonly)
     bm->addr_invalid = __bm_addr_invalid;
     bm->addr_string = __bm_addr_string;
     bm->block_header = __bm_block_header;
+    bm->can_truncate = __bm_can_truncate;
     bm->checkpoint = __bm_checkpoint;
     bm->checkpoint_last = __bm_checkpoint_last;
     bm->checkpoint_load = __bm_checkpoint_load;

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -194,6 +194,7 @@ struct __wt_bm {
     int (*addr_invalid)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
     int (*addr_string)(WT_BM *, WT_SESSION_IMPL *, WT_ITEM *, const uint8_t *, size_t);
     u_int (*block_header)(WT_BM *);
+    bool (*can_truncate)(WT_BM *, WT_SESSION_IMPL *);
     int (*checkpoint)(WT_BM *, WT_SESSION_IMPL *, WT_ITEM *, WT_CKPT *, bool);
     int (*checkpoint_last)(WT_BM *, WT_SESSION_IMPL *, char **, char **, WT_ITEM *);
     int (*checkpoint_load)(

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -8,6 +8,8 @@ extern WT_EXT *__wt_block_off_srch_inclusive(WT_EXTLIST *el, wt_off_t off)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern WT_HAZARD *__wt_hazard_check(WT_SESSION_IMPL *session, WT_REF *ref,
   WT_SESSION_IMPL **sessionp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wt_block_checkpoint_can_truncate(WT_BM *bm, WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_checksum_alt_match(const void *chunk, size_t len, uint32_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_compact_check_eligibility(WT_SESSION_IMPL *session, const char *uri)
@@ -33,6 +35,8 @@ extern bool __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_txn_active(WT_SESSION_IMPL *session, uint64_t txnid)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wti_block_extlist_can_truncate(WT_SESSION_IMPL *session, WT_BLOCK *block,
+  WT_EXTLIST *el) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_block_offset_invalid(WT_BLOCK *block, wt_off_t offset, uint32_t size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_cell_type_check(uint8_t cell_type, uint8_t dsk_type)

--- a/test/suite/test_checkpoint33.py
+++ b/test/suite/test_checkpoint33.py
@@ -105,9 +105,4 @@ class test_checkpoint33(test_cc_base, suite_subprocess):
             self.prout(f'File size: {self.get_size()}')
             time.sleep(0.1)
 
-        self.session.checkpoint()
-        self.session.checkpoint()
-
-        self.prout(f'File size: {self.get_size()}')
-        # It seems as though the minimum file size is 12KB with 4KB available for some reason.
         self.assertLessEqual(self.get_size(), 12 * 1024)

--- a/test/suite/test_checkpoint33.py
+++ b/test/suite/test_checkpoint33.py
@@ -36,7 +36,7 @@ from wtdataset import SimpleDataSet
 #
 class test_checkpoint33(test_cc_base, suite_subprocess):
     create_params = 'key_format=i,value_format=S,allocation_size=4KB,leaf_page_max=32KB,'
-    conn_config = 'cache_size=100MB,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),verbose=[checkpoint:2,compact:2]'
+    conn_config = 'cache_size=100MB,statistics=(all),statistics_log=(wait=1,json=true,on_close=true)'
     uri = 'table:test_checkpoint33'
 
     table_numkv = 10000
@@ -74,7 +74,7 @@ class test_checkpoint33(test_cc_base, suite_subprocess):
         self.session.create(self.uri, self.create_params)
         self.session.checkpoint()
         self.populate()
-        
+
         # Make everything stable at timestamp 3.
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(3)}')
 
@@ -107,7 +107,7 @@ class test_checkpoint33(test_cc_base, suite_subprocess):
 
         self.session.checkpoint()
         self.session.checkpoint()
-        
+
         self.prout(f'File size: {self.get_size()}')
         # It seems as though the minimum file size is 12KB with 4KB available for some reason.
         self.assertLessEqual(self.get_size(), 12 * 1024)


### PR DESCRIPTION
Checkpoint will currently skip files unless they are either dirty or have obsolete pages. This PR extends this criteria so that files that have available space at the end of the file are also checkpointed. This allows the file to be truncated at the end of the checkpoint. 
