### PR TITLE
WT-13890 Add check to ensure live restore read not enclose a hole

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -626,6 +626,10 @@ __live_restore_can_service_read(WT_LIVE_RESTORE_FILE_HANDLE *lr_fh, WT_SESSION_I
             /* All subsequent holes are past the read. We won't find matching holes. */
             break;
 
+        WT_ASSERT_ALWAYS(session, !(offset < hole->off && WT_EXTENT_END(hole) < read_end),
+          "Read (offset: %ld, len: %lu) encloses a hole (offset: %ld, len: %lu)", offset, len,
+          hole->off, hole->len);
+
         read_begins_in_hole = WT_OFFSET_IN_EXTENT(offset, hole);
         read_ends_in_hole = WT_OFFSET_IN_EXTENT(read_end, hole);
         if (read_begins_in_hole && read_ends_in_hole) {

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -627,7 +627,7 @@ __live_restore_can_service_read(WT_LIVE_RESTORE_FILE_HANDLE *lr_fh, WT_SESSION_I
             break;
 
         WT_ASSERT_ALWAYS(session, !(offset < hole->off && WT_EXTENT_END(hole) < read_end),
-          "Read (offset: %ld, len: %lu) encloses a hole (offset: %ld, len: %lu)", offset, len,
+          "Read (offset: %ld, len: %lu) encompasses a hole (offset: %ld, len: %lu)", offset, len,
           hole->off, hole->len);
 
         read_begins_in_hole = WT_OFFSET_IN_EXTENT(offset, hole);


### PR DESCRIPTION
Add assert to check read never encompasses a hole, that is, a read having `start offset < hole start offset` and `end offset > hole end offset`.