### PR TITLE
WT-12753 Improve error log message for lsm objects

### DIFF
--- a/src/support/err.c
+++ b/src/support/err.c
@@ -767,6 +767,9 @@ __wt_bad_object_type(WT_SESSION_IMPL *session, const char *uri) WT_GCC_FUNC_ATTR
       WT_PREFIX_MATCH(uri, "table:") || WT_PREFIX_MATCH(uri, "tiered:"))
         return (__wt_object_unsupported(session, uri));
 
+    if (WT_PREFIX_MATCH(uri, "lsm:"))
+        WT_RET_MSG(session, ENOTSUP, "lsm object type no longer supported: %s", uri);
+
     WT_RET_MSG(session, ENOTSUP, "unknown object type: %s", uri);
 }
 


### PR DESCRIPTION
Add a condition to give the user a more informative error message when they try to interact with lsm objects that are no longer supported.