### PR TITLE
WT-13867 Add callback for user to abort optional eviction

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -104,7 +104,7 @@ source_meta = [
     Config('type', 'file', r'''
         set the type of data source used to store a column group, index or simple table.
         By default, a \c "file:" URI is derived from the object name. The \c type configuration
-        can be used to switch to a different data source or an extension configured by the 
+        can be used to switch to a different data source or an extension configured by the
         application'''),
 ]
 
@@ -447,7 +447,7 @@ connection_runtime_config = [
         min='1MB', max='10TB'),
     Config('cache_max_wait_ms', '0', r'''
         the maximum number of milliseconds an application thread will wait for space to be
-        available in cache before giving up. Default will wait forever''',
+        available in cache before giving up. Default or 0 will wait forever. 1 will never wait''',
         min=0),
     Config('cache_stuck_timeout_ms', '300000', r'''
         the number of milliseconds to wait before a stuck cache times out in diagnostic mode.
@@ -1098,7 +1098,7 @@ session_config = [
     Config('cache_max_wait_ms', '0', r'''
         the maximum number of milliseconds an application thread will wait for space to be
         available in cache before giving up. Default value will be the global setting of the
-        connection config''',
+        connection config. 0 will wait forever. 1 will never wait''',
         min=0),
     Config('ignore_cache_size', 'false', r'''
         when set, operations performed by this session ignore the cache size and are not blocked
@@ -1257,9 +1257,9 @@ wiredtiger_open_common =\
         type='boolean'),
     Config('write_through', '', r'''
         Use \c FILE_FLAG_WRITE_THROUGH on Windows to write to files. Ignored on non-Windows
-        systems. Options are given as a list, such as <code>"write_through=[data]"</code>. 
+        systems. Options are given as a list, such as <code>"write_through=[data]"</code>.
         Configuring \c write_through requires care; see @ref write_through
-        Including \c "data" will cause WiredTiger data files to write through cache, including 
+        Including \c "data" will cause WiredTiger data files to write through cache, including
         \c "log" will cause WiredTiger log files to write through
         cache.''',
         type='list', choices=['data', 'log']),
@@ -1965,7 +1965,7 @@ methods = {
     Config('threads', '4', r'''
         maximum number of threads WiredTiger will start to help RTS. Each
         RTS worker thread uses a session from the configured WT_RTS_MAX_WORKERS''',
-        min=0, 
+        min=0,
         max=10),     # !!! Must match WT_RTS_MAX_WORKERS
 ]),
 

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -776,6 +776,10 @@ conn_stats = [
     ##########################################
     # Yield statistics
     ##########################################
+    YieldStat('application_cache_busy_ops', 'application thread operations waiting for mandatory cache eviction'),
+    YieldStat('application_cache_busy_time', 'application thread time waiting for mandatory cache eviction (usecs)'),
+    YieldStat('application_cache_idle_ops', 'application thread operations waiting for cache eviction while idle'),
+    YieldStat('application_cache_idle_time', 'application thread time waiting for cache eviction while idle (usecs)'),
     YieldStat('application_cache_ops', 'application thread operations waiting for cache'),
     YieldStat('application_cache_time', 'application thread time waiting for cache (usecs)'),
     YieldStat('application_evict_snapshot_refreshed', 'application thread snapshot refreshed for eviction'),
@@ -1163,6 +1167,8 @@ session_stats = [
     SessionStat('bytes_read', 'bytes read into cache'),
     SessionStat('bytes_write', 'bytes written from cache'),
     SessionStat('cache_time', 'time waiting for cache (usecs)'),
+    SessionStat('cache_time_busy', 'time waiting for mandatory cache eviction (usecs)'),
+    SessionStat('cache_time_idle', 'time waiting for cache eviction while idle (usecs)'),
     SessionStat('lock_dhandle_wait', 'dhandle lock wait time (usecs)'),
     SessionStat('lock_schema_wait', 'schema lock wait time (usecs)'),
     SessionStat('read_time', 'page read from disk to cache time (usecs)'),

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -227,9 +227,12 @@ __wt_evict_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 
     /* Retrieve the wait time and convert from milliseconds */
     WT_RET(__wt_config_gets(session, cfg, "cache_max_wait_ms", &cval));
-    evict->cache_max_wait_us = cval.val > 1 ? (uint64_t)(cval.val * WT_THOUSAND) :
-      cval.val == 1                         ? 1 :
-                                              0;
+    if (cval.val > 1)
+        evict->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
+    else if (cval.val == 1)
+        evict->cache_max_wait_us = 1;
+    else
+        evict->cache_max_wait_us = 0;
 
     /* Retrieve the timeout value and convert from seconds */
     WT_RET(__wt_config_gets(session, cfg, "cache_stuck_timeout_ms", &cval));

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -227,7 +227,9 @@ __wt_evict_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 
     /* Retrieve the wait time and convert from milliseconds */
     WT_RET(__wt_config_gets(session, cfg, "cache_max_wait_ms", &cval));
-    evict->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
+    evict->cache_max_wait_us = cval.val > 1 ? (uint64_t)(cval.val * WT_THOUSAND) :
+      cval.val == 1                         ? 1 :
+                                              0;
 
     /* Retrieve the timeout value and convert from seconds */
     WT_RET(__wt_config_gets(session, cfg, "cache_stuck_timeout_ms", &cval));

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -599,9 +599,10 @@ __evict_check_user_ok_with_eviction(WT_SESSION_IMPL *session, bool busy)
     if (busy || F_ISSET(session, WT_SESSION_INTERNAL))
         return (true);
 
-    if (session->event_handler->handle_general != NULL &&
-      session->event_handler->handle_general(session->event_handler, &S2C(session)->iface,
-        &session->iface, WT_EVENT_EVICTION, NULL) != 0)
+    WT_EVENT_HANDLER *event_handler = session->event_handler;
+    if (event_handler->handle_general != NULL &&
+      event_handler->handle_general(
+        event_handler, &S2C(session)->iface, &session->iface, WT_EVENT_EVICTION, NULL) != 0)
         return (false);
 
     return (true);

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -588,6 +588,25 @@ __wti_evict_hs_dirty(WT_SESSION_IMPL *session)
       ((uint64_t)(conn->evict->eviction_dirty_trigger * bytes_max) / 100));
 }
 
+/*
+ * __evict_check_user_ok_with_eviction --
+ *     Check if the user wants to abort eviction in this session. #private
+ */
+static bool
+__evict_check_user_ok_with_eviction(WT_SESSION_IMPL *session, bool busy)
+{
+    /* Ask the user only if eviction is optional and it's a user session. */
+    if (busy || F_ISSET(session, WT_SESSION_INTERNAL))
+        return (true);
+
+    if (session->event_handler->handle_general != NULL &&
+      session->event_handler->handle_general(session->event_handler, &S2C(session)->iface,
+        &session->iface, WT_EVENT_EVICTION, NULL) != 0)
+        return (false);
+
+    return (true);
+}
+
 /* !!!
  * __wt_evict_app_assist_worker_check --
  *     Check if eviction trigger thresholds have reached to determine whether application threads
@@ -607,11 +626,6 @@ static WT_INLINE int
 __wt_evict_app_assist_worker_check(
   WT_SESSION_IMPL *session, bool busy, bool readonly, bool *didworkp)
 {
-    WT_BTREE *btree;
-    WT_TXN_GLOBAL *txn_global;
-    WT_TXN_SHARED *txn_shared;
-    double pct_full;
-
     if (didworkp != NULL)
         *didworkp = false;
 
@@ -623,6 +637,10 @@ __wt_evict_app_assist_worker_check(
     if (F_ISSET(session->txn, WT_TXN_PREPARE))
         return (0);
 
+    /* FIXME-WT-12905: Pre-fetch threads are not allowed to be pulled into eviction. */
+    if (F_ISSET(session, WT_SESSION_PREFETCH_THREAD))
+        return (0);
+
     /*
      * If the transaction is a checkpoint cursor transaction, don't try to evict. Because eviction
      * keeps the current transaction snapshot, and the snapshot in a checkpoint cursor transaction
@@ -632,14 +650,21 @@ __wt_evict_app_assist_worker_check(
     if (F_ISSET(session->txn, WT_TXN_IS_CHECKPOINT))
         return (0);
 
+    /* Setting cache_max_wait_us to 1 effectively means "disable eviction when possible" */
+    uint64_t cache_max_wait_us = session->cache_max_wait_us != 0 ?
+      session->cache_max_wait_us :
+      S2C(session)->evict->cache_max_wait_us;
+    if (cache_max_wait_us == 1)
+        return (0);
+
     /*
      * If the current transaction is keeping the oldest ID pinned, it is in the middle of an
      * operation. This may prevent the oldest ID from moving forward, leading to deadlock, so only
      * evict what we can. Otherwise, we are at a transaction boundary and we can work harder to make
      * sure there is free space in the cache.
      */
-    txn_global = &S2C(session)->txn_global;
-    txn_shared = WT_SESSION_TXN_SHARED(session);
+    WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
+    WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(session);
     busy = busy || __wt_atomic_loadv64(&txn_shared->id) != WT_TXN_NONE ||
       session->hazards.num_active > 0 ||
       (__wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE &&
@@ -666,12 +691,17 @@ __wt_evict_app_assist_worker_check(
      * problem. We also don't block while reading metadata because we're likely to be holding some
      * other resources that could block checkpoints or eviction.
      */
-    btree = S2BT_SAFE(session);
+    WT_BTREE *btree = S2BT_SAFE(session);
     if (btree != NULL && (F_ISSET(btree, WT_BTREE_IN_MEMORY) || WT_IS_METADATA(session->dhandle)))
         return (0);
 
     /* Check if eviction is needed. */
+    double pct_full;
     if (!__wt_evict_needed(session, busy, readonly, &pct_full))
+        return (0);
+
+    /* Last check if application wants to prevent the thread from evicting. */
+    if (!__evict_check_user_ok_with_eviction(session, busy))
         return (0);
 
     /*

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -614,13 +614,12 @@ __evict_check_user_ok_with_eviction(WT_SESSION_IMPL *session, bool busy)
  *     should assist eviction worker threads with eviction of pages from the queues.
  *
  *     Input parameters:
- *       (1) `busy`: A flag indicating if the session is actively pinning resources, in which
- *            case dirty trigger is ignored.
+ *       (1) `busy`: A flag indicating if eviction is mandatory (true) or optional (false).
  *       (2) `readonly`: A flag indicating if the session is read-only, in which case dirty and
  *            update triggers are ignored.
  *       (3) `didworkp`: A pointer to indicate whether eviction work was done (optional).
  *
- *     Return an  error code from `__wti_evict_app_assist_worker` if it is unable to perform
+ *     Return an error code from `__wti_evict_app_assist_worker` if it is unable to perform
  *     meaningful work (eviction cache stuck).
  */
 static WT_INLINE int

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2805,32 +2805,19 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
 int
 __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, double pct_full)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_EVICT *evict;
     WT_TRACK_OP_DECL;
-    WT_TXN_GLOBAL *txn_global;
-    WT_TXN_SHARED *txn_shared;
-    uint64_t cache_max_wait_us, initial_progress, max_progress;
-    uint64_t elapsed, time_start, time_stop;
-    bool app_thread;
 
     WT_TRACK_OP_INIT(session);
 
-    conn = S2C(session);
-    evict = conn->evict;
-    time_start = 0;
-    txn_global = &conn->txn_global;
-    txn_shared = WT_SESSION_TXN_SHARED(session);
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    WT_EVICT *evict = conn->evict;
+    uint64_t time_start = 0;
+    WT_TXN_GLOBAL *txn_global = &conn->txn_global;
+    WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(session);
 
-    if (session->cache_max_wait_us != 0)
-        cache_max_wait_us = session->cache_max_wait_us;
-    else
-        cache_max_wait_us = evict->cache_max_wait_us;
-
-    /* FIXME-WT-12905: Pre-fetch threads are not allowed to be pulled into eviction. */
-    if (F_ISSET(session, WT_SESSION_PREFETCH_THREAD))
-        goto done;
+    uint64_t cache_max_wait_us =
+      session->cache_max_wait_us != 0 ? session->cache_max_wait_us : evict->cache_max_wait_us;
 
     /*
      * Before we enter the eviction generation, make sure this session has a cached history store
@@ -2850,8 +2837,7 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
     __wt_evict_server_wake(session);
 
     /* Track how long application threads spend doing eviction. */
-    app_thread = !F_ISSET(session, WT_SESSION_INTERNAL);
-    if (app_thread)
+    if (!F_ISSET(session, WT_SESSION_INTERNAL))
         time_start = __wt_clock(session);
 
     /*
@@ -2859,7 +2845,7 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
      * namely, the busy return and empty eviction queue. We do not need the calling functions to
      * have to deal with internal eviction return codes.
      */
-    for (initial_progress = __wt_atomic_loadv64(&evict->eviction_progress);; ret = 0) {
+    for (uint64_t initial_progress = __wt_atomic_loadv64(&evict->eviction_progress);; ret = 0) {
         /*
          * If eviction is stuck, check if this thread is likely causing problems and should be
          * rolled back. Ignore if in recovery, those transactions can't be rolled back.
@@ -2884,13 +2870,13 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
          * Additionally we don't return rollback which could confuse the caller.
          */
         if (__wt_op_timer_fired(session))
-            break;
+            goto err;
 
         /* Check if we have exceeded the global or the session timeout for waiting on the cache. */
         if (time_start != 0 && cache_max_wait_us != 0) {
-            time_stop = __wt_clock(session);
+            uint64_t time_stop = __wt_clock(session);
             if (session->cache_wait_us + WT_CLOCKDIFF_US(time_stop, time_start) > cache_max_wait_us)
-                break;
+                goto err;
         }
 
         /*
@@ -2904,13 +2890,18 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
         if (!busy && __wt_atomic_loadv64(&txn_shared->pinned_id) != WT_TXN_NONE &&
           __wt_atomic_loadv64(&txn_global->current) != __wt_atomic_loadv64(&txn_global->oldest_id))
             busy = true;
-        max_progress = busy ? 5 : 20;
+        uint64_t max_progress = busy ? 5 : 20;
 
         /* See if eviction is still needed. */
         if (!__wt_evict_needed(session, busy, readonly, &pct_full) ||
           (pct_full < 100.0 &&
             (__wt_atomic_loadv64(&evict->eviction_progress) > initial_progress + max_progress)))
-            break;
+            goto err;
+
+        if (!__evict_check_user_ok_with_eviction(session, busy)) {
+            ret = WT_ERROR; /* Prevent from requesting a rollback in the err handler. */
+            goto err;
+        }
 
         /* Evict a page. */
         switch (ret = __evict_page(session, false)) {
@@ -2919,12 +2910,12 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
                 goto err;
         /* FALLTHROUGH */
         case EBUSY:
-            break;
+            break; /* Continue the loop. */
         case WT_NOTFOUND:
             /* Allow the queue to re-populate before retrying. */
             __wt_cond_wait(session, conn->evict_threads.wait_cond, 10 * WT_THOUSAND, NULL);
             evict->app_waits++;
-            break;
+            break; /* Continue the loop. */
         default:
             goto err;
         }
@@ -2932,8 +2923,8 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
 
 err:
     if (time_start != 0) {
-        time_stop = __wt_clock(session);
-        elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
+        uint64_t time_stop = __wt_clock(session);
+        uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
         WT_STAT_CONN_INCR(session, application_cache_ops);
         WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
         WT_STAT_SESSION_INCRV(session, cache_time, elapsed);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2898,10 +2898,9 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
             (__wt_atomic_loadv64(&evict->eviction_progress) > initial_progress + max_progress)))
             goto err;
 
-        if (!__evict_check_user_ok_with_eviction(session, busy)) {
-            ret = 0; /* This is a no-error exit. */
+        if (!__evict_check_user_ok_with_eviction(session, busy))
+            /* At this point ret can only be 0, so it's a clean exit from the loop. */
             goto err;
-        }
 
         /* Evict a page. */
         switch (ret = __evict_page(session, false)) {

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2801,6 +2801,8 @@ __evict_page(WT_SESSION_IMPL *session, bool is_server)
  * __wti_evict_app_assist_worker --
  *     Worker function for __wt_evict_app_assist_worker_check: evict pages if the cache crosses
  *     eviction trigger thresholds.
+ *
+ * The function returns an error code from either __evict_page or __wt_txn_is_blocking.
  */
 int
 __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, double pct_full)

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2899,7 +2899,7 @@ __wti_evict_app_assist_worker(WT_SESSION_IMPL *session, bool busy, bool readonly
             goto err;
 
         if (!__evict_check_user_ok_with_eviction(session, busy)) {
-            ret = WT_ERROR; /* Prevent from requesting a rollback in the err handler. */
+            ret = 0; /* This is a no-error exit. */
             goto err;
         }
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2928,6 +2928,15 @@ err:
         WT_STAT_CONN_INCR(session, application_cache_ops);
         WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
         WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
+        if (busy) {
+            WT_STAT_CONN_INCR(session, application_cache_busy_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_busy_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time_busy, elapsed);
+        } else {
+            WT_STAT_CONN_INCR(session, application_cache_idle_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_idle_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time_idle, elapsed);
+        }
         session->cache_wait_us += elapsed;
         /*
          * Check if a rollback is required only if there has not been an error. Returning an error

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1044,8 +1044,12 @@ struct __wt_connection_stats {
     int64_t thread_read_active;
     int64_t thread_write_active;
     int64_t application_cache_ops;
+    int64_t application_cache_idle_ops;
+    int64_t application_cache_busy_ops;
     int64_t application_evict_snapshot_refreshed;
     int64_t application_cache_time;
+    int64_t application_cache_idle_time;
+    int64_t application_cache_busy_time;
     int64_t txn_release_blocked;
     int64_t dhandle_lock_blocked;
     int64_t page_index_slot_ref_blocked;
@@ -1424,6 +1428,8 @@ struct __wt_session_stats {
     int64_t write_time;
     int64_t lock_schema_wait;
     int64_t cache_time;
+    int64_t cache_time_idle;
+    int64_t cache_time_busy;
 };
 
 /* Statistics section: END */

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6903,196 +6903,216 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1630
 /*! thread-yield: application thread operations waiting for cache */
 #define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1631
+/*!
+ * thread-yield: application thread operations waiting for cache eviction
+ * while idle
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_IDLE_OPS		1632
+/*!
+ * thread-yield: application thread operations waiting for mandatory
+ * cache eviction
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_BUSY_OPS		1633
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1632
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1634
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1633
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1635
+/*!
+ * thread-yield: application thread time waiting for cache eviction while
+ * idle (usecs)
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_IDLE_TIME	1636
+/*!
+ * thread-yield: application thread time waiting for mandatory cache
+ * eviction (usecs)
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_BUSY_TIME	1637
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1634
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1638
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1635
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1639
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1636
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1640
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1637
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1641
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1638
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1642
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1639
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1643
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1640
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1644
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1641
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1645
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1642
+#define	WT_STAT_CONN_PAGE_SLEEP				1646
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1643
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1647
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1644
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1648
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1645
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1649
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1646
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1650
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1647
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1651
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1648
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1652
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1649
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1653
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1650
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1654
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1651
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1655
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1652
+#define	WT_STAT_CONN_TXN_PREPARE			1656
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1653
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1657
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1654
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1658
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1655
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1659
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1656
+#define	WT_STAT_CONN_TXN_QUERY_TS			1660
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1657
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1661
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1658
+#define	WT_STAT_CONN_TXN_RTS				1662
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1659
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1663
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1660
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1664
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1661
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1665
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1662
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1666
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1663
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1667
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1664
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1668
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1665
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1669
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1666
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1670
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1667
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1671
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1668
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1672
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1669
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1673
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1670
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1674
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1671
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1675
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1672
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1676
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1673
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1677
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1674
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1678
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1675
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1679
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1676
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1680
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1677
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1681
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1678
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1682
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1679
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1683
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1680
+#define	WT_STAT_CONN_TXN_SET_TS				1684
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1681
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1685
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1682
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1686
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1683
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1687
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1684
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1688
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1685
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1689
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1686
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1690
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1687
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1691
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1688
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1692
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1689
+#define	WT_STAT_CONN_TXN_BEGIN				1693
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1690
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1694
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1691
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1695
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1692
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1696
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1693
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1697
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1694
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1698
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1695
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1699
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1696
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1700
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1697
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1701
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1698
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1702
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1699
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1703
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1700
+#define	WT_STAT_CONN_TXN_COMMIT				1704
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1701
+#define	WT_STAT_CONN_TXN_ROLLBACK			1705
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1702
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1706
 
 /*!
  * @}
@@ -8005,6 +8025,10 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4006
 /*! session: time waiting for cache (usecs) */
 #define	WT_STAT_SESSION_CACHE_TIME			4007
+/*! session: time waiting for cache eviction while idle (usecs) */
+#define	WT_STAT_SESSION_CACHE_TIME_IDLE			4008
+/*! session: time waiting for mandatory cache eviction (usecs) */
+#define	WT_STAT_SESSION_CACHE_TIME_BUSY			4009
 /*! @} */
 /*
  * Statistics section: END

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3358,7 +3358,8 @@ typedef enum {
     WT_EVENT_COMPACT_CHECK, /*!< Compact check iteration. */
     WT_EVENT_CONN_CLOSE,    /*!< Connection closing. */
     WT_EVENT_CONN_READY,    /*!< Connection is ready. */
-    WT_EVENT_EVICTION,      /*!< The user session is about to be involved into eviction. */
+    WT_EVENT_EVICTION,      /*!< The user session is about to be involved into eviction.
+                             *   Non-zero return code stops eviction loop. */
 } WT_EVENT_TYPE;
 
 /*!

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -3356,8 +3356,9 @@ const char *wiredtiger_strerror(int error) WT_ATTRIBUTE_LIBRARY_VISIBLE;
 /*! WT_EVENT_HANDLER::special event types */
 typedef enum {
     WT_EVENT_COMPACT_CHECK, /*!< Compact check iteration. */
-    WT_EVENT_CONN_CLOSE, /*!< Connection closing. */
-    WT_EVENT_CONN_READY /*!< Connection is ready. */
+    WT_EVENT_CONN_CLOSE,    /*!< Connection closing. */
+    WT_EVENT_CONN_READY,    /*!< Connection is ready. */
+    WT_EVENT_EVICTION,      /*!< The user session is about to be involved into eviction. */
 } WT_EVENT_TYPE;
 
 /*!

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -866,7 +866,8 @@ struct __wt_session {
      * default \c true.}
      * @config{cache_max_wait_ms, the maximum number of milliseconds an application thread will wait
      * for space to be available in cache before giving up.  Default value will be the global
-     * setting of the connection config., an integer greater than or equal to \c 0; default \c 0.}
+     * setting of the connection config.  0 will wait forever.  1 will never wait., an integer
+     * greater than or equal to \c 0; default \c 0.}
      * @config{debug = (, configure debug specific behavior on a session.  Generally only used for
      * internal testing purposes., a set of related configuration options defined as follows.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_fail_before_turtle_update, Fail before writing a
@@ -2070,8 +2071,8 @@ struct __wt_connection {
      * empty.}
      * @config{ ),,}
      * @config{cache_max_wait_ms, the maximum number of milliseconds an application thread will wait
-     * for space to be available in cache before giving up.  Default will wait forever., an integer
-     * greater than or equal to \c 0; default \c 0.}
+     * for space to be available in cache before giving up.  Default or 0 will wait forever.  1 will
+     * never wait., an integer greater than or equal to \c 0; default \c 0.}
      * @config{cache_overhead, assume the heap allocator overhead is the specified percentage\, and
      * adjust the cache usage by that amount (for example\, if there is 10GB of data in cache\, a
      * percentage of 10 means WiredTiger treats this as 11GB). This value is configurable because
@@ -2498,7 +2499,8 @@ struct __wt_connection {
      * default \c true.}
      * @config{cache_max_wait_ms, the maximum number of milliseconds an application thread will wait
      * for space to be available in cache before giving up.  Default value will be the global
-     * setting of the connection config., an integer greater than or equal to \c 0; default \c 0.}
+     * setting of the connection config.  0 will wait forever.  1 will never wait., an integer
+     * greater than or equal to \c 0; default \c 0.}
      * @config{debug = (, configure debug specific behavior on a session.  Generally only used for
      * internal testing purposes., a set of related configuration options defined as follows.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;checkpoint_fail_before_turtle_update, Fail before writing a
@@ -2856,8 +2858,8 @@ struct __wt_connection {
  * sessions created\, and can be overridden in configuring \c cache_cursors in
  * WT_CONNECTION.open_session., a boolean flag; default \c true.}
  * @config{cache_max_wait_ms, the maximum number of milliseconds an application thread will wait for
- * space to be available in cache before giving up.  Default will wait forever., an integer greater
- * than or equal to \c 0; default \c 0.}
+ * space to be available in cache before giving up.  Default or 0 will wait forever.  1 will never
+ * wait., an integer greater than or equal to \c 0; default \c 0.}
  * @config{cache_overhead, assume the heap allocator overhead is the specified percentage\, and
  * adjust the cache usage by that amount (for example\, if there is 10GB of data in cache\, a
  * percentage of 10 means WiredTiger treats this as 11GB). This value is configurable because

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -545,10 +545,14 @@ __session_config_int(WT_SESSION_IMPL *session, const char *config)
     }
     WT_RET_NOTFOUND_OK(ret);
 
-    if ((ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval)) == 0)
-        session->cache_max_wait_us = cval.val > 1 ? (uint64_t)(cval.val * WT_THOUSAND) :
-          cval.val == 1                           ? 1 :
-                                                    0;
+    if ((ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval)) == 0) {
+        if (cval.val > 1)
+            session->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
+        else if (cval.val == 1)
+            session->cache_max_wait_us = 1;
+        else
+            session->cache_max_wait_us = 0;
+    }
     WT_RET_NOTFOUND_OK(ret);
 
     return (0);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -546,7 +546,9 @@ __session_config_int(WT_SESSION_IMPL *session, const char *config)
     WT_RET_NOTFOUND_OK(ret);
 
     if ((ret = __wt_config_getones(session, config, "cache_max_wait_ms", &cval)) == 0)
-        session->cache_max_wait_us = (uint64_t)(cval.val * WT_THOUSAND);
+        session->cache_max_wait_us = cval.val > 1 ? (uint64_t)(cval.val * WT_THOUSAND) :
+          cval.val == 1                           ? 1 :
+                                                    0;
     WT_RET_NOTFOUND_OK(ret);
 
     return (0);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1971,8 +1971,12 @@ static const char *const __stats_connection_desc[] = {
   "thread-state: active filesystem read calls",
   "thread-state: active filesystem write calls",
   "thread-yield: application thread operations waiting for cache",
+  "thread-yield: application thread operations waiting for cache eviction while idle",
+  "thread-yield: application thread operations waiting for mandatory cache eviction",
   "thread-yield: application thread snapshot refreshed for eviction",
   "thread-yield: application thread time waiting for cache (usecs)",
+  "thread-yield: application thread time waiting for cache eviction while idle (usecs)",
+  "thread-yield: application thread time waiting for mandatory cache eviction (usecs)",
   "thread-yield: connection close blocked waiting for transaction state stabilization",
   "thread-yield: data handle lock yielded",
   "thread-yield: get reference for page index and slot time sleeping (usecs)",
@@ -2720,8 +2724,12 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing thread_read_active */
     /* not clearing thread_write_active */
     stats->application_cache_ops = 0;
+    stats->application_cache_idle_ops = 0;
+    stats->application_cache_busy_ops = 0;
     stats->application_evict_snapshot_refreshed = 0;
     stats->application_cache_time = 0;
+    stats->application_cache_idle_time = 0;
+    stats->application_cache_busy_time = 0;
     stats->txn_release_blocked = 0;
     stats->dhandle_lock_blocked = 0;
     stats->page_index_slot_ref_blocked = 0;
@@ -3545,9 +3553,13 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->thread_read_active += WT_STAT_CONN_READ(from, thread_read_active);
     to->thread_write_active += WT_STAT_CONN_READ(from, thread_write_active);
     to->application_cache_ops += WT_STAT_CONN_READ(from, application_cache_ops);
+    to->application_cache_idle_ops += WT_STAT_CONN_READ(from, application_cache_idle_ops);
+    to->application_cache_busy_ops += WT_STAT_CONN_READ(from, application_cache_busy_ops);
     to->application_evict_snapshot_refreshed +=
       WT_STAT_CONN_READ(from, application_evict_snapshot_refreshed);
     to->application_cache_time += WT_STAT_CONN_READ(from, application_cache_time);
+    to->application_cache_idle_time += WT_STAT_CONN_READ(from, application_cache_idle_time);
+    to->application_cache_busy_time += WT_STAT_CONN_READ(from, application_cache_busy_time);
     to->txn_release_blocked += WT_STAT_CONN_READ(from, txn_release_blocked);
     to->dhandle_lock_blocked += WT_STAT_CONN_READ(from, dhandle_lock_blocked);
     to->page_index_slot_ref_blocked += WT_STAT_CONN_READ(from, page_index_slot_ref_blocked);
@@ -3634,6 +3646,8 @@ static const char *const __stats_session_desc[] = {
   "session: page write from cache to disk time (usecs)",
   "session: schema lock wait time (usecs)",
   "session: time waiting for cache (usecs)",
+  "session: time waiting for cache eviction while idle (usecs)",
+  "session: time waiting for mandatory cache eviction (usecs)",
 };
 
 int
@@ -3661,4 +3675,6 @@ __wt_stat_session_clear_single(WT_SESSION_STATS *stats)
     stats->write_time = 0;
     stats->lock_schema_wait = 0;
     stats->cache_time = 0;
+    stats->cache_time_idle = 0;
+    stats->cache_time_busy = 0;
 }

--- a/test/catch2/misc_tests/test_session_config.cpp
+++ b/test/catch2/misc_tests/test_session_config.cpp
@@ -88,8 +88,13 @@ TEST_CASE("cache_max_wait_ms", "[session_config]")
 
     /*
      * WiredTiger config strings accept negative values, but the session variable is a uint64_t.
-     * Overflow is allowed.
      */
     REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=-1") == 0);
-    REQUIRE(session->cache_max_wait_us == 0xfffffffffffffc18);
+    REQUIRE(session->cache_max_wait_us == 0);
+
+    /*
+     * Special treatment of a special value 1.
+     */
+    REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=1") == 0);
+    REQUIRE(session->cache_max_wait_us == 1);
 }

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -371,3 +371,11 @@ define_c_test(
     # This test takes over 15 minutes under TSan testing
     LABEL "long_running"
 )
+
+define_c_test(
+    TARGET wt13867_interrupt_eviction_handler
+    SOURCES wt13867_interrupt_eviction_handler/main.c
+    DIR_NAME wt13867_interrupt_eviction_handler
+    ARGUMENTS
+    DEPENDS "WT_POSIX"
+)

--- a/test/csuite/wt13867_interrupt_eviction_handler/main.c
+++ b/test/csuite/wt13867_interrupt_eviction_handler/main.c
@@ -207,7 +207,7 @@ redo1:
 redo2:
     do_interrupt_eviction = true;
     handle_general_called = false;
-    populate(session, WRITE_CYCLES);
+    populate(session, WRITE_CYCLES * cycle);
 
     GET_ALL_STATS(2);
     if (cache_busy_ops2 - cache_busy_ops1 < MIN_CACHE_OPS) {

--- a/test/csuite/wt13867_interrupt_eviction_handler/main.c
+++ b/test/csuite/wt13867_interrupt_eviction_handler/main.c
@@ -31,7 +31,7 @@
 #include <signal.h>
 
 /*
- * This test verifies that eviction can be iunterrupted.
+ * This test verifies that eviction can be interrupted.
  */
 #define NUM_RECORDS (10000)
 #define WRITE_CYCLES (40000)
@@ -77,59 +77,45 @@ handle_general(WT_EVENT_HANDLER *handler, WT_CONNECTION *conn, WT_SESSION *sessi
 }
 
 static WT_EVENT_HANDLER event_handler = {
-  NULL, NULL,            /* Message handlers */
-  NULL,                  /* Progress handler */
-  NULL,                  /* Close handler */
-  handle_general         /* General handler */
+  NULL, NULL,    /* Message handlers */
+  NULL,          /* Progress handler */
+  NULL,          /* Close handler */
+  handle_general /* General handler */
 };
 
-#define GET_STAT(KEY, VARIABLE) do { \
-    const char *desc, *pvalue; \
-    stat->set_key(stat, KEY); \
-    testutil_check(stat->search(stat)); \
-    testutil_check(stat->get_value(stat, &desc, &pvalue, &VARIABLE)); \
-    printf("%s = %" PRId64 "\n", #KEY, VARIABLE); \
-} while (0)
+#define GET_STAT(KEY, VARIABLE)                                           \
+    do {                                                                  \
+        const char *desc, *pvalue;                                        \
+        stat->set_key(stat, KEY);                                         \
+        testutil_check(stat->search(stat));                               \
+        testutil_check(stat->get_value(stat, &desc, &pvalue, &VARIABLE)); \
+        printf("%s = %" PRId64 "\n", #KEY, VARIABLE);                     \
+    } while (0)
 
-#define GET_STATS( \
-    CACHE_OPS_VAR, \
-    CACHE_TIME_VAR, \
-    CACHE_BUSY_OPS_VAR, \
-    CACHE_BUSY_TIME_VAR, \
-    CACHE_IDLE_OPS_VAR, \
-    CACHE_IDLE_TIME_VAR, \
-    BYTES_MAX_VAR, \
-    BYTES_INUSE_VAR \
-) do { \
-    WT_CURSOR *stat; \
-    testutil_check(session->open_cursor(session, "statistics:", NULL, NULL, &stat)); \
-    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_OPS, CACHE_OPS_VAR); \
-    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_TIME, CACHE_TIME_VAR); \
-    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_BUSY_OPS, CACHE_BUSY_OPS_VAR); \
-    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_BUSY_TIME, CACHE_BUSY_TIME_VAR); \
-    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_IDLE_OPS, CACHE_IDLE_OPS_VAR); \
-    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_IDLE_TIME, CACHE_IDLE_TIME_VAR); \
-    GET_STAT(WT_STAT_CONN_CACHE_BYTES_MAX, BYTES_MAX_VAR); \
-    GET_STAT(WT_STAT_CONN_CACHE_BYTES_INUSE, BYTES_INUSE_VAR); \
-    testutil_check(stat->close(stat)); \
-} while (0)
+#define GET_STATS(CACHE_OPS_VAR, CACHE_TIME_VAR, CACHE_BUSY_OPS_VAR, CACHE_BUSY_TIME_VAR, \
+  CACHE_IDLE_OPS_VAR, CACHE_IDLE_TIME_VAR, BYTES_MAX_VAR, BYTES_INUSE_VAR)                \
+    do {                                                                                  \
+        WT_CURSOR *stat;                                                                  \
+        testutil_check(session->open_cursor(session, "statistics:", NULL, NULL, &stat));  \
+        GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_OPS, CACHE_OPS_VAR);                      \
+        GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_TIME, CACHE_TIME_VAR);                    \
+        GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_BUSY_OPS, CACHE_BUSY_OPS_VAR);            \
+        GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_BUSY_TIME, CACHE_BUSY_TIME_VAR);          \
+        GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_IDLE_OPS, CACHE_IDLE_OPS_VAR);            \
+        GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_IDLE_TIME, CACHE_IDLE_TIME_VAR);          \
+        GET_STAT(WT_STAT_CONN_CACHE_BYTES_MAX, BYTES_MAX_VAR);                            \
+        GET_STAT(WT_STAT_CONN_CACHE_BYTES_INUSE, BYTES_INUSE_VAR);                        \
+        testutil_check(stat->close(stat));                                                \
+    } while (0)
 
-#define GET_ALL_STATS(IDX) \
-    printf("  Stats for cycle %d:\n", IDX); \
-    int64_t cache_ops##IDX, cache_time##IDX; \
-    int64_t cache_busy_ops##IDX, cache_busy_time##IDX; \
-    int64_t cache_idle_ops##IDX, cache_idle_time##IDX; \
-    int64_t cache_bytes_max##IDX, cache_bytes_inuse##IDX; \
-    GET_STATS( \
-        cache_ops##IDX, \
-        cache_time##IDX, \
-        cache_busy_ops##IDX, \
-        cache_busy_time##IDX, \
-        cache_idle_ops##IDX, \
-        cache_idle_time##IDX, \
-        cache_bytes_max##IDX, \
-        cache_bytes_inuse##IDX \
-    )
+#define GET_ALL_STATS(IDX)                                                                \
+    printf("  Stats for cycle %d:\n", IDX);                                               \
+    int64_t cache_ops##IDX, cache_time##IDX;                                              \
+    int64_t cache_busy_ops##IDX, cache_busy_time##IDX;                                    \
+    int64_t cache_idle_ops##IDX, cache_idle_time##IDX;                                    \
+    int64_t cache_bytes_max##IDX, cache_bytes_inuse##IDX;                                 \
+    GET_STATS(cache_ops##IDX, cache_time##IDX, cache_busy_ops##IDX, cache_busy_time##IDX, \
+      cache_idle_ops##IDX, cache_idle_time##IDX, cache_bytes_max##IDX, cache_bytes_inuse##IDX)
 
 /*
  * populate --

--- a/test/csuite/wt13867_interrupt_eviction_handler/main.c
+++ b/test/csuite/wt13867_interrupt_eviction_handler/main.c
@@ -1,0 +1,259 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+#include <sys/wait.h>
+#include <signal.h>
+
+/*
+ * This test verifies that eviction can be iunterrupted.
+ */
+#define NUM_RECORDS (10000)
+#define WRITE_CYCLES (40000)
+#define MIN_CACHE_OPS (100)
+
+/* The table URI. */
+#define TABLE_URI "table:evict"
+
+/* Constants and variables declaration. */
+static const char conn_config[] = "create,cache_size=1MB,statistics=(all)";
+static const char table_config[] =
+  "allocation_size=4KB,leaf_page_max=4KB,key_format=Q,value_format=" WT_UNCHECKED_STRING(QS);
+
+static char data_str[WT_KILOBYTE] = "";
+
+static bool do_interrupt_eviction = false;
+static bool handle_general_called = false;
+
+static WT_SESSION *my_session;
+
+/*
+ * handle_general --
+ *     General event handler.
+ */
+static int
+handle_general(WT_EVENT_HANDLER *handler, WT_CONNECTION *conn, WT_SESSION *session,
+  WT_EVENT_TYPE type, void *arg)
+{
+    (void)(handler);
+    (void)(conn);
+    (void)(session);
+    (void)(arg);
+
+    if (type != WT_EVENT_EVICTION)
+        return (0);
+
+    /* Make sure we only get called for our session - not any internal one. */
+    testutil_assert(session == my_session);
+
+    handle_general_called = true;
+
+    return (do_interrupt_eviction ? -1 : 0);
+}
+
+static WT_EVENT_HANDLER event_handler = {
+  NULL, NULL,            /* Message handlers */
+  NULL,                  /* Progress handler */
+  NULL,                  /* Close handler */
+  handle_general         /* General handler */
+};
+
+#define GET_STAT(KEY, VARIABLE) do { \
+    const char *desc, *pvalue; \
+    stat->set_key(stat, KEY); \
+    testutil_check(stat->search(stat)); \
+    testutil_check(stat->get_value(stat, &desc, &pvalue, &VARIABLE)); \
+    printf("%s = %" PRId64 "\n", #KEY, VARIABLE); \
+} while (0)
+
+#define GET_STATS( \
+    CACHE_OPS_VAR, \
+    CACHE_TIME_VAR, \
+    CACHE_BUSY_OPS_VAR, \
+    CACHE_BUSY_TIME_VAR, \
+    CACHE_IDLE_OPS_VAR, \
+    CACHE_IDLE_TIME_VAR, \
+    BYTES_MAX_VAR, \
+    BYTES_INUSE_VAR \
+) do { \
+    WT_CURSOR *stat; \
+    testutil_check(session->open_cursor(session, "statistics:", NULL, NULL, &stat)); \
+    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_OPS, CACHE_OPS_VAR); \
+    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_TIME, CACHE_TIME_VAR); \
+    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_BUSY_OPS, CACHE_BUSY_OPS_VAR); \
+    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_BUSY_TIME, CACHE_BUSY_TIME_VAR); \
+    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_IDLE_OPS, CACHE_IDLE_OPS_VAR); \
+    GET_STAT(WT_STAT_CONN_APPLICATION_CACHE_IDLE_TIME, CACHE_IDLE_TIME_VAR); \
+    GET_STAT(WT_STAT_CONN_CACHE_BYTES_MAX, BYTES_MAX_VAR); \
+    GET_STAT(WT_STAT_CONN_CACHE_BYTES_INUSE, BYTES_INUSE_VAR); \
+    testutil_check(stat->close(stat)); \
+} while (0)
+
+#define GET_ALL_STATS(IDX) \
+    printf("  Stats for cycle %d:\n", IDX); \
+    int64_t cache_ops##IDX, cache_time##IDX; \
+    int64_t cache_busy_ops##IDX, cache_busy_time##IDX; \
+    int64_t cache_idle_ops##IDX, cache_idle_time##IDX; \
+    int64_t cache_bytes_max##IDX, cache_bytes_inuse##IDX; \
+    GET_STATS( \
+        cache_ops##IDX, \
+        cache_time##IDX, \
+        cache_busy_ops##IDX, \
+        cache_busy_time##IDX, \
+        cache_idle_ops##IDX, \
+        cache_idle_time##IDX, \
+        cache_bytes_max##IDX, \
+        cache_bytes_inuse##IDX \
+    )
+
+/*
+ * populate --
+ *     Populate the table.
+ */
+static void
+populate(WT_SESSION *session, uint64_t count)
+{
+    WT_CURSOR *cursor;
+    WT_RAND_STATE rnd;
+
+    /* Use a static seed for better reproducible results. */
+    __wt_random_init_custom_seed(&rnd, 0);
+
+    uint64_t str_len = sizeof(data_str) / sizeof(data_str[0]);
+    for (uint64_t i = 0; i < str_len - 1; i++)
+        data_str[i] = 'a' + (uint32_t)__wt_random(&rnd) % 26;
+    data_str[str_len - 1] = '\0';
+
+    testutil_check(session->open_cursor(session, TABLE_URI, NULL, NULL, &cursor));
+
+    for (uint64_t i = 0; i < count; ++i) {
+        uint64_t val = (uint64_t)__wt_random(&rnd);
+        /* Populate random keys so that we don't have a single hot page. */
+        cursor->set_key(cursor, (uint64_t)__wt_random(&rnd) % NUM_RECORDS);
+        cursor->set_value(cursor, val, data_str);
+        testutil_check(cursor->insert(cursor));
+    }
+
+    testutil_check(cursor->close(cursor));
+}
+
+/*
+ * main --
+ *     The main method.
+ */
+int
+main(int argc, char *argv[])
+{
+    TEST_OPTS *opts, _opts;
+    WT_CONNECTION *conn;
+    WT_SESSION *session;
+    char home[1024];
+
+    opts = &_opts;
+    memset(opts, 0, sizeof(*opts));
+    testutil_check(testutil_parse_opts(argc, argv, opts));
+
+    /* Initialize database. */
+
+    testutil_work_dir_from_path(home, sizeof(home), "WT_TEST.evict-abort");
+    testutil_recreate_dir(home);
+
+    testutil_check(wiredtiger_open(home, &event_handler, conn_config, &conn));
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    my_session = session;
+    testutil_check(session->create(session, TABLE_URI, table_config));
+
+    /* Do operations without blocking eviction. */
+
+    uint64_t cycle = 1;
+redo1:
+    handle_general_called = false;
+    populate(session, WRITE_CYCLES * cycle);
+
+    GET_ALL_STATS(1);
+    if (cache_busy_ops1 < MIN_CACHE_OPS || cache_idle_ops1 < MIN_CACHE_OPS) {
+        /* If we didn't do enough cache operations, do more. */
+        cycle *= 2;
+        goto redo1;
+    }
+
+    /* Sanity checks. */
+    testutil_assert(handle_general_called);
+    testutil_assert(cache_ops1 > 0);
+    testutil_assert(cache_time1 > 0);
+    testutil_assert(cache_bytes_max1 > 0);
+    testutil_assert(cache_bytes_inuse1 > 0);
+
+    /* Both idle and busy counters should increase. */
+    testutil_assert(cache_busy_ops1 + cache_idle_ops1 == cache_ops1);
+    testutil_assert(cache_busy_time1 + cache_idle_time1 == cache_time1);
+
+    printf("Cache fill ratio = %" PRId64 "%%\n", cache_bytes_inuse1 * 100 / cache_bytes_max1);
+
+    /* Do operations blocking eviction. */
+
+    cycle = 1;
+redo2:
+    do_interrupt_eviction = true;
+    handle_general_called = false;
+    populate(session, WRITE_CYCLES);
+
+    GET_ALL_STATS(2);
+    if (cache_busy_ops2 - cache_busy_ops1 < MIN_CACHE_OPS) {
+        /* If we didn't do enough cache operations, do more. */
+        cycle *= 2;
+        goto redo2;
+    }
+
+    /* Sanity checks. */
+    testutil_assert(handle_general_called);
+    testutil_assert(cache_ops2 - cache_ops1 > 0);
+    testutil_assert(cache_time2 - cache_time1 > 0);
+    testutil_assert(cache_bytes_max2 > 0);
+    testutil_assert(cache_bytes_inuse2 > 0);
+
+    /* Busy counters should increase. */
+    testutil_assert(cache_busy_ops2 - cache_busy_ops1 > 0);
+    testutil_assert(cache_busy_time2 - cache_busy_time1 > 0);
+    /* Idle counters should remain the same. */
+    testutil_assert(cache_idle_ops2 - cache_idle_ops1 == 0);
+    testutil_assert(cache_idle_time2 - cache_idle_time1 == 0);
+
+    printf("Cache fill ratio = %" PRId64 "%%\n", cache_bytes_inuse2 * 100 / cache_bytes_max2);
+
+    /* Finish the test and clean up. */
+
+    do_interrupt_eviction = false;
+    testutil_check(session->close(session, NULL));
+    testutil_check(conn->close(conn, NULL));
+
+    if (!opts->preserve)
+        testutil_remove(home);
+    testutil_cleanup(opts);
+    return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
Add callback for user to abort optional eviction.

The `handle_general` callback is called with the event type `WT_EVENT_EVICTION` whenever a user thread is about to evict a page. If the callback returns an error (nonzero), the eviction helper loop will break as soon as the current page eviction is completed. We never interrupt a page eviction midway but can interrupt the loop that iterates through pages for eviction.

This PR also adds new statistics alongside the existing connection-level stats (`application_cache_ops`, `application_cache_time`) and session-level stats (`cache_time`). The new stats differentiate between "idle" and "busy" modes, which can also be understood as "optional" and "mandatory" eviction:
- Idle/Optional Eviction: When application threads assist eviction workers as a secondary activity that isn’t required for the requested operation.
- Busy/Mandatory Eviction: When an application thread must perform eviction to complete the requested operation.

The eviction blocking mechanism via `handle_general` only applies to "optional" eviction.

These stats provide insights into the trade-off between throughput and latency. While involving user threads in optional eviction increases overall throughput, it can cause latency spikes in individual operations.