### PR TITLE
SLS-745 Allow calling __wt_block_disagg_write_internal without the page log

### DIFF
--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -118,7 +118,8 @@ __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *bloc
     WT_ASSERT_ALWAYS(
       session, conn->layered_table_manager.leader, "Trying to write the page from a follower");
     /* Check that the checkpoint ID matches the current checkpoint in the page log. */
-    if (block_disagg->plhandle->page_log->pl_get_open_checkpoint != NULL) {
+    if (block_disagg->plhandle->page_log != NULL &&
+      block_disagg->plhandle->page_log->pl_get_open_checkpoint != NULL) {
         WT_RET(block_disagg->plhandle->page_log->pl_get_open_checkpoint(
           block_disagg->plhandle->page_log, &session->iface, &page_log_checkpoint_id));
         WT_ASSERT_ALWAYS(session, checkpoint_id == page_log_checkpoint_id,


### PR DESCRIPTION
Check that the page_log is not NULL before checking its contents, so that we can call __wt_block_disagg_write_internal without the page log being set up.