### PR TITLE
SLS-1011 Enable automated spell checking in WiredTiger disaggregated branch

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -5,7 +5,7 @@
 ################################################################
 # For disaggregated storage, we're not enforcing certain scripts yet.
 # TODO: remove changes to s_all that ignore certain scripts, and resolve resulting fallout.
-disagg_ignore="comment_style.py s_funcs s_longlines s_string s_void"
+disagg_ignore="comment_style.py s_funcs s_longlines"
 ################################################################
 
 . `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -90,9 +90,12 @@ Crummey
 CustomersPhone
 Cygwin
 DAX
+DBI
 DESC
 DHANDLE
 DIRECTIO
+DISAGG
+DISAGGREGATED
 DNE
 DONTNEED
 DS
@@ -100,6 +103,7 @@ DUPLICATEV
 Decrypt
 DeleteFileW
 Deterministically
+Disaggregated
 Dk
 DmpRvXx
 Dxxx
@@ -207,6 +211,7 @@ Kounavis
 LANGID
 LF
 LLVMFuzzerTestOneInput
+LMDB
 LOGOP
 LOGREC
 LOGSCAN
@@ -230,6 +235,7 @@ LogSink
 LogSystemInterface
 MADV
 MALLOC
+MDB
 MEM
 MEMALIGN
 MERCHANTABILITY
@@ -281,6 +287,7 @@ OVFL
 ObWgfvgw
 Optane
 Outfmt
+PALI
 PDEATHSIG
 PFX
 PID
@@ -338,10 +345,12 @@ Readonly
 Realloc
 RedHat
 Redistributions
+Reentrancy
 Rogerio
 Runtime
 SDK
 SIMD
+SLS
 SLVG
 SMT
 SPINLOCK
@@ -447,6 +456,7 @@ WiredTigerHS
 WiredTigerLAS
 WiredTigerLog
 WiredTigerPreplog
+WiredTigerShared
 WiredTigerTmplog
 WithSeeds
 Wmissing
@@ -498,6 +508,7 @@ auximage
 auxincr
 aws
 bInheritHandle
+backlink
 backoff
 bal
 basecfg
@@ -522,6 +533,7 @@ blkincr
 blkmod
 blkmods
 bm
+bmd
 bmp
 bnd
 bool
@@ -583,6 +595,7 @@ ckpt
 ckptfrag
 ckptlist
 cksum
+clayered
 cloexec
 closedir
 clsm
@@ -606,6 +619,7 @@ config
 configs
 conn
 connectionp
+const
 constantp
 consts
 cookiep
@@ -661,6 +675,7 @@ ddd
 decile
 deciles
 decl
+decompressor
 decr
 decrementing
 decrypt
@@ -674,6 +689,7 @@ del
 dequeued
 der
 dereference
+dereferencing
 desc
 designator
 dest
@@ -687,6 +703,8 @@ difftime
 dir
 directio
 dirlist
+disagg
+disaggregated
 disjunction
 disproportionally
 dlclose
@@ -817,6 +835,7 @@ gettimeofday
 getv
 ggg
 github
+globals
 globfree
 gobare
 goesc
@@ -890,6 +909,7 @@ isalnum
 isalpha
 isascii
 isb
+isd
 isdigit
 ish
 ishld
@@ -969,6 +989,7 @@ lru
 lseek
 lsm
 lsn
+lsnp
 lt
 lte
 lu
@@ -1034,6 +1055,7 @@ needvalue
 negint
 nentries
 nentriesp
+ness
 newbar
 newfile
 newuri
@@ -1042,6 +1064,7 @@ nextprev
 nf
 nfilename
 nhex
+nilly
 nlohmann
 nlpo
 nocase
@@ -1106,6 +1129,8 @@ pathnames
 perf
 pfx
 pid
+plh
+pluggable
 pmem
 poptable
 popthreads
@@ -1295,6 +1320,7 @@ sumv
 sunique
 sunused
 supd
+supercalafragalisticexpialadoshus
 superset
 sw
 sys

--- a/dist/s_void
+++ b/dist/s_void
@@ -32,6 +32,8 @@ func_ok()
 {
     sed \
         -e '/int __bm_stat$/d' \
+        -e '/int __bmd_free$/d' \
+        -e '/int __bmd_stat$/d' \
         -e '/int __checkpoint_presync$/d' \
         -e '/int __compact_uri_analyze$/d' \
         -e '/int __compact_walk_page_skip$/d' \
@@ -66,6 +68,25 @@ func_ok()
         -e '/int __win_terminate$/d' \
         -e '/int __wt_block_compact_end$/d' \
         -e '/int __wt_block_compact_start$/d' \
+        -e '/int __wt_block_disagg_checkpoint_start$/d' \
+        -e '/int __wt_block_disagg_checkpoint_unload$/d' \
+        -e '/int __wt_block_disagg_compact_end$/d' \
+        -e '/int __wt_block_disagg_compact_page_skip$/d' \
+        -e '/int __wt_block_disagg_compact_skip$/d' \
+        -e '/int __wt_block_disagg_compact_start$/d' \
+        -e '/int __wt_block_disagg_manager_drop$/d' \
+        -e '/int __wt_block_disagg_manager_size$/d' \
+        -e '/int __wt_block_disagg_map_discard$/d' \
+        -e '/int __wt_block_disagg_read$/d' \
+        -e '/int __wt_block_disagg_salvage_end$/d' \
+        -e '/int __wt_block_disagg_salvage_next$/d' \
+        -e '/int __wt_block_disagg_salvage_start$/d' \
+        -e '/int __wt_block_disagg_salvage_valid$/d' \
+        -e '/int __wt_block_disagg_sync$/d' \
+        -e '/int __wt_block_disagg_verify_addr$/d' \
+        -e '/int __wt_block_disagg_verify_end$/d' \
+        -e '/int __wt_block_disagg_verify_start$/d' \
+        -e '/int __wt_block_disagg_write_size$/d' \
         -e '/int __wt_block_manager_size$/d' \
         -e '/int __wt_block_tiered_load$/d' \
         -e '/int __wt_block_write_size$/d' \
@@ -144,6 +165,9 @@ func_ok()
         -e '/int nop_sizing$/d' \
         -e '/int nop_terminate$/d' \
         -e '/int os_errno$/d' \
+        -e '/int palm_err$/d' \
+        -e '/int palm_handle_get$/d' \
+        -e '/int palm_kv_err$/d' \
         -e '/int revint_terminate$/d' \
         -e '/int rotn_error$/d' \
         -e '/int rotn_sizing$/d' \

--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -345,8 +345,8 @@ palm_kv_err(PALM *palm, WT_SESSION *session, int ret, const char *format, ...)
     if (vsnprintf(buf, sizeof(buf), format, ap) >= (int)sizeof(buf))
         wt_api->err_printf(wt_api, session, "palm: error overflow");
     lmdb_error = mdb_strerror(ret);
-    wt_api->err_printf(wt_api, session, "palm lmdb: %s: %s", lmdb_error, buf);
-    PALM_VERBOSE_PRINT(palm, "palm lmdb: %s: %s\n", lmdb_error, buf);
+    wt_api->err_printf(wt_api, session, "palm LMDB: %s: %s", lmdb_error, buf);
+    PALM_VERBOSE_PRINT(palm, "palm LMDB: %s: %s\n", lmdb_error, buf);
     va_end(ap);
 
     return (WT_ERROR);
@@ -705,7 +705,7 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
 
         /* FIXME-SLS-950: Fix the sporadic failure in test_layered06. */
 #if 0
-        /* Validate backlinks. */
+        /* Validate back links. */
         if (count > 0) {
             if (matches.backlink_lsn != last_lsn)
                 PALM_KV_ERR(palm, session, EINVAL);
@@ -909,7 +909,7 @@ palm_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *config)
     PALM_KV_ERR(palm, NULL, connection->add_page_log(connection, "palm", &palm->page_log, NULL));
     PALM_KV_ERR(palm, NULL, palm_kv_env_create(&palm->kv_env, palm->cache_size_mb));
 
-    /* Build the lmdb home string. */
+    /* Build the LMDB home string. */
     home = connection->get_home(connection);
     len = strlen(home) + 20;
     palm->kv_home = malloc(len);
@@ -920,7 +920,7 @@ palm_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *config)
     strncpy(palm->kv_home, home, len);
     strncat(palm->kv_home, "/kv_home", len);
 
-    /* Create the lmdb home, or if it exists, use what is already there. */
+    /* Create the LMDB home, or if it exists, use what is already there. */
     ret = mkdir(palm->kv_home, 0777);
     if (ret != 0) {
         ret = errno;
@@ -932,7 +932,7 @@ palm_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *config)
         }
     }
 
-    /* Open the lmdb environment. */
+    /* Open the LMDB environment. */
     PALM_KV_ERR(palm, NULL, palm_kv_env_open(palm->kv_env, palm->kv_home));
 
 err:

--- a/ext/page_log/palm/palm_kv.c
+++ b/ext/page_log/palm/palm_kv.c
@@ -269,7 +269,7 @@ palm_kv_begin_transaction(PALM_KV_CONTEXT *context, PALM_KV_ENV *env, bool reado
 {
     context->env = env;
     context->lmdb_txn = NULL;
-    // TODO: report failures?  For all these funcs
+    /* TODO: report failures?  For all these functions */
     return (mdb_txn_begin(env->lmdb_env, NULL, readonly ? MDB_RDONLY : 0, &context->lmdb_txn));
 }
 

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -447,7 +447,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
      */
     for (i = 1; i < count; i++) {
         ip = &results[i];
-        /* TODO in principle we should end up not caring about which block mananger is backing the
+        /* TODO in principle we should end up not caring about which block manager is backing the
          * file. */
         blk = WT_BLOCK_HEADER_REF_FOR_DELTAS(results[i].mem);
 

--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -166,8 +166,10 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
         checkpoint_timestamp = conn->disaggregated_storage.cur_checkpoint_timestamp;
 
         WT_ERR(__wt_scr_alloc(session, 0, &buf));
-        WT_ERR(__wt_buf_fmt(
-          session, buf, "%.*s\ntimestamp=%" PRIx64, (int)cval.len, cval.str, checkpoint_timestamp));
+        WT_ERR(__wt_buf_fmt(session, buf,
+          "%.*s\n"
+          "timestamp=%" PRIx64,
+          (int)cval.len, cval.str, checkpoint_timestamp));
         WT_ERR(
           __wt_disagg_put_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, checkpoint_id, buf, &lsn));
         WT_RELEASE_WRITE(conn->disaggregated_storage.last_checkpoint_meta_lsn, lsn);
@@ -179,7 +181,7 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
 
         /* Check if we need to include any other metadata keys. */
         if (WT_SUFFIX_MATCH(block_disagg->name, ".wt")) {
-            /* TODO: Less hacky way of finding related metadata. */
+            /* TODO: Change this hack to a nicer way of finding related metadata. */
 
             WT_ERR(__wt_snprintf(md_key, len, "colgroup:%s", block_disagg->name));
             md_key[strlen(md_key) - 3] = '\0'; /* Remove the .wt suffix */
@@ -208,7 +210,7 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
 
         /* Check if we need to include any other metadata keys for layered tables. */
         if (WT_SUFFIX_MATCH(block_disagg->name, ".wt_stable")) {
-            /* TODO: Less hacky way of finding related metadata. */
+            /* TODO: Change this hack to a nicer way of finding related metadata. */
 
             WT_ERR(__wt_snprintf(md_key, len, "layered:%s", block_disagg->name));
             md_key[strlen(md_key) - 10] = '\0'; /* Remove the .wt_stable suffix */

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -111,7 +111,7 @@ reread:
         ++retry;
     }
     /*
-     * Output buffers do not need to be preallocated, the PALI interface does that.
+     * Output buffers do not need to be pre-allocated, the PALI interface does that.
      */
     WT_ERR(block_disagg->plhandle->plh_get(block_disagg->plhandle, &session->iface, page_id,
       checkpoint_id, &get_args, results_array, results_count));
@@ -178,7 +178,7 @@ reread:
                       block_disagg->name, size, page_id, checkpoint_id, swap.magic, expected_magic);
                     goto corrupt;
                 }
-                /* TODO: workaround MACOS build failure when passing macro to a string format. */
+                /* TODO: workaround MacOS build failure when passing macro to a string format. */
                 compatible_version = WT_BLOCK_DISAGG_COMPATIBLE_VERSION;
                 if (swap.compatible_version > compatible_version) {
                     __wt_errx(session,

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -20,7 +20,7 @@ __wt_block_disagg_header_byteswap(WT_BLOCK_DISAGG_HEADER *blk)
 
 /*
  * __wt_block_disagg_header_byteswap_copy --
- *     Place holder - might be necessaryt to handle network order.
+ *     Place holder - might be necessary to handle network order.
  */
 void
 __wt_block_disagg_header_byteswap_copy(WT_BLOCK_DISAGG_HEADER *from, WT_BLOCK_DISAGG_HEADER *to)

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -900,41 +900,6 @@ __wti_btree_new_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
     return (0);
 }
 
-// /*
-//  * __btree_preload --
-//  *     Pre-load internal pages.
-//  */
-// static int
-// __btree_preload(WT_SESSION_IMPL *session)
-// {
-//     WT_ADDR_COPY addr;
-//     WT_BTREE *btree;
-//     WT_DECL_ITEM(tmp);
-//     WT_DECL_RET;
-//     WT_REF *ref;
-//     uint64_t block_preload;
-
-//     btree = S2BT(session);
-//     block_preload = 0;
-
-//     WT_RET(__wt_scr_alloc(session, 0, &tmp));
-
-//     /* Pre-load the second-level internal pages. */
-//     WT_INTL_FOREACH_BEGIN (session, btree->root.page, ref)
-//         if (__wt_ref_addr_copy(session, ref, &addr)) {
-//             WT_ERR(
-//               __wt_blkcache_read(session, tmp, NULL, addr.block_cookie, addr.block_cookie_size));
-//             ++block_preload;
-//         }
-//     WT_INTL_FOREACH_END;
-
-// err:
-//     __wt_scr_free(session, &tmp);
-
-//     WT_STAT_CONN_INCRV(session, block_preload, block_preload);
-//     return (ret);
-// }
-
 /*
  * __btree_get_last_recno --
  *     Set the last record number for a column-store. Note that this is used to handle appending to

--- a/src/btree/bt_import.c
+++ b/src/btree/bt_import.c
@@ -107,8 +107,8 @@ __wt_import_repair(WT_SESSION_IMPL *session, const char *uri, char **configp)
 
     /*
      * TODO: import needs a little thought for shared tables once we've decided how to allocate
-     * shared file IDs. It's not enough (even temporarily) to just "share-ify" the allocated file
-     * ID, since if we do that it may clash with another imported shared ID.
+     * shared file IDs. It's not enough (even temporarily) to just share the allocated file ID,
+     * since if we do that it may clash with another imported shared ID.
      */
     WT_ERR(__wt_btree_shared(session, uri, cfg, &shared));
     if (shared)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -624,7 +624,7 @@ __wt_layered_table_manager_thread_run(WT_SESSION_IMPL *session_shared, WT_THREAD
 
     WT_STAT_CONN_SET(session, layered_table_manager_active, 0);
 
-    return (ret);
+    return (0);
 }
 
 /*

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -545,7 +545,7 @@ __layered_table_manager_checkpoint_one(WT_SESSION_IMPL *session)
         if ((entry = manager->entries[i]) != NULL &&
           entry->accumulated_write_bytes > WT_LAYERED_TABLE_CHECKPOINT_THRESHOLD) {
             /*
-             * Retrieve the current tranasaction ID - ensure it actually gets read from the shared
+             * Retrieve the current transaction ID - ensure it actually gets read from the shared
              * variable here, it would lead to data loss if it was read later and included
              * transaction IDs that aren't included in the checkpoint. It's OK for it to miss IDs -
              * this requires an "at least as much" guarantee, not an exact match guarantee.
@@ -608,7 +608,6 @@ __layered_table_manager_checkpoint_one(WT_SESSION_IMPL *session)
 int
 __wt_layered_table_manager_thread_run(WT_SESSION_IMPL *session_shared, WT_THREAD *thread)
 {
-    WT_DECL_RET;
     WT_SESSION_IMPL *session;
 
     WT_UNUSED(session_shared);
@@ -755,7 +754,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     leader = was_leader = conn->layered_table_manager.leader;
     npage_log = NULL;
 
-    /* Reconfig-only settings. */
+    /* Reconfigure-only settings. */
     if (reconfig) {
 
         /* Pick up a new checkpoint (followers only). */
@@ -1236,7 +1235,7 @@ err:
     return (ret);
 }
 
-/* TODO: use this function to drain the inges table */
+/* TODO: use this function to drain the ingest table */
 #ifdef __linux__
 static int __layered_drain_ingest_tables(WT_SESSION_IMPL *) __attribute__((unused));
 #endif

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -968,7 +968,7 @@ __clayered_put(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_I
 
 /*
  * __clayered_modify_int --
- *     Put an modiy into the desired tree.
+ *     Put an modify into the desired tree.
  */
 static WT_INLINE int
 __clayered_modify_int(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key,

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -403,7 +403,7 @@ __curversion_next_int(WT_CURSOR *cursor)
                 if (version_cursor->start_timestamp != WT_TS_NONE) {
                     if (WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw)) {
                         /*
-                         * We are done if we have an on-disk stop durable timstamp that is smaller
+                         * We are done if we have an on-disk stop durable timestamp that is smaller
                          * than or equal to the end timestamp.
                          */
                         if (cbt->upd_value->tw.durable_stop_ts <= version_cursor->start_timestamp)

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -483,7 +483,7 @@ struct __wt_block_disagg_header {
      * page, which must match the checksum found in this header. The checksum of the previous delta
      * or base page is stored in this block header, that must in turn match the checksum found in
      * the block header for the previous one. This is how we can verify that we have every expected
-     * delta and that each delta is uncorrupted.
+     * delta and that each delta is not corrupted.
      */
     uint32_t checksum;          /* 04-07: checksum */
     uint32_t previous_checksum; /* 08-11: checksum for previous delta or page */
@@ -491,7 +491,7 @@ struct __wt_block_disagg_header {
     /*
      * The reconciliation id tracks the "version" of a page or delta within a checkpoint. The first
      * write of a page at a checkpoint has id 0, the second has id 1. We use this number as a
-     * diagnostic to detect the kind of discrepency that occured when there is a checksum error.
+     * diagnostic to detect the kind of discrepancy that occurred when there is a checksum error.
      * Thus, overflowing a byte is not a cause for concern. Besides, overflows should be exceedingly
      * rare. It means checkpointing is much less frequent than the number of times a page needed to
      * be reconciled.

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -177,7 +177,7 @@ struct __wt_disaggregated_storage {
     char *stable_prefix;
     char *storage_source;
 
-    wt_shared uint64_t global_checkpoint_id;     /* The ID of the currenty opened checkpoint. */
+    wt_shared uint64_t global_checkpoint_id;     /* The ID of the currently opened checkpoint. */
                                                  /* Updates are protected by the checkpoint lock. */
     wt_shared uint64_t last_checkpoint_meta_lsn; /* The LSN of the last checkpoint metadata. */
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2394,7 +2394,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *chunk
             r->wrapup_checkpoint_compressed = true;
         }
         /*
-         * We need to assign a new page id for the root everytime. We don't support delta for
+         * We need to assign a new page id for the root every time. We don't support delta for
          * internal page yet.
          */
         __wt_page_block_meta_assign(session, &r->wrapup_checkpoint_block_meta);
@@ -2755,7 +2755,7 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
 
 /*
  * __rec_set_updates_durable --
- *     Set the updates druable. This must be called when the reconciliation can no longer fail.
+ *     Set the updates durable. This must be called when the reconciliation can no longer fail.
  */
 static WT_INLINE void
 __rec_set_updates_durable(WT_RECONCILE *r)

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -823,10 +823,10 @@ __recovery_file_scan(WT_RECOVERY *r)
      */
     /*
      * TODO: it's not something specific to this line, but note the places we call the namespace
-     * macros. The boundary is that the on-disk trees have namespaced IDs, but the maximum file ID
-     * variable is not namespaced. This avoids us having to increment it by a number other than one,
+     * macros. The boundary is that the on-disk trees have namespace IDs, but the maximum file ID
+     * variable is not namespace. This avoids us having to increment it by a number other than one,
      * among other annoyances, but they're all solvable problems. We can revisit this decision after
-     * using the namespaced file IDs for a while.
+     * using the tracked namespace file IDs for a while.
      */
     S2C(r->session)->next_file_id = WT_BTREE_ID_UNNAMESPACED(r->max_fileid);
 


### PR DESCRIPTION
The s_void and s_string scripts have been disabled against the disaggregated storage branch - fix accumulated errors and enable them again

ps: I tagged the branch name with SLS-1010, but the right ticket number is SLS-1011