### PR TITLE
WT-12411 Upgrade SWIG to a version that does not use package "imp" (#11302) [test only, not for merge!]

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -281,6 +281,7 @@ functions:
           source venv/bin/activate
           pip3 install find_libpython
           pip3 install swig==4.2.1
+          pip3 install find_libpython==0.4.0
           SYSPYLIB=`find_libpython`
           SYSPYINCDEF=
 
@@ -366,6 +367,23 @@ functions:
         set -o verbose
         echo "Starting 'make wiredtiger' step"
         ${PREPARE_PATH}
+
+        if ! command -v swig >/dev/null 2>&1; then
+            echo "SWIG is not installed. Skipping check ..."
+        else
+            SWIG_VERSION=$(swig -version | awk '/SWIG Version/ {print $3}')
+
+            if [[ "$(printf '%s\n' "4.0.0" "$SWIG_VERSION" | sort -V | head -n1)" == "4.0.0" ]]; then
+                echo "SWIG version $SWIG_VERSION is 4.0 or later."
+            else
+                echo "SWIG version $SWIG_VERSION is earlier than 4.0. Installing a newer version ..."
+                python3 -mvenv venv
+                source venv/bin/activate
+                pip3 install swig==4.2.1
+                swig -version
+            fi
+        fi
+
         if [ "$OS" = "Windows_NT" ]; then
           # Use the Windows powershell script to execute Ninja build (can't execute directly in a cygwin environment).
           powershell.exe '.\test\evergreen\build_windows.ps1 -build 1'


### PR DESCRIPTION
Upgrading to SWIG version 4.0 as the package "imp" is getting deprecated and version 4.0 and later removes the use of "imp"

(cherry picked from commit ab3450f66d723397e79964b20438fbbb8a2a6c17)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
