### PR TITLE
WT-13973 Fix WT_MAX_LSN_STRING macro usage across modules.

### DIFF
--- a/src/log/log.h
+++ b/src/log/log.h
@@ -45,6 +45,8 @@ union __wt_lsn {
 
 #define WT_LOG_FILENAME "WiredTigerLog" /* Log file name */
 
+#define WT_MAX_LSN_STRING 32
+
 /*
  * Atomically set the LSN. There are two forms. We need WT_ASSIGN_LSN because some compilers (at
  * least clang address sanitizer) does not do atomic 64-bit structure assignment so we need to

--- a/src/log/log_private.h
+++ b/src/log/log_private.h
@@ -20,8 +20,6 @@
 #define WT_LSN_MSG(lsn, msg) \
     __wt_msg(session, "%s LSN: [%" PRIu32 "][%" PRIu32 "]", (msg), (lsn)->l.file, (lsn)->l.offset)
 
-#define WT_MAX_LSN_STRING 32
-
 /*
  * Both of the macros below need to change if the content of __wt_lsn ever changes. The value is the
  * following: txnid, record type, operation type, file id, operation key, operation value


### PR DESCRIPTION
While working on [WT-13958](https://jira.mongodb.org/browse/WT-13958), I identified an inconsistency in the usage of the WT_MAX_LSN_STRING macro. Currently defined in log_private.h, it is being used by other modules (checkpoint & txn). This pull request has the changes to move WT_MAX_LSN_STRING to log.h to ensure proper visibility and usage across modules.