### PR TITLE
WT-13716 Prevent retention of fast truncated history store pages

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -195,9 +195,11 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_ERR(__wt_page_parent_modify_set(session, ref, false));
 
     /*
-     * History store truncation is non-transactional, and fast truncate in history store applies
-     * only to globally visible pages. Therefore, ensure `page_del` remains null. (`page_del` being
-     * null indicates that the fast truncated page is globally visible.)
+     * Allocate and initialize `page_del` for pages, excluding those in the history store.
+     *
+     * A `null` `page_del` means that a fast-truncated page is globally visible. Since truncation in
+     * the history store is non-transactional and applies only to globally visible pages, ensure
+     * that `page_del` remains null for history store pages.
      *
      * An exception is selective backup, which can truncate non-globally visible history store
      * pages. However, since this data is intended for permanent discard, it can also be treated as

--- a/test/suite/test_backup31.py
+++ b/test/suite/test_backup31.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+from wtbackup import backup_base
+from wiredtiger import stat
+
+class test_backup31(backup_base):
+    conn_config = 'cache_size=1G'
+    dir='backup.dir'
+    uris = [f"table:uri_{i}" for i in range(1, 11)]
+
+    def add_timestamp_data(self, uri, key, val, timestamp):
+        self.session.begin_transaction()
+        c = self.session.open_cursor(uri, None, None)
+        for i in range(0, 1000):
+            k = key + str(i)
+            v = val
+            c[k] = v
+        c.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(timestamp))
+
+    def test_backup31(self):
+        for uri in self.uris:
+            # create 10 URIs and large amount of data in each.
+            self.session.create(uri, "key_format=S,value_format=S")
+            for i in range(1, 10):
+                self.add_timestamp_data(uri, "key", f"val{i}", i)
+
+        # Ensure all the data added is stable to persist data in HS.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(15))
+        self.session.checkpoint()
+
+        # Take selective backup of last first 5 tables.
+        os.mkdir(self.dir)
+        self.take_selective_backup(self.dir, [uri.replace("table:", "") + ".wt" for uri in self.uris[-5:]])
+
+        # Open the backup directory. As part of opening, it will run RTS internally to truncate any HS pages
+        # that belong to the tables that are not part of the selective backup.
+        backup_conn = self.wiredtiger_open(self.dir, "backup_restore_target=[\"{0}\"]".format('","'.join(self.uris[:5])))
+        backup_session = backup_conn.open_session()
+        stat_cursor = backup_session.open_cursor('statistics:', None, None)
+
+        # Assert that fast truncate was performed.
+        fast_truncate_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        self.assertGreater(fast_truncate_pages, 0)
+
+        # Reopen the connection with verify_metadata=true. This will ensure that the metadata is verified and
+        # the tables that are not part of the selective backup don't exist in HS and metadata.
+        backup_conn.close()
+        backup_conn = self.wiredtiger_open(self.dir, "verify_metadata=true")
+        backup_conn.close()

--- a/test/suite/test_bug035.py
+++ b/test/suite/test_bug035.py
@@ -30,7 +30,13 @@ import os
 from wtbackup import backup_base
 from wiredtiger import stat
 
-class test_backup31(backup_base):
+# test_backup31.py
+# This test validates a fix for a bug related to selective backup and fast truncate.
+# The bug allowed fast-truncated history store pages to reappear in the backup
+# after a shutdown. This test ensures that when a selective backup is taken,
+# only the selected tables HS data and metadata are retained, and the unwanted tables
+# are removed from HS and metadata.
+class test_bug035(backup_base):
     conn_config = 'cache_size=1G'
     dir='backup.dir'
     uris = [f"table:uri_{i}" for i in range(1, 11)]
@@ -45,7 +51,7 @@ class test_backup31(backup_base):
         c.close()
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(timestamp))
 
-    def test_backup31(self):
+    def test_bug035(self):
         for uri in self.uris:
             # create 10 URIs and large amount of data in each.
             self.session.create(uri, "key_format=S,value_format=S")

--- a/test/suite/test_bug035.py
+++ b/test/suite/test_bug035.py
@@ -33,7 +33,7 @@ from wiredtiger import stat
 # test_bug035.py
 # This test validates a fix for a bug related to selective backup and fast truncate.
 # The bug allowed fast-truncated history store pages to reappear in the backup after
-# a shutdown. This test verifies that if a selective backup is taken, only the data from selected 
+# a shutdown. This test verifies that if a selective backup is taken, only the data from selected
 # tables (as part of backup) are retained in the history store and metadata, and the unwanted
 # tables are removed from HS and metadata.
 class test_bug035(backup_base):

--- a/test/suite/test_bug035.py
+++ b/test/suite/test_bug035.py
@@ -31,7 +31,7 @@ from wtbackup import backup_base
 from wiredtiger import stat
 
 # test_bug035.py
-# This test validates a fix for a bug related to selective backup and fast truncate.
+# This test validates a fix for a bug (WT-13716) related to selective backup and fast truncate.
 # The bug allowed fast-truncated history store pages to reappear in the backup after
 # a shutdown. This test verifies that if a selective backup is taken, only the data from selected
 # tables (as part of backup) are retained in the history store and metadata, and the unwanted

--- a/test/suite/test_bug035.py
+++ b/test/suite/test_bug035.py
@@ -30,7 +30,7 @@ import os
 from wtbackup import backup_base
 from wiredtiger import stat
 
-# test_backup31.py
+# test_bug035.py
 # This test validates a fix for a bug related to selective backup and fast truncate.
 # The bug allowed fast-truncated history store pages to reappear in the backup
 # after a shutdown. This test ensures that when a selective backup is taken,
@@ -53,7 +53,7 @@ class test_bug035(backup_base):
 
     def test_bug035(self):
         for uri in self.uris:
-            # create 10 URIs and large amount of data in each.
+            # create 10 URIs and add large amount of data in each.
             self.session.create(uri, "key_format=S,value_format=S")
             for i in range(1, 10):
                 self.add_timestamp_data(uri, "key", f"val{i}", i)
@@ -62,7 +62,7 @@ class test_bug035(backup_base):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(15))
         self.session.checkpoint()
 
-        # Take selective backup of last first 5 tables.
+        # Take selective backup of the first 5 tables.
         os.mkdir(self.dir)
         self.take_selective_backup(self.dir, [uri.replace("table:", "") + ".wt" for uri in self.uris[-5:]])
 


### PR DESCRIPTION
The problem described in the ticket is that, since the HS is non-transactional, page_del->committed is not set. This prevents the deletion of the page, causing reconciliation to retain the original version. By treating HS pages that are fast-truncated during selective backup as globally visible (even though they are non-globally visible) and setting page_del to null, we eliminate this issue. This allows us to remove the pages without checking visibility information, which is acceptable because the HS is non-transactional.