### PR TITLE
WT-13862 Update to api_err.py to include generation of sub-level error codes

### DIFF
--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -88,7 +88,7 @@ sub_errors = [
     'last API call was successful', '''
     This is some placeholder code that is used to check if multiple errors work.
     It should be changed later.'''),
-    Error('CWT_COMPACTION_ALREADY_RUNNING', -32001,
+    Error('WT_COMPACTION_ALREADY_RUNNING', -32001,
     "Cannot reconfigure background compaction while it's already running", '''
     This is some placeholder code that is used to check if multiple errors work.
     It should be changed later.'''),
@@ -206,7 +206,8 @@ tfile.close()
 format_srcfile(tmp_file)
 compare_srcfile(tmp_file, '../src/conn/api_strerror.c')
 
-def check_document_errors(tfile, skip, err_type, errors):
+# Checks if lines should be skipped and updates documentation block
+def check_write_document_errors(tfile, skip, err_type, errors):
     if line.count(f'IGNORE_BUILT_BY_API_{err_type}_END'):
         tfile.write(line)
         skip = 0
@@ -229,8 +230,8 @@ skip = 0
 for line in open(doc, 'r'):
     if not skip:
         tfile.write(line)
-    skip = check_document_errors(tfile, skip, 'ERR', errors)
-    skip = check_document_errors(tfile, skip, 'SUB_ERR', sub_errors)
+    skip = check_write_document_errors(tfile, skip, 'ERR', errors)
+    skip = check_write_document_errors(tfile, skip, 'SUB_ERR', sub_errors)
     
 tfile.close()
 format_srcfile(tmp_file)

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -81,6 +81,10 @@ errors = [
         result of a system crash. The application may choose to salvage the
         file or retry wiredtiger_open with the 'salvage=true' configuration
         setting.'''),
+    Error('WT_NONE', -32000,
+        'last API call was successful', '''
+        This sub-level error is generated when the API call succeeds. This should be the
+        sub-level error code generated if nothing wrong occurs.'''),
 ]
 
 # Update the #defines in the wiredtiger.in file.

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -134,18 +134,18 @@ errors = [
 
 sub_errors = [
     Error('WT_NONE', -32000,
-    'last API call was successful', '''
-    This is the default sub-level error code that should be used when there is no
-    sub-level error to pair with an error. It indicates that no further context
-    exists or is necessary.'''),
+        'last API call was successful', '''
+        This is the default sub-level error code that should be used when there is no
+        sub-level error to pair with an error. It indicates that no further context
+        exists or is necessary.'''),
     Error('WT_COMPACTION_ALREADY_RUNNING', -32001,
-    "Cannot reconfigure background compaction while it's already running", '''
-    This error is generated when the user tries to reconfigure the background
-    compaction while it is already running.'''),
+        "Cannot reconfigure background compaction while it's already running", '''
+        This error is generated when the user tries to reconfigure the background
+        compaction while it is already running.'''),
     Error('WT_SESSION_MAX', -32002,
-    "out of sessions, configured for XXX (including internal sessions)", '''
-    This sub-level error is generated when the user has created the max amount of
-    sessions configured.'''),
+        "out of sessions, configured for XXX (including internal sessions)", '''
+        This sub-level error is generated when the user has created the max amount of
+        sessions configured.'''),
 ]
 
 # Update the #defines in the wiredtiger.in file.

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -143,7 +143,7 @@ sub_errors = [
         This error is generated when the user tries to reconfigure the background
         compaction while it is already running.'''),
     Error('WT_SESSION_MAX', -32002,
-        "out of sessions, configured for XXX (including internal sessions)", '''
+        "out of sessions (including internal sessions)", '''
         This sub-level error is generated when the user has created the max amount of
         sessions configured.'''),
 ]

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -138,14 +138,6 @@ sub_errors = [
         This is the default sub-level error code that should be used when there is no
         sub-level error to pair with an error. It indicates that no further context
         exists or is necessary.'''),
-    Error('WT_COMPACTION_ALREADY_RUNNING', -32001,
-        "Cannot reconfigure background compaction while it's already running", '''
-        This error is generated when the user tries to reconfigure the background
-        compaction while it is already running.'''),
-    Error('WT_SESSION_MAX', -32002,
-        "out of sessions (including internal sessions)", '''
-        This sub-level error is generated when the user has created the max amount of
-        sessions configured.'''),
 ]
 
 # Update the #defines in the wiredtiger.in file.

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -86,20 +86,21 @@ errors = [
 sub_errors = [
     Error('WT_NONE', -32000,
     'last API call was successful', '''
-    This is some placeholder code that is used to check if multiple errors work.
-    It should be changed later.'''),
+    This is the default sub-level error code that should be used when there is no
+    sub-level error to pair with an error. It indicates that no further context
+    exists or is necessary.'''),
     Error('WT_COMPACTION_ALREADY_RUNNING', -32001,
     "Cannot reconfigure background compaction while it's already running", '''
-    This is some placeholder code that is used to check if multiple errors work.
-    It should be changed later.'''),
+    This error is generated when the user tries to reconfigure the background
+    compaction while it is already running.'''),
     Error('WT_SESSION_MAX', -32002,
     "out of sessions, configured for XXX (including internal sessions)", '''
-    This is some placeholder code that is used to check if multiple errors work.
-    It should be changed later.'''),
+    This sub-level error is generated when the user has created the max amount of
+    sessions configured.'''),
 ]
 
 # Checks if return section begins and updates error defines
-def check_write_errors(skip, tfile, err_type, errors):
+def check_write_errors(tfile, skip, err_type, errors):
     if line.count(err_type + ' return section: END'):
         tfile.write(line)
         skip = 0
@@ -128,16 +129,14 @@ skip = 0
 for line in open('../src/include/wiredtiger.in', 'r'):
     if not skip:
         tfile.write(line)
-    skip = check_write_errors(skip, tfile, 'Error', errors)
-    skip = check_write_errors(skip, tfile, 'Sub-level error', sub_errors)
+    skip = check_write_errors(tfile, skip, 'Error', errors)
+    skip = check_write_errors(tfile, skip, 'Sub-level error', sub_errors)
 tfile.close()
 compare_srcfile(tmp_file, '../src/include/wiredtiger.in')
 
 def write_err_cases(tfile, err_type, errors):
     tfile.write('''
-    \t/*
-    \t * Check for WiredTiger specific %s.
-    \t */
+    \t/* Check for WiredTiger specific %s. */
     \tswitch (error) {
     ''' % err_type)
     for err in errors:

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -45,12 +45,6 @@ __wt_wiredtiger_error(int error)
     switch (error) {
     case WT_NONE:
         return ("WT_NONE: last API call was successful");
-    case WT_COMPACTION_ALREADY_RUNNING:
-        return (
-          "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
-          "already running");
-    case WT_SESSION_MAX:
-        return ("WT_SESSION_MAX: out of sessions (including internal sessions)");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -17,9 +17,7 @@
 const char *
 __wt_wiredtiger_error(int error)
 {
-    /*
-     * Check for WiredTiger specific errors.
-     */
+    /* Check for WiredTiger specific errors. */
     switch (error) {
     case WT_ROLLBACK:
         return ("WT_ROLLBACK: conflict between concurrent operations");
@@ -43,9 +41,7 @@ __wt_wiredtiger_error(int error)
         return ("WT_TRY_SALVAGE: database corruption detected");
     }
 
-    /*
-     * Check for WiredTiger specific sub-level errors.
-     */
+    /* Check for WiredTiger specific sub-level errors. */
     switch (error) {
     case WT_NONE:
         return ("WT_NONE: last API call was successful");

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -49,9 +49,9 @@ __wt_wiredtiger_error(int error)
     switch (error) {
     case WT_NONE:
         return ("WT_NONE: last API call was successful");
-    case CWT_COMPACTION_ALREADY_RUNNING:
+    case WT_COMPACTION_ALREADY_RUNNING:
         return (
-          "CWT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
+          "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
           "already running");
     case WT_SESSION_MAX:
         return (

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -41,8 +41,21 @@ __wt_wiredtiger_error(int error)
         return ("WT_PREPARE_CONFLICT: conflict with a prepared update");
     case WT_TRY_SALVAGE:
         return ("WT_TRY_SALVAGE: database corruption detected");
+    }
+
+    /*
+     * Check for WiredTiger specific sub-level errors.
+     */
+    switch (error) {
     case WT_NONE:
         return ("WT_NONE: last API call was successful");
+    case CWT_COMPACTION_ALREADY_RUNNING:
+        return (
+          "CWT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
+          "already running");
+    case WT_SESSION_MAX:
+        return (
+          "WT_SESSION_MAX: out of sessions, configured for XXX (including internal sessions)");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -41,6 +41,8 @@ __wt_wiredtiger_error(int error)
         return ("WT_PREPARE_CONFLICT: conflict with a prepared update");
     case WT_TRY_SALVAGE:
         return ("WT_TRY_SALVAGE: database corruption detected");
+    case WT_NONE:
+        return ("WT_NONE: last API call was successful");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -50,8 +50,7 @@ __wt_wiredtiger_error(int error)
           "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
           "already running");
     case WT_SESSION_MAX:
-        return (
-          "WT_SESSION_MAX: out of sessions, configured for XXX (including internal sessions)");
+        return ("WT_SESSION_MAX: out of sessions (including internal sessions)");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -95,7 +95,7 @@ inclusive. The following is a list of the WiredTiger-specific return values:
 This is some placeholder code that is used to check if multiple errors work. It should be changed
 later.
 
-@par \c CWT_COMPACTION_ALREADY_RUNNING
+@par \c WT_COMPACTION_ALREADY_RUNNING
 This is some placeholder code that is used to check if multiple errors work. It should be changed
 later.
 

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -80,9 +80,28 @@ This error is generated when corruption is detected in an on-disk file. During n
 this may occur in rare circumstances as a result of a system crash. The application may choose to
 salvage the file or retry wiredtiger_open with the 'salvage=true' configuration setting.
 
+@if IGNORE_BUILT_BY_API_SUB_ERR_END
+@endif
+
+@section sub_error_list WiredTiger-specific sub-level errors
+
+WiredTiger-specific error codes are allocated from -32,000 to -32,199,
+inclusive. The following is a list of the WiredTiger-specific return values:
+
+@if IGNORE_BUILT_BY_API_SUB_ERR_BEGIN
+@endif
+
 @par \c WT_NONE
-This sub-level error is generated when the API call succeeds. This should be the sub-level error
-code generated if nothing wrong occurs.
+This is some placeholder code that is used to check if multiple errors work. It should be changed
+later.
+
+@par \c CWT_COMPACTION_ALREADY_RUNNING
+This is some placeholder code that is used to check if multiple errors work. It should be changed
+later.
+
+@par \c WT_SESSION_MAX
+This is some placeholder code that is used to check if multiple errors work. It should be changed
+later.
 
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -95,13 +95,6 @@ inclusive. The following is a list of the WiredTiger-specific return values:
 This is the default sub-level error code that should be used when there is no sub-level error to
 pair with an error. It indicates that no further context exists or is necessary.
 
-@par \c WT_COMPACTION_ALREADY_RUNNING
-This error is generated when the user tries to reconfigure the background compaction while it is
-already running.
-
-@par \c WT_SESSION_MAX
-This sub-level error is generated when the user has created the max amount of sessions configured.
-
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif
 

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -80,6 +80,10 @@ This error is generated when corruption is detected in an on-disk file. During n
 this may occur in rare circumstances as a result of a system crash. The application may choose to
 salvage the file or retry wiredtiger_open with the 'salvage=true' configuration setting.
 
+@par \c WT_NONE
+This sub-level error is generated when the API call succeeds. This should be the sub-level error
+code generated if nothing wrong occurs.
+
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif
 

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -92,16 +92,15 @@ inclusive. The following is a list of the WiredTiger-specific return values:
 @endif
 
 @par \c WT_NONE
-This is some placeholder code that is used to check if multiple errors work. It should be changed
-later.
+This is the default sub-level error code that should be used when there is no sub-level error to
+pair with an error. It indicates that no further context exists or is necessary.
 
 @par \c WT_COMPACTION_ALREADY_RUNNING
-This is some placeholder code that is used to check if multiple errors work. It should be changed
-later.
+This error is generated when the user tries to reconfigure the background compaction while it is
+already running.
 
 @par \c WT_SESSION_MAX
-This is some placeholder code that is used to check if multiple errors work. It should be changed
-later.
+This sub-level error is generated when the user has created the max amount of sessions configured.
 
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4015,14 +4015,52 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * wiredtiger_open with the 'salvage=true' configuration setting.
  */
 #define	WT_TRY_SALVAGE	(-31809)
-/*!
- * Last API call was successful.
- * This sub-level error is generated when the API call succeeds. This should be
- * the sub-level error code generated if nothing wrong occurs.
- */
-#define	WT_NONE	(-32000)
 /*
  * Error return section: END
+ * DO NOT EDIT: automatically built by dist/api_err.py.
+ */
+/*! @} */
+
+/*******************************************
+ * Sub-level error returns
+ *******************************************/
+/*!
+ * @name Sub-level error returns
+ * Along with error returns, WiredTiger can return an integer code indicating
+ * a more specific error. A return of -32,000 indicates that there is no more
+ * specific error; all other return values indicate a more specific error which
+ * provides greater context into the failure.
+ *
+ * WiredTiger reserves all values from -32,000 to -31,199 as possible sub-level
+ * error return values.
+ *
+ * The following are all of the WiredTiger-specific sub-level error returns:
+ * @{
+ */
+/*
+ * DO NOT EDIT: automatically built by dist/api_err.py.
+ * Sub-level error return section: BEGIN
+ */
+/*!
+ * Last API call was successful.
+ * This is some placeholder code that is used to check if multiple errors work.
+ * It should be changed later.
+ */
+#define	WT_NONE	(-32000)
+/*!
+ * Cannot reconfigure background compaction while it's already running.
+ * This is some placeholder code that is used to check if multiple errors work.
+ * It should be changed later.
+ */
+#define	CWT_COMPACTION_ALREADY_RUNNING	(-32001)
+/*!
+ * Out of sessions, configured for XXX (including internal sessions).
+ * This is some placeholder code that is used to check if multiple errors work.
+ * It should be changed later.
+ */
+#define	WT_SESSION_MAX	(-32002)
+/*
+ * Sub-level error return section: END
  * DO NOT EDIT: automatically built by dist/api_err.py.
  */
 /*! @} */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4055,7 +4055,7 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  */
 #define	WT_COMPACTION_ALREADY_RUNNING	(-32001)
 /*!
- * Out of sessions, configured for XXX (including internal sessions).
+ * Out of sessions (including internal sessions).
  * This sub-level error is generated when the user has created the max amount of
  * sessions configured.
  */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4015,6 +4015,12 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * wiredtiger_open with the 'salvage=true' configuration setting.
  */
 #define	WT_TRY_SALVAGE	(-31809)
+/*!
+ * Last API call was successful.
+ * This sub-level error is generated when the API call succeeds. This should be
+ * the sub-level error code generated if nothing wrong occurs.
+ */
+#define	WT_NONE	(-32000)
 /*
  * Error return section: END
  * DO NOT EDIT: automatically built by dist/api_err.py.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4052,7 +4052,7 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * This is some placeholder code that is used to check if multiple errors work.
  * It should be changed later.
  */
-#define	CWT_COMPACTION_ALREADY_RUNNING	(-32001)
+#define	WT_COMPACTION_ALREADY_RUNNING	(-32001)
 /*!
  * Out of sessions, configured for XXX (including internal sessions).
  * This is some placeholder code that is used to check if multiple errors work.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4048,18 +4048,6 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * exists or is necessary.
  */
 #define	WT_NONE	(-32000)
-/*!
- * Cannot reconfigure background compaction while it's already running.
- * This error is generated when the user tries to reconfigure the background
- * compaction while it is already running.
- */
-#define	WT_COMPACTION_ALREADY_RUNNING	(-32001)
-/*!
- * Out of sessions (including internal sessions).
- * This sub-level error is generated when the user has created the max amount of
- * sessions configured.
- */
-#define	WT_SESSION_MAX	(-32002)
 /*
  * Sub-level error return section: END
  * DO NOT EDIT: automatically built by dist/api_err.py.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4031,7 +4031,7 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * specific error; all other return values indicate a more specific error which
  * provides greater context into the failure.
  *
- * WiredTiger reserves all values from -32,000 to -31,199 as possible sub-level
+ * WiredTiger reserves all values from -32,000 to -32,199 as possible sub-level
  * error return values.
  *
  * The following are all of the WiredTiger-specific sub-level error returns:

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4043,20 +4043,21 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  */
 /*!
  * Last API call was successful.
- * This is some placeholder code that is used to check if multiple errors work.
- * It should be changed later.
+ * This is the default sub-level error code that should be used when there is no
+ * sub-level error to pair with an error. It indicates that no further context
+ * exists or is necessary.
  */
 #define	WT_NONE	(-32000)
 /*!
  * Cannot reconfigure background compaction while it's already running.
- * This is some placeholder code that is used to check if multiple errors work.
- * It should be changed later.
+ * This error is generated when the user tries to reconfigure the background
+ * compaction while it is already running.
  */
 #define	WT_COMPACTION_ALREADY_RUNNING	(-32001)
 /*!
  * Out of sessions, configured for XXX (including internal sessions).
- * This is some placeholder code that is used to check if multiple errors work.
- * It should be changed later.
+ * This sub-level error is generated when the user has created the max amount of
+ * sessions configured.
  */
 #define	WT_SESSION_MAX	(-32002)
 /*

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -7,7 +7,7 @@ if(HAVE_UNITTEST_ASSERTS)
 else()
     set(unittests
         misc_tests/test_acquire_release_macros.cpp
-        misc_tests/test_strerr.cpp
+        misc_tests/test_strerror.cpp
         misc_tests/test_binary_search_string.cpp
         misc_tests/test_bitmap.cpp
         misc_tests/test_crc32.cpp

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -7,6 +7,7 @@ if(HAVE_UNITTEST_ASSERTS)
 else()
     set(unittests
         misc_tests/test_acquire_release_macros.cpp
+        misc_tests/test_strerr.cpp
         misc_tests/test_binary_search_string.cpp
         misc_tests/test_bitmap.cpp
         misc_tests/test_crc32.cpp

--- a/test/catch2/misc_tests/test_strerror.cpp
+++ b/test/catch2/misc_tests/test_strerror.cpp
@@ -28,8 +28,7 @@ TEST_CASE("Test generation of sub-level error codes when strerror is called")
           {-32001,
             "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
             "already running"},
-          {-32002,
-            "WT_SESSION_MAX: out of sessions, configured for XXX (including internal sessions)"},
+          {-32002, "WT_SESSION_MAX: out of sessions (including internal sessions)"},
         };
 
         for (auto const [code, expected] : errors)

--- a/test/catch2/misc_tests/test_strerror.cpp
+++ b/test/catch2/misc_tests/test_strerror.cpp
@@ -1,0 +1,37 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+#include "wt_internal.h"
+#include <string>
+
+TEST_CASE("Test generation of sub-level error codes when strerror is called")
+{
+    /* Basic default sub-level error code */
+    std::string result = wiredtiger_strerror(-32000);
+    std::string expected("WT_NONE: last API call was successful");
+    CHECK(result == expected);
+
+    SECTION("Unique sub-level error codes")
+    {
+        CHECK(true);
+        /*
+        WT_COMPACTION_ALREADY_RUNNING
+        WT_SESSION_MAX
+        WT_CACHE_OVERFLOW
+        WT_WRITE_CONFLICT
+        WT_OLDEST_FOR_EVICTION
+        WT_CONFLICT_BACKUP
+        WT_CONFLICT_DHANDLE
+        WT_CONFLICT_SCHEMA_LOCK
+        WT_UNCOMMITTED_DATA
+        WT_DIRTY_DATA
+        WT_CONFLICT_TABLE_LOCK
+        */
+    }
+}

--- a/test/catch2/misc_tests/test_strerror.cpp
+++ b/test/catch2/misc_tests/test_strerror.cpp
@@ -10,28 +10,29 @@
 #include "wt_internal.h"
 #include <string>
 
+static void
+check_error_code(int error, std::string expected)
+{
+    std::string result = wiredtiger_strerror(error);
+    CHECK(result == expected);
+}
+
 TEST_CASE("Test generation of sub-level error codes when strerror is called")
 {
     /* Basic default sub-level error code */
-    std::string result = wiredtiger_strerror(-32000);
-    std::string expected("WT_NONE: last API call was successful");
-    CHECK(result == expected);
+    check_error_code(-32000, "WT_NONE: last API call was successful");
 
     SECTION("Unique sub-level error codes")
     {
-        CHECK(true);
-        /*
-        WT_COMPACTION_ALREADY_RUNNING
-        WT_SESSION_MAX
-        WT_CACHE_OVERFLOW
-        WT_WRITE_CONFLICT
-        WT_OLDEST_FOR_EVICTION
-        WT_CONFLICT_BACKUP
-        WT_CONFLICT_DHANDLE
-        WT_CONFLICT_SCHEMA_LOCK
-        WT_UNCOMMITTED_DATA
-        WT_DIRTY_DATA
-        WT_CONFLICT_TABLE_LOCK
-        */
+        std::vector<std::pair<int, std::string>> errors = {
+          {-32001,
+            "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
+            "already running"},
+          {-32002,
+            "WT_SESSION_MAX: out of sessions, configured for XXX (including internal sessions)"},
+        };
+
+        for (auto const [code, expected] : errors)
+            check_error_code(code, expected);
     }
 }

--- a/test/catch2/misc_tests/test_strerror.cpp
+++ b/test/catch2/misc_tests/test_strerror.cpp
@@ -21,17 +21,4 @@ TEST_CASE("Test generation of sub-level error codes when strerror is called")
 {
     /* Basic default sub-level error code */
     check_error_code(-32000, "WT_NONE: last API call was successful");
-
-    SECTION("Unique sub-level error codes")
-    {
-        std::vector<std::pair<int, std::string>> errors = {
-          {-32001,
-            "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's "
-            "already running"},
-          {-32002, "WT_SESSION_MAX: out of sessions (including internal sessions)"},
-        };
-
-        for (auto const [code, expected] : errors)
-            check_error_code(code, expected);
-    }
 }

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -40,4 +40,4 @@ class test_strerror(wttest.WiredTigerTestCase, suite_subprocess):
     def test_strerror(self):
         assert self.session.strerror(-32000) == "WT_NONE: last API call was successful"
         assert self.session.strerror(-32001) == "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's already running"
-        assert self.session.strerror(-32002) == "WT_SESSION_MAX: out of sessions, configured for XXX (including internal sessions)"
+        assert self.session.strerror(-32002) == "WT_SESSION_MAX: out of sessions (including internal sessions)"

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -39,5 +39,3 @@ class test_strerror(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_strerror(self):
         assert self.session.strerror(-32000) == "WT_NONE: last API call was successful"
-        assert self.session.strerror(-32001) == "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's already running"
-        assert self.session.strerror(-32002) == "WT_SESSION_MAX: out of sessions (including internal sessions)"

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -35,7 +35,7 @@ from suite_subprocess import suite_subprocess
 
 # test_strerror01.py
 #     Test generation of sub-level error codes when using calling strerror
-class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
+class test_strerror(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_strerror(self):
         assert self.session.strerror(-32000) == "WT_NONE: last API call was successful"

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# wt_util
+# [END_TAGS]
+
+import wttest
+from suite_subprocess import suite_subprocess
+
+# test_strerror01.py
+#     Test generation of sub-level error codes when using calling strerror
+class test_dump(wttest.WiredTigerTestCase, suite_subprocess):
+
+    def test_strerror(self):
+        assert self.session.strerror(-32000) == "WT_NONE: last API call was successful"

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -27,14 +27,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # [TEST_TAGS]
-# wt_util
+# session_api
 # [END_TAGS]
 
 import wttest
 from suite_subprocess import suite_subprocess
 
 # test_strerror01.py
-#     Test generation of sub-level error codes when using calling strerror
+#     Test generation of sub-level error codes when using calling strerror.
 class test_strerror(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_strerror(self):

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -39,3 +39,5 @@ class test_strerror(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_strerror(self):
         assert self.session.strerror(-32000) == "WT_NONE: last API call was successful"
+        assert self.session.strerror(-32001) == "WT_COMPACTION_ALREADY_RUNNING: Cannot reconfigure background compaction while it's already running"
+        assert self.session.strerror(-32002) == "WT_SESSION_MAX: out of sessions, configured for XXX (including internal sessions)"

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -40,6 +40,7 @@
 |Rollback To Stable||[test_checkpoint_snapshot03.py](../test/suite/test_checkpoint_snapshot03.py), [test_rollback_to_stable16.py](../test/suite/test_rollback_to_stable16.py), [test_rollback_to_stable18.py](../test/suite/test_rollback_to_stable18.py)
 |Salvage|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py)
 |Schema Api||[test_schema03.py](../test/suite/test_schema03.py)
+|Session Api||[test_strerror01.py](../test/suite/test_strerror01.py)
 |Session Api|Reconfigure|[test_reconfig04.py](../test/suite/test_reconfig04.py), [test_reconfig05.py](../test/suite/test_reconfig05.py)
 |Session Api|Verify|[test_bug005.py](../test/suite/test_bug005.py)
 |Statistics||[test_stat_log02.py](../test/suite/test_stat_log02.py)
@@ -49,4 +50,4 @@
 |Truncate||[test_truncate01.py](../test/suite/test_truncate01.py)
 |Truncate|Prepare|[test_prepare13.py](../test/suite/test_prepare13.py)
 |Verify|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py), [test_timestamp18.py](../test/suite/test_timestamp18.py)
-|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_dump02.py](../test/suite/test_dump02.py), [test_dump03.py](../test/suite/test_dump03.py), [test_strerror01.py](../test/suite/test_strerror01.py), [test_util11.py](../test/suite/test_util11.py)
+|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_dump02.py](../test/suite/test_dump02.py), [test_dump03.py](../test/suite/test_dump03.py), [test_util11.py](../test/suite/test_util11.py)

--- a/test/test_coverage.md
+++ b/test/test_coverage.md
@@ -49,4 +49,4 @@
 |Truncate||[test_truncate01.py](../test/suite/test_truncate01.py)
 |Truncate|Prepare|[test_prepare13.py](../test/suite/test_prepare13.py)
 |Verify|Prepare|[test_prepare_hs03.py](../test/suite/test_prepare_hs03.py), [test_timestamp18.py](../test/suite/test_timestamp18.py)
-|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_dump02.py](../test/suite/test_dump02.py), [test_dump03.py](../test/suite/test_dump03.py), [test_util11.py](../test/suite/test_util11.py)
+|Wt Util||[test_backup01.py](../test/suite/test_backup01.py), [test_dump.py](../test/suite/test_dump.py), [test_dump01.py](../test/suite/test_dump01.py), [test_dump02.py](../test/suite/test_dump02.py), [test_dump03.py](../test/suite/test_dump03.py), [test_strerror01.py](../test/suite/test_strerror01.py), [test_util11.py](../test/suite/test_util11.py)


### PR DESCRIPTION
Updated api_err.py to include functionality to generate sub-level error codes. The design is the same as the current error codes, and the subset of integer codes for the sub-level errors start from -32000
