### PR TITLE
WT-13837 Set up code owners to guard backport PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# All backports must be approved by the backport-approvers Github team.
+* @wiredtiger/backport-approvers
+
+# Exclude some test and non-functional folders from the backport approvals.
+bench/
+dist/
+test/
+tools/


### PR DESCRIPTION
The `.github/CODEOWNERS` file introduced in this PR coupled with a newly created [backport-approvers](https://github.com/orgs/wiredtiger/teams/backport-approvers/members) Github team will enable one member of the team to be auto-assigned as a reviewer for backport PRs in a round-robin fashion to guard the PR merge, i.e. backport PRs without approval from one of backport-approvers won't be able to merge. This is in line with the [server backport review & approval policy](https://wiki.corp.mongodb.com/display/KERNEL/Database+SERVER+Backports+Policy+and+Workflow#DatabaseSERVERBackportsPolicyandWorkflow-Approving/DecliningaBackport). 

The code change and Github team configuration have been tested using the [mongodb-8.0-test](https://github.com/wiredtiger/wiredtiger/tree/mongodb-8.0-test) branch and the below 3 x test PRs:
- [1st test PR](https://github.com/wiredtiger/wiredtiger/pull/11337) touches both `src` and `test` folders. Member 1 (Jeremy) of the backport-approvers Github team was auto-assigned as a reviewer. An approval from the member enabled the merge of the PR.
- [2nd test PR](https://github.com/wiredtiger/wiredtiger/pull/11338) touches both `src` and `test` folders. The PR was auto-assigned to member 2 (Etienne) of the backport-approvers Github team. Without approval from the member the PR is blocked for merge.
- [3rd test PR](https://github.com/wiredtiger/wiredtiger/pull/11339) touches only the `test` folder. No member of the backport-approvers Github team was auto-assigned as a reviewer, as it's a non-functional change.

For reviewers reference, Here is the [Github documentation for code ownership](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), and the [server CODEOWNERS file for the v8.0 release branch](https://github.com/10gen/mongo/blob/v8.0/.github/CODEOWNERS).