### PR TITLE
SLS-518 Fix largest key implementation and implement a simple random cursor for oligarch table

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1098,6 +1098,54 @@ err:
 }
 
 /*
+ * __wti_cursor_largest_key --
+ *     WT_CURSOR->largest_key default implementation..
+ */
+int
+__wti_cursor_largest_key(WT_CURSOR *cursor)
+{
+    WT_CURSOR_BTREE *cbt;
+    WT_DECL_ITEM(key);
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    bool key_only;
+
+    cbt = (WT_CURSOR_BTREE *)cursor;
+    key_only = F_ISSET(cursor, WT_CURSTD_KEY_ONLY);
+    CURSOR_API_CALL(cursor, session, ret, largest_key, cbt->dhandle);
+
+    if (WT_CURSOR_BOUNDS_SET(cursor))
+        WT_ERR_MSG(session, EINVAL, "setting bounds is not compatible with cursor largest key");
+
+    WT_ERR(__wt_scr_alloc(session, 0, &key));
+
+    /* Reset the cursor to give up the cursor position. */
+    WT_ERR(cursor->reset(cursor));
+
+    /* Set the flag to bypass value read. */
+    F_SET(cursor, WT_CURSTD_KEY_ONLY);
+
+    /* Call btree cursor prev to get the largest key. */
+    WT_WITH_CHECKPOINT(session, cbt, ret = __wt_btcur_prev(cbt, false));
+    WT_ERR(ret);
+
+    /* Copy the key as we will reset the cursor after that. */
+    WT_ERR(__wt_buf_set(session, key, cursor->key.data, cursor->key.size));
+    WT_ERR(cursor->reset(cursor));
+    WT_ERR(__wt_buf_set(session, &cursor->key, key->data, key->size));
+    /* Set the key as external. */
+    F_SET(cursor, WT_CURSTD_KEY_EXT);
+
+err:
+    if (!key_only)
+        F_CLR(cursor, WT_CURSTD_KEY_ONLY);
+    __wt_scr_free(session, &key);
+    if (ret != 0)
+        WT_TRET(cursor->reset(cursor));
+    API_END_RET_STAT(session, ret, cursor_largest_key);
+}
+
+/*
  * __wt_curfile_open --
  *     WT_SESSION->open_cursor method for the btree cursor type.
  */

--- a/src/cursor/cur_oligarch.c
+++ b/src/cursor/cur_oligarch.c
@@ -1309,6 +1309,7 @@ __coligarch_next_random(WT_CURSOR *cursor)
     WT_ERR(__coligarch_enter(coligarch, false, false));
 
     for (;;) {
+        /* TODO: consider the size of ingest table in the future. */
         c = coligarch->stable_cursor;
         /*
          * This call to next_random on the ingest table can potentially end in WT_NOTFOUND if the

--- a/src/cursor/cur_oligarch.c
+++ b/src/cursor/cur_oligarch.c
@@ -1301,10 +1301,8 @@ __coligarch_next_random(WT_CURSOR *cursor)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     int exact;
-    bool leave;
 
     coligarch = (WT_CURSOR_OLIGARCH *)cursor;
-    leave = false;
 
     CURSOR_API_CALL(cursor, session, ret, next, coligarch->dhandle);
     __cursor_novalue(cursor);

--- a/test/suite/test_oligarch10.py
+++ b/test/suite/test_oligarch10.py
@@ -83,6 +83,14 @@ class test_oligarch10(wttest.WiredTigerTestCase):
         self.assertEqual(cursor.largest_key(), 0)
         self.assertEqual(cursor.get_key(), self.nitems)
 
+        self.session.begin_transaction()
+        cursor[self.nitems + 100] = f'Value'
+
+        # Check the largest key before commit
+        self.assertEqual(cursor.largest_key(), 0)
+        self.assertEqual(cursor.get_key(), self.nitems + 100)
+        self.session.rollback_transaction()
+
         # Ensure that all data makes it to the follower
         conn_follow.reconfigure('disaggregated=(checkpoint_id=1)') # TODO Use a real checkpoint ID
 

--- a/test/suite/test_oligarch13.py
+++ b/test/suite/test_oligarch13.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+import wiredtiger
+from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_oligarch13.py
+# Simple testing for oligarch random cursor
+class test_oligarch13(wttest.WiredTigerTestCase, DisaggConfigMixin):
+
+    conn_base_config = 'oligarch_log=(enabled),transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(stable_prefix=.,page_log=palm),'
+    disagg_storages = gen_disagg_storages('test_oligarch13', disagg_only = True)
+    uri = "oligarch:test_oligarch13"
+    nitems = 1000
+
+    scenarios = make_scenarios(disagg_storages)
+
+    def conn_config(self):
+        return self.conn_base_config + 'disaggregated=(role="leader")'
+
+    # Load the storage store extension.
+    def conn_extensions(self, extlist):
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def test_oligarch_random_cursor(self):
+        self.session.create(self.uri, "key_format=S,value_format=S")
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        value1 = "aaaa"
+
+        for i in range(self.nitems):
+            cursor[str(i)] = value1
+
+        # XXX
+        # Inserted timing delays around reopen, apparently needed because of the
+        # oligarch watcher implementation
+        import time
+        time.sleep(1.0)
+        self.session.checkpoint()
+
+        for i in range(self.nitems, 2 * self.nitems):
+            cursor[str(i)] = value1
+
+        cursor.close()
+
+        random_cursor = self.session.open_cursor(self.uri, None, "next_random=true")
+        self.assertEquals(random_cursor.next(), 0)
+        random_cursor.close()
+
+        # XXX
+        # Inserted timing delays around reopen, apparently needed because of the
+        # oligarch watcher implementation
+        import time
+        time.sleep(1.0)
+        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
+            f'checkpoint_id={self.disagg_get_complete_checkpoint()})'
+        self.reopen_conn(config = follower_config)
+        time.sleep(1.0)
+
+        random_cursor = self.session.open_cursor(self.uri, None, "next_random=true,force=true")
+        self.assertEquals(random_cursor.next(), 0)
+        random_cursor.close()
+
+
+    # def test_empty_table(self):
+    #     self.session.create(self.uri, "key_format=S,value_format=S")
+
+    #     random_cursor = self.session.open_cursor(self.uri, None, "next_random=true")
+    #     self.assertEquals(random_cursor.next(), wiredtiger.WT_NOTFOUND)
+    #     random_cursor.close()


### PR DESCRIPTION
Fix the implementation of the largest key implementation. The previous implementation only implements the largest visible keys. However, largest key should return the largest key even it's not visibility.

Implement the random cursor function for oligarch table. I borrowed the main implementation from the lsm code. It is not a uniform random solution yet as it doesn't consider the key size of the ingest table and the stable table but it should work for now.

Fix a bug in oligarch search near.

