### PR TITLE
WT-13667 Support compiling WiredTiger with SWIG 4.3.0 version (v6.0 backport) (#11456)

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -653,7 +653,7 @@ OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, search_near, (self))
 		metadata = PyBytes_FromStringAndSize(*$1, *$2);
 		$result = metadata;
 		data = PyBytes_FromStringAndSize(*$3, *$4);
-		$result = SWIG_Python_AppendOutput($result, data);
+		$result = SWIG_AppendOutput($result, data);
 	}
 }
 


### PR DESCRIPTION
1ac6f25bff

Co-authored-by: Etienne Petrel <77254506+etienneptl@users.noreply.github.com>
(cherry picked from commit fb4019c82e9410791dadf8eb3ca4b86463b47050)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
