### PR TITLE
WT-14073 Fix the implementation of feature flag for "using soft pointers in eviction server".

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2153,9 +2153,9 @@ __evict_walk_prepare(WT_SESSION_IMPL *session, uint32_t *walk_flagsp)
         if (btree->evict_ref == NULL && (++btree->linear_walk_restarts) & 1) {
             if (S2C(session)->evict->use_npos_in_pass)
                 /* Alternate with rand_prev so that the start of the tree is visited more often */
-                goto rand_next;
-            else
                 goto rand_prev;
+            else
+                goto rand_next;
         }
         break;
     case WT_EVICT_WALK_PREV:
@@ -2163,7 +2163,7 @@ __evict_walk_prepare(WT_SESSION_IMPL *session, uint32_t *walk_flagsp)
         if (btree->evict_ref == NULL && (++btree->linear_walk_restarts) & 1) {
             if (S2C(session)->evict->use_npos_in_pass)
                 /* Alternate with rand_next so that the end of the tree is visited more often */
-                goto rand_prev;
+                goto rand_next;
             else
                 goto rand_prev;
         }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2150,15 +2150,23 @@ __evict_walk_prepare(WT_SESSION_IMPL *session, uint32_t *walk_flagsp)
     switch (btree->evict_start_type) {
     case WT_EVICT_WALK_NEXT:
         /* Each time when evict_ref is null, alternate between linear and random walk */
-        if (btree->evict_ref == NULL && (++btree->linear_walk_restarts) & 1)
-            /* Alternate with rand_prev so that the start of the tree is visited more often */
-            goto rand_prev;
+        if (btree->evict_ref == NULL && (++btree->linear_walk_restarts) & 1) {
+            if (S2C(session)->evict->use_npos_in_pass)
+                /* Alternate with rand_prev so that the start of the tree is visited more often */
+                goto rand_next;
+            else
+                goto rand_prev;
+        }
         break;
     case WT_EVICT_WALK_PREV:
         /* Each time when evict_ref is null, alternate between linear and random walk */
-        if (btree->evict_ref == NULL && (++btree->linear_walk_restarts) & 1)
-            /* Alternate with rand_next so that the end of the tree is visited more often */
-            goto rand_next;
+        if (btree->evict_ref == NULL && (++btree->linear_walk_restarts) & 1) {
+            if (S2C(session)->evict->use_npos_in_pass)
+                /* Alternate with rand_next so that the end of the tree is visited more often */
+                goto rand_prev;
+            else
+                goto rand_prev;
+        }
         FLD_SET(*walk_flagsp, WT_READ_PREV);
         break;
     case WT_EVICT_WALK_RAND_PREV:


### PR DESCRIPTION
This change mitigates BF-35698 where WT-13790 did not completely hide all changes behind the feature flag.

This PR completes that work by flipping the two "goto"s back in place if the new behavior is disabled.

The initial change is done in WT-12644.