### PR TITLE
SLS-984 Ignore RTS message for disaggregated hook.

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2207,6 +2207,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
+          # The absolute minimum test to make sure that the hook works.
           unit_test_args: -v 2 --hook disagg base01
 
   - name: unit-test-hook-tiered

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2200,7 +2200,7 @@ tasks:
           unit_test_args: -v 2 -R cursor13 join02 join07 schema03 timestamp22
 
   - name: unit-test-hook-disagg
-    tags: ["python"]
+    tags: ["pull_request", "python"]
     depends_on:
     - name: compile
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2199,6 +2199,16 @@ tasks:
         vars:
           unit_test_args: -v 2 -R cursor13 join02 join07 schema03 timestamp22
 
+  - name: unit-test-hook-disagg
+    tags: ["python"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 --hook disagg base01
+
   - name: unit-test-hook-tiered
     tags: ["python"]
     depends_on:
@@ -5555,6 +5565,7 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: unit-test-zstd
     - name: unit-test-random-seed
+    - name: unit-test-hook-disagg
     - name: unit-test-hook-tiered
     - name: unit-test-hook-tiered-with-delays
     - name: unit-test-hook-tiered-timestamp

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-import datetime, inspect, os, random, wiredtiger
+import datetime, functools, inspect, os, random, wiredtiger
 
 # These routines help run the various page log sources used by disaggregated storage.
 # They are required to manage the generation of disaggregated storage specific configurations.
@@ -55,6 +55,19 @@ def gen_disagg_storages(test_name='', disagg_only = False):
         return disagg_storages[:-1]
 
     return disagg_storages
+
+# For disaggregated test cases, we generally want to ignore verbose warnings about RTS at shutdown.
+def disagg_ignore_expected_output(testcase):
+    testcase.ignoreStdoutPattern('WT_VERB_RTS')
+
+# A decorator for a disaggregated test class, that ignores verbose warnings about RTS at shutdown.
+def disagg_test_class(cls):
+    class DisaggTestCaseClass(cls):
+        @functools.wraps(cls, updated=())
+        def __init__(self, *args, **kwargs):
+            super(DisaggTestCaseClass, self).__init__(*args, **kwargs)
+            disagg_ignore_expected_output(self)
+    return DisaggTestCaseClass
 
 # This mixin class provides disaggregated storage configuration methods.
 class DisaggConfigMixin:

--- a/test/suite/test_layered01.py
+++ b/test/suite/test_layered01.py
@@ -27,13 +27,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin
+from helper_disagg import DisaggConfigMixin, disagg_test_class
 from wtscenario import make_scenarios
 
 StorageSource = wiredtiger.StorageSource  # easy access to constants
 
 # test_layered01.py
 #    Basic layered tree creation test
+@disagg_test_class
 class test_layered01(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     uri_base = "test_layered01"
@@ -47,10 +48,6 @@ class test_layered01(wttest.WiredTigerTestCase, DisaggConfigMixin):
             ("file:" + uri_base + ".wt_ingest", ''),
             ("file:" + uri_base + ".wt_stable", '')
             ]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered02.py
+++ b/test/suite/test_layered02.py
@@ -27,9 +27,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, wiredtiger, wttest
+from helper_disagg import disagg_test_class
 
 # test_layered02.py
 #    Basic layered tree cursor creation
+@disagg_test_class
 class test_layered02(wttest.WiredTigerTestCase):
 
     uri_base = "test_layered02"
@@ -37,10 +39,6 @@ class test_layered02(wttest.WiredTigerTestCase):
                 + 'disaggregated=(stable_prefix=.,page_log=palm),'
 
     uri = "layered:" + uri_base
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered03.py
+++ b/test/suite/test_layered03.py
@@ -27,11 +27,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
+from helper_disagg import disagg_test_class
 
 StorageSource = wiredtiger.StorageSource  # easy access to constants
 
 # test_layered03.py
 #    Basic layered tree cursor insert and read
+@disagg_test_class
 class test_layered03(wttest.WiredTigerTestCase):
 
     uri_base = "test_layered03"
@@ -39,10 +41,6 @@ class test_layered03(wttest.WiredTigerTestCase):
                 + 'disaggregated=(stable_prefix=.,page_log=palm),'
 
     uri = "layered:" + uri_base
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered04.py
+++ b/test/suite/test_layered04.py
@@ -27,9 +27,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
+from helper_disagg import disagg_test_class
 
 # test_layered04.py
 #    Add enough content to trigger a checkpoint in the stable table.
+@disagg_test_class
 class test_layered04(wttest.WiredTigerTestCase):
     nitems = 50000
     uri_base = "test_layered04"
@@ -39,10 +41,6 @@ class test_layered04(wttest.WiredTigerTestCase):
     # conn_config = 'log=(enabled)'
 
     uri = "layered:" + uri_base
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the directory store extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered05.py
+++ b/test/suite/test_layered05.py
@@ -27,11 +27,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
+from helper_disagg import disagg_test_class
 
 StorageSource = wiredtiger.StorageSource  # easy access to constants
 
 # test_layered05.py
 #    Add enough content to trigger a checkpoint in the stable table.
+@disagg_test_class
 class test_layered05(wttest.WiredTigerTestCase):
     nitems = 100000
     uri_base = "test_layered05"
@@ -40,10 +42,6 @@ class test_layered05(wttest.WiredTigerTestCase):
     conn_config = base_conn_config + 'disaggregated=(role="leader"),'
 
     uri = "layered:" + uri_base
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered06.py
+++ b/test/suite/test_layered06.py
@@ -27,11 +27,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin
+from helper_disagg import DisaggConfigMixin, disagg_test_class
 from wtscenario import make_scenarios
 
 # test_layered06.py
 #    Start a second WT that shares the stable content with the first.
+@disagg_test_class
 class test_layered06(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     conn_base_config = 'layered_table_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
@@ -45,10 +46,6 @@ class test_layered06(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     # TODO do Python tests expect a field named uri?
     uri = "layered:test_layered06"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered07.py
+++ b/test/suite/test_layered07.py
@@ -27,10 +27,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin
+from helper_disagg import DisaggConfigMixin, disagg_test_class
 
 # test_layered07.py
 #    Start a second WT that becomes leader and checke that content appears in the first.
+@disagg_test_class
 class test_layered07(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500
 
@@ -41,10 +42,6 @@ class test_layered07(wttest.WiredTigerTestCase, DisaggConfigMixin):
     create_session_config = 'key_format=S,value_format=S'
 
     uri = "layered:test_layered07"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered08.py
+++ b/test/suite/test_layered08.py
@@ -27,12 +27,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered08.py
 # Simple read write testing using the page log API
 
+@disagg_test_class
 class test_layered08(wttest.WiredTigerTestCase, DisaggConfigMixin):
     encrypt = [
         ('none', dict(encryptor='none', encrypt_args='')),
@@ -51,10 +52,6 @@ class test_layered08(wttest.WiredTigerTestCase, DisaggConfigMixin):
     scenarios = make_scenarios(encrypt, compress, disagg_storages)
 
     nitems = 10000
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     def conn_config(self):
         enc_conf = 'encryption=(name={0},{1})'.format(self.encryptor, self.encrypt_args)

--- a/test/suite/test_layered09.py
+++ b/test/suite/test_layered09.py
@@ -28,12 +28,13 @@
 
 import wttest
 import wiredtiger
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered09.py
 # Simple read write testing for leaf page delta
 
+@disagg_test_class
 class test_layered09(wttest.WiredTigerTestCase, DisaggConfigMixin):
     encrypt = [
         ('none', dict(encryptor='none', encrypt_args='')),
@@ -58,10 +59,6 @@ class test_layered09(wttest.WiredTigerTestCase, DisaggConfigMixin):
     scenarios = make_scenarios(encrypt, compress, disagg_storages, uris)
 
     nitems = 1000
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     def session_create_config(self):
         # The delta percentage of 200 is an arbitrary large value, intended to produce

--- a/test/suite/test_layered10.py
+++ b/test/suite/test_layered10.py
@@ -27,11 +27,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered10.py
 #    Additional layered table & cursor methods.
+@disagg_test_class
 class test_layered10(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 100_000
 
@@ -43,10 +44,6 @@ class test_layered10(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     disagg_storages = gen_disagg_storages('test_layered10', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered11.py
+++ b/test/suite/test_layered11.py
@@ -27,10 +27,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin
+from helper_disagg import DisaggConfigMixin, disagg_test_class
 
 # test_layered11.py
 #    Create an artificial delay in materializing pages from the page service.
+@disagg_test_class
 class test_layered11(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 5000
     uri_base = "test_layered11"
@@ -39,10 +40,6 @@ class test_layered11(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_config = conn_base_config + 'disaggregated=(role="leader"),'
 
     uri = "layered:" + uri_base
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered12.py
+++ b/test/suite/test_layered12.py
@@ -27,10 +27,11 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin
+from helper_disagg import DisaggConfigMixin, disagg_test_class
 
 # test_layered12.py
 #    Pick up different checkpoints.
+@disagg_test_class
 class test_layered12(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500
 
@@ -41,10 +42,6 @@ class test_layered12(wttest.WiredTigerTestCase, DisaggConfigMixin):
     create_session_config = 'key_format=S,value_format=S'
 
     uri = "layered:test_layered12"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered13.py
+++ b/test/suite/test_layered13.py
@@ -27,11 +27,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered13.py
 #    More than one table.
+@disagg_test_class
 class test_layered13(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500
 
@@ -46,10 +47,6 @@ class test_layered13(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     disagg_storages = gen_disagg_storages('test_layered13', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered14.py
+++ b/test/suite/test_layered14.py
@@ -28,11 +28,12 @@
 
 import wttest
 import wiredtiger
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered14.py
 # Simple testing for layered random cursor
+@disagg_test_class
 class test_layered14(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     conn_base_config = 'layered_table_log=(enabled),transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
@@ -42,10 +43,6 @@ class test_layered14(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 1000
 
     scenarios = make_scenarios(disagg_storages)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     def conn_config(self):
         return self.conn_base_config + 'disaggregated=(role="leader")'

--- a/test/suite/test_layered15.py
+++ b/test/suite/test_layered15.py
@@ -27,11 +27,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, os.path, shutil, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered15.py
 #    Start without local files.
+@disagg_test_class
 class test_layered15(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500
 
@@ -52,10 +53,6 @@ class test_layered15(wttest.WiredTigerTestCase, DisaggConfigMixin):
     scenarios = make_scenarios(disagg_storages)
 
     num_restarts = 0
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
 
     # Load the page log extension, which has object storage support
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered16.py
+++ b/test/suite/test_layered16.py
@@ -27,11 +27,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, os.path, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered16.py
 #    Test layered table modify
+@disagg_test_class
 class test_layered16(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_config = 'layered_table_log=(enabled),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                 + 'disaggregated=(stable_prefix=.,page_log=palm,role="leader"),'

--- a/test/suite/test_layered17.py
+++ b/test/suite/test_layered17.py
@@ -27,11 +27,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, os.path, shutil, time, wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered17.py
 #    Check timestamps.
+@disagg_test_class
 class test_layered17(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500
 

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -498,6 +498,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
 
     def ignoreStdoutPattern(self, pattern, re_flags = 0):
         self.ignore_regex = re.compile(pattern, re_flags)
+        if hasattr(self, 'captureout'):
+            self.captureout.setIgnorePattern(self.ignore_regex)
 
     def readyDirectoryForRemoval(self, directory):
         # Make sure any read-only files or directories left behind


### PR DESCRIPTION
- Created a disagg helper function that ignores the RTS warning
- Changed the hook for wiredtiger_open to call the new helper function.
- Make a minimal disaggregated hook test part of evergreen PR testing.
- Added a class decorator for disagg-only tests that call the new helper.
- Changed all layered tests to use the class decorator to ignore RTS warning.

