### PR TITLE
WT-11253 Add basic ignore_prepare to test format.

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -397,6 +397,7 @@ typedef struct {
     uint64_t last; /* truncate range */
     WT_ITEM *lastkey, _lastkey;
 
+    bool ignore_prepare;   /* read with ignore_prepare */
     bool repeatable_reads; /* if read ops repeatable */
     bool repeatable_wrap;  /* if circular buffer wrapped */
     uint64_t opid;         /* Operation ID */
@@ -468,7 +469,7 @@ void snap_track(TINFO *, thread_op);
 void table_dump_page(WT_SESSION *, const char *, TABLE *, uint64_t, const char *);
 void table_verify(TABLE *, void *);
 void timestamp_init(void);
-uint64_t timestamp_maximum_committed(void);
+uint64_t timestamp_minimum_committed(void);
 void timestamp_once(WT_SESSION *, bool, bool);
 void replay_adjust_key(TINFO *, uint64_t);
 uint64_t replay_commit_ts(TINFO *);

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -29,11 +29,11 @@
 #include "format.h"
 
 /*
- * timestamp_maximum_committed --
- *     Return the largest timestamp that's no longer in use.
+ * timestamp_minimum_committed --
+ *     Return the timestamp lesser than the minimum of in-use committed timestamps.
  */
 uint64_t
-timestamp_maximum_committed(void)
+timestamp_minimum_committed(void)
 {
     TINFO **tlp;
     uint64_t commit_ts, ts;
@@ -111,7 +111,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
     conn = g.wts_conn;
 
     /* Get the maximum not-in-use timestamp, noting that it may not be set. */
-    oldest_timestamp = stable_timestamp = timestamp_maximum_committed();
+    oldest_timestamp = stable_timestamp = timestamp_minimum_committed();
     if (oldest_timestamp == 0)
         return;
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -497,10 +497,10 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
 static void
 begin_transaction_ts(TINFO *tinfo)
 {
-    const char* config;
     WT_DECL_RET;
     WT_SESSION *session;
     uint64_t ts;
+    const char *config;
 
     session = tinfo->session;
 
@@ -518,7 +518,7 @@ begin_transaction_ts(TINFO *tinfo)
         ts = mmrand(&tinfo->data_rnd, 1, 4) == 1 ? 0 : timestamp_minimum_committed();
     if (ts != 0) {
         /* 10% of times configure ignore_prepare */
-        if (GV(OPS_PREPARE) && (mmrand(&tinfo->data_rnd, 1, 10) == 1 )) {
+        if (GV(OPS_PREPARE) && (mmrand(&tinfo->data_rnd, 1, 10) == 1)) {
             config = "ignore_prepare=true";
             tinfo->ignore_prepare = true;
         } else {
@@ -526,7 +526,7 @@ begin_transaction_ts(TINFO *tinfo)
             tinfo->ignore_prepare = false;
         }
 
-        wt_wrap_begin_transaction(session,config);
+        wt_wrap_begin_transaction(session, config);
 
         /*
          * If the timestamp has aged out of the system, we'll get EINVAL when we try and set it.
@@ -758,11 +758,10 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
          * If we're in a snapshot-isolation transaction, optionally reserve a row (it's an update so
          * can't be done at lower isolation levels). Reserving a row in an implicit transaction will
          * work, but doesn't make sense. Reserving a row before a read won't be useful but it's not
-         * unexpected.
-         * a row cannot be reserved with ignore prepare.
+         * unexpected. A row cannot be reserved with ignore prepare.
          */
-        if (intxn && iso_level == ISOLATION_SNAPSHOT && tinfo->ignore_prepare == false 
-            && mmrand(&tinfo->data_rnd, 0, 20) == 1) {
+        if (intxn && iso_level == ISOLATION_SNAPSHOT && tinfo->ignore_prepare == false &&
+          mmrand(&tinfo->data_rnd, 0, 20) == 1) {
             switch (table->type) {
             case ROW:
                 ret = row_reserve(tinfo, positioned);
@@ -1125,11 +1124,12 @@ rollback_retry:
         }
 
         /*
-         * Select an operation: updates cannot happen at lower isolation levels or with ignore_prepare
-         * and modify must be in an explicit transaction.
+         * Select an operation: updates cannot happen at lower isolation levels or with
+         * ignore_prepare and modify must be in an explicit transaction.
          */
         op = READ;
-        if ((iso_level == ISOLATION_IMPLICIT || iso_level == ISOLATION_SNAPSHOT ) && (tinfo->ignore_prepare == false)) {
+        if ((iso_level == ISOLATION_IMPLICIT || iso_level == ISOLATION_SNAPSHOT) &&
+          (tinfo->ignore_prepare == false)) {
             i = mmrand(&tinfo->data_rnd, 1, 100);
             if (i < TV(OPS_PCT_DELETE)) {
                 op = REMOVE;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -497,6 +497,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
 static void
 begin_transaction_ts(TINFO *tinfo)
 {
+    const char* config;
     WT_DECL_RET;
     WT_SESSION *session;
     uint64_t ts;
@@ -514,9 +515,18 @@ begin_transaction_ts(TINFO *tinfo)
          * both modes: 75% of the time, pick a read timestamp before any commit timestamp still in
          * use, 25% of the time don't set a timestamp at all.
          */
-        ts = mmrand(&tinfo->data_rnd, 1, 4) == 1 ? 0 : timestamp_maximum_committed();
+        ts = mmrand(&tinfo->data_rnd, 1, 4) == 1 ? 0 : timestamp_minimum_committed();
     if (ts != 0) {
-        wt_wrap_begin_transaction(session, NULL);
+        /* 10% of times configure ignore_prepare */
+        if (GV(OPS_PREPARE) && (mmrand(&tinfo->data_rnd, 1, 10) == 1 )) {
+            config = "ignore_prepare=true";
+            tinfo->ignore_prepare = true;
+        } else {
+            config = NULL;
+            tinfo->ignore_prepare = false;
+        }
+
+        wt_wrap_begin_transaction(session,config);
 
         /*
          * If the timestamp has aged out of the system, we'll get EINVAL when we try and set it.
@@ -528,7 +538,6 @@ begin_transaction_ts(TINFO *tinfo)
             trace_uri_op(tinfo, NULL, "begin snapshot read-ts=%" PRIu64 " (repeatable)", ts);
             return;
         }
-
         testutil_assert(ret == EINVAL);
         testutil_check(session->rollback_transaction(session, NULL));
     }
@@ -569,6 +578,7 @@ commit_transaction(TINFO *tinfo, bool prepared)
     session = tinfo->session;
 
     ++tinfo->commit;
+    tinfo->ignore_prepare = false;
 
     ts = 0; /* -Wconditional-uninitialized */
     if (g.transaction_timestamps_config) {
@@ -614,6 +624,7 @@ rollback_transaction(TINFO *tinfo)
     session = tinfo->session;
 
     ++tinfo->rollback;
+    tinfo->ignore_prepare = false;
 
     testutil_check(session->rollback_transaction(session, NULL));
     replay_rollback(tinfo);
@@ -748,8 +759,10 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
          * can't be done at lower isolation levels). Reserving a row in an implicit transaction will
          * work, but doesn't make sense. Reserving a row before a read won't be useful but it's not
          * unexpected.
+         * a row cannot be reserved with ignore prepare.
          */
-        if (intxn && iso_level == ISOLATION_SNAPSHOT && mmrand(&tinfo->data_rnd, 0, 20) == 1) {
+        if (intxn && iso_level == ISOLATION_SNAPSHOT && tinfo->ignore_prepare == false 
+            && mmrand(&tinfo->data_rnd, 0, 20) == 1) {
             switch (table->type) {
             case ROW:
                 ret = row_reserve(tinfo, positioned);
@@ -1112,11 +1125,11 @@ rollback_retry:
         }
 
         /*
-         * Select an operation: updates cannot happen at lower isolation levels and modify must be
-         * in an explicit transaction.
+         * Select an operation: updates cannot happen at lower isolation levels or with ignore_prepare
+         * and modify must be in an explicit transaction.
          */
         op = READ;
-        if (iso_level == ISOLATION_IMPLICIT || iso_level == ISOLATION_SNAPSHOT) {
+        if ((iso_level == ISOLATION_IMPLICIT || iso_level == ISOLATION_SNAPSHOT ) && (tinfo->ignore_prepare == false)) {
             i = mmrand(&tinfo->data_rnd, 1, 100);
             if (i < TV(OPS_PCT_DELETE)) {
                 op = REMOVE;

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -694,7 +694,7 @@ snap_repeat_single(TINFO *tinfo)
     int count;
 
     /* Repeat an operation that's before any running operation. */
-    ts = timestamp_maximum_committed();
+    ts = timestamp_minimum_committed();
 
     /*
      * Start at a random spot in the list of operations and look for a read to retry. Stop when


### PR DESCRIPTION
To add the basic capability to check ignore_prepare to test format.
This change sets the ignore_prepare setting to transactions randomly and if ignore_prepare is set will ensure only reads are performed as per the transaction semantics.

Changes:
1. function name change to reflect the function logic.
2. Occasionally set ignore_prepare and ensure the transaction will perform only read operations as write operations are forbidden when ignore_prepare is set. 
