### PR TITLE
WT-12238 Check ref address when skipping pages in compact (v8.0) (#10538)

### DIFF
--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -173,10 +173,10 @@ __compact_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_REF_LOCK(session, ref, &previous_state);
 
     /*
-     * Don't bother rewriting deleted pages but also don't skip. The on-disk block is discarded by
-     * the next checkpoint.
+     * Don't bother rewriting deleted pages but also don't skip. The on-disk block with an address
+     * is discarded by the next checkpoint, if it has not already been freed.
      */
-    if (previous_state == WT_REF_DELETED && ref->page_del == NULL)
+    if (previous_state == WT_REF_DELETED && ref->page_del == NULL && ref->addr != NULL)
         *skipp = false;
 
     /*


### PR DESCRIPTION
While traversing entries on an internal page, compact will decide to checkpoint the tree if it sees pages in the WT_REF_DELETED state as checkpoint will delete the underlying blocks, freeing up space for compact to reclaim. However, compact will repeatedly see pages in the WT_REF_DELETED state even after they are freed as the index in the parent page is not updated unless a split occurs.

The ref address is freed when we free the underlying blocks. Adding a check for the ref address here ensures we only proceed with the compact checkpoint (and another compact pass) if the underlying blocks have not already been freed.

(cherry picked from commit bc9d22aafcbe6446e9d6a5800ecffcf36c3b5e7d)
