### PR TITLE
WT-13527 Migrating to new IBM-hosted zSeries hosts

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3763,6 +3763,8 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           <<: *configure_flags_with_builtins
+          # FIXME-WT-13690: Enable ZSTD compression once failure has been resolved.
+          HAVE_BUILTIN_EXTENSION_ZSTD: -DHAVE_BUILTIN_EXTENSION_ZSTD=0
       - func: "format test script"
         vars:
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config
@@ -5698,7 +5700,6 @@ buildvariants:
   batchtime: 4320 # 3 days
   expansions:
     ENABLE_TCMALLOC: 0
-    # FIXME-WT-13690: Enable ZSTD compression once failure has been resolved.
     posix_configure_flags: -DENABLE_ZSTD=0
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
@@ -5736,8 +5737,6 @@ buildvariants:
   batchtime: 120 # 2 hours
   expansions:
     ENABLE_TCMALLOC: 0
-    # FIXME-WT-13690: Enable ZSTD compression once failure has been resolved.
-    posix_configure_flags: -DENABLE_ZSTD=0
     # Use half number of vCPU to avoid OOM kill failure
     num_jobs: $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
   tasks:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5735,7 +5735,7 @@ buildvariants:
   - rhel8-zseries-small
   batchtime: 120 # 2 hours
   expansions:
-    ENABLE_TCMALLOC: 0'
+    ENABLE_TCMALLOC: 0
     # FIXME-WT-13690: Enable ZSTD compression once failure has been resolved.
     posix_configure_flags: -DENABLE_ZSTD=0
     # Use half number of vCPU to avoid OOM kill failure

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5694,10 +5694,11 @@ buildvariants:
 - name: big-endian
   display_name: "~ Big-endian (s390x/zSeries)"
   run_on:
-  - rhel80-zseries-build
+  - rhel8-zseries-small
   batchtime: 4320 # 3 days
   expansions:
     ENABLE_TCMALLOC: 0
+    # FIXME-WT-13690: Enable ZSTD compression once failure has been resolved.
     posix_configure_flags: -DENABLE_ZSTD=0
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
@@ -5731,10 +5732,12 @@ buildvariants:
 - name: rhel8-zseries
   display_name: "~ RHEL8 zSeries"
   run_on:
-  - rhel80-zseries-test
+  - rhel8-zseries-small
   batchtime: 120 # 2 hours
   expansions:
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 0'
+    # FIXME-WT-13690: Enable ZSTD compression once failure has been resolved.
+    posix_configure_flags: -DENABLE_ZSTD=0
     # Use half number of vCPU to avoid OOM kill failure
     num_jobs: $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
   tasks:


### PR DESCRIPTION
The change intends to migrate to IBM-hosted Series machines. Currently WT-13690 was created as fallout. I have added a FIXME that would be addressed went the fix came in.