### PR TITLE
WT-13232 Don't return prepare conflicts with a key adjacent to a truncation range

### DIFF
--- a/src/include/truncate.h
+++ b/src/include/truncate.h
@@ -17,6 +17,8 @@ struct __wt_truncate_info {
     const char *uri;
     WT_CURSOR *start;
     WT_CURSOR *stop;
+    WT_CURSOR *orig_start;
+    WT_CURSOR *orig_stop;
     WT_ITEM *orig_start_key;
     WT_ITEM *orig_stop_key;
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1596,7 +1596,8 @@ err:
 
 /*
  * __check_key_outside_truncate_range --
- *     Checks if the key falls outside the truncate range, inclusive of the start and stop keys if provided.
+ *     Checks if the key falls outside the truncate range, inclusive of the start and stop keys if
+ *     provided.
  */
 static bool
 __check_key_outside_truncate_range(WT_CURSOR *current, WT_TRUNCATE_INFO *trunc_info)
@@ -1725,7 +1726,8 @@ __wt_session_range_truncate(
         if (orig_start_key != NULL) {
             ret = start->search_near(start, &cmp);
             if (ret == WT_PREPARE_CONFLICT) {
-                /* Don't return a prepare conflict if the key we land on falls outside the truncate range. */
+                /* Don't return a prepare conflict if the key we land on falls outside the truncate
+                 * range. */
                 if (__check_key_outside_truncate_range(start, trunc_info)) {
                     F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
                     WT_ERR_NOTFOUND_OK(start->search_near(start, &cmp), true);
@@ -1743,7 +1745,8 @@ __wt_session_range_truncate(
         if (needs_next_prev) {
             ret = start->next(start);
             if (ret == WT_PREPARE_CONFLICT) {
-                /* Don't return a prepare conflict if the key we land on falls outside the truncate range. */
+                /* Don't return a prepare conflict if the key we land on falls outside the truncate
+                 * range. */
                 if (__check_key_outside_truncate_range(start, trunc_info)) {
                     F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
                     WT_ERR_NOTFOUND_OK(start->next(start), true);
@@ -1762,7 +1765,8 @@ __wt_session_range_truncate(
     if (stop != NULL && !F_ISSET(stop, WT_CURSTD_KEY_INT)) {
         ret = stop->search_near(stop, &cmp);
         if (ret == WT_PREPARE_CONFLICT) {
-            /* Don't return a prepare conflict if the key we land on falls outside the truncate range. */
+            /* Don't return a prepare conflict if the key we land on falls outside the truncate
+             * range. */
             if (__check_key_outside_truncate_range(stop, trunc_info)) {
                 F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
                 WT_ERR_NOTFOUND_OK(stop->search_near(stop, &cmp), true);
@@ -1779,7 +1783,8 @@ __wt_session_range_truncate(
         if (needs_next_prev) {
             ret = stop->prev(stop);
             if (ret == WT_PREPARE_CONFLICT) {
-                /* Don't return a prepare conflict if the key we land on falls outside the truncate range. */
+                /* Don't return a prepare conflict if the key we land on falls outside the truncate
+                 * range. */
                 if (__check_key_outside_truncate_range(stop, trunc_info)) {
                     F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
                     WT_ERR_NOTFOUND_OK(stop->prev(stop), true);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1596,7 +1596,7 @@ err:
 
 /*
  * __check_key_outside_truncate_range --
- *     Checks if the key falls outside the truncate range, inclusive of the start and stop keys if
+ *     Checks if a cursor is positioned on a key that falls outside the truncate range, inclusive of the start and stop keys if
  *     provided.
  */
 static bool
@@ -1745,8 +1745,10 @@ __wt_session_range_truncate(
         if (needs_next_prev) {
             ret = start->next(start);
             if (ret == WT_PREPARE_CONFLICT) {
-                /* Don't return a prepare conflict if the key we land on falls outside the truncate
-                 * range. */
+                /* 
+                 * Don't return a prepare conflict if the key we land on falls outside the truncate
+                 * range. 
+                 */
                 if (__check_key_outside_truncate_range(start, trunc_info)) {
                     F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
                     WT_ERR_NOTFOUND_OK(start->next(start), true);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1601,7 +1601,17 @@ err:
 static bool
 __check_key_outside_truncate_range(WT_CURSOR *current, WT_TRUNCATE_INFO *trunc_info)
 {
-    return (current->key.data < trunc_info->orig_start_key->data || current->key.data > trunc_info->orig_stop_key->data);
+    if (trunc_info->orig_start_key != NULL) {
+        if (current->key.data < trunc_info->orig_start_key->data)
+            return (true);
+    }
+
+    if (trunc_info->orig_stop_key != NULL) {
+        if (current->key.data > trunc_info->orig_stop_key->data)
+            return (true);
+    }
+
+    return (false);
 }
 
 /*

--- a/test/evergreen/run_model_workloads.sh
+++ b/test/evergreen/run_model_workloads.sh
@@ -20,13 +20,6 @@ do
     echo
     echo "Testing workload $BASENAME_WORKLOAD"
 
-    # FIXME-WT-13232 The WT-12539 workload can be re-enabled once we've confirmed
-    # how to handle prepare conflicts on keys adjacent to the truncation range.
-    if [[ "$BASENAME_WORKLOAD" = "WT-12539" ]]; then
-        echo "Skipping workload"
-        continue
-    fi
-
     ./model_test -R -h "WT_TEST_$BASENAME_WORKLOAD" -w "$W"
     RESULT="$?"
 

--- a/test/model/src/core/kv_table.cpp
+++ b/test/model/src/core/kv_table.cpp
@@ -272,28 +272,6 @@ kv_table::truncate(kv_transaction_ptr txn, const data_value &start, const data_v
     auto stop_iter = stop == model::NONE ? _data.end() : _data.upper_bound(stop);
 
     try {
-        /* FIXME-WT-13232 Disable this check or make it FLCS only (depending on the fix). */
-        /*
-         * WiredTiger's implementation of truncate returns a prepare conflict if the key following
-         * (or, in some cases, preceding) the truncate range belongs to a prepared transaction. In
-         * the case of FLCS, skip all implicitly created items before and after the truncation
-         * range.
-         */
-        for (auto i = stop_iter; i != _data.end(); i++) {
-            if (i->second.has_prepared())
-                throw known_issue_exception("WT-13232");
-            if (!i->second.exists(txn) || i->second.implicit())
-                continue;
-            break;
-        }
-        for (auto i = std::reverse_iterator(start_iter); i != _data.rend(); i++) {
-            if (i->second.has_prepared())
-                throw known_issue_exception("WT-13232");
-            if (!i->second.exists(txn) || i->second.implicit())
-                continue;
-            break;
-        }
-
         for (auto i = start_iter; i != stop_iter; i++) {
             std::shared_ptr<kv_update> update = fix_timestamps(std::make_shared<kv_update>(
               _config.type == kv_table_type::column_fix ? ZERO : NONE, txn));

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -70,7 +70,6 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     update_existing = 0.1;
 
     prepared_transaction = 0.25;
-    max_delay_after_prepare = 25; /* FIXME-WT-13232 This must be a small number until it's fixed. */
     use_set_commit_timestamp = 0.25;
     nonprepared_transaction_rollback = 0.1;
     prepared_transaction_rollback_after_prepare = 0.1;

--- a/test/suite/test_truncate23.py
+++ b/test/suite/test_truncate23.py
@@ -122,10 +122,6 @@ class test_truncate23(wttest.WiredTigerTestCase):
         Test boundary conditions for truncate with and without prepared transactions.
         '''
 
-        # This test is disabled until we determine how to handle prepare conflicts with keys adjacent
-        # to the truncation range
-        self.skipTest("FIXME-WT-13232")
-
         # First test this without the prepared transactions to ensure that everything works.
         for prepared in [False, True]:
 


### PR DESCRIPTION
Unfortunately, it seems that after making this fix, the RTS test/model is getting stuck on another malformed workload which is why that test is not coming out clean. I've raised another ticket to address that here: https://jira.mongodb.org/browse/WT-13742