### PR TITLE
WT-13549 Investigate block checksum getting cleared when performing read()

### DIFF
--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -223,6 +223,12 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
         __wt_block_header_byteswap_copy(blk, &swap);
         check_size = F_ISSET(&swap, WT_BLOCK_DATA_CKSUM) ? size : WT_BLOCK_COMPRESS_SKIP;
         if (swap.checksum == checksum) {
+            /*
+             * Set block header checksum to 0 to allow the checksum to be computed, as its
+             * calculation includes the block header. Not clearing it would result in the checksum
+             * being miscalculated. blk->checksum remains cleared, as it will not be revisited
+             * during a B-tree traversal.
+             */
             blk->checksum = 0;
             if (__wt_checksum_match(buf->mem, check_size, checksum)) {
                 /*


### PR DESCRIPTION
After investigating the code logic, it is clear that blk->checksum needs to be cleared for the calculation of the checksum and will remain cleared since it will not be revisited during a B-tree traversal. Therefore, there is no need to reset it to its original value, and no code changes are required.

However, during the investigation, a lot of time was spent understanding the logic of the code and why blk->checksum is cleared and not reset. To avoid similar confusion in the future, I am adding a comment here for reference.