### PR TITLE
SLS-1164 Pin the content in the ingest table if they are needed by any layered cursor

### DIFF
--- a/dist/filelist
+++ b/dist/filelist
@@ -239,6 +239,7 @@ src/support/scratch.c
 src/support/stat.c
 src/support/thread_group.c
 src/support/timestamp.c
+src/support/ts_min_heap.c
 src/support/update_vector.c
 src/tiered/tiered_config.c
 src/tiered/tiered_handle.c

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -853,6 +853,7 @@ hashtable
 hashval
 havesize
 hdr
+heapify
 hhh
 hijinx
 hpp

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -174,6 +174,9 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
         btree->evict_disabled_open = true;
     }
 
+    WT_ERR(__wt_spin_init(session, &btree->ts_min_heap_lock, "ts min heap lock"));
+    WT_ERR(__wt_ts_min_heap_init(session, &btree->ts_min_heap));
+
     if (0) {
 err:
         WT_TRET(__wt_btree_close(session));
@@ -240,6 +243,9 @@ __wt_btree_close(WT_SESSION_IMPL *session)
         /* Close the underlying block manager reference. */
         WT_TRET(bm->close(bm, session));
     }
+
+    __wt_spin_destroy(session, &btree->ts_min_heap_lock);
+    __wt_ts_min_heap_free(session, &btree->ts_min_heap);
 
     return (ret);
 }

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -245,6 +245,7 @@ __wt_btree_close(WT_SESSION_IMPL *session)
     }
 
     __wt_spin_destroy(session, &btree->ts_min_heap_lock);
+    WT_ASSERT(session, btree->ts_min_heap.size == 0);
     __wt_ts_min_heap_free(session, &btree->ts_min_heap);
 
     return (ret);

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -355,7 +355,7 @@ __wt_update_obsolete_check(
     WT_PAGE *page;
     WT_TXN_GLOBAL *txn_global;
     WT_UPDATE *first, *next;
-    wt_timestamp_t last_ckpt_timestamp;
+    wt_timestamp_t pinned_ts_ingest;
     size_t size;
     uint64_t oldest_id;
     u_int count;
@@ -369,8 +369,7 @@ __wt_update_obsolete_check(
     if (WT_PAGE_TRYLOCK(session, page) != 0)
         return;
 
-    WT_ACQUIRE_READ(
-      last_ckpt_timestamp, S2C(session)->disaggregated_storage.last_checkpoint_timestamp);
+    WT_ACQUIRE_READ(pinned_ts_ingest, S2BT(session)->pinned_ts_ingest);
 
     oldest_id = __wt_txn_oldest_id(session);
 
@@ -407,8 +406,8 @@ __wt_update_obsolete_check(
          */
         if (__wt_txn_upd_visible_all(session, upd) ||
           (F_ISSET(CUR2BT(cbt), WT_BTREE_GARBAGE_COLLECT) &&
-            (WT_TXNID_LT(upd->txnid, oldest_id) && last_ckpt_timestamp != WT_TS_NONE &&
-              upd->durable_ts <= last_ckpt_timestamp))) {
+            (WT_TXNID_LT(upd->txnid, oldest_id) && pinned_ts_ingest != WT_TS_NONE &&
+              upd->durable_ts <= pinned_ts_ingest))) {
             if (first == NULL && WT_UPDATE_DATA_VALUE(upd))
                 first = upd;
         } else

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -187,9 +187,9 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
     locked = false;
 
     if ((c = clayered->stable_cursor) != NULL) {
-        if (clayered->checkpoint_timestamp != WT_TS_NONE) {
+        if (clayered->checkpoint_timestamp != WT_TS_NONE && clayered->ingest_cursor != NULL) {
             session = CUR2S(c);
-            ingest_btree = CUR2BT(c);
+            ingest_btree = CUR2BT(clayered->ingest_cursor);
             __wt_spin_lock(session, &ingest_btree->ts_min_heap_lock);
             locked = true;
             WT_ERR(

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -241,6 +241,7 @@ __clayered_open_cursors(WT_CURSOR_LAYERED *clayered, bool update)
     conn = S2C(session);
     layered = (WT_LAYERED_TABLE *)session->dhandle;
     checkpoint_timestamp = WT_TS_NONE;
+    ingest_btree = NULL;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -198,7 +198,7 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
             __wt_spin_unlock(session, &ingest_btree->ts_min_heap_lock);
             locked = false;
         }
-        WT_RET(c->close(c));
+        WT_ERR(c->close(c));
         clayered->stable_cursor = NULL;
     }
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -182,7 +182,9 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
     bool locked;
 
     clayered->current_cursor = NULL;
+    session = NULL;
     locked = false;
+
     if ((c = clayered->stable_cursor) != NULL) {
         WT_RET(c->close(c));
         clayered->stable_cursor = NULL;

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -196,10 +196,10 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
             locked = true;
             WT_ERR(
               __wt_ts_min_heap_remove(&ingest_btree->ts_min_heap, clayered->checkpoint_timestamp));
+            clayered->checkpoint_timestamp = WT_TS_NONE;
             WT_ERR(__wt_update_pinned_ts_ingest(session, ingest_btree));
             __wt_spin_unlock(session, &ingest_btree->ts_min_heap_lock);
             locked = false;
-            clayered->checkpoint_timestamp = NULL;
         }
     }
 
@@ -336,10 +336,10 @@ __clayered_open_cursors(WT_CURSOR_LAYERED *clayered, bool update)
             locked = true;
             WT_ERR(
               __wt_ts_min_heap_insert(session, &ingest_btree->ts_min_heap, checkpoint_timestamp));
+            clayered->checkpoint_timestamp = checkpoint_timestamp;
             WT_ERR(__wt_update_pinned_ts_ingest(session, ingest_btree));
             __wt_spin_unlock(session, &ingest_btree->ts_min_heap_lock);
             locked = false;
-            clayered->checkpoint_timestamp = checkpoint_timestamp;
         }
     }
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -183,6 +183,7 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
 
     clayered->current_cursor = NULL;
     session = NULL;
+    ingest_btree = NULL;
     locked = false;
 
     if ((c = clayered->stable_cursor) != NULL) {

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -240,7 +240,6 @@ __clayered_open_cursors(WT_CURSOR_LAYERED *clayered, bool update)
     session = CUR2S(clayered);
     conn = S2C(session);
     layered = (WT_LAYERED_TABLE *)session->dhandle;
-    checkpoint_timestamp = WT_TS_NONE;
     ingest_btree = NULL;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -187,8 +187,10 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
     locked = false;
 
     if ((c = clayered->stable_cursor) != NULL) {
+        WT_ERR(c->close(c));
+        clayered->stable_cursor = NULL;
         if (clayered->checkpoint_timestamp != WT_TS_NONE && clayered->ingest_cursor != NULL) {
-            session = CUR2S(c);
+            session = CUR2S(clayered->ingest_cursor);
             ingest_btree = CUR2BT(clayered->ingest_cursor);
             __wt_spin_lock(session, &ingest_btree->ts_min_heap_lock);
             locked = true;
@@ -198,8 +200,6 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
             __wt_spin_unlock(session, &ingest_btree->ts_min_heap_lock);
             locked = false;
         }
-        WT_ERR(c->close(c));
-        clayered->stable_cursor = NULL;
     }
 
     if ((c = clayered->ingest_cursor) != NULL) {

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -187,11 +187,6 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
     locked = false;
 
     if ((c = clayered->stable_cursor) != NULL) {
-        WT_RET(c->close(c));
-        clayered->stable_cursor = NULL;
-    }
-
-    if ((c = clayered->ingest_cursor) != NULL) {
         if (clayered->checkpoint_timestamp != WT_TS_NONE) {
             session = CUR2S(c);
             ingest_btree = CUR2BT(c);
@@ -203,6 +198,11 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
             __wt_spin_unlock(session, &ingest_btree->ts_min_heap_lock);
             locked = false;
         }
+        WT_RET(c->close(c));
+        clayered->stable_cursor = NULL;
+    }
+
+    if ((c = clayered->ingest_cursor) != NULL) {
         WT_ERR(c->close(c));
         clayered->ingest_cursor = NULL;
     }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -307,7 +307,9 @@ __clayered_open_cursors(WT_CURSOR_LAYERED *clayered, bool update)
              * checkpoint across different WiredTiger instances eventually.
              */
             ckpt_cfg[cfg_pos++] = ",raw,checkpoint_use_history=false,force=true";
-        }
+        } else
+            checkpoint_timestamp = WT_TS_NONE;
+
         ckpt_cfg[cfg_pos] = NULL;
         ret = __wt_open_cursor(
           session, layered->stable_uri, &clayered->iface, ckpt_cfg, &clayered->stable_cursor);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1659,6 +1659,16 @@ struct __wt_update_vector {
     size_t size;
 };
 
+/* WT_TS_MIN_HEAP --
+ * A resizable minimum heap to store the smallest timestamp needs to be pinned in the ingest table
+ * for layered table.
+ */
+struct __wt_ts_min_heap {
+    size_t size;
+    size_t capacity;
+    wt_timestamp_t *data;
+};
+
 /*
  * WT_MODIFY_MEM_FRACTION
  *	Limit update chains to a fraction of the base document size.

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -272,6 +272,11 @@ struct __wt_btree {
     /* The next page ID available for allocation in disaggregated storage for this tree. */
     wt_shared uint64_t next_page_id;
 
+    WT_SPINLOCK ts_min_heap_lock;
+    WT_TS_MIN_HEAP ts_min_heap;
+    wt_shared wt_timestamp_t
+      pinned_ts_ingest; /* The pinned timestamp of the ingest table by the opening checkpoints */
+
 /*
  * Flag values up to 0xfff are reserved for WT_DHANDLE_XXX. See comment with dhandle flags for an
  * explanation.

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -632,9 +632,10 @@ struct __wt_cursor_layered {
 
     WT_DATA_HANDLE *dhandle;
 
-    WT_CURSOR *current_cursor; /* The current cursor for iteration */
-    WT_CURSOR *ingest_cursor;  /* The ingest table */
-    WT_CURSOR *stable_cursor;  /* The stable table */
+    WT_CURSOR *current_cursor;           /* The current cursor for iteration */
+    WT_CURSOR *ingest_cursor;            /* The ingest table */
+    WT_CURSOR *stable_cursor;            /* The stable table */
+    wt_timestamp_t checkpoint_timestamp; /* The checkpoint timestamp of the stable table */
 
     int64_t next_random_seed;
     u_int next_random_sample_size;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1397,6 +1397,14 @@ extern int __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ts_min_heap_get_min(WT_TS_MIN_HEAP *heap, wt_timestamp_t *tsp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ts_min_heap_init(WT_SESSION_IMPL *session, WT_TS_MIN_HEAP *heap)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ts_min_heap_insert(WT_SESSION_IMPL *session, WT_TS_MIN_HEAP *heap,
+  wt_timestamp_t ts) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ts_min_heap_remove(WT_TS_MIN_HEAP *heap, wt_timestamp_t ts)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_exists(WT_SESSION_IMPL *session, bool *existp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_init(WT_SESSION_IMPL *session, bool verify_meta, const char *cfg[])
@@ -1466,6 +1474,8 @@ extern int __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_unexpected_object_type(
   WT_SESSION_IMPL *session, const char *uri, const char *expect) WT_GCC_FUNC_DECL_ATTRIBUTE((cold))
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_update_pinned_ts_ingest(WT_SESSION_IMPL *session, WT_BTREE *btree)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_update_vector_push(WT_UPDATE_VECTOR *updates, WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -2130,6 +2140,7 @@ extern void __wt_tiered_remove_work(WT_SESSION_IMPL *session, WT_TIERED *tiered,
 extern void __wt_tiered_requeue_work(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry);
 extern void __wt_tiered_work_free(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry);
 extern void __wt_timestamp_to_hex_string(wt_timestamp_t ts, char *hex_timestamp);
+extern void __wt_ts_min_heap_free(WT_SESSION_IMPL *session, WT_TS_MIN_HEAP *heap);
 extern void __wt_txn_bump_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_close_checkpoint_cursor(WT_SESSION_IMPL *session, WT_TXN **txn_arg);
 extern void __wt_txn_destroy(WT_SESSION_IMPL *session);

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -108,8 +108,8 @@ struct __wt_reconcile {
     /* Track the pinned stable timestamp at the time reconciliation started. */
     wt_timestamp_t rec_start_pinned_stable_ts;
 
-    /* Track the last disaggregated checkpoint timestamp reconciliation started. */
-    wt_timestamp_t rec_last_checkpoint_timestamp;
+    /* Track the pinned timestamp for the ingest table. */
+    wt_timestamp_t rec_pinned_ts_ingest;
 
     /* Track the page's maximum transaction/timestamp. */
     uint64_t max_txn;

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -445,6 +445,8 @@ struct __wt_time_window;
 typedef struct __wt_time_window WT_TIME_WINDOW;
 struct __wt_truncate_info;
 typedef struct __wt_truncate_info WT_TRUNCATE_INFO;
+struct __wt_ts_min_heap;
+typedef struct __wt_ts_min_heap WT_TS_MIN_HEAP;
 struct __wt_txn;
 typedef struct __wt_txn WT_TXN;
 struct __wt_txn_global;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -609,9 +609,8 @@ __rec_row_garbage_collect_fixup_update_list(WT_SESSION_IMPL *session, WT_RECONCI
     if (first_upd->type == WT_UPDATE_TOMBSTONE)
         return (0);
 
-    if (WT_TXNID_LT(first_upd->txnid, r->last_running) &&
-      r->rec_last_checkpoint_timestamp != WT_TS_NONE &&
-      first_upd->durable_ts <= r->rec_last_checkpoint_timestamp) {
+    if (WT_TXNID_LT(first_upd->txnid, r->last_running) && r->rec_pinned_ts_ingest != WT_TS_NONE &&
+      first_upd->durable_ts <= r->rec_pinned_ts_ingest) {
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5, "%s",
           "layered table record garbage collected 5");
         WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
@@ -651,9 +650,8 @@ __rec_row_garbage_collect_fixup_insert_list(
     if (first_upd->type == WT_UPDATE_TOMBSTONE)
         return (0);
 
-    if (WT_TXNID_LT(first_upd->txnid, r->last_running) &&
-      r->rec_last_checkpoint_timestamp != WT_TS_NONE &&
-      first_upd->durable_ts <= r->rec_last_checkpoint_timestamp) {
+    if (WT_TXNID_LT(first_upd->txnid, r->last_running) && r->rec_pinned_ts_ingest != WT_TS_NONE &&
+      first_upd->durable_ts <= r->rec_pinned_ts_ingest) {
         /* __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_1, "%s", */
         /*   "layered table record garbage collected 4"); */
         WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
@@ -960,8 +958,8 @@ __wti_rec_row_leaf(
           (__wt_txn_tw_stop_visible_all(session, twp) ||
             (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
               WT_TXNID_LT(twp->start_txn, r->last_running) &&
-              r->rec_last_checkpoint_timestamp != WT_TS_NONE &&
-              twp->durable_start_ts <= r->rec_last_checkpoint_timestamp))) {
+              r->rec_pinned_ts_ingest != WT_TS_NONE &&
+              twp->durable_start_ts <= r->rec_pinned_ts_ingest))) {
             /*
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
                 __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_1, "%s",
@@ -1031,8 +1029,8 @@ __wti_rec_row_leaf(
                 __wt_txn_tw_start_visible_all(session, twp) ||
                 (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
                   WT_TXNID_LT(twp->start_txn, r->last_running) &&
-                  r->rec_last_checkpoint_timestamp != WT_TS_NONE &&
-                  twp->durable_start_ts <= r->rec_last_checkpoint_timestamp));
+                  r->rec_pinned_ts_ingest != WT_TS_NONE &&
+                  twp->durable_start_ts <= r->rec_pinned_ts_ingest));
 
             /* The first time we find an overflow record, discard the underlying blocks. */
             if (F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW) && vpack->raw != WT_CELL_VALUE_OVFL_RM)

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -641,8 +641,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
 
     __wt_txn_pinned_stable_timestamp(session, &r->rec_start_pinned_stable_ts);
 
-    WT_ACQUIRE_READ(r->rec_last_checkpoint_timestamp,
-      S2C(session)->disaggregated_storage.last_checkpoint_timestamp);
+    WT_ACQUIRE_READ(r->rec_pinned_ts_ingest, btree->pinned_ts_ingest);
 
     /*
      * The checkpoint transaction doesn't pin the oldest txn id, therefore the global last_running

--- a/src/support/ts_min_heap.c
+++ b/src/support/ts_min_heap.c
@@ -90,11 +90,13 @@ __ts_min_heapify(WT_TS_MIN_HEAP *heap, size_t index)
 static void
 __ts_min_heap_remove_min(WT_TS_MIN_HEAP *heap)
 {
+    wt_timestamp_t root;
+
     if (heap->size == 1)
         heap->size--;
     return;
 
-    wt_timestamp_t root = heap->data[0];
+    root = heap->data[0];
     heap->data[0] = heap->data[heap->size - 1];
     heap->size--;
     __ts_min_heapify(heap, 0);

--- a/src/support/ts_min_heap.c
+++ b/src/support/ts_min_heap.c
@@ -90,13 +90,10 @@ __ts_min_heapify(WT_TS_MIN_HEAP *heap, size_t index)
 static void
 __ts_min_heap_remove_min(WT_TS_MIN_HEAP *heap)
 {
-    wt_timestamp_t root;
-
     if (heap->size == 1)
         heap->size--;
     return;
 
-    root = heap->data[0];
     heap->data[0] = heap->data[heap->size - 1];
     heap->size--;
     __ts_min_heapify(heap, 0);

--- a/src/support/ts_min_heap.c
+++ b/src/support/ts_min_heap.c
@@ -20,6 +20,8 @@ __wt_ts_min_heap_init(WT_SESSION_IMPL *session, WT_TS_MIN_HEAP *heap)
     heap->size = 0;
     heap->capacity = WT_TS_MIN_HEAP_DEFAULT_CAPACITY;
     WT_RET(__wt_calloc(session, heap->capacity, sizeof(wt_timestamp_t), &heap->data));
+
+    return (0);
 }
 
 /*

--- a/src/support/ts_min_heap.c
+++ b/src/support/ts_min_heap.c
@@ -1,0 +1,166 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wt_internal.h"
+
+#define WT_TS_MIN_HEAP_DEFAULT_CAPACITY 50
+
+/*
+ * __wt_ts_min_heap_init --
+ *     Initialize a timestamp min heap.
+ */
+int
+__wt_ts_min_heap_init(WT_SESSION_IMPL *session, WT_TS_MIN_HEAP *heap)
+{
+    heap->size = 0;
+    heap->capacity = WT_TS_MIN_HEAP_DEFAULT_CAPACITY;
+    WT_RET(__wt_calloc(session, heap->capacity, sizeof(wt_timestamp_t), &heap->data));
+}
+
+/*
+ * __swap_ts --
+ *     Swap two timestamps.
+ */
+static WT_INLINE void
+__swap_ts(wt_timestamp_t *x, wt_timestamp_t *y)
+{
+    wt_timestamp_t temp;
+
+    temp = *x;
+    *x = *y;
+    *y = temp;
+}
+
+/*
+ * __wt_ts_min_heap_insert --
+ *     Insert a timestamp to the heap.
+ */
+int
+__wt_ts_min_heap_insert(WT_SESSION_IMPL *session, WT_TS_MIN_HEAP *heap, wt_timestamp_t ts)
+{
+    size_t alloc, i;
+
+    if (heap->size >= heap->capacity)
+        WT_RET(__wt_realloc(session, &alloc, heap->capacity * sizeof(wt_timestamp_t), &heap->data));
+
+    heap->size++;
+    i = heap->size - 1;
+    heap->data[i] = ts;
+    while (i != 0 && heap->data[(i - 1) / 2] > heap->data[i]) {
+        __swap_ts(&heap->data[i], &heap->data[(i - 1) / 2]);
+        i = (i - 1) / 2;
+    }
+
+    return (0);
+}
+
+/*
+ * __ts_min_heapify --
+ *     build the heap.
+ */
+static void
+__ts_min_heapify(WT_TS_MIN_HEAP *heap, size_t index)
+{
+    size_t left, right, smallest;
+
+    left = 2 * index + 1;
+    right = 2 * index + 2;
+    smallest = index;
+    if (left < heap->size && heap->data[left] < heap->data[smallest]) {
+        smallest = left;
+    }
+    if (right < heap->size && heap->data[right] < heap->data[smallest]) {
+        smallest = right;
+    }
+    if (smallest != index) {
+        __swap_ts(&heap->data[index], &heap->data[smallest]);
+        __ts_min_heapify(heap, smallest);
+    }
+}
+
+/*
+ * __ts_min_heap_remove_min --
+ *     Remove the smallest value.
+ */
+static void
+__ts_min_heap_remove_min(WT_TS_MIN_HEAP *heap)
+{
+    if (heap->size == 1)
+        heap->size--;
+    return;
+
+    wt_timestamp_t root = heap->data[0];
+    heap->data[0] = heap->data[heap->size - 1];
+    heap->size--;
+    __ts_min_heapify(heap, 0);
+}
+
+/*
+ * __ts_min_heap_find_index --
+ *     Find the index for a timestamp.
+ */
+static int
+__ts_min_heap_find_index(WT_TS_MIN_HEAP *heap, wt_timestamp_t ts, size_t *index)
+{
+    size_t i;
+
+    for (i = 0; i < heap->size; ++i) {
+        if (heap->data[i] == ts) {
+            *index = i;
+            return (0);
+        }
+    }
+
+    return (WT_NOTFOUND);
+}
+
+/*
+ * __wt_ts_min_heap_remove --
+ *     Remove a value from the heap.
+ */
+int
+__wt_ts_min_heap_remove(WT_TS_MIN_HEAP *heap, wt_timestamp_t ts)
+{
+    size_t index;
+
+    WT_RET(__ts_min_heap_find_index(heap, ts, &index));
+
+    heap->data[index] = WT_TS_NONE;
+    while (index != 0 && heap->data[(index - 1) / 2] > heap->data[index]) {
+        __swap_ts(&heap->data[index], &heap->data[(index - 1) / 2]);
+        index = (index - 1) / 2;
+    }
+    __ts_min_heap_remove_min(heap);
+
+    return (0);
+}
+
+/*
+ * __wt_ts_min_heap_get_min --
+ *     Get the minimum value in the heap.
+ */
+int
+__wt_ts_min_heap_get_min(WT_TS_MIN_HEAP *heap, wt_timestamp_t *tsp)
+{
+    if (heap->size == 0)
+        return (WT_NOTFOUND);
+
+    *tsp = heap->data[0];
+    return (0);
+}
+
+/*
+ * __wt_ts_min_heap_free --
+ *     Free the memory for ts min heap.
+ */
+void
+__wt_ts_min_heap_free(WT_SESSION_IMPL *session, WT_TS_MIN_HEAP *heap)
+{
+    if (heap->data != NULL)
+        __wt_free(session, heap->data);
+}

--- a/src/support/ts_min_heap.c
+++ b/src/support/ts_min_heap.c
@@ -92,9 +92,10 @@ __ts_min_heapify(WT_TS_MIN_HEAP *heap, size_t index)
 static void
 __ts_min_heap_remove_min(WT_TS_MIN_HEAP *heap)
 {
-    if (heap->size == 1)
+    if (heap->size == 1) {
         heap->size--;
-    return;
+        return;
+    }
 
     heap->data[0] = heap->data[heap->size - 1];
     heap->size--;


### PR DESCRIPTION
This is a POC change to ping the content in the ingest table if it is still needed by any layered cursor.

The idea is to use a min heap to track when a stable cursor is opened in the layered cursor. When we open a stable cursor, we add its checkpoint timestamp to the min heap. Reconciliation checks the minimum timestamp in the min heap to decide whether we still need to keep the data in the ingest table or not.

I want to first get some feedback if this is the right direction from the team before I do more work on this.