### PR TITLE
WT-13783 Fix clang analyzer dead code in schema_plan.c

### DIFF
--- a/src/schema/schema_plan.c
+++ b/src/schema/schema_plan.c
@@ -189,7 +189,7 @@ __wt_struct_plan(WT_SESSION_IMPL *session, WT_TABLE *table, const char *columns,
     for (i = 0; (ret = __wt_config_next(&conf, &k, &v)) == 0; i++) {
         have_it = false;
 
-        while ((__find_next_col(session, table, &k, &cg, &col, &coltype)) == 0 &&
+        while ((ret = __find_next_col(session, table, &k, &cg, &col, &coltype)) == 0 &&
           (!have_it || cg != start_cg || col != start_col)) {
             /*
              * First we move to the column. If that is in a different column group to the last
@@ -228,6 +228,8 @@ __wt_struct_plan(WT_SESSION_IMPL *session, WT_TABLE *table, const char *columns,
                 WT_RET(__wt_buf_catfmt(session, plan, "%c", WT_PROJ_REUSE));
             current_col = col + 1;
         }
+
+        WT_RET(ret);
     }
     WT_RET_TEST(ret != WT_NOTFOUND, ret);
 

--- a/src/schema/schema_plan.c
+++ b/src/schema/schema_plan.c
@@ -229,7 +229,7 @@ __wt_struct_plan(WT_SESSION_IMPL *session, WT_TABLE *table, const char *columns,
             current_col = col + 1;
         }
 
-        WT_RET(ret);
+        WT_RET_NOTFOUND_OK(ret);
     }
     WT_RET_TEST(ret != WT_NOTFOUND, ret);
 

--- a/src/schema/schema_plan.c
+++ b/src/schema/schema_plan.c
@@ -189,7 +189,7 @@ __wt_struct_plan(WT_SESSION_IMPL *session, WT_TABLE *table, const char *columns,
     for (i = 0; (ret = __wt_config_next(&conf, &k, &v)) == 0; i++) {
         have_it = false;
 
-        while ((ret = __find_next_col(session, table, &k, &cg, &col, &coltype)) == 0 &&
+        while ((__find_next_col(session, table, &k, &cg, &col, &coltype)) == 0 &&
           (!have_it || cg != start_cg || col != start_col)) {
             /*
              * First we move to the column. If that is in a different column group to the last


### PR DESCRIPTION
The return value from `__find_next_col` can be overwritten by the outer for loop before it's checked. This adds a return value check within the while loop to check the return status of `__find_next_col`.