### PR TITLE
WT-13377 Reconfiguring a session with cache_max_wait_ms does not accept a value of zero (v7.0 backport) (#11177)

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2525,6 +2525,8 @@ extern int __ut_ovfl_discard_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT
   const char *tag) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_ovfl_discard_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_session_config_int(WT_SESSION_IMPL *session, const char *config)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bool skip_off);
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);
 

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -12,6 +12,7 @@ else()
         tests/test_fnv.cpp
         tests/test_pow.cpp
         tests/test_reconciliation_tracking.cpp
+        tests/test_session_config.cpp
         tests/test_tailq.cpp
         tests/block/test_bitstring.cpp
         tests/block/test_block_ckpt.cpp

--- a/test/unittest/tests/test_session_config.cpp
+++ b/test/unittest/tests/test_session_config.cpp
@@ -1,0 +1,87 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "wrappers/mock_session.h"
+
+/*
+ * session_config.cpp: Test one of the session configuration functions, __session_config_int. Ensure
+ * that the relevant configurations correctly modify the session state.
+ */
+
+/*
+ * Check a basic configuration that sets and clears a flag.
+ */
+static void
+test_config_flag(WT_SESSION_IMPL *session, const std::string &config_param, const int flag)
+{
+    std::string param_true = config_param + "=true";
+    std::string param_false = config_param + "=false";
+    REQUIRE(__ut_session_config_int(session, param_true.c_str()) == 0);
+    REQUIRE(F_ISSET(session, flag));
+    REQUIRE(__ut_session_config_int(session, param_false.c_str()) == 0);
+    REQUIRE(!F_ISSET(session, flag));
+    REQUIRE(__ut_session_config_int(session, param_true.c_str()) == 0);
+    REQUIRE(__ut_session_config_int(session, "") == 0);
+    REQUIRE(F_ISSET(session, flag));
+}
+
+TEST_CASE("Session config - test setting and clearing a flag", "[session_config]")
+{
+    /* Build Mock session, this will automatically create a mock connection. */
+    std::shared_ptr<MockSession> session_mock = MockSession::buildTestMockSession();
+    WT_SESSION_IMPL *session = session_mock->getWtSessionImpl();
+
+    SECTION("ignore_cache_size")
+    {
+        test_config_flag(session, "ignore_cache_size", WT_SESSION_IGNORE_CACHE_SIZE);
+    }
+
+    SECTION("cache_cursors")
+    {
+        test_config_flag(session, "cache_cursors", WT_SESSION_CACHE_CURSORS);
+    }
+
+    SECTION("debug.release_evict_page")
+    {
+        test_config_flag(session, "debug.release_evict_page", WT_SESSION_DEBUG_RELEASE_EVICT);
+    }
+}
+
+TEST_CASE("cache_max_wait_ms", "[session_config]")
+{
+    /* Build Mock session, this will automatically create a mock connection. */
+    std::shared_ptr<MockSession> session_mock = MockSession::buildTestMockSession();
+    WT_SESSION_IMPL *session = session_mock->getWtSessionImpl();
+
+    REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=2000") == 0);
+    REQUIRE(session->cache_max_wait_us == 2000 * WT_THOUSAND);
+
+    /* Test that setting to zero works correctly. */
+    REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=0") == 0);
+    REQUIRE(session->cache_max_wait_us == 0);
+
+    /*
+     * This call should not error out or return WT_NOTFOUND with invalid strings. We should depend
+     * __wt_config_getones unit tests for correctness. Currently that test does not exist.
+     */
+    REQUIRE(__ut_session_config_int(session, NULL) == 0);
+    REQUIRE(__ut_session_config_int(session, "") == 0);
+    REQUIRE(__ut_session_config_int(session, "foo=10000") == 0);
+    REQUIRE(__ut_session_config_int(session, "bad_string") == 0);
+    REQUIRE(session->cache_max_wait_us == 0);
+
+    /*
+     * WiredTiger config strings accept negative values, but the session variable is a uint64_t.
+     * Overflow is allowed.
+     */
+    REQUIRE(__ut_session_config_int(session, "cache_max_wait_ms=-1") == 0);
+    REQUIRE(session->cache_max_wait_us == 0xfffffffffffffc18);
+}


### PR DESCRIPTION
1e1d3fa085

---------

Co-authored-by: Luke Pearson <luke.pearson@mongodb.com>
Co-authored-by: Luke Chen <luke.chen@mongodb.com>
(cherry picked from commit 357fd20c8ba2be720e2af5cfef80758bc8273112)
