### PR TITLE
SLS-554 Add checkpoint timestamp to PALI and to checkpoint metadata

### DIFF
--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -440,7 +440,7 @@ err:
  */
 static int
 palm_complete_checkpoint_ext(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t checkpoint_id,
-  const WT_ITEM *checkpoint_metadata, uint64_t *lsnp)
+  uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata, uint64_t *lsnp)
 {
     PALM *palm;
     PALM_KV_CONTEXT context;
@@ -472,8 +472,9 @@ palm_complete_checkpoint_ext(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_
         goto err;
     }
 
-    PALM_KV_ERR(
-      palm, session, palm_kv_put_checkpoint(&context, lsn, checkpoint_id, checkpoint_metadata));
+    PALM_KV_ERR(palm, session,
+      palm_kv_put_checkpoint(
+        &context, lsn, checkpoint_id, checkpoint_timestamp, checkpoint_metadata));
     PALM_KV_ERR(palm, session, palm_kv_put_global(&context, PALM_KV_GLOBAL_REVISION, lsn + 1));
     PALM_KV_ERR(palm, session, palm_kv_put_global(&context, PALM_KV_GLOBAL_CHECKPOINT_STARTED, 0));
     PALM_KV_ERR(palm, session,
@@ -496,7 +497,7 @@ err:
 static int
 palm_complete_checkpoint(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t checkpoint_id)
 {
-    return (palm_complete_checkpoint_ext(page_log, session, checkpoint_id, NULL, NULL));
+    return (palm_complete_checkpoint_ext(page_log, session, checkpoint_id, 0, NULL, NULL));
 }
 
 /*

--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -537,7 +537,8 @@ err:
  */
 static int
 palm_get_complete_checkpoint_ext(WT_PAGE_LOG *page_log, WT_SESSION *session,
-  uint64_t *checkpoint_lsn, uint64_t *checkpoint_id, WT_ITEM *checkpoint_metadata)
+  uint64_t *checkpoint_lsn, uint64_t *checkpoint_id, uint64_t *checkpoint_timestamp,
+  WT_ITEM *checkpoint_metadata)
 {
     PALM *palm;
     PALM_KV_CONTEXT context;
@@ -547,10 +548,12 @@ palm_get_complete_checkpoint_ext(WT_PAGE_LOG *page_log, WT_SESSION *session,
 
     metadata = NULL;
     metadata_len = 0;
-    if (checkpoint_id != NULL)
-        *checkpoint_id = 0;
     if (checkpoint_lsn != NULL)
         *checkpoint_lsn = 0;
+    if (checkpoint_id != NULL)
+        *checkpoint_id = 0;
+    if (checkpoint_timestamp != NULL)
+        *checkpoint_timestamp = 0;
     if (checkpoint_metadata != NULL)
         memset(checkpoint_metadata, 0, sizeof(WT_ITEM));
 
@@ -561,7 +564,7 @@ palm_get_complete_checkpoint_ext(WT_PAGE_LOG *page_log, WT_SESSION *session,
 
     PALM_KV_ERR(palm, session,
       palm_kv_get_last_checkpoint(
-        &context, checkpoint_lsn, checkpoint_id, &metadata, &metadata_len));
+        &context, checkpoint_lsn, checkpoint_id, checkpoint_timestamp, &metadata, &metadata_len));
     if (checkpoint_metadata != NULL) {
         PALM_KV_ERR(palm, session, palm_resize_item(checkpoint_metadata, metadata_len));
         memcpy(checkpoint_metadata->mem, metadata, metadata_len);

--- a/ext/page_log/palm/palm_kv.c
+++ b/ext/page_log/palm/palm_kv.c
@@ -531,7 +531,8 @@ palm_kv_put_checkpoint(PALM_KV_CONTEXT *context, uint64_t checkpoint_lsn, uint64
 
 int
 palm_kv_get_last_checkpoint(PALM_KV_CONTEXT *context, uint64_t *checkpoint_lsn,
-  uint64_t *checkpoint_id, void **checkpoint_metadata, size_t *checkpoint_metadata_size)
+  uint64_t *checkpoint_id, uint64_t *checkpoint_timestamp, void **checkpoint_metadata,
+  size_t *checkpoint_metadata_size)
 {
     CKPT_KEY ckpt_key;
     MDB_cursor *cursor;
@@ -556,10 +557,12 @@ palm_kv_get_last_checkpoint(PALM_KV_CONTEXT *context, uint64_t *checkpoint_lsn,
     ckpt_key = *(CKPT_KEY *)kval.mv_data;
     swap_ckpt_key(&ckpt_key, &ckpt_key);
 
-    if (checkpoint_id != NULL)
-        *checkpoint_id = ckpt_key.checkpoint_id;
     if (checkpoint_lsn != NULL)
         *checkpoint_lsn = ckpt_key.lsn;
+    if (checkpoint_id != NULL)
+        *checkpoint_id = ckpt_key.checkpoint_id;
+    if (checkpoint_timestamp != NULL)
+        *checkpoint_timestamp = ckpt_key.checkpoint_timestamp;
     if (checkpoint_metadata != NULL)
         *checkpoint_metadata = vval.mv_data;
     if (checkpoint_metadata_size != NULL)

--- a/ext/page_log/palm/palm_kv.c
+++ b/ext/page_log/palm/palm_kv.c
@@ -91,6 +91,7 @@ typedef struct CKPT_KEY {
      * rather than the data.
      */
     uint64_t checkpoint_id;
+    uint64_t checkpoint_timestamp;
 } CKPT_KEY;
 
 static bool palm_need_swap = true; /* TODO: derive this */
@@ -506,7 +507,7 @@ palm_kv_next_page_match(PALM_KV_PAGE_MATCHES *matches)
 
 int
 palm_kv_put_checkpoint(PALM_KV_CONTEXT *context, uint64_t checkpoint_lsn, uint64_t checkpoint_id,
-  const WT_ITEM *checkpoint_metadata)
+  uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata)
 {
     CKPT_KEY ckpt_key;
     MDB_val kval;
@@ -518,6 +519,7 @@ palm_kv_put_checkpoint(PALM_KV_CONTEXT *context, uint64_t checkpoint_lsn, uint64
 
     ckpt_key.lsn = checkpoint_lsn;
     ckpt_key.checkpoint_id = checkpoint_id;
+    ckpt_key.checkpoint_timestamp = checkpoint_timestamp;
     swap_ckpt_key(&ckpt_key, &ckpt_key);
 
     kval.mv_size = sizeof(ckpt_key);

--- a/ext/page_log/palm/palm_kv.h
+++ b/ext/page_log/palm/palm_kv.h
@@ -98,6 +98,6 @@ int palm_kv_get_page_matches(PALM_KV_CONTEXT *context, uint64_t table_id, uint64
   uint64_t lsn, uint64_t checkpoint_id, PALM_KV_PAGE_MATCHES *matchesp);
 bool palm_kv_next_page_match(PALM_KV_PAGE_MATCHES *matches);
 int palm_kv_put_checkpoint(PALM_KV_CONTEXT *context, uint64_t checkpoint_lsn,
-  uint64_t checkpoint_id, const WT_ITEM *checkpoint_metadata);
+  uint64_t checkpoint_id, uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata);
 int palm_kv_get_last_checkpoint(PALM_KV_CONTEXT *context, uint64_t *checkpoint_lsn,
   uint64_t *checkpoint_id, void **checkpoint_metadata, size_t *checkpoint_metadata_size);

--- a/ext/page_log/palm/palm_kv.h
+++ b/ext/page_log/palm/palm_kv.h
@@ -100,4 +100,5 @@ bool palm_kv_next_page_match(PALM_KV_PAGE_MATCHES *matches);
 int palm_kv_put_checkpoint(PALM_KV_CONTEXT *context, uint64_t checkpoint_lsn,
   uint64_t checkpoint_id, uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata);
 int palm_kv_get_last_checkpoint(PALM_KV_CONTEXT *context, uint64_t *checkpoint_lsn,
-  uint64_t *checkpoint_id, void **checkpoint_metadata, size_t *checkpoint_metadata_size);
+  uint64_t *checkpoint_id, uint64_t *checkpoint_timestamp, void **checkpoint_metadata,
+  size_t *checkpoint_metadata_size);

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -1219,6 +1219,10 @@ SIDESTEP_METHOD(__wt_page_log, pl_complete_checkpoint,
   (WT_SESSION *session, int checkpoint_id),
   (self, session, checkpoint_id))
 
+SIDESTEP_METHOD(__wt_page_log, pl_complete_checkpoint_ext,
+  (WT_SESSION *session, int checkpoint_id, uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata, uint64_t *lsnp),
+  (self, session, checkpoint_id, checkpoint_timestamp, checkpoint_metadata, lsnp))
+
 SIDESTEP_METHOD(__wt_page_log, pl_get_complete_checkpoint,
   (WT_SESSION *session, int *checkpoint_id),
   (self, session, checkpoint_id))

--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -167,7 +167,7 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
 
         WT_ERR(__wt_scr_alloc(session, 0, &buf));
         WT_ERR(__wt_buf_fmt(
-          session, buf, "%.*s\ntimestamp=%" PRIu64, (int)cval.len, cval.str, checkpoint_timestamp));
+          session, buf, "%.*s\ntimestamp=%" PRIx64, (int)cval.len, cval.str, checkpoint_timestamp));
         WT_ERR(
           __wt_disagg_put_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, checkpoint_id, buf, &lsn));
         WT_RELEASE_WRITE(conn->disaggregated_storage.last_checkpoint_meta_lsn, lsn);

--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -128,15 +128,14 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
     size_t len;
-    uint64_t checkpoint_id, lsn;
-    char *entry, *md_key;
+    uint64_t checkpoint_id, checkpoint_timestamp, lsn;
+    char *md_key;
     const char *md_value;
 
     block_disagg = (WT_BLOCK_DISAGG *)bm->block;
     conn = S2C(session);
 
     buf = NULL;
-    entry = NULL;
     md_cursor = NULL;
     md_key = NULL;
 
@@ -164,14 +163,11 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
     if (strcmp(block_disagg->name, WT_DISAGG_METADATA_FILE) == 0) {
         /* Get the config we want to print to the metadata file */
         WT_ERR(__wt_config_getones(session, md_value, "checkpoint", &cval));
+        checkpoint_timestamp = conn->disaggregated_storage.cur_checkpoint_timestamp;
 
-        len = cval.len + 1; /* +1 for the last byte */
-        WT_ERR(__wt_calloc_def(session, len, &entry));
-        WT_ERR(__wt_snprintf(entry, len, "%.*s", (int)cval.len, cval.str));
-
-        WT_ERR(__wt_scr_alloc(session, len, &buf));
-        memcpy(buf->mem, entry, len);
-        buf->size = len - 1;
+        WT_ERR(__wt_scr_alloc(session, 0, &buf));
+        WT_ERR(__wt_buf_fmt(
+          session, buf, "%.*s\ntimestamp=%" PRIu64, (int)cval.len, cval.str, checkpoint_timestamp));
         WT_ERR(
           __wt_disagg_put_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, checkpoint_id, buf, &lsn));
         WT_RELEASE_WRITE(conn->disaggregated_storage.last_checkpoint_meta_lsn, lsn);
@@ -232,7 +228,6 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
 err:
     __wt_scr_free(session, &buf);
     __wt_free(session, md_key);
-    __wt_free(session, entry); /* TODO may not have been allocated */
     if (md_cursor != NULL)
         WT_TRET(__wt_metadata_cursor_release(session, &md_cursor));
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -52,8 +52,8 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, uint64_
     WT_DECL_RET;
     WT_SESSION_IMPL *internal_session, *shared_metadata_session;
     size_t len, metadata_value_cfg_len;
-    uint64_t global_checkpoint_id;
-    char *buf, *cfg_ret, *metadata_value_cfg, *layered_ingest_uri;
+    uint64_t checkpoint_timestamp, global_checkpoint_id;
+    char *buf, *cfg_ret, *checkpoint_config, *metadata_value_cfg, *layered_ingest_uri;
     const char *cfg[3], *current_value, *metadata_key, *metadata_value;
 
     conn = S2C(session);
@@ -92,10 +92,21 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, uint64_
 
     /* Add the terminating zero byte to the end of the buffer. */
     len = item->size + 1;
-    WT_ERR(__wt_calloc_def(session, len, &buf));
+    WT_ERR(__wt_calloc_def(session, len, &buf)); /* This already zeroes out the buffer. */
     memcpy(buf, item->data, item->size);
-    buf[item->size] = '\0';
 
+    /* Parse out the checkpoint config string. */
+    checkpoint_config = strchr(buf, '\n');
+    if (checkpoint_config == NULL)
+        WT_ERR_MSG(session, EINVAL, "Invalid checkpoint metadata: No checkpoint config string");
+    *checkpoint_config = '\0';
+    checkpoint_config++;
+
+    /* Parse the checkpoint config. */
+    WT_ERR(__wt_config_getones(session, checkpoint_config, "timestamp", &cval));
+    checkpoint_timestamp = (uint64_t)cval.val;
+
+    /* Save the metadata key-value pair. */
     metadata_key = WT_DISAGG_METADATA_URI;
     metadata_value = buf;
 
@@ -213,6 +224,9 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, uint64_
      * are protected by the checkpoint lock.
      */
     WT_RELEASE_WRITE(conn->disaggregated_storage.global_checkpoint_id, checkpoint_id + 1);
+
+    /* Update the checkpoint timestamp. */
+    WT_RELEASE_WRITE(conn->disaggregated_storage.last_checkpoint_timestamp, checkpoint_timestamp);
 
 err:
     if (cursor != NULL)
@@ -1299,6 +1313,7 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
     WT_DECL_ITEM(meta);
     WT_DECL_RET;
     WT_DISAGGREGATED_STORAGE *disagg;
+    wt_timestamp_t checkpoint_timestamp;
     uint64_t checkpoint_id, meta_lsn;
 
     conn = S2C(session);
@@ -1313,6 +1328,7 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
 
     WT_ACQUIRE_READ(meta_lsn, conn->disaggregated_storage.last_checkpoint_meta_lsn);
     WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
+    WT_ACQUIRE_READ(checkpoint_timestamp, conn->disaggregated_storage.cur_checkpoint_timestamp);
     WT_ASSERT(session, meta_lsn > 0); /* The metadata page should be written by now. */
     WT_ASSERT(session, checkpoint_id >= WT_DISAGG_CHECKPOINT_ID_FIRST);
 
@@ -1328,9 +1344,12 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
              */
             WT_ERR(__wt_buf_fmt(
               session, meta, "id=%" PRIu64 ",metadata_lsn=%" PRIu64, checkpoint_id, meta_lsn));
-            WT_ERR(disagg->npage_log->page_log->pl_complete_checkpoint_ext(
-              disagg->npage_log->page_log, &session->iface, checkpoint_id, meta, NULL));
+            WT_ERR(
+              disagg->npage_log->page_log->pl_complete_checkpoint_ext(disagg->npage_log->page_log,
+                &session->iface, checkpoint_id, (uint64_t)checkpoint_timestamp, meta, NULL));
         }
+        WT_RELEASE_WRITE(
+          conn->disaggregated_storage.last_checkpoint_timestamp, checkpoint_timestamp);
     }
 
     WT_ERR(__wt_disagg_begin_checkpoint(session, checkpoint_id + 1));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -104,7 +104,10 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, uint64_
 
     /* Parse the checkpoint config. */
     WT_ERR(__wt_config_getones(session, checkpoint_config, "timestamp", &cval));
-    checkpoint_timestamp = (uint64_t)cval.val;
+    if (cval.len > 0 && cval.val == 0)
+        checkpoint_timestamp = WT_TS_NONE;
+    else
+        WT_ERR(__wt_txn_parse_timestamp(session, "checkpoint", &checkpoint_timestamp, &cval));
 
     /* Save the metadata key-value pair. */
     metadata_key = WT_DISAGG_METADATA_URI;

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -181,6 +181,9 @@ struct __wt_disaggregated_storage {
                                                  /* Updates are protected by the checkpoint lock. */
     wt_shared uint64_t last_checkpoint_meta_lsn; /* The LSN of the last checkpoint metadata. */
 
+    wt_timestamp_t cur_checkpoint_timestamp; /* The timestamp of the in-progress checkpoint. */
+    wt_shared wt_timestamp_t last_checkpoint_timestamp; /* The timestamp of the last checkpoint. */
+
     WT_NAMED_PAGE_LOG *npage_log;
     WT_PAGE_LOG_HANDLE *page_log_meta;
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5584,11 +5584,12 @@ struct __wt_page_log {
      * @param session the current WiredTiger session
      * @param checkpoint_id the checkpoint id to use. Must be greater than any other
      *        checkpoint_id used with this call.
+     * @param checkpoint_timestamp the stable timestamp associated with the checkpoint
      * @param checkpoint_metadata the buffer with checkpoint metadata
      * @param lsnp an optional output argument for the checkpoint completion record's LSN
      */
     int (*pl_complete_checkpoint_ext)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t checkpoint_id,
-         const WT_ITEM *checkpoint_metadata, uint64_t *lsnp);
+        uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata, uint64_t *lsnp);
 
     /*!
      * Get the most recent completed checkpoint number.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5572,7 +5572,8 @@ struct __wt_page_log {
      * @param checkpoint_id the checkpoint id to use. Must be greater than any other
      *        checkpoint_id used with this call.
      */
-    int (*pl_complete_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t checkpoint_id);
+    int (*pl_complete_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session,
+        uint64_t checkpoint_id);
 
     /*!
      * Complete checkpointing using the given checkpoint_id. This implies that other
@@ -5588,8 +5589,9 @@ struct __wt_page_log {
      * @param checkpoint_metadata the buffer with checkpoint metadata
      * @param lsnp an optional output argument for the checkpoint completion record's LSN
      */
-    int (*pl_complete_checkpoint_ext)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t checkpoint_id,
-        uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata, uint64_t *lsnp);
+    int (*pl_complete_checkpoint_ext)(WT_PAGE_LOG *page_log, WT_SESSION *session,
+        uint64_t checkpoint_id, uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata,
+        uint64_t *lsnp);
 
     /*!
      * Get the most recent completed checkpoint number.
@@ -5600,7 +5602,8 @@ struct __wt_page_log {
      * @param session the current WiredTiger session
      * @param checkpoint_id the checkpoint id returned
      */
-    int (*pl_get_complete_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t *checkpoint_id);
+    int (*pl_get_complete_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session,
+        uint64_t *checkpoint_id);
 
     /*!
      * Get information about the most recently completed checkpoint.
@@ -5611,10 +5614,12 @@ struct __wt_page_log {
      * @param session the current WiredTiger session
      * @param checkpoint_lsn the checkpoint LSN
      * @param checkpoint_id the checkpoint ID
+     * @param checkpoint_timestamp the checkpoint timestamp
      * @param checkpoint_metadata the checkpoint metadata
      */
-    int (*pl_get_complete_checkpoint_ext)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t *checkpoint_lsn,
-        uint64_t *checkpoint_id, WT_ITEM *checkpoint_metadata);
+    int (*pl_get_complete_checkpoint_ext)(WT_PAGE_LOG *page_log, WT_SESSION *session,
+        uint64_t *checkpoint_lsn, uint64_t *checkpoint_id, uint64_t *checkpoint_timestamp,
+        WT_ITEM *checkpoint_metadata);
 
     /*!
      * Get the most recently opened checkpoint number.
@@ -5625,7 +5630,8 @@ struct __wt_page_log {
      * @param session the current WiredTiger session
      * @param checkpoint_id the checkpoint id returned
      */
-    int (*pl_get_open_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t *checkpoint_id);
+    int (*pl_get_open_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session,
+        uint64_t *checkpoint_id);
 
     /*!
      * Open a handle for further operations on a table.
@@ -5637,7 +5643,8 @@ struct __wt_page_log {
      * @param table_id the unique table id for the given table
      * @param plh the returned handle
      */
-    int (*pl_open_handle)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t table_id, WT_PAGE_LOG_HANDLE **plh);
+    int (*pl_open_handle)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t table_id,
+        WT_PAGE_LOG_HANDLE **plh);
 
     /*!
      * A callback performed when the page log service or reference is closed

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -148,7 +148,7 @@ class DisaggConfigMixin:
 
     # Get the metadata about the last completed checkpoint
     def disagg_get_complete_checkpoint_meta(self, conn=None):
-        (_, _, m) = self.disagg_get_complete_checkpoint_ext(conn)
+        (_, _, _, m) = self.disagg_get_complete_checkpoint_ext(conn)
         return m
 
     # Get the currently open checkpoint
@@ -177,7 +177,7 @@ class DisaggConfigMixin:
         # Leader step down
         conn_leader.reconfigure(f'disaggregated=(role="follower")')
 
-        (_, complete_id, meta) = self.disagg_get_complete_checkpoint_ext(conn_leader)
+        (_, complete_id, _, meta) = self.disagg_get_complete_checkpoint_ext(conn_leader)
         self.assertGreater(complete_id, 0)
         open_id = self.disagg_get_open_checkpoint(conn_leader)
         if open_id == 0:

--- a/test/suite/test_layered15.py
+++ b/test/suite/test_layered15.py
@@ -208,7 +208,7 @@ class test_layered15(wttest.WiredTigerTestCase, DisaggConfigMixin):
         time.sleep(1)
         self.session.checkpoint()
         time.sleep(1)
-        (_, checkpoint_id, checkpoint_meta) = self.disagg_get_complete_checkpoint_ext()
+        (_, checkpoint_id, _, checkpoint_meta) = self.disagg_get_complete_checkpoint_ext()
 
         # Ensure that the shared metadata table has all the expected URIs after the checkpoint
         self.check_shared_metadata(self.all_uris)

--- a/test/suite/test_layered17.py
+++ b/test/suite/test_layered17.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, os.path, shutil, time, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered17.py
+#    Check timestamps.
+class test_layered17(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    nitems = 500
+
+    conn_base_config = 'layered_table_log=(enabled),statistics=(all),' \
+                     + 'statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'checkpoint=(precise=true),disaggregated=(stable_prefix=.,page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    create_session_config = 'key_format=S,value_format=S'
+
+    table_name = "test_layered17"
+
+    disagg_storages = gen_disagg_storages('test_layered17', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages, [
+        ('layered', dict(prefix='layered:')),
+        ('shared', dict(prefix='table:')),
+    ])
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    # Custom test case setup
+    def early_setup(self):
+        os.mkdir('follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+
+    # Test timestamps
+    def test_layered17(self):
+
+        # Create table
+        self.uri = self.prefix + self.table_name
+        table_config = self.create_session_config
+        if not self.uri.startswith('layered'):
+            table_config += ',block_manager=disagg,layered_table_log=(enabled=false),log=(enabled=false)'
+        self.session.create(self.uri, table_config)
+
+        #
+        # Phase 1: Add data at timestamp 100, stable timestamp 100
+        #
+
+        # Put data to the table
+        value_prefix1 = 'aaa'
+        timestamp1 = 100
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            cursor[str(i)] = value_prefix1 + str(i)
+            if i % 250 == 0:
+                time.sleep(1)
+        cursor.close()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(timestamp1)}')
+
+        time.sleep(1)
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(timestamp1)}')
+        self.session.checkpoint()
+        time.sleep(1)
+
+        # Check the timestamps
+        _, _, checkpoint_timestamp, _ = self.disagg_get_complete_checkpoint_ext()
+        self.assertEquals(timestamp1, checkpoint_timestamp)
+
+        # Create the follower
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + 'disaggregated=(role="follower")')
+        self.disagg_advance_checkpoint(conn_follow)
+        session_follow = conn_follow.open_session('')
+
+        # Check the table in the follower
+        cursor = session_follow.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            self.assertEquals(cursor[str(i)], value_prefix1 + str(i))
+        cursor.close()
+
+        #
+        # Phase 2: Add data at timestamp 200, stable timestamp 200
+        #
+
+        # Put more data to the table
+        value_prefix2 = 'bbb'
+        timestamp2 = 200
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 50 == 0:
+                cursor[str(i)] = value_prefix2 + str(i)
+            if i % 250 == 0:
+                time.sleep(1)
+        cursor.close()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(timestamp2)}')
+
+        time.sleep(1)
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(timestamp2)}')
+        self.session.checkpoint()
+        time.sleep(1)
+
+        # Check the timestamps
+        _, _, checkpoint_timestamp, _ = self.disagg_get_complete_checkpoint_ext()
+        self.assertEquals(timestamp2, checkpoint_timestamp)
+
+        # Pick up the new checkpoint
+        if not self.uri.startswith('layered'):
+            # FIXME-SLS-915: This should not require reopening the connection.
+            session_follow.close()
+            conn_follow.close()
+            conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + 'disaggregated=(role="follower")')
+            session_follow = conn_follow.open_session('')
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Check the table in the follower
+        cursor = session_follow.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 50 == 0:
+                self.assertEquals(cursor[str(i)], value_prefix2 + str(i))
+            else:
+                self.assertEquals(cursor[str(i)], value_prefix1 + str(i))
+        cursor.close()
+
+        #
+        # Phase 3: Add data at timestamp 300, stable timestamp 250
+        #
+
+        # Put more data to the table
+        value_prefix3 = 'ccc'
+        timestamp3 = 300
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 25 == 0:
+                cursor[str(i)] = value_prefix3 + str(i)
+            if i % 250 == 0:
+                time.sleep(1)
+        cursor.close()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(timestamp3)}')
+
+        time.sleep(1)
+        stable_timestamp3 = (timestamp2 + timestamp3) // 2
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(stable_timestamp3)}')
+        self.session.checkpoint()
+        time.sleep(1)
+
+        # Check the timestamps
+        _, _, checkpoint_timestamp, _ = self.disagg_get_complete_checkpoint_ext()
+        self.assertEquals(stable_timestamp3, checkpoint_timestamp)
+
+        # Pick up the new checkpoint
+        if not self.uri.startswith('layered'):
+            # FIXME-SLS-915: This should not require reopening the connection.
+            session_follow.close()
+            conn_follow.close()
+            conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + 'disaggregated=(role="follower")')
+            session_follow = conn_follow.open_session('')
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Check the table in the follower (should not see the latest changes)
+        cursor = session_follow.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 50 == 0:
+                self.assertEquals(cursor[str(i)], value_prefix2 + str(i))
+            else:
+                self.assertEquals(cursor[str(i)], value_prefix1 + str(i))
+        cursor.close()
+
+        session_follow.close()
+        conn_follow.close()


### PR DESCRIPTION
This PR adds the checkpoint timestamp to (1) PALI's {{pl_complete_checkpoint_ext}}, and (2) the disagg. struct in the connection struct. Picking up the checkpoint does NOT set the stable timestamp, as requested by a comment on the ticket.

Note that {{pl_complete_checkpoint}} will be deprecated after the server migrates to using the new variant with a different function signature. (We may also rename {{pl_complete_checkpoint_ext}} back to {{pl_complete_checkpoint}} at some later point.)