### PR TITLE
WT-13798 Implement a random WiredTiger timing stress configuration within workload generator

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3763,6 +3763,22 @@ tasks:
             # Keep repeating the model test for 60 minutes
             ./model_test -l 2000-3000 -t 3600
 
+  - name: model-test-long-random-config
+    tags: ["model_checking"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/model/tools"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            # Keep repeating the model test for 60 minutes
+            ./model_test -l 100-200 -g -t 3600
+
   - name: model-test-long-with-coverage
     tags: ["model_checking"]
     commands:
@@ -5421,6 +5437,8 @@ buildvariants:
       batchtime: 1440 # once a day
     - name: model-test-long-with-coverage
       batchtime: 1440 # once a day
+    - name: model-test-long-random-config
+      batchtime: 1440 # once a day
     - name: csuite-long-running
       batchtime: 1440 # once a day
     - name: live-restore-long
@@ -5822,6 +5840,8 @@ buildvariants:
     - name: model-test-long
       batchtime: 1440 # once a day
     - name: model-test-long-with-coverage
+      batchtime: 1440 # once a day
+    - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: model-unit-test
     - name: s3-tiered-storage-extensions-test

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -31,16 +31,6 @@
 #include "model/driver/kv_workload_generator.h"
 #include "model/util.h"
 
-/*
- * Configuration.
- */
-#define ENV_CONFIG                                             \
-    "cache_size=20M,create,"                                   \
-    "debug_mode=(table_logging=true,checkpoint_retention=5),"  \
-    "eviction_updates_target=20,eviction_updates_trigger=90,"  \
-    "log=(enabled,file_max=10M,remove=false),session_max=100," \
-    "statistics=(all),statistics_log=(wait=1,json,on_close)"
-
 namespace model {
 
 /*
@@ -87,16 +77,16 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     prepared_transaction_rollback_after_prepare = 0.1;
     prepared_transaction_rollback_before_prepare = 0.1;
 
-    timing_stress_ckpt_slow = 0.2;
-    timing_stress_ckpt_evict_page = 0.2;
-    timing_stress_ckpt_handle = 0.2;
-    timing_stress_ckpt_stop = 0.2;
-    timing_stress_compact_slow = 0.2;
-    timing_stress_hs_ckpt_delay = 0.2;
-    timing_stress_hs_search = 0.2;
-    timing_stress_hs_sweep_race = 0.2;
-    timing_stress_prepare_ckpt_delay = 0.2;
-    timing_stress_commit_txn_slow = 0.2;
+    timing_stress_ckpt_slow = 0.1;
+    timing_stress_ckpt_evict_page = 0.1;
+    timing_stress_ckpt_handle = 0.1;
+    timing_stress_ckpt_stop = 0.1;
+    timing_stress_compact_slow = 0.1;
+    timing_stress_hs_ckpt_delay = 0.1;
+    timing_stress_hs_search = 0.1;
+    timing_stress_hs_sweep_race = 0.1;
+    timing_stress_prepare_ckpt_delay = 0.1;
+    timing_stress_commit_txn_slow = 0.1;
 }
 
 /*
@@ -335,37 +325,35 @@ kv_workload_generator::choose_table(kv_workload_sequence_ptr txn)
 }
 
 /*
- * kv_workload_generator::generate_rand_stress_configs --
- *     Generate random WiredTiger timing stress configurations.
+ * kv_workload_generator::generate_connection_config --
+ *     Generate random WiredTiger connection configurations.
  */
 std::string
-kv_workload_generator::generate_rand_stress_configs()
+kv_workload_generator::generate_connection_config()
 {
-    std::string wt_env_config = std::string(ENV_CONFIG);
+    std::string wt_env_config;
     probability_switch(_random.next_float())
     {
         probability_case(_spec.timing_stress_ckpt_slow) wt_env_config +=
-          ",timing_stress_for_test=[checkpoint_slow]";
+          "timing_stress_for_test=[checkpoint_slow]";
         probability_case(_spec.timing_stress_ckpt_evict_page) wt_env_config +=
-          ",timing_stress_for_test=[checkpoint_evict_page]";
+          "timing_stress_for_test=[checkpoint_evict_page]";
         probability_case(_spec.timing_stress_ckpt_handle) wt_env_config +=
-          ",timing_stress_for_test=[checkpoint_handle]";
+          "timing_stress_for_test=[checkpoint_handle]";
         probability_case(_spec.timing_stress_ckpt_stop) wt_env_config +=
-          ",timing_stress_for_test=[checkpoint_stop]";
+          "timing_stress_for_test=[checkpoint_stop]";
         probability_case(_spec.timing_stress_compact_slow) wt_env_config +=
-          ",timing_stress_for_test=[compact_slow]";
+          "timing_stress_for_test=[compact_slow]";
         probability_case(_spec.timing_stress_hs_ckpt_delay) wt_env_config +=
-          ",timing_stress_for_test=[history_store_checkpoint_delay]";
+          "timing_stress_for_test=[history_store_checkpoint_delay]";
         probability_case(_spec.timing_stress_hs_search) wt_env_config +=
-          ",timing_stress_for_test=[history_store_search]";
+          "timing_stress_for_test=[history_store_search]";
         probability_case(_spec.timing_stress_hs_sweep_race) wt_env_config +=
-          ",timing_stress_for_test=[history_store_sweep_race]";
+          "timing_stress_for_test=[history_store_sweep_race]";
         probability_case(_spec.timing_stress_prepare_ckpt_delay) wt_env_config +=
-          ",timing_stress_for_test=[prepare_checkpoint_delay]";
+          "timing_stress_for_test=[prepare_checkpoint_delay]";
         probability_case(_spec.timing_stress_commit_txn_slow) wt_env_config +=
-          ",timing_stress_for_test=[commit_transaction_slow]";
-        probability_default wt_env_config =
-          std::string(ENV_CONFIG) + ",timing_stress_for_test=[commit_transaction_slow]";
+          "timing_stress_for_test=[commit_transaction_slow]";
     }
     return wt_env_config;
 }

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -88,6 +88,14 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     prepared_transaction_rollback_before_prepare = 0.1;
 
     timing_stress_ckpt_slow = 0.2;
+    timing_stress_ckpt_evict_page = 0.2;
+    timing_stress_ckpt_handle = 0.2;
+    timing_stress_ckpt_stop = 0.2;
+    timing_stress_compact_slow = 0.2;
+    timing_stress_hs_ckpt_delay = 0.2;
+    timing_stress_hs_search = 0.2;
+    timing_stress_hs_sweep_race = 0.2;
+    timing_stress_prepare_ckpt_delay = 0.2;
     timing_stress_commit_txn_slow = 0.2;
 }
 
@@ -338,6 +346,22 @@ kv_workload_generator::generate_rand_stress_configs()
     {
         probability_case(_spec.timing_stress_ckpt_slow) wt_env_config +=
           ",timing_stress_for_test=[checkpoint_slow]";
+        probability_case(_spec.timing_stress_ckpt_evict_page) wt_env_config +=
+          ",timing_stress_for_test=[checkpoint_evict_page]";
+        probability_case(_spec.timing_stress_ckpt_handle) wt_env_config +=
+          ",timing_stress_for_test=[checkpoint_handle]";
+        probability_case(_spec.timing_stress_ckpt_stop) wt_env_config +=
+          ",timing_stress_for_test=[checkpoint_stop]";
+        probability_case(_spec.timing_stress_compact_slow) wt_env_config +=
+          ",timing_stress_for_test=[compact_slow]";
+        probability_case(_spec.timing_stress_hs_ckpt_delay) wt_env_config +=
+          ",timing_stress_for_test=[history_store_checkpoint_delay]";
+        probability_case(_spec.timing_stress_hs_search) wt_env_config +=
+          ",timing_stress_for_test=[history_store_search]";
+        probability_case(_spec.timing_stress_hs_sweep_race) wt_env_config +=
+          ",timing_stress_for_test=[history_store_sweep_race]";
+        probability_case(_spec.timing_stress_prepare_ckpt_delay) wt_env_config +=
+          ",timing_stress_for_test=[prepare_checkpoint_delay]";
         probability_case(_spec.timing_stress_commit_txn_slow) wt_env_config +=
           ",timing_stress_for_test=[commit_transaction_slow]";
         probability_default wt_env_config =

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -31,6 +31,16 @@
 #include "model/driver/kv_workload_generator.h"
 #include "model/util.h"
 
+/*
+ * Configuration.
+ */
+#define ENV_CONFIG                                             \
+    "cache_size=20M,create,"                                   \
+    "debug_mode=(table_logging=true,checkpoint_retention=5),"  \
+    "eviction_updates_target=20,eviction_updates_trigger=90,"  \
+    "log=(enabled,file_max=10M,remove=false),session_max=100," \
+    "statistics=(all),statistics_log=(wait=1,json,on_close)"
+
 namespace model {
 
 /*
@@ -76,6 +86,9 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     nonprepared_transaction_rollback = 0.1;
     prepared_transaction_rollback_after_prepare = 0.1;
     prepared_transaction_rollback_before_prepare = 0.1;
+
+    timing_stress_ckpt_slow = 0.2;
+    timing_stress_commit_txn_slow = 0.2;
 }
 
 /*
@@ -311,6 +324,26 @@ kv_workload_generator::choose_table(kv_workload_sequence_ptr txn)
         throw model_exception("No tables.");
 
     return _tables_list[_random.next_index(_tables_list.size())];
+}
+
+/*
+ * kv_workload_generator::generate_rand_stress_configs --
+ *     Generate random WiredTiger timing stress configurations.
+ */
+std::string
+kv_workload_generator::generate_rand_stress_configs()
+{
+    std::string wt_env_config = std::string(ENV_CONFIG);
+    probability_switch(_random.next_float())
+    {
+        probability_case(_spec.timing_stress_ckpt_slow) wt_env_config +=
+          ",timing_stress_for_test=[checkpoint_slow]";
+        probability_case(_spec.timing_stress_commit_txn_slow) wt_env_config +=
+          ",timing_stress_for_test=[commit_transaction_slow]";
+        probability_default wt_env_config =
+          std::string(ENV_CONFIG) + ",timing_stress_for_test=[commit_transaction_slow]";
+    }
+    return wt_env_config;
 }
 
 /*

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -33,6 +33,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include "model/driver/kv_workload.h"
 #include "model/driver/kv_workload_sequence.h"
@@ -100,6 +101,9 @@ struct kv_workload_generator_spec {
     float prepared_transaction_rollback_after_prepare;
     float prepared_transaction_rollback_before_prepare;
 
+    /* Probabilities of WiredTiger timing stress configurations. */
+    float timing_stress_ckpt_slow;
+    float timing_stress_commit_txn_slow;
     /*
      * kv_workload_generator_spec::kv_workload_generator_spec --
      *     Create the generator specification using default probability values.
@@ -429,6 +433,15 @@ public:
         return generator.workload();
     }
 
+    static std::string
+    generate_configurations(
+      const kv_workload_generator_spec &spec = _default_spec, uint64_t seed = 0)
+    {
+        uint64_t base_seed = model::random::next_seed(__wt_rdtsc() ^ time(NULL));
+        kv_workload_generator generator(spec, base_seed);
+        return generator.generate_rand_stress_configs();
+    }
+
 protected:
     /*
      * kv_workload_generator::kv_workload_generator --
@@ -470,6 +483,12 @@ protected:
      *     Create a table.
      */
     void create_table();
+
+    /*
+     * kv_workload_generator::generate_rand_stress_configs --
+     *     Generate random WiredTiger timing stress configurations.
+     */
+    std::string generate_rand_stress_configs();
 
     /*
      * kv_workload_generator::generate_key --

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -102,7 +102,7 @@ struct kv_workload_generator_spec {
     float prepared_transaction_rollback_before_prepare;
 
     /* Probabilities of WiredTiger timing stress configurations. */
-    /* FIXME : Refactor this code and move into a seperate structure. */
+    /* FIXME : Refactor this code and move into a separate structure. */
     float timing_stress_ckpt_slow;
     float timing_stress_ckpt_evict_page;
     float timing_stress_ckpt_handle;
@@ -113,6 +113,7 @@ struct kv_workload_generator_spec {
     float timing_stress_hs_sweep_race;
     float timing_stress_prepare_ckpt_delay;
     float timing_stress_commit_txn_slow;
+
     /*
      * kv_workload_generator_spec::kv_workload_generator_spec --
      *     Create the generator specification using default probability values.
@@ -448,7 +449,7 @@ public:
     {
         uint64_t base_seed = model::random::next_seed(__wt_rdtsc() ^ time(NULL));
         kv_workload_generator generator(spec, base_seed);
-        return generator.generate_rand_stress_configs();
+        return generator.generate_connection_config();
     }
 
 protected:
@@ -494,10 +495,10 @@ protected:
     void create_table();
 
     /*
-     * kv_workload_generator::generate_rand_stress_configs --
+     * kv_workload_generator::generate_connection_config --
      *     Generate random WiredTiger timing stress configurations.
      */
-    std::string generate_rand_stress_configs();
+    std::string generate_connection_config();
 
     /*
      * kv_workload_generator::generate_key --

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -102,7 +102,7 @@ struct kv_workload_generator_spec {
     float prepared_transaction_rollback_before_prepare;
 
     /* Probabilities of WiredTiger timing stress configurations. */
-    /* FIXME : Refactor this code and move into a separate structure. */
+    /* FIXME-WT-13878 : Refactor this code and move into a separate structure. */
     float timing_stress_ckpt_slow;
     float timing_stress_ckpt_evict_page;
     float timing_stress_ckpt_handle;

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -444,11 +444,9 @@ public:
     }
 
     static std::string
-    generate_configurations(
-      const kv_workload_generator_spec &spec = _default_spec, uint64_t seed = 0)
+    generate_configurations(uint64_t seed = 0)
     {
-        uint64_t base_seed = model::random::next_seed(__wt_rdtsc() ^ time(NULL));
-        kv_workload_generator generator(spec, base_seed);
+        kv_workload_generator generator(_default_spec, seed);
         return generator.generate_connection_config();
     }
 

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -102,7 +102,16 @@ struct kv_workload_generator_spec {
     float prepared_transaction_rollback_before_prepare;
 
     /* Probabilities of WiredTiger timing stress configurations. */
+    /* FIXME : Refactor this code and move into a seperate structure. */
     float timing_stress_ckpt_slow;
+    float timing_stress_ckpt_evict_page;
+    float timing_stress_ckpt_handle;
+    float timing_stress_ckpt_stop;
+    float timing_stress_compact_slow;
+    float timing_stress_hs_ckpt_delay;
+    float timing_stress_hs_search;
+    float timing_stress_hs_sweep_race;
+    float timing_stress_prepare_ckpt_delay;
     float timing_stress_commit_txn_slow;
     /*
      * kv_workload_generator_spec::kv_workload_generator_spec --

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -315,34 +315,6 @@ test_workload_generator(void)
 }
 
 /*
- * test_workload_generator_rand_config --
- *     Test the workload generator.
- */
-static void
-test_workload_generator_rand_config(void)
-{
-    int retries = 0;
-
-    while (true) {
-        try {
-            std::shared_ptr<model::kv_workload> workload = model::kv_workload_generator::generate();
-            std::string rand_env_config = model::kv_workload_generator::generate_configurations();
-
-            /* Run the workload in the model and in WiredTiger, then verify. */
-            std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
-            verify_workload(*workload, opts, test_home, rand_env_config.c_str());
-
-            break;
-        } catch (model::known_issue_exception &) {
-            /* Try again. */
-        }
-
-        if (retries++ > 10)
-            throw model::model_exception("Too many retries for workload generation");
-    }
-}
-
-/*
  * test_workload_parse --
  *     Test the workload parser.
  */
@@ -465,7 +437,6 @@ main(int argc, char *argv[])
         test_workload_restart();
         test_workload_crash();
         test_workload_generator();
-        test_workload_generator_rand_config();
         test_workload_parse();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;

--- a/test/model/test/model_workload/main.cpp
+++ b/test/model/test/model_workload/main.cpp
@@ -315,6 +315,34 @@ test_workload_generator(void)
 }
 
 /*
+ * test_workload_generator_rand_config --
+ *     Test the workload generator.
+ */
+static void
+test_workload_generator_rand_config(void)
+{
+    int retries = 0;
+
+    while (true) {
+        try {
+            std::shared_ptr<model::kv_workload> workload = model::kv_workload_generator::generate();
+            std::string rand_env_config = model::kv_workload_generator::generate_configurations();
+
+            /* Run the workload in the model and in WiredTiger, then verify. */
+            std::string test_home = std::string(home) + DIR_DELIM_STR + "generator";
+            verify_workload(*workload, opts, test_home, rand_env_config.c_str());
+
+            break;
+        } catch (model::known_issue_exception &) {
+            /* Try again. */
+        }
+
+        if (retries++ > 10)
+            throw model::model_exception("Too many retries for workload generation");
+    }
+}
+
+/*
  * test_workload_parse --
  *     Test the workload parser.
  */
@@ -437,6 +465,7 @@ main(int argc, char *argv[])
         test_workload_restart();
         test_workload_crash();
         test_workload_generator();
+        test_workload_generator_rand_config();
         test_workload_parse();
     } catch (std::exception &e) {
         std::cerr << "Test failed with exception: " << e.what() << std::endl;

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -796,8 +796,11 @@ main(int argc, char *argv[])
             }
 
             /* Generate random timing stress configurations and add it to the WiredTiger config. */
-            if (generate_timing_stress_configurations)
-                rand_env_config = model::kv_workload_generator::generate_configurations();
+            if (generate_timing_stress_configurations){
+                uint64_t base_seed = model::random::next_seed(__wt_rdtsc() ^ time(NULL));
+                rand_env_config = model::kv_workload_generator::generate_configurations(base_seed);
+                conn_config = model::join(rand_env_config, conn_config);
+            }
 
             /* Add the connection and table configurations to the workload. */
             if (!table_config.empty())
@@ -817,7 +820,7 @@ main(int argc, char *argv[])
 
             /* Run and verify the workload. */
             try {
-                run_and_verify(workload, home, rand_env_config);
+                run_and_verify(workload, home);
             } catch (std::exception &e) {
                 std::cerr << e.what() << std::endl;
                 if (reduce)

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -796,9 +796,8 @@ main(int argc, char *argv[])
             }
 
             /* Generate random timing stress configurations and add it to the WiredTiger config. */
-            if (generate_timing_stress_configurations){
-                uint64_t base_seed = model::random::next_seed(__wt_rdtsc() ^ time(NULL));
-                rand_env_config = model::kv_workload_generator::generate_configurations(base_seed);
+            if (generate_timing_stress_configurations) {
+                rand_env_config = model::kv_workload_generator::generate_configurations(seed);
                 conn_config = model::join(rand_env_config, conn_config);
             }
 

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -779,8 +779,8 @@ main(int argc, char *argv[])
         /* Run the test, potentially many times. */
         uint64_t next_seed = base_seed;
         for (uint64_t iteration = 1;; iteration++) {
-            std::string rand_env_config;
             uint64_t seed = next_seed;
+            std::string wt_conn_config = conn_config;
             next_seed = model::random::next_seed(next_seed);
 
             std::cout << "Iteration " << iteration << ", seed 0x" << std::hex << seed << std::dec
@@ -797,16 +797,17 @@ main(int argc, char *argv[])
 
             /* Generate random timing stress configurations and add it to the WiredTiger config. */
             if (generate_timing_stress_configurations) {
+                std::string rand_env_config;
                 rand_env_config = model::kv_workload_generator::generate_configurations(seed);
-                conn_config = model::join(rand_env_config, conn_config);
+                wt_conn_config = model::join(wt_conn_config, rand_env_config);
             }
 
             /* Add the connection and table configurations to the workload. */
             if (!table_config.empty())
                 workload->prepend(std::move(model::operation::wt_config("table", table_config)));
-            if (!conn_config.empty())
+            if (!wt_conn_config.empty())
                 workload->prepend(
-                  std::move(model::operation::wt_config("connection", conn_config)));
+                  std::move(model::operation::wt_config("connection", wt_conn_config)));
 
             /* If we only want to print the workload, then do so. */
             if (print_only) {


### PR DESCRIPTION
This pull request has the following changes :

- Implement a new feature in the RTS Model workload generator that will allow for the generation of random WiredTiger timing stress configurations, enabling comprehensive testing of various scenarios.
- Added an argument option to the model_test to enable generating the random timing stress configuration.
- Added an evergreen task to run the model test with the new random timing stress configuration.