### PR TITLE
WT-14019 Add a check for a NULL session in __wt_session_set_last_error

### DIFF
--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -144,17 +144,16 @@ __wt_session_set_last_error(
   WT_SESSION_IMPL *session, int err, int sub_level_err, const char *fmt, ...)
 {
     WT_DECL_RET;
-    WT_ERROR_INFO *err_info = &(session->err_info);
-
-    /* Validate the sub level error code. */
-    WT_ASSERT(session, __wt_is_valid_sub_level_error(sub_level_err));
 
     /*
      * Only update the error struct if an error occurs during a session API call, or if the error
-     * struct is being initialized.
+     * struct is being initialized. If the session is NULL, there is nothing to update.
      */
-    if (!F_ISSET(session, WT_SESSION_SAVE_ERRORS))
+    if (session == NULL || !F_ISSET(session, WT_SESSION_SAVE_ERRORS))
         return (0);
+
+    /* Validate the incoming sub level error code. */
+    WT_ASSERT(session, __wt_is_valid_sub_level_error(sub_level_err));
 
     /*
      * Load error codes and message into err_info. If the message is empty or is NULL (indicating
@@ -165,6 +164,7 @@ __wt_session_set_last_error(
      * and err_msg should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a
      * strcmp to validate that we never set err = 0 with a custom message.
      */
+    WT_ERROR_INFO *err_info = &(session->err_info);
     err_info->err = err;
     err_info->sub_level_err = sub_level_err;
     if (fmt != NULL && strlen(fmt) == 0)

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
@@ -30,6 +30,11 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
     WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
     WT_ERROR_INFO *err_info = &(session_impl->err_info);
 
+    SECTION("Test with NULL session")
+    {
+        REQUIRE(__wt_session_set_last_error(NULL, 0, WT_NONE, WT_ERROR_INFO_EMPTY) == 0);
+    }
+
     SECTION("Test with initial values")
     {
         const char *err_msg_content = WT_ERROR_INFO_EMPTY;


### PR DESCRIPTION
`__wt_session_set_last_error` assumes that the session is non-NULL but Coverity has found a handful of cases where this isn't true. An extra check has been added so that the function returns `0` if a null session is passed in.