### PR TITLE
SLS-1199 Reuse the HS cursor during reconciliation, if possible

### DIFF
--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -355,6 +355,7 @@ struct __wt_cursor_hs {
     WT_CURSOR *file_cursor; /* Queries of regular history store data */
     WT_TIME_WINDOW time_window;
     uint32_t btree_id;
+    uint32_t hs_id;
     WT_ITEM *datastore_key;
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -570,6 +570,8 @@ extern int __wt_curhs_search_near_after(WT_SESSION_IMPL *session, WT_CURSOR *cur
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curhs_search_near_before(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curhs_set_btree_id(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t btree_id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curjoin_join(WT_SESSION_IMPL *session, WT_CURSOR_JOIN *cjoin, WT_INDEX *idx,
@@ -1941,6 +1943,8 @@ extern u_int __wt_hazard_count(WT_SESSION_IMPL *session, WT_REF *ref)
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_checksum_with_seed_sw(uint32_t seed, const void *chunk, size_t len)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern uint32_t __wt_curhs_get_btree_id(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_log2_int(uint32_t n) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_nlpo2(uint32_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -797,15 +797,8 @@ __rec_cleanup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     btree = S2BT(session);
 
-    /*
-     * The history store cursor cannot be shared across btrees now that we can have more than one
-     * history store table, so close it. We need to do this because the reconciliation struct could
-     * be reused for a different btree.
-     */
-    if (r->hs_cursor != NULL) {
-        WT_RET(r->hs_cursor->close(r->hs_cursor));
-        r->hs_cursor = NULL;
-    }
+    if (r->hs_cursor != NULL)
+        WT_RET(r->hs_cursor->reset(r->hs_cursor));
 
     if (btree->type == BTREE_ROW)
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
@@ -3248,6 +3241,7 @@ __wti_rec_hs_clear_on_tombstone(
   WT_SESSION_IMPL *session, WT_RECONCILE *r, uint64_t recno, WT_ITEM *rowkey, bool reinsert)
 {
     WT_BTREE *btree;
+    WT_DECL_RET;
     WT_ITEM hs_recno_key, *key;
     uint8_t hs_recno_key_buf[WT_INTPACK64_MAXSIZE], *p;
 
@@ -3266,9 +3260,20 @@ __wti_rec_hs_clear_on_tombstone(
         key = &hs_recno_key;
     }
 
-    /* Open a history store cursor if we don't yet have one. */
+    /*
+     * Open a history store cursor if we don't yet have one. If we already have it, check if it
+     * matches the current btree and attempt to reuse it if it does not.
+     */
     if (r->hs_cursor == NULL)
         WT_RET(__wt_curhs_open(session, btree->id, NULL, &r->hs_cursor));
+    else if (__wt_curhs_get_btree_id(session, r->hs_cursor) != btree->id) {
+        WT_RET_ERROR_OK(ret = __wt_curhs_set_btree_id(session, r->hs_cursor, btree->id), EINVAL);
+        if (ret != 0) {
+            WT_RET(r->hs_cursor->close(r->hs_cursor));
+            r->hs_cursor = NULL;
+            WT_RET(__wt_curhs_open(session, btree->id, NULL, &r->hs_cursor));
+        }
+    }
 
     /*
      * From WT_TS_NONE delete/reinsert all the history store content of the key. The test of


### PR DESCRIPTION
Reuse the existing history store cursor during reconciliation, if it can be reused for the next btree.