### PR TITLE
WT-13806 Fixed incorrect calculation for number of reserved session slots

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -642,7 +642,7 @@ connection_runtime_config = [
                 maximum number of threads WiredTiger will start to help evict pages from cache. The
                 number of threads started will vary depending on the current eviction load. Each
                 eviction worker thread uses a session from the configured session_max''',
-                min=1, max=20),
+                min=1, max=20), # !!! Must match WT_EVICT_MAX_WORKERS
             Config('threads_min', '1', r'''
                 minimum number of threads WiredTiger will start to help evict pages from
                 cache. The number of threads currently running will vary depending on the

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2567,11 +2567,9 @@ __conn_session_size(WT_SESSION_IMPL *session, const char *cfg[], uint32_t *vp)
     v = WT_EXTRA_INTERNAL_SESSIONS;
 
     /* Then, add in the thread counts applications can configure. */
-    WT_RET(__wt_config_gets(session, cfg, "eviction.threads_max", &cval));
-    v += cval.val;
+    v += WT_EVICT_MAX_WORKERS;
 
-    WT_RET(__wt_config_gets(session, cfg, "lsm_manager.worker_thread_max", &cval));
-    v += cval.val;
+    v += WT_LSM_MAX_WORKERS;
 
     /* If live restore is enabled add its thread count. */
     if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE)) {

--- a/src/evict/evict.h
+++ b/src/evict/evict.h
@@ -137,6 +137,8 @@ struct __wt_evict {
 #define WT_EVICT_CALL_URGENT 0x4u   /* Urgent eviction */
 /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
 
+#define WT_EVICT_MAX_WORKERS 20
+
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
 extern bool __wt_evict_page_urgent(WT_SESSION_IMPL *session, WT_REF *ref)


### PR DESCRIPTION
Wiredtiger calls `__conn_session_size` during `wiredtiger_open` to reserve the session slots that threads can use. Currently for eviction workers and lsm_manager workers, we use the configured max threads value.

Both eviction max worker and lsm_manager max worker can be changed by the **WT_CONNECTION::reconfigure** API, and during the reconfiguration we don't recalculate the number of reserved session slots, causing potential running out of available session slots problem.

For lsm_manager workers I changed the code to use the macro `WT_LSM_MAX_WORKERS` (The max value we can configure for `lsm_manager.worker_thread_max`) to calculate the session slots. I have done the same for eviction, added a `WT_EVICT_MAX_WORKERS` in `evict.h` and used the value to calculate the session slots as well.