### PR TITLE
WT-13750 Refactor two if checks using a function

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -695,7 +695,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
      * sync.
      */
     deleted_entries = 0;
-    if (!WT_BTREE_SYNCING(btree) || WT_SESSION_BTREE_SYNC(session))
+    if (!__wt_btree_syncing_by_other_session(session))
         for (i = 0; i < parent_entries; ++i) {
             next_ref = pindex->index[i];
             WT_ASSERT(session, WT_REF_GET_STATE(next_ref) != WT_REF_SPLIT);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2073,7 +2073,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
      * If reconciliation requires multiple blocks and checkpoint is running we'll eventually fail,
      * unless we're the checkpoint thread. Big pages take a lot of writes, avoid wasting work.
      */
-    if (!last_block && WT_BTREE_SYNCING(btree) && !WT_SESSION_BTREE_SYNC(session)) {
+    if (!last_block && __wt_btree_syncing_by_other_session(session)) {
         WT_STAT_CONN_DSRC_INCR(
           session, cache_eviction_blocked_multi_block_reconciliation_during_checkpoint);
         return (__wt_set_return(session, EBUSY));


### PR DESCRIPTION
Two checks can be replaced by using the __wt_btree_syncing_by_other_session function. It should improve the readability of the code.