### PR TITLE
WT-14099 Remove extra checks before recording error info

### DIFF
--- a/src/include/api.h
+++ b/src/include/api.h
@@ -127,7 +127,7 @@
          * will not be overwritten. The struct can only be overwritten if 0 is passed      \
          * as the error code (this occurs when the err_info struct is reset).              \
          */                                                                                \
-        if ((ret) != 0 && (ret) != (s)->err_info.err)                                      \
+        if ((ret) != 0)                                                                    \
             __wt_session_set_last_error(s, ret, WT_NONE, WT_ERROR_INFO_EMPTY);             \
         if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL))                \
             __wt_op_timer_stop(s);                                                         \

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -37,7 +37,7 @@ __drop_file(
     /* Close all btree handles associated with this file. */
     WT_WITH_HANDLE_LIST_WRITE_LOCK(
       session, ret = __wt_conn_dhandle_close_all(session, uri, true, force, check_visibility));
-    if (ret == EBUSY && session->err_info.err != EBUSY)
+    if (ret == EBUSY)
         WT_RET_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
     WT_RET(ret);
 
@@ -133,7 +133,7 @@ __drop_table(
      * table that are already open must at least be closed before this call proceeds.
      */
     ret = __wt_schema_get_table_uri(session, uri, true, WT_DHANDLE_EXCLUSIVE, &table);
-    if (ret == EBUSY && session->err_info.err != EBUSY)
+    if (ret == EBUSY)
         WT_ERR_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
     WT_ERR(ret);
     WT_ERR(__wti_schema_release_table_gen(session, &table, true));
@@ -222,7 +222,7 @@ __drop_tiered(
     name = NULL;
     /* Get the tiered data handle. */
     ret = __wt_session_get_dhandle(session, uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE);
-    if (ret == EBUSY && session->err_info.err != EBUSY)
+    if (ret == EBUSY)
         WT_RET_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
     WT_RET(ret);
     got_dhandle = true;
@@ -249,7 +249,7 @@ __drop_tiered(
     got_dhandle = false;
     WT_WITH_HANDLE_LIST_WRITE_LOCK(
       session, ret = __wt_conn_dhandle_close_all(session, uri, true, force, check_visibility));
-    if (ret == EBUSY && session->err_info.err != EBUSY)
+    if (ret == EBUSY)
         WT_ERR_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
     WT_ERR(ret);
 
@@ -271,7 +271,7 @@ __drop_tiered(
         WT_WITHOUT_DHANDLE(session,
           WT_WITH_HANDLE_LIST_WRITE_LOCK(
             session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force, false)));
-        if (ret == EBUSY && session->err_info.err != EBUSY)
+        if (ret == EBUSY)
             WT_ERR_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
         WT_ERR(ret);
         WT_ERR(__wt_metadata_remove(session, tier->name));
@@ -290,7 +290,7 @@ __drop_tiered(
         WT_WITHOUT_DHANDLE(session,
           WT_WITH_HANDLE_LIST_WRITE_LOCK(
             session, ret = __wt_conn_dhandle_close_all(session, tier->name, true, force, false)));
-        if (ret == EBUSY && session->err_info.err != EBUSY)
+        if (ret == EBUSY)
             WT_ERR_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
         WT_ERR(ret);
         WT_ERR(__wt_metadata_remove(session, tier->name));


### PR DESCRIPTION
In [WT-14030](https://jira.mongodb.org/browse/WT-14030), the `__wt_session_set_last_error function` was updated to no longer overwrite errors that had been stored in the `err_info` struct at a previous point in the current API call.

As a consequence there are several extra checks that can be and now have been safely removed, since they aim to accomplish the same thing, mostly located in `schema_drop.c`.