### PR TITLE
WT-13961 Add a message when background compaction returns EBUSY because of an unprocessed previous command

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -806,10 +806,8 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
 
     /* Wait for any previous signal to be processed first. */
     __wt_spin_lock(session, &conn->background_compact.lock);
-    if (conn->background_compact.signalled) {
-        ret = EBUSY;
-        goto err;
-    }
+    if (conn->background_compact.signalled)
+        WT_ERR_MSG(session, EBUSY, "Background compact is busy processing a previous command");
 
     running = __wt_atomic_loadbool(&conn->background_compact.running);
 


### PR DESCRIPTION
Background compaction returns `EBUSY` whenever an application interacts with it and a previous background compact command has not been processed yet. In WiredTiger, there are many reasons why an application can get EBUSY, the changes improve the error handling by logging a message whenever the application faces this scenario.