### PR TITLE
WT-13772 Remove use of WT_ITEM_ALIGNED in util_block

### DIFF
--- a/test/catch2/block/util_block.cpp
+++ b/test/catch2/block/util_block.cpp
@@ -103,7 +103,6 @@ create_write_buffer(WT_BM *bm, std::shared_ptr<mock_session> session, std::strin
     test_and_validate_write_size(bm, session, buf_memsize, allocation_size);
 
     // Initialize the buffer with aligned size.
-    F_SET(buf, WT_ITEM_ALIGNED);
     REQUIRE(__wt_buf_initsize(session->get_wt_session_impl(), buf, buf_memsize) == 0);
 
     /*


### PR DESCRIPTION
The removal of the directIO feature in WT-13227 also removed the flag `WT_ITEM_ALIGNED`. It is no longer necessary to set the flag as no other logic relies on the alignment flag.