### PR TITLE
SLS-558 Handle advancing checkpoint in failure cases

### DIFF
--- a/src/conn/conn_oligarch.c
+++ b/src/conn/conn_oligarch.c
@@ -1135,7 +1135,7 @@ __wt_disagg_begin_checkpoint(WT_SESSION_IMPL *session, uint64_t next_checkpoint_
  *     Advance to the next checkpoint. If the current checkpoint is 0, just start the next one.
  */
 int
-__wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session)
+__wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DISAGGREGATED_STORAGE *disagg;
@@ -1153,8 +1153,10 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session)
     WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
     WT_ASSERT(session, checkpoint_id > 0);
 
-    WT_RET(disagg->npage_log->page_log->pl_complete_checkpoint(
-      disagg->npage_log->page_log, &session->iface, checkpoint_id));
+    if (ckpt_success)
+        WT_RET(disagg->npage_log->page_log->pl_complete_checkpoint(
+          disagg->npage_log->page_log, &session->iface, checkpoint_id));
+
     WT_RET(__wt_disagg_begin_checkpoint(session, checkpoint_id + 1));
 
     return (0);

--- a/src/conn/conn_oligarch.c
+++ b/src/conn/conn_oligarch.c
@@ -1082,6 +1082,7 @@ __wt_disagg_put_meta(
         WT_ASSERT(session, disagg->bstorage_meta == NULL);
         WT_RET(disagg->page_log_meta->plh_put(
           disagg->page_log_meta, &session->iface, page_id, checkpoint_id, &put_args, item));
+        __wt_atomic_addv64(&disagg->num_meta_put, 1);
         return (0);
     }
 
@@ -1089,6 +1090,7 @@ __wt_disagg_put_meta(
         WT_RET(
           disagg->bstorage_meta->fh_obj_put(disagg->bstorage_meta, &session->iface, page_id, item));
         WT_RET(disagg->bstorage_meta->fh_obj_checkpoint(disagg->bstorage_meta, &session->iface));
+        __wt_atomic_addv64(&disagg->num_meta_put, 1);
         return (0);
     }
 
@@ -1124,6 +1126,7 @@ __wt_disagg_begin_checkpoint(WT_SESSION_IMPL *session, uint64_t next_checkpoint_
 
     /* Store is sufficient because updates are protected by the checkpoint lock. */
     WT_RELEASE_WRITE(disagg->global_checkpoint_id, next_checkpoint_id);
+    disagg->num_meta_put_at_ckpt_begin = disagg->num_meta_put;
     return (0);
 }
 

--- a/src/conn/conn_oligarch.c
+++ b/src/conn/conn_oligarch.c
@@ -1082,7 +1082,6 @@ __wt_disagg_put_meta(
         WT_ASSERT(session, disagg->bstorage_meta == NULL);
         WT_RET(disagg->page_log_meta->plh_put(
           disagg->page_log_meta, &session->iface, page_id, checkpoint_id, &put_args, item));
-        __wt_atomic_addv64(&disagg->num_meta_put, 1);
         return (0);
     }
 
@@ -1090,7 +1089,6 @@ __wt_disagg_put_meta(
         WT_RET(
           disagg->bstorage_meta->fh_obj_put(disagg->bstorage_meta, &session->iface, page_id, item));
         WT_RET(disagg->bstorage_meta->fh_obj_checkpoint(disagg->bstorage_meta, &session->iface));
-        __wt_atomic_addv64(&disagg->num_meta_put, 1);
         return (0);
     }
 
@@ -1126,7 +1124,6 @@ __wt_disagg_begin_checkpoint(WT_SESSION_IMPL *session, uint64_t next_checkpoint_
 
     /* Store is sufficient because updates are protected by the checkpoint lock. */
     WT_RELEASE_WRITE(disagg->global_checkpoint_id, next_checkpoint_id);
-    disagg->num_meta_put_at_ckpt_begin = disagg->num_meta_put;
     return (0);
 }
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -185,7 +185,11 @@ struct __wt_disaggregated_storage {
     WT_BUCKET_STORAGE *bstorage;
     WT_NAMED_STORAGE_SOURCE *nstorage;
     WT_FILE_HANDLE *bstorage_meta;
-    /* Updates are protected by the checkpoint lock. */
+
+    wt_shared uint64_t num_meta_put; /* The number metadata puts since connection open. */
+
+    uint64_t num_meta_put_at_ckpt_begin; /* The number metadata puts at checkpoint begin. */
+                                         /* Updates are protected by the checkpoint lock. */
 };
 
 /*

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -185,11 +185,7 @@ struct __wt_disaggregated_storage {
     WT_BUCKET_STORAGE *bstorage;
     WT_NAMED_STORAGE_SOURCE *nstorage;
     WT_FILE_HANDLE *bstorage_meta;
-
-    wt_shared uint64_t num_meta_put; /* The number metadata puts since connection open. */
-
-    uint64_t num_meta_put_at_ckpt_begin; /* The number metadata puts at checkpoint begin. */
-                                         /* Updates are protected by the checkpoint lock. */
+    /* Updates are protected by the checkpoint lock. */
 };
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -760,7 +760,7 @@ extern int __wt_dhandle_update_write_gens(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_direct_io_size_check(WT_SESSION_IMPL *session, const char **cfg,
   const char *config_name, uint32_t *allocsizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session)
+extern int __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_begin_checkpoint(WT_SESSION_IMPL *session, uint64_t next_checkpoint_id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1484,17 +1484,9 @@ err:
     }
 
     session->isolation = txn->isolation = WT_ISO_READ_UNCOMMITTED;
-    if (tracking)
-        WT_TRET(__wt_meta_track_off(session, false, failed));
-
-    /*
-     * Update the global checkpoint ID in disaggregated storage. This has to be done after
-     * checkpoint resolve, which happens when we turn off metadata tracking above.
-     */
-    if (!failed && ret == 0 /* ensure that turning off meta tracking worked */) {
-        WT_ACQUIRE_READ(num_meta_put, conn->disaggregated_storage.num_meta_put);
-        if (conn->disaggregated_storage.num_meta_put_at_ckpt_begin < num_meta_put)
-            WT_TRET(__wt_disagg_advance_checkpoint(session));
+    if (tracking) {
+        if (__wt_meta_track_off(session, false, failed) != 0)
+            return (__wt_panic(session, WT_PANIC, "Failed to turn off metadata tracking."));
     }
 
     __checkpoint_set_scrub_target(session, 0.0);
@@ -1521,6 +1513,17 @@ err:
         WT_TRET(__wt_txn_checkpoint_log(session, full,
           (ret == 0 && !idle) ? WT_TXN_LOG_CKPT_STOP : WT_TXN_LOG_CKPT_CLEANUP, NULL));
     }
+
+    /*
+     * Update the global checkpoint ID in disaggregated storage. This has to be done after
+     * checkpoint resolve, which happens when we turn off metadata tracking above.
+     *
+     * Ensure that turning off meta tracking worked.
+     */
+    WT_ACQUIRE_READ(num_meta_put, conn->disaggregated_storage.num_meta_put);
+    if (conn->disaggregated_storage.num_meta_put_at_ckpt_begin < num_meta_put)
+        if (__wt_disagg_advance_checkpoint(session, !failed && ret == 0) != 0)
+            return (__wt_panic(session, WT_PANIC, "Failed to advance the checkpoint."));
 
     for (i = 0; i < session->ckpt_handle_next; ++i) {
         if (session->ckpt_handle[i] == NULL)

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1112,8 +1112,8 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     wt_timestamp_t ckpt_tmp_ts;
     size_t namelen;
     uint64_t ckpt_tree_duration_usecs, fsync_duration_usecs, generation, hs_ckpt_duration_usecs;
-    uint64_t num_meta_put, time_start_ckpt_tree, time_start_fsync, time_start_hs,
-      time_stop_ckpt_tree, time_stop_fsync, time_stop_hs;
+    uint64_t time_start_ckpt_tree, time_start_fsync, time_start_hs, time_stop_ckpt_tree,
+      time_stop_fsync, time_stop_hs;
     u_int i;
     const char *name;
     bool can_skip, failed, full, idle, logging, tracking, use_timestamp;
@@ -1520,10 +1520,8 @@ err:
      *
      * Ensure that turning off meta tracking worked.
      */
-    WT_ACQUIRE_READ(num_meta_put, conn->disaggregated_storage.num_meta_put);
-    if (conn->disaggregated_storage.num_meta_put_at_ckpt_begin < num_meta_put)
-        if (__wt_disagg_advance_checkpoint(session, !failed && ret == 0) != 0)
-            return (__wt_panic(session, WT_PANIC, "Failed to advance the checkpoint."));
+    if (__wt_disagg_advance_checkpoint(session, !failed && ret == 0) != 0)
+        return (__wt_panic(session, WT_PANIC, "Failed to advance the checkpoint."));
 
     for (i = 0; i < session->ckpt_handle_next; ++i) {
         if (session->ckpt_handle[i] == NULL)


### PR DESCRIPTION
We should still advance the checkpoint id in the failure case. This is important for the page service. We may write some pages partially in the failed checkpoint. We need to distinguish them by advancing the checkpoint id.