### PR TITLE
WT-13880 Fix truncate calls in test_live_restore.cpp

### DIFF
--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -68,7 +68,8 @@ public:
         _collections.emplace_back(uri);
         // TODO: Is it possible to validate that the data we get from a collection is the same as
         // the data we saved to it? To check for bugs in filename logic in the file system?
-        session->create(session.get(), uri.c_str(), DEFAULT_FRAMEWORK_SCHEMA.c_str());
+        testutil_check(
+          session->create(session.get(), uri.c_str(), DEFAULT_FRAMEWORK_SCHEMA.c_str()));
         scoped_cursor cursor = session.open_scoped_cursor(uri.c_str());
         WT_IGNORE_RET(cursor->next(cursor.get()));
     }
@@ -143,8 +144,9 @@ trigger_fs_truncate(scoped_session &session)
     // Truncate from a random key all the way to the end of the collection and then call compact
     const std::string coll_name = db.get_random_collection();
     scoped_cursor rnd_cursor = session.open_scoped_cursor(coll_name, "next_random=true");
-    session->truncate(session.get(), coll_name.c_str(), rnd_cursor.get(), nullptr, nullptr);
-    session->compact(session.get(), coll_name.c_str(), nullptr);
+    testutil_check(rnd_cursor->next(rnd_cursor.get()));
+    testutil_check(session->truncate(session.get(), NULL, rnd_cursor.get(), nullptr, nullptr));
+    testutil_check(session->compact(session.get(), coll_name.c_str(), nullptr));
 }
 
 std::string
@@ -191,7 +193,7 @@ remove(scoped_session &session, scoped_cursor &cursor, std::string &coll)
     }
     testutil_assert(ret == 0);
     const char *tmp_key;
-    ran_cursor->get_key(ran_cursor.get(), &tmp_key);
+    testutil_check(ran_cursor->get_key(ran_cursor.get(), &tmp_key));
     cursor->set_key(cursor.get(), tmp_key);
     testutil_check(cursor->remove(cursor.get()));
 }


### PR DESCRIPTION
The `truncate` calls in `test_live_restore.cpp` were broken for multiple reasons. Firstly we were passing both the table URI and a start cursor which is disallowed. Secondly the start cursor wasn't being positioned on the table.
This PR fixes both issues and adds `testutil_check` calls to all WT API calls that were missing them.