### PR TITLE
WT-13874 Fix a typo in live restore FS comment

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1001,9 +1001,9 @@ __live_restore_fs_remove(
     }
 
     /*
-     * The tombstone here is useful as it tells us that we will never need to look in the
-     * source for this file in the future. One such case is when a file is created, removed and
-     * then created again with the same name.
+     * The tombstone here is useful as it tells us that we will never need to look in the source for
+     * this file in the future. One such case is when a file is created, removed and then created
+     * again with the same name.
      */
     __live_restore_fs_create_tombstone(fs, session, name, flags);
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1002,7 +1002,7 @@ __live_restore_fs_remove(
 
     /*
      * The tombstone here is useful as it tells us that we will never need to look in the
-     * destination for this file in the future. One such case is when a file is created, removed and
+     * source for this file in the future. One such case is when a file is created, removed and
      * then created again with the same name.
      */
     __live_restore_fs_create_tombstone(fs, session, name, flags);


### PR DESCRIPTION
Fix a typo where the tombstone in live restore file system is used to tell us that we will never need to look in the source for this file in the future.