### PR TITLE
WT-13856 New macro WT_RET_SUB and WT_ERR_SUB

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2660,8 +2660,11 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
      * Don't flush data from modified trees independent of system-wide checkpoint. Flushing trees
      * can lead to files that are inconsistent on disk after a crash.
      */
-    if (btree->modified && !bulk && !metadata)
-        return (__wt_set_return(session, EBUSY));
+    if (btree->modified && !bulk && !metadata) {
+        ret = __wt_set_return(session, EBUSY);
+        WT_RET_SUB(
+          session, ret, WT_DIRTY_DATA, "the table has dirty data and can not be dropped yet");
+    }
 
     /*
      * Make sure there isn't a potential race between backup copying the metadata and a checkpoint

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -819,8 +819,8 @@ __wt_background_compact_signal(WT_SESSION_IMPL *session, const char *config)
 
     /* The background compact configuration cannot be changed while it's already running. */
     if (enable && running && strcmp(stripped_config, conn->background_compact.config) != 0)
-        WT_ERR_MSG(
-          session, EINVAL, "Cannot reconfigure background compaction while it's already running.");
+        WT_ERR_SUB(session, EINVAL, WT_COMPACTION_ALREADY_RUNNING,
+          "Cannot reconfigure background compaction while it's already running.");
 
     /* If we haven't changed states, we're done. */
     if (enable == running)

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -323,7 +323,8 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
         WT_ASSERT_ALWAYS(session, btree->max_upd_txn != WT_TXN_ABORTED,
           "Assert failure: session: %s: btree->max_upd_txn == WT_TXN_ABORTED", session->name);
         if (check_visibility && !__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
-            return (EBUSY);
+            WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,
+              "the table has uncommitted data and can not be dropped yet");
 
         /* Turn off eviction. */
         WT_RET(__wt_evict_file_exclusive_on(session));

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -53,6 +53,12 @@
         __wt_err(session, ret, __VA_ARGS__); \
         goto err;                            \
     } while (0)
+#define WT_ERR_SUB(session, v, sub_v, ...)                                          \
+    do {                                                                            \
+        ret = (v);                                                                  \
+        WT_IGNORE_RET(__wt_session_set_last_error(session, v, sub_v, __VA_ARGS__)); \
+        goto err;                                                                   \
+    } while (0)
 #define WT_ERR_TEST(a, v, keep) \
     do {                        \
         if (a) {                \
@@ -87,6 +93,12 @@
         int __ret = (v);                       \
         __wt_err(session, __ret, __VA_ARGS__); \
         return (__ret);                        \
+    } while (0)
+#define WT_RET_SUB(session, v, sub_v, ...)                                          \
+    do {                                                                            \
+        int __ret = (v);                                                            \
+        WT_IGNORE_RET(__wt_session_set_last_error(session, v, sub_v, __VA_ARGS__)); \
+        return (__ret);                                                             \
     } while (0)
 #define WT_RET_TEST(a, v) \
     do {                  \

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
         misc_tests/test_is_valid_sub_level_error.cpp
         misc_tests/test_intpack.cpp
         misc_tests/test_pow.cpp
+        misc_tests/test_msg_macros.cpp
         misc_tests/test_prepare_mod_sort.cpp
         misc_tests/test_reconciliation_tracking.cpp
         misc_tests/test_session_config.cpp

--- a/test/catch2/misc_tests/test_msg_macros.cpp
+++ b/test/catch2/misc_tests/test_msg_macros.cpp
@@ -1,0 +1,82 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+#include "wt_internal.h"
+#include "../wrappers/connection_wrapper.h"
+
+/*
+ * [wt_msg]: test_msg_macros.cpp
+ * Tests the macros for storing verbose information about the last error of the session.
+ */
+
+int
+test_wt_ret_sub(
+  WT_SESSION_IMPL *session_impl, int err, int sub_level_err, const char *err_msg_content)
+{
+    WT_RET_SUB(session_impl, err, sub_level_err, "%s", err_msg_content);
+}
+
+int
+test_wt_err_sub(
+  WT_SESSION_IMPL *session_impl, int err, int sub_level_err, const char *err_msg_content)
+{
+    WT_DECL_RET;
+    WT_ERR_SUB(session_impl, err, sub_level_err, "%s", err_msg_content);
+err:
+    return (ret);
+}
+
+TEST_CASE("Test WT_RET_SUB, WT_ERR_SUB macros", "[message_macros]")
+{
+    WT_CONNECTION *conn;
+    WT_SESSION *session;
+    WT_SESSION_IMPL *session_impl;
+    const char *err_msg_content;
+
+    connection_wrapper conn_wrapper = connection_wrapper(".", "create");
+    conn = conn_wrapper.get_wt_connection();
+    REQUIRE(conn->open_session(conn, NULL, NULL, &session) == 0);
+    session_impl = (WT_SESSION_IMPL *)session;
+
+    SECTION("Test WT_RET_SUB with initial values")
+    {
+        err_msg_content = "";
+        test_wt_ret_sub(session_impl, 0, WT_NONE, err_msg_content);
+        CHECK(session_impl->err_info.err == 0);
+        CHECK(session_impl->err_info.sub_level_err == WT_NONE);
+        CHECK(strcmp(session_impl->err_info.err_msg, err_msg_content) == 0);
+    }
+
+    SECTION("Test WT_ERR_SUB with initial values")
+    {
+        err_msg_content = "";
+        test_wt_err_sub(session_impl, 0, WT_NONE, err_msg_content);
+        CHECK(session_impl->err_info.err == 0);
+        CHECK(session_impl->err_info.sub_level_err == WT_NONE);
+        CHECK(strcmp(session_impl->err_info.err_msg, err_msg_content) == 0);
+    }
+
+    SECTION("Test WT_RET_SUB with EINVAL error WT_COMPACTION_ALREADY_RUNNING sub_level_error")
+    {
+        err_msg_content = "Some EINVAL error";
+        test_wt_ret_sub(session_impl, EINVAL, WT_COMPACTION_ALREADY_RUNNING, err_msg_content);
+        CHECK(session_impl->err_info.err == EINVAL);
+        CHECK(session_impl->err_info.sub_level_err == WT_COMPACTION_ALREADY_RUNNING);
+        CHECK(strcmp(session_impl->err_info.err_msg, err_msg_content) == 0);
+    }
+
+    SECTION("Test WT_ERR_SUB with EINVAL error WT_COMPACTION_ALREADY_RUNNING sub_level_error")
+    {
+        err_msg_content = "Some EINVAL error";
+        test_wt_err_sub(session_impl, EINVAL, WT_COMPACTION_ALREADY_RUNNING, err_msg_content);
+        CHECK(session_impl->err_info.err == EINVAL);
+        CHECK(session_impl->err_info.sub_level_err == WT_COMPACTION_ALREADY_RUNNING);
+        CHECK(strcmp(session_impl->err_info.err_msg, err_msg_content) == 0);
+    }
+}

--- a/test/suite/test_compact06.py
+++ b/test/suite/test_compact06.py
@@ -30,6 +30,7 @@ import time
 import wiredtiger
 from compact_util import compact_util
 from wiredtiger import stat
+import errno
 
 # test_compact06.py
 # Test background compaction API usage.
@@ -62,9 +63,12 @@ class test_compact06(compact_util):
 
         # We cannot reconfigure the background server.
         for item in self.configuration_items:
-            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-                self.session.compact(None, f'background=true,{item}'),
-                '/Cannot reconfigure background compaction while it\'s already running/')
+            self.assertRaisesException(wiredtiger.WiredTigerError, lambda:
+                self.session.compact(None, f'background=true,{item}'))
+            err, sub_level_err, err_msg = self.session.get_last_error()
+            self.assertEqual(err, errno.EINVAL)
+            self.assertEqual(sub_level_err, wiredtiger.WT_COMPACTION_ALREADY_RUNNING)
+            self.assertEqual(err_msg, "Cannot reconfigure background compaction while it's already running.")
 
         # Wait for background compaction to start and skip the HS.
         while self.get_bg_compaction_files_skipped() == 0:

--- a/test/suite/test_error_info.py
+++ b/test/suite/test_error_info.py
@@ -26,15 +26,75 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import errno
 import wiredtiger, wttest, time
 from wtdataset import SimpleDataSet
+from compact_util import compact_util
+
+import unittest
 
 # test_error_info.py
 #   Test that the placeholder get_last_error() session API returns placeholder error values.
-class test_error_info(wttest.WiredTigerTestCase):
+class test_error_info(compact_util):
+    table_name1 = 'table:test_error'
+
+    def check_error(self, error, sub_level_error, error_msg):
+        err, sub_level_err, err_msg = self.session.get_last_error()
+        self.assertEqual(err, error)
+        self.assertEqual(sub_level_err, sub_level_error)
+        self.assertEqual(err_msg, error_msg)
+
+    def test_compaction_already_running(self):
+        # Create a basic large table.
+        SimpleDataSet(self, self.table_name1, 1000, key_format='S', value_format='S').populate()
+
+        # Enable the background compaction server.
+        self.turn_on_bg_compact()
+
+        # Attempt to reconfigure.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: self.session.compact(None, f'background=true,free_space_target=10MB'))
+
+        # Expect error code, sub-error code and error message to reflect compaction already running.
+        self.check_error(errno.EINVAL, wiredtiger.WT_COMPACTION_ALREADY_RUNNING, "Cannot reconfigure background compaction while it's already running.")
+
+    def test_uncommitted_data(self):
+        # Create a simple table.
+        self.session.create(self.table_name1, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(self.table_name1)
+
+        # Start a transaction and insert a key and value.
+        self.session.begin_transaction()
+        cursor.set_key('key')
+        cursor.set_value('value')
+        self.assertEqual(cursor.update(), 0)
+        cursor.close()
+
+        # Attempt to drop the table without committing the transaction.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: self.session.drop(self.table_name1, None))
+
+        # Expect error code, sub-error code and error message to reflect uncommitted data.
+        self.check_error(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and can not be dropped yet")
+
+    def test_dirty_data(self):
+        # Create a simple table.
+        self.session.create(self.table_name1, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(self.table_name1)
+
+        # Start a transaction, insert a key and value, and commit the transaction.
+        self.session.begin_transaction()
+        cursor.set_key('key')
+        cursor.set_value('value')
+        self.assertEqual(cursor.update(), 0)
+        self.assertEqual(self.session.commit_transaction(), 0)
+        cursor.close()
+
+        time.sleep(1)
+
+        # Attempt to drop the table without performing a checkpoint.
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: self.session.drop(self.table_name1, None))
+
+        # Expect error code, sub-error code and error message to reflect dirty data.
+        self.check_error(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and can not be dropped yet")
 
     def test_error_info(self):
-        err, sub_level_err, err_msg = self.session.get_last_error()
-        self.assertEqual(err, 0)
-        self.assertEqual(sub_level_err, wiredtiger.WT_NONE)
-        self.assertEqual(err_msg, "")
+        self.check_error(0, wiredtiger.WT_NONE, "")


### PR DESCRIPTION
Created new macros WT_RET_SUB and WT_ERR_SUB and implemented use in three use cases (WT_COMPACTION_ALREADY_RUNNING, WT_UNCOMMITTED_DATA and WT_DIRTY_DATA).
