### PR TITLE
SLS-1005 Derive delta_count from result_count after calling plh_get

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -202,7 +202,8 @@ reread:
                     block_meta->backlink_checkpoint_id = get_args.backlink_checkpoint_id;
                     block_meta->base_checkpoint_id = get_args.base_checkpoint_id;
                     block_meta->disagg_lsn = get_args.lsn;
-                    block_meta->delta_count = get_args.delta_count;
+                    block_meta->delta_count =
+                      get_args.delta_count == 0 ? *results_count - 1 : get_args.delta_count;
                     block_meta->checksum = checksum;
                     if (block_meta->delta_count > 0) {
                         WT_ASSERT(

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -952,7 +952,7 @@ __wt_disagg_get_meta(
             count = 1;
             WT_RET(disagg->page_log_meta->plh_get(disagg->page_log_meta, &session->iface, page_id,
               checkpoint_id, &get_args, item, &count));
-            WT_ASSERT(session, count <= 1 && get_args.delta_count == 0); /* TODO: corrupt data */
+            WT_ASSERT(session, count <= 1); /* TODO: corrupt data */
 
             /* Found the data. */
             if (count == 1)


### PR DESCRIPTION
Derive the value of delta_count from the number of returned results if it's not set.

I did not yet deprecate the delta_count field; this should be done after the Server stops using it.