### PR TITLE
WT-13991 Remove spin lock from __wt_ckpt_session

### DIFF
--- a/src/checkpoint/checkpoint.h
+++ b/src/checkpoint/checkpoint.h
@@ -14,8 +14,6 @@
  *     Per-session checkpoint information.
  */
 struct __wt_ckpt_session {
-    WT_SPINLOCK lock; /* Checkpoint spinlock */
-
     uint64_t write_gen; /* Write generation override, during checkpoint cursor ops */
 
     /* Checkpoint handles */


### PR DESCRIPTION
This is dead code and therefore can be removed.