### PR TITLE
WT-13091 Make cursor_copy debug mode more precise (v6.0 backport) (#10848)

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -380,8 +380,10 @@ __wt_cursor_get_keyv(WT_CURSOR *cursor, uint32_t flags, va_list ap)
         WT_ERR(__wt_cursor_kv_not_set(cursor, true));
 
     /* Force an allocated copy when using cursor copy debug. */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY))
+    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
         WT_ERR(__wt_buf_grow(session, &cursor->key, cursor->key.size));
+        F_SET(cursor, WT_CURSTD_DEBUG_COPY_KEY);
+    }
 
     if (WT_CURSOR_RECNO(cursor)) {
         if (LF_ISSET(WT_CURSTD_RAW)) {
@@ -529,8 +531,10 @@ __wt_cursor_get_valuev(WT_CURSOR *cursor, va_list ap)
         WT_ERR(__wt_cursor_kv_not_set(cursor, false));
 
     /* Force an allocated copy when using cursor copy debug. */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY))
+    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
         WT_ERR(__wt_buf_grow(session, &cursor->value, cursor->value.size));
+        F_SET(cursor, WT_CURSTD_DEBUG_COPY_VALUE);
+    }
 
     /* Fast path some common cases. */
     fmt = cursor->value_format;


### PR DESCRIPTION
9d1b71861

(cherry picked from commit cd0aeb5c8ea1fff19110f8e8f942eda218707b72)
