### PR TITLE
WT-13875 Ensure backups cannot be taken for the duration of a live restore

### DIFF
--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -164,7 +164,7 @@ sub_errors = [
         transaction ID and needs to be rolled back.'''),
     Error('WT_CONFLICT_BACKUP', -32006,
         "Conflict performing operation due to running backup", '''
-        This sub-level error indicates that there is conflict perform the operation
+        This sub-level error indicates that there is a conflict performing the operation
         because of a running backup in the system.'''),
     Error('WT_CONFLICT_DHANDLE', -32007,
         "Another thread currently holds the data handle of the table", '''
@@ -189,8 +189,8 @@ sub_errors = [
         This sub-level error indicates that a concurrent operation is performing
         a checkpoint.'''),
     Error('WT_CONFLICT_LIVE_RESTORE', -32013,
-        "Conflict performing operation due to running live restore", '''
-        This sub-level error indicates that there is conflict perform the operation
+        "Conflict performing operation due to an in-progress live restore", '''
+        This sub-level error indicates that there is a conflict performing the operation
         because of a running live restore in the system.'''),
 ]
 

--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -188,6 +188,10 @@ sub_errors = [
         "Another thread currently holds the checkpoint lock", '''
         This sub-level error indicates that a concurrent operation is performing
         a checkpoint.'''),
+    Error('WT_CONFLICT_LIVE_RESTORE', -32013,
+        "Conflict performing operation due to running live restore", '''
+        This sub-level error indicates that there is conflict perform the operation
+        because of a running live restore in the system.'''),
 ]
 
 # Update the #defines in the wiredtiger.in file.

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -69,6 +69,9 @@ __wt_wiredtiger_error(int error)
         return ("WT_CONFLICT_TABLE_LOCK: Another thread currently holds the table lock");
     case WT_CONFLICT_CHECKPOINT_LOCK:
         return ("WT_CONFLICT_CHECKPOINT_LOCK: Another thread currently holds the checkpoint lock");
+    case WT_CONFLICT_LIVE_RESTORE:
+        return (
+          "WT_CONFLICT_LIVE_RESTORE: Conflict performing operation due to running live restore");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -71,7 +71,8 @@ __wt_wiredtiger_error(int error)
         return ("WT_CONFLICT_CHECKPOINT_LOCK: Another thread currently holds the checkpoint lock");
     case WT_CONFLICT_LIVE_RESTORE:
         return (
-          "WT_CONFLICT_LIVE_RESTORE: Conflict performing operation due to running live restore");
+          "WT_CONFLICT_LIVE_RESTORE: Conflict performing operation due to an in-progress live "
+          "restore");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -115,8 +115,8 @@ This sub-level error indicates that a given transaction has the oldest transacti
 be rolled back.
 
 @par \c WT_CONFLICT_BACKUP
-This sub-level error indicates that there is conflict perform the operation because of a running
-backup in the system.
+This sub-level error indicates that there is a conflict performing the operation because of a
+running backup in the system.
 
 @par \c WT_CONFLICT_DHANDLE
 This sub-level error indicates that a concurrent operation is holding the data handle of the table.
@@ -138,8 +138,8 @@ This sub-level error indicates that a concurrent operation is performing a table
 This sub-level error indicates that a concurrent operation is performing a checkpoint.
 
 @par \c WT_CONFLICT_LIVE_RESTORE
-This sub-level error indicates that there is conflict perform the operation because of a running
-live restore in the system.
+This sub-level error indicates that there is a conflict performing the operation because of a
+running live restore in the system.
 
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -137,6 +137,10 @@ This sub-level error indicates that a concurrent operation is performing a table
 @par \c WT_CONFLICT_CHECKPOINT_LOCK
 This sub-level error indicates that a concurrent operation is performing a checkpoint.
 
+@par \c WT_CONFLICT_LIVE_RESTORE
+This sub-level error indicates that there is conflict perform the operation because of a running
+live restore in the system.
+
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4142,6 +4142,12 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * checkpoint.
  */
 #define	WT_CONFLICT_CHECKPOINT_LOCK	(-32012)
+/*!
+ * Conflict performing operation due to running live restore.
+ * This sub-level error indicates that there is conflict perform the operation
+ * because of a running live restore in the system.
+ */
+#define	WT_CONFLICT_LIVE_RESTORE	(-32013)
 /*
  * Sub-level error return section: END
  * DO NOT EDIT: automatically built by dist/api_err.py.

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -4104,8 +4104,8 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
 #define	WT_OLDEST_FOR_EVICTION	(-32005)
 /*!
  * Conflict performing operation due to running backup.
- * This sub-level error indicates that there is conflict perform the operation
- * because of a running backup in the system.
+ * This sub-level error indicates that there is a conflict performing the
+ * operation because of a running backup in the system.
  */
 #define	WT_CONFLICT_BACKUP	(-32006)
 /*!
@@ -4143,9 +4143,9 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  */
 #define	WT_CONFLICT_CHECKPOINT_LOCK	(-32012)
 /*!
- * Conflict performing operation due to running live restore.
- * This sub-level error indicates that there is conflict perform the operation
- * because of a running live restore in the system.
+ * Conflict performing operation due to an in-progress live restore.
+ * This sub-level error indicates that there is a conflict performing the
+ * operation because of a running live restore in the system.
  */
 #define	WT_CONFLICT_LIVE_RESTORE	(-32013)
 /*

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -688,7 +688,8 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
     case 'b':
         if (WT_PREFIX_MATCH(uri, "backup:")) {
             if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
-                WT_RET_MSG(session, EINVAL, "backup cannot be taken when live restore is enabled");
+                WT_RET_SUB(session, ret, WT_CONFLICT_BACKUP,
+                  "backup cannot be taken when live restore is enabled");
             WT_RET(__wt_curbackup_open(session, uri, other, cfg, cursorp));
         }
         break;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -688,7 +688,7 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
     case 'b':
         if (WT_PREFIX_MATCH(uri, "backup:")) {
             if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
-                WT_RET_SUB(session, ret, WT_CONFLICT_BACKUP,
+                WT_RET_SUB(session, EINVAL, WT_CONFLICT_BACKUP,
                   "backup cannot be taken when live restore is enabled");
             WT_RET(__wt_curbackup_open(session, uri, other, cfg, cursorp));
         }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -686,8 +686,11 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
             WT_RET(__wt_curmetadata_open(session, uri, owner, cfg, cursorp));
         break;
     case 'b':
-        if (WT_PREFIX_MATCH(uri, "backup:"))
+        if (WT_PREFIX_MATCH(uri, "backup:")) {
+            if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+                WT_RET_MSG(session, EINVAL, "backup cannot be taken when live restore is enabled");
             WT_RET(__wt_curbackup_open(session, uri, other, cfg, cursorp));
+        }
         break;
     case 's':
         if (WT_PREFIX_MATCH(uri, "statistics:")) {

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -688,7 +688,7 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
     case 'b':
         if (WT_PREFIX_MATCH(uri, "backup:")) {
             if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
-                WT_RET_SUB(session, EBUSY, WT_CONFLICT_LIVE_RESTORE,
+                WT_RET_SUB(session, EINVAL, WT_CONFLICT_LIVE_RESTORE,
                   "backup cannot be taken when live restore is enabled");
             WT_RET(__wt_curbackup_open(session, uri, other, cfg, cursorp));
         }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -688,7 +688,7 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
     case 'b':
         if (WT_PREFIX_MATCH(uri, "backup:")) {
             if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
-                WT_RET_SUB(session, EINVAL, WT_CONFLICT_BACKUP,
+                WT_RET_SUB(session, EBUSY, WT_CONFLICT_LIVE_RESTORE,
                   "backup cannot be taken when live restore is enabled");
             WT_RET(__wt_curbackup_open(session, uri, other, cfg, cursorp));
         }

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -48,6 +48,7 @@ else()
         sub_level_error/unit/test_sub_level_error_msg_macros.cpp
         sub_level_error/unit/test_sub_level_error_rollback.cpp
         sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
+        sub_level_error/unit/test_sub_level_error_live_restore_conflict.cpp
     )
 endif()
 

--- a/test/catch2/sub_level_error/api/test_sub_level_error_strerror.cpp
+++ b/test/catch2/sub_level_error/api/test_sub_level_error_strerror.cpp
@@ -43,6 +43,8 @@ TEST_CASE("Test generation of sub-level error codes when strerror is called",
             "WT_CONFLICT_TABLE_LOCK: Another thread currently holds the table lock"},
           {WT_CONFLICT_CHECKPOINT_LOCK,
             "WT_CONFLICT_CHECKPOINT_LOCK: Another thread currently holds the checkpoint lock"},
+          {WT_CONFLICT_LIVE_RESTORE,
+            "WT_CONFLICT_LIVE_RESTORE: Conflict performing operation due to running live restore"},
         };
 
         for (auto const [code, expected] : errors)

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
@@ -26,7 +26,6 @@
 #define CONFLICT_CHECKPOINT_LOCK_MSG "another thread is currently holding the checkpoint lock"
 #define CONFLICT_SCHEMA_LOCK_MSG "another thread is currently holding the schema lock"
 #define CONFLICT_TABLE_LOCK_MSG "another thread is currently holding the table lock"
-#define CONFLICT_LIVE_RESTORE_WITH_BACKUP_MSG "backup cannot be taken when live restore is enabled"
 
 /*
  * This test case covers EBUSY errors resulting from drop while cursors are still open on the table.
@@ -184,27 +183,4 @@ TEST_CASE("Test conflicts with checkpoint/schema/table locks", "[sub_level_error
     /* Drop the table once the tests are completed. */
     REQUIRE(session_a->drop(session_a, URI, NULL) == 0);
     utils::check_error_info(err_info_a, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
-}
-
-/*
- * This test case covers EBUSY errors resulting from live restore conflicts with other operations.
- */
-TEST_CASE(
-  "Test WT_CONFLICT_LIVE_RESTORE", "[sub_level_error_live_restore_conflict],[sub_level_error]")
-{
-    WT_SESSION *session = NULL;
-    WT_ERROR_INFO *err_info = NULL;
-    WT_CURSOR *cursor;
-
-    SECTION("Test WT_CONFLICT_LIVE_RESTORE while opening backup cursor")
-    {
-        connection_wrapper conn_wrapper =
-          connection_wrapper(".", "create=true,live_restore=(enabled=true, path=WT_LR_SOURCE)");
-        utils::prepare_session_and_error(&conn_wrapper, &session, &err_info);
-
-        REQUIRE(session->open_cursor(session, "backup:", NULL, NULL, &cursor) == EBUSY);
-        REQUIRE(cursor == NULL);
-        utils::check_error_info(
-          err_info, EBUSY, WT_CONFLICT_LIVE_RESTORE, CONFLICT_LIVE_RESTORE_WITH_BACKUP_MSG);
-    }
 }

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_live_restore_conflict.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_live_restore_conflict.cpp
@@ -1,0 +1,45 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <thread>
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "../../wrappers/connection_wrapper.h"
+#include "../utils_sub_level_error.h"
+#include "../../../utility/test_util.h"
+
+/*
+ * [sub_level_error_live_restore_conflict]: test_sub_level_error_live_restore_conflict.cpp
+ * Tests live restore sub level errors, and ensure that the correct sub level error
+ * codes and messages are stored.
+ */
+#define CONFLICT_LIVE_RESTORE_WITH_BACKUP_MSG "backup cannot be taken when live restore is enabled"
+
+/*
+ * This test case covers EINVAL error resulting from live restore conflicts with other operations.
+ */
+TEST_CASE(
+  "Test WT_CONFLICT_LIVE_RESTORE", "[sub_level_error_live_restore_conflict],[sub_level_error]")
+{
+    WT_SESSION *session = NULL;
+    WT_ERROR_INFO *err_info = NULL;
+    WT_CURSOR *cursor;
+
+    SECTION("Test WT_CONFLICT_LIVE_RESTORE while opening backup cursor")
+    {
+        connection_wrapper conn_wrapper =
+          connection_wrapper(".", "create=true,live_restore=(enabled=true, path=WT_LR_SOURCE)");
+        utils::prepare_session_and_error(&conn_wrapper, &session, &err_info);
+
+        REQUIRE(session->open_cursor(session, "backup:", NULL, NULL, &cursor) == EINVAL);
+        REQUIRE(cursor == NULL);
+        utils::check_error_info(
+          err_info, EINVAL, WT_CONFLICT_LIVE_RESTORE, CONFLICT_LIVE_RESTORE_WITH_BACKUP_MSG);
+    }
+}

--- a/test/suite/test_strerror01.py
+++ b/test/suite/test_strerror01.py
@@ -50,6 +50,7 @@ class test_strerror(wttest.WiredTigerTestCase, suite_subprocess):
         (wiredtiger.WT_DIRTY_DATA, "WT_DIRTY_DATA: Table has dirty data"),
         (wiredtiger.WT_CONFLICT_TABLE_LOCK, "WT_CONFLICT_TABLE_LOCK: Another thread currently holds the table lock"),
         (wiredtiger.WT_CONFLICT_CHECKPOINT_LOCK, "WT_CONFLICT_CHECKPOINT_LOCK: Another thread currently holds the checkpoint lock"),
+        (wiredtiger.WT_CONFLICT_LIVE_RESTORE, "WT_CONFLICT_LIVE_RESTORE: Conflict performing operation due to running live restore"),
     ]
 
     def check_error_code(self, error, expected):


### PR DESCRIPTION
This PR is to add logic to ensure live restore is not running when open a backup cursor.