### PR TITLE
WT-14053 Enable test/model in ASAN

### DIFF
--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -18,7 +18,7 @@ function(create_test_executable target)
         PARSE_ARGV
         1
         "CREATE_TEST"
-        "CXX"
+        "CXX;NO_TEST_UTIL"
         "EXECUTABLE_NAME;BINARY_DIR"
         "SOURCES;INCLUDES;ADDITIONAL_FILES;ADDITIONAL_DIRECTORIES;LIBS;FLAGS"
     )
@@ -92,7 +92,10 @@ function(create_test_executable target)
     endif()
 
     # Link the base set of libraries for a wiredtiger C/CXX test.
-    target_link_libraries(${target} wt::wiredtiger test_util)
+    target_link_libraries(${target} wt::wiredtiger)
+    if(NOT CREATE_TEST_NO_TEST_UTIL)
+        target_link_libraries(${target} test_util)
+    endif()
     if(NOT "${CREATE_TEST_LIBS}" STREQUAL "")
         target_link_libraries(${target} ${CREATE_TEST_LIBS})
     endif()

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -4,6 +4,8 @@
 # are used when compiling the test executable.
 #   target - Target name of the test.
 #   SOURCES <source files> - Sources to compile for the given test.
+#   CXX - Indicates that this is a C++ test.
+#   NO_TEST_UTIL - Do not link against the test_util library.
 #   EXECUTABLE_NAME <name> - A name for the output test binary. Defaults to the target name if not given.
 #   BINARY_DIR <dir> - The output directory to install the binaries. Defaults to 'CMAKE_CURRENT_BINARY_DIR' if not given.
 #   INCLUDES <includes> - Additional includes for building the test binary.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5306,9 +5306,13 @@ buildvariants:
     # Exclude wt12015_backup_corruption for ASan builds. It creates false positives when it deliberately kills processes that invoke corruption.
     ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.model_checking !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
+    - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
     - name: examples-c-test
     - name: format-asan-smoke-test
+    - name: model-test-long
+      batchtime: 1440 # once a day
+    - name: model-test-long-random-config
+      batchtime: 1440 # once a day
     - name: live-restore-long
 
 - name: ubuntu2004-tsan

--- a/test/model/test/CMakeLists.txt
+++ b/test/model/test/CMakeLists.txt
@@ -21,27 +21,27 @@ target_link_libraries(wiredtiger_model_test_common wiredtiger_model wt::wiredtig
 create_test_executable(test_model_basic
     SOURCES model_basic/main.cpp
     LIBS wiredtiger_model wiredtiger_model_test_common
-    CXX
+    CXX NO_TEST_UTIL
 )
 create_test_executable(test_model_checkpoint
     SOURCES model_checkpoint/main.cpp
     LIBS wiredtiger_model wiredtiger_model_test_common
-    CXX
+    CXX NO_TEST_UTIL
 )
 create_test_executable(test_model_rts
     SOURCES model_rts/main.cpp
     LIBS wiredtiger_model wiredtiger_model_test_common
-    CXX
+    CXX NO_TEST_UTIL
 )
 create_test_executable(test_model_transaction
     SOURCES model_transaction/main.cpp
     LIBS wiredtiger_model wiredtiger_model_test_common
-    CXX
+    CXX NO_TEST_UTIL
 )
 create_test_executable(test_model_workload
     SOURCES model_workload/main.cpp
     LIBS wiredtiger_model wiredtiger_model_test_common
-    CXX
+    CXX NO_TEST_UTIL
 )
 
 # The test script.

--- a/test/model/tools/CMakeLists.txt
+++ b/test/model/tools/CMakeLists.txt
@@ -6,10 +6,10 @@ include(${CMAKE_SOURCE_DIR}/cmake/helpers.cmake)
 create_test_executable(model_test
     SOURCES model_test/main.cpp
     LIBS wiredtiger_model wiredtiger_model_test_common
-    CXX
+    CXX NO_TEST_UTIL
 )
 create_test_executable(model_verify_debug_log
     SOURCES model_verify_debug_log/main.cpp
     LIBS wiredtiger_model wiredtiger_model_test_common
-    CXX
+    CXX NO_TEST_UTIL
 )


### PR DESCRIPTION
Fix ASAN issues in test/model and enable the relevant tasks in Evergreen.

Fixed ASAN issues:
* Include the test_util library only once. It used to be linked twice, once through the test's "common" test utility library, and once through create_test_executable.
* Fix a memory leak in the model (the details are described in the comment).