### PR TITLE
WT-14007 Update Evergreen to trigger the MacOS tests again

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1331,11 +1331,10 @@ variables:
     tasks:
       # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - switch back to the 'compile' task.
       - name: compile-no-upload
-      # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - enable these tests again.
-      #- name: make-check-test
+      - name: make-check-test
       # Use a special version of unit-test for macOS that checks for Python version consistency.
-      #- name: unit-test-macos
-      #- name: fops
+      - name: unit-test-macos
+      - name: fops
       - name: memory-model-test-mac
         batchtime: 40320 # 28 days
 
@@ -2076,10 +2075,14 @@ tasks:
 
   - name: unit-test-macos
     tags: ["python"]
-    depends_on:
-      - name: compile
+    # FIXME-WT-13951 - Put back the dependency on the compile task.
+    # depends_on:
+    #   - name: compile
     commands:
-      - func: "fetch artifacts"
+    # FIXME-WT-13951 - Fetch the artifacts instead of getting the project and compiling again.
+      # - func: "fetch artifacts"
+      - func: "get project"
+      - func: "compile wiredtiger"
       - func: "python config check"
       - func: "unit test"
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2595,7 +2595,6 @@ tasks:
 
   # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - remove this task.
   - name: fops-macos
-    tags: ["pull_request"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1334,7 +1334,8 @@ variables:
       - name: make-check-test
       # Use a special version of unit-test for macOS that checks for Python version consistency.
       - name: unit-test-macos
-      - name: fops
+      # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - switch back to the 'fops' task.
+      - name: fops-macos
       - name: memory-model-test-mac
         batchtime: 40320 # 28 days
 
@@ -2591,6 +2592,22 @@ tasks:
             else
               ./test_fops
             fi
+
+  # FIXME-WT-13951 Re-enable MacOS testing on the Evergreen waterfall - remove this task.
+  - name: fops-macos
+    tags: ["pull_request"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/fops"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            ./test_fops
 
   - name: bench-tiered-push-pull-s3
     commands:


### PR DESCRIPTION
The changes enable the MacOS tests on Evergreen.