### PR TITLE
SLS-492 Add transaction id support for deltas

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -143,6 +143,7 @@ __bt_reconstruct_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *delta)
             value.data = unpack.value;
             value.size = unpack.value_size;
             WT_ERR(__wt_upd_alloc(session, &value, WT_UPDATE_STANDARD, &standard_value, &tmp_size));
+            standard_value->txnid = unpack.tw.start_txn;
             standard_value->start_ts = unpack.tw.start_ts;
             standard_value->durable_ts = unpack.tw.durable_start_ts;
             F_SET(standard_value, WT_UPDATE_DURABLE | WT_UPDATE_RESTORED_FROM_DELTA);
@@ -150,6 +151,7 @@ __bt_reconstruct_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *delta)
 
             if (WT_TIME_WINDOW_HAS_STOP(&unpack.tw)) {
                 WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &tmp_size));
+                tombstone->txnid = unpack.tw.stop_txn;
                 tombstone->start_ts = unpack.tw.stop_ts;
                 tombstone->durable_ts = unpack.tw.durable_stop_ts;
                 F_SET(tombstone, WT_UPDATE_DURABLE | WT_UPDATE_RESTORED_FROM_DELTA);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -139,30 +139,31 @@ __wt_page_header_byteswap(WT_PAGE_HEADER *dsk)
  *value bytes.
  */
 struct __wt_delta_header {
+    uint64_t write_gen; /* 0-7: write generation */
     /*
      * Memory size of the delta.
      */
-    uint32_t mem_size; /* 00-03: in-memory size */
+    uint32_t mem_size; /* 08-11: in-memory size */
 
     union {
-        uint32_t entries; /* 04-07: number of cells on page */
-        uint32_t datalen; /* 04-07: overflow data length */
+        uint32_t entries; /* 12-15: number of cells on page */
+        uint32_t datalen; /* 12-15: overflow data length */
     } u;
 
-    uint8_t version; /* 08: version */
+    uint8_t version; /* 16: version */
 
-    uint8_t type; /* 09: page type */
+    uint8_t type; /* 17: page type */
 
-    uint8_t flags; /* 10: flags */
+    uint8_t flags; /* 18: flags */
 
-    uint8_t unused; /* 11: unused padding */
+    uint8_t unused; /* 19: unused padding */
 };
 
 /*
  * WT_DELTA_HEADER_SIZE is the number of bytes we allocate for the structure: if the compiler
  * inserts padding it will break the world.
  */
-#define WT_DELTA_HEADER_SIZE 12
+#define WT_DELTA_HEADER_SIZE 20
 
 /*
  * The number of deltas for a base page must be strictly less than WT_DELTA_LIMIT. Changes past that
@@ -194,6 +195,7 @@ static WT_INLINE void
 __wt_delta_header_byteswap(WT_DELTA_HEADER *dsk)
 {
 #ifdef WORDS_BIGENDIAN
+    dsk->write_gen = __wt_bswap64(dsk->write_gen);
     dsk->mem_size = __wt_bswap64(dsk->mem_size);
     dsk->u.entries = __wt_bswap32(dsk->u.entries);
 #else

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -249,10 +249,12 @@ struct __wt_cell_unpack_delta {
 
     WT_TIME_WINDOW tw;
 
-#define WT_DELTA_HAS_START_TS 0x01u
-#define WT_DELTA_HAS_START_DURABLE_TS 0x02u
-#define WT_DELTA_HAS_STOP_TS 0x04u
-#define WT_DELTA_HAS_STOP_DURABLE_TS 0x08u
-#define WT_DELTA_IS_DELETE 0x10u
+#define WT_DELTA_HAS_START_TXN_ID 0x01u
+#define WT_DELTA_HAS_START_TS 0x02u
+#define WT_DELTA_HAS_START_DURABLE_TS 0x04u
+#define WT_DELTA_HAS_STOP_TXN_ID 0x08u
+#define WT_DELTA_HAS_STOP_TS 0x10u
+#define WT_DELTA_HAS_STOP_DURABLE_TS 0x20u
+#define WT_DELTA_IS_DELETE 0x40u
     uint8_t flags;
 };

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1158,11 +1158,11 @@ __cell_redo_page_del_cleanup(
 }
 
 /*
- * __cell_unpack_window_cleanup_common --
+ * __cell_unpack_window_need_cleanup --
  *     Clean up cells loaded from a previous run.
  */
-static WT_INLINE void
-__cell_unpack_window_cleanup_common(WT_SESSION_IMPL *session, uint64_t dsk_write_gen)
+static WT_INLINE bool
+__cell_unpack_window_need_cleanup(WT_SESSION_IMPL *session, uint64_t dsk_write_gen)
 {
     uint64_t write_gen;
 
@@ -1202,10 +1202,12 @@ __cell_unpack_window_cleanup_common(WT_SESSION_IMPL *session, uint64_t dsk_write
 
     WT_ASSERT(session, dsk_write_gen != 0);
     if (dsk_write_gen > write_gen)
-        return;
+        return (false);
 
     if (F_ISSET(session, WT_SESSION_DEBUG_DO_NOT_CLEAR_TXN_ID))
-        return;
+        return (false);
+
+    return (true);
 }
 
 /*
@@ -1216,8 +1218,8 @@ static WT_INLINE void
 __cell_unpack_window_cleanup_addr(
   WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_ADDR *unpack_addr)
 {
-    __cell_unpack_window_cleanup_common(session, dsk->write_gen);
-    __cell_addr_window_cleanup(session, dsk, unpack_addr);
+    if (__cell_unpack_window_need_cleanup(session, dsk->write_gen))
+        __cell_addr_window_cleanup(session, dsk, unpack_addr);
 }
 
 /*
@@ -1228,8 +1230,8 @@ static WT_INLINE void
 __cell_unpack_window_cleanup_kv(
   WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL_UNPACK_KV *unpack_kv)
 {
-    __cell_unpack_window_cleanup_common(session, dsk->write_gen);
-    __cell_kv_window_cleanup(session, unpack_kv);
+    if (__cell_unpack_window_need_cleanup(session, dsk->write_gen))
+        __cell_kv_window_cleanup(session, unpack_kv);
 }
 
 /*
@@ -1240,8 +1242,8 @@ static WT_INLINE void
 __cell_unpack_window_cleanup_delta(
   WT_SESSION_IMPL *session, const WT_DELTA_HEADER *dsk, WT_CELL_UNPACK_DELTA *unpack_delta)
 {
-    __cell_unpack_window_cleanup_common(session, dsk->write_gen);
-    __cell_delta_window_cleanup(session, unpack_delta);
+    if (__cell_unpack_window_need_cleanup(session, dsk->write_gen))
+        __cell_delta_window_cleanup(session, unpack_delta);
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2966,8 +2966,8 @@ static WT_INLINE void __wt_cell_type_reset(
   WT_SESSION_IMPL *session, WT_CELL *cell, u_int old_type, u_int new_type);
 static WT_INLINE void __wt_cell_unpack_addr(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,
   WT_CELL *cell, WT_CELL_UNPACK_ADDR *unpack_addr);
-static WT_INLINE void __wt_cell_unpack_delta(
-  WT_SESSION_IMPL *session, WT_DELTA_CELL *cell, WT_CELL_UNPACK_DELTA *unpack);
+static WT_INLINE void __wt_cell_unpack_delta(WT_SESSION_IMPL *session, const WT_DELTA_HEADER *dsk,
+  WT_DELTA_CELL *cell, WT_CELL_UNPACK_DELTA *unpack);
 static WT_INLINE void __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,
   WT_CELL *cell, WT_CELL_UNPACK_KV *unpack_value);
 static WT_INLINE void __wt_cond_wait(


### PR DESCRIPTION
Delta can be read back by the same node so it also needs to handle transaction id.
