### PR TITLE
WT-14105 Create function to reset checkpoint snapshot

### DIFF
--- a/src/checkpoint/checkpoint.h
+++ b/src/checkpoint/checkpoint.h
@@ -191,6 +191,7 @@ extern void __wt_checkpoint_handle_stats(
 extern void __wt_checkpoint_handle_stats_clear(WT_SESSION_IMPL *session);
 extern void __wt_checkpoint_progress_stats(WT_SESSION_IMPL *session, uint64_t write_bytes);
 extern void __wt_checkpoint_signal(WT_SESSION_IMPL *session, wt_off_t logsize);
+extern void __wt_checkpoint_snapshot_clear(WT_CKPT_SNAPSHOT *snapshot);
 extern void __wt_checkpoint_timer_stats(WT_SESSION_IMPL *session);
 extern void __wt_checkpoint_timer_stats_clear(WT_SESSION_IMPL *session);
 extern void __wt_checkpoint_tree_reconcile_update(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE *ta);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -651,6 +651,23 @@ __wt_checkpoint_progress_stats(WT_SESSION_IMPL *session, uint64_t write_bytes)
 }
 
 /*
+ * __wt_checkpoint_snapshot_clear --
+ *     Clear checkpoint snapshot data.
+ */
+void
+__wt_checkpoint_snapshot_clear(WT_CKPT_SNAPSHOT *snapshot)
+{
+    snapshot->ckpt_id = 0;
+    snapshot->oldest_ts = WT_TS_NONE;
+    snapshot->snapshot_count = 0;
+    snapshot->snapshot_max = WT_TXN_MAX;
+    snapshot->snapshot_min = WT_TXN_MAX;
+    snapshot->snapshot_txns = NULL;
+    snapshot->snapshot_write_gen = 0;
+    snapshot->stable_ts = WT_TS_NONE;
+}
+
+/*
  * __wt_checkpoint_verbose_timer_started --
  *     Indicate whether the checkpoint verbose tracking timer has started.
  */

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1191,14 +1191,7 @@ __wt_curfile_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, c
      * This initialization is repeated when opening the underlying data handle, which is ugly, but
      * cleanup requires the initialization have happened even if not opening a checkpoint handle.
      */
-    ckpt_snapshot.ckpt_id = 0;
-    ckpt_snapshot.oldest_ts = WT_TS_NONE;
-    ckpt_snapshot.stable_ts = WT_TS_NONE;
-    ckpt_snapshot.snapshot_write_gen = 0;
-    ckpt_snapshot.snapshot_max = WT_TXN_MAX;
-    ckpt_snapshot.snapshot_min = WT_TXN_MAX;
-    ckpt_snapshot.snapshot_txns = NULL;
-    ckpt_snapshot.snapshot_count = 0;
+    __wt_checkpoint_snapshot_clear(&ckpt_snapshot);
 
     /* Get the handle and lock it while the cursor is using it. */
     if (LF_ISSET(WT_DHANDLE_EXCLUSIVE) && checkpoint_wait)

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -456,16 +456,8 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
 
     if (hs_dhandlep != NULL)
         *hs_dhandlep = NULL;
-    if (ckpt_snapshot != NULL) {
-        ckpt_snapshot->ckpt_id = 0;
-        ckpt_snapshot->oldest_ts = WT_TS_NONE;
-        ckpt_snapshot->stable_ts = WT_TS_NONE;
-        ckpt_snapshot->snapshot_write_gen = 0;
-        ckpt_snapshot->snapshot_min = WT_TXN_MAX;
-        ckpt_snapshot->snapshot_max = WT_TXN_MAX;
-        ckpt_snapshot->snapshot_txns = NULL;
-        ckpt_snapshot->snapshot_count = 0;
-    }
+    if (ckpt_snapshot != NULL)
+        __wt_checkpoint_snapshot_clear(ckpt_snapshot);
 
     /*
      * This function exists to handle checkpoint configuration. Callers that never open a checkpoint


### PR DESCRIPTION
The changes introduce a new function `__wt_checkpoint_snapshot_clear` to reset a checkpoint snapshot.