### PR TITLE
WT-13926 Increase the margin of error in test_evict02.py for expected stats values

### DIFF
--- a/test/suite/test_eviction02.py
+++ b/test/suite/test_eviction02.py
@@ -52,7 +52,7 @@ class test_eviction02(eviction_util):
         nrows = 10000
         prev_obsolete_tw_value = 0
         # Stats may have a stale value, allow some buffer.
-        threshold = self.obsolete_tw_max * 2
+        threshold = self.obsolete_tw_max * 2.5
         uri = 'table:eviction02'
         value = 'k' * 1024
 


### PR DESCRIPTION
The stats value can be stale, increase the buffer to take this into account.