### PR TITLE
SLS-486 Don't evict pages that belongs to the next checkpoint

### DIFF
--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -112,7 +112,6 @@ __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *bloc
     page_id = block_meta->page_id;
     /* Get the checkpoint ID. */
     WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
-    /* TODO: we need to restrict evicting pages in the next checkpoint. */
     WT_ASSERT_ALWAYS(session, checkpoint_id == block_meta->checkpoint_id,
       "The page checkpoint id doesn't match the current checkpoint id");
     /* Check that the checkpoint ID matches the current checkpoint in the page log. */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -36,7 +36,6 @@ __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
      * some IDs for now.
      */
     page_id = __wt_atomic_fetch_add64(&btree->next_page_id, 1);
-    /* TODO: we need to restrict evicting pages in the next checkpoint. */
     WT_ASSERT(session, page_id >= WT_BLOCK_MIN_PAGE_ID);
 
     meta->page_id = page_id;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1890,7 +1890,6 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     WT_BTREE *btree;
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
-    uint64_t checkpoint_id;
     bool modified;
 
     if (inmem_splitp != NULL)
@@ -1971,8 +1970,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
       btree->checkpoint_gen == __wt_gen(session, WT_GEN_CHECKPOINT))
         /*
          * TODO: we only know that the btree has been visited by the latest checkpoint. But we don't
-         * know if we have opened a new checkpoint or not. We need to record the last finished
-         * checkpoint id to be able to narrow the window here.
+         * know if we have opened a new checkpoint or not. We need to know this information to be
+         * able to narrow the window here.
          */
         return (false);
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1890,6 +1890,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     WT_BTREE *btree;
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
+    uint64_t checkpoint_id;
     bool modified;
 
     if (inmem_splitp != NULL)
@@ -1968,6 +1969,11 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     /* Don't evict the disaggregated page that should belong to the next checkpoint. */
     if (modified && F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
       btree->checkpoint_gen == __wt_gen(session, WT_GEN_CHECKPOINT))
+        /*
+         * TODO: we only know that the btree has been visited by the latest checkpoint. But we don't
+         * know if we have opened a new checkpoint or not. We need to record the last finished
+         * checkpoint id to be able to narrow the window here.
+         */
         return (false);
 
     /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1890,7 +1890,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     WT_BTREE *btree;
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
-    bool ckpt_running, modified;
+    bool modified;
 
     if (inmem_splitp != NULL)
         *inmem_splitp = false;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1989,7 +1989,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     }
 
     /* If the metadata page is clean but has modifications that appear too new to evict, skip it. */
-    if (WT_IS_METADATA(S2BT(session)->dhandle) && !modified &&
+    if (WT_IS_METADATA(btree->dhandle) && !modified &&
       !__wt_txn_visible_all(session, mod->rec_max_txn, mod->rec_max_timestamp)) {
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_recently_modified);
         return (false);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1967,7 +1967,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
 
     /* Don't evict the disaggregated page that should belong to the next checkpoint. */
     if (modified && F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
-      btree->checkpoint_gen < __wt_gen(session, WT_GEN_CHECKPOINT))
+      btree->checkpoint_gen == __wt_gen(session, WT_GEN_CHECKPOINT))
         return (false);
 
     /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1972,11 +1972,9 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * before we set the checkpoint running flag to false.
      */
     if (modified && F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
-      btree->checkpoint_gen == __wt_gen(session, WT_GEN_CHECKPOINT)) {
-        WT_ACQUIRE_READ_WITH_BARRIER(ckpt_running, S2C(session)->txn_global.checkpoint_running);
-        if (ckpt_running)
-            return (false);
-    }
+      btree->checkpoint_gen == __wt_gen(session, WT_GEN_CHECKPOINT) &&
+      __wt_atomic_loadvbool(&S2C(session)->txn_global.checkpoint_running))
+        return (false);
 
     /*
      * Check we are not evicting an accessible internal page with an active split generation.

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1904,6 +1904,11 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     if (F_ISSET_ATOMIC_8(ref, WT_REF_FLAG_PREFETCH))
         return (false);
 
+    /* Don't evict the disaggregated page that should belong to the next checkpoint. */
+    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+      btree->checkpoint_gen < __wt_gen(session, WT_GEN_CHECKPOINT))
+        return (false);
+
     /* Pages without modify structures can always be evicted, it's just discarding a disk image. */
     if (mod == NULL)
         return (true);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2434,7 +2434,6 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         /* We must only have one delta. Building deltas for split case is a future thing. */
         WT_ASSERT(session, last_block);
         multi->block_meta = *block_meta;
-        /* TODO: we need to restrict evicting pages in the next checkpoint. */
         WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
         if (checkpoint_id != multi->block_meta.checkpoint_id) {
             WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
@@ -2456,7 +2455,6 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         if (last_block && r->multi_next == 1 && block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
             multi->block_meta = *block_meta;
             multi->block_meta.delta_count = 0;
-            /* TODO: we need to restrict evicting pages in the next checkpoint. */
             WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
             if (checkpoint_id != multi->block_meta.checkpoint_id) {
                 WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);


### PR DESCRIPTION
Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
