### PR TITLE
SLS-1041 Expand disagg hook coverage

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -922,7 +922,8 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
 
     /* TODO this check is lifted from elsewhere - needs to be done more nicely. */
     if (cfg != NULL && cfg[0] != NULL && cfg[1] != NULL && (cfg[2] != NULL || cfg[1][0] != '\0')) {
-        WT_RET_NOTFOUND_OK(__wt_config_gets(session, cfg, "force", &cval));
+        ret = __wt_config_gets(session, cfg, "force", &cval);
+        WT_RET_NOTFOUND_OK(ret);
         if (ret == 0 && WT_CONFIG_LIT_MATCH("true", cval))
             force = true;
     }

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -782,6 +782,34 @@ functions:
             ${python_binary|python3} ../test/suite/run.py ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1
         fi
 
+  "unit test parallel":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        ${PREPARE_TEST_ENV}
+        # no_run will contain a list of files we don't want to run,
+        # do_run will contain a list of files we want to run.
+        no_run=$(mktemp)
+        do_run=$(mktemp)
+        sed -e 's/ *#.*//' -e '/^$/d' < ${unit_test_parallel_ignore} > $no_run
+        cd ./test/suite; ls test_*.py | fgrep -vf $no_run > $do_run
+        cd cmake_build
+        threads_command="-j ${nproc}"
+        if [[ -n "${num_jobs}" ]]; then
+          threads_command="-j ${num_jobs}"
+        fi
+        py=${python_binary|python3}
+        echo "Using $threads_command for 'unit test parallel'"
+        if [ ${check_coverage|false} = true ]; then
+            ../tools/pytest_parallel --python $py $threads_command ${unit_test_parallel_args|-v 2} ${unit_test_variant_args} -- $(cat $do_run) 2>&1 || echo "Ignoring failed test as we are checking test coverage"
+        else
+            ../tools/pytest_parallel --python $py $threads_command ${unit_test_parallel_args|-v 2} ${unit_test_variant_args} -- $(cat $do_run) 2>&1
+        fi
+
   "code coverage analysis":
     command: shell.exec
     params:
@@ -2205,10 +2233,11 @@ tasks:
     - name: compile
     commands:
       - func: "fetch artifacts"
-      - func: "unit test"
+      - func: "unit test parallel"
         vars:
           # The absolute minimum test to make sure that the hook works.
-          unit_test_args: -v 2 --hook disagg base01
+          unit_test_parallel_ignore: test/suite/hook_disagg.fail
+          unit_test_parallel_args: -v 2 --timeout 60 --hook disagg=(role=leader)
 
   - name: unit-test-hook-tiered
     tags: ["python"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -796,7 +796,7 @@ functions:
         no_run=$(mktemp)
         do_run=$(mktemp)
         sed -e 's/ *#.*//' -e '/^$/d' < ${unit_test_parallel_ignore} > $no_run
-        cd ./test/suite; ls test_*.py | fgrep -vf $no_run > $do_run
+        (cd ./test/suite; ls test_*.py) | fgrep -vf $no_run > $do_run
         cd cmake_build
         threads_command="-j ${nproc}"
         if [[ -n "${num_jobs}" ]]; then
@@ -2227,7 +2227,7 @@ tasks:
         vars:
           unit_test_args: -v 2 -R cursor13 join02 join07 schema03 timestamp22
 
-  - name: unit-test-hook-disagg
+  - name: unit-test-hook-disagg-leader
     tags: ["pull_request", "python"]
     depends_on:
     - name: compile
@@ -2235,9 +2235,20 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test parallel"
         vars:
-          # The absolute minimum test to make sure that the hook works.
+          # As leader, run the set of tests that are not in the fail list.
           unit_test_parallel_ignore: test/suite/hook_disagg.fail
           unit_test_parallel_args: -v 2 --timeout 60 --hook disagg=(role=leader)
+
+  - name: unit-test-hook-disagg-follower
+    tags: ["pull_request", "python"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          # As follower, run a minimal functionality test
+          unit_test_args: -v 2 --timeout 60 --hook disagg=(role=follower) base01
 
   - name: unit-test-hook-tiered
     tags: ["python"]
@@ -5595,7 +5606,8 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: unit-test-zstd
     - name: unit-test-random-seed
-    - name: unit-test-hook-disagg
+    - name: unit-test-hook-disagg-leader
+    - name: unit-test-hook-disagg-follower
     - name: unit-test-hook-tiered
     - name: unit-test-hook-tiered-with-delays
     - name: unit-test-hook-tiered-timestamp

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2237,7 +2237,7 @@ tasks:
         vars:
           # As leader, run the set of tests that are not in the fail list.
           unit_test_parallel_ignore: test/suite/hook_disagg.fail
-          unit_test_parallel_args: -v 2 --timeout 60 --hook disagg=(role=leader)
+          unit_test_parallel_args: -v 2 --timeout 60 --hook "disagg=(role=leader)"
 
   - name: unit-test-hook-disagg-follower
     tags: ["pull_request", "python"]
@@ -2248,7 +2248,7 @@ tasks:
       - func: "unit test"
         vars:
           # As follower, run a minimal functionality test
-          unit_test_args: -v 2 --timeout 60 --hook disagg=(role=follower) base01
+          unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower)" base01
 
   - name: unit-test-hook-tiered
     tags: ["python"]

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -1,0 +1,240 @@
+# This file is used by evergreen.yml when running the python test suite with "--hook disagg" (see hook_disagg.py).
+# This list are test files that are not run, they are known failures or time out (run longer than 30 seconds).
+# The reasons for the failures are not known, they'll need to be triaged.
+test_alter01.py # times out
+test_alter02.py # times out
+test_alter03.py
+test_alter04.py
+test_autoclose.py
+test_base02.py
+test_base04.py
+test_bug003.py
+test_bug006.py
+test_bug010.py
+test_bug019.py # times out
+test_bug027.py
+test_bug029.py
+test_bulk01.py # times out
+test_bulk02.py
+test_cc01.py # times out
+test_cc02.py # times out
+test_cc03.py
+test_cc04.py # times out
+test_cc05.py # times out
+test_checkpoint01.py
+test_checkpoint02.py # times out
+test_checkpoint07.py
+test_checkpoint08.py
+test_checkpoint09.py
+test_checkpoint10.py
+test_checkpoint11.py
+test_checkpoint12.py
+test_checkpoint13.py
+test_checkpoint14.py
+test_checkpoint15.py
+test_checkpoint16.py
+test_checkpoint17.py
+test_checkpoint18.py
+test_checkpoint19.py
+test_checkpoint20.py
+test_checkpoint21.py
+test_checkpoint22.py
+test_checkpoint24.py
+test_checkpoint25.py
+test_checkpoint27.py
+test_checkpoint28.py
+test_checkpoint29.py
+test_checkpoint30.py
+test_checkpoint32.py
+test_checkpoint33.py # times out
+test_checkpoint34.py # times out
+test_checkpoint_snapshot01.py
+test_checkpoint_snapshot02.py # times out
+test_checkpoint_snapshot03.py # times out
+test_checkpoint_snapshot05.py # times out
+test_checkpoint_snapshot06.py # times out
+test_compat01.py
+test_compat03.py # times out
+test_compat04.py
+test_compat05.py # times out
+test_config01.py # times out
+test_config02.py
+test_config03.py # times out
+test_config04.py
+test_config09.py
+test_config11.py # times out
+test_cursor01.py
+test_cursor02.py
+test_cursor03.py
+test_cursor05.py
+test_cursor06.py
+test_cursor10.py
+test_cursor12.py # times out
+test_cursor13.py
+test_cursor17.py
+test_cursor20.py
+test_cursor21.py
+test_cursor_random.py # times out
+test_cursor_random02.py # times out
+test_drop.py
+test_drop03.py
+test_drop_create.py
+test_dump.py
+test_dump01.py
+test_dump02.py
+test_dump03.py
+test_dupc.py
+test_durability01.py
+test_durable_rollback_to_stable.py
+test_durable_ts01.py
+test_durable_ts03.py
+test_empty.py
+test_encrypt01.py # times out
+test_encrypt04.py
+test_encrypt06.py
+test_env01.py
+test_eviction01.py
+test_export01.py
+test_hs01.py
+test_hs06.py # times out
+test_hs07.py # times out
+test_hs09.py
+test_hs10.py # times out
+test_hs11.py # times out
+test_hs18.py
+test_hs21.py
+test_hs24.py # times out
+test_hs30.py
+test_hs32.py # times out
+test_hs_evict_race01.py # times out
+test_import02.py
+test_import04.py
+test_import06.py # times out
+test_import07.py
+test_import08.py
+test_import09.py # times out
+test_import10.py
+test_log03.py # times out
+test_metadata_cursor01.py
+test_metadata_cursor02.py
+test_metadata_cursor03.py
+test_metadata_cursor04.py
+test_overwrite.py
+test_prefetch02.py # times out
+test_prepare03.py
+test_prepare08.py # times out
+test_prepare09.py # times out
+test_prepare11.py
+test_prepare12.py # times out
+test_prepare13.py # times out
+test_prepare20.py
+test_prepare21.py # times out
+test_prepare23.py # times out
+test_prepare29.py
+test_prepare_cursor01.py
+test_prepare_hs02.py
+test_prepare_hs03.py
+test_prepare_hs04.py # times out
+test_recovery01.py
+test_readonly01.py
+test_rename.py
+test_reserve.py
+test_rollback_to_stable07.py # times out
+test_rollback_to_stable10.py # times out
+test_rollback_to_stable11.py
+test_rollback_to_stable12.py # times out
+test_rollback_to_stable13.py # times out
+test_rollback_to_stable14.py # times out
+test_rollback_to_stable20.py # times out
+test_rollback_to_stable22.py # times out
+test_rollback_to_stable23.py
+test_rollback_to_stable24.py
+test_rollback_to_stable25.py # times out
+test_rollback_to_stable26.py # times out
+test_rollback_to_stable28.py
+test_rollback_to_stable29.py # times out
+test_rollback_to_stable30.py
+test_rollback_to_stable31.py # times out
+test_rollback_to_stable32.py # times out
+test_rollback_to_stable34.py # times out
+test_rollback_to_stable35.py # times out
+test_rollback_to_stable36.py
+test_rollback_to_stable37.py # times out
+test_rollback_to_stable38.py # times out
+test_rollback_to_stable39.py # times out
+test_rollback_to_stable40.py
+test_rollback_to_stable41.py
+test_rollback_to_stable42.py
+test_schema02.py
+test_schema08.py # times out
+test_scrub_eviction_prepare.py
+test_shared_cache01.py # times out
+test_stat01.py
+test_stat02.py
+test_stat03.py
+test_stat04.py
+test_stat05.py
+test_stat06.py
+test_stat_log02.py
+test_sweep03.py
+test_tiered16.py
+test_tiered17.py
+test_timestamp03.py # times out
+test_timestamp04.py # times out
+test_timestamp05.py
+test_timestamp06.py # times out
+test_timestamp07.py # times out
+test_timestamp08.py
+test_timestamp10.py # times out
+test_timestamp12.py
+test_timestamp20.py # times out
+test_truncate05.py # times out
+test_truncate06.py # times out
+test_truncate07.py # times out
+test_truncate08.py # times out
+test_truncate09.py # times out
+test_truncate10.py # times out
+test_truncate11.py # times out
+test_truncate12.py
+test_truncate13.py # times out
+test_truncate14.py # times out
+test_truncate15.py # times out
+test_truncate17.py
+test_truncate19.py # times out
+test_txn02.py
+test_txn04.py
+test_txn06.py
+test_txn08.py
+test_txn09.py
+test_txn10.py
+test_txn14.py
+test_txn16.py
+test_txn18.py
+test_txn19.py
+test_txn22.py
+test_txn23.py # times out
+test_txn24.py # times out
+test_txn27.py # times out
+test_upgrade.py
+test_util01.py
+test_util02.py # times out
+test_util03.py
+test_util04.py
+test_util07.py
+test_util09.py
+test_util11.py
+test_util12.py
+test_util13.py
+test_util14.py
+test_util15.py
+test_util16.py
+test_util17.py
+test_util18.py
+test_util19.py
+test_util20.py
+test_util21.py
+test_util22.py
+test_verbose01.py
+test_verbose02.py
+test_verbose03.py
+test_verbose04.py

--- a/tools/pytest_parallel
+++ b/tools/pytest_parallel
@@ -25,15 +25,22 @@ EOF
 
 # Wait for one process to exit, if it has a bad status, show that in the output log.
 waitone() {
-    local proc=
-    wait -n -p proc
+    # Grab the list of pids running before and after waiting
+    local before="$(jobs -p)"
+    wait -n
     local procstatus=$?
+    local after="$(jobs -p)"
+
     if [ "$procstatus" != 0 ]; then
-        ecode=1
+        # Get the pid missing from the second list, that's the failed one
+        proc=$(echo "$before $after" | tr ' ' '\n' | sort | uniq -u)
+
+        # Now we can get its name, show a message
         local name=${procs[$proc]}
         msg="ERROR: $name process returned $procstatus"
         echo "$msg"
         summary="${summary}  ${msg}"$'\n'
+        ecode=1
     fi
 }
 

--- a/tools/pytest_parallel
+++ b/tools/pytest_parallel
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Procs is an associative array.  procs[pid] => python_file_name
+declare -A procs
+verbose="-v 2"
+ecode=0
+summary=""
+python="python3"
+
+Usage() {
+    cat <<EOF
+Usage: pytest_parallel [ options ] [ run.py-options ] -- tests
+
+This must be run from the build directory.
+
+Options:
+    -j parallel_count
+    --python python_executable
+
+run.py options and help follow:
+----------------------------------------------------------------
+EOF
+    $python ../test/suite/run.py --help
+}
+
+# Wait for one process to exit, if it has a bad status, show that in the output log.
+waitone() {
+    local proc=
+    wait -n -p proc
+    local procstatus=$?
+    if [ "$procstatus" != 0 ]; then
+        ecode=1
+        local name=${procs[$proc]}
+        msg="ERROR: $name process returned $procstatus"
+        echo "$msg"
+        summary="${summary}  ${msg}"$'\n'
+    fi
+}
+
+# Wait for one process to exit, if it has a bad status, show that in the output log.
+showprocs() {
+    echo -n "Waiting on processes: "
+    # Add an extra arg in case all processes are gone
+    for proc in $(jobs -p) ignore; do
+        if [ "$proc" = ignore ]; then
+            continue
+        fi
+        local name=${procs[$proc]}
+        echo -n " $name [$proc]"
+    done
+    echo ''
+}
+
+# Parse arguments
+parallel_count=$(nproc)
+run_py_options="--noremove"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -j )
+            parallel_count="$2"
+            shift; shift
+            ;;
+        --python )    # python executable
+            python="$2"
+            shift; shift
+            ;;
+        --help )
+            Usage
+            exit 1
+            ;;
+        -- )
+            # The end of the options
+            shift
+            break
+            ;;
+        * )
+            run_py_options="$run_py_options $1"
+            shift
+            ;;
+    esac
+done
+
+if [ "$#" = 0 ]; then
+    Usage
+    exit 1
+fi
+
+if [ ! -f wt ]; then
+    echo "Must be run from a build directory"
+    exit 1
+fi
+
+# Add a label to any output.
+# This function is run as a separate process.
+# It exits with the status from the command
+label_output() {
+    label="$1"
+    shift
+    "$@" 2>&1 | sed -e "s/^/$label: /"
+    exit ${PIPESTATUS[0]}
+}
+
+# run individual Python tests scripts in the background - it's faster than using run.py -j
+rm -rf WT_TEST
+for pyfile in "$@"; do
+    # Run the test script in the background - modify output so we know what test it is coming from.
+    echo running "$python ../test/suite/run.py $run_py_options $pyfile"
+    label_output "$pyfile" "$python" ../test/suite/run.py $run_py_options $pyfile &
+    procs["$!"]="$pyfile"
+
+    # Wait if we're up to the limit of processes allowed.
+    if [ $(jobs -p | wc -l) -ge $parallel_count ]; then
+        waitone
+    fi
+done
+
+# Wait for last running processes
+while [ $(jobs -p | wc -l) -gt 0 ]; do
+    echo "$procs"
+    showprocs
+    waitone
+done
+
+if [ "$summary" = '' ]; then
+    echo "Success"
+else
+    echo ""
+    echo "Summary:"
+    echo -n "$summary"
+fi
+exit $ecode

--- a/tools/pytest_parallel
+++ b/tools/pytest_parallel
@@ -44,7 +44,8 @@ waitone() {
     fi
 }
 
-# Wait for one process to exit, if it has a bad status, show that in the output log.
+# Show processes that we are waiting for.  This is helpful for diagnosing hangs and
+# just general progress near the end of a run.
 showprocs() {
     echo -n "Waiting on processes: "
     # Add an extra arg in case all processes are gone
@@ -60,6 +61,10 @@ showprocs() {
 
 # Parse arguments
 parallel_count=$(nproc)
+
+# We want to always tell run.py to not remove the WT_TEST directory
+# before it starts its run.  Otherwise some test processes will get their
+# home directory removed out from underneath them.
 run_py_options="--noremove"
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -104,7 +109,7 @@ label_output() {
     label="$1"
     shift
     "$@" 2>&1 | sed -e "s/^/$label: /"
-    exit ${PIPESTATUS[0]}
+    return ${PIPESTATUS[0]}
 }
 
 # run individual Python tests scripts in the background - it's faster than using run.py -j


### PR DESCRIPTION
Includes a shell script to run python test files in parallel
Includes a small fix that allows us to enable several more tests:
- when looking up a dhandle in disagg via `__wt_session_get_dhandle`, the base config is not always used.
  If `force` is not specified, the return from the config lookup is WT_NOTFOUND.  The way the error check is
  written, we try to deref a NULL string on WT_NOTFOUND.