### PR TITLE
WT-13972 Fix typedef to include __wti_xxx typedef structs in wt_internal.h

### DIFF
--- a/dist/s_typedef
+++ b/dist/s_typedef
@@ -32,7 +32,7 @@ build() {
     l=`ls ../src/*/*.h ../src/include/*.in |
         sed -e '/wiredtiger.*/d' -e '/queue.h/d'` || exit $?
     grep -E -h \
-        '^[[:space:]]*(((struct|union)[[:space:]].*__wt_.*{)|WT_PACKED_STRUCT_BEGIN)' \
+        '^[[:space:]]*(((struct|union)[[:space:]].*__wti?_.*{)|WT_PACKED_STRUCT_BEGIN)' \
         $l |
         sed -e 's/WT_PACKED_STRUCT_BEGIN(\(.*\))/struct \1 {/' \
             -e 's/WT_COMPILER_TYPE_ALIGN(.*)[ ]*//' \


### PR DESCRIPTION
While working on [WT-13958](https://jira.mongodb.org/browse/WT-13958), I observed that __wti_xxx structures defined in log_private.h were not being included in wt_internal.h. This was due to a limitation in the s_typedef function. This pull request has the changes to modify s_typedef function regular expression to include __wti_xxx structures in wt_internal.h along with __wt_xxx structures..
