### PR TITLE
Revert "WT-13893 Convert RuntimeError to TypeError in test_autclose.py for macOS"

### DIFF
--- a/test/suite/test_autoclose.py
+++ b/test/suite/test_autoclose.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import sys, wttest
+import wttest
 
 # test_autoclose
 class test_autoclose(wttest.WiredTigerTestCase):
@@ -36,9 +36,6 @@ class test_autoclose(wttest.WiredTigerTestCase):
     handles are also closed.
     """
     uri = 'table:test_autoclose'
-    # Note: SWIG generates a TypeError instead of a RuntimeError for several cases.
-    # The same error on all platforms would be better.
-    expected_exception = TypeError if sys.platform.startswith('darwin') else RuntimeError
 
     def create_table(self):
         self.session.create(self.uri,
@@ -60,7 +57,7 @@ class test_autoclose(wttest.WiredTigerTestCase):
         inscursor = self.open_cursor()
         inscursor['key1'] = 'value1'
         inscursor.close()
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(RuntimeError,
                                        lambda: inscursor.next(),
                                        '/wt_cursor.* is None/')
         self.drop_table()
@@ -75,7 +72,7 @@ class test_autoclose(wttest.WiredTigerTestCase):
         inscursor = self.open_cursor()
         inscursor['key1'] = 'value1'
         self.session.close()
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(RuntimeError,
                                        lambda: inscursor.next(),
                                        '/wt_cursor.* is None/')
         self.close_conn()
@@ -89,7 +86,7 @@ class test_autoclose(wttest.WiredTigerTestCase):
         inscursor = self.open_cursor()
         inscursor['key1'] = 'value1'
         self.close_conn()
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(RuntimeError,
                                        lambda: inscursor.next(),
                                        '/wt_cursor.* is None/')
 
@@ -120,12 +117,14 @@ class test_autoclose(wttest.WiredTigerTestCase):
         inscursor2 = self.session.open_cursor(None, inscursor, None)
         inscursor.compare(inscursor2)
 
+        # Note: SWIG generates a TypeError in this case.
+        # A RuntimeError to match the other cases would be better.
         inscursor2.close()
         self.assertRaises(TypeError,
                           lambda: inscursor.compare(inscursor2))
 
         inscursor2 = None
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(RuntimeError,
                                        lambda: inscursor.compare(inscursor2),
                                        '/wt_cursor.* is None/')
 
@@ -134,7 +133,7 @@ class test_autoclose(wttest.WiredTigerTestCase):
         Use a session handle after it is explicitly closed.
         """
         self.session.close()
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(RuntimeError,
                                        lambda: self.create_table(),
                                        '/wt_session.* is None/')
         self.close_conn()
@@ -144,7 +143,7 @@ class test_autoclose(wttest.WiredTigerTestCase):
         Use a session handle after the connection is closed.
         """
         self.close_conn()
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(RuntimeError,
                                        lambda: self.create_table(),
                                        '/wt_session.* is None/')
 
@@ -154,6 +153,6 @@ class test_autoclose(wttest.WiredTigerTestCase):
         """
         conn = self.conn
         self.close_conn()
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(RuntimeError,
                                        lambda: conn.open_session(None),
                                        '/wt_connection.* is None/')


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#11429
Reverting, I found more tests failing for the same reason.