### PR TITLE
WT-14008 Force reinstall layercparse when using modstat

### DIFF
--- a/dist/modularity/init.sh
+++ b/dist/modularity/init.sh
@@ -36,6 +36,6 @@ want_update() {
 }
 
 if want_update; then
-    pip3 -q --disable-pip-version-check install git+"$REPO_URL@$BRANCH"
+    pip3 -q --disable-pip-version-check install --force-reinstall git+"$REPO_URL@$BRANCH"
     echo "$REMOTE_HASH" > "$HASH_FILE"
 fi

--- a/dist/modularity/init.sh
+++ b/dist/modularity/init.sh
@@ -36,6 +36,8 @@ want_update() {
 }
 
 if want_update; then
+    # Force reinstall `layercparse` to ensure the latest changes are applied, 
+    # as `pip install` does not update automatically for new commits.
     pip3 -q --disable-pip-version-check install --force-reinstall git+"$REPO_URL@$BRANCH"
     echo "$REMOTE_HASH" > "$HASH_FILE"
 fi


### PR DESCRIPTION
For some reason, pip install for layercparse sticks to the current version, so new commits don’t trigger a fresh installation of layercparse. To address this, we need to forcefully reinstall layercparse whenever newer commits are made to the repo. This can be achieved by appending --force-reinstall to the pip install command.