### PR TITLE
SLS-1004 Use dec output for page IDs, etc., and hex for checksums for consistency

### DIFF
--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -635,9 +635,9 @@ palm_handle_put(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     PALM_KV_ERR(palm, session, ret);
 
     PALM_VERBOSE_PRINT(palm_handle->palm,
-      "palm_handle_put(plh=%p, table_id=%" PRIx64 ", page_id=%" PRIx64 ", lsn=%" PRIx64
-      ", checkpoint_id=%" PRIx64 ", backlink_lsn=%" PRIx64 ", base_lsn=%" PRIx64
-      ", backlink_checkpoint_id=%" PRIx64 ", base_checkpoint_id=%" PRIx64
+      "palm_handle_put(plh=%p, table_id=%" PRIu64 ", page_id=%" PRIu64 ", lsn=%" PRIu64
+      ", checkpoint_id=%" PRIu64 ", backlink_lsn=%" PRIu64 ", base_lsn=%" PRIu64
+      ", backlink_checkpoint_id=%" PRIu64 ", base_checkpoint_id=%" PRIu64
       ", is_delta=%d, buf=\n%s)\n",
       (void *)plh, palm_handle->table_id, page_id, lsn, checkpoint_id, put_args->backlink_lsn,
       put_args->base_lsn, put_args->backlink_checkpoint_id, put_args->base_checkpoint_id, is_delta,
@@ -656,8 +656,8 @@ err:
     palm_kv_rollback_transaction(&context);
 
     PALM_VERBOSE_PRINT(palm_handle->palm,
-      "palm_handle_put(plh=%p, table_id=%" PRIx64 ", page_id=%" PRIx64 ", lsn=%" PRIx64
-      ", checkpoint_id=%" PRIx64 ", is_delta=%d) returned %d\n",
+      "palm_handle_put(plh=%p, table_id=%" PRIu64 ", page_id=%" PRIu64 ", lsn=%" PRIu64
+      ", checkpoint_id=%" PRIu64 ", is_delta=%d) returned %d\n",
       (void *)plh, palm_handle->table_id, page_id, lsn, checkpoint_id, is_delta, ret);
     return (ret);
 }
@@ -689,8 +689,8 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
     palm_init_context(palm, &context);
 
     PALM_VERBOSE_PRINT(palm_handle->palm,
-      "palm_handle_get(plh=%p, table_id=%" PRIx64 ", page_id=%" PRIx64 ", lsn=%" PRIx64
-      ", checkpoint_id=%" PRIx64 ")...\n",
+      "palm_handle_get(plh=%p, table_id=%" PRIu64 ", page_id=%" PRIu64 ", lsn=%" PRIu64
+      ", checkpoint_id=%" PRIu64 ")...\n",
       (void *)plh, palm_handle->table_id, page_id, lsn, checkpoint_id);
     PALM_KV_RET(palm, session, palm_kv_begin_transaction(&context, palm->kv_env, false));
     PALM_KV_ERR(palm, session,
@@ -747,16 +747,16 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
 err:
     palm_kv_rollback_transaction(&context);
     PALM_VERBOSE_PRINT(palm_handle->palm,
-      "palm_handle_get(plh=%p, table_id=%" PRIx64 ", page_id=%" PRIx64 ", lsn=%" PRIx64
-      ", checkpoint_id=%" PRIx64 ") returns %d (in %d parts)\n",
+      "palm_handle_get(plh=%p, table_id=%" PRIu64 ", page_id=%" PRIu64 ", lsn=%" PRIu64
+      ", checkpoint_id=%" PRIu64 ") returns %d (in %d parts)\n",
       (void *)plh, palm_handle->table_id, page_id, lsn, checkpoint_id, ret, (int)count);
     if (ret == 0) {
         for (i = 0; i < count; ++i)
             PALM_VERBOSE_PRINT(
               palm_handle->palm, "   part %d: %s\n", (int)i, palm_verbose_item(&results_array[i]));
         PALM_VERBOSE_PRINT(palm_handle->palm,
-          "   metadata: backlink_lsn=%" PRIx64 ", base_lsn=%" PRIx64
-          ", backlink_checkpoint_id=%" PRIx64 ", base_checkpoint_id=%" PRIx64 "\n",
+          "   metadata: backlink_lsn=%" PRIu64 ", base_lsn=%" PRIu64
+          ", backlink_checkpoint_id=%" PRIu64 ", base_checkpoint_id=%" PRIu64 "\n",
           get_args->backlink_lsn, get_args->base_lsn, get_args->backlink_checkpoint_id,
           get_args->base_checkpoint_id);
     }

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -49,7 +49,7 @@ __block_disagg_read_checksum_err(WT_SESSION_IMPL *session, const char *name, uin
       "%s: read checksum error for %" PRIu32
       "B block at "
       "page %" PRIu64 ", ckpt %" PRIu64 ": %s of %" PRIu32 " (%" PRIu64
-      ") doesn't match expected checksum of %" PRIu32 " (%" PRIu64 ")",
+      ") doesn't match expected checksum of %" PRIx32 " (%" PRIu64 ")",
       name, size, page_id, checkpoint_id, context_msg, checksum, rec_id, expected_checksum,
       expected_rec_id);
 }
@@ -86,7 +86,7 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
 
     __wt_verbose(session, WT_VERB_READ,
       "page_id %" PRIu64 ", lsn %" PRIu64 ", checkpoint_id %" PRIu64 ", reconciliation_id %" PRIu64
-      ", size %" PRIu32 ", checksum %" PRIu32,
+      ", size %" PRIu32 ", checksum %" PRIx32,
       page_id, lsn, checkpoint_id, reconciliation_id, size, checksum);
 
     WT_STAT_CONN_INCR(session, disagg_block_get);
@@ -103,7 +103,7 @@ reread:
          */
         __wt_verbose_notice(session, WT_VERB_READ,
           "retry #%" PRIu32 " for page_id %" PRIu64 ", checkpoint_id %" PRIu64
-          ", reconciliation_id %" PRIu64 ", size %" PRIu32 ", checksum %" PRIu32,
+          ", reconciliation_id %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
           retry, page_id, checkpoint_id, reconciliation_id, size, checksum);
         __wt_sleep(0, 10000 + retry * 5000);
         memset(results_array, 0, *results_count * sizeof(results_array[0]));

--- a/tools/wt_palm_decode.py
+++ b/tools/wt_palm_decode.py
@@ -115,9 +115,11 @@ class ColumnParser:
         if 'swap' in self.columns[n]:
             swap = self.columns[n]['swap']
         if swap:
-            val = dehex(swapstr(self.match.group(n)))
+            val = swapstr(self.match.group(n))
         else:
-            val = dehex(self.match.group(n))
+            val = self.match.group(n)
+        if 'hex' not in self.columns[n]:
+            val = dehex(val)
         return f'{nm}={val}{trail}'
 
 # Patterns to match and group ints of specified lengths
@@ -208,8 +210,8 @@ def palm_dump_block_header(vstr):
                 { 'name' : 'version' },
                 { 'name' : 'compatible_version' },
                 { 'name' : 'header_size' },
-                { 'name' : 'checksum', 'swap' : True  },
-                { 'name' : 'previous_checksum', 'swap' : True  },
+                { 'name' : 'checksum', 'hex' : True, 'swap' : True },
+                { 'name' : 'previous_checksum', 'hex' : True, 'swap' : True  },
                 { 'name' : 'reconciliation_id' },
                 { 'name' : 'flags' },
                 { 'name' : 'PADDING' },


### PR DESCRIPTION
Improve the consistency of output by using base 10 numbers for page IDs, checkpoint IDs, etc., and hex numbers for checksums.