### PR TITLE
WT-11946 Bug Fix for the WT command line tool JSON dump option

### DIFF
--- a/src/support/json.c
+++ b/src/support/json.c
@@ -170,8 +170,12 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bu
                 }
                 s += n;
             }
-        if (bufsz > 0)
+        if (bufsz > 0) {
+            /* Expect just enough remaining buffer for closing quotes and terminator*/
+            WT_ASSERT(session, bufsz == 2);
             *buf++ = '"';
+            *buf++ = '\0';
+        }
         *retsizep += s;
         return (0);
     case 'U':
@@ -193,8 +197,11 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bu
             }
             s += n;
         }
-        if (bufsz > 0)
+        if (bufsz > 0) {
+            WT_ASSERT(session, bufsz == 2);
             *buf++ = '"';
+            *buf++ = '\0';
+        }
         *retsizep += s;
         return (0);
     case 'b':

--- a/src/support/json.c
+++ b/src/support/json.c
@@ -172,7 +172,7 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bu
                 s += n;
             }
         if (bufsz > 0) {
-            /* Expect just enough remaining buffer for closing quotes and terminator*/
+            /* Expect just enough remaining buffer for closing quotes and terminator. */
             WT_ASSERT(session, bufsz == 2);
             *buf++ = '"';
             *buf++ = '\0';

--- a/src/support/json.c
+++ b/src/support/json.c
@@ -172,7 +172,7 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bu
                 s += n;
             }
         if (bufsz > 0) {
-            /* 
+            /*
              * bufsz is calculated in advance, and decremented when each character is added to the
              * buffer, therefore we should only expect the remaining buffer to have closing quotes
              * and a NULL terminator.

--- a/src/support/json.c
+++ b/src/support/json.c
@@ -60,8 +60,8 @@ static int __json_pack_size(
 
 /*
  * __json_unpack_char --
- *     Unpack a single character into JSON escaped format. Can be called with NULL buf for sizing,
- *     and won't overwrite the buffer end in any case.
+ *     Unpack a single character into JSON escaped format. This can be called with NULL buf for
+ *     sizing, and won't overwrite the buffer end in any case.
  */
 static size_t
 __json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
@@ -116,8 +116,8 @@ __json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
 
 /*
  * __json_unpack_put --
- *     Unpack a packed byte string as formatted for JSON into a string buffer. Can be called with
- *     NULL buf to calculate the required size of the buffer.
+ *     Unpack a packed byte string as formatted for JSON into a string buffer. This can be called
+ *     with NULL buf to calculate the required size of the buffer.
  */
 static int
 __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bufsz,
@@ -172,7 +172,11 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bu
                 s += n;
             }
         if (bufsz > 0) {
-            /* Expect just enough remaining buffer for closing quotes and terminator. */
+            /* 
+             * bufsz is calculated in advance, and decremented when each character is added to the
+             * buffer, therefore we should only expect the remaining buffer to have closing quotes
+             * and a NULL terminator.
+             */
             WT_ASSERT(session, bufsz == 2);
             *buf++ = '"';
             *buf++ = '\0';
@@ -370,8 +374,8 @@ __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
 
 /*
  * __wt_json_unpack_str --
- *     Unpack a string into JSON escaped format. Can be called with NULL buf for sizing and won't
- *     overwrite the buffer end in any case.
+ *     Unpack a string into JSON escaped format. This can be called with NULL buf for sizing and
+ *     won't overwrite the buffer end in any case.
  */
 size_t
 __wt_json_unpack_str(u_char *dest, size_t dest_len, const u_char *src, size_t src_len)

--- a/src/support/json.c
+++ b/src/support/json.c
@@ -116,7 +116,8 @@ __json_unpack_char(u_char ch, u_char *buf, size_t bufsz, bool force_unicode)
 
 /*
  * __json_unpack_put --
- *     Calculate the size of a packed byte string as formatted for JSON.
+ *     Unpack a packed byte string as formatted for JSON into a string buffer. Can be called with
+ *     NULL buf to calculate the required size of the buffer.
  */
 static int
 __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bufsz,

--- a/test/suite/test_dump05.py
+++ b/test/suite/test_dump05.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from suite_subprocess import suite_subprocess
+
+# test_dump05.py
+# test dump utility with -j option, validate JSON format
+class test_dump05(wttest.WiredTigerTestCase, suite_subprocess):
+    output = "dump.out"
+
+    # Check that the dumped records are in valid JSON format
+    def validate_json_dump(self, create_params):
+        uri = 'table:test_dump'
+        self.session.create(uri, create_params)
+
+        keyA = "keyA"
+        keyB = "keyB"
+        value = 'value'
+        n = 10
+
+        # Generate records with varying key/value lengths
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, n, 2):
+            suffix = i * str(i)
+            cursor[keyA+suffix] = value + suffix
+        for i in range(1, n, 2):
+            suffix = i * str(n-i)
+            cursor[keyB+suffix] = value + suffix
+        cursor.close()
+
+        # Perform checkpoint, to clean the dirty pages and place values on disk.
+        self.session.checkpoint()
+
+        # Call dump with -j option
+        self.runWt(['dump', '-j', uri], outfilename=self.output)
+
+        # Ensure correct number of quotes and no junk after final quotes
+        self.check_file_not_contains(self.output, "/\"key0\" : \"(\")+\",\n/")
+        self.check_file_not_contains(self.output, "/\"value0\" : \"(\")+\"\n/")
+
+        # Ensure valid records exist
+        self.check_file_contains(self.output, "/\"key0\" : \"[^\"]+\",\n/")
+        self.check_file_contains(self.output, "/\"value0\" : \"[^\"]+\"\n/")
+
+    # Test with strings
+    def test_dump_string(self):
+        self.validate_json_dump(create_params='key_format=S,value_format=S')
+
+    # Test with bytes
+    def test_dump_bytes(self):
+        self.validate_json_dump(create_params='key_format=u,value_format=u')

--- a/test/suite/test_dump05.py
+++ b/test/suite/test_dump05.py
@@ -30,17 +30,17 @@ import wttest
 from suite_subprocess import suite_subprocess
 
 # test_dump05.py
-# test dump utility with -j option, validate JSON format
+# Test dump utility with -j option, validate JSON format.
 class test_dump05(wttest.WiredTigerTestCase, suite_subprocess):
-    output = "dump.out"
+    output = 'dump.out'
 
     # Check that the dumped records are in valid JSON format
     def validate_json_dump(self, create_params):
         uri = 'table:test_dump'
         self.session.create(uri, create_params)
 
-        keyA = "keyA"
-        keyB = "keyB"
+        keyA = 'keyA'
+        keyB = 'keyB'
         value = 'value'
         n = 10
 
@@ -48,25 +48,22 @@ class test_dump05(wttest.WiredTigerTestCase, suite_subprocess):
         cursor = self.session.open_cursor(uri)
         for i in range(1, n, 2):
             suffix = i * str(i)
-            cursor[keyA+suffix] = value + suffix
+            cursor[keyA + suffix] = value + suffix
         for i in range(1, n, 2):
-            suffix = i * str(n-i)
-            cursor[keyB+suffix] = value + suffix
+            suffix = i * str(n - i)
+            cursor[keyB + suffix] = value + suffix
         cursor.close()
-
-        # Perform checkpoint, to clean the dirty pages and place values on disk.
-        self.session.checkpoint()
 
         # Call dump with -j option
         self.runWt(['dump', '-j', uri], outfilename=self.output)
 
         # Ensure correct number of quotes and no junk after final quotes
-        self.check_file_not_contains(self.output, "/\"key0\" : \"(\")+\",\n/")
-        self.check_file_not_contains(self.output, "/\"value0\" : \"(\")+\"\n/")
+        self.check_file_not_contains(self.output, '/\"key0\" : \"(\")+\",\n/')
+        self.check_file_not_contains(self.output, '/\"value0\" : \"(\")+\"\n/')
 
         # Ensure valid records exist
-        self.check_file_contains(self.output, "/\"key0\" : \"[^\"]+\",\n/")
-        self.check_file_contains(self.output, "/\"value0\" : \"[^\"]+\"\n/")
+        self.check_file_contains(self.output, '/\"key0\" : \"[^\"]+\",\n/')
+        self.check_file_contains(self.output, '/\"value0\" : \"[^\"]+\"\n/')
 
     # Test with strings
     def test_dump_string(self):


### PR DESCRIPTION
This error occurs when the WT command line tool is used to dump a table in json format (with the `-j` param).

There is a buffer (`buf`) in `json.c` being reused for loading lines of text to be dumped, and in some cases (particularly if subsequent lines are shorter than previous ones) the buffer is underfilled without adding a corresponding null terminator.
This leads to junk values being included at the end of each line in the dump output.

I've added in that null terminator where it's needed, as well as a check that the `bufsz` counter was calculated correctly, such that when it's time to add the closing quotes and null terminator, `bufsz = 2`.

I've also written a test case that creates a table with key/value pairs of varying lengths (this would guarantee the inclusion of junk values in the dump, pre-bugfix) and validates the dump output.
