### PR TITLE
SLS-1017 Simplify test/suite IDs for disaggregated storage

### DIFF
--- a/test/py_utility/abstract_test_case.py
+++ b/test/py_utility/abstract_test_case.py
@@ -440,6 +440,16 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
         '''
         return self.module_file().replace('.py', '')
 
+    @staticmethod
+    def simplify_name(name):
+        # Remove unnecessary information from the ID, such as the helper names.
+        name = re.sub(r'^helper_[^.]*\.', '', name)
+        name = name.replace('.<locals>', '')
+        return name
+
+    def id(self):
+        return self.simplify_name(super().id())
+
     def current_test_id(self):
         '''
         Return a test ID. Use this instead of the actual id() function, because we lose its context
@@ -479,7 +489,7 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
             methodName = self._savedTestMethodName
         else:
             methodName = self._testMethodName
-        return "%s.%s.%s" %  (self.__module__, self.class_name(), methodName)
+        return self.simplify_name("%s.%s.%s" %  (self.__module__, self.class_name(), methodName))
 
     #
     # Debugging

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -62,12 +62,12 @@ def disagg_ignore_expected_output(testcase):
 
 # A decorator for a disaggregated test class, that ignores verbose warnings about RTS at shutdown.
 def disagg_test_class(cls):
-    class DisaggTestCaseClass(cls):
+    class disagg_test_case_class(cls):
         @functools.wraps(cls, updated=())
         def __init__(self, *args, **kwargs):
-            super(DisaggTestCaseClass, self).__init__(*args, **kwargs)
+            super(disagg_test_case_class, self).__init__(*args, **kwargs)
             disagg_ignore_expected_output(self)
-    return DisaggTestCaseClass
+    return disagg_test_case_class
 
 # This mixin class provides disaggregated storage configuration methods.
 class DisaggConfigMixin:


### PR DESCRIPTION
The test/suite currently generates unreadable test IDs and names, such as:

```
helper_disagg.disagg_test_class.<locals>.@disagg@test@case@class.test_layered07
```

This simplifies these names and IDs a bit, and most importantly, removes the `<` and `>` characters (simply just by removing `<locals>`), so that the string can be safely used in a shell:

```
tisagg_test_class.disagg_test_case_class.test_layered07
```