### PR TITLE
WT-13710 Fix "s_docs -l" run failure

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -184,8 +184,10 @@ check_docs_data()
     }
 }
 
-build()
+setup_doxygen()
 {
+    [[ -n "$doxyfile" ]] && return
+
     # We require doxygen which may not be installed.
     type doxygen > /dev/null 2>&1 || {
         echo "$0 skipped: doxygen not found"
@@ -203,6 +205,11 @@ build()
             echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17, 1.9.1, 1.9.3 or 1.11.*"
             exit 0
     esac
+}
+
+build()
+{
+    setup_doxygen
 
     # Build from scratch on demand.
     [ "$1" -eq 0 ] || (cd .. && rm -rf docs && mkdir docs)
@@ -268,6 +275,7 @@ while :
         shift;;
     -l)    # Generate the top-level landing page in ../docs/top
         filter="$filter| sed '/GENERATE_MAN/s,=.*,=NO,';"
+        setup_doxygen
         filter="$filter cat top/$doxyfile"
         additional_languages=0
         shift;;

--- a/src/docs/top/Doxyfile.11
+++ b/src/docs/top/Doxyfile.11
@@ -1,0 +1,1 @@
+Doxyfile

--- a/src/docs/top/Doxyfile.9
+++ b/src/docs/top/Doxyfile.9
@@ -1,0 +1,1 @@
+Doxyfile


### PR DESCRIPTION
The "s_docs -l" command run failed because the `doxyfile` variable is not set. The setting is located in the `build` function, which is not called in the command invocation path. 

The solution is to abstract the doxyfile setting and doxygen command checking logic into a new function, and call the function in all paths that doxyfile is needed. Also added 2 symlink files to avoid the doxyfile not found error when running the command with the specific versions of doxygen (9 and 11).