### PR TITLE
WT-13447 Reset background compaction stats after a full iteration with run_once (v8.0) (#10976)

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -533,7 +533,9 @@ __background_compact_server(void *arg)
                 full_iteration = false;
                 WT_ERR(__wt_buf_set(session, uri, WT_BACKGROUND_COMPACT_URI_PREFIX,
                   strlen(WT_BACKGROUND_COMPACT_URI_PREFIX) + 1));
-                __background_compact_list_cleanup(session, BACKGROUND_COMPACT_CLEANUP_STALE_STAT);
+                __background_compact_list_cleanup(session,
+                  conn->background_compact.run_once ? BACKGROUND_COMPACT_CLEANUP_OFF :
+                                                      BACKGROUND_COMPACT_CLEANUP_STALE_STAT);
             }
 
             if (cache_pressure) {


### PR DESCRIPTION
The background compaction thread is supposed to clean all its stats when disabled by the application or when `run_once` is configured to `true` and all the files have been parsed. The changes address the second scenario that was missing.

(cherry picked from commit 56cb49226bc2d639a8192dfbb2d088d281098b7d)