### PR TITLE
WT-13766 Disable truncate commit timestamp validation for non-standalone builds

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1808,7 +1808,15 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
             }
             break;
         case WT_TXN_OP_REF_DELETE:
+            /*
+             * For non-standalone builds, skip truncate commit timestamp validation, as MongoDB
+             * doesn't use timestamps with truncate operations.
+             */
+#ifdef WT_STANDALONE_BUILD
             WT_ERR(__wt_txn_op_set_timestamp(session, op, true));
+#else
+            WT_ERR(__wt_txn_op_set_timestamp(session, op, false));
+#endif
             break;
         case WT_TXN_OP_TRUNCATE_COL:
         case WT_TXN_OP_TRUNCATE_ROW:

--- a/test/suite/test_truncate28.py
+++ b/test/suite/test_truncate28.py
@@ -48,6 +48,9 @@ class test_truncate28(wttest.WiredTigerTestCase):
         if wiredtiger.diagnostic_build():
             self.skipTest('requires a non-diagnostic build')
 
+        if not wiredtiger.standalone_build():
+            self.skipTest('requires a standalone build')
+
         nrows = 10000
         uri = 'table:test_truncate27'
         self.session.create(uri, 'key_format=i,value_format=S')


### PR DESCRIPTION
Currently, a non-standalone build (MongoDB) doesn't use timestamps with
truncate operations. Skip truncate commit timestamp validation to this
build to remove any unnecessary regression until they are used.