### PR TITLE
SLS-1144 Re-enable code cleanliness checks in WiredTiger

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1666,13 +1666,14 @@ methods = {
                     only dump updates that are visible to the session''',
                     type='boolean', undoc=True),
                 Config('start_timestamp', '', r'''
-                    Only return updates with durable timestamps larger than the start timestamp. If a
-                    tombstone has a timestamp larger than the start timestamp but the associated full
-                    value has a timestamp smaller than the start timestamp, it returns the tombstone and
-                    the full value.''', undoc=True),
+                    Only return updates with durable timestamps larger than the start timestamp. If
+                    a tombstone has a timestamp larger than the start timestamp but the associated
+                    full value has a timestamp smaller than the start timestamp, it returns the
+                    tombstone and the full value.''', undoc=True),
                 Config('timestamp_order', 'false', r'''
                     Return the updates in timestamp order from newest to oldest and ignore duplicate
-                    updates and updates that are from the same transaction with the same timestamp.''',
+                    updates and updates that are from the same transaction with the same timestamp.
+                    ''',
                     type='boolean', undoc=True),
         ]),
         Config('release_evict', 'false', r'''

--- a/dist/s_all
+++ b/dist/s_all
@@ -5,7 +5,7 @@
 ################################################################
 # For disaggregated storage, we're not enforcing certain scripts yet.
 # TODO: remove changes to s_all that ignore certain scripts, and resolve resulting fallout.
-disagg_ignore="comment_style.py s_funcs"
+disagg_ignore="comment_style.py"
 ################################################################
 
 . `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh

--- a/dist/s_all
+++ b/dist/s_all
@@ -5,7 +5,7 @@
 ################################################################
 # For disaggregated storage, we're not enforcing certain scripts yet.
 # TODO: remove changes to s_all that ignore certain scripts, and resolve resulting fallout.
-disagg_ignore="comment_style.py s_funcs s_longlines"
+disagg_ignore="comment_style.py s_funcs"
 ################################################################
 
 . `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh

--- a/dist/s_all
+++ b/dist/s_all
@@ -2,12 +2,6 @@
 
 # Run standard scripts.
 
-################################################################
-# For disaggregated storage, we're not enforcing certain scripts yet.
-# TODO: remove changes to s_all that ignore certain scripts, and resolve resulting fallout.
-disagg_ignore="comment_style.py"
-################################################################
-
 . `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
 cd_dist
 t_pfx=__s_all_tmp_

--- a/dist/s_all
+++ b/dist/s_all
@@ -115,10 +115,6 @@ run()
     local t="${t_pfx}-${name}-$$"
     [[ "$name" =~ .*\.py$ ]] && cmd="python3 $cmd" || cmd="/bin/bash $cmd"
     [[ -z "$bg" ]] && status "Running: $name"
-    if echo " $disagg_ignore " | grep " $1 " >/dev/null; then
-        echo "$name skipped for disaggregated storage"
-        return
-    fi
     $cmd > $t 2>&1
     [[ -z "$bg" ]] && status ""
     errchk "$name" "$t" "$flags"

--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -3,6 +3,7 @@ WT_CRC32_ENTRY
 WT_CURDUMP_PASS
 __bit_ffs
 __bit_nclr
+__layered_drain_ingest_tables
 __ovfl_discard_dump
 __ovfl_reuse_dump
 __wt_bloom_drop

--- a/src/block_disagg/block_disagg_open.c
+++ b/src/block_disagg/block_disagg_open.c
@@ -8,21 +8,6 @@
 
 #include "wt_internal.h"
 
-#if 0
-/*
- * __wt_block_disagg_manager_drop --
- *     Drop a file - this isn't currently called. The disaggregated manager isn't being notified
- *     when an object should be cleaned up. Doing so will require wiring in non-default block
- *     managers such that the metadata tracking knows which to call. It should also move into the
- *     block manager interface, rather than being a direct call.
- */
-int
-__wt_block_disagg_manager_drop(WT_SESSION_IMPL *session, const char *filename, bool durable)
-{
-    return (0);
-}
-#endif
-
 /*
  * __wt_block_disagg_manager_create --
  *     Create a file - it's a bit of a game with a new block manager. The file is created when

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -925,11 +925,11 @@ __btree_preload(WT_SESSION_IMPL *session)
     WT_INTL_FOREACH_BEGIN (session, btree->root.page, ref)
         if (__wt_ref_addr_copy(session, ref, &addr)) {
             /*
-             * The below call passes in a nul for the block metadata argument - if we want to
-             * start calling this for disaggregated storage we will need to revisit that.
+             * The below call passes in a nul for the block metadata argument - if we want to start
+             * calling this for disaggregated storage we will need to revisit that.
              */
-            WT_ERR(__wt_blkcache_read(session, tmp,
-                        NULL, addr.block_cookie, addr.block_cookie_size));
+            WT_ERR(
+              __wt_blkcache_read(session, tmp, NULL, addr.block_cookie, addr.block_cookie_size));
             ++block_preload;
         }
     WT_INTL_FOREACH_END;

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -903,6 +903,45 @@ __wti_btree_new_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
 }
 
 /*
+ * __btree_preload --
+ *     Pre-load internal pages.
+ */
+static int
+__btree_preload(WT_SESSION_IMPL *session)
+{
+    WT_ADDR_COPY addr;
+    WT_BTREE *btree;
+    WT_DECL_ITEM(tmp);
+    WT_DECL_RET;
+    WT_REF *ref;
+    uint64_t block_preload;
+
+    btree = S2BT(session);
+    block_preload = 0;
+
+    WT_RET(__wt_scr_alloc(session, 0, &tmp));
+
+    /* Pre-load the second-level internal pages. */
+    WT_INTL_FOREACH_BEGIN (session, btree->root.page, ref)
+        if (__wt_ref_addr_copy(session, ref, &addr)) {
+            /*
+             * The below call passes in a nul for the block metadata argument - if we want to
+             * start calling this for disaggregated storage we will need to revisit that.
+             */
+            WT_ERR(__wt_blkcache_read(session, tmp,
+                        NULL, addr.block_cookie, addr.block_cookie_size));
+            ++block_preload;
+        }
+    WT_INTL_FOREACH_END;
+
+err:
+    __wt_scr_free(session, &tmp);
+
+    WT_STAT_CONN_INCRV(session, block_preload, block_preload);
+    return (ret);
+}
+
+/*
  * __btree_get_last_recno --
  *     Set the last record number for a column-store. Note that this is used to handle appending to
  *     a column store after a truncate operation. It is not related to the WT_CURSOR::largest_key

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -11,7 +11,7 @@
 static int __btree_conf(WT_SESSION_IMPL *, WT_CKPT *ckpt, bool);
 static int __btree_get_last_recno(WT_SESSION_IMPL *);
 static int __btree_page_sizes(WT_SESSION_IMPL *);
-// static int __btree_preload(WT_SESSION_IMPL *);
+static int __btree_preload(WT_SESSION_IMPL *);
 static int __btree_tree_open_empty(WT_SESSION_IMPL *, bool);
 
 /*
@@ -146,8 +146,10 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
             WT_ERR(__wti_btree_tree_open(session, root_addr, root_addr_size));
 
             /* Warm the cache, if possible. */
-            // WT_WITH_PAGE_INDEX(session, ret = __btree_preload(session));
-            // WT_ERR(ret);
+            if (!__wt_conn_is_disagg(session)) {
+                WT_WITH_PAGE_INDEX(session, ret = __btree_preload(session));
+                WT_ERR(ret);
+            }
 
             /* Get the last record number in a column-store file. */
             if (btree->type != BTREE_ROW)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -211,8 +211,6 @@ extern int __wt_block_disagg_corrupt(WT_BM *bm, WT_SESSION_IMPL *session, const 
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_manager_create(WT_SESSION_IMPL *session, WT_BUCKET_STORAGE *bstorage,
   const char *filename) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_block_disagg_manager_drop(WT_SESSION_IMPL *session, const char *filename,
-  bool durable) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_manager_open(WT_SESSION_IMPL *session, const char *uri,
   const char *cfg[], bool forced_salvage, bool readonly, WT_BM **bmp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1017,8 +1015,6 @@ extern int __wt_meta_checkpoint_clear(WT_SESSION_IMPL *session, const char *fnam
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_checkpoint_last_name(
   WT_SESSION_IMPL *session, const char *fname, const char **namep, int64_t *orderp, uint64_t *timep)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_meta_ckpt_order(WT_SESSION_IMPL *session, int64_t *orderp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_ckptlist_get(WT_SESSION_IMPL *session, const char *fname, bool update,
   WT_CKPT **ckptbasep, size_t *allocated) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -642,24 +642,6 @@ __meta_blk_mods_load(
 }
 
 /*
- * __wt_meta_ckpt_order --
- *     Get the checkpoint order of the metadata table.
- */
-int
-__wt_meta_ckpt_order(WT_SESSION_IMPL *session, int64_t *orderp)
-{
-    WT_CKPT ckpt;
-    WT_DATA_HANDLE *dhandle;
-
-    dhandle = WT_SESSION_META_DHANDLE(session);
-
-    WT_RET(__wt_meta_checkpoint(session, dhandle->name, dhandle->checkpoint, &ckpt));
-    *orderp = ckpt.order;
-
-    return (0);
-}
-
-/*
  * __meta_ckptlist_allocate_new_ckpt --
  *     Provided a checkpoint list, allocate a new checkpoint. Either use the last checkpoint in the
  *     list or the file metadata to initialize this new checkpoint.


### PR DESCRIPTION
The WiredTiger disaggregated storage branch has disabled a few of our regular code cleanliness checks to expedite development. It's time to re-enable those checks.

