### PR TITLE
WT-13916 Hide the implementation of the live restore server from the connection

### DIFF
--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -410,7 +410,7 @@ struct __wt_connection_impl {
 
     WT_BACKGROUND_COMPACT background_compact; /* Background compaction server */
 
-    WT_LIVE_RESTORE_SERVER live_restore_server; /* Live restore server. */
+    WT_LIVE_RESTORE_SERVER *live_restore_server; /* Live restore server. */
 
     WT_HEURISTIC_CONTROLS heuristic_controls; /* Heuristic controls configuration */
 

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -8,29 +8,6 @@
 
 #pragma once
 
-/*
- * WT_LIVE_RESTORE_WORK_ITEM --
- *     A single item of work to be worked on by a thread.
- */
-struct __wt_live_restore_work_item {
-    char *uri;
-    TAILQ_ENTRY(__wt_live_restore_work_item) q; /* List of URIs queued for background migration. */
-};
-
-/*
- * WT_LIVE_RESTORE_SERVER --
- *     The live restore server object that is kept on the connection. Holds a thread group and the
- *     work queue, with some additional info.
- */
-struct __wt_live_restore_server {
-    WT_THREAD_GROUP threads;
-    wt_shared uint32_t threads_working;
-    WT_SPINLOCK queue_lock;
-    uint64_t queue_size;
-
-    TAILQ_HEAD(__wt_live_restore_work_queue, __wt_live_restore_work_item) work_queue;
-};
-
 #define WT_LIVE_RESTORE_INIT 0x0
 #define WT_LIVE_RESTORE_IN_PROGRESS 0x1
 #define WT_LIVE_RESTORE_COMPLETE 0x2

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -32,32 +32,27 @@ struct __wt_live_restore_hole_node {
 };
 
 /*
- * WT_LIVE_RESTORE_DESTINATION_METADATA --
- *     Metadata kept along side a file handle to track holes in the destination file.
- */
-typedef struct {
-    WT_FILE_HANDLE *fh;
-    bool complete;
-
-    /* We need to get back to the file system when checking for tombstone files. */
-    WT_LIVE_RESTORE_FS *back_pointer;
-
-    /*
-     * The hole list tracks which ranges in the destination file are holes. As the migration
-     * continues the holes will be gradually filled by either data from the source or new writes.
-     * Holes in these extents should only shrink and never grow.
-     */
-    WT_LIVE_RESTORE_HOLE_NODE *hole_list_head;
-} WT_LIVE_RESTORE_DESTINATION_METADATA;
-
-/*
  * __wt_live_restore_file_handle --
  *     A file handle in a live restore file system.
  */
 struct __wt_live_restore_file_handle {
     WT_FILE_HANDLE iface;
     WT_FILE_HANDLE *source;
-    WT_LIVE_RESTORE_DESTINATION_METADATA destination;
+    /* Metadata kept along side a file handle to track holes in the destination file. */
+    struct {
+        WT_FILE_HANDLE *fh;
+        bool complete;
+
+        /* We need to get back to the file system when checking for tombstone files. */
+        WT_LIVE_RESTORE_FS *back_pointer;
+
+        /*
+        * The hole list tracks which ranges in the destination file are holes. As the migration
+        * continues the holes will be gradually filled by either data from the source or new writes.
+        * Holes in these extents should only shrink and never grow.
+        */
+        WT_LIVE_RESTORE_HOLE_NODE *hole_list_head;
+    } destination;
 
     WT_FS_OPEN_FILE_TYPE file_type;
 };

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -95,6 +95,29 @@ struct __wt_live_restore_fs {
     uint8_t debug_flags;
 };
 
+/*
+ * WT_LIVE_RESTORE_WORK_ITEM --
+ *     A single item of work to be worked on by a thread.
+ */
+struct __wt_live_restore_work_item {
+    char *uri;
+    TAILQ_ENTRY(__wt_live_restore_work_item) q; /* List of URIs queued for background migration. */
+};
+
+/*
+ * WT_LIVE_RESTORE_SERVER --
+ *     The live restore server object that is kept on the connection. Holds a thread group and the
+ *     work queue, with some additional info.
+ */
+struct __wt_live_restore_server {
+    WT_THREAD_GROUP threads;
+    wt_shared uint32_t threads_working;
+    WT_SPINLOCK queue_lock;
+    uint64_t queue_size;
+
+    TAILQ_HEAD(__wt_live_restore_work_queue, __wt_live_restore_work_item) work_queue;
+};
+
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
 extern int __wti_live_restore_fs_fill_holes(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -47,10 +47,10 @@ struct __wt_live_restore_file_handle {
         WT_LIVE_RESTORE_FS *back_pointer;
 
         /*
-        * The hole list tracks which ranges in the destination file are holes. As the migration
-        * continues the holes will be gradually filled by either data from the source or new writes.
-        * Holes in these extents should only shrink and never grow.
-        */
+         * The hole list tracks which ranges in the destination file are holes. As the migration
+         * continues the holes will be gradually filled by either data from the source or new
+         * writes. Holes in these extents should only shrink and never grow.
+         */
         WT_LIVE_RESTORE_HOLE_NODE *hole_list_head;
     } destination;
 

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -227,8 +227,9 @@ __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char *cfg[])
     if (!F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
         return (0);
 
-    WT_ERR(__wt_calloc_one(session, &S2C(session)->live_restore_server));
-    WT_LIVE_RESTORE_SERVER *server = S2C(session)->live_restore_server;
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    WT_ERR(__wt_calloc_one(session, &conn->live_restore_server));
+    WT_LIVE_RESTORE_SERVER *server = conn->live_restore_server;
 
     /* Read the threads_max config, zero threads is valid in which case we don't do anything. */
     WT_CONFIG_ITEM cval;
@@ -271,7 +272,7 @@ __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char *cfg[])
 
     if (0) {
 err:
-        __wt_free(session, server);
+        __wt_free(session, conn->live_restore_server);
     }
     return (ret);
 }


### PR DESCRIPTION
We could've been a bit more #modular prior when implementing the live restore server. By forward declaring the type and making it a pointer on the connection instead of the full struct we can move the struct definitions inside the `live_restore_private.h` header.