### PR TITLE
WT-13835 Updating the live restore API configuration

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1105,11 +1105,11 @@ wiredtiger_open_live_restore_configuration = [
         Config('enabled', 'false', r'''whether live restore is enabled or not.''', type='boolean'),
         Config('path', '', r'''the path to the backup that will be restored from.'''),
         Config('threads_max', '8', r'''
-            maximum number of threads WiredTiger will start to migrate data from the backup to
+            maximum number of threads WiredTiger will start to migrate data from the backup to the
             running WiredTiger database.''',
             min=1, max=20),
         Config('threads_min', '1', r'''
-            minimum number of threads WiredTiger will start to migrate data from the backup to
+            minimum number of threads WiredTiger will start to migrate data from the backup to the
             running WiredTiger database.''',
             min=1, max=20),
     ])

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1106,12 +1106,14 @@ wiredtiger_open_live_restore_configuration = [
         Config('path', '', r'''the path to the backup that will be restored from.'''),
         Config('threads_max', '8', r'''
             maximum number of threads WiredTiger will start to migrate data from the backup to the
-            running WiredTiger database.''',
-            min=1, max=20),
+            running WiredTiger database. Each worker thread uses a session handle from the
+            configured session_max''',
+            min=1, max=12),
         Config('threads_min', '1', r'''
             minimum number of threads WiredTiger will start to migrate data from the backup to the
-            running WiredTiger database.''',
-            min=1, max=20),
+            running WiredTiger database.  Each worker thread uses a session handle from the
+            configured session_max''',
+            min=1, max=12),
     ])
 ]
 

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1101,7 +1101,8 @@ wiredtiger_open_tiered_storage_configuration = [
 
 # At this stage live restore intentionally does not support reconfiguring the number of worker
 # threads. If that becomes necessary in the future we'll need to break out the thread count config
-# and add it to the reconfigure items too.
+# and add it to the reconfigure items too. That will also introduce the need for a MAX_WORKER or
+# similar macro.
 wiredtiger_open_live_restore_configuration = [
     Config('live_restore', '', r'''Live restore configuration options. These options control the
     behavior of WiredTiger when live restoring from a backup.''', type='category', subconfig = [

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1104,19 +1104,14 @@ wiredtiger_open_tiered_storage_configuration = [
 # and add it to the reconfigure items too.
 wiredtiger_open_live_restore_configuration = [
     Config('live_restore', '', r'''Live restore configuration options. These options control the
-    behavior of WiredTiger when restoring from a backup.''', type='category', subconfig = [
+    behavior of WiredTiger when live restoring from a backup.''', type='category', subconfig = [
         Config('enabled', 'false', r'''whether live restore is enabled or not.''', type='boolean'),
         Config('path', '', r'''the path to the backup that will be restored from.'''),
         Config('threads_max', '8', r'''
             maximum number of threads WiredTiger will start to migrate data from the backup to the
             running WiredTiger database. Each worker thread uses a session handle from the
             configured session_max''',
-            min=1, max=12),
-        Config('threads_min', '1', r'''
-            minimum number of threads WiredTiger will start to migrate data from the backup to the
-            running WiredTiger database.  Each worker thread uses a session handle from the
-            configured session_max''',
-            min=1, max=12),
+            min=1, max=12)
     ])
 ]
 

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1099,6 +1099,9 @@ wiredtiger_open_tiered_storage_configuration = [
     ]),
 ]
 
+# At this stage live restore intentionally does not support reconfiguring the number of worker
+# threads. If that becomes necessary in the future we'll need to break out the thread count config
+# and add it to the reconfigure items too.
 wiredtiger_open_live_restore_configuration = [
     Config('live_restore', '', r'''Live restore configuration options. These options control the
     behavior of WiredTiger when restoring from a backup.''', type='category', subconfig = [

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1099,6 +1099,22 @@ wiredtiger_open_tiered_storage_configuration = [
     ]),
 ]
 
+wiredtiger_open_live_restore_configuration = [
+    Config('live_restore', '', r'''Live restore configuration options. These options control the
+    behavior of WiredTiger when restoring from a backup.''', type='category', subconfig = [
+        Config('enabled', 'false', r'''whether live restore is enabled or not.''', type='boolean'),
+        Config('path', '', r'''the path to the backup that will be restored from.'''),
+        Config('threads_max', '8', r'''
+            maximum number of threads WiredTiger will start to migrate data from the backup to
+            running WiredTiger database.''',
+            min=1, max=20),
+        Config('threads_min', '1', r'''
+            minimum number of threads WiredTiger will start to migrate data from the backup to
+            running WiredTiger database.''',
+            min=1, max=20),
+    ])
+]
+
 chunk_cache_configuration_common = [
     Config('pinned', '', r'''
         List of "table:" URIs exempt from cache eviction. Capacity config overrides this,
@@ -1191,10 +1207,9 @@ wiredtiger_open_common =\
     wiredtiger_open_chunk_cache_configuration +\
     wiredtiger_open_compatibility_configuration +\
     wiredtiger_open_log_configuration +\
+    wiredtiger_open_live_restore_configuration +\
     wiredtiger_open_tiered_storage_configuration +\
     wiredtiger_open_statistics_log_configuration + [
-    Config('aux_path', '', r'''The auxiliary path configuration specifies a second path to a
-        WiredTiger database. This is then used to perform a live backup restore process.'''),
     Config('backup_restore_target', '', r'''
         If non-empty and restoring from a backup, restore only the table object targets listed.
         WiredTiger will remove all the metadata entries for the tables that are not listed in

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -2599,10 +2599,10 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_live_restore_subconfigs[] =
     INT64_MAX, NULL},
   {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 253, INT64_MIN,
     INT64_MAX, NULL},
-  {"threads_max", "int", NULL, "min=1,max=20", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 216, 1,
-    20, NULL},
-  {"threads_min", "int", NULL, "min=1,max=20", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 217, 1,
-    20, NULL},
+  {"threads_max", "int", NULL, "min=1,max=12", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 216, 1,
+    12, NULL},
+  {"threads_min", "int", NULL, "min=1,max=12", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 217, 1,
+    12, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -2509,21 +2509,21 @@ static const char *confchk_type_choices[] = {
   __WT_CONFIG_CHOICE_FILE, __WT_CONFIG_CHOICE_DRAM, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_chunk_cache_subconfigs[] = {
-  {"capacity", "int", NULL, "min=512KB,max=100TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 281,
+  {"capacity", "int", NULL, "min=512KB,max=100TB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 280,
     512LL * WT_KILOBYTE, 100LL * WT_TERABYTE, NULL},
   {"chunk_cache_evict_trigger", "int", NULL, "min=0,max=100", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 282, 0, 100, NULL},
+    WT_CONFIG_COMPILED_TYPE_INT, 281, 0, 100, NULL},
   {"chunk_size", "int", NULL, "min=512KB,max=100GB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 75,
     512LL * WT_KILOBYTE, 100LL * WT_GIGABYTE, NULL},
   {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 37, INT64_MIN,
     INT64_MAX, NULL},
   {"flushed_data_cache_insertion", "boolean", NULL, NULL, NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_BOOLEAN, 284, INT64_MIN, INT64_MAX, NULL},
+    WT_CONFIG_COMPILED_TYPE_BOOLEAN, 283, INT64_MIN, INT64_MAX, NULL},
   {"hashsize", "int", NULL, "min=64,max=1048576", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 178,
     64, 1048576LL, NULL},
   {"pinned", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 193, INT64_MIN,
     INT64_MAX, NULL},
-  {"storage_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 283,
+  {"storage_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 282,
     INT64_MIN, INT64_MAX, NULL},
   {"type", "string", NULL, "choices=[\"FILE\",\"DRAM\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_STRING, 9, INT64_MIN, INT64_MAX, confchk_type_choices},
@@ -2539,9 +2539,9 @@ static const uint8_t
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_compatibility_subconfigs[] = {
   {"release", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 195, INT64_MIN,
     INT64_MAX, NULL},
-  {"require_max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 285,
+  {"require_max", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 284,
     INT64_MIN, INT64_MAX, NULL},
-  {"require_min", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 286,
+  {"require_min", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 285,
     INT64_MIN, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -2557,7 +2557,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_encryption_subconfigs[] = {
     INT64_MAX, NULL},
   {"name", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 20, INT64_MIN,
     INT64_MAX, NULL},
-  {"secretkey", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 291, INT64_MIN,
+  {"secretkey", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 290, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -2579,10 +2579,10 @@ static const char *confchk_file_extend_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_hash_subconfigs[] = {
-  {"buckets", "int", NULL, "min=64,max=65536", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 295, 64,
+  {"buckets", "int", NULL, "min=64,max=65536", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 294, 64,
     65536, NULL},
   {"dhandle_buckets", "int", NULL, "min=64,max=65536", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    296, 64, 65536, NULL},
+    295, 64, 65536, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_wiredtiger_open_hash_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0,
@@ -2593,6 +2593,24 @@ static const uint8_t confchk_wiredtiger_open_hash_subconfigs_jump[WT_CONFIG_JUMP
 
 static const char *confchk_json_output2_choices[] = {
   __WT_CONFIG_CHOICE_error, __WT_CONFIG_CHOICE_message, NULL};
+
+static const WT_CONFIG_CHECK confchk_wiredtiger_open_live_restore_subconfigs[] = {
+  {"enabled", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 37, INT64_MIN,
+    INT64_MAX, NULL},
+  {"path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 253, INT64_MIN,
+    INT64_MAX, NULL},
+  {"threads_max", "int", NULL, "min=1,max=20", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 216, 1,
+    20, NULL},
+  {"threads_min", "int", NULL, "min=1,max=20", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 217, 1,
+    20, NULL},
+  {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
+
+static const uint8_t
+  confchk_wiredtiger_open_live_restore_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
 
 static const char *confchk_recover_choices[] = {
   __WT_CONFIG_CHOICE_error, __WT_CONFIG_CHOICE_on, NULL};
@@ -2752,17 +2770,15 @@ static const char *confchk_write_through_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
-  {"aux_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 276, INT64_MIN,
-    INT64_MAX, NULL},
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 277,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 172,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    278, -1, 1LL * WT_MEGABYTE, NULL},
+    277, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    279, INT64_MIN, INT64_MAX, NULL},
+    278, INT64_MIN, INT64_MAX, NULL},
   {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 183, 0,
@@ -2780,7 +2796,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     190, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 280,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 279,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 192,
@@ -2789,15 +2805,15 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 194,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 287, 500, INT64_MAX, NULL},
-  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 288,
+    WT_CONFIG_COMPILED_TYPE_INT, 286, 500, INT64_MAX, NULL},
+  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 287,
     INT64_MIN, INT64_MAX, NULL},
-  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 289, INT64_MIN,
+  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 288, INT64_MIN,
     INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 17,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
     INT64_MIN, INT64_MAX, NULL},
-  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 290, INT64_MIN,
+  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN,
     INT64_MAX, NULL},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
@@ -2823,7 +2839,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 226, 0, 10LL * WT_TERABYTE, NULL},
   {"exclusive", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 101,
     INT64_MIN, INT64_MAX, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 291, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -2833,16 +2849,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 227, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics2_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 293, INT64_MIN, INT64_MAX, confchk_file_extend_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN, INT64_MAX, confchk_file_extend_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 228,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     232, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 294, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 293, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 297, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 296, 15,
     INT64_MAX, NULL},
   {"heuristic_controls", "category", NULL, NULL,
     confchk_wiredtiger_open_heuristic_controls_subconfigs, 3,
@@ -2851,13 +2867,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 237,
     INT64_MIN, INT64_MAX, NULL},
-  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298,
+  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 297,
     INT64_MIN, INT64_MAX, NULL},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 239,
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output2_choices},
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+    confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
+    INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
     confchk_wiredtiger_open_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
     INT64_MAX, NULL},
@@ -2953,8 +2972,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
 static const uint8_t confchk_wiredtiger_open_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 18, 20, 33, 35,
-  36, 40, 42, 43, 43, 45, 48, 48, 50, 51, 51, 53, 60, 63, 65, 67, 68, 68, 68, 68, 68, 68, 68, 68};
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 17, 19, 32, 34,
+  35, 39, 41, 42, 42, 45, 48, 48, 50, 51, 51, 53, 60, 63, 65, 67, 68, 68, 68, 68, 68, 68, 68, 68};
 
 static const char *confchk_extra_diagnostics3_choices[] = {__WT_CONFIG_CHOICE_all,
   __WT_CONFIG_CHOICE_checkpoint_validate, __WT_CONFIG_CHOICE_cursor_check,
@@ -3012,17 +3031,15 @@ static const char *confchk_write_through2_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
-  {"aux_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 276, INT64_MIN,
-    INT64_MAX, NULL},
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 277,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 172,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    278, -1, 1LL * WT_MEGABYTE, NULL},
+    277, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    279, INT64_MIN, INT64_MAX, NULL},
+    278, INT64_MIN, INT64_MAX, NULL},
   {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 183, 0,
@@ -3040,7 +3057,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     190, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 280,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 279,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 192,
@@ -3049,15 +3066,15 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 194,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 287, 500, INT64_MAX, NULL},
-  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 288,
+    WT_CONFIG_COMPILED_TYPE_INT, 286, 500, INT64_MAX, NULL},
+  {"config_base", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 287,
     INT64_MIN, INT64_MAX, NULL},
-  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 289, INT64_MIN,
+  {"create", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 288, INT64_MIN,
     INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 17,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
     INT64_MIN, INT64_MAX, NULL},
-  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 290, INT64_MIN,
+  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN,
     INT64_MAX, NULL},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
@@ -3083,7 +3100,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 226, 0, 10LL * WT_TERABYTE, NULL},
   {"exclusive", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 101,
     INT64_MIN, INT64_MAX, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 291, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -3093,16 +3110,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 227, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics3_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 293, INT64_MIN, INT64_MAX, confchk_file_extend2_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN, INT64_MAX, confchk_file_extend2_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 228,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     232, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 294, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 293, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 297, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 296, 15,
     INT64_MAX, NULL},
   {"heuristic_controls", "category", NULL, NULL,
     confchk_wiredtiger_open_heuristic_controls_subconfigs, 3,
@@ -3111,13 +3128,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
   {"history_store", "category", NULL, NULL, confchk_wiredtiger_open_history_store_subconfigs, 1,
     confchk_wiredtiger_open_history_store_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 237,
     INT64_MIN, INT64_MAX, NULL},
-  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 298,
+  {"in_memory", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 297,
     INT64_MIN, INT64_MAX, NULL},
   {"io_capacity", "category", NULL, NULL, confchk_wiredtiger_open_io_capacity_subconfigs, 2,
     confchk_wiredtiger_open_io_capacity_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 239,
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output3_choices},
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+    confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
+    INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
     confchk_wiredtiger_open_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
     INT64_MAX, NULL},
@@ -3215,8 +3235,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
 static const uint8_t confchk_wiredtiger_open_all_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 18, 20, 33,
-  35, 36, 40, 42, 43, 43, 45, 48, 48, 50, 51, 51, 53, 60, 63, 65, 68, 69, 69, 69, 69, 69, 69, 69,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 17, 19, 32,
+  34, 35, 39, 41, 42, 42, 45, 48, 48, 50, 51, 51, 53, 60, 63, 65, 68, 69, 69, 69, 69, 69, 69, 69,
   69};
 
 static const char *confchk_extra_diagnostics4_choices[] = {__WT_CONFIG_CHOICE_all,
@@ -3275,17 +3295,15 @@ static const char *confchk_write_through3_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
-  {"aux_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 276, INT64_MIN,
-    INT64_MAX, NULL},
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 277,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 172,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    278, -1, 1LL * WT_MEGABYTE, NULL},
+    277, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    279, INT64_MIN, INT64_MAX, NULL},
+    278, INT64_MIN, INT64_MAX, NULL},
   {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 183, 0,
@@ -3303,7 +3321,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     190, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 280,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 279,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 192,
@@ -3312,11 +3330,11 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 194,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 287, 500, INT64_MAX, NULL},
+    WT_CONFIG_COMPILED_TYPE_INT, 286, 500, INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 17,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
     INT64_MIN, INT64_MAX, NULL},
-  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 290, INT64_MIN,
+  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN,
     INT64_MAX, NULL},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
@@ -3340,7 +3358,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 225, 0, 10LL * WT_TERABYTE, NULL},
   {"eviction_updates_trigger", "int", NULL, "min=0,max=10TB", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_INT, 226, 0, 10LL * WT_TERABYTE, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 291, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -3350,16 +3368,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 227, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics4_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 293, INT64_MIN, INT64_MAX, confchk_file_extend3_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN, INT64_MAX, confchk_file_extend3_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 228,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     232, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 294, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 293, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 297, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 296, 15,
     INT64_MAX, NULL},
   {"heuristic_controls", "category", NULL, NULL,
     confchk_wiredtiger_open_heuristic_controls_subconfigs, 3,
@@ -3373,6 +3391,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output4_choices},
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+    confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
+    INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
     confchk_wiredtiger_open_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
     INT64_MAX, NULL},
@@ -3466,8 +3487,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
 static const uint8_t confchk_wiredtiger_open_basecfg_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 16, 18,
-  30, 32, 33, 37, 38, 39, 39, 41, 44, 44, 46, 47, 47, 49, 56, 59, 59, 62, 63, 63, 63, 63, 63, 63,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 15, 17,
+  29, 31, 32, 36, 37, 38, 38, 41, 44, 44, 46, 47, 47, 49, 56, 59, 59, 62, 63, 63, 63, 63, 63, 63,
   63, 63};
 
 static const char *confchk_extra_diagnostics5_choices[] = {__WT_CONFIG_CHOICE_all,
@@ -3526,17 +3547,15 @@ static const char *confchk_write_through4_choices[] = {
   __WT_CONFIG_CHOICE_data, __WT_CONFIG_CHOICE_log, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
-  {"aux_path", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 276, INT64_MIN,
-    INT64_MAX, NULL},
-  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 277,
+  {"backup_restore_target", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 276,
     INT64_MIN, INT64_MAX, NULL},
   {"block_cache", "category", NULL, NULL, confchk_wiredtiger_open_block_cache_subconfigs, 12,
     confchk_wiredtiger_open_block_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 172,
     INT64_MIN, INT64_MAX, NULL},
   {"buffer_alignment", "int", NULL, "min=-1,max=1MB", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    278, -1, 1LL * WT_MEGABYTE, NULL},
+    277, -1, 1LL * WT_MEGABYTE, NULL},
   {"builtin_extension_config", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING,
-    279, INT64_MIN, INT64_MAX, NULL},
+    278, INT64_MIN, INT64_MAX, NULL},
   {"cache_cursors", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 270,
     INT64_MIN, INT64_MAX, NULL},
   {"cache_max_wait_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 183, 0,
@@ -3554,7 +3573,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs, 2,
     confchk_wiredtiger_open_checkpoint_cleanup_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY,
     190, INT64_MIN, INT64_MAX, NULL},
-  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 280,
+  {"checkpoint_sync", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 279,
     INT64_MIN, INT64_MAX, NULL},
   {"chunk_cache", "category", NULL, NULL, confchk_wiredtiger_open_chunk_cache_subconfigs, 9,
     confchk_wiredtiger_open_chunk_cache_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 192,
@@ -3563,11 +3582,11 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     confchk_wiredtiger_open_compatibility_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 194,
     INT64_MIN, INT64_MAX, NULL},
   {"compile_configuration_count", "int", NULL, "min=500", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_INT, 287, 500, INT64_MAX, NULL},
+    WT_CONFIG_COMPILED_TYPE_INT, 286, 500, INT64_MAX, NULL},
   {"debug_mode", "category", NULL, NULL, confchk_wiredtiger_open_debug_mode_subconfigs, 17,
     confchk_wiredtiger_open_debug_mode_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 196,
     INT64_MIN, INT64_MAX, NULL},
-  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 290, INT64_MIN,
+  {"direct_io", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 289, INT64_MIN,
     INT64_MAX, NULL},
   {"encryption", "category", NULL, NULL, confchk_wiredtiger_open_encryption_subconfigs, 3,
     confchk_wiredtiger_open_encryption_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 19,
@@ -3591,7 +3610,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     WT_CONFIG_COMPILED_TYPE_INT, 225, 0, 10LL * WT_TERABYTE, NULL},
   {"eviction_updates_trigger", "int", NULL, "min=0,max=10TB", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_INT, 226, 0, 10LL * WT_TERABYTE, NULL},
-  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN,
+  {"extensions", "list", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 291, INT64_MIN,
     INT64_MAX, NULL},
   {"extra_diagnostics", "list", NULL,
     "choices=[\"all\",\"checkpoint_validate\",\"cursor_check\""
@@ -3601,16 +3620,16 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_LIST, 227, INT64_MIN, INT64_MAX,
     confchk_extra_diagnostics5_choices},
   {"file_extend", "list", NULL, "choices=[\"data\",\"log\"]", NULL, 0, NULL,
-    WT_CONFIG_COMPILED_TYPE_LIST, 293, INT64_MIN, INT64_MAX, confchk_file_extend4_choices},
+    WT_CONFIG_COMPILED_TYPE_LIST, 292, INT64_MIN, INT64_MAX, confchk_file_extend4_choices},
   {"file_manager", "category", NULL, NULL, confchk_wiredtiger_open_file_manager_subconfigs, 3,
     confchk_wiredtiger_open_file_manager_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 228,
     INT64_MIN, INT64_MAX, NULL},
   {"generation_drain_timeout_ms", "int", NULL, "min=0", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
     232, 0, INT64_MAX, NULL},
   {"hash", "category", NULL, NULL, confchk_wiredtiger_open_hash_subconfigs, 2,
-    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 294, INT64_MIN,
+    confchk_wiredtiger_open_hash_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 293, INT64_MIN,
     INT64_MAX, NULL},
-  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 297, 15,
+  {"hazard_max", "int", NULL, "min=15", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 296, 15,
     INT64_MAX, NULL},
   {"heuristic_controls", "category", NULL, NULL,
     confchk_wiredtiger_open_heuristic_controls_subconfigs, 3,
@@ -3624,6 +3643,9 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output5_choices},
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+    confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
+    INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
     confchk_wiredtiger_open_log_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 36, INT64_MIN,
     INT64_MAX, NULL},
@@ -3715,8 +3737,8 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
 static const uint8_t confchk_wiredtiger_open_usercfg_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 5, 16, 18,
-  30, 32, 33, 37, 38, 39, 39, 41, 44, 44, 46, 47, 47, 49, 56, 59, 59, 61, 62, 62, 62, 62, 62, 62,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 15, 17,
+  29, 31, 32, 36, 37, 38, 38, 41, 44, 44, 46, 47, 47, 49, 56, 59, 59, 61, 62, 62, 62, 62, 62, 62,
   62, 62};
 
 static const WT_CONFIG_ENTRY config_entries[] = {
@@ -4053,7 +4075,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "verbose=[],version=(major=0,minor=0),write_timestamp_usage=none",
     confchk_tiered_meta, 52, confchk_tiered_meta_jump, 48, WT_CONF_SIZING_NONE, false},
   {"wiredtiger_open",
-    "aux_path=,backup_restore_target=,"
+    "backup_restore_target=,"
     "block_cache=(blkcache_eviction_aggression=1800,"
     "cache_on_checkpoint=true,cache_on_writes=true,enabled=false,"
     "full_target=95,hashsize=32768,max_percent_overhead=10,"
@@ -4088,7 +4110,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "in_memory=false,io_capacity=(chunk_cache=0,total=0),"
-    "json_output=[],log=(archive=true,compressor=,enabled=false,"
+    "json_output=[],live_restore=(enabled=false,path=,threads_max=8,"
+    "threads_min=1),log=(archive=true,compressor=,enabled=false,"
     "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
     "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
     "remove=true,zero_fill=false),lsm_manager=(merge=true,"
@@ -4108,7 +4131,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "verify_metadata=false,write_through=",
     confchk_wiredtiger_open, 68, confchk_wiredtiger_open_jump, 49, WT_CONF_SIZING_NONE, false},
   {"wiredtiger_open_all",
-    "aux_path=,backup_restore_target=,"
+    "backup_restore_target=,"
     "block_cache=(blkcache_eviction_aggression=1800,"
     "cache_on_checkpoint=true,cache_on_writes=true,enabled=false,"
     "full_target=95,hashsize=32768,max_percent_overhead=10,"
@@ -4143,7 +4166,8 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "in_memory=false,io_capacity=(chunk_cache=0,total=0),"
-    "json_output=[],log=(archive=true,compressor=,enabled=false,"
+    "json_output=[],live_restore=(enabled=false,path=,threads_max=8,"
+    "threads_min=1),log=(archive=true,compressor=,enabled=false,"
     "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
     "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
     "remove=true,zero_fill=false),lsm_manager=(merge=true,"
@@ -4164,7 +4188,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     confchk_wiredtiger_open_all, 69, confchk_wiredtiger_open_all_jump, 50, WT_CONF_SIZING_NONE,
     false},
   {"wiredtiger_open_basecfg",
-    "aux_path=,backup_restore_target=,"
+    "backup_restore_target=,"
     "block_cache=(blkcache_eviction_aggression=1800,"
     "cache_on_checkpoint=true,cache_on_writes=true,enabled=false,"
     "full_target=95,hashsize=32768,max_percent_overhead=10,"
@@ -4199,6 +4223,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "io_capacity=(chunk_cache=0,total=0),json_output=[],"
+    "live_restore=(enabled=false,path=,threads_max=8,threads_min=1),"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
@@ -4219,7 +4244,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     confchk_wiredtiger_open_basecfg, 63, confchk_wiredtiger_open_basecfg_jump, 51,
     WT_CONF_SIZING_NONE, false},
   {"wiredtiger_open_usercfg",
-    "aux_path=,backup_restore_target=,"
+    "backup_restore_target=,"
     "block_cache=(blkcache_eviction_aggression=1800,"
     "cache_on_checkpoint=true,cache_on_writes=true,enabled=false,"
     "full_target=95,hashsize=32768,max_percent_overhead=10,"
@@ -4254,6 +4279,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "io_capacity=(chunk_cache=0,total=0),json_output=[],"
+    "live_restore=(enabled=false,path=,threads_max=8,threads_min=1),"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -2601,8 +2601,6 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_live_restore_subconfigs[] =
     INT64_MAX, NULL},
   {"threads_max", "int", NULL, "min=1,max=12", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 216, 1,
     12, NULL},
-  {"threads_min", "int", NULL, "min=1,max=12", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 217, 1,
-    12, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t
@@ -2610,7 +2608,7 @@ static const uint8_t
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
 
 static const char *confchk_recover_choices[] = {
   __WT_CONFIG_CHOICE_error, __WT_CONFIG_CHOICE_on, NULL};
@@ -2874,7 +2872,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output2_choices},
-  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 3,
     confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
     INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
@@ -3135,7 +3133,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_all[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output3_choices},
-  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 3,
     confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
     INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
@@ -3391,7 +3389,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_basecfg[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output4_choices},
-  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 3,
     confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
     INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
@@ -3643,7 +3641,7 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_usercfg[] = {
     INT64_MIN, INT64_MAX, NULL},
   {"json_output", "list", NULL, "choices=[\"error\",\"message\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_LIST, 242, INT64_MIN, INT64_MAX, confchk_json_output5_choices},
-  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 4,
+  {"live_restore", "category", NULL, NULL, confchk_wiredtiger_open_live_restore_subconfigs, 3,
     confchk_wiredtiger_open_live_restore_subconfigs_jump, WT_CONFIG_COMPILED_TYPE_CATEGORY, 298,
     INT64_MIN, INT64_MAX, NULL},
   {"log", "category", NULL, NULL, confchk_wiredtiger_open_log_subconfigs, 12,
@@ -4110,17 +4108,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "in_memory=false,io_capacity=(chunk_cache=0,total=0),"
-    "json_output=[],live_restore=(enabled=false,path=,threads_max=8,"
-    "threads_min=1),log=(archive=true,compressor=,enabled=false,"
-    "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
-    "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
-    "remove=true,zero_fill=false),lsm_manager=(merge=true,"
-    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
-    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),prefetch=(available=false,default=false),"
-    "readonly=false,rollback_to_stable=(threads=4),salvage=false,"
-    "session_max=100,session_scratch_max=2MB,session_table_cache=true"
-    ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+    "json_output=[],live_restore=(enabled=false,path=,threads_max=8),"
+    "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
+    "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
+    ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
+    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
+    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "prefetch=(available=false,default=false),readonly=false,"
+    "rollback_to_stable=(threads=4),salvage=false,session_max=100,"
+    "session_scratch_max=2MB,session_table_cache=true,"
+    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
     "statistics=none,statistics_log=(json=false,on_close=false,"
     "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
@@ -4166,17 +4164,17 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "in_memory=false,io_capacity=(chunk_cache=0,total=0),"
-    "json_output=[],live_restore=(enabled=false,path=,threads_max=8,"
-    "threads_min=1),log=(archive=true,compressor=,enabled=false,"
-    "file_max=100MB,force_write_wait=0,os_cache_dirty_pct=0,"
-    "path=\".\",prealloc=true,prealloc_init_count=1,recover=on,"
-    "remove=true,zero_fill=false),lsm_manager=(merge=true,"
-    "worker_thread_max=4),mmap=true,mmap_all=false,multiprocess=false"
-    ",operation_timeout_ms=0,operation_tracking=(enabled=false,"
-    "path=\".\"),prefetch=(available=false,default=false),"
-    "readonly=false,rollback_to_stable=(threads=4),salvage=false,"
-    "session_max=100,session_scratch_max=2MB,session_table_cache=true"
-    ",shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
+    "json_output=[],live_restore=(enabled=false,path=,threads_max=8),"
+    "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
+    "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
+    ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
+    "lsm_manager=(merge=true,worker_thread_max=4),mmap=true,"
+    "mmap_all=false,multiprocess=false,operation_timeout_ms=0,"
+    "operation_tracking=(enabled=false,path=\".\"),"
+    "prefetch=(available=false,default=false),readonly=false,"
+    "rollback_to_stable=(threads=4),salvage=false,session_max=100,"
+    "session_scratch_max=2MB,session_table_cache=true,"
+    "shared_cache=(chunk=10MB,name=,quota=0,reserve=0,size=500MB),"
     "statistics=none,statistics_log=(json=false,on_close=false,"
     "path=\".\",sources=,timestamp=\"%b %d %H:%M:%S\",wait=0),"
     "tiered_storage=(auth_token=,bucket=,bucket_prefix=,"
@@ -4223,7 +4221,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "io_capacity=(chunk_cache=0,total=0),json_output=[],"
-    "live_restore=(enabled=false,path=,threads_max=8,threads_min=1),"
+    "live_restore=(enabled=false,path=,threads_max=8),"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
@@ -4279,7 +4277,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "io_capacity=(chunk_cache=0,total=0),json_output=[],"
-    "live_restore=(enabled=false,path=,threads_max=8,threads_min=1),"
+    "live_restore=(enabled=false,path=,threads_max=8),"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2658,6 +2658,12 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
 #endif
     }
 
+    /*
+     * The live restore code validates that there isn't a file system so this check may seem
+     * redundant. However that validation only happens when live restore is enabled. As such we need
+     * this check too to ensure we don't overwrite the user specified system. It could be improved
+     * by adding more specific error messages.
+     */
     if (conn->file_system == NULL) {
         if (F_ISSET(conn, WT_CONN_IN_MEMORY))
             WT_RET(__wt_os_inmemory(session));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2622,6 +2622,54 @@ __conn_chk_file_system(WT_SESSION_IMPL *session, bool readonly)
 }
 
 /*
+ * __conn_config_file_system --
+ *     Configure the file system on the connection if the user hasn't added a custom file system.
+ */
+static int
+__conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
+{
+    WT_CONFIG_ITEM cval;
+    /*
+     * If the application didn't configure its own file system, configure one of ours. Check to
+     * ensure we have a valid file system.
+     *
+     * Check the "live_restore" config. If it is provided validate that a custom file system has not
+     * been provided, and that the connection is not in memory or Windows.
+     */
+    WT_RET(__wt_config_gets(session, cfg, "live_restore.enabled", &cval));
+
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    if (cval.val) {
+        F_SET(conn, WT_CONN_LIVE_RESTORE);
+        /* Live restore compatibility checks. */
+        if (conn->file_system != NULL)
+            WT_RET_MSG(session, EINVAL, "Live restore is not compatible with custom file systems.");
+        if (F_ISSET(conn, WT_CONN_IN_MEMORY))
+            WT_RET_MSG(
+              session, EINVAL, "Live restore is not compatible with in-memory connections.");
+#ifdef _MSC_VER
+        WT_ERR_MSG(session, EINVAL, "Live restore is not supported on Windows.");
+#endif
+    }
+
+    if (conn->file_system == NULL) {
+        if (F_ISSET(conn, WT_CONN_IN_MEMORY))
+            WT_RET(__wt_os_inmemory(session));
+        else {
+#if defined(_MSC_VER)
+            WT_ERR(__wt_os_win(session));
+#else
+            if (F_ISSET(conn, WT_CONN_LIVE_RESTORE))
+                WT_RET(__wt_os_live_restore_fs(session, cfg, conn->home, &conn->file_system));
+            else
+                WT_RET(__wt_os_posix(session, &conn->file_system));
+#endif
+        }
+    }
+    return (__conn_chk_file_system(session, F_ISSET(conn, WT_CONN_READONLY)));
+}
+
+/*
  * wiredtiger_dummy_session_init --
  *     Initialize the connection's dummy session.
  */
@@ -2818,44 +2866,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      */
     WT_ERR(__conn_load_extensions(session, cfg, true));
 
-    /*
-     * If the application didn't configure its own file system, configure one of ours. Check to
-     * ensure we have a valid file system.
-     *
-     * Check the "aux_path" config. If it is provided validate that a custom file system has not
-     * been provided, and that the connection is not in memory or Windows.
-     */
-    WT_ERR(__wt_config_gets(session, cfg, "aux_path", &cval));
-
-    if (cval.len != 0) {
-        /* Live restore compatibility checks. */
-        if (conn->file_system != NULL)
-            WT_ERR_MSG(session, EINVAL, "Live restore is not compatible with custom file systems.");
-        if (F_ISSET(conn, WT_CONN_IN_MEMORY))
-            WT_ERR_MSG(
-              session, EINVAL, "Live restore is not compatible with in-memory connections.");
-#ifdef _MSC_VER
-        WT_ERR_MSG(session, EINVAL, "Live restore is not supported on Windows.");
-#endif
-    }
-
-    if (conn->file_system == NULL) {
-        if (F_ISSET(conn, WT_CONN_IN_MEMORY))
-            WT_ERR(__wt_os_inmemory(session));
-        else {
-#if defined(_MSC_VER)
-            WT_ERR(__wt_os_win(session));
-#else
-            /* If an "aux_path" has been provided setup the live restore file system. */
-            if (cval.len != 0) {
-                F_SET(conn, WT_CONN_LIVE_RESTORE);
-                WT_ERR(__wt_os_live_restore_fs(session, &cval, conn->home, &conn->file_system));
-            } else
-                WT_ERR(__wt_os_posix(session, &conn->file_system));
-#endif
-        }
-    }
-    WT_ERR(__conn_chk_file_system(session, F_ISSET(conn, WT_CONN_READONLY)));
+    /* Configure the file system on the connection. */
+    WT_ERR(__conn_config_file_system(session, cfg));
 
     /* Make sure no other thread of control already owns this database. */
     WT_ERR(__conn_single(session, cfg));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2643,12 +2643,12 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
         F_SET(conn, WT_CONN_LIVE_RESTORE);
         /* Live restore compatibility checks. */
         if (conn->file_system != NULL)
-            WT_RET_MSG(session, EINVAL, "Live restore is not compatible with custom file systems.");
+            WT_RET_MSG(session, EINVAL, "Live restore is not compatible with custom file systems");
         if (F_ISSET(conn, WT_CONN_IN_MEMORY))
             WT_RET_MSG(
-              session, EINVAL, "Live restore is not compatible with in-memory connections.");
+              session, EINVAL, "Live restore is not compatible with an in-memory connections");
 #ifdef _MSC_VER
-        WT_ERR_MSG(session, EINVAL, "Live restore is not supported on Windows.");
+        WT_ERR_MSG(session, EINVAL, "Live restore is not supported on Windows");
 #endif
     }
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2654,7 +2654,7 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
             WT_RET_MSG(
               session, EINVAL, "Live restore is not compatible with an in-memory connections");
 #ifdef _MSC_VER
-        WT_ERR_MSG(session, EINVAL, "Live restore is not supported on Windows");
+        WT_RET_MSG(session, EINVAL, "Live restore is not supported on Windows");
 #endif
     }
 
@@ -2663,7 +2663,7 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
             WT_RET(__wt_os_inmemory(session));
         else {
 #if defined(_MSC_VER)
-            WT_ERR(__wt_os_win(session));
+            WT_RET(__wt_os_win(session));
 #else
             if (F_ISSET(conn, WT_CONN_LIVE_RESTORE))
                 WT_RET(__wt_os_live_restore_fs(session, cfg, conn->home, &conn->file_system));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2573,6 +2573,12 @@ __conn_session_size(WT_SESSION_IMPL *session, const char *cfg[], uint32_t *vp)
     WT_RET(__wt_config_gets(session, cfg, "lsm_manager.worker_thread_max", &cval));
     v += cval.val;
 
+    /* If live restore is enabled add its thread count. */
+    if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE)) {
+        WT_RET(__wt_config_gets(session, cfg, "live_restore.threads_max", &cval));
+        v += cval.val;
+    }
+
     v += WT_RTS_MAX_WORKERS;
 
     WT_RET(__wt_config_gets(session, cfg, "session_max", &cval));

--- a/src/include/conf.h
+++ b/src/include/conf.h
@@ -172,10 +172,10 @@ WT_CONF_API_DECLARE(object, meta, 5, 64);
 WT_CONF_API_DECLARE(table, meta, 2, 13);
 WT_CONF_API_DECLARE(tier, meta, 5, 65);
 WT_CONF_API_DECLARE(tiered, meta, 5, 67);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 24, 175);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 24, 176);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 24, 170);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 24, 169);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 24, 174);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 24, 175);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 24, 169);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 24, 168);
 
 #define WT_CONF_API_ELEMENTS 53
 

--- a/src/include/conf.h
+++ b/src/include/conf.h
@@ -172,10 +172,10 @@ WT_CONF_API_DECLARE(object, meta, 5, 64);
 WT_CONF_API_DECLARE(table, meta, 2, 13);
 WT_CONF_API_DECLARE(tier, meta, 5, 65);
 WT_CONF_API_DECLARE(tiered, meta, 5, 67);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 23, 171);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 23, 172);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 23, 166);
-WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 23, 165);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open, 24, 175);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_all, 24, 176);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_basecfg, 24, 170);
+WT_CONF_API_DECLARE(GLOBAL, wiredtiger_open_usercfg, 24, 169);
 
 #define WT_CONF_API_ELEMENTS 53
 

--- a/src/include/conf_keys.h
+++ b/src/include/conf_keys.h
@@ -27,12 +27,13 @@
 #define WT_CONF_ID_Eviction 215ULL
 #define WT_CONF_ID_File_manager 228ULL
 #define WT_CONF_ID_Flush_tier 161ULL
-#define WT_CONF_ID_Hash 294ULL
+#define WT_CONF_ID_Hash 293ULL
 #define WT_CONF_ID_Heuristic_controls 233ULL
 #define WT_CONF_ID_History_store 237ULL
 #define WT_CONF_ID_Import 102ULL
 #define WT_CONF_ID_Incremental 121ULL
 #define WT_CONF_ID_Io_capacity 239ULL
+#define WT_CONF_ID_Live_restore 298ULL
 #define WT_CONF_ID_Log 36ULL
 #define WT_CONF_ID_Lsm 66ULL
 #define WT_CONF_ID_Lsm_manager 249ULL
@@ -53,12 +54,11 @@
 #define WT_CONF_ID_archive 243ULL
 #define WT_CONF_ID_auth_token 48ULL
 #define WT_CONF_ID_auto_throttle 67ULL
-#define WT_CONF_ID_aux_path 276ULL
 #define WT_CONF_ID_available 305ULL
 #define WT_CONF_ID_background 95ULL
 #define WT_CONF_ID_background_compact 197ULL
 #define WT_CONF_ID_backup 165ULL
-#define WT_CONF_ID_backup_restore_target 277ULL
+#define WT_CONF_ID_backup_restore_target 276ULL
 #define WT_CONF_ID_blkcache_eviction_aggression 175ULL
 #define WT_CONF_ID_block_allocation 14ULL
 #define WT_CONF_ID_block_compressor 15ULL
@@ -70,9 +70,9 @@
 #define WT_CONF_ID_bound 92ULL
 #define WT_CONF_ID_bucket 49ULL
 #define WT_CONF_ID_bucket_prefix 50ULL
-#define WT_CONF_ID_buckets 295ULL
-#define WT_CONF_ID_buffer_alignment 278ULL
-#define WT_CONF_ID_builtin_extension_config 279ULL
+#define WT_CONF_ID_buckets 294ULL
+#define WT_CONF_ID_buffer_alignment 277ULL
+#define WT_CONF_ID_builtin_extension_config 278ULL
 #define WT_CONF_ID_bulk 114ULL
 #define WT_CONF_ID_cache 166ULL
 #define WT_CONF_ID_cache_cursors 270ULL
@@ -84,7 +84,7 @@
 #define WT_CONF_ID_cache_resident 16ULL
 #define WT_CONF_ID_cache_size 185ULL
 #define WT_CONF_ID_cache_stuck_timeout_ms 186ULL
-#define WT_CONF_ID_capacity 281ULL
+#define WT_CONF_ID_capacity 280ULL
 #define WT_CONF_ID_checkpoint 56ULL
 #define WT_CONF_ID_checkpoint_backup_info 57ULL
 #define WT_CONF_ID_checkpoint_cleanup 158ULL
@@ -94,13 +94,13 @@
 #define WT_CONF_ID_checkpoint_lsn 58ULL
 #define WT_CONF_ID_checkpoint_read_timestamp 117ULL
 #define WT_CONF_ID_checkpoint_retention 199ULL
-#define WT_CONF_ID_checkpoint_sync 280ULL
+#define WT_CONF_ID_checkpoint_sync 279ULL
 #define WT_CONF_ID_checkpoint_use_history 115ULL
 #define WT_CONF_ID_checkpoint_wait 108ULL
 #define WT_CONF_ID_checksum 17ULL
 #define WT_CONF_ID_chunk 257ULL
 #define WT_CONF_ID_chunk_cache 241ULL
-#define WT_CONF_ID_chunk_cache_evict_trigger 282ULL
+#define WT_CONF_ID_chunk_cache_evict_trigger 281ULL
 #define WT_CONF_ID_chunk_count_limit 73ULL
 #define WT_CONF_ID_chunk_max 74ULL
 #define WT_CONF_ID_chunk_size 75ULL
@@ -113,21 +113,21 @@
 #define WT_CONF_ID_columns 7ULL
 #define WT_CONF_ID_commit_timestamp 2ULL
 #define WT_CONF_ID_compare_timestamp 103ULL
-#define WT_CONF_ID_compile_configuration_count 287ULL
+#define WT_CONF_ID_compile_configuration_count 286ULL
 #define WT_CONF_ID_compressor 299ULL
 #define WT_CONF_ID_config 266ULL
-#define WT_CONF_ID_config_base 288ULL
+#define WT_CONF_ID_config_base 287ULL
 #define WT_CONF_ID_configuration 200ULL
 #define WT_CONF_ID_consolidate 122ULL
 #define WT_CONF_ID_corruption_abort 198ULL
-#define WT_CONF_ID_create 289ULL
+#define WT_CONF_ID_create 288ULL
 #define WT_CONF_ID_cursor_copy 201ULL
 #define WT_CONF_ID_cursor_reposition 202ULL
 #define WT_CONF_ID_cursors 167ULL
 #define WT_CONF_ID_default 306ULL
-#define WT_CONF_ID_dhandle_buckets 296ULL
+#define WT_CONF_ID_dhandle_buckets 295ULL
 #define WT_CONF_ID_dictionary 18ULL
-#define WT_CONF_ID_direct_io 290ULL
+#define WT_CONF_ID_direct_io 289ULL
 #define WT_CONF_ID_do_not_clear_txn_id 137ULL
 #define WT_CONF_ID_drop 160ULL
 #define WT_CONF_ID_dryrun 96ULL
@@ -161,16 +161,16 @@
 #define WT_CONF_ID_exclude 97ULL
 #define WT_CONF_ID_exclusive 101ULL
 #define WT_CONF_ID_exclusive_refreshed 94ULL
-#define WT_CONF_ID_extensions 292ULL
+#define WT_CONF_ID_extensions 291ULL
 #define WT_CONF_ID_extra_diagnostics 227ULL
 #define WT_CONF_ID_file 123ULL
-#define WT_CONF_ID_file_extend 293ULL
+#define WT_CONF_ID_file_extend 292ULL
 #define WT_CONF_ID_file_max 238ULL
 #define WT_CONF_ID_file_metadata 104ULL
 #define WT_CONF_ID_final_flush 163ULL
 #define WT_CONF_ID_flush_time 83ULL
 #define WT_CONF_ID_flush_timestamp 84ULL
-#define WT_CONF_ID_flushed_data_cache_insertion 284ULL
+#define WT_CONF_ID_flushed_data_cache_insertion 283ULL
 #define WT_CONF_ID_force 109ULL
 #define WT_CONF_ID_force_stop 124ULL
 #define WT_CONF_ID_force_write_wait 300ULL
@@ -182,7 +182,7 @@
 #define WT_CONF_ID_granularity 125ULL
 #define WT_CONF_ID_handles 168ULL
 #define WT_CONF_ID_hashsize 178ULL
-#define WT_CONF_ID_hazard_max 297ULL
+#define WT_CONF_ID_hazard_max 296ULL
 #define WT_CONF_ID_huffman_key 23ULL
 #define WT_CONF_ID_huffman_value 24ULL
 #define WT_CONF_ID_id 59ULL
@@ -190,7 +190,7 @@
 #define WT_CONF_ID_ignore_in_memory_cache_size 25ULL
 #define WT_CONF_ID_ignore_prepare 149ULL
 #define WT_CONF_ID_immutable 63ULL
-#define WT_CONF_ID_in_memory 298ULL
+#define WT_CONF_ID_in_memory 297ULL
 #define WT_CONF_ID_inclusive 93ULL
 #define WT_CONF_ID_internal_item_max 26ULL
 #define WT_CONF_ID_internal_key_max 27ULL
@@ -272,13 +272,13 @@
 #define WT_CONF_ID_remove_files 111ULL
 #define WT_CONF_ID_remove_shared 112ULL
 #define WT_CONF_ID_repair 107ULL
-#define WT_CONF_ID_require_max 285ULL
-#define WT_CONF_ID_require_min 286ULL
+#define WT_CONF_ID_require_max 284ULL
+#define WT_CONF_ID_require_min 285ULL
 #define WT_CONF_ID_reserve 259ULL
 #define WT_CONF_ID_rollback_error 207ULL
 #define WT_CONF_ID_run_once 99ULL
 #define WT_CONF_ID_salvage 307ULL
-#define WT_CONF_ID_secretkey 291ULL
+#define WT_CONF_ID_secretkey 290ULL
 #define WT_CONF_ID_session_max 308ULL
 #define WT_CONF_ID_session_scratch_max 309ULL
 #define WT_CONF_ID_session_table_cache 310ULL
@@ -296,7 +296,7 @@
 #define WT_CONF_ID_stable_timestamp 147ULL
 #define WT_CONF_ID_start_generation 78ULL
 #define WT_CONF_ID_statistics 134ULL
-#define WT_CONF_ID_storage_path 283ULL
+#define WT_CONF_ID_storage_path 282ULL
 #define WT_CONF_ID_stress_skiplist 209ULL
 #define WT_CONF_ID_strict 148ULL
 #define WT_CONF_ID_suffix 79ULL
@@ -469,6 +469,12 @@ static const struct {
         uint64_t total;
     } Io_capacity;
     struct {
+        uint64_t enabled;
+        uint64_t path;
+        uint64_t threads_max;
+        uint64_t threads_min;
+    } Live_restore;
+    struct {
         uint64_t archive;
         uint64_t compressor;
         uint64_t enabled;
@@ -553,7 +559,6 @@ static const struct {
     uint64_t allocation_size;
     uint64_t app_metadata;
     uint64_t append;
-    uint64_t aux_path;
     uint64_t background;
     uint64_t backup;
     uint64_t backup_restore_target;
@@ -843,6 +848,12 @@ static const struct {
     WT_CONF_ID_Io_capacity | (WT_CONF_ID_total << 16),
   },
   {
+    WT_CONF_ID_Live_restore | (WT_CONF_ID_enabled << 16),
+    WT_CONF_ID_Live_restore | (WT_CONF_ID_path << 16),
+    WT_CONF_ID_Live_restore | (WT_CONF_ID_threads_max << 16),
+    WT_CONF_ID_Live_restore | (WT_CONF_ID_threads_min << 16),
+  },
+  {
     WT_CONF_ID_Log | (WT_CONF_ID_archive << 16),
     WT_CONF_ID_Log | (WT_CONF_ID_compressor << 16),
     WT_CONF_ID_Log | (WT_CONF_ID_enabled << 16),
@@ -927,7 +938,6 @@ static const struct {
   WT_CONF_ID_allocation_size,
   WT_CONF_ID_app_metadata,
   WT_CONF_ID_append,
-  WT_CONF_ID_aux_path,
   WT_CONF_ID_background,
   WT_CONF_ID_backup,
   WT_CONF_ID_backup_restore_target,

--- a/src/include/conf_keys.h
+++ b/src/include/conf_keys.h
@@ -472,7 +472,6 @@ static const struct {
         uint64_t enabled;
         uint64_t path;
         uint64_t threads_max;
-        uint64_t threads_min;
     } Live_restore;
     struct {
         uint64_t archive;
@@ -851,7 +850,6 @@ static const struct {
     WT_CONF_ID_Live_restore | (WT_CONF_ID_enabled << 16),
     WT_CONF_ID_Live_restore | (WT_CONF_ID_path << 16),
     WT_CONF_ID_Live_restore | (WT_CONF_ID_threads_max << 16),
-    WT_CONF_ID_Live_restore | (WT_CONF_ID_threads_min << 16),
   },
   {
     WT_CONF_ID_Log | (WT_CONF_ID_archive << 16),

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3194,8 +3194,8 @@ struct __wt_connection {
  * the messages from the WT_EVENT_HANDLER::handle_error method., a list\, with values chosen from
  * the following options: \c "error"\, \c "message"; default \c [].}
  * @config{live_restore = (, Live restore configuration options.  These options control the behavior
- * of WiredTiger when restoring from a backup., a set of related configuration options defined as
- * follows.}
+ * of WiredTiger when live restoring from a backup., a set of related configuration options defined
+ * as follows.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, whether live restore is enabled or not., a
  * boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the path to the backup
@@ -3204,10 +3204,6 @@ struct __wt_connection {
  * threads_max, maximum number of threads WiredTiger will start to migrate data from the backup to
  * the running WiredTiger database.  Each worker thread uses a session handle from the configured
  * session_max., an integer between \c 1 and \c 12; default \c 8.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;
- * threads_min, minimum number of threads WiredTiger will start to migrate data from the backup to
- * the running WiredTiger database.  Each worker thread uses a session handle from the configured
- * session_max., an integer between \c 1 and \c 12; default \c 1.}
  * @config{ ),,}
  * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
  * session_max., a set of related configuration options defined as follows.}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2850,8 +2850,6 @@ struct __wt_connection {
  * event handler is installed that writes error messages to stderr. See
  * @ref event_message_handling for more information.
  * @configstart{wiredtiger_open, see dist/api_data.py}
- * @config{aux_path, The auxiliary path configuration specifies a second path to a WiredTiger
- * database.  This is then used to perform a live backup restore process., a string; default empty.}
  * @config{backup_restore_target, If non-empty and restoring from a backup\, restore only the table
  * object targets listed.  WiredTiger will remove all the metadata entries for the tables that are
  * not listed in the list from the reconstructed metadata.  The target list must include URIs of
@@ -3195,6 +3193,20 @@ struct __wt_connection {
  * given as a list\, where each option specifies an event handler category e.g.  'error' represents
  * the messages from the WT_EVENT_HANDLER::handle_error method., a list\, with values chosen from
  * the following options: \c "error"\, \c "message"; default \c [].}
+ * @config{live_restore = (, Live restore configuration options.  These options control the behavior
+ * of WiredTiger when restoring from a backup., a set of related configuration options defined as
+ * follows.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;enabled, whether live restore is enabled or not., a
+ * boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;path, the path to the backup
+ * that will be restored from., a string; default empty.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+ * threads_max, maximum number of threads WiredTiger will start to migrate data from the backup to
+ * running WiredTiger database., an integer between \c 1 and \c 20; default \c 8.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of threads WiredTiger will start to
+ * migrate data from the backup to running WiredTiger database., an integer between \c 1 and \c 20;
+ * default \c 1.}
+ * @config{ ),,}
  * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
  * session_max., a set of related configuration options defined as follows.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;compressor, configure a compressor for log records.  Permitted

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3202,10 +3202,12 @@ struct __wt_connection {
  * that will be restored from., a string; default empty.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;
  * threads_max, maximum number of threads WiredTiger will start to migrate data from the backup to
- * the running WiredTiger database., an integer between \c 1 and \c 20; default \c 8.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of threads WiredTiger will start to
- * migrate data from the backup to the running WiredTiger database., an integer between \c 1 and \c
- * 20; default \c 1.}
+ * the running WiredTiger database.  Each worker thread uses a session handle from the configured
+ * session_max., an integer between \c 1 and \c 12; default \c 8.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+ * threads_min, minimum number of threads WiredTiger will start to migrate data from the backup to
+ * the running WiredTiger database.  Each worker thread uses a session handle from the configured
+ * session_max., an integer between \c 1 and \c 12; default \c 1.}
  * @config{ ),,}
  * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
  * session_max., a set of related configuration options defined as follows.}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3202,10 +3202,10 @@ struct __wt_connection {
  * that will be restored from., a string; default empty.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;
  * threads_max, maximum number of threads WiredTiger will start to migrate data from the backup to
- * running WiredTiger database., an integer between \c 1 and \c 20; default \c 8.}
+ * the running WiredTiger database., an integer between \c 1 and \c 20; default \c 8.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of threads WiredTiger will start to
- * migrate data from the backup to running WiredTiger database., an integer between \c 1 and \c 20;
- * default \c 1.}
+ * migrate data from the backup to the running WiredTiger database., an integer between \c 1 and \c
+ * 20; default \c 1.}
  * @config{ ),,}
  * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
  * session_max., a set of related configuration options defined as follows.}

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -10,7 +10,7 @@
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
-extern int __wt_os_live_restore_fs(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *source_cfg,
+extern int __wt_os_live_restore_fs(WT_SESSION_IMPL *session, const char *cfg[],
   const char *destination, WT_FILE_SYSTEM **fsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 
 #ifdef HAVE_UNITTEST

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1162,10 +1162,7 @@ __wt_os_live_restore_fs(
 
     lr_fs->source.which = WT_LIVE_RESTORE_FS_LAYER_SOURCE;
 
-    /* Configure the background thread count. */
-    WT_ERR(__wt_config_gets(session, cfg, "live_restore.threads_min", &cval));
-    lr_fs->background_threads_min = (uint8_t)cval.val;
-
+    /* Configure the background thread count maximum. */
     WT_ERR(__wt_config_gets(session, cfg, "live_restore.threads_max", &cval));
     lr_fs->background_threads_max = (uint8_t)cval.val;
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1113,13 +1113,15 @@ __live_restore_fs_terminate(WT_FILE_SYSTEM *fs, WT_SESSION *wt_session)
 
 /*
  * __validate_live_restore_path --
- *     Confirm that the given source directory is openable.
+ *     Confirm that the given source directory is able to be opened.
  */
 static int
-__validate_live_restore_path(WT_FILE_SYSTEM *fs, WT_SESSION_IMPL *session, const char *path) {
+__validate_live_restore_path(WT_FILE_SYSTEM *fs, WT_SESSION_IMPL *session, const char *path)
+{
     WT_FILE_HANDLE *fh;
     /* Open the source directory. At this stage we do not validate what files it contains. */
-    WT_RET(fs->fs_open_file(fs, (WT_SESSION *)session, path, WT_FS_OPEN_FILE_TYPE_DIRECTORY, 0, &fh));
+    WT_RET(
+      fs->fs_open_file(fs, (WT_SESSION *)session, path, WT_FS_OPEN_FILE_TYPE_DIRECTORY, 0, &fh));
     fh->close(fh, (WT_SESSION *)session);
 
     return (0);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1122,9 +1122,7 @@ __validate_live_restore_path(WT_FILE_SYSTEM *fs, WT_SESSION_IMPL *session, const
     /* Open the source directory. At this stage we do not validate what files it contains. */
     WT_RET(
       fs->fs_open_file(fs, (WT_SESSION *)session, path, WT_FS_OPEN_FILE_TYPE_DIRECTORY, 0, &fh));
-    fh->close(fh, (WT_SESSION *)session);
-
-    return (0);
+    return (fh->close(fh, (WT_SESSION *)session));
 }
 
 /*

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -86,6 +86,9 @@ struct __wt_live_restore_fs {
     WT_FILE_SYSTEM *os_file_system; /* The storage file system. */
     WT_LIVE_RESTORE_FS_LAYER destination;
     WT_LIVE_RESTORE_FS_LAYER source;
+
+    uint8_t background_threads_min;
+    uint8_t background_threads_max;
 };
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -87,7 +87,6 @@ struct __wt_live_restore_fs {
     WT_LIVE_RESTORE_FS_LAYER destination;
     WT_LIVE_RESTORE_FS_LAYER source;
 
-    uint8_t background_threads_min;
     uint8_t background_threads_max;
 };
 

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -310,7 +310,8 @@ main(int argc, char *argv[])
     if (argc > 1 && argv[1][1] == 'f') {
         fresh_start = true;
         logger::log_msg(LOG_WARN, "Started in -f mode will clean up existing directories");
-        testutil_remove(SOURCE_DIR);
+        // Live restore expects the source directory to exist.
+        testutil_recreate_dir(SOURCE_DIR);
         testutil_remove("WT_TEST");
     }
     // We will recreate this directory every time, on exit the contents in it will be moved to

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -302,8 +302,8 @@ main(int argc, char *argv[])
 
     /* Create a connection, set the cache size and specify the home directory. */
     // TODO: Make verbosity level configurable at runtime.
-    const std::string conn_config =
-      CONNECTION_CREATE + ",aux_path=\"" + SOURCE_DIR + "\",cache_size=1GB,verbose=[fileops:2]";
+    const std::string conn_config = CONNECTION_CREATE + ",live_restore=(enabled=true,path=\"" +
+      SOURCE_DIR + "\"),cache_size=1GB,verbose=[fileops:2]";
 
     logger::log_msg(LOG_TRACE, "arg count: " + std::to_string(argc));
     bool fresh_start = false;

--- a/test/suite/test_live_restore01.py
+++ b/test/suite/test_live_restore01.py
@@ -65,3 +65,12 @@ class test_live_restore01(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.open_conn(config="live_restore=(enabled=true,path=\"fake.fake.fake\")"),
             "/fake.fake.fake/")
+
+        # Specify the max number of threads
+        self.open_conn(config="live_restore=(enabled=true,path=\".\",threads_max=12)")
+        self.close_conn()
+
+        # Specify one too many threads.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.open_conn(config="live_restore=(enabled=true,path=\".\",threads_max=13)"),
+            "/Value too large for key/")

--- a/test/suite/test_live_restore01.py
+++ b/test/suite/test_live_restore01.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+import wiredtiger, wttest
+
+# test_live_restore01.py
+# Test live restore compatibility with various other connection options.
+class test_live_restore01(wttest.WiredTigerTestCase):
+    def test_live_restore01(self):
+        # Close the default connection.
+        self.close_conn()
+
+        # Test that live restore connection will fail on windows.
+        if os.name == 'nt':
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda: self.open_conn(config="live_restore=(enabled=true,path=\".\")"),
+                "/Live restore is not supported on Windows/")
+            return
+
+        # Open a valid connection.
+        self.open_conn(config="live_restore=(enabled=true,path=\".\")")
+        self.close_conn()
+
+        # Specify an in memory connection with live restore.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.open_conn(config="in_memory=true,live_restore=(enabled=true,path=\".\")"),
+            "/Live restore is not compatible with an in-memory connection/")

--- a/test/suite/test_live_restore01.py
+++ b/test/suite/test_live_restore01.py
@@ -51,3 +51,17 @@ class test_live_restore01(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.open_conn(config="in_memory=true,live_restore=(enabled=true,path=\".\")"),
             "/Live restore is not compatible with an in-memory connection/")
+
+        # Specify an in memory connection with live restore not enabled.
+        self.open_conn(config="in_memory=true,live_restore=(enabled=false,path=\".\")")
+        self.close_conn()
+
+        # Specify an empty path string.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.open_conn(config="live_restore=(enabled=true,path=\"\")"),
+            "/No such file or directory/")
+
+        # Specify a non existant path.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.open_conn(config="live_restore=(enabled=true,path=\"fake.fake.fake\")"),
+            "/fake.fake.fake/")


### PR DESCRIPTION
The PoC live restore configuration relied on an `aux_path` parameter to specify the live restore path, additionally the existence of a path indicated that a live restore was in progress. A better defined API is needed to distinguish live restore from other usages of `aux_path`. To that end the `aux_path` config is removed and a `live_restore` configuration takes its place. 

It accepts the following options:
- `enabled`
- `path`
- `threads_max`