### PR TITLE
SLS-488 Set the checkpointids for the page

### DIFF
--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -376,6 +376,10 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     if (bm->read_multiple == NULL) {
         WT_RET(__wt_calloc_def(session, 1, &tmp));
         WT_CLEAR(tmp[0]);
+        /*
+         * TODO: we read garbage value for block meta from the block cache for non-disaggregated
+         * case. Pass a NULL for now.
+         */
         WT_ERR(__wt_blkcache_read(session, &tmp[0], NULL, addr, addr_size));
         *buf_count = 1;
         *buf = tmp;

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -376,7 +376,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     if (bm->read_multiple == NULL) {
         WT_RET(__wt_calloc_def(session, 1, &tmp));
         WT_CLEAR(tmp[0]);
-        WT_ERR(__wt_blkcache_read(session, &tmp[0], block_meta, addr, addr_size));
+        WT_ERR(__wt_blkcache_read(session, &tmp[0], NULL, addr, addr_size));
         *buf_count = 1;
         *buf = tmp;
         return (0);

--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -47,7 +47,7 @@ __bmd_checkpoint_pack_raw(WT_BLOCK_DISAGG *block_disagg, WT_SESSION_IMPL *sessio
         WT_RET(__wt_buf_init(session, &ckpt->raw, WT_BLOCK_CHECKPOINT_BUFFER));
         endp = ckpt->raw.mem;
         WT_RET(__wt_block_disagg_write_internal(
-          session, block_disagg, root_image, block_meta, block_meta, &size, &checksum, true, true));
+          session, block_disagg, root_image, block_meta, &size, &checksum, true, true));
         WT_RET(__wt_block_disagg_ckpt_pack(block_disagg, &endp, block_meta->page_id,
           block_meta->checkpoint_id, block_meta->reconciliation_id, size, checksum));
         ckpt->raw.size = WT_PTRDIFF(endp, ckpt->raw.mem);

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -110,7 +110,9 @@ __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *bloc
 
     /* Get the page ID. */
     page_id = block_meta->page_id;
-
+    WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
+    WT_ASSERT_ALWAYS(session, checkpoint_id == block_meta->checkpoint_id,
+      "The page checkpoint id doesn't match the current checkpoint id");
     /* Check that the checkpoint ID matches the current checkpoint in the page log. */
     if (block_disagg->plhandle->page_log->pl_get_open_checkpoint != NULL) {
         WT_RET(block_disagg->plhandle->page_log->pl_get_open_checkpoint(

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -112,10 +112,7 @@ __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *bloc
     page_id = block_meta->page_id;
     /* Get the checkpoint ID. */
     WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
-    /*
-     * TODO: this assertion holds now but will need to change when we fix checkpoint id assignment
-     * for eviction during a checkpoint.
-     */
+    /* TODO: we need to restrict evicting pages in the next checkpoint. */
     WT_ASSERT_ALWAYS(session, checkpoint_id == block_meta->checkpoint_id,
       "The page checkpoint id doesn't match the current checkpoint id");
     /* Check that the checkpoint ID matches the current checkpoint in the page log. */

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -110,7 +110,12 @@ __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *bloc
 
     /* Get the page ID. */
     page_id = block_meta->page_id;
+    /* Get the checkpoint ID. */
     WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
+    /*
+     * TODO: this assertion holds now but will need to change when we fix checkpoint id assignment
+     * for eviction during a checkpoint.
+     */
     WT_ASSERT_ALWAYS(session, checkpoint_id == block_meta->checkpoint_id,
       "The page checkpoint id doesn't match the current checkpoint id");
     /* Check that the checkpoint ID matches the current checkpoint in the page log. */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -36,7 +36,7 @@ __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
      * some IDs for now.
      */
     page_id = __wt_atomic_fetch_add64(&btree->next_page_id, 1);
-    /* TODO: need to fix checkpoint id assignment for eviction during a checkpoint. */
+    /* TODO: we need to restrict evicting pages in the next checkpoint. */
     WT_ASSERT(session, page_id >= WT_BLOCK_MIN_PAGE_ID);
 
     meta->page_id = page_id;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -36,6 +36,7 @@ __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
      * some IDs for now.
      */
     page_id = __wt_atomic_fetch_add64(&btree->next_page_id, 1);
+    /* TODO: need to fix checkpoint id assignment for eviction during a checkpoint. */
     WT_ASSERT(session, page_id >= WT_BLOCK_MIN_PAGE_ID);
 
     meta->page_id = page_id;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -23,7 +23,7 @@ void
 __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
 {
     WT_BTREE *btree;
-    uint64_t page_id;
+    uint64_t checkpoint_id, page_id;
 
     btree = S2BT(session);
 
@@ -41,13 +41,12 @@ __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
     meta->page_id = page_id;
     /* A new page hasn't been reconciled. Starts with 0. */
     meta->reconciliation_id = 0;
-    /*
-     * TODO: hard code the checkpoint id to 1. In the future, should assign to the current
-     * checkpoint id.
-     */
-    meta->checkpoint_id = 1;
-    meta->backlink_checkpoint_id = 1;
-    meta->base_checkpoint_id = 1;
+
+    WT_ACQUIRE_READ(checkpoint_id, S2C(session)->disaggregated_storage.global_checkpoint_id);
+    /* For a new page, everything starts with the current checkpoint id. */
+    meta->checkpoint_id = checkpoint_id;
+    meta->backlink_checkpoint_id = checkpoint_id;
+    meta->base_checkpoint_id = checkpoint_id;
     meta->disagg_lsn = 0;
     /*
      * 0 means there is no delta written for this page yet. We always write a full page for a new

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -252,9 +252,8 @@ extern int __wt_block_disagg_write(WT_SESSION_IMPL *session, WT_BLOCK *block, WT
   WT_PAGE_BLOCK_META *block_meta, uint8_t *addr, size_t *addr_sizep, bool data_checksum,
   bool checkpoint_io) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_disagg,
-  WT_ITEM *buf, const WT_PAGE_BLOCK_META *block_meta, WT_PAGE_BLOCK_META *new_block_meta,
-  uint32_t *sizep, uint32_t *checksump, bool data_checksum, bool checkpoint_io)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_ITEM *buf, WT_PAGE_BLOCK_META *block_meta, uint32_t *sizep, uint32_t *checksump,
+  bool data_checksum, bool checkpoint_io) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_write_size(size_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_free(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2326,6 +2326,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         return (__wt_illegal_value(session, page->type));
     }
     multi->supd_restore = false;
+    WT_CLEAR(multi->block_meta);
     multi->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
     /* Set the key. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2420,6 +2420,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         /* We must only have one delta. Building deltas for split case is a future thing. */
         WT_ASSERT(session, last_block);
         multi->block_meta = *block_meta;
+        /* TODO: need to fix checkpoint id assignment for eviction during a checkpoint. */
         WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
         if (checkpoint_id != multi->block_meta.checkpoint_id) {
             WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
@@ -2440,6 +2441,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         if (last_block && r->multi_next == 1 && block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
             multi->block_meta = *block_meta;
             multi->block_meta.delta_count = 0;
+            /* TODO: need to fix checkpoint id assignment for eviction during a checkpoint. */
             WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
             if (checkpoint_id != multi->block_meta.checkpoint_id) {
                 WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2272,16 +2272,19 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
   WT_ITEM *compressed_image, bool last_block)
 {
     WT_BTREE *btree;
+    WT_CONNECTION_IMPL *conn;
     WT_MULTI *multi;
     WT_PAGE *page;
     WT_PAGE_BLOCK_META *block_meta;
     size_t addr_size, compressed_size;
+    uint64_t checkpoint_id;
     uint8_t addr[WT_BTREE_MAX_ADDR_COOKIE];
     bool build_delta;
 #ifdef HAVE_DIAGNOSTIC
     bool verify_image;
 #endif
 
+    conn = S2C(session);
     btree = S2BT(session);
     page = r->page;
     build_delta = false;
@@ -2417,9 +2420,17 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         /* We must only have one delta. Building deltas for split case is a future thing. */
         WT_ASSERT(session, last_block);
         multi->block_meta = *block_meta;
+        WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
+        if (checkpoint_id != multi->block_meta.checkpoint_id) {
+            WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
+            multi->block_meta.backlink_checkpoint_id = multi->block_meta.checkpoint_id;
+            multi->block_meta.checkpoint_id = checkpoint_id;
+            multi->block_meta.reconciliation_id = 0;
+        } else
+            ++multi->block_meta.reconciliation_id;
         ++multi->block_meta.delta_count;
-        /* TODO: reset reconciliation id to 0 if we start a new checkpoint id. */
-        ++multi->block_meta.reconciliation_id;
+
+        /* Get the checkpoint ID. */
         WT_RET(__wt_blkcache_write(session, &r->delta, &multi->block_meta, addr, &addr_size,
           &compressed_size, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
         /* Turn off compression adjustment for delta. */
@@ -2429,8 +2440,15 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         if (last_block && r->multi_next == 1 && block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
             multi->block_meta = *block_meta;
             multi->block_meta.delta_count = 0;
-            /* TODO: reset reconciliation id to 0 if we start a new checkpoint id. */
-            ++multi->block_meta.reconciliation_id;
+            WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
+            if (checkpoint_id != multi->block_meta.checkpoint_id) {
+                WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
+                multi->block_meta.backlink_checkpoint_id = multi->block_meta.checkpoint_id;
+                multi->block_meta.checkpoint_id = checkpoint_id;
+                multi->block_meta.base_checkpoint_id = checkpoint_id;
+                multi->block_meta.reconciliation_id = 0;
+            } else
+                ++multi->block_meta.reconciliation_id;
         } else
             __wt_page_block_meta_assign(session, &multi->block_meta);
         WT_RET(__rec_write(session, compressed_image == NULL ? &chunk->image : compressed_image,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2420,10 +2420,11 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         /* We must only have one delta. Building deltas for split case is a future thing. */
         WT_ASSERT(session, last_block);
         multi->block_meta = *block_meta;
-        /* TODO: need to fix checkpoint id assignment for eviction during a checkpoint. */
+        /* TODO: we need to restrict evicting pages in the next checkpoint. */
         WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
         if (checkpoint_id != multi->block_meta.checkpoint_id) {
             WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
+            /* Delta reuse the previous base checkpoint id. */
             multi->block_meta.backlink_checkpoint_id = multi->block_meta.checkpoint_id;
             multi->block_meta.checkpoint_id = checkpoint_id;
             multi->block_meta.reconciliation_id = 0;
@@ -2441,7 +2442,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         if (last_block && r->multi_next == 1 && block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
             multi->block_meta = *block_meta;
             multi->block_meta.delta_count = 0;
-            /* TODO: need to fix checkpoint id assignment for eviction during a checkpoint. */
+            /* TODO: we need to restrict evicting pages in the next checkpoint. */
             WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
             if (checkpoint_id != multi->block_meta.checkpoint_id) {
                 WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2327,7 +2327,6 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
     }
     multi->supd_restore = false;
     WT_CLEAR(multi->block_meta);
-    multi->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
     /* Set the key. */
     if (btree->type == BTREE_ROW)


### PR DESCRIPTION
@pmacko86 As discussed in the previous pr, this pr changes to let btree own the responsibility to assign page id and checkpoint id to a page. It also sets the base checkpoint id and backlink checkpoint id of a page.

TODO: fix the checkpoint id assign logic with further discussion.
