### PR TITLE
WT-14063 Implement a preliminary live restore performance test

### DIFF
--- a/bench/wtperf/runners/500m-btree-50r50u-live-restore-no-server.wtperf
+++ b/bench/wtperf/runners/500m-btree-50r50u-live-restore-no-server.wtperf
@@ -1,0 +1,26 @@
+# wtperf options file: simulate MongoDB.
+# The configuration for the connection and table are from mongoDB.
+# We use multiple tables to simulate collections and indexes.
+# This test assumes that its correlating populate already completed and exists.
+#
+# Set cache to half of memory of AWS perf instance.  Enable logging and
+# checkpoints.  Collect wiredtiger stats for ftdc.
+conn_config="cache_size=16G,checkpoint=(wait=60,log_size=2GB),session_max=20000,log=(enabled),eviction=(threads_max=8)"
+create=false
+compression="snappy"
+sess_config="isolation=snapshot"
+table_config="type=file"
+table_count=2
+# close_conn as false allows this test to close/finish faster, but if running
+# as the set, the next test will need to run recovery.
+close_conn=false
+key_sz=40
+value_sz=120
+max_latency=2000
+pareto=20
+report_interval=10
+run_time=7200
+sample_interval=10
+sample_rate=1
+threads=((count=10,reads=1),(count=10,updates=1))
+warmup=120

--- a/bench/wtperf/runners/500m-btree-50r50u-live-restore-no-server.wtperf
+++ b/bench/wtperf/runners/500m-btree-50r50u-live-restore-no-server.wtperf
@@ -1,4 +1,5 @@
 # wtperf options file: simulate MongoDB.
+# This test is identical to the 500m-btree-50r50u tests, but with live restore enabled to understand the perf impacts of live restore. Any changes to that file should be also be made here.
 # The configuration for the connection and table are from mongoDB.
 # We use multiple tables to simulate collections and indexes.
 # This test assumes that its correlating populate already completed and exists.

--- a/bench/wtperf/runners/500m-btree-50r50u-live-restore-no-server.wtperf
+++ b/bench/wtperf/runners/500m-btree-50r50u-live-restore-no-server.wtperf
@@ -6,7 +6,7 @@
 #
 # Set cache to half of memory of AWS perf instance.  Enable logging and
 # checkpoints.  Collect wiredtiger stats for ftdc.
-conn_config="cache_size=16G,checkpoint=(wait=60,log_size=2GB),session_max=20000,log=(enabled),eviction=(threads_max=8)"
+conn_config="create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),cache_size=16G,checkpoint=(wait=60,log_size=2GB),session_max=20000,log=(enabled),eviction=(threads_max=8),live_restore=(enabled=true,path=SOURCE,threads_max=0)"
 create=false
 compression="snappy"
 sess_config="isolation=snapshot"

--- a/bench/wtperf/runners/500m-btree-50r50u-live-restore.wtperf
+++ b/bench/wtperf/runners/500m-btree-50r50u-live-restore.wtperf
@@ -1,0 +1,26 @@
+# wtperf options file: simulate MongoDB.
+# The configuration for the connection and table are from mongoDB.
+# We use multiple tables to simulate collections and indexes.
+# This test assumes that its correlating populate already completed and exists.
+#
+# Set cache to half of memory of AWS perf instance.  Enable logging and
+# checkpoints.  Collect wiredtiger stats for ftdc.
+conn_config="cache_size=16G,checkpoint=(wait=60,log_size=2GB),session_max=20000,log=(enabled),eviction=(threads_max=8)"
+create=false
+compression="snappy"
+sess_config="isolation=snapshot"
+table_config="type=file"
+table_count=2
+# close_conn as false allows this test to close/finish faster, but if running
+# as the set, the next test will need to run recovery.
+close_conn=false
+key_sz=40
+value_sz=120
+max_latency=2000
+pareto=20
+report_interval=10
+run_time=7200
+sample_interval=10
+sample_rate=1
+threads=((count=10,reads=1),(count=10,updates=1))
+warmup=120

--- a/bench/wtperf/runners/500m-btree-50r50u-live-restore.wtperf
+++ b/bench/wtperf/runners/500m-btree-50r50u-live-restore.wtperf
@@ -5,7 +5,7 @@
 #
 # Set cache to half of memory of AWS perf instance.  Enable logging and
 # checkpoints.  Collect wiredtiger stats for ftdc.
-conn_config="cache_size=16G,checkpoint=(wait=60,log_size=2GB),session_max=20000,log=(enabled),eviction=(threads_max=8)"
+conn_config="create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),cache_size=16G,checkpoint=(wait=60,log_size=2GB),session_max=20000,log=(enabled),eviction=(threads_max=8),live_restore=(enabled=true,path=SOURCE)"
 create=false
 compression="snappy"
 sess_config="isolation=snapshot"

--- a/bench/wtperf/runners/500m-btree-50r50u-live-restore.wtperf
+++ b/bench/wtperf/runners/500m-btree-50r50u-live-restore.wtperf
@@ -1,5 +1,5 @@
 # wtperf options file: simulate MongoDB.
-# The configuration for the connection and table are from mongoDB.
+# This test is identical to the 500m-btree-50r50u tests, but with live restore enabled (without background threads) to understand the perf impacts of live restore. Any changes to that file should be also be made here.
 # We use multiple tables to simulate collections and indexes.
 # This test assumes that its correlating populate already completed and exists.
 #

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5113,16 +5113,16 @@ tasks:
             mkdir WT_TEST_0_0
       - func: "run-perf-test"
         vars:
-          perf-test-name: 500m-btree-50r50u-live-restore.wtperf
+          perf-test-name: 500m-btree-50r50u-live-restore-no-server.wtperf
           maxruns: 1
           no_create: true
           wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),live_restore=(enabled=true,path=SOURCE,threads_max=0)"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
       - func: "upload stats to atlas"
         vars:
-          test-name: 500m-btree-50r50u-live-restore.wtperf
+          test-name: 500m-btree-50r50u-live-restore-no-server.wtperf
       - func: "upload stats to evergreen"
         vars:
-          test-name: 500m-btree-50r50u-live-restore.wtperf
+          test-name: 500m-btree-50r50u-live-restore-no-server.wtperf
       - func: "cleanup"
 
   - name: many-dhandle-stress

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5043,6 +5043,86 @@ tasks:
         vars:
           test-name: checkpoint-stress.wtperf
 
+  - name: perf-test-live-restore
+    tags: ["long-perf"]
+    depends_on:
+      - name: perf-test-long-500m-btree-populate
+    commands:
+      - command: timeout.update
+        params:
+          exec_timeout_secs: 10800
+          timeout_secs: 10800
+      # Fetch the compile artifacts.
+      - func: "fetch artifacts"
+      # Fetch the database created by perf-test-long-500m-btree-populate task. This will be used
+      # as the source for live restore.
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: perf-test-long-500m-btree-populate
+          destination: "wiredtiger/cmake_build/bench/wtperf/SOURCE"
+      # Create an empty home directory to be used as the destination for live restore.
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/bench/wtperf"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            mkdir WT_TEST_0_0
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: 500m-btree-50r50u-live-restore.wtperf
+          maxruns: 1
+          no_create: true
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),live_restore=(enabled=true,path=SOURCE)"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+      - func: "upload stats to atlas"
+        vars:
+          test-name: 500m-btree-50r50u-live-restore.wtperf
+      - func: "upload stats to evergreen"
+        vars:
+          test-name: 500m-btree-50r50u-live-restore.wtperf
+      - func: "cleanup"
+      
+  - name: perf-test-live-restore
+    tags: ["long-perf"]
+    depends_on:
+      - name: perf-test-long-500m-btree-populate
+    commands:
+      - command: timeout.update
+        params:
+          exec_timeout_secs: 10800
+          timeout_secs: 10800
+      # Fetch the compile artifacts.
+      - func: "fetch artifacts"
+      # Fetch the database created by perf-test-long-500m-btree-populate task. This will be used
+      # as the source for live restore.
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: perf-test-long-500m-btree-populate
+          destination: "wiredtiger/cmake_build/bench/wtperf/SOURCE"
+      # Create an empty home directory to be used as the destination for live restore.
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/bench/wtperf"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            mkdir WT_TEST_0_0
+      - func: "run-perf-test"
+        vars:
+          perf-test-name: 500m-btree-50r50u-live-restore.wtperf
+          maxruns: 1
+          no_create: true
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),live_restore=(enabled=true,path=SOURCE)"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+      - func: "upload stats to atlas"
+        vars:
+          test-name: 500m-btree-50r50u-live-restore.wtperf
+      - func: "upload stats to evergreen"
+        vars:
+          test-name: 500m-btree-50r50u-live-restore.wtperf
+      - func: "cleanup"
+
   - name: many-dhandle-stress
     depends_on:
       - name: compile

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5045,6 +5045,7 @@ tasks:
 
   - name: perf-test-live-restore
     tags: ["long-perf"]
+    patch_only: true
     depends_on:
       - name: perf-test-long-500m-btree-populate
     commands:
@@ -5083,8 +5084,9 @@ tasks:
           test-name: 500m-btree-50r50u-live-restore.wtperf
       - func: "cleanup"
       
-  - name: perf-test-live-restore
+  - name: perf-test-live-restore-no-server
     tags: ["long-perf"]
+    patch_only: true
     depends_on:
       - name: perf-test-long-500m-btree-populate
     commands:
@@ -5114,7 +5116,7 @@ tasks:
           perf-test-name: 500m-btree-50r50u-live-restore.wtperf
           maxruns: 1
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),live_restore=(enabled=true,path=SOURCE)"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),live_restore=(enabled=true,path=SOURCE,threads_max=0)"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
       - func: "upload stats to atlas"
         vars:
           test-name: 500m-btree-50r50u-live-restore.wtperf

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5075,7 +5075,7 @@ tasks:
           perf-test-name: 500m-btree-50r50u-live-restore.wtperf
           maxruns: 1
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),live_restore=(enabled=true,path=SOURCE)"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -ops ['"read", "update", "warnings", "max_latency_read_update"']
       - func: "upload stats to atlas"
         vars:
           test-name: 500m-btree-50r50u-live-restore.wtperf
@@ -5083,7 +5083,7 @@ tasks:
         vars:
           test-name: 500m-btree-50r50u-live-restore.wtperf
       - func: "cleanup"
-      
+
   - name: perf-test-live-restore-no-server
     tags: ["long-perf"]
     patch_only: true
@@ -5116,7 +5116,7 @@ tasks:
           perf-test-name: 500m-btree-50r50u-live-restore-no-server.wtperf
           maxruns: 1
           no_create: true
-          wtarg: -args ['"-C create,statistics=(fast),statistics_log=(json,wait=1,sources=[file:]),live_restore=(enabled=true,path=SOURCE,threads_max=0)"'] -ops ['"read", "update", "warnings", "max_latency_read_update"']
+          wtarg: -ops ['"read", "update", "warnings", "max_latency_read_update"']
       - func: "upload stats to atlas"
         vars:
           test-name: 500m-btree-50r50u-live-restore-no-server.wtperf


### PR DESCRIPTION
This adds two new perf tests for live restore:
1. Uses live restore with background migration
2. Uses live restore but disables all background migration threads

The tests are currently labelled as `patch_only` and should be enabled in the mainline patches once the project implementation is complete and perf results are stable.

Please see the Jira comments for preliminary results. 