### PR TITLE
WT-13770 Update test/format not to use error code 127

### DIFF
--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -400,7 +400,7 @@ report_running_configs()
 
 # Wait for a process to die. Handle both child and non-child processes.
 # $1 pid
-# Return <exit code> of process if child or 127 if non-child
+# Return <exit code> of process if child or 117 if non-child
 wait_for_process()
 {
 	pid=$1
@@ -545,6 +545,8 @@ resolve()
 		# process exited with a likely failure, call it a failure.
 		signame=""
 		case $eret in
+		117)
+			signame="FORMAT_FAILED_TO_KILL_PARENT_THREAD";;
 		$((128 + 3)))
 			signame="SIGQUIT";;
 		$((128 + 4)))

--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -404,7 +404,7 @@ report_running_configs()
 wait_for_process()
 {
 	pid=$1
-	ret=127
+	ret=117
 
 	if [ `pstree -p $$ | grep -w $pid | wc -l` -gt "0" ]; then
 		# Can still produce "wait: pid XXXX is not a child of this shell" due to process


### PR DESCRIPTION
127 is a reserved error code indicating "command not found" but we're using it to report an error when test/format. Change this code to the unreserved code 117 instead.