### PR TITLE
WT-14069 Handle live restore worker getting EBUSY.

### DIFF
--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -161,7 +161,7 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
     ret = wt_session->open_cursor(wt_session, work_item->uri, NULL, NULL, &cursor);
     if (ret != 0)
         __wt_verbose_debug1(session, WT_VERB_LIVE_RESTORE,
-          "Live restore worker: Open cursor to %s ret %d", work_item->uri, ret);
+          "Live restore worker: Error opening cursor to %s, ret %d", work_item->uri, ret);
     if (ret == ENOENT) {
         /* Free the work item. */
         __live_restore_free_work_item(session, &work_item);
@@ -174,6 +174,8 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
         __wt_spin_lock(session, &server->queue_lock);
         TAILQ_INSERT_TAIL(&server->work_queue, work_item, q);
         __wt_spin_unlock(session, &server->queue_lock);
+        if (server->work_items_remaining < server->threads_working)
+            __wt_sleep(0, 100 * WT_THOUSAND);
         return (0);
     }
     WT_RET(ret);

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -74,8 +74,12 @@ err:
 static void
 __live_restore_free_work_item(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_WORK_ITEM **work_itemp)
 {
+    WTI_LIVE_RESTORE_SERVER *server = S2C(session)->live_restore_server;
+
     __wt_free(session, (*work_itemp)->uri);
     __wt_free(session, *work_itemp);
+    WT_STAT_CONN_SET(
+      session, live_restore_work_remaining, __wt_atomic_sub64(&server->work_items_remaining, 1));
 
     *work_itemp = NULL;
 }
@@ -155,9 +159,21 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
     WT_CURSOR *cursor;
     WT_SESSION *wt_session = (WT_SESSION *)session;
     ret = wt_session->open_cursor(wt_session, work_item->uri, NULL, NULL, &cursor);
+    if (ret != 0)
+        __wt_verbose_debug1(session, WT_VERB_LIVE_RESTORE,
+          "Live restore worker: Open cursor to %s ret %d", work_item->uri, ret);
     if (ret == ENOENT) {
         /* Free the work item. */
         __live_restore_free_work_item(session, &work_item);
+        return (0);
+    } else if (ret == EBUSY) {
+        /*
+         * Someone else has exclusive access to the table. Add it back to the work queue and try
+         * again later.
+         */
+        __wt_spin_lock(session, &server->queue_lock);
+        TAILQ_INSERT_TAIL(&server->work_queue, work_item, q);
+        __wt_spin_unlock(session, &server->queue_lock);
         return (0);
     }
     WT_RET(ret);
@@ -176,12 +192,10 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
       session, WT_VERB_LIVE_RESTORE, "Live restore worker: Filling holes in %s", work_item->uri);
     ret = __wti_live_restore_fs_fill_holes(fh, wt_session);
     __wt_verbose_debug1(session, WT_VERB_LIVE_RESTORE,
-      "Live restore worker: Finished finished filling holes in %s", work_item->uri);
+      "Live restore worker: Finished finished filling holes in %s ret %d", work_item->uri, ret);
 
     /* Free the work item. */
     __live_restore_free_work_item(session, &work_item);
-    WT_STAT_CONN_SET(
-      session, live_restore_work_remaining, __wt_atomic_sub64(&server->work_items_remaining, 1));
     WT_TRET(cursor->close(cursor));
     return (ret);
 }

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -179,8 +179,7 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
         TAILQ_INSERT_TAIL(&server->work_queue, work_item, q);
         __wt_spin_unlock(session, &server->queue_lock);
         if (remain < (uint64_t)threads)
-            ;
-        __wt_sleep(0, 100 * WT_THOUSAND);
+            __wt_sleep(0, 100 * WT_THOUSAND);
         return (0);
     }
     WT_RET(ret);

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -36,7 +36,7 @@ __thread_run(void *arg)
  */
 err:
     if (thread->stop_func != NULL)
-        ret = thread->stop_func(session, thread);
+        WT_TRET(thread->stop_func(session, thread));
 
     if (ret != 0 && F_ISSET(thread, WT_THREAD_PANIC_FAIL))
         WT_IGNORE_RET(__wt_panic(session, ret, "Unrecoverable utility thread error"));


### PR DESCRIPTION
Here is the change to handle EBUSY. The branch for 14005 running with this change is passing the failing CONFIG.
