### PR TITLE
WT-14067 Script changes for backup directory and compatibility.

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -490,7 +490,7 @@ upgrade_downgrade()
 	    # changed. So copy it for older releases if testing against a
 	    # develop run that is doing backups.
 	    dir2=$top/$format_dir_branch2/RUNDIR.$am
-	    if [ "$2" == "develop" && -e $dir2/BACKUP ]; then
+	    if [ -e $dir2/BACKUP -a ! -e $dir2/BACKUP.copy ] ; then
                 echo "Copying backup directory for older releases"
 		cp -rp $dir2/BACKUP $dir2/BACKUP.copy
 	    fi

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -485,6 +485,15 @@ upgrade_downgrade()
                 echo "transaction.timestamps=1" >> $config
                 echo "transaction.implicit=0" >> $config
             fi
+	    # Older releases (8.0 and older) expect to find a BACKUP.copy
+	    # directory if BACKUP exists. After 8.0 the directory structure
+	    # changed. So copy it for older releases if testing against a
+	    # develop run that is doing backups.
+	    dir2=$top/$format_dir_branch2/RUNDIR.$am
+	    if [ "$2" == "develop" && -e $dir2/BACKUP ]; then
+                echo "Copying backup directory for older releases"
+		cp -rp $dir2/BACKUP $dir2/BACKUP.copy
+	    fi
             echo "$1 format running on $2 access method $am..."
             cd "$top/$format_dir_branch1"
             flags="-1Rq $(bflag $1)"


### PR DESCRIPTION
Luke and Ravi - Please review carefully these changes to the compatibility script. How do I test this script change since compatibility tests don't normally run with PR tests? Also how do I test it since backups may or may not randomly get configured in the format run.

My local testing was that I pulled the code out into a small local script:
```
#!/usr/bin/env bash
dir2=./RUNDIR
if [ -e $dir2/BACKUP ]; then
	echo "Copying backup directory for older releases"
	cp -rp $dir2/BACKUP $dir2/BACKUP.copy
fi
```
and ran the compatibility reproducer I've been using and it succeeded.