### PR TITLE
WT-13733 Split the reconcile header file into two seperate headers

### DIFF
--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 # instead of in src/include/. As a result all relevant code is contained to a single folder. 
 # Adding modules to this list will automatically generate those headers, and we expect this list to 
 # grow as we modularise the code base.
-SELF_CONTAINED_MODULES = ["log", "evict", "reconcile"]
+SELF_CONTAINED_MODULES = ["evict", "log", "reconcile"]
 
 DO_NOT_EDIT_BEGIN = "/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */\n"
 DO_NOT_EDIT_END = "/* DO NOT EDIT: automatically built by prototypes.py: END */\n"

--- a/dist/prototypes.py
+++ b/dist/prototypes.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 # instead of in src/include/. As a result all relevant code is contained to a single folder. 
 # Adding modules to this list will automatically generate those headers, and we expect this list to 
 # grow as we modularise the code base.
-SELF_CONTAINED_MODULES = ["log", "evict"]
+SELF_CONTAINED_MODULES = ["log", "evict", "reconcile"]
 
 DO_NOT_EDIT_BEGIN = "/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */\n"
 DO_NOT_EDIT_END = "/* DO NOT EDIT: automatically built by prototypes.py: END */\n"

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -271,18 +271,6 @@ extern int __wt_buf_fmt(WT_SESSION_IMPL *session, WT_ITEM *buf, const char *fmt,
 extern int __wt_buf_grow_worker(WT_SESSION_IMPL *session, WT_ITEM *buf, size_t size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_bulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_bulk_insert_fix(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool deleted)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_bulk_insert_fix_bitmap(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_bulk_insert_var(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool deleted)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_calc_modify(WT_SESSION_IMPL *wt_session, const WT_ITEM *oldv, const WT_ITEM *newv,
   size_t maxdiff, WT_MODIFY *entries, int *nentriesp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -845,8 +833,6 @@ extern int __wt_os_inmemory(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_COMMON *unpack,
   WT_ITEM *store, bool *decoded) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ovfl_remove(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_KV *unpack)
@@ -895,12 +881,6 @@ extern int __wt_realloc_aligned(WT_SESSION_IMPL *session, size_t *bytes_allocate
   size_t bytes_to_allocate, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_realloc_noclear(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret,
   size_t bytes_to_allocate, void *retp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *kv,
-  uint8_t type, WT_TIME_WINDOW *tw, uint64_t rle) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_rec_dictionary_lookup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *val,
-  WT_REC_DICTIONARY **dpp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage,
-  uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_remove_if_exists(WT_SESSION_IMPL *session, const char *name, bool durable)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_remove_locked(WT_SESSION_IMPL *session, const char *name, bool *removed)
@@ -1454,16 +1434,6 @@ extern int __wti_meta_track_insert(WT_SESSION_IMPL *session, const char *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_meta_track_update(WT_SESSION_IMPL *session, const char *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_ovfl_reuse_add(WT_SESSION_IMPL *session, WT_PAGE *page, const uint8_t *addr,
-  size_t addr_size, const void *value, size_t value_size)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_ovfl_reuse_search(WT_SESSION_IMPL *session, WT_PAGE *page, uint8_t **addrp,
-  size_t *addr_sizep, const void *value, size_t value_size)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_ovfl_track_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_ovfl_track_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image,
   uint32_t flags, WT_PAGE **pagep, bool *preparedp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1472,36 +1442,6 @@ extern int __wti_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
 extern int __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prefetch_destroy(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_child_modify(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *ref,
-  WT_CHILD_MODIFY_STATE *cmsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
-  WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_col_var(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
-  WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_dictionary_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, u_int slots)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r,
-  uint64_t recno, WT_ITEM *rowkey, bool reinsert) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_row_leaf(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
-  WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_split_finish(WT_SESSION_IMPL *session, WT_RECONCILE *r)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_split_grow(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t add_len)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_split_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page,
-  uint64_t recno, uint64_t primary_size, uint32_t auxiliary_size)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
-  WT_ROW *rip, WT_CELL_UNPACK_KV *vpack, WT_UPDATE_SELECT *upd_select)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey(WT_SESSION_IMPL *session, uint32_t cell_offset, const void *key,
   size_t size, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1619,8 +1559,6 @@ extern uint32_t __wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_DECL_
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern uint32_t __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_cursor_checkpoint_id(WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint64_t __wt_gen(WT_SESSION_IMPL *session, int which)
@@ -1719,8 +1657,6 @@ extern void __wt_optrack_flush_buffer(WT_SESSION_IMPL *s);
 extern void __wt_optrack_record_funcid(
   WT_SESSION_IMPL *session, const char *func, uint16_t *func_idp);
 extern void __wt_os_stdio(WT_SESSION_IMPL *session);
-extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);
-extern void __wt_ovfl_reuse_free(WT_SESSION_IMPL *session, WT_PAGE *page);
 extern void __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep);
 extern void __wt_random_init(WT_RAND_STATE volatile *rnd_state)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
@@ -1830,10 +1766,6 @@ extern void __wti_lsm_tree_writelock(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_
 extern void __wti_lsm_tree_writeunlock(WT_SESSION_IMPL *session, WT_LSM_TREE *lsm_tree);
 extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
-extern void __wti_rec_col_fix_write_auxheader(WT_SESSION_IMPL *session, uint32_t entries,
-  uint32_t aux_start_offset, uint32_t auxentries, uint8_t *image, size_t size);
-extern void __wti_rec_dictionary_free(WT_SESSION_IMPL *session, WT_RECONCILE *r);
-extern void __wti_rec_dictionary_reset(WT_RECONCILE *r);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entryp);
 extern void __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start,
@@ -2425,12 +2357,6 @@ extern int __ut_chunkcache_bitmap_alloc(WT_SESSION_IMPL *session, size_t *bit_in
 extern int __ut_ckpt_add_blkmod_entry(WT_SESSION_IMPL *session, WT_BLOCK_MODS *blk_mod,
   wt_off_t offset, wt_off_t len) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_ckpt_verify_modified_bits(WT_ITEM *original_bitmap, WT_ITEM *new_bitmap, bool *ok)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __ut_ovfl_discard_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell,
-  const char *tag) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __ut_ovfl_discard_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __ut_ovfl_track_init(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_session_config_int(WT_SESSION_IMPL *session, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -542,7 +542,7 @@ typedef uint64_t wt_timestamp_t;
 #include "meta.h" /* required by block.h */
 #include "optrack.h"
 #include "os.h"
-#include "reconcile.h"
+#include "../reconcile/reconcile.h"
 #include "rollback_to_stable.h"
 #include "schema.h"
 #include "tiered.h"

--- a/src/reconcile/reconcile.h
+++ b/src/reconcile/reconcile.h
@@ -1,12 +1,14 @@
 /*-
  * Copyright (c) 2014-present MongoDB, Inc.
  * Copyright (c) 2008-2014 WiredTiger, Inc.
- *	All rights reserved.
+ * All rights reserved.
  *
  * See the file LICENSE for redistribution information.
  */
 
 #pragma once
+
+#include "reconcile_private.h"
 
 /*
  * WT_REC_KV--
@@ -349,16 +351,6 @@ struct __wt_reconcile {
     WT_CURSOR *hs_cursor;
 };
 
-typedef struct {
-    WT_UPDATE *upd;       /* Update to write (or NULL) */
-    WT_UPDATE *tombstone; /* The tombstone to write (or NULL) */
-
-    WT_TIME_WINDOW tw;
-
-    bool upd_saved;       /* An element on the row's update chain was saved */
-    bool no_ts_tombstone; /* Tombstone without a timestamp */
-} WT_UPDATE_SELECT;
-
 /*
  * WT_CHILD_RELEASE, WT_CHILD_RELEASE_ERR --
  *	Macros to clean up during internal-page reconciliation, releasing the hazard pointer we're
@@ -376,24 +368,6 @@ typedef struct {
         WT_CHILD_RELEASE(session, hazard, ref);    \
         WT_ERR(ret);                               \
     } while (0)
-
-/*
- * WT_CHILD_MODIFY_STATE --
- *	We review child pages (while holding the child page's WT_REF lock), during internal-page
- * reconciliation. This structure encapsulates the child page's returned information/state.
- */
-typedef struct {
-    enum {
-        WT_CHILD_IGNORE,   /* Ignored child */
-        WT_CHILD_MODIFIED, /* Modified child */
-        WT_CHILD_ORIGINAL, /* Original child */
-        WT_CHILD_PROXY     /* Deleted child: proxy */
-    } state;               /* Returned child state */
-
-    WT_PAGE_DELETED del; /* WT_CHILD_PROXY state fast-truncate information */
-
-    bool hazard; /* If currently holding a child hazard pointer */
-} WT_CHILD_MODIFY_STATE;
 
 /*
  * Macros from fixed-length entries to/from bytes.
@@ -415,3 +389,42 @@ typedef struct {
  * Enumeration used to track the context of reconstructing modifies within a update list.
  */
 typedef enum { WT_OPCTX_TRANSACTION, WT_OPCTX_RECONCILATION } WT_OP_CONTEXT;
+
+/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
+
+extern int __wt_bulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bulk_insert_fix(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool deleted)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bulk_insert_fix_bitmap(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bulk_insert_var(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool deleted)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ovfl_discard_add(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *kv,
+  uint8_t type, WT_TIME_WINDOW *tw, uint64_t rle) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_rec_dictionary_lookup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_KV *val,
+  WT_REC_DICTIONARY **dpp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage,
+  uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern uint32_t __wt_split_page_size(int split_pct, uint32_t maxpagesize, uint32_t allocsize)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_ovfl_discard_free(WT_SESSION_IMPL *session, WT_PAGE *page);
+extern void __wt_ovfl_reuse_free(WT_SESSION_IMPL *session, WT_PAGE *page);
+
+#ifdef HAVE_UNITTEST
+extern int __ut_ovfl_discard_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell,
+  const char *tag) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_ovfl_discard_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_ovfl_track_init(WT_SESSION_IMPL *session, WT_PAGE *page)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+
+#endif
+
+/* DO NOT EDIT: automatically built by prototypes.py: END */

--- a/src/reconcile/reconcile.h
+++ b/src/reconcile/reconcile.h
@@ -11,92 +11,6 @@
 #include "reconcile_private.h"
 
 /*
- * WT_REC_KV--
- *	An on-page key/value item we're building.
- */
-struct __wt_rec_kv {
-    WT_ITEM buf;  /* Data */
-    WT_CELL cell; /* Cell and cell's length */
-    size_t cell_len;
-    size_t len; /* Total length of cell + data */
-};
-
-/*
- * WT_REC_DICTIONARY --
- *  We optionally build a dictionary of values for leaf pages. Where
- * two value cells are identical, only write the value once, the second
- * and subsequent copies point to the original cell. The dictionary is
- * fixed size, but organized in a skip-list to make searches faster.
- */
-struct __wt_rec_dictionary {
-    uint64_t hash;   /* Hash value */
-    uint32_t offset; /* Matching cell */
-
-    u_int depth; /* Skiplist */
-    WT_REC_DICTIONARY *next[0];
-};
-
-/*
- * WT_REC_CHUNK --
- *	Reconciliation split chunk. If the total chunk size crosses the split size additional
- *  information is stored about where that is.
- */
-struct __wt_rec_chunk {
-    /*
-     * These fields track the amount of entries and their associated timestamps prior to the split
-     * boundary.
-     */
-    uint32_t entries_before_split_boundary;
-    WT_TIME_AGGREGATE ta_before_split_boundary;
-
-    /* These fields track the key or recno of the very first entry past the split boundary. */
-    uint64_t recno_at_split_boundary;
-    WT_ITEM key_at_split_boundary;
-
-    /*
-     * This time aggregate tracks the aggregated timestamps of all the entries past the split
-     * boundary. Merged with the "before" entry it will equal the full time aggregate for the chunk.
-     */
-    WT_TIME_AGGREGATE ta_after_split_boundary;
-
-    /*
-     * The recno and entries fields are the starting record number of the chunk (for column-store
-     * splits), and the number of entries in the chunk.
-     *
-     * The key for a row-store page; no column-store key is needed because the page's recno, stored
-     * in the recno field, is the column-store key.
-     */
-    uint32_t entries;
-    uint64_t recno;
-    WT_ITEM key;
-    WT_TIME_AGGREGATE ta;
-
-    size_t min_offset; /* byte offset */
-
-    WT_ITEM image; /* disk-image */
-
-    /* For fixed-length column store, track where the time windows start and how many we have. */
-    uint32_t aux_start_offset;
-    uint32_t auxentries;
-};
-
-/*
- * Reconciliation tracks two time aggregates per chunk, one for the full chunk and one for the part
- * of the chunk past the split boundary. In every situation that we write to the main aggregate we
- * need to write to the "after" aggregate. These helper macros were added with that in mind.
- */
-#define WT_REC_CHUNK_TA_UPDATE(session, chunk, tw)                                    \
-    do {                                                                              \
-        WT_TIME_AGGREGATE_UPDATE((session), &(chunk)->ta, (tw));                      \
-        WT_TIME_AGGREGATE_UPDATE((session), &(chunk)->ta_after_split_boundary, (tw)); \
-    } while (0)
-#define WT_REC_CHUNK_TA_MERGE(session, chunk, ta_agg)                                    \
-    do {                                                                                 \
-        WT_TIME_AGGREGATE_MERGE((session), &(chunk)->ta, (ta_agg));                      \
-        WT_TIME_AGGREGATE_MERGE((session), &(chunk)->ta_after_split_boundary, (ta_agg)); \
-    } while (0)
-
-/*
  * WT_DELETE_HS_UPD --
  *	Update that needs to be deleted from the history store.
  */
@@ -350,40 +264,6 @@ struct __wt_reconcile {
     bool hs_clear_on_tombstone;
     WT_CURSOR *hs_cursor;
 };
-
-/*
- * WT_CHILD_RELEASE, WT_CHILD_RELEASE_ERR --
- *	Macros to clean up during internal-page reconciliation, releasing the hazard pointer we're
- * holding on a child page.
- */
-#define WT_CHILD_RELEASE(session, hazard, ref)                          \
-    do {                                                                \
-        if (hazard) {                                                   \
-            (hazard) = false;                                           \
-            WT_TRET(__wt_page_release(session, ref, WT_READ_NO_EVICT)); \
-        }                                                               \
-    } while (0)
-#define WT_CHILD_RELEASE_ERR(session, hazard, ref) \
-    do {                                           \
-        WT_CHILD_RELEASE(session, hazard, ref);    \
-        WT_ERR(ret);                               \
-    } while (0)
-
-/*
- * Macros from fixed-length entries to/from bytes.
- */
-#define WT_COL_FIX_BYTES_TO_ENTRIES(btree, bytes) ((uint32_t)((((bytes)*8) / (btree)->bitcnt)))
-#define WT_COL_FIX_ENTRIES_TO_BYTES(btree, entries) \
-    ((uint32_t)WT_ALIGN((entries) * (btree)->bitcnt, 8))
-
-#define WT_UPDATE_SELECT_INIT(upd_select)       \
-    do {                                        \
-        (upd_select)->upd = NULL;               \
-        (upd_select)->tombstone = NULL;         \
-        (upd_select)->upd_saved = false;        \
-        (upd_select)->no_ts_tombstone = false;  \
-        WT_TIME_WINDOW_INIT(&(upd_select)->tw); \
-    } while (0)
 
 /*
  * Enumeration used to track the context of reconstructing modifies within a update list.

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -26,6 +26,110 @@ typedef struct {
     bool hazard; /* If currently holding a child hazard pointer */
 } WT_CHILD_MODIFY_STATE;
 
+/*
+ * WT_CHILD_RELEASE, WT_CHILD_RELEASE_ERR --
+ *	Macros to clean up during internal-page reconciliation, releasing the hazard pointer we're
+ * holding on a child page.
+ */
+#define WT_CHILD_RELEASE(session, hazard, ref)                          \
+    do {                                                                \
+        if (hazard) {                                                   \
+            (hazard) = false;                                           \
+            WT_TRET(__wt_page_release(session, ref, WT_READ_NO_EVICT)); \
+        }                                                               \
+    } while (0)
+#define WT_CHILD_RELEASE_ERR(session, hazard, ref) \
+    do {                                           \
+        WT_CHILD_RELEASE(session, hazard, ref);    \
+        WT_ERR(ret);                               \
+    } while (0)
+
+/*
+ * WT_REC_KV--
+ *	An on-page key/value item we're building.
+ */
+struct __wt_rec_kv {
+    WT_ITEM buf;  /* Data */
+    WT_CELL cell; /* Cell and cell's length */
+    size_t cell_len;
+    size_t len; /* Total length of cell + data */
+};
+
+/*
+ * WT_REC_DICTIONARY --
+ *  We optionally build a dictionary of values for leaf pages. Where
+ * two value cells are identical, only write the value once, the second
+ * and subsequent copies point to the original cell. The dictionary is
+ * fixed size, but organized in a skip-list to make searches faster.
+ */
+struct __wt_rec_dictionary {
+    uint64_t hash;   /* Hash value */
+    uint32_t offset; /* Matching cell */
+
+    u_int depth; /* Skiplist */
+    WT_REC_DICTIONARY *next[0];
+};
+
+/*
+ * WT_REC_CHUNK --
+ *	Reconciliation split chunk. If the total chunk size crosses the split size additional
+ *  information is stored about where that is.
+ */
+struct __wt_rec_chunk {
+    /*
+     * These fields track the amount of entries and their associated timestamps prior to the split
+     * boundary.
+     */
+    uint32_t entries_before_split_boundary;
+    WT_TIME_AGGREGATE ta_before_split_boundary;
+
+    /* These fields track the key or recno of the very first entry past the split boundary. */
+    uint64_t recno_at_split_boundary;
+    WT_ITEM key_at_split_boundary;
+
+    /*
+     * This time aggregate tracks the aggregated timestamps of all the entries past the split
+     * boundary. Merged with the "before" entry it will equal the full time aggregate for the chunk.
+     */
+    WT_TIME_AGGREGATE ta_after_split_boundary;
+
+    /*
+     * The recno and entries fields are the starting record number of the chunk (for column-store
+     * splits), and the number of entries in the chunk.
+     *
+     * The key for a row-store page; no column-store key is needed because the page's recno, stored
+     * in the recno field, is the column-store key.
+     */
+    uint32_t entries;
+    uint64_t recno;
+    WT_ITEM key;
+    WT_TIME_AGGREGATE ta;
+
+    size_t min_offset; /* byte offset */
+
+    WT_ITEM image; /* disk-image */
+
+    /* For fixed-length column store, track where the time windows start and how many we have. */
+    uint32_t aux_start_offset;
+    uint32_t auxentries;
+};
+
+/*
+ * Reconciliation tracks two time aggregates per chunk, one for the full chunk and one for the part
+ * of the chunk past the split boundary. In every situation that we write to the main aggregate we
+ * need to write to the "after" aggregate. These helper macros were added with that in mind.
+ */
+#define WT_REC_CHUNK_TA_UPDATE(session, chunk, tw)                                    \
+    do {                                                                              \
+        WT_TIME_AGGREGATE_UPDATE((session), &(chunk)->ta, (tw));                      \
+        WT_TIME_AGGREGATE_UPDATE((session), &(chunk)->ta_after_split_boundary, (tw)); \
+    } while (0)
+#define WT_REC_CHUNK_TA_MERGE(session, chunk, ta_agg)                                    \
+    do {                                                                                 \
+        WT_TIME_AGGREGATE_MERGE((session), &(chunk)->ta, (ta_agg));                      \
+        WT_TIME_AGGREGATE_MERGE((session), &(chunk)->ta_after_split_boundary, (ta_agg)); \
+    } while (0)
+
 typedef struct {
     WT_UPDATE *upd;       /* Update to write (or NULL) */
     WT_UPDATE *tombstone; /* The tombstone to write (or NULL) */
@@ -35,6 +139,22 @@ typedef struct {
     bool upd_saved;       /* An element on the row's update chain was saved */
     bool no_ts_tombstone; /* Tombstone without a timestamp */
 } WT_UPDATE_SELECT;
+
+#define WT_UPDATE_SELECT_INIT(upd_select)       \
+    do {                                        \
+        (upd_select)->upd = NULL;               \
+        (upd_select)->tombstone = NULL;         \
+        (upd_select)->upd_saved = false;        \
+        (upd_select)->no_ts_tombstone = false;  \
+        WT_TIME_WINDOW_INIT(&(upd_select)->tw); \
+    } while (0)
+
+/*
+ * Macros from fixed-length entries to/from bytes.
+ */
+#define WT_COL_FIX_BYTES_TO_ENTRIES(btree, bytes) ((uint32_t)((((bytes)*8) / (btree)->bitcnt)))
+#define WT_COL_FIX_ENTRIES_TO_BYTES(btree, entries) \
+    ((uint32_t)WT_ALIGN((entries) * (btree)->bitcnt, 8))
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -1,0 +1,90 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ * All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#pragma once
+
+/*
+ * WT_CHILD_MODIFY_STATE --
+ *	We review child pages (while holding the child page's WT_REF lock), during internal-page
+ * reconciliation. This structure encapsulates the child page's returned information/state.
+ */
+typedef struct {
+    enum {
+        WT_CHILD_IGNORE,   /* Ignored child */
+        WT_CHILD_MODIFIED, /* Modified child */
+        WT_CHILD_ORIGINAL, /* Original child */
+        WT_CHILD_PROXY     /* Deleted child: proxy */
+    } state;               /* Returned child state */
+
+    WT_PAGE_DELETED del; /* WT_CHILD_PROXY state fast-truncate information */
+
+    bool hazard; /* If currently holding a child hazard pointer */
+} WT_CHILD_MODIFY_STATE;
+
+typedef struct {
+    WT_UPDATE *upd;       /* Update to write (or NULL) */
+    WT_UPDATE *tombstone; /* The tombstone to write (or NULL) */
+
+    WT_TIME_WINDOW tw;
+
+    bool upd_saved;       /* An element on the row's update chain was saved */
+    bool no_ts_tombstone; /* Tombstone without a timestamp */
+} WT_UPDATE_SELECT;
+
+/* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
+
+extern int __wti_ovfl_reuse_add(WT_SESSION_IMPL *session, WT_PAGE *page, const uint8_t *addr,
+  size_t addr_size, const void *value, size_t value_size)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_ovfl_reuse_search(WT_SESSION_IMPL *session, WT_PAGE *page, uint8_t **addrp,
+  size_t *addr_sizep, const void *value, size_t value_size)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_ovfl_track_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_ovfl_track_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_child_modify(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *ref,
+  WT_CHILD_MODIFY_STATE *cmsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_col_fix(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
+  WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_col_var(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
+  WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_dictionary_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, u_int slots)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_hs_clear_on_tombstone(WT_SESSION_IMPL *session, WT_RECONCILE *r,
+  uint64_t recno, WT_ITEM *rowkey, bool reinsert) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_row_leaf(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref,
+  WT_SALVAGE_COOKIE *salvage) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_split(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t next_len)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_split_finish(WT_SESSION_IMPL *session, WT_RECONCILE *r)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_split_grow(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t add_len)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_split_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page,
+  uint64_t recno, uint64_t primary_size, uint32_t auxiliary_size)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_rec_upd_select(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins,
+  WT_ROW *rip, WT_CELL_UNPACK_KV *vpack, WT_UPDATE_SELECT *upd_select)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wti_rec_col_fix_write_auxheader(WT_SESSION_IMPL *session, uint32_t entries,
+  uint32_t aux_start_offset, uint32_t auxentries, uint8_t *image, size_t size);
+extern void __wti_rec_dictionary_free(WT_SESSION_IMPL *session, WT_RECONCILE *r);
+extern void __wti_rec_dictionary_reset(WT_RECONCILE *r);
+
+#ifdef HAVE_UNITTEST
+
+#endif
+
+/* DO NOT EDIT: automatically built by prototypes.py: END */


### PR DESCRIPTION
Now the reconcile module has two header files.
1. reconcile.h
2. reconcile_private.h.

The reconcile.h has all the public members and the reconcile_private.h has all the private members of the reconcile module.
