### PR TITLE
WT-13943 Write catch2 tests for live restore fs_directory_list

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1288,6 +1288,8 @@ su
 subdir
 subdirectories
 subdirectory
+subfolder
+subfolders
 subget
 subgetraw
 subgets

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -320,7 +320,7 @@ FLD_AREALLSET(uint64_t field, uint64_t mask)
 
 /* Check if a string matches a suffix. */
 #define WT_SUFFIX_MATCH(str, sfx) \
-    (strlen(str) >= strlen(sfx) && strcmp(&str[strlen(str) - strlen(sfx)], sfx) == 0)
+    (strlen(str) >= strlen(sfx) && strcmp(&(str)[strlen(str) - strlen(sfx)], sfx) == 0)
 
 /* Check if a string matches a prefix, and move past it. */
 #define WT_PREFIX_SKIP(str, pfx) (WT_PREFIX_MATCH(str, pfx) ? ((str) += strlen(pfx), 1) : 0)

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -288,6 +288,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
     uint32_t count_dest = 0, count_src = 0;
     char **dirlist_dest, **dirlist_src, **entries, **namep, *path_dest, *path_src, *temp_path;
     bool dest_exist = false, have_tombstone = false;
+    bool dest_folder_exists = false, source_folder_exists = false;
 
     *dirlistp = dirlist_dest = dirlist_src = entries = NULL;
     path_dest = path_src = temp_path = NULL;
@@ -298,45 +299,67 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
     /* Get files from destination. */
     WT_ERR(__live_restore_fs_backing_filename(
       &lr_fs->destination, session, lr_fs->destination.home, directory, &path_dest));
-    WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(
-                      lr_fs->os_file_system, wt_session, path_dest, prefix, &dirlist_dest, countp),
-      ENOENT, false);
 
-    for (namep = dirlist_dest; namep != NULL && *namep != NULL; namep++)
-        if (!WT_SUFFIX_MATCH(*namep, WT_LIVE_RESTORE_FS_TOMBSTONE_SUFFIX)) {
-            WT_ERR(__wt_realloc_def(session, &dirallocsz, count_dest + 1, &entries));
-            WT_ERR(__wt_strdup(session, *namep, &entries[count_dest]));
-            ++count_dest;
+    WT_ERR(lr_fs->os_file_system->fs_exist(
+      lr_fs->os_file_system, wt_session, path_dest, &dest_folder_exists));
 
-            if (single)
-                goto done;
-        }
+    if (dest_folder_exists) {
+        WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, wt_session,
+                          path_dest, prefix, &dirlist_dest, countp),
+          ENOENT, false);
+
+        for (namep = dirlist_dest; namep != NULL && *namep != NULL; namep++)
+            if (!WT_SUFFIX_MATCH(*namep, WT_LIVE_RESTORE_FS_TOMBSTONE_SUFFIX)) {
+                WT_ERR(__wt_realloc_def(session, &dirallocsz, count_dest + 1, &entries));
+                WT_ERR(__wt_strdup(session, *namep, &entries[count_dest]));
+                ++count_dest;
+
+                if (single)
+                    goto done;
+            }
+    }
 
     /* Get files from source. */
     WT_ERR(__live_restore_fs_backing_filename(
       &lr_fs->source, session, lr_fs->destination.home, directory, &path_src));
-    WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(
-                      lr_fs->os_file_system, wt_session, path_src, prefix, &dirlist_src, countp),
-      ENOENT, false);
 
-    for (namep = dirlist_src; namep != NULL && *namep != NULL; namep++) {
-        /* We're iterating files in the source, but we want to check if they exist in the destination, so create the file path to the backing destination file. */
-        WT_ERR(__live_restore_create_file_path(session, &lr_fs->destination, *namep, &temp_path));
-        WT_ERR_NOTFOUND_OK(
-          __live_restore_fs_has_file(lr_fs, &lr_fs->destination, session, temp_path, &dest_exist),
-          false);
-        WT_ERR(__dest_has_tombstone(lr_fs, temp_path, session, &have_tombstone));
+    WT_ERR(lr_fs->os_file_system->fs_exist(
+      lr_fs->os_file_system, wt_session, path_src, &source_folder_exists));
 
-        if (!dest_exist && !have_tombstone) {
-            WT_ERR(__wt_realloc_def(session, &dirallocsz, count_dest + count_src + 1, &entries));
-            WT_ERR(__wt_strdup(session, *namep, &entries[count_dest + count_src]));
-            ++count_src;
+    if (source_folder_exists) {
+        WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, wt_session,
+                          path_src, prefix, &dirlist_src, countp),
+          ENOENT, false);
+
+        for (namep = dirlist_src; namep != NULL && *namep != NULL; namep++) {
+            /*
+             * We're iterating files in the source, but we want to check if they exist in the
+             * destination, so create the file path to the backing destination file.
+             */
+            WT_ERR(
+              __live_restore_create_file_path(session, &lr_fs->destination, *namep, &temp_path));
+            WT_ERR_NOTFOUND_OK(__live_restore_fs_has_file(
+                                 lr_fs, &lr_fs->destination, session, temp_path, &dest_exist),
+              false);
+            WT_ERR(__dest_has_tombstone(lr_fs, temp_path, session, &have_tombstone));
+
+            if (!dest_exist && !have_tombstone) {
+                WT_ERR(
+                  __wt_realloc_def(session, &dirallocsz, count_dest + count_src + 1, &entries));
+                WT_ERR(__wt_strdup(session, *namep, &entries[count_dest + count_src]));
+                ++count_src;
+            }
+
+            __wt_free(session, temp_path);
+            if (single)
+                goto done;
         }
-
-        __wt_free(session, temp_path);
-        if (single)
-            goto done;
     }
+
+    if (!dest_folder_exists && !source_folder_exists)
+        WT_ERR_MSG(session, WT_NOTFOUND,
+          "Cannot report contents of '%s'. Folder does not exist in the source or destination.",
+          directory);
 
 done:
 err:

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -320,8 +320,8 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
       ENOENT, false);
 
     for (namep = dirlist_src; namep != NULL && *namep != NULL; namep++) {
-        /* Create file path for the file from the source directory. */
-        WT_ERR(__live_restore_create_file_path(session, &lr_fs->source, *namep, &temp_path));
+        /* We're iterating files in the source, but we want to check if they exist in the destination, so create the file path to the backing destination file. */
+        WT_ERR(__live_restore_create_file_path(session, &lr_fs->destination, *namep, &temp_path));
         WT_ERR_NOTFOUND_OK(
           __live_restore_fs_has_file(lr_fs, &lr_fs->destination, session, temp_path, &dest_exist),
           false);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -305,9 +305,8 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
       lr_fs->os_file_system, wt_session, path_dest, &dest_folder_exists));
 
     if (dest_folder_exists) {
-        WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, wt_session,
-                          path_dest, prefix, &dirlist_dest, &num_dest_files),
-          ENOENT, false);
+        WT_ERR(lr_fs->os_file_system->fs_directory_list(
+          lr_fs->os_file_system, wt_session, path_dest, prefix, &dirlist_dest, &num_dest_files));
 
         for (namep = dirlist_dest; namep != NULL && *namep != NULL; namep++)
             if (!WT_SUFFIX_MATCH(*namep, WT_LIVE_RESTORE_FS_TOMBSTONE_SUFFIX)) {
@@ -328,9 +327,8 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
       lr_fs->os_file_system, wt_session, path_src, &source_folder_exists));
 
     if (source_folder_exists) {
-        WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, wt_session,
-                          path_src, prefix, &dirlist_src, &num_src_files),
-          ENOENT, false);
+        WT_ERR(lr_fs->os_file_system->fs_directory_list(
+          lr_fs->os_file_system, wt_session, path_src, prefix, &dirlist_src, &num_src_files));
 
         for (namep = dirlist_src; namep != NULL && *namep != NULL; namep++) {
             /*
@@ -358,7 +356,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
     }
 
     if (!dest_folder_exists && !source_folder_exists)
-        WT_ERR_MSG(session, WT_NOTFOUND,
+        WT_ERR_MSG(session, ENOENT,
           "Cannot report contents of '%s'. Folder does not exist in the source or destination.",
           directory);
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -289,6 +289,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
     char **dirlist_dest, **dirlist_src, **entries, **namep, *path_dest, *path_src, *temp_path;
     bool dest_exist = false, have_tombstone = false;
     bool dest_folder_exists = false, source_folder_exists = false;
+    uint32_t num_src_files = 0, num_dest_files = 0;
 
     *dirlistp = dirlist_dest = dirlist_src = entries = NULL;
     path_dest = path_src = temp_path = NULL;
@@ -305,7 +306,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
 
     if (dest_folder_exists) {
         WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, wt_session,
-                          path_dest, prefix, &dirlist_dest, countp),
+                          path_dest, prefix, &dirlist_dest, &num_dest_files),
           ENOENT, false);
 
         for (namep = dirlist_dest; namep != NULL && *namep != NULL; namep++)
@@ -328,7 +329,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
 
     if (source_folder_exists) {
         WT_ERR_ERROR_OK(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, wt_session,
-                          path_src, prefix, &dirlist_src, countp),
+                          path_src, prefix, &dirlist_src, &num_src_files),
           ENOENT, false);
 
         for (namep = dirlist_src; namep != NULL && *namep != NULL; namep++) {
@@ -367,9 +368,10 @@ err:
     __wt_free(session, path_src);
     __wt_free(session, temp_path);
     if (dirlist_dest != NULL)
-        WT_TRET(__live_restore_fs_directory_list_free(fs, wt_session, dirlist_dest, count_dest));
+        WT_TRET(
+          __live_restore_fs_directory_list_free(fs, wt_session, dirlist_dest, num_dest_files));
     if (dirlist_src != NULL)
-        WT_TRET(__live_restore_fs_directory_list_free(fs, wt_session, dirlist_src, count_src));
+        WT_TRET(__live_restore_fs_directory_list_free(fs, wt_session, dirlist_src, num_src_files));
 
     *dirlistp = entries;
     *countp = count_dest + count_src;

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 
 # Live restore is not supported on Windows
 if(NOT WT_WIN)
+    set(unittests live_restore/api/test_live_restore_fs_directory_list.cpp ${unittests})
     set(unittests live_restore/unit/test_live_restore_extent_list.cpp ${unittests})
 endif()
 

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -16,14 +16,17 @@
 #include <set>
 
 using namespace utils;
-using namespace std;
+
+using lr_files = std::set<std::string>;
 
 const std::string NO_DIR = "NO_DIRECTORY";
 
-// Return the list of files in the directory, optionally specifying a subdirectory or prefix all
-// files must match. An expected return code can also be provided. If we expect an error and it
-// fires we'll still return an empty list of files.
-static set<string>
+/*
+ * Run directory_list and return the files found as a set for easy comparisons. Optionally specify a
+ * subdirectory too look in or a prefix all results must match. An expected return code can also be
+ * provided. If we expect an error and it fires we'll still return an empty list of files.
+ */
+static lr_files
 directory_list(live_restore_test_env &env, const std::string &directory = NO_DIR,
   const std::string &prefix = "", int expect_ret = 0)
 {
@@ -52,14 +55,14 @@ directory_list(live_restore_test_env &env, const std::string &directory = NO_DIR
     return found_files;
 }
 
-static set<string>
+static lr_files
 directory_list_subfolder(
   live_restore_test_env &env, const std::string &directory, int expect_ret = 0)
 {
     return directory_list(env, directory, "", expect_ret);
 }
 
-static set<string>
+static lr_files
 directory_list_prefix(live_restore_test_env &env, const std::string &prefix, int expect_ret = 0)
 {
     return directory_list(env, env.DB_DEST, prefix, expect_ret);
@@ -86,96 +89,96 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
     SECTION("Directory list - Test when files only exist in the destination")
     {
         // Start with an empty directory.
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
 
         // Progressively add files
         create_file(env.dest_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1});
+        REQUIRE(directory_list(env) == lr_files{file_1});
 
         create_file(env.dest_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2});
 
         create_file(env.dest_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2, file_3});
 
         // And then delete them
         testutil_remove(env.dest_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_3});
 
         testutil_remove(env.dest_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_3});
+        REQUIRE(directory_list(env) == lr_files{file_3});
 
         testutil_remove(env.dest_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
     }
 
     SECTION("Directory list - Test when files only exist in the source")
     {
         // Start with an empty directory.
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
 
         // Progressively add files
         create_file(env.source_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1});
+        REQUIRE(directory_list(env) == lr_files{file_1});
 
         create_file(env.source_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2});
 
         create_file(env.source_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2, file_3});
 
         // And then delete them
         testutil_remove(env.source_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_3});
 
         testutil_remove(env.source_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_3});
+        REQUIRE(directory_list(env) == lr_files{file_3});
 
         testutil_remove(env.source_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
     }
 
     SECTION("Directory list - Test when files exist in both source and destination")
     {
         // Start with an empty directory.
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
 
         // Progressively add files
         create_file(env.dest_file_path(file_1).c_str());
         create_file(env.source_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1});
+        REQUIRE(directory_list(env) == lr_files{file_1});
 
         create_file(env.dest_file_path(file_2).c_str());
         create_file(env.source_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2});
 
         create_file(env.dest_file_path(file_3).c_str());
         create_file(env.source_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2, file_3});
 
         // And then delete them
         testutil_remove(env.dest_file_path(file_2).c_str());
         testutil_remove(env.source_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_3});
 
         testutil_remove(env.dest_file_path(file_1).c_str());
         testutil_remove(env.source_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_3});
+        REQUIRE(directory_list(env) == lr_files{file_3});
 
         testutil_remove(env.dest_file_path(file_3).c_str());
         testutil_remove(env.source_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
     }
 
     SECTION("Directory list - Test when files exist either in source or destination, but not both")
     {
         // Add one file to the source.
         create_file(env.source_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1});
+        REQUIRE(directory_list(env) == lr_files{file_1});
 
         // And now the destination.
         create_file(env.dest_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2});
     }
 
     SECTION(
@@ -185,46 +188,46 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         create_file(env.source_file_path(file_1).c_str());
         create_file(env.source_file_path(file_2).c_str());
         create_file(env.source_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_2, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_2, file_3});
 
         // Now progressively add tombstones. The files are no longer reported.
         create_file(env.tombstone_file_path(file_2).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_1, file_3});
+        REQUIRE(directory_list(env) == lr_files{file_1, file_3});
 
         create_file(env.tombstone_file_path(file_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{file_3});
+        REQUIRE(directory_list(env) == lr_files{file_3});
 
         create_file(env.tombstone_file_path(file_3).c_str());
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
 
         // Now add the tombstone before the file to confirm it isn't reported.
         create_file(env.tombstone_file_path(file_4).c_str());
         create_file(env.source_file_path(file_4).c_str());
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
     }
 
     SECTION("Directory list - Test directory list reports subfolders")
     {
         // Only in the destination
         testutil_mkdir(subfolder_dest_path.c_str());
-        REQUIRE(directory_list(env) == set<string>{subfolder});
+        REQUIRE(directory_list(env) == lr_files{subfolder});
 
         // And then deleted
         testutil_remove(subfolder_dest_path.c_str());
-        REQUIRE(directory_list(env) == set<string>{});
+        REQUIRE(directory_list(env) == lr_files{});
 
         // Only in the source
         testutil_mkdir(subfolder_source_path.c_str());
-        REQUIRE(directory_list(env) == set<string>{subfolder});
+        REQUIRE(directory_list(env) == lr_files{subfolder});
 
         // Now in both
         testutil_mkdir(subfolder_dest_path.c_str());
-        REQUIRE(directory_list(env) == set<string>{subfolder});
+        REQUIRE(directory_list(env) == lr_files{subfolder});
 
         // Check that we *don't* report the contents, just the subfolder itself
         std::string subfile_1 = subfolder + "/" + file_1;
         create_file(env.dest_file_path(subfile_1).c_str());
-        REQUIRE(directory_list(env) == set<string>{subfolder});
+        REQUIRE(directory_list(env) == lr_files{subfolder});
     }
 
     SECTION(
@@ -236,14 +239,14 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
 
         // But if the subfolder exists in either backing directory we'll return successfully.
         testutil_mkdir(subfolder_dest_path.c_str());
-        REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{});
+        REQUIRE(directory_list(env, subfolder_dest_path) == lr_files{});
 
         testutil_remove(subfolder_dest_path.c_str());
         testutil_mkdir(subfolder_source_path.c_str());
-        REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{});
+        REQUIRE(directory_list(env, subfolder_dest_path) == lr_files{});
 
         testutil_mkdir(subfolder_dest_path.c_str());
-        REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{});
+        REQUIRE(directory_list(env, subfolder_dest_path) == lr_files{});
     }
 
     SECTION("Directory list - Test multi-level subdirectories")
@@ -255,7 +258,7 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         testutil_mkdir(subsubfolder_dest_path.c_str());
         create_file(subsubfolder_file_1_path.c_str());
 
-        REQUIRE(directory_list(env, subsubfolder_dest_path) == set<string>{"file_1.txt"});
+        REQUIRE(directory_list(env, subsubfolder_dest_path) == lr_files{"file_1.txt"});
     }
 
     SECTION("Directory list - Test reporting contents of a subdirectory")
@@ -273,7 +276,7 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
 
         // Note we're returning file_1 here, not subfile_1. Since we're reporting the
         // contents of the subfolder the file names are relative to that folder.
-        REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{file_1, file_2});
+        REQUIRE(directory_list(env, subfolder_dest_path) == lr_files{file_1, file_2});
     }
 
     SECTION("Directory list - Test only files matching the specified prefix are returned")
@@ -284,24 +287,24 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         testutil_mkdir(subfolder_dest_path.c_str());
 
         // Report all files and folders when prefix == ""
-        REQUIRE(directory_list_prefix(env, "") == set<string>{file_1, file_2, subfolder});
+        REQUIRE(directory_list_prefix(env, "") == lr_files{file_1, file_2, subfolder});
 
         // Now only report the files
-        REQUIRE(directory_list_prefix(env, "file") == set<string>{file_1, file_2});
+        REQUIRE(directory_list_prefix(env, "file") == lr_files{file_1, file_2});
 
         // Only the folder
-        REQUIRE(directory_list_prefix(env, "sub") == set<string>{subfolder});
+        REQUIRE(directory_list_prefix(env, "sub") == lr_files{subfolder});
 
         // Only file_1. The prefix is the entire file name
-        REQUIRE(directory_list_prefix(env, file_1) == set<string>{file_1});
+        REQUIRE(directory_list_prefix(env, file_1) == lr_files{file_1});
 
         // A prefix longer than any files or folders in the directory
-        REQUIRE(directory_list_prefix(env, string(10000, 'A')) == set<string>{});
+        REQUIRE(directory_list_prefix(env, std::string(10000, 'A')) == lr_files{});
 
         // The prefix is actually a suffix
-        REQUIRE(directory_list_prefix(env, "_1.txt") == set<string>{});
+        REQUIRE(directory_list_prefix(env, "_1.txt") == lr_files{});
 
         // The prefix is matches a file's full name but then has additional characters
-        REQUIRE(directory_list_prefix(env, "file_1.txt.txt.txt") == set<string>{});
+        REQUIRE(directory_list_prefix(env, "file_1.txt.txt.txt") == lr_files{});
     }
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -231,11 +231,11 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
     }
 
     SECTION(
-      "Directory list - Test WT_NOTFOUND is returned when listing the contents of a subfolder that "
+      "Directory list - Test ENOENT is returned when listing the contents of a subfolder that "
       "doesn't exist")
     {
-        // When the subfolder doesn't exist expect a WT_NOTFOUND will be returned.
-        directory_list_subfolder(env, subfolder_dest_path, WT_NOTFOUND);
+        // When the subfolder doesn't exist expect a ENOENT will be returned.
+        directory_list_subfolder(env, subfolder_dest_path, ENOENT);
 
         // But if the subfolder exists in either backing directory we'll return successfully.
         testutil_mkdir(subfolder_dest_path.c_str());

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -7,9 +7,9 @@
  */
 
 /*
- * Tests of the Live Restore file systems, directory list functions.
- * These functions report which files exist in the unified live restore directory, hiding whether they're in the destination, source, or both backing directories.
- * [live_restore_directory_list]
+ * Tests of the Live Restore file systems, directory list functions. These functions report which
+ * files exist in the unified live restore directory, hiding whether they're in the destination,
+ * source, or both backing directories. [live_restore_directory_list]
  */
 
 #include "../utils_live_restore.h"
@@ -172,7 +172,8 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         REQUIRE(directory_list(env) == set<string>{file_1, file_2});
     }
 
-    SECTION("Directory list - Test a file isn't reported when there's a tombstone in the destination")
+    SECTION(
+      "Directory list - Test a file isn't reported when there's a tombstone in the destination")
     {
         // Add some files to the source.
         create_file(env.source_file_path(file_1).c_str());
@@ -220,7 +221,9 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         REQUIRE(directory_list(env) == set<string>{subfolder});
     }
 
-    SECTION("Directory list - Test WT_NOTFOUND is returned when the subfolder doesn't exist")
+    SECTION(
+      "Directory list - Test WT_NOTFOUND is returned when listing the contents of a subfolder that "
+      "doesn't exist")
     {
         // When the subfolder doesn't exist expect a WT_NOTFOUND will be returned.
         directory_list_subfolder(env, subfolder_dest_path, WT_NOTFOUND);
@@ -237,10 +240,11 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{});
     }
 
-    SECTION("Directory list - Test multiple level subdirectories")
+    SECTION("Directory list - Test multi-level subdirectories")
     {
         std::string subsubfolder_dest_path = env.DB_DEST + "/" + subfolder + "/subsubfolder";
-        std::string subsubfolder_file_1_path = env.DB_DEST + "/" + subfolder + "/subsubfolder/file_1.txt";
+        std::string subsubfolder_file_1_path =
+          env.DB_DEST + "/" + subfolder + "/subsubfolder/file_1.txt";
         testutil_mkdir(subfolder_dest_path.c_str());
         testutil_mkdir(subsubfolder_dest_path.c_str());
         create_file(subsubfolder_file_1_path.c_str());
@@ -264,7 +268,5 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         // Note we're returning file_1 here, not subfile_1. Since we're reporting the
         // contents of the subfolder the file names are relative to that folder.
         REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{file_1, file_2});
-
     }
-
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -225,8 +225,8 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         REQUIRE(directory_list(env) == lr_files{subfolder});
 
         // Check that we *don't* report the contents, just the subfolder itself
-        std::string subfile_1 = subfolder + "/" + file_1;
-        create_file(env.dest_file_path(subfile_1).c_str());
+        std::string sub_file_1 = subfolder + "/" + file_1;
+        create_file(env.dest_file_path(sub_file_1).c_str());
         REQUIRE(directory_list(env) == lr_files{subfolder});
     }
 
@@ -251,14 +251,14 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
 
     SECTION("Directory list - Test multi-level subdirectories")
     {
-        std::string subsubfolder_dest_path = env.DB_DEST + "/" + subfolder + "/subsubfolder";
-        std::string subsubfolder_file_1_path =
-          env.DB_DEST + "/" + subfolder + "/subsubfolder/file_1.txt";
+        std::string sub_subfolder_dest_path = env.DB_DEST + "/" + subfolder + "/sub_subfolder";
+        std::string sub_subfolder_file_1_path =
+          env.DB_DEST + "/" + subfolder + "/sub_subfolder/file_1.txt";
         testutil_mkdir(subfolder_dest_path.c_str());
-        testutil_mkdir(subsubfolder_dest_path.c_str());
-        create_file(subsubfolder_file_1_path.c_str());
+        testutil_mkdir(sub_subfolder_dest_path.c_str());
+        create_file(sub_subfolder_file_1_path.c_str());
 
-        REQUIRE(directory_list(env, subsubfolder_dest_path) == lr_files{"file_1.txt"});
+        REQUIRE(directory_list(env, sub_subfolder_dest_path) == lr_files{"file_1.txt"});
     }
 
     SECTION("Directory list - Test reporting contents of a subdirectory")
@@ -267,14 +267,14 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         testutil_mkdir(subfolder_source_path.c_str());
 
         // To keep this test short we'll just test on file in each backing directory.
-        // We've tested other behaviour above
-        std::string subfile_1 = subfolder + "/" + file_1;
-        create_file(env.dest_file_path(subfile_1).c_str());
+        // We've tested other behaviors above
+        std::string sub_file_1 = subfolder + "/" + file_1;
+        create_file(env.dest_file_path(sub_file_1).c_str());
 
-        std::string subfile_2 = subfolder + "/" + file_2;
-        create_file(env.source_file_path(subfile_2).c_str());
+        std::string sub_file_2 = subfolder + "/" + file_2;
+        create_file(env.source_file_path(sub_file_2).c_str());
 
-        // Note we're returning file_1 here, not subfile_1. Since we're reporting the
+        // Note we're returning file_1 here, not sub_file_1. Since we're reporting the
         // contents of the subfolder the file names are relative to that folder.
         REQUIRE(directory_list(env, subfolder_dest_path) == lr_files{file_1, file_2});
     }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -80,4 +80,35 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         testutil_remove(env.dest_file_path(file_3).c_str());
         REQUIRE(all_expected_files_found(env, "", {}));
     }
+
+    SECTION("Directory list - Test files that only exist in the source")
+    {
+        std::string file_1 = "file1.txt";
+        std::string file_2 = "file2.txt";
+        std::string file_3 = "file3.txt";
+
+        // Start with an empty directory.
+        REQUIRE(all_expected_files_found(env, "", {}));
+
+        // And now 1 file
+        create_file(env.source_file_path(file_1).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1}));
+
+        // And now 2 and then 3 files
+        create_file(env.source_file_path(file_2).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_2}));
+
+        create_file(env.source_file_path(file_3).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_2, file_3}));
+
+        // And now delete the files
+        testutil_remove(env.source_file_path(file_2).c_str());
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_3}));
+
+        testutil_remove(env.source_file_path(file_1).c_str());
+        REQUIRE(all_expected_files_found(env, "", {file_3}));
+
+        testutil_remove(env.source_file_path(file_3).c_str());
+        REQUIRE(all_expected_files_found(env, "", {}));
+    }
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -236,4 +236,15 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         testutil_mkdir(subfolder_dest_path.c_str());
         REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{});
     }
+
+    SECTION("Directory list - Test multiple level subdirectories")
+    {
+        std::string subsubfolder_dest_path = env.DB_DEST + "/" + subfolder + "/subsubfolder";
+        std::string subsubfolder_file_1_path = env.DB_DEST + "/" + subfolder + "/subsubfolder/file_1.txt";
+        testutil_mkdir(subfolder_dest_path.c_str());
+        testutil_mkdir(subsubfolder_dest_path.c_str());
+        create_file(subsubfolder_file_1_path.c_str());
+
+        REQUIRE(directory_list(env, subsubfolder_dest_path) == set<string>{"file_1.txt"});
+    }
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -247,4 +247,24 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
 
         REQUIRE(directory_list(env, subsubfolder_dest_path) == set<string>{"file_1.txt"});
     }
+
+    SECTION("Directory list - Test reporting contents of a subdirectory")
+    {
+        testutil_mkdir(subfolder_dest_path.c_str());
+        testutil_mkdir(subfolder_source_path.c_str());
+
+        // To keep this test short we'll just test on file in each backing directory.
+        // We've tested other behaviour above
+        std::string subfile_1 = subfolder + "/" + file_1;
+        create_file(env.dest_file_path(subfile_1).c_str());
+
+        std::string subfile_2 = subfolder + "/" + file_2;
+        create_file(env.source_file_path(subfile_2).c_str());
+
+        // Note we're returning file_1 here, not subfile_1. Since we're reporting the
+        // contents of the subfolder the file names are relative to that folder.
+        REQUIRE(directory_list(env, subfolder_dest_path) == set<string>{file_1, file_2});
+
+    }
+
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -66,13 +66,13 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         REQUIRE(directory_list_is(env, "", {}));
 
         // Progressively add files
-        create_file(env.dest_file_path(file_1).c_str(), 1000);
+        create_file(env.dest_file_path(file_1).c_str());
         REQUIRE(directory_list_is(env, "", {file_1}));
 
-        create_file(env.dest_file_path(file_2).c_str(), 1000);
+        create_file(env.dest_file_path(file_2).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2}));
 
-        create_file(env.dest_file_path(file_3).c_str(), 1000);
+        create_file(env.dest_file_path(file_3).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2, file_3}));
 
         // And then delete them
@@ -92,13 +92,13 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         REQUIRE(directory_list_is(env, "", {}));
 
         // Progressively add files
-        create_file(env.source_file_path(file_1).c_str(), 1000);
+        create_file(env.source_file_path(file_1).c_str());
         REQUIRE(directory_list_is(env, "", {file_1}));
 
-        create_file(env.source_file_path(file_2).c_str(), 1000);
+        create_file(env.source_file_path(file_2).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2}));
 
-        create_file(env.source_file_path(file_3).c_str(), 1000);
+        create_file(env.source_file_path(file_3).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2, file_3}));
 
         // And then delete them
@@ -118,16 +118,16 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         REQUIRE(directory_list_is(env, "", {}));
 
         // Progressively add files
-        create_file(env.dest_file_path(file_1).c_str(), 1000);
-        create_file(env.source_file_path(file_1).c_str(), 1000);
+        create_file(env.dest_file_path(file_1).c_str());
+        create_file(env.source_file_path(file_1).c_str());
         REQUIRE(directory_list_is(env, "", {file_1}));
 
-        create_file(env.dest_file_path(file_2).c_str(), 1000);
-        create_file(env.source_file_path(file_2).c_str(), 1000);
+        create_file(env.dest_file_path(file_2).c_str());
+        create_file(env.source_file_path(file_2).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2}));
 
-        create_file(env.dest_file_path(file_3).c_str(), 1000);
-        create_file(env.source_file_path(file_3).c_str(), 1000);
+        create_file(env.dest_file_path(file_3).c_str());
+        create_file(env.source_file_path(file_3).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2, file_3}));
 
         // And then delete them
@@ -147,35 +147,35 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
     SECTION("Directory list - Test when files exist either in source or destination, but not both")
     {
         // Add one file to the source.
-        create_file(env.source_file_path(file_1).c_str(), 1000);
+        create_file(env.source_file_path(file_1).c_str());
         REQUIRE(directory_list_is(env, "", {file_1}));
 
         // And now the destination.
-        create_file(env.dest_file_path(file_2).c_str(), 1000);
+        create_file(env.dest_file_path(file_2).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2}));
     }
 
     SECTION("Directory list - Test a file isn't reported when there's a tombstone in the destination")
     {
         // Add some files to the source.
-        create_file(env.source_file_path(file_1).c_str(), 1000);
-        create_file(env.source_file_path(file_2).c_str(), 1000);
-        create_file(env.source_file_path(file_3).c_str(), 1000);
+        create_file(env.source_file_path(file_1).c_str());
+        create_file(env.source_file_path(file_2).c_str());
+        create_file(env.source_file_path(file_3).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_2, file_3}));
 
         // Now progressively add tombstones. The files are no longer reported.
-        create_file(env.tombstone_file_path(file_2).c_str(), 1000);
+        create_file(env.tombstone_file_path(file_2).c_str());
         REQUIRE(directory_list_is(env, "", {file_1, file_3}));
 
-        create_file(env.tombstone_file_path(file_1).c_str(), 1000);
+        create_file(env.tombstone_file_path(file_1).c_str());
         REQUIRE(directory_list_is(env, "", {file_3}));
 
-        create_file(env.tombstone_file_path(file_3).c_str(), 1000);
+        create_file(env.tombstone_file_path(file_3).c_str());
         REQUIRE(directory_list_is(env, "", {}));
 
         // Now add the tombstone before the file to confirm it isn't reported.
-        create_file(env.tombstone_file_path(file_4).c_str(), 1000);
-        create_file(env.source_file_path(file_4).c_str(), 1000);
+        create_file(env.tombstone_file_path(file_4).c_str());
+        create_file(env.source_file_path(file_4).c_str());
         REQUIRE(directory_list_is(env, "", {}));
     }
 
@@ -199,7 +199,7 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
 
         // Check that we *don't* report the contents, just the subfolder itself
         std::string subfile_1 = subfolder + "/" + file_1;
-        create_file(env.dest_file_path(subfile_1).c_str(), 1000);
+        create_file(env.dest_file_path(subfile_1).c_str());
         REQUIRE(directory_list_is(env, "", {subfolder}));
     }
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -56,6 +56,10 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
     std::string file_3 = "file3.txt";
     std::string file_4 = "file4.txt";
 
+    std::string subfolder = "subfolder";
+    std::string subfolder_dest_path = env.DB_DEST + "/" + subfolder;
+    std::string subfolder_source_path = env.DB_SOURCE + "/" + subfolder;
+
     SECTION("Directory list - Test when files only exist in the destination")
     {
         // Start with an empty directory.
@@ -173,5 +177,29 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         create_file(env.tombstone_file_path(file_4).c_str(), 1000);
         create_file(env.source_file_path(file_4).c_str(), 1000);
         REQUIRE(directory_list_is(env, "", {}));
+    }
+
+    SECTION("Directory list - Test directory list reports subfolders")
+    {
+        // Only in the destination
+        testutil_mkdir(subfolder_dest_path.c_str());
+        REQUIRE(directory_list_is(env, "", {subfolder}));
+
+        // And then deleted
+        testutil_remove(subfolder_dest_path.c_str());
+        REQUIRE(directory_list_is(env, "", {}));
+
+        // Only in the source
+        testutil_mkdir(subfolder_source_path.c_str());
+        REQUIRE(directory_list_is(env, "", {subfolder}));
+
+        // Now in both
+        testutil_mkdir(subfolder_dest_path.c_str());
+        REQUIRE(directory_list_is(env, "", {subfolder}));
+
+        // Check that we *don't* report the contents, just the subfolder itself
+        std::string subfile_1 = subfolder + "/" + file_1;
+        create_file(env.dest_file_path(subfile_1).c_str(), 1000);
+        REQUIRE(directory_list_is(env, "", {subfolder}));
     }
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -145,4 +145,20 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         testutil_remove(env.source_file_path(file_3).c_str());
         REQUIRE(all_expected_files_found(env, "", {}));
     }
+
+    SECTION("Directory list - Test files when are present in source or destination, but not both")
+    {
+        std::string file_1 = "file1.txt";
+        std::string file_2 = "file2.txt";
+        std::string file_3 = "file3.txt";
+
+        // Add one file to the source.
+        create_file(env.source_file_path(file_1).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1}));
+
+        // And now the destination.
+        create_file(env.dest_file_path(file_2).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_2}));
+    }
+
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -1,0 +1,83 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * Tests of the Live Restore file systems, directory list functions.
+ * These functions report which files exist in the unified live restore directory, hiding whether they're in the destination, source, or both backing directories.
+ * [live_restore_directory_list]
+ */
+
+#include "../utils_live_restore.h"
+#include <set>
+
+using namespace utils;
+
+static bool all_expected_files_found(live_restore_test_env& env, const std::string& prefix, const std::set<std::string>& expected_files) {
+
+    WT_SESSION *wt_session = reinterpret_cast<WT_SESSION *>(env.session);
+    WT_LIVE_RESTORE_FS *lr_fs = env.lr_fs;
+
+    char **dirlist = NULL;
+    uint32_t count;
+
+    lr_fs->iface.fs_directory_list(
+        (WT_FILE_SYSTEM *)lr_fs, wt_session, env.DB_DEST.c_str(), prefix.c_str(), &dirlist, &count);
+
+    REQUIRE(count == expected_files.size());
+    std::set<std::string> found_files{};
+    for (int i = 0; i < count; i++) {
+        std::string found_file(dirlist[i]);
+        found_files.insert(found_file);
+    }
+
+    bool match = found_files == expected_files;
+    lr_fs->iface.fs_directory_list_free((WT_FILE_SYSTEM *)lr_fs, wt_session, dirlist, count);
+    return match;
+
+}
+
+TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory_list]")
+{
+    /*
+     * Note: this code runs once per SECTION so we're creating a brand new WT database for each
+     * section. If this gets slow we can make it static and manually clear the destination and
+     * source for each section.
+     */
+    live_restore_test_env env;
+
+    SECTION("Directory list - Test files that only exist in the destination")
+    {
+        std::string file_1 = "file1.txt";
+        std::string file_2 = "file2.txt";
+        std::string file_3 = "file3.txt";
+
+        // Start with an empty directory.
+        REQUIRE(all_expected_files_found(env, "", {}));
+
+        // And now 1 file
+        create_file(env.dest_file_path(file_1).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1}));
+
+        // And now 2 and then 3 files
+        create_file(env.dest_file_path(file_2).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_2}));
+
+        create_file(env.dest_file_path(file_3).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_2, file_3}));
+
+        // And now delete the files
+        testutil_remove(env.dest_file_path(file_2).c_str());
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_3}));
+
+        testutil_remove(env.dest_file_path(file_1).c_str());
+        REQUIRE(all_expected_files_found(env, "", {file_3}));
+
+        testutil_remove(env.dest_file_path(file_3).c_str());
+        REQUIRE(all_expected_files_found(env, "", {}));
+    }
+}

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -59,18 +59,17 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         // Start with an empty directory.
         REQUIRE(all_expected_files_found(env, "", {}));
 
-        // And now 1 file
+        // Progressively add files
         create_file(env.dest_file_path(file_1).c_str(), 1000);
         REQUIRE(all_expected_files_found(env, "", {file_1}));
 
-        // And now 2 and then 3 files
         create_file(env.dest_file_path(file_2).c_str(), 1000);
         REQUIRE(all_expected_files_found(env, "", {file_1, file_2}));
 
         create_file(env.dest_file_path(file_3).c_str(), 1000);
         REQUIRE(all_expected_files_found(env, "", {file_1, file_2, file_3}));
 
-        // And now delete the files
+        // And then delete them
         testutil_remove(env.dest_file_path(file_2).c_str());
         REQUIRE(all_expected_files_found(env, "", {file_1, file_3}));
 
@@ -90,24 +89,59 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         // Start with an empty directory.
         REQUIRE(all_expected_files_found(env, "", {}));
 
-        // And now 1 file
+        // Progressively add files
         create_file(env.source_file_path(file_1).c_str(), 1000);
         REQUIRE(all_expected_files_found(env, "", {file_1}));
 
-        // And now 2 and then 3 files
         create_file(env.source_file_path(file_2).c_str(), 1000);
         REQUIRE(all_expected_files_found(env, "", {file_1, file_2}));
 
         create_file(env.source_file_path(file_3).c_str(), 1000);
         REQUIRE(all_expected_files_found(env, "", {file_1, file_2, file_3}));
 
-        // And now delete the files
+        // And then delete them
         testutil_remove(env.source_file_path(file_2).c_str());
         REQUIRE(all_expected_files_found(env, "", {file_1, file_3}));
 
         testutil_remove(env.source_file_path(file_1).c_str());
         REQUIRE(all_expected_files_found(env, "", {file_3}));
 
+        testutil_remove(env.source_file_path(file_3).c_str());
+        REQUIRE(all_expected_files_found(env, "", {}));
+    }
+
+    SECTION("Directory list - Test files when files are present in both source and destination")
+    {
+        std::string file_1 = "file1.txt";
+        std::string file_2 = "file2.txt";
+        std::string file_3 = "file3.txt";
+
+        // Start with an empty directory.
+        REQUIRE(all_expected_files_found(env, "", {}));
+
+        // Progressively add files
+        create_file(env.dest_file_path(file_1).c_str(), 1000);
+        create_file(env.source_file_path(file_1).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1}));
+
+        create_file(env.dest_file_path(file_2).c_str(), 1000);
+        create_file(env.source_file_path(file_2).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_2}));
+
+        create_file(env.dest_file_path(file_3).c_str(), 1000);
+        create_file(env.source_file_path(file_3).c_str(), 1000);
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_2, file_3}));
+
+        // And then delete them
+        testutil_remove(env.dest_file_path(file_2).c_str());
+        testutil_remove(env.source_file_path(file_2).c_str());
+        REQUIRE(all_expected_files_found(env, "", {file_1, file_3}));
+
+        testutil_remove(env.dest_file_path(file_1).c_str());
+        testutil_remove(env.source_file_path(file_1).c_str());
+        REQUIRE(all_expected_files_found(env, "", {file_3}));
+
+        testutil_remove(env.dest_file_path(file_3).c_str());
         testutil_remove(env.source_file_path(file_3).c_str());
         REQUIRE(all_expected_files_found(env, "", {}));
     }

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -252,13 +252,12 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
     SECTION("Directory list - Test multi-level subdirectories")
     {
         std::string sub_subfolder_dest_path = env.DB_DEST + "/" + subfolder + "/sub_subfolder";
-        std::string sub_subfolder_file_1_path =
-          env.DB_DEST + "/" + subfolder + "/sub_subfolder/file_1.txt";
+        std::string sub_subfolder_file_1_path = sub_subfolder_dest_path + "/" + file_1;
         testutil_mkdir(subfolder_dest_path.c_str());
         testutil_mkdir(sub_subfolder_dest_path.c_str());
         create_file(sub_subfolder_file_1_path.c_str());
 
-        REQUIRE(directory_list(env, sub_subfolder_dest_path) == lr_files{"file_1.txt"});
+        REQUIRE(directory_list(env, sub_subfolder_dest_path) == lr_files{file_1});
     }
 
     SECTION("Directory list - Test reporting contents of a subdirectory")
@@ -304,7 +303,7 @@ TEST_CASE("Live Restore Directory List", "[live_restore],[live_restore_directory
         // The prefix is actually a suffix
         REQUIRE(directory_list_prefix(env, "_1.txt") == lr_files{});
 
-        // The prefix is matches a file's full name but then has additional characters
+        // The prefix matches a file's full name but then has additional characters
         REQUIRE(directory_list_prefix(env, "file_1.txt.txt.txt") == lr_files{});
     }
 }

--- a/test/catch2/live_restore/live_restore_test_env.cpp
+++ b/test/catch2/live_restore/live_restore_test_env.cpp
@@ -64,7 +64,7 @@ std::string
 live_restore_test_env::tombstone_file_path(const std::string &file_name)
 {
     // Tombstone files only exist in the destination folder.
-    return DB_DEST + "/" + file_name + ".deleted";
+    return DB_DEST + "/" + file_name + WT_LIVE_RESTORE_FS_TOMBSTONE_SUFFIX;
 }
 
 } // namespace utils.

--- a/test/catch2/live_restore/live_restore_test_env.cpp
+++ b/test/catch2/live_restore/live_restore_test_env.cpp
@@ -60,4 +60,11 @@ live_restore_test_env::source_file_path(const std::string &file_name)
     return DB_SOURCE + "/" + file_name;
 }
 
+std::string
+live_restore_test_env::tombstone_file_path(const std::string &file_name)
+{
+    // Tombstone files only exist in the destination folder.
+    return DB_DEST + "/" + file_name + ".deleted";
+}
+
 } // namespace utils.

--- a/test/catch2/live_restore/live_restore_test_env.h
+++ b/test/catch2/live_restore/live_restore_test_env.h
@@ -36,6 +36,7 @@ public:
 
     std::string dest_file_path(const std::string &file_name);
     std::string source_file_path(const std::string &file_name);
+    std::string tombstone_file_path(const std::string &file_name);
 };
 
 } // namespace utils.

--- a/test/catch2/live_restore/utils_live_restore.h
+++ b/test/catch2/live_restore/utils_live_restore.h
@@ -19,7 +19,7 @@ bool extent_list_in_order(WT_LIVE_RESTORE_FILE_HANDLE *lr_fh);
 std::string extent_list_str(WT_LIVE_RESTORE_FILE_HANDLE *lr_fh);
 
 // File op helpers
-void create_file(const std::string &filepath, int len);
+void create_file(const std::string &filepath, int len = 1);
 int open_lr_fh(const live_restore_test_env &env, const std::string &dest_file,
   WT_LIVE_RESTORE_FILE_HANDLE **lr_fhp);
 


### PR DESCRIPTION
Add catch2 testing for `fs_directory_list` along with a few bug fixes revealed by testing.