### PR TITLE
WT-14066 Set sub-level error code and message with python tests for drop EBUSY workflows (checkpoint lock conflict)

### DIFF
--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -184,6 +184,10 @@ sub_errors = [
         "Another thread currently holds the table lock", '''
         This sub-level error indicates that a concurrent operation is performing
         a table operation.'''),
+    Error('WT_CONFLICT_CHECKPOINT_LOCK', -32012,
+        "Another thread currently holds the checkpoint lock", '''
+        This sub-level error indicates that a concurrent operation is performing
+        a checkpoint.'''),
 ]
 
 # Update the #defines in the wiredtiger.in file.

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1017,6 +1017,7 @@ multiblock
 multicycle
 multiprocess
 multithreaded
+multithreading
 munmap
 mutex
 mutexes

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -67,6 +67,8 @@ __wt_wiredtiger_error(int error)
         return ("WT_DIRTY_DATA: Table has dirty data");
     case WT_CONFLICT_TABLE_LOCK:
         return ("WT_CONFLICT_TABLE_LOCK: Another thread currently holds the table lock");
+    case WT_CONFLICT_CHECKPOINT_LOCK:
+        return ("WT_CONFLICT_CHECKPOINT_LOCK: Another thread currently holds the checkpoint lock");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -134,6 +134,9 @@ This sub-level error returns when the table has dirty content.
 @par \c WT_CONFLICT_TABLE_LOCK
 This sub-level error indicates that a concurrent operation is performing a table operation.
 
+@par \c WT_CONFLICT_CHECKPOINT_LOCK
+This sub-level error indicates that a concurrent operation is performing a checkpoint.
+
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4136,6 +4136,12 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * table operation.
  */
 #define	WT_CONFLICT_TABLE_LOCK	(-32011)
+/*!
+ * Another thread currently holds the checkpoint lock.
+ * This sub-level error indicates that a concurrent operation is performing a
+ * checkpoint.
+ */
+#define	WT_CONFLICT_CHECKPOINT_LOCK	(-32012)
 /*
  * Sub-level error return section: END
  * DO NOT EDIT: automatically built by dist/api_err.py.

--- a/test/catch2/sub_level_error/api/test_sub_level_error_strerror.cpp
+++ b/test/catch2/sub_level_error/api/test_sub_level_error_strerror.cpp
@@ -41,6 +41,8 @@ TEST_CASE("Test generation of sub-level error codes when strerror is called",
           {WT_DIRTY_DATA, "WT_DIRTY_DATA: Table has dirty data"},
           {WT_CONFLICT_TABLE_LOCK,
             "WT_CONFLICT_TABLE_LOCK: Another thread currently holds the table lock"},
+          {WT_CONFLICT_CHECKPOINT_LOCK,
+            "WT_CONFLICT_CHECKPOINT_LOCK: Another thread currently holds the checkpoint lock"},
         };
 
         for (auto const [code, expected] : errors)

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
@@ -163,8 +163,8 @@ TEST_CASE("Test WT_CONFLICT_BACKUP and WT_CONFLICT_DHANDLE", "[sub_level_error_d
  *
  * We need different threads holding the lock versus performing the drop (as opposed to having
  * another session take the lock within the same thread). This is because the Windows implementation
- * of __wt_spin_lock/__wt_try_spin_lock will take the lock if has already been taken by the same
- * thread, resulting in a successful (no conflicts) drop.
+ * of __wt_spin_lock/__wt_try_spin_lock will still take the lock if it has already been taken by the
+ * same thread, resulting in a successful (no conflicts) drop.
  */
 TEST_CASE("Test conflicts with checkpoint/schema/table locks", "[sub_level_error_drop_conflict]")
 {

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -49,6 +49,7 @@ class test_strerror(wttest.WiredTigerTestCase, suite_subprocess):
         (wiredtiger.WT_UNCOMMITTED_DATA, "WT_UNCOMMITTED_DATA: Table has uncommitted data"),
         (wiredtiger.WT_DIRTY_DATA, "WT_DIRTY_DATA: Table has dirty data"),
         (wiredtiger.WT_CONFLICT_TABLE_LOCK, "WT_CONFLICT_TABLE_LOCK: Another thread currently holds the table lock"),
+        (wiredtiger.WT_CONFLICT_CHECKPOINT_LOCK, "WT_CONFLICT_CHECKPOINT_LOCK: Another thread currently holds the checkpoint lock"),
     ]
 
     def check_error_code(self, error, expected):


### PR DESCRIPTION
This ticket involves reproducing one of the EBUSY drop workflows and making sure that the get_last_error API works as appropriate. The idea is that the API should be able to provide more information on why an EBUSY has been returned from the drop() call. 
The following scenarios have been added, reproduced, handled using `__wt_session_set_last_error`, and tested:

- `EBUSY`, `WT_CONFLICT_CHECKPOINT_LOCK`, another thread has the schema lock