### PR TITLE
WT-9102 Migrate WT Mac tests from macOS 10.14 to 11.0 (v5.0 backport)

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -159,7 +159,7 @@ functions:
         set -o verbose
 
         MACOS_PYTHON_FLAGS=
-        if [ "${build_variant|}" = "macos-1014-cmake" ]; then
+        if [ "${build_variant|}" = "macos-11-cmake" ]; then
           # For mac builds, we want explicitly tell cmake which python to use, as
           # well as the matching library directory and header files. The find_libpython
           # module gives us the library.
@@ -4146,13 +4146,13 @@ buildvariants:
     - name: make-check-test
     - name: unit-test
 
-- name: macos-1014
-  display_name: OS X 10.14
+- name: macos-11
+  display_name: OS X 11
   run_on:
-  - macos-1014
+  - macos-11
   batchtime: 120 # 2 hours
   expansions:
-    configure_env_vars: PATH=/opt/mongodbtoolchain/v3/bin:$PATH ADD_CFLAGS="-ggdb -fPIC"
+    configure_env_vars: ADD_CFLAGS="-ggdb -fPIC -Wno-poison-system-directories"
     posix_configure_flags:
       --enable-silent-rules
       --enable-diagnostic
@@ -4161,9 +4161,9 @@ buildvariants:
       --enable-strict
       --enable-static
       --prefix=$(pwd)/LOCAL_INSTALL
-    python_binary: '/opt/mongodbtoolchain/v3/bin/python3'
+    python_binary: '/Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9'
     smp_command: -j $(sysctl -n hw.logicalcpu)
-    make_command: PATH=/opt/mongodbtoolchain/v3/bin:$PATH ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future make
+    make_command: ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future make
     test_env_vars: 
       PATH=/opt/mongodbtoolchain/v3/bin:$PATH
       top_dir=$(git rev-parse --show-toplevel)
@@ -4175,10 +4175,10 @@ buildvariants:
     - name: unit-test-with-compile
     - name: fops
 
-- name: macos-1014-cmake
-  display_name: "* OS X 10.14 CMake"
+- name: macos-11-cmake
+  display_name: "* OS X 11 CMake"
   run_on:
-  - macos-1014
+  - macos-11
   batchtime: 120 # 2 hours
   expansions:
     posix_configure_flags:


### PR DESCRIPTION
Upgrading macos machines from version 10.14 to 11 as 10.14 is getting deprecated.