### PR TITLE
WT-13876 Require read/writes in live restore are a multiple of the backing file system's block size

### DIFF
--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -74,6 +74,7 @@ typedef enum {
 struct __wt_live_restore_fs_layer {
     const char *home;
     WT_LIVE_RESTORE_FS_LAYER_TYPE which;
+    size_t fs_block_size;
 };
 
 /*


### PR DESCRIPTION
Per the description in `__live_restore_validate_size` if we read/write to a file at a size other than the filesystem's block size our hole tracking metadata will be incorrect after a file reopen. To resolve this require all read/writes are a multiple of the block size, excluding when we touch the entire file.