### PR TITLE
WT-13911 Fix configuration related issue in many-collection-test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4055,6 +4055,8 @@ tasks:
             pip3 install lorem==0.1.1 pymongo==3.12.2 "pymongo[srv]==3.12.2"
             mongod_path=$(find -L ../../mongo/build -executable -type f -path \*/bin/mongod)
             echo "mongod_path = '$mongod_path'"
+            # Log the actual path, using ls to display any symlinks
+            ls -l $mongod_path
             ./run_many_coll.sh $mongod_path mongodb.log config/many-collection-testing many-collection clean-and-populate
       - func: "convert-to-atlas-evergreen-format"
         vars:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4053,7 +4053,8 @@ tasks:
             source venv/bin/activate
             # Need both pymongo and pymongo[srv] as upload-results-atlas.py uses mongo+srv for the URI.
             pip3 install lorem==0.1.1 pymongo==3.12.2 "pymongo[srv]==3.12.2"
-            mongod_path=$(find ../../mongo/build -executable -type f -path \*/bin/mongod)
+            mongod_path=$(find -L ../../mongo/build -executable -type f -path \*/bin/mongod)
+            echo "mongod_path = '$mongod_path'"
             ./run_many_coll.sh $mongod_path mongodb.log config/many-collection-testing many-collection clean-and-populate
       - func: "convert-to-atlas-evergreen-format"
         vars:


### PR DESCRIPTION
Recently the many-collection-test Evergreen task has had a number of failures, where the test has failed to find the mongod binary. It seems that (sometimes at least) a symlink is used to point to the actual location of the mongodb binary, and the code in evergreen.yml was not finding the binary as a result.

The solution is to add the '-L' command line option to `find` to follow symbolic links. This change also prints out the mongod path to assist with future debugging.
