### PR TITLE
SLS-895 Use scrub eviction more often

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -674,12 +674,11 @@ __evict_update_work(WT_SESSION_IMPL *session)
 
     /*
      * Configure scrub - which reinstates clean equivalents of reconciled dirty pages. This is
-     * useful because an evicted dirty page isn't necessarily a good proxy for knowing if the
-     * page will be accessed again soon. Be more aggressive about scrubbing in disaggregated
-     * storage because the cost of retrieving a recently reconciled page is higher in that
-     * configuration.
-     * In the local storage case use scrub if we are less than half way to the clean, dirty or
-     * updates triggers.
+     * useful because an evicted dirty page isn't necessarily a good proxy for knowing if the page
+     * will be accessed again soon. Be more aggressive about scrubbing in disaggregated storage
+     * because the cost of retrieving a recently reconciled page is higher in that configuration. In
+     * the local storage case use scrub if we are less than half way to the clean, dirty or updates
+     * triggers.
      */
     if (__wt_conn_is_disagg(session) && bytes_inuse < (uint64_t)(trigger * bytes_max) / 100)
         LF_SET(WT_CACHE_EVICT_SCRUB);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -606,7 +606,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
     WT_BTREE *hs_tree;
     WT_CACHE *cache;
     WT_CONNECTION_IMPL *conn;
-    double dirty_target, dirty_trigger, target, trigger, updates_target, updates_trigger;
+    double dirty_target, target, trigger, updates_target;
     uint64_t bytes_dirty, bytes_inuse, bytes_max, bytes_updates;
     uint32_t flags;
 
@@ -614,11 +614,9 @@ __evict_update_work(WT_SESSION_IMPL *session)
     cache = conn->cache;
 
     dirty_target = __wt_eviction_dirty_target(cache);
-    dirty_trigger = cache->eviction_dirty_trigger;
     target = cache->eviction_target;
     trigger = cache->eviction_trigger;
     updates_target = cache->eviction_updates_target;
-    updates_trigger = cache->eviction_updates_trigger;
 
     /* Build up the new state. */
     flags = 0;
@@ -676,10 +674,8 @@ __evict_update_work(WT_SESSION_IMPL *session)
      * Scrub dirty pages and keep them in cache if we are less than half way to the clean, dirty or
      * updates triggers.
      */
-    if (bytes_inuse < (uint64_t)((target + trigger) * bytes_max) / 200) {
-        if (bytes_dirty < (uint64_t)((dirty_target + dirty_trigger) * bytes_max) / 200 &&
-          bytes_updates < (uint64_t)((updates_target + updates_trigger) * bytes_max) / 200)
-            LF_SET(WT_CACHE_EVICT_SCRUB);
+    if (bytes_inuse < (uint64_t)((target + trigger) * bytes_max) / 150) {
+        LF_SET(WT_CACHE_EVICT_SCRUB);
     } else
         LF_SET(WT_CACHE_EVICT_NOKEEP);
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -826,15 +826,10 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
     else if (!WT_IS_METADATA(btree->dhandle)) {
         LF_SET(WT_REC_HS);
 
-        /*
-         * Scrub and we're supposed to or toss it in sometimes if we are in debugging mode.
-         *
-         * Note that don't scrub if checkpoint is running on the tree.
-         */
-        if (!WT_SESSION_BTREE_SYNC(session) &&
-          (F_ISSET(cache, WT_CACHE_EVICT_SCRUB) ||
-            (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
-              __wt_random(&session->rnd) % 3 == 0)))
+        /* Scrub if enabled, or occasionally if stress testing is enabled. */
+        if (F_ISSET(cache, WT_CACHE_EVICT_SCRUB) ||
+          (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
+            __wt_random(&session->rnd) % 3 == 0))
             LF_SET(WT_REC_SCRUB);
     }
 


### PR DESCRIPTION
In disaggregated storage we want to keep recently reconciled pages in cache more aggressively, since there will usually be a delay after the initial write before they are available to be read back in.
