### PR TITLE
SLS-1274 Support tables with type=layered

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -212,7 +212,29 @@ __wt_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool f
         if (WT_SUFFIX_MATCH(block_disagg->name, ".wt_stable")) {
             /* TODO: Change this hack to a nicer way of finding related metadata. */
 
+            WT_ERR(__wt_snprintf(md_key, len, "colgroup:%s", block_disagg->name));
+            md_key[strlen(md_key) - 10] = '\0'; /* Remove the .wt_stable suffix */
+            md_cursor->set_key(md_cursor, md_key);
+            WT_ERR_NOTFOUND_OK(md_cursor->search(md_cursor), true);
+            if (ret == 0) {
+                WT_ERR(md_cursor->get_value(md_cursor, &md_value));
+                WT_SAVE_DHANDLE(session,
+                  ret = __block_disagg_update_shared_metadata(bm, session, md_key, md_value));
+                WT_ERR(ret);
+            }
+
             WT_ERR(__wt_snprintf(md_key, len, "layered:%s", block_disagg->name));
+            md_key[strlen(md_key) - 10] = '\0'; /* Remove the .wt_stable suffix */
+            md_cursor->set_key(md_cursor, md_key);
+            WT_ERR_NOTFOUND_OK(md_cursor->search(md_cursor), true);
+            if (ret == 0) {
+                WT_ERR(md_cursor->get_value(md_cursor, &md_value));
+                WT_SAVE_DHANDLE(session,
+                  ret = __block_disagg_update_shared_metadata(bm, session, md_key, md_value));
+                WT_ERR(ret);
+            }
+
+            WT_ERR(__wt_snprintf(md_key, len, "table:%s", block_disagg->name));
             md_key[strlen(md_key) - 10] = '\0'; /* Remove the .wt_stable suffix */
             md_cursor->set_key(md_cursor, md_key);
             WT_ERR_NOTFOUND_OK(md_cursor->search(md_cursor), true);

--- a/test/suite/test_layered15.py
+++ b/test/suite/test_layered15.py
@@ -41,7 +41,7 @@ class test_layered15(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     create_session_config = 'key_format=S,value_format=S'
 
-    layered_uris = ["layered:test_layered15a", "layered:test_layered15b"]
+    layered_uris = ["table:test_layered15a", "layered:test_layered15b"]
     file_uris = ["file:test_layered15c"]
     table_uris = ["table:test_layered15d"]
     all_uris = layered_uris + file_uris + table_uris
@@ -118,7 +118,10 @@ class test_layered15(wttest.WiredTigerTestCase, DisaggConfigMixin):
         for uri in self.all_uris:
             cfg = self.create_session_config
             if not uri.startswith('layered'):
-                cfg += ',block_manager=disagg,log=(enabled=false)'
+                if uri in self.layered_uris:
+                    cfg += ',block_manager=disagg,type=layered'
+                else:
+                    cfg += ',block_manager=disagg,log=(enabled=false)'
             self.session.create(uri, cfg)
 
         # Put data to tables

--- a/test/suite/test_layered17.py
+++ b/test/suite/test_layered17.py
@@ -47,8 +47,9 @@ class test_layered17(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     disagg_storages = gen_disagg_storages('test_layered17', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
-        ('layered', dict(prefix='layered:')),
-        ('shared', dict(prefix='table:')),
+        ('layered-prefix', dict(prefix='layered:', table_config='')),
+        ('layered-type', dict(prefix='table:', table_config='block_manager=disagg,type=layered')),
+        ('shared', dict(prefix='table:', table_config='block_manager=disagg,log=(enabled=false)')),
     ])
 
     def __init__(self, *args, **kwargs):
@@ -73,10 +74,8 @@ class test_layered17(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         # Create table
         self.uri = self.prefix + self.table_name
-        table_config = self.create_session_config
-        if not self.uri.startswith('layered'):
-            table_config += ',block_manager=disagg,log=(enabled=false)'
-        self.session.create(self.uri, table_config)
+        config = self.create_session_config + ',' + self.table_config
+        self.session.create(self.uri, config)
 
         #
         # Phase 1: Add data at timestamp 100, stable timestamp 100

--- a/test/suite/test_layered25.py
+++ b/test/suite/test_layered25.py
@@ -47,8 +47,9 @@ class test_layered25(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     disagg_storages = gen_disagg_storages('test_layered25', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
-        ('layered', dict(prefix='layered:')),
-        ('shared', dict(prefix='table:')),
+        ('layered-prefix', dict(prefix='layered:', table_config='')),
+        ('layered-type', dict(prefix='table:', table_config='block_manager=disagg,type=layered')),
+        ('shared', dict(prefix='table:', table_config='block_manager=disagg,log=(enabled=false)')),
     ])
 
     num_restarts = 0
@@ -91,10 +92,8 @@ class test_layered25(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         # Create table
         self.uri = self.prefix + self.table_name
-        table_config = self.create_session_config
-        if not self.uri.startswith('layered'):
-            table_config += ',block_manager=disagg,log=(enabled=false)'
-        self.session.create(self.uri, table_config)
+        config = self.create_session_config + ',' + self.table_config
+        self.session.create(self.uri, config)
 
         # Put data to the table
         value_prefix1 = 'aaa'


### PR DESCRIPTION
Include relevant metadata when checkpointing a table with "type=layered." Add this table type to a few tests.