### PR TITLE
WT-14070 Prevent saving errors at the end commit transaction or rollback transaction

### DIFF
--- a/test/suite/test_error_info04.py
+++ b/test/suite/test_error_info04.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger
+from error_info_util import error_info_util
+
+# test_error_info04.py
+#   Test that when committing or rolling back a transaction, after successfully committing or 
+#   rolling back, if an error occurs in __wti_evict_app_assist_worker it is not saved in err_info.
+class test_error_info04(error_info_util):
+    uri = "table:test_error_info.wt"
+
+    def test_commit_transaction_skip_save(self):
+        # Configure connection with very low cache wait time and dirty trigger. 
+        self.conn.reconfigure('cache_max_wait_ms=2,eviction_dirty_target=1,eviction_dirty_trigger=2')
+
+        # Create a basic table.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+        # Open a session and cursor.
+        cursor = self.session.open_cursor(self.uri)
+
+        # Start a transaction and insert a value large enough to trigger eviction app worker threads.
+        self.session.begin_transaction()
+        cursor.set_key("key_a")
+        cursor.set_value("a"*1024*5000)
+        cursor.update()
+        with self.expectedStdoutPattern("transaction rolled back because of cache overflow"):
+            self.assertEqual(self.session.commit_transaction(), 0)
+            self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")
+
+            self.session.checkpoint()
+    
+    def test_rollback_transaction_skip_save(self):
+        # Configure connection with very low cache max wait time and dirty trigger.
+        self.conn.reconfigure('cache_max_wait_ms=2,eviction_dirty_target=1,eviction_dirty_trigger=2')
+
+        # Create a basic table.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+        # Open a session and cursor.
+        cursor = self.session.open_cursor(self.uri)
+
+        # Start a transaction and insert a value large enough to trigger eviction app worker threads.
+        self.session.begin_transaction()
+        cursor.set_key("key_b")
+        cursor.set_value("b"*1024*5000)
+        cursor.update()
+        with self.expectedStdoutPattern("transaction rolled back because of cache overflow"):
+            self.assertEqual(self.session.rollback_transaction(), 0)
+            self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")


### PR DESCRIPTION
At the end of the API calls `session->commit_transaction `and `session->rollback_transaction`, the `WT_SESSION_SAVE_ERRORS` flag is cleared before `__wt_evict_app_assist_worker_check` is called. This prevent errors from being saved in the err_info struct. The flag is then restored after.

Python tests have been written to test both of these API calls.