### PR TITLE
WT-14095 Zero pad the usecs in messages.

### DIFF
--- a/src/support/err.c
+++ b/src/support/err.c
@@ -280,10 +280,10 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
     if (is_json) {
         WT_ERROR_APPEND(p, remain, "\"ts_sec\":%" PRIuMAX ",", (uintmax_t)ts.tv_sec);
         WT_ERROR_APPEND(
-          p, remain, "\"ts_usec\":%" PRIuMAX ",", (uintmax_t)ts.tv_nsec / WT_THOUSAND);
+          p, remain, "\"ts_usec\":%.6" PRIuMAX ",", (uintmax_t)ts.tv_nsec / WT_THOUSAND);
         WT_ERROR_APPEND(p, remain, "\"thread\":\"%s\",", tid);
     } else
-        WT_ERROR_APPEND(p, remain, "[%" PRIuMAX ":%" PRIuMAX "][%s]", (uintmax_t)ts.tv_sec,
+        WT_ERROR_APPEND(p, remain, "[%" PRIuMAX ":%.6" PRIuMAX "][%s]", (uintmax_t)ts.tv_sec,
           (uintmax_t)ts.tv_nsec / WT_THOUSAND, tid);
 
     /* Error prefix. */

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -280,7 +280,7 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
     if (is_json) {
         WT_ERROR_APPEND(p, remain, "\"ts_sec\":%" PRIuMAX ",", (uintmax_t)ts.tv_sec);
         WT_ERROR_APPEND(
-          p, remain, "\"ts_usec\":%.6" PRIuMAX ",", (uintmax_t)ts.tv_nsec / WT_THOUSAND);
+          p, remain, "\"ts_usec\":%" PRIuMAX ",", (uintmax_t)ts.tv_nsec / WT_THOUSAND);
         WT_ERROR_APPEND(p, remain, "\"thread\":\"%s\",", tid);
     } else
         WT_ERROR_APPEND(p, remain, "[%" PRIuMAX ":%.6" PRIuMAX "][%s]", (uintmax_t)ts.tv_sec,


### PR DESCRIPTION
Minor change to zero pad time. It now looks like this:
```
[1738862523:095470][11633:0x1f6858840], file:WiredTiger.wt, WT_CURSOR.reset: [WT_VERB_API][DEBUG_1]: CALL: WT_CURSOR:reset
[1738862523:100489][11633:0x1f6858840], file:WiredTiger.wt, metadata-ckpt: [WT_VERB_WRITE][DEBUG_2]: write: WT_HOME/WiredTiger.turtle.set, fd=5, offset=0, len=1411
```

