### PR TITLE
WT-14040 Implement live restore state tracking locking and correctness

### DIFF
--- a/dist/filelist
+++ b/dist/filelist
@@ -115,7 +115,8 @@ src/history/hs_cursor.c
 src/history/hs_rec.c
 src/history/hs_verify.c
 src/live_restore/live_restore_fs.c       POSIX_HOST
-src/live_restore/live_restore_server.c       POSIX_HOST
+src/live_restore/live_restore_server.c   POSIX_HOST
+src/live_restore/live_restore_state.c    POSIX_HOST
 src/log/log.c
 src/log/log_auto.c
 src/log/log_cursor.c

--- a/dist/filelist.bzl
+++ b/dist/filelist.bzl
@@ -204,6 +204,7 @@ WT_FILELIST_ZSERIES_HOST = ['src/checksum/zseries/crc32-s390x.c', 'src/checksum/
 
 WT_FILELIST_POSIX_HOST = ['src/live_restore/live_restore_fs.c',
  'src/live_restore/live_restore_server.c',
+ 'src/live_restore/live_restore_state.c',
  'src/os_posix/os_dir.c',
  'src/os_posix/os_dlopen.c',
  'src/os_posix/os_fallocate.c',

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1195,6 +1195,7 @@ repositioned
 repositions
 requeue
 resizable
+restore's
 ret
 revint
 rf

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -15,6 +15,7 @@ ARG
 ARGS
 ASAN
 ASM
+ASan
 AUS
 AWS
 AWS's
@@ -454,6 +455,7 @@ WiredTigerCheckpoint
 WiredTigerChunkCache
 WiredTigerHS
 WiredTigerLAS
+WiredTigerLR
 WiredTigerLog
 WiredTigerPreplog
 WiredTigerTmplog

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -15,7 +15,6 @@ ARG
 ARGS
 ASAN
 ASM
-ASan
 AUS
 AWS
 AWS's

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3066,6 +3066,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
 
     WT_ERR(__wt_conf_compile_init(session, cfg));
     WT_ERR(__wti_conn_statistics_config(session, cfg));
+    __wt_live_restore_init_stats(session);
     WT_ERR(__wti_sweep_config(session, cfg));
 
     /* Initialize the OS page size for mmap */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2672,6 +2672,9 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
         }
     }
 
+#ifndef _MSC_VER
+    /* FIXME-WT-14051 Add windows support. */
+
     /*
      * Live restore leaves the state file on disk after live restore has completed, otherwise we'll
      * run into issues when the user reopens a WiredTiger with the same live restore config but
@@ -2682,6 +2685,7 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
     if (!live_restore_enabled)
         WT_RET(
           __wt_live_restore_delete_complete_state_file(session, conn->file_system, conn->home));
+#endif
 
     return (__conn_chk_file_system(session, F_ISSET(conn, WT_CONN_READONLY)));
 }
@@ -3067,7 +3071,10 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
 
     WT_ERR(__wt_conf_compile_init(session, cfg));
     WT_ERR(__wti_conn_statistics_config(session, cfg));
+#ifndef _MSC_VER
+    /* FIXME-WT-14051 Add windows support. */
     __wt_live_restore_init_stats(session);
+#endif
     WT_ERR(__wti_sweep_config(session, cfg));
 
     /* Initialize the OS page size for mmap */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3145,6 +3145,13 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     WT_ERR(__conn_version_verify(session));
 
     /*
+     * If live restore is enabled then live restores log pre-copy must be run first. That logic
+     * creates the log folder which version verify needs to access to determine the log version
+     * we're using.
+     */
+    WT_ERR(__conn_version_verify(session));
+
+    /*
      * Configuration completed; optionally write a base configuration file.
      */
     WT_ERR(__conn_write_base_config(session, cfg));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2671,6 +2671,17 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
 #endif
         }
     }
+
+    /*
+     * Live restore leaves the state file on disk after live restore has completed, otherwise we'll
+     * run into issues when the connection is reopened with a live restore config, but live restore
+     * has completed. To address this clean up the file when we open wiredtiger with a non-live
+     * restore config. This is expected to happen immediately after live restore completes.
+     */
+    if (!live_restore_enabled)
+        WT_RET(
+          __wt_live_restore_delete_complete_state_file(session, conn->file_system, conn->home));
+
     return (__conn_chk_file_system(session, F_ISSET(conn, WT_CONN_READONLY)));
 }
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3164,9 +3164,9 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
 #endif
 
     /*
-     * If live restore is enabled then live restores setup recovery must be run before this
-     * function. Set up recovery creates the log folder in the destination which version verify
-     * accesses to determine the log version being used using.
+     * If live restore is enabled, then live restore's setup must be run before this function. The
+     * setup creates the log path directory in the destination, if needed. The version verify
+     * function accesses this path to determine the log version being used.
      */
     WT_ERR(__conn_version_verify(session));
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3158,7 +3158,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
 
     /*
      * If live restore is enabled then live restores setup recovery must be run before this
-     * function. Set up recovery creates the log folder in the destination which version accesses to
+     * function. Set up recovery creates the log folder in the destination which version verify accesses to
      * determine the log version being used using.
      */
     WT_ERR(__conn_version_verify(session));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3158,8 +3158,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
 
     /*
      * If live restore is enabled then live restores setup recovery must be run before this
-     * function. Set up recovery creates the log folder in the destination which version verify accesses to
-     * determine the log version being used using.
+     * function. Set up recovery creates the log folder in the destination which version verify
+     * accesses to determine the log version being used using.
      */
     WT_ERR(__conn_version_verify(session));
 

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -8,9 +8,6 @@
 
 #pragma once
 
-// TODO - We should be able to expose these values to the server by exposing them in
-// wiredtiger.(h|in)
-//        Look into this.
 /*
  * Live restore state reported to the server so it knows when to terminate live restore.
  *

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -29,6 +29,7 @@ extern int __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_os_live_restore_fs(WT_SESSION_IMPL *session, const char *cfg[],
   const char *destination, WT_FILE_SYSTEM **fsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern void __wt_live_restore_init_stats(WT_SESSION_IMPL *session);
 
 #ifdef HAVE_UNITTEST
 

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -15,6 +15,8 @@
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
+extern int __wt_live_restore_delete_complete_state_file(WT_SESSION_IMPL *session,
+  WT_FILE_SYSTEM *fs, const char *folder) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_fh_extent_to_metadata(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh,
   WT_ITEM *extent_string) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_fh_import_extents_from_string(WT_SESSION_IMPL *session,

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -8,9 +8,15 @@
 
 #pragma once
 
+// TODO - We should be able to expose these values to the server by exposing them in
+// wiredtiger.(h|in)
+//        Look into this.
 /*
- * Live restore stats are reported to the server. These are less granular than the internal
- * WTI_LIVE_RESTORE_STATE.
+ * Live restore state reported to the server so it knows when to terminate live restore.
+ *
+ * !!! The server doesn't have access to these macros and instead checks them by value. i.e. to
+ * know live restore has completed the server reads the stat and checks for the value 2. Do not
+ * change these values without updating the server.
  */
 #define WT_LIVE_RESTORE_INIT 0x0
 #define WT_LIVE_RESTORE_IN_PROGRESS 0x1

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -9,11 +9,11 @@
 #pragma once
 
 /*
- * Live restore state reported to the server so it knows when to terminate live restore.
+ * Live restore state reported to the application so it knows when to terminate live restore.
  *
- * !!! The server doesn't have access to these macros and instead checks them by value. i.e. to
- * know live restore has completed the server reads the stat and checks for the value 2. Do not
- * change these values without updating the server.
+ * !!! MongoDB doesn't have access to these macros and instead checks them by value. i.e. to
+ * know live restore has completed the server layer reads the stat and checks for the value 2. Do
+ * not change these values without updating the relevant code in the server layer.
  */
 #define WT_LIVE_RESTORE_INIT 0x0
 #define WT_LIVE_RESTORE_IN_PROGRESS 0x1
@@ -22,7 +22,7 @@
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
 extern int __wt_live_restore_delete_complete_state_file(WT_SESSION_IMPL *session,
-  WT_FILE_SYSTEM *fs, const char *folder) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_FILE_SYSTEM *fs, const char *directory) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_fh_extent_to_metadata(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh,
   WT_ITEM *extent_string) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_fh_import_extents_from_string(WT_SESSION_IMPL *session,

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+// TODO - Intentionally separate from the state file states. Think about this.
 #define WT_LIVE_RESTORE_INIT 0x0
 #define WT_LIVE_RESTORE_IN_PROGRESS 0x1
 #define WT_LIVE_RESTORE_COMPLETE 0x2

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -8,7 +8,10 @@
 
 #pragma once
 
-// TODO - Intentionally separate from the state file states. Think about this.
+/*
+ * Live restore stats are reported to the server. These are less granular than the internal
+ * WTI_LIVE_RESTORE_STATE.
+ */
 #define WT_LIVE_RESTORE_INIT 0x0
 #define WT_LIVE_RESTORE_IN_PROGRESS 0x1
 #define WT_LIVE_RESTORE_COMPLETE 0x2

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1880,7 +1880,7 @@ __wt_os_live_restore_fs(
     if (!__wt_ispo2((uint32_t)lr_fs->read_size))
         WT_ERR_MSG(session, EINVAL, "the live restore read size must be a power of two");
 
-    WT_ERR(__wt_spin_init(session, &lr_fs->state_file_lock, "state file access lock"));
+    WT_ERR(__wt_rwlock_init(session, &lr_fs->state_lock));
     WT_ERR(__wti_live_restore_validate_directories(session, lr_fs));
     WT_ERR(__wti_live_restore_init_state(session, lr_fs));
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1779,18 +1779,7 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
 
     WT_DECL_ITEM(filename);
     WT_FH *fh = NULL;
-    WT_FILE_HANDLE *log_folder_fh = NULL;
     uint32_t lognum;
-
-    /* Open and close the log folder. This creates it in the destination if it didn't exist. */
-    WT_DECL_ITEM(log_folder_path);
-    WT_RET(__wt_scr_alloc(session, 0, &log_folder_path));
-    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, conn->log_mgr.log_path,
-      UINTMAX_MAX, UINT32_MAX, log_folder_path));
-
-    lr_fs->iface.fs_open_file((WT_FILE_SYSTEM *)lr_fs, (WT_SESSION *)session, log_folder_path->data,
-      WT_FS_OPEN_FILE_TYPE_DIRECTORY, 0, &log_folder_fh);
-    log_folder_fh->close(log_folder_fh, (WT_SESSION *)session);
 
     /* Get a list of actual log files. */
     WT_ERR(__wt_log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
@@ -1833,7 +1822,6 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
 err:
     WT_TRET(__wt_fs_directory_list_free(session, &logfiles, logcount));
     __wt_scr_free(session, &filename);
-    __wt_scr_free(session, &log_folder_path);
     return (ret);
 }
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1322,9 +1322,6 @@ __wt_live_restore_fh_extent_to_metadata(
         return (WT_NOTFOUND);
 
     WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh = (WTI_LIVE_RESTORE_FILE_HANDLE *)fh;
-    // TODO - Discuss. I've removed the if file->complete return (NOTFOUND) here. Once we have
-    // bitmaps "" is no longer a valid hole string so we don't need to worry about differentiation
-    // of empty extents and files that haven't started migrating.
 
     wt_off_t prev_off = 0;
     WTI_LIVE_RESTORE_HOLE_NODE *head = lr_fh->destination.hole_list_head;

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1779,8 +1779,8 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
 
     WT_DECL_ITEM(filename);
     WT_FH *fh = NULL;
-    uint32_t lognum;
     WT_FILE_HANDLE *log_folder_fh = NULL;
+    uint32_t lognum;
 
     /* Open and close the log folder. This creates it in the destination if it didn't exist. */
     WT_DECL_ITEM(log_folder_path);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1223,8 +1223,6 @@ __wt_live_restore_fh_import_extents_from_string(
     if (state >= WTI_LIVE_RESTORE_STATE_CLEAN_UP)
         return (0);
 
-    // TODO - this is solved by the bitmap change. An empty string means never copied (or fully
-    // copied, but at that point the state is CLEAN_UP or COMPLETE so we know not to copy.)
     /*
      * This function can be called for file handles that already have an in memory extent list. For
      * this to happen the destination file was created for the first time and a single file size

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -285,6 +285,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
     bool dest_folder_exists = false, source_folder_exists = false;
     uint32_t num_src_files = 0, num_dest_files = 0;
     WT_DECL_ITEM(filename);
+    WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
     *dirlistp = dirlist_dest = dirlist_src = entries = NULL;
     path_dest = path_src = temp_path = NULL;
@@ -318,7 +319,6 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
      * Once we're past the background migration stage we never need to access the source directory
      * again.
      */
-    WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
     if (state > WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION)
         goto done;
 
@@ -1792,6 +1792,7 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
     WT_DECL_ITEM(filename);
     WT_FH *fh = NULL;
     uint32_t lognum;
+    WT_FILE_HANDLE *log_folder_fh = NULL;
 
     /* Open and close the log folder. This creates it in the destination if it didn't exist. */
     WT_DECL_ITEM(log_folder_path);
@@ -1799,7 +1800,6 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
     WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, conn->log_mgr.log_path,
       UINTMAX_MAX, UINT32_MAX, log_folder_path));
 
-    WT_FILE_HANDLE *log_folder_fh = NULL;
     lr_fs->iface.fs_open_file((WT_FILE_SYSTEM *)lr_fs, (WT_SESSION *)session, log_folder_path->data,
       WT_FS_OPEN_FILE_TYPE_DIRECTORY, 0, &log_folder_fh);
     log_folder_fh->close(log_folder_fh, (WT_SESSION *)session);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -170,10 +170,10 @@ __live_restore_fs_create_stop_file(
 
     /*
      * Check the live restore state hasn't changed during creation. If state has changed the stop
-     * file is now redundant as we're at or after the CLEAN_UP stage when we delete all stop files.
+     * file is now redundant since we're at or after the CLEAN_UP stage and can be deleted.
      */
     if (__wti_live_restore_get_state(session, lr_fs) != WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION)
-        /* ENOENT is ok here. The stop file cleanup logic might delete the file before we do. */
+        /* ENOENT is ok here. The another thread might delete the file before we do. */
         WT_ERR_ERROR_OK(
           lr_fs->os_file_system->fs_remove(lr_fs->os_file_system, &session->iface, path_marker, 0),
           ENOENT, false);
@@ -1783,7 +1783,7 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
         return (0);
 
     if (!F_ISSET(&conn->log_mgr, WT_LOG_CONFIG_ENABLED)) {
-        /* There are no logs to copy across. Jump straight to background migration. */
+        /* There are no logs to copy across. Move on to background migration. */
         WT_RET(__wti_live_restore_set_state(
           session, lr_fs, WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION));
         return (0);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1761,8 +1761,6 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
       "configured read size is %" WT_SIZET_FMT " bytes\n",
       lr_fs->source.home, lr_fs->destination.home, lr_fs->read_size);
 
-    WT_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
-
     if (!F_ISSET(&conn->log_mgr, WT_LOG_CONFIG_ENABLED)) {
         /* There are no logs to copy across. Jump straight to background migration. */
         WT_RET(__wti_live_restore_set_state(
@@ -1770,7 +1768,7 @@ __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
         return (0);
     }
 
-    if (state != WTI_LIVE_RESTORE_STATE_LOG_COPY)
+    if (__wti_live_restore_get_state(session, lr_fs) != WTI_LIVE_RESTORE_STATE_LOG_COPY)
         return (0);
 
     WT_DECL_ITEM(filename);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -319,7 +319,6 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
      * again.
      */
     WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
-    // TODO - get input on this. It's a deviation from WT style
     if (state > WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION)
         goto done;
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1738,6 +1738,7 @@ __live_restore_fs_terminate(WT_FILE_SYSTEM *fs, WT_SESSION *wt_session)
     WT_ASSERT(session, lr_fs->os_file_system != NULL);
     WT_RET(lr_fs->os_file_system->terminate(lr_fs->os_file_system, wt_session));
 
+    __wt_rwlock_destroy(session, &lr_fs->state_lock);
     __wt_free(session, lr_fs->source.home);
     __wt_free(session, lr_fs);
     return (0);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -318,7 +318,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
      * Once we're past the background migration stage we never need to access the source directory
      * again.
      */
-    WT_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
+    WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
     // TODO - get input on this. It's a deviation from WT style
     if (state > WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION)
         goto done;
@@ -1218,7 +1218,7 @@ __wt_live_restore_fh_import_extents_from_string(
      * Once we're in the clean up stage or later all data has been migrated across to the
      * destination. There's nothing to import.
      */
-    WT_LIVE_RESTORE_STATE state =
+    WTI_LIVE_RESTORE_STATE state =
       __wti_live_restore_get_state(session, (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system);
     if (state >= WTI_LIVE_RESTORE_STATE_CLEAN_UP)
         return (0);
@@ -1318,7 +1318,7 @@ __wt_live_restore_fh_extent_to_metadata(
         return (WT_NOTFOUND);
 
     /* Once we're past the background migration stage there's no need to track hole information. */
-    WT_LIVE_RESTORE_STATE state =
+    WTI_LIVE_RESTORE_STATE state =
       __wti_live_restore_get_state(session, (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system);
     if (state >= WTI_LIVE_RESTORE_STATE_CLEAN_UP)
         return (WT_NOTFOUND);
@@ -1454,7 +1454,7 @@ __live_restore_setup_lr_fh_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *l
     /* Open it in the destination layer. */
     WT_RET(__live_restore_fs_open_in_destination(lr_fs, session, lr_fh, name, flags, !dest_exist));
 
-    WT_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
+    WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
     if (have_stop || state > WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION) {
         /*

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -133,7 +133,7 @@ struct __wti_live_restore_fs {
     size_t read_size;
 
     WT_LIVE_RESTORE_STATE state;
-    WT_SPINLOCK state_file_lock;
+    WT_RWLOCK state_lock;
 };
 
 /*

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -96,6 +96,10 @@ struct __wti_live_restore_fs_layer {
     WTI_LIVE_RESTORE_FS_LAYER_TYPE which;
 };
 
+/*
+ * Live restore states. As live restore progresses we will transition through each of these states
+ * one by one.
+ */
 typedef enum {
     /*
      * This is not a valid state. We return it when there is no state file on disk and therefore
@@ -103,8 +107,11 @@ typedef enum {
      */
     WTI_LIVE_RESTORE_STATE_NONE = 0,
     /*
-     * TODO - proper explanation for why we copy logs first. Something about the metafile needing to
-     * be populated before the migration threads come online.
+     * For background migration to identify which files that need migrating we must first restore
+     * the metadata file, which requires replaying and updating log files. This leaves us in a
+     * situation where we need to track log file's live restore metadata before we have full access
+     * to it. To resolve this we manually copy all log files at the start of live restore so we know
+     * they're always fully located in the destination directory.
      */
     WTI_LIVE_RESTORE_STATE_LOG_COPY = 1,
     /*

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -113,8 +113,9 @@ typedef enum {
      */
     WTI_LIVE_RESTORE_STATE_LOG_COPY = 1,
     /*
-     * Where the majority of work takes place. Users can perform reads/writes while we copy backing
-     * data to the destination in the background.
+     * The background migration state is where the majority is where the majority of work takes
+     * place. Users can perform reads/writes while we copy backing data to the destination in the
+     * background.
      */
     WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION = 2,
     /* We've completed background migration and are now cleaning up any live restore metadata. */

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -98,31 +98,34 @@ struct __wti_live_restore_fs_layer {
 
 /*
  * Live restore states. As live restore progresses we will transition through each of these states
- * one by one.
+ * one by one. Live restore transitions through each state in the order they are listed below.
  */
 typedef enum {
     /*
      * This is not a valid state. We return it when there is no state file on disk and therefore
      * we're not in live restore yet.
      */
-    WTI_LIVE_RESTORE_STATE_NONE = 0,
+    WTI_LIVE_RESTORE_STATE_NONE,
     /*
      * Log files aren't tracked in the metadata file, which we use to identify which files need
      * background migrating. To resolve this we copy all log files to the destination at the start
      * of live restore.
      */
-    WTI_LIVE_RESTORE_STATE_LOG_COPY = 1,
+    WTI_LIVE_RESTORE_STATE_LOG_COPY,
     /*
      * The background migration state is where the majority is where the majority of work takes
      * place. Users can perform reads/writes while we copy backing data to the destination in the
      * background.
      */
-    WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION = 2,
+    WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION,
     /* We've completed background migration and are now cleaning up any live restore metadata. */
-    WTI_LIVE_RESTORE_STATE_CLEAN_UP = 3,
+    WTI_LIVE_RESTORE_STATE_CLEAN_UP,
     /* We've completed the live restore. */
-    WTI_LIVE_RESTORE_STATE_COMPLETE = 4
+    WTI_LIVE_RESTORE_STATE_COMPLETE
 } WTI_LIVE_RESTORE_STATE;
+
+#define WTI_LIVE_RESTORE_MIGRATION_COMPLETE(state) \
+    ((state) == WTI_LIVE_RESTORE_STATE_CLEAN_UP || (state) == WTI_LIVE_RESTORE_STATE_COMPLETE)
 
 /*
  * __wti_live_restore_fs --

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -107,11 +107,9 @@ typedef enum {
      */
     WTI_LIVE_RESTORE_STATE_NONE = 0,
     /*
-     * For background migration to identify which files that need migrating we must first restore
-     * the metadata file, which requires replaying and updating log files. This leaves us in a
-     * situation where we need to track log file's live restore metadata before we have full access
-     * to it. To resolve this we manually copy all log files at the start of live restore so we know
-     * they're always fully located in the destination directory.
+     * Log files aren't tracked in the metadata file, which we use to identify which files need
+     * background migrating. To resolve this we copy all log files to the destination at the start
+     * of live restore.
      */
     WTI_LIVE_RESTORE_STATE_LOG_COPY = 1,
     /*

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -29,7 +29,7 @@
 /* As extent ranges are inclusive we want >= and <= on both ends of the range. */
 #define WTI_OFFSET_IN_EXTENT(addr, ext) ((addr) >= (ext)->off && (addr) <= WTI_EXTENT_END(ext))
 
-#define WT_LIVE_RESTORE_STATE_FILE "live_restore.state"
+#define WT_LIVE_RESTORE_STATE_FILE "WiredTigerLR.state"
 
 /*
  * __wti_live_restore_hole_node --

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -128,7 +128,6 @@ struct __wti_live_restore_fs {
     WT_FILE_SYSTEM *os_file_system; /* The storage file system. */
     WTI_LIVE_RESTORE_FS_LAYER destination;
     WTI_LIVE_RESTORE_FS_LAYER source;
-    bool finished;
 
     uint8_t background_threads_max;
     size_t read_size;

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -172,6 +172,8 @@ struct __wti_live_restore_server {
 
 extern WTI_LIVE_RESTORE_STATE __wti_live_restore_get_state(WT_SESSION_IMPL *session,
   WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern WTI_LIVE_RESTORE_STATE __wti_live_restore_get_state_no_lock(WT_SESSION_IMPL *session,
+  WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_cleanup_stop_files(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_fs_fill_holes(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -169,8 +169,6 @@ extern WT_LIVE_RESTORE_STATE __wti_live_restore_get_state(WT_SESSION_IMPL *sessi
   WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_cleanup_stop_files(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_live_restore_delete_state_file(WT_SESSION_IMPL *session,
-  WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_fs_fill_holes(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_init_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -29,7 +29,7 @@
 /* As extent ranges are inclusive we want >= and <= on both ends of the range. */
 #define WTI_OFFSET_IN_EXTENT(addr, ext) ((addr) >= (ext)->off && (addr) <= WTI_EXTENT_END(ext))
 
-#define WT_LIVE_RESTORE_STATE_FILE "WiredTigerLR.state"
+#define WTI_LIVE_RESTORE_STATE_FILE "WiredTigerLR.state"
 
 /*
  * __wti_live_restore_hole_node --
@@ -116,7 +116,7 @@ typedef enum {
     WTI_LIVE_RESTORE_STATE_CLEAN_UP = 3,
     /* We've completed the live restore. */
     WTI_LIVE_RESTORE_STATE_COMPLETE = 4
-} WT_LIVE_RESTORE_STATE;
+} WTI_LIVE_RESTORE_STATE;
 
 /*
  * __wti_live_restore_fs --
@@ -132,7 +132,7 @@ struct __wti_live_restore_fs {
     uint8_t background_threads_max;
     size_t read_size;
 
-    WT_LIVE_RESTORE_STATE state;
+    WTI_LIVE_RESTORE_STATE state;
     WT_RWLOCK state_lock;
 };
 
@@ -165,7 +165,7 @@ struct __wti_live_restore_server {
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
-extern WT_LIVE_RESTORE_STATE __wti_live_restore_get_state(WT_SESSION_IMPL *session,
+extern WTI_LIVE_RESTORE_STATE __wti_live_restore_get_state(WT_SESSION_IMPL *session,
   WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_cleanup_stop_files(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -174,7 +174,7 @@ extern int __wti_live_restore_fs_fill_holes(WT_FILE_HANDLE *fh, WT_SESSION *wt_s
 extern int __wti_live_restore_init_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_set_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs,
-  WT_LIVE_RESTORE_STATE new_state) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WTI_LIVE_RESTORE_STATE new_state) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_validate_directories(WT_SESSION_IMPL *session,
   WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -175,10 +175,10 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
     WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
     /*
-     * We don't want to race with copying the log files. We cannot start work until we've reached
-     * the background migration state.
+     * Wait until we're out of the log pre-copy stage. Otherwise we might race with the log copy
+     * thread.
      */
-    if (state < WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION) {
+    if (state == WTI_LIVE_RESTORE_STATE_NONE || state == WTI_LIVE_RESTORE_STATE_LOG_COPY) {
         __wt_sleep(0, 10000);
         return (0);
     }

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -22,8 +22,6 @@ __live_restore_worker_check(WT_SESSION_IMPL *session)
     return (true);
 }
 
-// TODO - We should be able to bypass starting the server and just call clean_up directly.
-// Discuss in review and either fix or do it in a new ticket.
 /*
  * __live_restore_clean_up --
  *     Clean up live restore metadata once background migration has completed. This will be called
@@ -93,6 +91,10 @@ __live_restore_worker_stop(WT_SESSION_IMPL *session, WT_THREAD *ctx)
     if (server->threads_working == 0) {
         /* If all the threads are stopped and the queue is empty background migration is done. */
         if (TAILQ_EMPTY(&server->work_queue))
+            /*
+             * FIXME-WT-14113 This is currently the only path the calls live restore clean up, but it requires us to start up the background migration threads first.
+             * When WiredTiger starts in a post-background migration state we should call this directly instead of spinning up the server.
+             */
             WT_ERR(__live_restore_clean_up(session, ctx));
 
         /*

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -177,10 +177,10 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
     WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
     /*
-     * Don't start work until we're in the correct state. This prevents the background migration
+     * Don't start work until we've reached the background migration stage. This prevents the background migration
      * threads from racing with log pre-copy.
      */
-    if (state == WTI_LIVE_RESTORE_STATE_NONE || state == WTI_LIVE_RESTORE_STATE_LOG_COPY) {
+    if (state < WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION) {
         __wt_sleep(0, 10000);
         return (0);
     }

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -92,8 +92,10 @@ __live_restore_worker_stop(WT_SESSION_IMPL *session, WT_THREAD *ctx)
         /* If all the threads are stopped and the queue is empty background migration is done. */
         if (TAILQ_EMPTY(&server->work_queue))
             /*
-             * FIXME-WT-14113 This is currently the only path the calls live restore clean up, but it requires us to start up the background migration threads first.
-             * When WiredTiger starts in a post-background migration state we should call this directly instead of spinning up the server.
+             * FIXME-WT-14113 This is currently the only path the calls live restore clean up, but
+             * it requires us to start up the background migration threads first. When WiredTiger
+             * starts in a post-background migration state we should call this directly instead of
+             * spinning up the server.
              */
             WT_ERR(__live_restore_clean_up(session, ctx));
 

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -81,8 +81,6 @@ __live_restore_worker_stop(WT_SESSION_IMPL *session, WT_THREAD *ctx)
             if (state != WTI_LIVE_RESTORE_STATE_COMPLETE)
                 WT_ERR(
                   __wti_live_restore_set_state(session, lr_fs, WTI_LIVE_RESTORE_STATE_COMPLETE));
-
-            // TODO - update the tech design. The state file is no longer deleted at this point
         }
         /*
          * Future proofing: in general unless the conn is closing the queue must be empty if there

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -64,7 +64,6 @@ __live_restore_worker_stop(WT_SESSION_IMPL *session, WT_THREAD *ctx)
             WT_ERR(__wti_live_restore_cleanup_stop_files(session));
 
             uint64_t time_diff_ms;
-            WT_STAT_CONN_SET(session, live_restore_state, WT_LIVE_RESTORE_COMPLETE);
             __wt_timer_evaluate_ms(session, &server->start_timer, &time_diff_ms);
             __wt_verbose(session, WT_VERB_LIVE_RESTORE_PROGRESS,
               "Completed restoring %" PRIu64 " files in %" PRIu64 " seconds",
@@ -355,13 +354,6 @@ __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_ERR(__wt_spin_init(
       session, &conn->live_restore_server->queue_lock, "live restore migration work queue"));
-
-    /*
-     * Set the in progress state before we run the threads. If we do it after there's a chance we'll
-     * context switch and then this state will happen after the finish state. By setting it here it
-     * also means we transition through all valid states.
-     */
-    WT_STAT_CONN_SET(session, live_restore_state, WT_LIVE_RESTORE_IN_PROGRESS);
 
     /*
      * Even if we start from an empty database the history store file will exist before we get here

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -55,7 +55,7 @@ __live_restore_worker_stop(WT_SESSION_IMPL *session, WT_THREAD *ctx)
               WT_CONFIG_BASE(session, WT_SESSION_checkpoint), "force=true", NULL};
             WT_ERR(__wt_checkpoint_db(ctx->session, cfg, true));
 
-            WT_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
+            WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
             if (state == WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION)
                 WT_ERR(
@@ -160,7 +160,7 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
     uint64_t time_diff_ms;
 
     WTI_LIVE_RESTORE_FS *lr_fs = (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system;
-    WT_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
+    WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
     /*
      * Don't start work until we're in the correct state. This prevents the background migration

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -177,8 +177,8 @@ __live_restore_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
     WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
     /*
-     * Don't start work until we've reached the background migration stage. This prevents the background migration
-     * threads from racing with log pre-copy.
+     * Don't start work until we've reached the background migration stage. This prevents the
+     * background migration threads from racing with log pre-copy.
      */
     if (state < WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION) {
         __wt_sleep(0, 10000);

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -101,8 +101,7 @@ err:
     if (fh != NULL)
         WT_TRET(fh->close(fh, &session->iface));
 
-    if (state_file_name != NULL)
-        __wt_scr_free(session, &state_file_name);
+    __wt_scr_free(session, &state_file_name);
 
     return (ret);
 }

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -64,7 +64,7 @@ __live_restore_state_from_string(
  * __live_restore_get_state_from_file --
  *     Read the live restore state from the on-disk file. If it doesn't exist we return NONE. The
  *     caller must already hold the live restore state lock. This function takes a *non-live
- *     restore* file system, for example the backing posix file system used when accessing the
+ *     restore* file system, for example, the backing posix file system, used when accessing the
  *     source or destination directly.
  */
 static int
@@ -109,8 +109,8 @@ err:
 
 /*
  * __live_restore_set_public_state --
- *     WiredTiger reports a simplified live restore state to the server which the server uses to
- *     determine when they can end live restore.
+ *     WiredTiger reports a simplified live restore state to the application which is used to
+ *     determine when the application can restart once live restore has completed.
  */
 static void
 __live_restore_set_public_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_STATE state)
@@ -299,14 +299,12 @@ __wti_live_restore_get_state_no_lock(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_
 
 /*
  * __wt_live_restore_delete_complete_state_file --
- *     Provided with a folder delete any live restore state file contained within, provided that the
- *     file is in the COMPLETE state. This function takes a *non-live restore* file system as it is
- *     expected to be called by non-live restore file systems after live restore has completed and
- *     WiredTiger has stated in non-live restore mode
+ *     If the state file in the given directory is in the COMPLETE state, then it can be deleted.
+ *     This function takes a non-live restore backing file system.
  */
 int
 __wt_live_restore_delete_complete_state_file(
-  WT_SESSION_IMPL *session, WT_FILE_SYSTEM *fs, const char *folder)
+  WT_SESSION_IMPL *session, WT_FILE_SYSTEM *fs, const char *directory)
 {
     WT_DECL_RET;
 
@@ -315,13 +313,13 @@ __wt_live_restore_delete_complete_state_file(
     bool lr_state_file_exists = false;
 
     WT_ERR(__wt_filename_construct(
-      session, folder, WTI_LIVE_RESTORE_STATE_FILE, UINTMAX_MAX, UINT32_MAX, lr_state_file));
+      session, directory, WTI_LIVE_RESTORE_STATE_FILE, UINTMAX_MAX, UINT32_MAX, lr_state_file));
     WT_ERR(
       fs->fs_exist(fs, (WT_SESSION *)session, (char *)lr_state_file->data, &lr_state_file_exists));
 
     if (lr_state_file_exists) {
         WTI_LIVE_RESTORE_STATE source_state;
-        __live_restore_get_state_from_file(session, fs, folder, &source_state);
+        __live_restore_get_state_from_file(session, fs, directory, &source_state);
         if (source_state == WTI_LIVE_RESTORE_STATE_COMPLETE)
             WT_ERR(fs->fs_remove(fs, (WT_SESSION *)session, (char *)lr_state_file->data, 0));
     }

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -1,0 +1,392 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *  All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+#include "live_restore_private.h"
+
+/*
+ * __live_restore_state_to_string --
+ *     Convert a live restore state to its string representation.
+ */
+static void
+__live_restore_state_to_string(WT_LIVE_RESTORE_STATE state, char *state_strp)
+{
+    switch (state) {
+    case WTI_LIVE_RESTORE_STATE_NONE:
+        strcpy(state_strp, "WTI_LIVE_RESTORE_STATE_NONE");
+        break;
+    case WTI_LIVE_RESTORE_STATE_LOG_COPY:
+        strcpy(state_strp, "WTI_LIVE_RESTORE_STATE_LOG_COPY");
+        break;
+    case WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION:
+        strcpy(state_strp, "WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION");
+        break;
+    case WTI_LIVE_RESTORE_STATE_CLEAN_UP:
+        strcpy(state_strp, "WTI_LIVE_RESTORE_STATE_CLEAN_UP");
+        break;
+    case WTI_LIVE_RESTORE_STATE_COMPLETE:
+        strcpy(state_strp, "WTI_LIVE_RESTORE_STATE_COMPLETE");
+        break;
+    }
+}
+
+/*
+ * __live_restore_state_from_string --
+ *     Convert a string to its live restore state.
+ */
+static int
+__live_restore_state_from_string(
+  WT_SESSION_IMPL *session, char *state_str, WT_LIVE_RESTORE_STATE *statep)
+{
+
+    if (strcmp(state_str, "WTI_LIVE_RESTORE_STATE_NONE") == 0)
+        *statep = WTI_LIVE_RESTORE_STATE_NONE;
+    else if (strcmp(state_str, "WTI_LIVE_RESTORE_STATE_LOG_COPY") == 0)
+        *statep = WTI_LIVE_RESTORE_STATE_LOG_COPY;
+    else if (strcmp(state_str, "WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION") == 0)
+        *statep = WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION;
+    else if (strcmp(state_str, "WTI_LIVE_RESTORE_STATE_CLEAN_UP") == 0)
+        *statep = WTI_LIVE_RESTORE_STATE_CLEAN_UP;
+    else if (strcmp(state_str, "WTI_LIVE_RESTORE_STATE_COMPLETE") == 0)
+        *statep = WTI_LIVE_RESTORE_STATE_COMPLETE;
+    else
+        WT_RET_MSG(session, EINVAL, "Invalid state string: '%s' ", state_str);
+
+    return (0);
+}
+
+/*
+ * __live_restore_get_state_from_file --
+ *     Read the live restore state from the on-disk file. If it doesn't exist we return NONE.
+ */
+static int
+__live_restore_get_state_from_file(
+  WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs, WT_LIVE_RESTORE_STATE *statep)
+{
+    WT_DECL_RET;
+
+    WT_DECL_ITEM(state_file_name);
+
+    WT_FILE_HANDLE *fh = NULL;
+
+    // TODO - should be read/write lock
+    // TODO - change lock to just state lock, not state file
+
+    WT_RET(__wt_scr_alloc(session, 0, &state_file_name));
+
+    bool state_file_exists = false;
+
+    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WT_LIVE_RESTORE_STATE_FILE,
+      UINTMAX_MAX, UINT32_MAX, state_file_name));
+    lr_fs->os_file_system->fs_exist(lr_fs->os_file_system, (WT_SESSION *)session,
+      (char *)state_file_name->data, &state_file_exists);
+
+    if (!state_file_exists)
+        *statep = WTI_LIVE_RESTORE_STATE_NONE;
+    else {
+        char state_str[128];
+
+        lr_fs->os_file_system->fs_open_file(lr_fs->os_file_system, (WT_SESSION *)session,
+          (char *)state_file_name->data, WT_FS_OPEN_FILE_TYPE_REGULAR, WT_FS_OPEN_EXCLUSIVE, &fh);
+
+        wt_off_t file_size;
+        lr_fs->os_file_system->fs_size(
+          lr_fs->os_file_system, (WT_SESSION *)session, (char *)state_file_name->data, &file_size);
+
+        fh->fh_read(fh, (WT_SESSION *)session, 0, (size_t) file_size, state_str);
+
+        WT_ERR(__live_restore_state_from_string(session, state_str, statep));
+    }
+
+err:
+    if (fh != NULL)
+        WT_TRET(fh->close(fh, &session->iface));
+
+    if (state_file_name != NULL)
+        __wt_scr_free(session, &state_file_name);
+
+    return (ret);
+}
+
+/*
+ * __wti_live_restore_set_state --
+ *     Update the live restore state in memory and persist it to the on-disk state file.
+ */
+int
+__wti_live_restore_set_state(
+  WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs, WT_LIVE_RESTORE_STATE new_state)
+{
+
+    WT_DECL_RET;
+    WT_FILE_HANDLE *fh = NULL;
+
+    __wt_spin_lock(session, &lr_fs->state_file_lock);
+
+    /* State should always be initialized on start up. If we ever try to set state without first
+     * reading it something's gone wrong. */
+    WT_ASSERT_ALWAYS(
+      session, lr_fs->state != WTI_LIVE_RESTORE_STATE_NONE, "Live restore state not initialized!");
+
+    /* Validity checking. There is a defined transition of states and we should never skip or repeat
+     * a state. */
+    switch (new_state) {
+    case WTI_LIVE_RESTORE_STATE_NONE:
+        /* We should never manually transition to NONE. This is a placeholder for when state is not
+         * set. */
+        WT_ASSERT(session, false);
+        break;
+    case WTI_LIVE_RESTORE_STATE_LOG_COPY:
+        WT_ASSERT(session, lr_fs->state == WTI_LIVE_RESTORE_STATE_NONE);
+        break;
+    case WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION:
+        WT_ASSERT(session, lr_fs->state == WTI_LIVE_RESTORE_STATE_LOG_COPY);
+        break;
+    case WTI_LIVE_RESTORE_STATE_CLEAN_UP:
+        WT_ASSERT(session, lr_fs->state == WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION);
+        break;
+    case WTI_LIVE_RESTORE_STATE_COMPLETE:
+        /* COMPLETE should only be set manually when we delete the state file. If we use this
+         * function it will attempt to write the state to the state file we just deleted. */
+        WT_ERR_MSG(session, EINVAL, "Attempting to set state to COMPLETE via set_state()");
+        break;
+    }
+
+    WT_DECL_ITEM(state_file_name);
+    WT_RET(__wt_scr_alloc(session, 0, &state_file_name));
+
+    bool state_file_exists = false;
+
+    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WT_LIVE_RESTORE_STATE_FILE,
+      UINTMAX_MAX, UINT32_MAX, state_file_name));
+    lr_fs->os_file_system->fs_exist(lr_fs->os_file_system, (WT_SESSION *)session,
+      (char *)state_file_name->data, &state_file_exists);
+
+    /* This should be created on live restore start up. If it's not present we've called set state
+     * too early. */
+    WT_ASSERT_ALWAYS(session, state_file_exists, "State file doesn't exist!");
+
+    char state_to_write[128];
+    __live_restore_state_to_string(new_state, state_to_write);
+    lr_fs->os_file_system->fs_open_file(lr_fs->os_file_system, (WT_SESSION *)session,
+      (char *)state_file_name->data, WT_FS_OPEN_FILE_TYPE_REGULAR, WT_FS_OPEN_EXCLUSIVE, &fh);
+    fh->fh_write(fh, (WT_SESSION *)session, 0, 128, state_to_write);
+
+    lr_fs->state = new_state;
+
+err:
+    __wt_spin_unlock(session, &lr_fs->state_file_lock);
+
+    if (fh != NULL)
+        // TODO - check other calls for proper ret handling
+        WT_TRET(fh->close(fh, &session->iface));
+
+    __wt_scr_free(session, &state_file_name);
+
+    return (ret);
+}
+
+/*
+ * __wti_live_restore_init_state --
+ *     Initialize the live restore state. Read the state from file if it exists, otherwise we start
+ *     in the log copy state and need to create the file on disk.
+ */
+int
+__wti_live_restore_init_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
+{
+    WT_DECL_RET;
+    WT_FILE_HANDLE *fh = NULL;
+    bool state_file_exists = false;
+    WT_DECL_ITEM(state_file_name);
+
+    WT_ASSERT_ALWAYS(session, lr_fs->state == WTI_LIVE_RESTORE_STATE_NONE,
+      "Attempting to initialize already initialized state!");
+
+    WT_RET(__wt_scr_alloc(session, 0, &state_file_name));
+
+    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WT_LIVE_RESTORE_STATE_FILE,
+      UINTMAX_MAX, UINT32_MAX, state_file_name));
+    lr_fs->os_file_system->fs_exist(lr_fs->os_file_system, (WT_SESSION *)session,
+      (char *)state_file_name->data, &state_file_exists);
+
+    WT_LIVE_RESTORE_STATE state;
+
+    __wt_spin_lock(session, &lr_fs->state_file_lock);
+    WT_ERR(__live_restore_get_state_from_file(session, lr_fs, &state));
+    __wt_spin_unlock(session, &lr_fs->state_file_lock);
+
+    if (state != WTI_LIVE_RESTORE_STATE_NONE) {
+        lr_fs->state = state;
+    } else {
+        /*
+         * The state file doesn't exist which means we're starting a brand new live restore. Create
+         * the state file in the log copy state.
+         */
+        char state_to_write[128];
+        __live_restore_state_to_string(WTI_LIVE_RESTORE_STATE_LOG_COPY, state_to_write);
+
+        // TODO - check all posix calls for proper ret handling
+        WT_ERR(lr_fs->os_file_system->fs_open_file(lr_fs->os_file_system, (WT_SESSION *)session,
+          (char *)state_file_name->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
+          WT_FS_OPEN_CREATE | WT_FS_OPEN_EXCLUSIVE, &fh));
+
+        fh->fh_write(
+          fh, (WT_SESSION *)session, 0, 128, state_to_write);
+
+        lr_fs->state = WTI_LIVE_RESTORE_STATE_LOG_COPY;
+    }
+
+err:
+
+    // TODO - run ASan
+    __wt_scr_free(session, &state_file_name);
+
+    if (fh != NULL)
+        WT_TRET(fh->close(fh, &session->iface));
+
+    return (ret);
+}
+
+/*
+ * __wti_live_restore_delete_state_file --
+ *     At the end of live restore delete the state file. This is the atomic operation the finishes
+ *     live restore.
+ */
+int
+__wti_live_restore_delete_state_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
+{
+    WT_DECL_RET;
+    WT_FILE_HANDLE *fh = NULL;
+    bool state_file_exists = false;
+    WT_DECL_ITEM(state_file_name);
+
+    WT_ASSERT_ALWAYS(session, lr_fs->state == WTI_LIVE_RESTORE_STATE_CLEAN_UP,
+      "Cannot delete state file unless we've just finished cleaning up stop files!");
+
+    WT_RET(__wt_scr_alloc(session, 0, &state_file_name));
+
+    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WT_LIVE_RESTORE_STATE_FILE,
+      UINTMAX_MAX, UINT32_MAX, state_file_name));
+    lr_fs->os_file_system->fs_exist(lr_fs->os_file_system, (WT_SESSION *)session,
+      (char *)state_file_name->data, &state_file_exists);
+
+    __wt_spin_lock(session, &lr_fs->state_file_lock);
+    WT_ERR(lr_fs->os_file_system->fs_remove(
+      lr_fs->os_file_system, (WT_SESSION *)session, (char *)state_file_name->data, 0));
+    lr_fs->state = WTI_LIVE_RESTORE_STATE_COMPLETE;
+    // TODO - move state update to here
+
+err:
+    __wt_spin_unlock(session, &lr_fs->state_file_lock);
+
+    // TODO - run ASan
+    __wt_scr_free(session, &state_file_name);
+
+    if (fh != NULL)
+        WT_TRET(fh->close(fh, &session->iface));
+
+    return (ret);
+}
+
+/*
+ * __wti_live_restore_get_state --
+ *     Get the live restore state. If it's not available in memory read it from the on-disk state
+ *     file.
+ */
+WT_LIVE_RESTORE_STATE
+__wti_live_restore_get_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
+{
+    WT_LIVE_RESTORE_STATE state;
+    __wt_spin_lock(session, &lr_fs->state_file_lock);
+    state = lr_fs->state;
+    // printf("Getting state: %d\n", state);
+    __wt_spin_unlock(session, &lr_fs->state_file_lock);
+
+    /* We initialize state on startup. This shouldn't be possible. */
+    WT_ASSERT_ALWAYS(session, state != WTI_LIVE_RESTORE_STATE_NONE, "State not initialized!");
+
+    return (state);
+}
+
+/*
+ * __wti_live_restore_validate_directories --
+ *     Validate the source and destination directories are in a valid state on startup.
+ */
+int
+__wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
+{
+    WT_DECL_RET;
+
+    char **dirlist_source = NULL;
+    uint32_t num_source_files = 0;
+
+    char **dirlist_dest = NULL;
+    uint32_t num_dest_files = 0;
+
+    /* First up: Check that the source doesn't contain any live restore metadata files. */
+    WT_ERR(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, (WT_SESSION *)session,
+      lr_fs->source.home, "", &dirlist_source, &num_source_files));
+
+    for (uint32_t i = 0; i < num_source_files; ++i) {
+        if (WT_SUFFIX_MATCH(dirlist_source[i], WTI_LIVE_RESTORE_STOP_FILE_SUFFIX) ||
+          strcmp(dirlist_source[i], WT_LIVE_RESTORE_STATE_FILE) == 0) {
+            // TODO - also broken by jank tests
+            // WT_ERR_MSG(session, EINVAL,
+            //   "Source directory contains live restore metadata file: %s. This implies it is a "
+            //   "destination directory that hasn't finished restoration",
+            //   dirlist_source[i]);
+        }
+    }
+
+    /* Now check the destination folder */
+    WT_LIVE_RESTORE_STATE state;
+    __wt_spin_lock(session, &lr_fs->state_file_lock);
+    WT_ERR(__live_restore_get_state_from_file(session, lr_fs, &state));
+    __wt_spin_unlock(session, &lr_fs->state_file_lock);
+
+    WT_ERR(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, (WT_SESSION *)session,
+      lr_fs->destination.home, "", &dirlist_dest, &num_dest_files));
+
+    switch (state) {
+    case WTI_LIVE_RESTORE_STATE_NONE:
+        /* This is a branch new live restore. The destination folder shouldn't contain anything. */
+        // FIXME - tonnes of tests break this assumption
+        // if (num_dest_files > 0) {
+        //     WT_ERR_MSG(session, EINVAL,
+        //       "Live restore state is about to start but destination directory is not empty!");
+        // }
+        break;
+    case WTI_LIVE_RESTORE_STATE_LOG_COPY:
+        // TODO - ugh
+        // for (uint32_t i = 0; i < num_dest_files; ++i) {
+        //     if (!WT_SUFFIX_MATCH(dirlist_dest[i], ".log") &&
+        //       strcmp(dirlist_dest[i], WT_LIVE_RESTORE_STATE_FILE) != 0)
+        //         WT_ERR_MSG(session, EINVAL,
+        //           "Live restore state is in log copy phase but the destination contains files "
+        //           "other than logs or the state file: %s", dirlist_dest[i]);
+        // }
+        break;
+    case WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION:
+    case WTI_LIVE_RESTORE_STATE_CLEAN_UP:
+        /* There's no invalid state to check in these cases. */
+        break;
+    case WTI_LIVE_RESTORE_STATE_COMPLETE:
+        /* This function is only called on WiredTiger open and COMPLETE can only be set when we
+         * finish live restore. */
+        WT_ASSERT_ALWAYS(session, false, "Unreachable state COMPLETE!");
+        break;
+    }
+
+err:
+    if (dirlist_source != NULL)
+        __wt_free(session, dirlist_source);
+
+    if (dirlist_dest != NULL)
+        __wt_free(session, dirlist_dest);
+
+    return (ret);
+}

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -157,7 +157,7 @@ __wti_live_restore_set_state(
     }
 
     WT_DECL_ITEM(state_file_name);
-    WT_RET(__wt_scr_alloc(session, 0, &state_file_name));
+    WT_ERR(__wt_scr_alloc(session, 0, &state_file_name));
 
     bool state_file_exists = false;
 
@@ -353,7 +353,7 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
     WT_ERR(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, (WT_SESSION *)session,
       lr_fs->destination.home, "", &dirlist_dest, &num_dest_files));
 
-    // TODO - run Sean's mongo test
+    // TODO - run Sean's server test
 
     // TODO - make sure we have tests that restart during the log copy stage
 

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -107,12 +107,12 @@ err:
 }
 
 /*
- * __live_restore_set_public_state --
- *     WiredTiger reports a simplified live restore state to the application which is used to
- *     determine when the application can restart once live restore has completed.
+ * __live_restore_report_state_to_application --
+ *     WiredTiger reports a simplified live restore state to the application which lets it know it
+ *     can restart on completion of live restore.
  */
 static void
-__live_restore_set_public_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_STATE state)
+__live_restore_report_state_to_application(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_STATE state)
 {
     switch (state) {
     case WTI_LIVE_RESTORE_STATE_NONE:
@@ -194,7 +194,7 @@ __wti_live_restore_set_state(
     WT_ERR(fh->fh_write(fh, (WT_SESSION *)session, 0, 128, state_to_write));
 
     lr_fs->state = new_state;
-    __live_restore_set_public_state(session, new_state);
+    __live_restore_report_state_to_application(session, new_state);
 
 err:
     __wt_writeunlock(session, &lr_fs->state_lock);
@@ -452,6 +452,6 @@ __wt_live_restore_init_stats(WT_SESSION_IMPL *session)
          */
         WTI_LIVE_RESTORE_FS *lr_fs = ((WTI_LIVE_RESTORE_FS *)S2C(session)->file_system);
         WTI_LIVE_RESTORE_STATE state = lr_fs->state;
-        __live_restore_set_public_state(session, state);
+        __live_restore_report_state_to_application(session, state);
     }
 }

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -266,8 +266,7 @@ err:
 
 /*
  * __wti_live_restore_get_state --
- *     Get the live restore state. If it's not available in memory read it from the on-disk state
- *     file.
+ *     Get the live restore state.
  */
 WTI_LIVE_RESTORE_STATE
 __wti_live_restore_get_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
@@ -319,7 +318,7 @@ err:
 
 /*
  * __wti_live_restore_validate_directories --
- *     Validate the source and destination directories are in a valid state on startup.
+ *     Validate the source and destination directories are in the correct state on startup.
  */
 int
 __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -376,17 +376,12 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
     WT_ERR(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, (WT_SESSION *)session,
       lr_fs->destination.home, "", &dirlist_dest, &num_dest_files));
 
-    // TODO - run Sean's server test
-
-    // TODO - make sure we have tests that restart during the log copy stage
-
-    // TODO - New catch2 test explicitly for states
-
     switch (state) {
     case WTI_LIVE_RESTORE_STATE_NONE:
         /*
-         * We can't control for everything that the user might put into the folder, but we can
-         * control for WiredTiger files.
+         * Ideally we'd prevent live restore from starting when there are any files already present
+         * in the destination, but we can't control for everything that the user might put into the
+         * folder. Instead only check for WiredTiger files.
          */
         for (uint32_t i = 0; i < num_dest_files; ++i) {
             if (WT_PREFIX_MATCH(dirlist_dest[i], WT_WIREDTIGER) ||

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -191,8 +191,8 @@ __wti_live_restore_set_state(
       (char *)state_file_name->data, &state_file_exists));
 
     /*
-     * The state file is either already present or created on live restore initialization. If it's not present we've called set state
-     * too early.
+     * The state file is either already present or created on live restore initialization. If it's
+     * not present we've called set state too early.
      */
     WT_ASSERT_ALWAYS(session, state_file_exists, "State file doesn't exist!");
 

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -391,13 +391,11 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
     }
 
 err:
-    if (dirlist_source != NULL)
-        WT_TRET(lr_fs->os_file_system->fs_directory_list_free(
-          lr_fs->os_file_system, (WT_SESSION *)session, dirlist_source, num_source_files));
+    WT_TRET(lr_fs->os_file_system->fs_directory_list_free(
+      lr_fs->os_file_system, (WT_SESSION *)session, dirlist_source, num_source_files));
 
-    if (dirlist_dest != NULL)
-        WT_TRET(lr_fs->os_file_system->fs_directory_list_free(
-          lr_fs->os_file_system, (WT_SESSION *)session, dirlist_dest, num_source_files));
+    WT_TRET(lr_fs->os_file_system->fs_directory_list_free(
+      lr_fs->os_file_system, (WT_SESSION *)session, dirlist_dest, num_dest_files));
 
     return (ret);
 }

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -468,7 +468,7 @@ __wt_live_restore_init_stats(WT_SESSION_IMPL *session)
          * stat server starts.
          */
         WTI_LIVE_RESTORE_FS *lr_fs = ((WTI_LIVE_RESTORE_FS *)S2C(session)->file_system);
-        WTI_LIVE_RESTORE_STATE state = lr_fs->state;
+        WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
         __live_restore_report_state_to_application(session, state);
     }
 }

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -73,13 +73,13 @@ __live_restore_get_state_from_file(WT_SESSION_IMPL *session, WT_FILE_SYSTEM *fs,
 {
     WT_DECL_RET;
     WT_FILE_HANDLE *fh = NULL;
+    bool state_file_exists = false;
 
     WT_DECL_ITEM(state_file_name);
     WT_RET(__wt_scr_alloc(session, 0, &state_file_name));
     WT_ERR(__wt_filename_construct(session, backing_folder, WTI_LIVE_RESTORE_STATE_FILE,
       UINTMAX_MAX, UINT32_MAX, state_file_name));
 
-    bool state_file_exists = false;
     WT_ERR(
       fs->fs_exist(fs, (WT_SESSION *)session, (char *)state_file_name->data, &state_file_exists));
     if (!state_file_exists)
@@ -139,6 +139,8 @@ __wti_live_restore_set_state(
   WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs, WTI_LIVE_RESTORE_STATE new_state)
 {
     WT_DECL_RET;
+    WT_FILE_HANDLE *fh = NULL;
+    bool state_file_exists = false;
 
     __wt_writelock(session, &lr_fs->state_lock);
 
@@ -175,8 +177,6 @@ __wti_live_restore_set_state(
     WT_DECL_ITEM(state_file_name);
     WT_ERR(__wt_scr_alloc(session, 0, &state_file_name));
 
-    bool state_file_exists = false;
-
     WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WTI_LIVE_RESTORE_STATE_FILE,
       UINTMAX_MAX, UINT32_MAX, state_file_name));
     WT_ERR(lr_fs->os_file_system->fs_exist(lr_fs->os_file_system, (WT_SESSION *)session,
@@ -188,7 +188,6 @@ __wti_live_restore_set_state(
      */
     WT_ASSERT_ALWAYS(session, state_file_exists, "State file doesn't exist!");
 
-    WT_FILE_HANDLE *fh = NULL;
     char state_to_write[128];
     __live_restore_state_to_string(new_state, state_to_write);
     WT_ERR(lr_fs->os_file_system->fs_open_file(lr_fs->os_file_system, (WT_SESSION *)session,

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -282,6 +282,22 @@ __wti_live_restore_get_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_f
 }
 
 /*
+ * __wti_live_restore_get_state_no_lock --
+ *     Get the live restore state without taking a lock. The caller must hold the state lock when
+ *     calling this function.
+ */
+WTI_LIVE_RESTORE_STATE
+__wti_live_restore_get_state_no_lock(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
+{
+    WTI_LIVE_RESTORE_STATE state = lr_fs->state;
+
+    /* We initialize state on startup. This shouldn't be possible. */
+    WT_ASSERT_ALWAYS(session, state != WTI_LIVE_RESTORE_STATE_NONE, "State not initialized!");
+
+    return (state);
+}
+
+/*
  * __wt_live_restore_delete_complete_state_file --
  *     Provided with a folder delete any live restore state file contained within, provided that the
  *     file is in the COMPLETE state. This function takes a *non-live restore* file system as it is

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -14,7 +14,7 @@
  *     Convert a live restore state to its string representation.
  */
 static void
-__live_restore_state_to_string(WT_LIVE_RESTORE_STATE state, char *state_strp)
+__live_restore_state_to_string(WTI_LIVE_RESTORE_STATE state, char *state_strp)
 {
     switch (state) {
     case WTI_LIVE_RESTORE_STATE_NONE:
@@ -41,7 +41,7 @@ __live_restore_state_to_string(WT_LIVE_RESTORE_STATE state, char *state_strp)
  */
 static int
 __live_restore_state_from_string(
-  WT_SESSION_IMPL *session, char *state_str, WT_LIVE_RESTORE_STATE *statep)
+  WT_SESSION_IMPL *session, char *state_str, WTI_LIVE_RESTORE_STATE *statep)
 {
 
     if (strcmp(state_str, "WTI_LIVE_RESTORE_STATE_NONE") == 0)
@@ -69,7 +69,7 @@ __live_restore_state_from_string(
  */
 static int
 __live_restore_get_state_from_file(WT_SESSION_IMPL *session, WT_FILE_SYSTEM *fs,
-  const char *backing_folder, WT_LIVE_RESTORE_STATE *statep)
+  const char *backing_folder, WTI_LIVE_RESTORE_STATE *statep)
 {
     WT_DECL_RET;
 
@@ -81,8 +81,8 @@ __live_restore_get_state_from_file(WT_SESSION_IMPL *session, WT_FILE_SYSTEM *fs,
 
     bool state_file_exists = false;
 
-    WT_ERR(__wt_filename_construct(session, backing_folder, WT_LIVE_RESTORE_STATE_FILE, UINTMAX_MAX,
-      UINT32_MAX, state_file_name));
+    WT_ERR(__wt_filename_construct(session, backing_folder, WTI_LIVE_RESTORE_STATE_FILE,
+      UINTMAX_MAX, UINT32_MAX, state_file_name));
     WT_ERR(
       fs->fs_exist(fs, (WT_SESSION *)session, (char *)state_file_name->data, &state_file_exists));
 
@@ -118,7 +118,7 @@ err:
  */
 int
 __wti_live_restore_set_state(
-  WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs, WT_LIVE_RESTORE_STATE new_state)
+  WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs, WTI_LIVE_RESTORE_STATE new_state)
 {
 
     WT_DECL_RET;
@@ -158,7 +158,7 @@ __wti_live_restore_set_state(
 
     bool state_file_exists = false;
 
-    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WT_LIVE_RESTORE_STATE_FILE,
+    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WTI_LIVE_RESTORE_STATE_FILE,
       UINTMAX_MAX, UINT32_MAX, state_file_name));
     WT_ERR(lr_fs->os_file_system->fs_exist(lr_fs->os_file_system, (WT_SESSION *)session,
       (char *)state_file_name->data, &state_file_exists));
@@ -206,12 +206,12 @@ __wti_live_restore_init_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_
 
     WT_RET(__wt_scr_alloc(session, 0, &state_file_name));
 
-    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WT_LIVE_RESTORE_STATE_FILE,
+    WT_ERR(__wt_filename_construct(session, lr_fs->destination.home, WTI_LIVE_RESTORE_STATE_FILE,
       UINTMAX_MAX, UINT32_MAX, state_file_name));
     WT_ERR(lr_fs->os_file_system->fs_exist(lr_fs->os_file_system, (WT_SESSION *)session,
       (char *)state_file_name->data, &state_file_exists));
 
-    WT_LIVE_RESTORE_STATE state;
+    WTI_LIVE_RESTORE_STATE state;
 
     WT_ERR(__live_restore_get_state_from_file(
       session, lr_fs->os_file_system, lr_fs->destination.home, &state));
@@ -251,10 +251,10 @@ err:
  *     Get the live restore state. If it's not available in memory read it from the on-disk state
  *     file.
  */
-WT_LIVE_RESTORE_STATE
+WTI_LIVE_RESTORE_STATE
 __wti_live_restore_get_state(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs)
 {
-    WT_LIVE_RESTORE_STATE state;
+    WTI_LIVE_RESTORE_STATE state;
     __wt_readlock(session, &lr_fs->state_lock);
     state = lr_fs->state;
     __wt_readunlock(session, &lr_fs->state_lock);
@@ -283,12 +283,12 @@ __wt_live_restore_delete_complete_state_file(
     bool lr_state_file_exists = false;
 
     WT_ERR(__wt_filename_construct(
-      session, folder, WT_LIVE_RESTORE_STATE_FILE, UINTMAX_MAX, UINT32_MAX, lr_state_file));
+      session, folder, WTI_LIVE_RESTORE_STATE_FILE, UINTMAX_MAX, UINT32_MAX, lr_state_file));
     WT_ERR(
       fs->fs_exist(fs, (WT_SESSION *)session, (char *)lr_state_file->data, &lr_state_file_exists));
 
     if (lr_state_file_exists) {
-        WT_LIVE_RESTORE_STATE source_state;
+        WTI_LIVE_RESTORE_STATE source_state;
         __live_restore_get_state_from_file(session, fs, folder, &source_state);
         if (source_state == WTI_LIVE_RESTORE_STATE_COMPLETE)
             WT_ERR(fs->fs_remove(fs, (WT_SESSION *)session, (char *)lr_state_file->data, 0));
@@ -333,7 +333,7 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
 
     for (uint32_t i = 0; i < num_source_files; ++i) {
         if (WT_SUFFIX_MATCH(dirlist_source[i], WTI_LIVE_RESTORE_STOP_FILE_SUFFIX) ||
-          strcmp(dirlist_source[i], WT_LIVE_RESTORE_STATE_FILE) == 0) {
+          strcmp(dirlist_source[i], WTI_LIVE_RESTORE_STATE_FILE) == 0) {
             WT_ERR_MSG(session, EINVAL,
               "Source directory contains live restore metadata file: %s. This implies it is a "
               "destination directory that hasn't finished restoration",
@@ -342,7 +342,7 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
     }
 
     /* Now check the destination folder */
-    WT_LIVE_RESTORE_STATE state;
+    WTI_LIVE_RESTORE_STATE state;
     __wt_readlock(session, &lr_fs->state_lock);
     WT_ERR(__live_restore_get_state_from_file(
       session, lr_fs->os_file_system, lr_fs->destination.home, &state));
@@ -369,7 +369,7 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
     case WTI_LIVE_RESTORE_STATE_LOG_COPY:
         for (uint32_t i = 0; i < num_dest_files; ++i) {
             if (!WT_SUFFIX_MATCH(dirlist_dest[i], ".log") &&
-              strcmp(dirlist_dest[i], WT_LIVE_RESTORE_STATE_FILE) != 0)
+              strcmp(dirlist_dest[i], WTI_LIVE_RESTORE_STATE_FILE) != 0)
                 WT_ERR_MSG(session, EINVAL,
                   "Live restore state is in log copy phase but the destination contains files "
                   "other than logs or the state file: %s",

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -391,10 +391,12 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
 
 err:
     if (dirlist_source != NULL)
-        __wt_free(session, dirlist_source);
+        lr_fs->os_file_system->fs_directory_list_free(
+          lr_fs->os_file_system, (WT_SESSION *)session, dirlist_source, num_source_files);
 
     if (dirlist_dest != NULL)
-        __wt_free(session, dirlist_dest);
+        lr_fs->os_file_system->fs_directory_list_free(
+          lr_fs->os_file_system, (WT_SESSION *)session, dirlist_dest, num_source_files);
 
     return (ret);
 }

--- a/test/catch2/live_restore/api/test_live_restore_fh_extent_import_export.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fh_extent_import_export.cpp
@@ -270,5 +270,6 @@ TEST_CASE("Live Restore extent export", "[live_restore],[live_restore_extent_imp
         __wt_free(session, lr_fh->destination.hole_list_head);
     }
 
+    __wt_free(session, lr_fh);
     __wt_buf_free(session, &string);
 }

--- a/test/catch2/live_restore/api/test_live_restore_fh_extent_import_export.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fh_extent_import_export.cpp
@@ -199,7 +199,6 @@ TEST_CASE("Live Restore extent export", "[live_restore],[live_restore_extent_imp
 {
     live_restore_test_env env;
     WT_SESSION_IMPL *session = env.session;
-    WT_SESSION *wt_session = (WT_SESSION *)session;
 
     WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh;
     REQUIRE(__wt_calloc_one(session, &lr_fh) == 0);

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -67,7 +67,7 @@ file_list_equals(lr_files list, lr_files check)
     list.erase(WT_BASECONFIG);
     list.erase(WT_SINGLETHREAD);
     list.erase(WT_HS_FILE);
-    list.erase(WT_LIVE_RESTORE_STATE_FILE);
+    list.erase(WTI_LIVE_RESTORE_STATE_FILE);
 
     if (list != check) {
         std::cout << "Mismatch between list and check!" << std::endl;

--- a/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_directory_list.cpp
@@ -13,6 +13,7 @@
  */
 
 #include "../utils_live_restore.h"
+#include <iostream>
 #include <set>
 
 using namespace utils;
@@ -66,6 +67,21 @@ file_list_equals(lr_files list, lr_files check)
     list.erase(WT_BASECONFIG);
     list.erase(WT_SINGLETHREAD);
     list.erase(WT_HS_FILE);
+    list.erase(WT_LIVE_RESTORE_STATE_FILE);
+
+    if (list != check) {
+        std::cout << "Mismatch between list and check!" << std::endl;
+        std::cout << "List: ";
+        for (const auto &file : list)
+            std::cout << file << " ";
+        std::cout << std::endl;
+
+        std::cout << "Check: ";
+        for (const auto &file : check)
+            std::cout << file << " ";
+        std::cout << std::endl;
+    }
+
     return list == check;
 }
 

--- a/test/catch2/live_restore/live_restore_test_env.cpp
+++ b/test/catch2/live_restore/live_restore_test_env.cpp
@@ -45,7 +45,6 @@ live_restore_test_env::live_restore_test_env()
     testutil_remove(temp_file.c_str());
     session = conn->create_session();
     lr_fs = (WTI_LIVE_RESTORE_FS *)conn->get_wt_connection_impl()->file_system;
-    lr_fs->finished = false;
 }
 
 std::string

--- a/test/catch2/live_restore/live_restore_test_env.cpp
+++ b/test/catch2/live_restore/live_restore_test_env.cpp
@@ -24,7 +24,7 @@ live_restore_test_env::live_restore_test_env()
     testutil_recreate_dir(DB_SOURCE.c_str());
 
     static std::string cfg_string =
-      "create=true,live_restore=(enabled=true, path=" + DB_SOURCE + ")";
+      "create=true,live_restore=(enabled=true, path=" + DB_SOURCE + ",threads_max=0)";
     conn = std::make_unique<connection_wrapper>(DB_DEST.c_str(), cfg_string.c_str());
 
     session = conn->create_session();

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -122,7 +122,6 @@ static const char *SOURCE_PATH = "WT_LIVE_RESTORE_SOURCE";
 static const char *HOME_PATH = DEFAULT_DIR;
 
 /* Declarations to avoid the error raised by -Werror=missing-prototypes. */
-void do_random_crud(scoped_session &session, bool fresh_start);
 void create_collection(scoped_session &session);
 void read(scoped_session &session);
 void trigger_fs_truncate(scoped_session &session);
@@ -342,7 +341,7 @@ configure_database(scoped_session &session)
 static void
 run_restore(const std::string &home, const std::string &source, const int64_t thread_count,
   const int64_t collection_count, const int64_t op_count, const bool background_thread_mode,
-  const int64_t verbose_level, const bool first, const bool die, const bool recovery)
+  const int64_t verbose_level, const bool die, const bool recovery)
 {
     /* Create a connection, set the cache size and specify the home directory. */
     const std::string verbose_string = verbose_level == 0 ?
@@ -357,21 +356,14 @@ run_restore(const std::string &home, const std::string &source, const int64_t th
     /* Create connection. */
     if (recovery)
         connection_manager::instance().reopen(conn_config, home);
-    else {
-        /*
-         * We only want to create the log directory when no source directory is available to copy it
-         * from. This is only true when it's the first iteration of the loop *and* we're not recovering
-         * from a crash.
-         */
-        bool create_log_directory = first && !recovery;
-        connection_manager::instance().create(conn_config, home, create_log_directory);
-    }
+    else
+        connection_manager::instance().create(conn_config, home, false);
 
     auto crud_session = connection_manager::instance().create_session();
     if (recovery)
         configure_database(crud_session);
     if (!background_thread_mode)
-        do_random_crud(crud_session, collection_count, op_count, first, conn_config, home);
+        do_random_crud(crud_session, collection_count, op_count, false, conn_config, home);
     if (die)
         raise(SIGKILL);
 
@@ -391,6 +383,29 @@ run_restore(const std::string &home, const std::string &source, const int64_t th
 
     // We need to close the session here because the connection close will close it out for us if we
     // don't. Then we'll crash because we'll double close a WT session.
+    crud_session.close_session();
+    connection_manager::instance().close();
+}
+
+// Populate an initial database to be live restores. This will be used for the first live restore
+// and after that we can use the restored database from the prior iterations as the source.
+static void
+create_db(const std::string &home, const int64_t thread_count, const int64_t collection_count,
+  const int64_t op_count, const int64_t verbose_level)
+{
+    /* Create a connection, set the cache size and specify the home directory. */
+    const std::string conn_config = CONNECTION_CREATE +
+      ",cache_size=5GB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true,"
+      "path=journal)";
+
+    /*
+     * Open the connection and create the log folder. In futre runs this is copued by live restore.
+     */
+    connection_manager::instance().create(conn_config, home, true);
+
+    auto crud_session = connection_manager::instance().create_session();
+    do_random_crud(crud_session, collection_count, op_count, true, conn_config, home);
+
     crud_session.close_session();
     connection_manager::instance().close();
 }
@@ -511,8 +526,18 @@ main(int argc, char *argv[])
     if (!recovery) {
         // Delete any existing source dir and home path.
         logger::log_msg(LOG_INFO, "Source path: " + std::string(SOURCE_PATH));
-        testutil_recreate_dir(SOURCE_PATH);
+
+        testutil_remove(SOURCE_PATH);
         testutil_remove(home_path.c_str());
+
+        // We need to create a database to restore from initially.
+        create_db(home_path, thread_count, coll_count, op_count, verbose_level);
+        testutil_move(home_path.c_str(), SOURCE_PATH);
+    } else {
+        // Assuming this run is following a -d "death" run then the previous home path will be the
+        // source path.
+        testutil_remove(SOURCE_PATH);
+        testutil_move(home_path.c_str(), SOURCE_PATH);
     }
 
     /* When setting up the database we don't want to wait for the background threads to complete. */
@@ -524,7 +549,7 @@ main(int argc, char *argv[])
     for (int i = 0; i < it_count; i++) {
         logger::log_msg(LOG_INFO, "!!!! Beginning iteration: " + std::to_string(i) + " !!!!");
         run_restore(home_path, SOURCE_PATH, thread_count, coll_count, op_count,
-          background_thread_debug_mode, verbose_level, i == 0, i == death_it, recovery);
+          background_thread_debug_mode, verbose_level, i == death_it, recovery);
         testutil_remove(SOURCE_PATH);
         testutil_move(home_path.c_str(), SOURCE_PATH);
     }

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -285,12 +285,12 @@ do_random_crud(scoped_session &session, const int64_t collection_count, const in
         }
 
         if (ran < 3) {
+            logger::log_msg(LOG_INFO, "Taking checkpoint");
             // 0.01% Checkpoint.
             testutil_check(session->checkpoint(session.get(), NULL));
-            logger::log_msg(LOG_INFO, "Taking checkpoint");
         } else if (ran < 5) {
-            reopen_conn(session, conn_config, home);
             logger::log_msg(LOG_INFO, "Reopening connection");
+            reopen_conn(session, conn_config, home);
 
             session = std::move(connection_manager::instance().create_session());
         } else if (ran < 9000) {
@@ -526,17 +526,11 @@ main(int argc, char *argv[])
     if (!recovery) {
         // Delete any existing source dir and home path.
         logger::log_msg(LOG_INFO, "Source path: " + std::string(SOURCE_PATH));
-
         testutil_remove(SOURCE_PATH);
         testutil_remove(home_path.c_str());
 
         // We need to create a database to restore from initially.
         create_db(home_path, thread_count, coll_count, op_count, verbose_level);
-        testutil_move(home_path.c_str(), SOURCE_PATH);
-    } else {
-        // Assuming this run is following a -d "death" run then the previous home path will be the
-        // source path.
-        testutil_remove(SOURCE_PATH);
         testutil_move(home_path.c_str(), SOURCE_PATH);
     }
 

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -288,7 +288,7 @@ do_random_crud(scoped_session &session, const int64_t collection_count, const in
             logger::log_msg(LOG_INFO, "Taking checkpoint");
             // 0.01% Checkpoint.
             testutil_check(session->checkpoint(session.get(), NULL));
-        } else if (ran < 5) {
+        } else if (ran < 15) {
             logger::log_msg(LOG_INFO, "Reopening connection");
             reopen_conn(session, conn_config, home);
 

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -387,20 +387,17 @@ run_restore(const std::string &home, const std::string &source, const int64_t th
     connection_manager::instance().close();
 }
 
-// Populate an initial database to be live restores. This will be used for the first live restore
+// Populate an initial database to be live restored. This will be used for the first live restore
 // and after that we can use the restored database from the prior iterations as the source.
 static void
 create_db(const std::string &home, const int64_t thread_count, const int64_t collection_count,
   const int64_t op_count, const int64_t verbose_level)
 {
-    /* Create a connection, set the cache size and specify the home directory. */
     const std::string conn_config = CONNECTION_CREATE +
       ",cache_size=5GB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true,"
       "path=journal)";
 
-    /*
-     * Open the connection and create the log folder. In future runs this is copied by live restore.
-     */
+    // Open the connection and create the log folder. In future runs this is copied by live restore.
     connection_manager::instance().create(conn_config, home, true);
 
     auto crud_session = connection_manager::instance().create_session();

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -357,8 +357,15 @@ run_restore(const std::string &home, const std::string &source, const int64_t th
     /* Create connection. */
     if (recovery)
         connection_manager::instance().reopen(conn_config, home);
-    else
-        connection_manager::instance().create(conn_config, home, true);
+    else {
+        /*
+         * We only want to create the log directory when no source directory is available to copy it
+         * from. This is only true when it's the first iteration of the loop *and* we're not recovering
+         * from a crash.
+         */
+        bool create_log_directory = first && !recovery;
+        connection_manager::instance().create(conn_config, home, create_log_directory);
+    }
 
     auto crud_session = connection_manager::instance().create_session();
     if (recovery)

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -357,7 +357,7 @@ run_restore(const std::string &home, const std::string &source, const int64_t th
     if (recovery)
         connection_manager::instance().reopen(conn_config, home);
     else
-        connection_manager::instance().create(conn_config, home, false);
+        connection_manager::instance().create(conn_config, home, true);
 
     auto crud_session = connection_manager::instance().create_session();
     if (recovery)

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -399,7 +399,7 @@ create_db(const std::string &home, const int64_t thread_count, const int64_t col
       "path=journal)";
 
     /*
-     * Open the connection and create the log folder. In futre runs this is copued by live restore.
+     * Open the connection and create the log folder. In future runs this is copied by live restore.
      */
     connection_manager::instance().create(conn_config, home, true);
 

--- a/test/suite/test_live_restore01.py
+++ b/test/suite/test_live_restore01.py
@@ -47,9 +47,7 @@ class test_live_restore01(wttest.WiredTigerTestCase):
     def expect_failure(self, config_str, expected_error):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.open_conn("DEST", config=config_str), expected_error)
-
         # No need to clean up the destination as WiredTiger failed to open.
-
 
     def test_live_restore01(self):
         # Close the default connection.

--- a/test/suite/test_live_restore01.py
+++ b/test/suite/test_live_restore01.py
@@ -28,52 +28,66 @@
 
 import os
 import wiredtiger, wttest
+from helper import copy_wiredtiger_home
+import glob
+import shutil
 
 # test_live_restore01.py
 # Test live restore compatibility with various other connection options.
 class test_live_restore01(wttest.WiredTigerTestCase):
+
+    def expect_success(self, config_str):
+        self.open_conn("DEST", config=config_str)
+        self.close_conn()
+
+        # Clean out the destination. Subsequent live_restore opens will expect it to contain nothing.
+        shutil.rmtree("DEST")
+        os.mkdir("DEST")
+
+    def expect_failure(self, config_str, expected_error):
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.open_conn("DEST", config=config_str), expected_error)
+
+        # No need to clean up the destination as WiredTiger failed to open.
+
+
     def test_live_restore01(self):
         # Close the default connection.
         self.close_conn()
 
+        copy_wiredtiger_home(self, '.', "SOURCE")
+        # Remove everything but SOURCE / stderr / stdout.
+        for f in glob.glob("*"):
+            if not f == "SOURCE" and not f == "stderr.txt" and not f == "stdout.txt":
+                os.remove(f)
+
+        os.mkdir("DEST")
+
         # Test that live restore connection will fail on windows.
         if os.name == 'nt':
-            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-                lambda: self.open_conn(config="live_restore=(enabled=true,path=\".\")"),
-                "/Live restore is not supported on Windows/")
+            self.expect_failure("live_restore=(enabled=true,path=SOURCE)", "/Live restore is not supported on Windows/")
             return
 
         # Open a valid connection.
-        self.open_conn(config="live_restore=(enabled=true,path=\".\")")
-        self.close_conn()
+        self.expect_success("live_restore=(enabled=true,path=SOURCE)")
 
         # Specify an in memory connection with live restore.
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.open_conn(config="in_memory=true,live_restore=(enabled=true,path=\".\")"),
-            "/Live restore is not compatible with an in-memory connection/")
+        self.expect_failure("in_memory=true,live_restore=(enabled=true,path=SOURCE)", "/Live restore is not compatible with an in-memory connection/")
 
         # Specify an in memory connection with live restore not enabled.
-        self.open_conn(config="in_memory=true,live_restore=(enabled=false,path=\".\")")
-        self.close_conn()
+        self.expect_success("in_memory=true,live_restore=(enabled=false,path=SOURCE)")
 
         # Specify an empty path string.
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.open_conn(config="live_restore=(enabled=true,path=\"\")"),
-            "/No such file or directory/")
+        self.expect_failure("live_restore=(enabled=true,path=\"\")", "/No such file or directory/")
 
         # Specify a non existant path.
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.open_conn(config="live_restore=(enabled=true,path=\"fake.fake.fake\")"),
-            "/fake.fake.fake/")
+        self.expect_failure("live_restore=(enabled=true,path=\"fake.fake.fake\")", "/fake.fake.fake/")
 
         # Specify the max number of threads
-        self.open_conn(config="live_restore=(enabled=true,path=\".\",threads_max=12)")
-        self.close_conn()
+        self.expect_success("live_restore=(enabled=true,path=SOURCE,threads_max=12)")
 
         # Specify one too many threads.
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.open_conn(config="live_restore=(enabled=true,path=\".\",threads_max=13)"),
-            "/Value too large for key/")
+        self.expect_failure("live_restore=(enabled=true,path=SOURCE,threads_max=13)", "/Value too large for key/")
 
         # Specify the minimum allowed number of threads.
-        self.open_conn(config="live_restore=(enabled=true,path=\".\",threads_max=0)")
+        self.expect_success("live_restore=(enabled=true,path=SOURCE,threads_max=0)")

--- a/test/suite/test_live_restore02.py
+++ b/test/suite/test_live_restore02.py
@@ -77,7 +77,8 @@ class test_live_restore02(wttest.WiredTigerTestCase):
             if not f == "SOURCE" and not f == "stderr.txt" and not f == "stdout.txt":
                 os.remove(f)
 
-        self.open_conn(config="statistics=(all),live_restore=(enabled=true,path=\"SOURCE\",threads_max=1)")
+        os.mkdir("DEST")
+        self.open_conn("DEST", config="statistics=(all),live_restore=(enabled=true,path=\"SOURCE\",threads_max=1)")
 
         state = 0
         timeout = 120

--- a/test/suite/test_live_restore03.py
+++ b/test/suite/test_live_restore03.py
@@ -63,7 +63,8 @@ class test_live_restore03(wttest.WiredTigerTestCase):
 
         # Open a connection with no live restore background threads to avoid opening file handles
         # in the background.
-        self.open_conn(config="statistics=(all),live_restore=(enabled=true,path=\"SOURCE\",threads_max=0)")
+        os.mkdir("DEST")
+        self.open_conn("DEST",config="statistics=(all),live_restore=(enabled=true,path=\"SOURCE\",threads_max=0)")
 
         # Query the data source block size statistic.
         for uri in uris:


### PR DESCRIPTION
Add more granular states to Live Restore for each of the stages it progresses through. This change adds checks that we always progress through the changes in the correct order and adds both validation and behaviour changes based on the current state WiredTiger is in.

The state is stored in memory during operation, but also persisted to disk to allow WiredTiger to restart in the correct state across restarts and crashes.