### PR TITLE
WT-13746 Don't leave dirty btrees after RTS/recovery/shutdown

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -22,30 +22,36 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
 
     WT_ASSERT_SPINLOCK_OWNED(session, &S2BT(session)->flush_lock);
 
-    mod = ref->page->modify;
-    txn = session->txn;
-
     /*
-     * We can skip some dirty pages during a checkpoint. The requirements:
+     * Don't skip checkpoint if at least one of the following conditions is met:
      *
-     * 1. Not a history btree. As part of the checkpointing the data store, we will move the older
-     *    values into the history store without using any transactions. This led to representation
-     *    of all the modifications on the history store page with a transaction that is maximum than
-     *    the checkpoint snapshot. But these modifications are done by the checkpoint itself, so we
-     *    shouldn't ignore them for consistency.
-     * 2. they must be leaf pages,
-     * 3. there is a snapshot transaction active (which is the case in ordinary application
-     *    checkpoints but not all internal cases),
-     * 4. the first dirty update on the page is sufficiently recent the checkpoint transaction would
-     *     skip them,
-     * 5. there's already an address for every disk block involved.
+     *  - This checkpoint happens during RTS, recovery or shutdown. Those scenarios should not leave
+     * anything dirty behind.
+     *  - This is the history store btree. As part of the checkpointing the data store, we will move
+     * the older values into the history store without using any transactions. This led to
+     * representation of all the modifications on the history store page with a transaction that is
+     * maximum than the checkpoint snapshot. But these modifications are done by the checkpoint
+     * itself, so we shouldn't ignore them for consistency.
+     * - If we got to this point and we are dealing with an internal page, this means at least one
+     * of its leaf pages has been reconciled and we need to process the internal page as well.
+     * - There is no snapshot transaction active. Usually, there is one in ordinary application
+     * checkpoints but not all internal cases. Furthermore, this guarantees the metadata file is
+     * never skipped.
+     * - the checkpoint's snapshot includes the first dirty update on the page.
+     * - Not every disk block involved has a disk address.
      */
+    if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))
+        return (false);
+    if (F_ISSET(S2C(session), WT_CONN_RECOVERING) | WT_CONN_CLOSING_CHECKPOINT)
+        return (false);
     if (WT_IS_HS(session->dhandle))
         return (false);
     if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         return (false);
+    txn = session->txn;
     if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
         return (false);
+    mod = ref->page->modify;
     if (!WT_TXNID_LT(txn->snapshot_data.snap_max, mod->first_dirty_txn))
         return (false);
 

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -31,10 +31,8 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
 
     /*
      * This is the history store btree. As part of the checkpointing the data store, we will move
-     * the older values into the history store without using any transactions. This led to
-     * representation of all the modifications on the history store page with a transaction that is
-     * maximum than the checkpoint snapshot. But these modifications are done by the checkpoint
-     * itself, so we shouldn't ignore them for consistency.
+     * the older values into the history store without using any transactions, we shouldn't ignore
+     * them for consistency
      */
     if (WT_IS_HS(session->dhandle))
         return (false);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -42,7 +42,7 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
      */
     if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))
         return (false);
-    if (F_ISSET(S2C(session), WT_CONN_RECOVERING) | WT_CONN_CLOSING_CHECKPOINT)
+    if (F_ISSET(S2C(session), WT_CONN_RECOVERING | WT_CONN_CLOSING_CHECKPOINT))
         return (false);
     if (WT_IS_HS(session->dhandle))
         return (false);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -58,7 +58,7 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
             if (multi->addr.addr == NULL)
                 return (false);
 
-     /* RTS, recovery or shutdown should not leave anything dirty behind. */
+    /* RTS, recovery or shutdown should not leave anything dirty behind. */
     if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))
         return (false);
     if (F_ISSET(S2C(session), WT_CONN_RECOVERING | WT_CONN_CLOSING_CHECKPOINT))
@@ -68,7 +68,7 @@ __sync_checkpoint_can_skip(WT_SESSION_IMPL *session, WT_REF *ref)
      * There is no snapshot transaction active. Usually, there is one in ordinary application
      * checkpoints but not all internal cases. Furthermore, this guarantees the metadata file is
      * never skipped.
-     * */
+     */
     if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
         return (false);
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -331,7 +331,7 @@ struct __wt_page_modify {
     uint64_t obsolete_check_txn;
     wt_timestamp_t obsolete_check_timestamp;
 
-    /* The largest transaction seen on the page by reconciliation. */
+    /* The largest transaction and timestamp seen on the page by reconciliation. */
     uint64_t rec_max_txn;
     wt_timestamp_t rec_max_timestamp;
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -698,6 +698,20 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
         /* Assert we never dirty a checkpoint handle. */
         WT_ASSERT(session, !WT_READING_CHECKPOINT(session));
 
+        /*
+         * We should never set a btree dirty when checkpoint is triggered by RTS, recovery or when
+         * closing the connection. Those specific scenarios should always leave the database clean.
+         * The only exception is related to the metadata file: it is expected to be marked as dirty
+         * whenever a btree is checkpointed.
+         */
+        if (WT_SESSION_BTREE_SYNC(session) && !WT_IS_METADATA(session->dhandle) &&
+          !FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_CHECKPOINT_EVICT_PAGE)) {
+            WT_ASSERT_ALWAYS(session, !F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE), "%s",
+              "A btree is marked dirty during RTS");
+            WT_ASSERT_ALWAYS(session,
+              !F_ISSET(S2C(session), WT_CONN_RECOVERING | WT_CONN_CLOSING_CHECKPOINT), "%s",
+              "A btree is marked dirty during recovery or shutdown");
+        }
         S2BT(session)->modified = true;
         WT_FULL_BARRIER();
 


### PR DESCRIPTION
The changes ensure WiredTiger does not leave btrees dirty in specific scenarios such as RTS, recovery and shutdown. In those scenarios, since there should not be other actors using the btrees, checkpoint should be able to process them and mark them clean.