### PR TITLE
WT-13977 Re-enable Mac compiles on Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1329,11 +1329,13 @@ variables:
       # Must disable TCMALLOC as it may be picked up locally and its not on all hosts.
       ENABLE_TCMALLOC: 0
     tasks:
-      - name: compile
-      - name: make-check-test
-        # Use a special version of unit-test for macOS that checks for Python version consistency.
-      - name: unit-test-macos
-      - name: fops
+      # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - switch back to the 'compile' task.
+      - name: compile-no-upload
+      # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - enable these tests again.
+      #- name: make-check-test
+      # Use a special version of unit-test for macOS that checks for Python version consistency.
+      #- name: unit-test-macos
+      #- name: fops
       - name: memory-model-test-mac
         batchtime: 40320 # 28 days
 
@@ -1428,6 +1430,13 @@ tasks:
       - func: "get project"
       - func: "compile wiredtiger"
       - func: "upload artifact"
+      - func: "cleanup"
+
+  # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - remove this task.
+  - name: compile-no-upload
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
       - func: "cleanup"
 
   # production build with --disable-shared
@@ -5559,7 +5568,6 @@ buildvariants:
 - <<: *mac_test_template
   name: macos-14-arm64
   display_name: "macOS 14 (ARM64)"
-  patch_only: true
   run_on:
     - macos-14-arm64
   #batchtime: 120 # 2 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5570,7 +5570,7 @@ buildvariants:
   display_name: "macOS 14 (ARM64)"
   run_on:
     - macos-14-arm64
-  #batchtime: 120 # 2 hours
+  batchtime: 120 # 2 hours
   expansions:
     python_binary: '/Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11'
     python_config_search_string: '_Python3_EXECUTABLE'


### PR DESCRIPTION
Re-enable Mac compiles on Evergreen, but avoid uploading artefacts (which was causing the problem that stopped Mac builds), or running other tests as there are other issues to be tackled there. This PR will at least ensure that we go back to compiling on Macs and thereby avoid any Mac compiler incompatible code changes being made.

We'll get Mac tests working again, and re-enable artefact uploading, in later tickets.


