### PR TITLE
WT-13841 Fix minor Coverity warnings in live restore

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -798,7 +798,12 @@ __live_restore_fh_find_holes_in_dest_file(
     }
 
 err:
-    WT_SYSCALL(close(fd), ret);
+    /*
+     * This should be wrapped in WT_SYSCALL but that will overwrite prior error codes. It's more
+     * important to catch errors reported earlier in this function than catching an error from
+     * closing the file.
+     */
+    WT_IGNORE_RET(close(fd));
     return (ret);
 }
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -331,7 +331,6 @@ __live_restore_fs_free_extent_list(WT_SESSION_IMPL *session, WT_LIVE_RESTORE_FIL
     WT_LIVE_RESTORE_HOLE_LIST *hole;
     WT_LIVE_RESTORE_HOLE_LIST *temp;
 
-    temp = hole = NULL;
     hole = lr_fh->destination.hole_list;
     lr_fh->destination.hole_list = NULL;
 
@@ -763,7 +762,7 @@ __live_restore_fh_find_holes_in_dest_file(
     int fd;
 
     data_end_offset = 0;
-    fd = open(filename, O_RDONLY);
+    WT_SYSCALL(((fd = open(filename, O_RDONLY)) == -1 ? -1 : 0), ret);
 
     /* Check that we opened a valid file descriptor. */
     WT_ASSERT(session, fcntl(fd, F_GETFD) != -1 || errno != EBADF);
@@ -799,7 +798,7 @@ __live_restore_fh_find_holes_in_dest_file(
     }
 
 err:
-    close(fd);
+    WT_SYSCALL(close(fd), ret);
     return (ret);
 }
 
@@ -904,7 +903,7 @@ __live_restore_fs_open_file(WT_FILE_SYSTEM *fs, WT_SESSION *wt_session, const ch
                  */
                 wt_off_t source_size;
 
-                lr_fh->source->fh_size(lr_fh->source, wt_session, &source_size);
+                WT_ERR(lr_fh->source->fh_size(lr_fh->source, wt_session, &source_size));
                 __wt_verbose_debug1(session, WT_VERB_FILEOPS,
                   "Creating destination file backed by source file. Copying size (%" PRId64
                   ") from source "
@@ -916,7 +915,8 @@ __live_restore_fs_open_file(WT_FILE_SYSTEM *fs, WT_SESSION *wt_session, const ch
                  * the file. We're bypassing the live_restore layer so we don't try to modify the
                  * extents in hole_list.
                  */
-                lr_fh->destination.fh->fh_truncate(lr_fh->destination.fh, wt_session, source_size);
+                WT_ERR(lr_fh->destination.fh->fh_truncate(
+                  lr_fh->destination.fh, wt_session, source_size));
 
                 /*
                  * Initialize the extent as one hole covering the entire file. We need to read

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -763,6 +763,7 @@ __live_restore_fh_find_holes_in_dest_file(
 
     data_end_offset = 0;
     WT_SYSCALL(((fd = open(filename, O_RDONLY)) == -1 ? -1 : 0), ret);
+    WT_ERR(ret);
 
     /* Check that we opened a valid file descriptor. */
     WT_ASSERT(session, fcntl(fd, F_GETFD) != -1 || errno != EBADF);
@@ -798,12 +799,7 @@ __live_restore_fh_find_holes_in_dest_file(
     }
 
 err:
-    /*
-     * This should be wrapped in WT_SYSCALL but that will overwrite prior error codes. It's more
-     * important to catch errors reported earlier in this function than catching an error from
-     * closing the file.
-     */
-    WT_IGNORE_RET(close(fd));
+    WT_SYSCALL_TRET(close(fd), ret);
     return (ret);
 }
 

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -255,15 +255,12 @@ do_random_crud(scoped_session &session, bool fresh_start)
         if (ran < 5000) {
             // 50% Write.
             write(session, false);
-            continue;
         } else if (ran <= 9980) {
             // 49.8% Read.
             read(session);
-            continue;
         } else if (ran <= 10000) {
             // 0.2% fs_truncate
             trigger_fs_truncate(session);
-            continue;
         } else {
             logger::log_msg(LOG_ERROR,
               "do_random_crud RNG (" + std::to_string(ran) + ") didn't find an operation to run");


### PR DESCRIPTION
Fix 6 minor/trivial Coverity warnings raised after merging in the live restore code.