### PR TITLE
WT-13837 Set up code owners to guard backport PRs (#11340)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# All backports must be approved by the backport-approvers Github team.
+* @wiredtiger/backport-approvers
+
+# Exclude some test and non-functional folders from the backport approvals.
+bench/
+dist/
+test/
+tools/


### PR DESCRIPTION
The `.github/CODEOWNERS` file introduced in this PR coupled with a newly created
[backport-approvers](https://github.com/orgs/wiredtiger/teams/backport-approvers/members) Github team will enable one member of the team to be auto-assigned as a reviewer for backport PRs in a round-robin fashion to guard the PR merge, i.e. backport PRs without approval from one of backport-approvers won't be able to merge. This is in line with the [server backport review & approval
policy](https://wiki.corp.mongodb.com/display/KERNEL/Database+SERVER+Backports+Policy+and+Workflow#DatabaseSERVERBackportsPolicyandWorkflow-Approving/DecliningaBackport).

(cherry picked from commit 32bae8667150a1c23f9911424793857e4d8ee3b8)