### PR TITLE
WT-13745 Revert "WT-13591 Don't leave dirty btrees after RTS/recovery/shutdown(#11061)"

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -22,36 +22,30 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
 
     WT_ASSERT_SPINLOCK_OWNED(session, &S2BT(session)->flush_lock);
 
+    mod = ref->page->modify;
+    txn = session->txn;
+
     /*
-     * Don't skip checkpoint if at least one of the following conditions is met:
+     * We can skip some dirty pages during a checkpoint. The requirements:
      *
-     *  - This checkpoint happens during RTS, recovery or shutdown. Those scenarios should not leave
-     * anything dirty behind.
-     *  - This is the history store btree. As part of the checkpointing the data store, we will move
-     * the older values into the history store without using any transactions. This led to
-     * representation of all the modifications on the history store page with a transaction that is
-     * maximum than the checkpoint snapshot. But these modifications are done by the checkpoint
-     * itself, so we shouldn't ignore them for consistency.
-     * - If we got to this point and we are dealing with an internal page, this means at least one
-     * of its leaf pages has been reconciled and we need to process the internal page as well.
-     * - There is no snapshot transaction active. Usually, there is one in ordinary application
-     * checkpoints but not all internal cases. Furthermore, this guarantees the metadata file is
-     * never skipped.
-     * - the checkpoint's snapshot includes the first dirty update on the page.
-     * - Not every disk block involved has a disk address.
+     * 1. Not a history btree. As part of the checkpointing the data store, we will move the older
+     *    values into the history store without using any transactions. This led to representation
+     *    of all the modifications on the history store page with a transaction that is maximum than
+     *    the checkpoint snapshot. But these modifications are done by the checkpoint itself, so we
+     *    shouldn't ignore them for consistency.
+     * 2. they must be leaf pages,
+     * 3. there is a snapshot transaction active (which is the case in ordinary application
+     *    checkpoints but not all internal cases),
+     * 4. the first dirty update on the page is sufficiently recent the checkpoint transaction would
+     *     skip them,
+     * 5. there's already an address for every disk block involved.
      */
-    if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))
-        return (false);
-    if (F_ISSET(S2C(session), WT_CONN_RECOVERING) | WT_CONN_CLOSING_CHECKPOINT)
-        return (false);
     if (WT_IS_HS(session->dhandle))
         return (false);
     if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         return (false);
-    txn = session->txn;
     if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
         return (false);
-    mod = ref->page->modify;
     if (!WT_TXNID_LT(txn->snapshot_data.snap_max, mod->first_dirty_txn))
         return (false);
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -331,7 +331,7 @@ struct __wt_page_modify {
     uint64_t obsolete_check_txn;
     wt_timestamp_t obsolete_check_timestamp;
 
-    /* The largest transaction and timestamp seen on the page by reconciliation. */
+    /* The largest transaction seen on the page by reconciliation. */
     uint64_t rec_max_txn;
     wt_timestamp_t rec_max_timestamp;
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -698,20 +698,6 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
         /* Assert we never dirty a checkpoint handle. */
         WT_ASSERT(session, !WT_READING_CHECKPOINT(session));
 
-        /*
-         * We should never set a btree dirty when checkpoint is triggered by RTS, recovery or when
-         * closing the connection. Those specific scenarios should always leave the database clean.
-         * The only exception is related to the metadata file: it is expected to be marked as dirty
-         * whenever a btree is checkpointed.
-         */
-        if (WT_SESSION_BTREE_SYNC(session) && !WT_IS_METADATA(session->dhandle) &&
-          !FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_CHECKPOINT_EVICT_PAGE)) {
-            WT_ASSERT_ALWAYS(session, !F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE), "%s",
-              "A btree is marked dirty during RTS");
-            WT_ASSERT_ALWAYS(session,
-              !F_ISSET(S2C(session), WT_CONN_RECOVERING | WT_CONN_CLOSING_CHECKPOINT), "%s",
-              "A btree is marked dirty during recovery or shutdown");
-        }
         S2BT(session)->modified = true;
         WT_FULL_BARRIER();
 

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -436,8 +436,6 @@ __wti_rts_btree_walk_btree(WT_SESSION_IMPL *session, wt_timestamp_t rollback_tim
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
-    wt_timestamp_t stable_timestamp;
-    uint64_t oldest_id;
 
     btree = S2BT(session);
     conn = S2C(session);
@@ -460,18 +458,5 @@ __wti_rts_btree_walk_btree(WT_SESSION_IMPL *session, wt_timestamp_t rollback_tim
     if (btree->root.page == NULL)
         return (0);
 
-    WT_RET(__rts_btree_walk(session, rollback_timestamp));
-
-    /*
-     * Now the unstable data has been rolled back, we can set the reconciliation information to
-     * reflect that the tree only contains stable data. The fields are set in a way to ensure RTS
-     * does not mark the btree as dirty when checkpoint is happening.
-     */
-    oldest_id = __wt_atomic_loadv64(&conn->txn_global.oldest_id);
-    stable_timestamp = __wt_atomic_loadv64(&conn->txn_global.stable_timestamp);
-    WT_ASSERT(session, oldest_id > WT_TXN_NONE);
-    btree->rec_max_txn = oldest_id - 1;
-    btree->rec_max_timestamp = stable_timestamp;
-
-    return (0);
+    return (__rts_btree_walk(session, rollback_timestamp));
 }


### PR DESCRIPTION
This reverts commit bda87786ee50cb98aa03633011f0225068f68f0c.
