### PR TITLE
WT-14132 Update value to wake up the obsolete cleanup thread

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -8,7 +8,8 @@
 
 #include "wt_internal.h"
 
-#define WT_CHECKPOINT_CLEANUP_FILE_INTERVAL 1 /* 1 second */
+#define WT_CHECKPOINT_CLEANUP_DEFAULT_WAKE_UP_INTERVAL 5 /* 5 seconds */
+#define WT_CHECKPOINT_CLEANUP_FILE_INTERVAL 1            /* 1 second */
 #define WT_URI_FILE_PREFIX "file:"
 
 /*
@@ -758,7 +759,8 @@ __checkpoint_cleanup(void *arg)
     __wt_seconds(session, &last);
     for (;;) {
         /* We want to ensure the thread checks often enough if it is supposed to work. */
-        cleanup_interval = WT_MIN(conn->cc_cleanup.interval, 5);
+        cleanup_interval =
+          WT_MIN(conn->cc_cleanup.interval, WT_CHECKPOINT_CLEANUP_DEFAULT_WAKE_UP_INTERVAL);
 
         /* Check periodically in case the signal was missed. */
         __wt_cond_wait_signal(session, conn->cc_cleanup.cond, cleanup_interval * WT_MILLION,

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -749,7 +749,7 @@ __checkpoint_cleanup(void *arg)
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
-    uint64_t last, now;
+    uint64_t cleanup_interval, last, now;
     bool cv_signalled;
 
     session = arg;
@@ -757,9 +757,12 @@ __checkpoint_cleanup(void *arg)
 
     __wt_seconds(session, &last);
     for (;;) {
+        /* We want to ensure the thread checks often enough if it is supposed to work. */
+        cleanup_interval = WT_MIN(conn->cc_cleanup.interval, 5);
+
         /* Check periodically in case the signal was missed. */
-        __wt_cond_wait_signal(session, conn->cc_cleanup.cond,
-          conn->cc_cleanup.interval * WT_MILLION, __checkpoint_cleanup_run_chk, &cv_signalled);
+        __wt_cond_wait_signal(session, conn->cc_cleanup.cond, cleanup_interval * WT_MILLION,
+          __checkpoint_cleanup_run_chk, &cv_signalled);
 
         /* Check if we're quitting. */
         if (!__checkpoint_cleanup_run_chk(session))

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -758,8 +758,8 @@ __checkpoint_cleanup(void *arg)
     __wt_seconds(session, &last);
     for (;;) {
         /* Check periodically in case the signal was missed. */
-        __wt_cond_wait_signal(session, conn->cc_cleanup.cond, 5 * WT_MILLION,
-          __checkpoint_cleanup_run_chk, &cv_signalled);
+        __wt_cond_wait_signal(session, conn->cc_cleanup.cond,
+          conn->cc_cleanup.interval * WT_MILLION, __checkpoint_cleanup_run_chk, &cv_signalled);
 
         /* Check if we're quitting. */
         if (!__checkpoint_cleanup_run_chk(session))


### PR DESCRIPTION
The changes use `conn->cc_cleanup.interval` instead of a hardcoded value of 5 seconds to wake up the obsolete cleanup thread.