### PR TITLE
WT-13506 Dynamically generate github token for code coverage comment in PRs (#11013) (v8.0 backport)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3062,6 +3062,11 @@ tasks:
           remote_file: wiredtiger/${build_variant}/${revision}/${dependent_task}_${build_id}-${execution}/full_coverage_report.json
           bucket: build_external
           local_file: wiredtiger/coverage_report/full_coverage_report.json
+      - command: github.generate_token
+        params:
+          expansion_name: github_token
+          permissions:
+            pull_requests: write
       - command: shell.exec
         vars:
           dependent_task: coverage-report
@@ -3099,7 +3104,7 @@ tasks:
               echo "Detected Github PR ${github_pr_number}"
               pr_args+="--github_repo ${github_org}/${github_repo} "
               pr_args+="--github_pr_number ${github_pr_number} "
-              pr_args+="--github_token ${github_app_token} "
+              pr_args+="--github_token ${github_token} "
             fi
 
             ######################################################


### PR DESCRIPTION
The code coverage report PR comment recently broke, likely because
support for the previous token was removed as part of the move to the
dynamic token tooling.

(cherry picked from commit 3f506d1aa6e92628677b31badf6233c8cc82ea6a)