### PR TITLE
Revert "WT-13849 Fix read pinned_timestamp multiple times in __wt_txn_pinned_timestamp"

### DIFF
--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -816,18 +816,16 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
 {
     WT_TXN_GLOBAL *txn_global;
     wt_timestamp_t checkpoint_ts, pinned_ts;
-    bool has_pinned_timestamp;
+
+    *pinned_tsp = WT_TS_NONE;
 
     txn_global = &S2C(session)->txn_global;
 
     /*
      * There is no need to go further if no pinned timestamp has been set yet.
      */
-    WT_ACQUIRE_READ_WITH_BARRIER(has_pinned_timestamp, txn_global->has_pinned_timestamp);
-    if (!has_pinned_timestamp) {
-        *pinned_tsp = WT_TS_NONE;
+    if (!txn_global->has_pinned_timestamp)
         return;
-    }
 
     /* If we have a version cursor open, use the pinned timestamp when it is opened. */
     if (S2C(session)->version_cursor_count > 0) {
@@ -835,14 +833,7 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
         return;
     }
 
-    /*
-     * It is important to ensure we only read the global pinned timestamp once. Otherwise, we may
-     * return a pinned timestamp that is larger than the checkpoint timestamp. For example, the
-     * first time we read the global pinned timestamp as 100 and set it to the local variable
-     * pinned_ts. If the checkpoint timestamp is 110 and the second time we read the global pinned
-     * timestamp as 120, we will return 120 instead of the checkpoint timestamp 110.
-     */
-    WT_ACQUIRE_READ_WITH_BARRIER(pinned_ts, txn_global->pinned_timestamp);
+    *pinned_tsp = pinned_ts = txn_global->pinned_timestamp;
 
     /*
      * The read of checkpoint timestamp needs to be carefully ordered: it needs to be after we have
@@ -851,12 +842,11 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
      * pinned. If a checkpoint is starting and we have to use the checkpoint timestamp, we take the
      * minimum of it with the oldest timestamp, which is what we want.
      */
+    WT_ACQUIRE_BARRIER();
     checkpoint_ts = txn_global->checkpoint_timestamp;
 
-    if (checkpoint_ts != WT_TS_NONE && checkpoint_ts < pinned_ts)
+    if (checkpoint_ts != 0 && checkpoint_ts < pinned_ts)
         *pinned_tsp = checkpoint_ts;
-    else
-        *pinned_tsp = pinned_ts;
 }
 
 /*

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -304,11 +304,11 @@ __wti_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force)
     __wti_txn_get_pinned_timestamp(
       session, &pinned_timestamp, WT_TXN_TS_ALREADY_LOCKED | WT_TXN_TS_INCLUDE_OLDEST);
 
-    if (pinned_timestamp != WT_TS_NONE &&
+    if (pinned_timestamp != 0 &&
       (!txn_global->has_pinned_timestamp || force ||
         txn_global->pinned_timestamp < pinned_timestamp)) {
-        WT_RELEASE_WRITE_WITH_BARRIER(txn_global->pinned_timestamp, pinned_timestamp);
-        WT_RELEASE_WRITE_WITH_BARRIER(txn_global->has_pinned_timestamp, true);
+        txn_global->pinned_timestamp = pinned_timestamp;
+        txn_global->has_pinned_timestamp = true;
         txn_global->oldest_is_pinned = txn_global->pinned_timestamp == txn_global->oldest_timestamp;
         txn_global->stable_is_pinned = txn_global->pinned_timestamp == txn_global->stable_timestamp;
         __wt_verbose_timestamp(session, pinned_timestamp, "Updated pinned timestamp");


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#11300

@ajmorton I used the deprecated macro in the pr. Will revert and change that.