### PR TITLE
SLS-51 Write disk image for update restore eviction

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2415,8 +2415,10 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
             return (__wt_set_return(session, EBUSY));
 
         /*
-         * If we need to restore the page to memory, copy the disk image if it is not disaggregated
-         * or it is empty.
+         * If we need to restore the page to memory, copy the disk image.
+         *
+         * We need to write the disk image for disaggregated storage as a later reconciliation may
+         * build a delta that is based on a page image that was never written to disk.
          */
         if (multi->supd_restore && (!F_ISSET(btree, WT_BTREE_DISAGGREGATED) || chunk->entries == 0))
             goto copy_image;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2415,7 +2415,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
             return (__wt_set_return(session, EBUSY));
 
         /* If we need to restore the page to memory, copy the disk image. */
-        if (multi->supd_restore)
+        if (multi->supd_restore && chunk->entries == 0)
             goto copy_image;
 
         WT_ASSERT_ALWAYS(session, chunk->entries > 0, "Trying to write an empty chunk");

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2405,17 +2405,17 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
         goto copy_image;
 
     /* Check the eviction flag as checkpoint also saves updates. */
-    if (F_ISSET(r, WT_REC_EVICT) && multi->supd != NULL) {
+    if (F_ISSET(r, WT_REC_EVICT) && multi->supd != NULL && chunk->entries == 0) {
         /*
          * XXX If no entries were used, the page is empty and we can only restore eviction/restore
          * or history store updates against empty row-store leaf pages, column-store modify attempts
          * to allocate a zero-length array.
          */
-        if (r->page->type != WT_PAGE_ROW_LEAF && chunk->entries == 0)
+        if (r->page->type != WT_PAGE_ROW_LEAF)
             return (__wt_set_return(session, EBUSY));
 
-        /* If we need to restore the page to memory, copy the disk image. */
-        if (multi->supd_restore && chunk->entries == 0)
+        /* If we need to restore the page to memory, copy the disk image if it is empty. */
+        if (multi->supd_restore)
             goto copy_image;
 
         WT_ASSERT_ALWAYS(session, chunk->entries > 0, "Trying to write an empty chunk");


### PR DESCRIPTION
We currently skip write the disk image to disk if it's an update restore eviction because it will be written again by the checkpoint later anyway. However, it is not correct if we have delta. We need to ensure the delta is built on a disk image that has been written to disk. Change to always write the disk image even for update restore eviction.
