### PR TITLE
WT-14137 Atomically copy "regular" files on open and remove the log copy stage of live restore.

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3127,21 +3127,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      * we may need the log path and encryption and compression settings.
      */
     WT_ERR(__wt_logmgr_config(session, cfg, false));
-
-#ifndef _MSC_VER
-    /*
-     * Recovery replays the log files to rebuild the metadata file that live restore depends on,
-     * because of this we copy them across prior to recovery commencing. This also helps ensure that
-     * the system is in a valid state for the log subsystem as it does some less common file
-     * manipulations.
-     *
-     * Note: The function __conn_version_verify opens a single log file to check version details.
-     * This has to happen after live restore has completed the log file transfer otherwise the
-     * extent lists will be incorrect for that log file.
-     */
-    if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS))
-        WT_ERR(__wt_live_restore_setup_recovery(session));
-#endif
     WT_ERR(__conn_version_verify(session));
 
     /*

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -22,8 +22,6 @@ extern int __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_server_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_live_restore_setup_recovery(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_os_live_restore_fs(WT_SESSION_IMPL *session, const char *cfg[],
   const char *destination, WT_FILE_SYSTEM **fsp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1489,8 +1489,8 @@ err:
 
 /*
  * __live_restore_setup_lr_fh_file_data --
- *     Open a b-tree of "data" file type. In live restore these are the only types of files that we
- *     track holes for.
+ *     Open a data file type (probably a b-tree). In live restore these are the only types of files
+ *     that we track holes for.
  */
 static int
 __live_restore_setup_lr_fh_file_data(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *lr_fs,
@@ -1521,7 +1521,7 @@ __live_restore_setup_lr_fh_file_data(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_
              * has a length of zero, but we want its length to be the same as the source file. Set
              * its size by truncating. This is a positive length truncate so it actually extends the
              * file. We're bypassing the live_restore layer so we don't try to modify the relevant
-             * bitmap entries.
+             * extent entries.
              */
             WT_RET(
               lr_fh->destination.fh->fh_truncate(lr_fh->destination.fh, wt_session, source_size));
@@ -1571,16 +1571,12 @@ __live_restore_setup_lr_fh_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *l
      *  - WT_FS_OPEN_FILE_TYPE_LOG
      *  - WT_FS_OPEN_FILE_TYPE_REGULAR
      *
-     * Right now we handle everything but the checkpoint type, the log and regular type files are
-     * assumed to be complete. Log files are special in that they are copied prior to live restore
-     * commencing which means they are automatically complete. Regular files are copied on open,
-     * this would be metadata files like the turtle file and the base config files, etc.
-     *
-     * Given our copy on open philosophy it may be possible to remove the log pre-copy phase
-     * completely and also make log files copy on open.
+     * Right now we handle everything but the checkpoint type which appears to be unused. Log and
+     * regular files are treated the same in that they are atomically copied on open. Then for any
+     * subsequent open they will be immediately complete.
      *
      * Data type files are the b-trees, they are not copied on open and are expected to go through
-     * the bitmap import path which will initialize a file size bitmap for them.
+     * the extent import path which will initialize the relevant extent lists.
      */
     WT_ASSERT(session, file_type != WT_FS_OPEN_FILE_TYPE_CHECKPOINT);
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1396,7 +1396,7 @@ err:
 
 /*
  * __live_restore_remove_temporary_file --
- *     Remove a temporary file if it exists. If it does exist, log a warning.
+ *     Remove a temporary file if it exists. If it does exist, log a message.
  */
 static int
 __live_restore_remove_temporary_file(
@@ -1446,6 +1446,7 @@ __live_restore_fs_atomic_copy_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS
     WT_ERR(__live_restore_fs_backing_filename(
       &lr_fs->destination, session, lr_fs->destination.home, filename, &dest_path));
 
+    /* In theory we may have crashed during a temporary file copy, remove that file now. */
     WT_ERR(__live_restore_remove_temporary_file(
       session, lr_fs->os_file_system, dest_path, &tmp_dest_path));
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1396,7 +1396,7 @@ err:
 
 /*
  * __live_restore_remove_temporary_file --
- *     Remove a temporary file if it exists. If it does exist, log a message.
+ *     Remove a temporary file and log a message if it exists.
  */
 static int
 __live_restore_remove_temporary_file(

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1435,6 +1435,12 @@ __live_restore_fs_atomic_copy_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS
     char *buf = NULL, *source_path = NULL, *dest_path = NULL, *tmp_dest_path = NULL;
     bool dest_closed = false;
 
+    /*
+     * FIXME-WT-14040: We expect that most of these copies will happen prior to the migration phase.
+     * But definitely by the end of the migration this function should not be called. We should
+     * assert that.
+     */
+
     WT_ASSERT(session, type == WT_FS_OPEN_FILE_TYPE_LOG || type == WT_FS_OPEN_FILE_TYPE_REGULAR);
     __wt_verbose_debug2(session, WT_VERB_LIVE_RESTORE,
       "Atomically copying %s file (%s) from source to dest.\n",

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1420,19 +1420,17 @@ __live_restore_fs_atomic_copy_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS
   WT_FS_OPEN_FILE_TYPE type, const char *filename)
 {
     WT_DECL_RET;
+    WT_FILE_HANDLE *source_fh = NULL, *dest_fh = NULL;
     WT_SESSION *wt_session = (WT_SESSION *)session;
+    size_t read_size = lr_fs->read_size, len;
+    wt_off_t source_size;
     char *buf = NULL, *source_path = NULL, *dest_path = NULL, *tmp_dest_path = NULL;
     bool dest_closed = false;
-    size_t read_size = lr_fs->read_size;
 
     WT_ASSERT(session, type == WT_FS_OPEN_FILE_TYPE_LOG || type == WT_FS_OPEN_FILE_TYPE_REGULAR);
     __wt_verbose_debug2(session, WT_VERB_LIVE_RESTORE,
       "Transferring %s file (%s) from source to dest.\n",
       type == WT_FS_OPEN_FILE_TYPE_LOG ? "log" : "regular", filename);
-
-    wt_off_t source_size;
-    size_t len;
-    WT_FILE_HANDLE *source_fh = NULL, *dest_fh = NULL;
 
     /* Get the full source and destination file names. */
     WT_ERR(__live_restore_fs_backing_filename(

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -19,7 +19,7 @@
  *  - It may have been renamed, again we create a stop file in case it is recreated.
  */
 #define WTI_LIVE_RESTORE_STOP_FILE_SUFFIX ".stop"
-
+#define WTI_LIVE_RESTORE_TEMP_FILE_SUFFIX ".lr_tmp"
 /*
  * WTI_OFFSET_END returns the last byte used by a range (inclusive). i.e. if we have an offset=0 and
  * length=1024 WTI_OFFSET_END returns 1023

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -63,6 +63,7 @@ struct __wti_live_restore_file_handle {
          * writes. Holes in these extents should only shrink and never grow.
          */
         WTI_LIVE_RESTORE_HOLE_NODE *hole_list_head;
+        bool newly_created;
     } destination;
 
     WT_FS_OPEN_FILE_TYPE file_type;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -10,6 +10,7 @@
 #include "log_private.h"
 
 static int __log_newfile(WT_SESSION_IMPL *, bool, bool *);
+static int __log_openfile(WT_SESSION_IMPL *, uint32_t, uint32_t, WT_FH **);
 static int __log_truncate(WT_SESSION_IMPL *, WT_LSN *, bool, bool);
 static int __log_write_internal(WT_SESSION_IMPL *, WT_ITEM *, WT_LSN *, uint32_t);
 
@@ -59,11 +60,11 @@ __log_checksum_match(WT_ITEM *buf, uint32_t reclen)
 }
 
 /*
- * __wt_log_get_files --
+ * __log_get_files --
  *     Retrieve the list of all log-related files of the given prefix type.
  */
-int
-__wt_log_get_files(WT_SESSION_IMPL *session, const char *file_prefix, char ***filesp, u_int *countp)
+static int
+__log_get_files(WT_SESSION_IMPL *session, const char *file_prefix, char ***filesp, u_int *countp)
 {
     WT_LOG_MANAGER *log_mgr;
     const char *log_path;
@@ -120,15 +121,15 @@ __log_prealloc_remove(WT_SESSION_IMPL *session)
      * Clean up any old interim pre-allocated files. We clean up these files because settings may
      * have changed upon reboot and we want those settings to take effect right away.
      */
-    WT_ERR(__wt_log_get_files(session, WTI_LOG_TMPNAME, &logfiles, &logcount));
+    WT_ERR(__log_get_files(session, WTI_LOG_TMPNAME, &logfiles, &logcount));
     for (i = 0; i < logcount; i++) {
-        WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+        WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &lognum));
         WT_ERR(__wti_log_remove(session, WTI_LOG_TMPNAME, lognum));
     }
     WT_ERR(__wt_fs_directory_list_free(session, &logfiles, logcount));
-    WT_ERR(__wt_log_get_files(session, WTI_LOG_PREPNAME, &logfiles, &logcount));
+    WT_ERR(__log_get_files(session, WTI_LOG_PREPNAME, &logfiles, &logcount));
     for (i = 0; i < logcount; i++) {
-        WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+        WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &lognum));
         WT_ERR(__wti_log_remove(session, WTI_LOG_PREPNAME, lognum));
     }
 err:
@@ -273,7 +274,7 @@ __log_fsync_file(WT_SESSION_IMPL *session, WT_LSN *min_lsn, const char *method, 
          * different file than we want.
          */
         if (use_own_fh)
-            WT_ERR(__wt_log_openfile(session, min_lsn->l.file, 0, &log_fh));
+            WT_ERR(__log_openfile(session, min_lsn->l.file, 0, &log_fh));
         else
             log_fh = log->log_fh;
         __wt_verbose(session, WT_VERB_LOG, "%s: sync %s to LSN %" PRIu32 "/%" PRIu32, method,
@@ -511,10 +512,10 @@ __wt_log_get_backup_files(
      */
     F_SET(log, WTI_LOG_FORCE_NEWFILE);
     WT_RET(__wti_log_force_write(session, true, NULL));
-    WT_RET(__wt_log_get_files(session, WT_LOG_FILENAME, &files, &count));
+    WT_RET(__log_get_files(session, WT_LOG_FILENAME, &files, &count));
 
     for (max = 0, i = 0; i < count;) {
-        WT_ERR(__wt_log_extract_lognum(session, files[i], &id));
+        WT_ERR(__wti_log_extract_lognum(session, files[i], &id));
         if ((active_only && id < min_file) || id > max_file) {
             /*
              * Any files not being returned are individually freed and the array adjusted.
@@ -556,11 +557,11 @@ __wt_log_filename(WT_SESSION_IMPL *session, uint32_t id, const char *file_prefix
 }
 
 /*
- * __wt_log_extract_lognum --
+ * __wti_log_extract_lognum --
  *     Given a log file name, extract out the log number.
  */
 int
-__wt_log_extract_lognum(WT_SESSION_IMPL *session, const char *name, uint32_t *id)
+__wti_log_extract_lognum(WT_SESSION_IMPL *session, const char *name, uint32_t *id)
 {
     const char *p;
 
@@ -604,9 +605,9 @@ __wt_log_reset(WT_SESSION_IMPL *session, uint32_t lognum)
      * new one so that log file numbers are contiguous in the file system.
      */
     WT_RET(__wt_close(session, &log->log_fh));
-    WT_RET(__wt_log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
+    WT_RET(__log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
     for (i = 0; i < logcount; i++) {
-        WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &old_lognum));
+        WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &old_lognum));
         WT_ASSERT(session, old_lognum < lognum || lognum == 1);
         WT_ERR(__wti_log_remove(session, WT_LOG_FILENAME, old_lognum));
     }
@@ -844,11 +845,11 @@ err:
 }
 
 /*
- * __wt_log_openfile --
+ * __log_openfile --
  *     Open a log file with the given log file number and return the WT_FH.
  */
-int
-__wt_log_openfile(WT_SESSION_IMPL *session, uint32_t id, uint32_t flags, WT_FH **fhp)
+static int
+__log_openfile(WT_SESSION_IMPL *session, uint32_t id, uint32_t flags, WT_FH **fhp)
 {
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
@@ -914,7 +915,7 @@ __log_open_verify(WT_SESSION_IMPL *session, uint32_t id, WT_FH **fhp, WT_LSN *ls
     /*
      * Read in the log file header and verify it.
      */
-    WT_ERR(__wt_log_openfile(session, id, 0, &fh));
+    WT_ERR(__log_openfile(session, id, 0, &fh));
     WT_ERR(__log_fs_read(session, fh, 0, allocsize, buf->mem));
     logrec = (WT_LOG_RECORD *)buf->mem;
     __wti_log_record_byteswap(logrec);
@@ -1094,7 +1095,7 @@ __log_alloc_prealloc(WT_SESSION_IMPL *session, uint32_t to_num)
         return (WT_NOTFOUND);
 
     /* We have a file to use. */
-    WT_ERR(__wt_log_extract_lognum(session, logfiles[0], &from_num));
+    WT_ERR(__wti_log_extract_lognum(session, logfiles[0], &from_num));
 
     WT_ERR(__wt_scr_alloc(session, 0, &from_path));
     WT_ERR(__wt_scr_alloc(session, 0, &to_path));
@@ -1451,7 +1452,7 @@ __log_truncate(WT_SESSION_IMPL *session, WT_LSN *lsn, bool this_log, bool salvag
      * out every time. Check before doing work, and if there's a not-supported error, turn off
      * future truncates.
      */
-    WT_ERR(__wt_log_openfile(session, lsn->l.file, 0, &log_fh));
+    WT_ERR(__log_openfile(session, lsn->l.file, 0, &log_fh));
     WT_ERR(__log_truncate_file(session, log_fh, __wt_lsn_offset(lsn)));
     WT_ERR(__wt_fsync(session, log_fh, true));
     WT_ERR(__wt_close(session, &log_fh));
@@ -1465,9 +1466,9 @@ __log_truncate(WT_SESSION_IMPL *session, WT_LSN *lsn, bool this_log, bool salvag
      */
     if (this_log)
         goto err;
-    WT_ERR(__wt_log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
+    WT_ERR(__log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
     for (i = 0; i < logcount; i++) {
-        WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+        WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &lognum));
         if (lognum > lsn->l.file && lognum < log->trunc_lsn.l.file) {
             opened = false;
             if (salvage_mode) {
@@ -1489,7 +1490,7 @@ __log_truncate(WT_SESSION_IMPL *session, WT_LSN *lsn, bool this_log, bool salvag
                 salvage_last = lognum;
             }
             if (!opened)
-                WT_ERR(__wt_log_openfile(session, lognum, 0, &log_fh));
+                WT_ERR(__log_openfile(session, lognum, 0, &log_fh));
             /*
              * If there are intervening files pre-allocated, truncate them to the end of the log
              * file header.
@@ -1550,7 +1551,7 @@ __wti_log_allocfile(WT_SESSION_IMPL *session, uint32_t lognum, const char *dest)
     /*
      * Set up the temporary file.
      */
-    WT_ERR(__wt_log_openfile(session, tmp_id, WT_LOG_OPEN_CREATE_OK, &log_fh));
+    WT_ERR(__log_openfile(session, tmp_id, WT_LOG_OPEN_CREATE_OK, &log_fh));
     WT_ERR(__log_file_header(session, log_fh, NULL, true));
     WT_ERR(__log_prealloc(session, log_fh));
     WT_ERR(__wt_fsync(session, log_fh, true));
@@ -1604,9 +1605,9 @@ __wt_log_compat_verify(WT_SESSION_IMPL *session)
 
     lastlog = 0;
 
-    WT_ERR(__wt_log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
+    WT_ERR(__log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
     for (i = 0; i < logcount; i++) {
-        WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+        WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &lognum));
         lastlog = WT_MAX(lastlog, lognum);
     }
     if (lastlog != 0)
@@ -1661,9 +1662,9 @@ again:
     firstlog = UINT32_MAX;
     need_salvage = false;
 
-    WT_ERR(__wt_log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
+    WT_ERR(__log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
     for (i = 0; i < logcount; i++) {
-        WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+        WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &lognum));
         lastlog = WT_MAX(lastlog, lognum);
         firstlog = WT_MIN(firstlog, lognum);
     }
@@ -1713,7 +1714,7 @@ again:
          */
         if (F_ISSET(&conn->log_mgr, WT_LOG_DOWNGRADED)) {
             for (i = 0; i < logcount; ++i) {
-                WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+                WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &lognum));
                 /*
                  * By sending in a NULL file handle, we don't have to close the file.
                  */
@@ -2107,11 +2108,11 @@ __wt_log_scan(WT_SESSION_IMPL *session, WT_LSN *start_lsnp, WT_LSN *end_lsnp, ui
          * boundaries should always be a multiple of this.
          */
         firstlog = UINT32_MAX;
-        WT_RET(__wt_log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
+        WT_RET(__log_get_files(session, WT_LOG_FILENAME, &logfiles, &logcount));
         if (logcount == 0)
             WT_RET_MSG(session, ENOTSUP, "no log files found");
         for (i = 0; i < logcount; i++) {
-            WT_ERR(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+            WT_ERR(__wti_log_extract_lognum(session, logfiles[i], &lognum));
             lastlog = WT_MAX(lastlog, lognum);
             firstlog = WT_MIN(firstlog, lognum);
         }

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -181,8 +181,6 @@ extern int __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const cha
   WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_compat_verify(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_log_extract_lognum(WT_SESSION_IMPL *session, const char *name, uint32_t *id)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_filename(WT_SESSION_IMPL *session, uint32_t id, const char *file_prefix,
   WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_flush(WT_SESSION_IMPL *session, uint32_t flags)
@@ -193,11 +191,7 @@ extern int __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_get_backup_files(WT_SESSION_IMPL *session, char ***filesp, u_int *countp,
   uint32_t *maxid, bool active_only) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_log_get_files(WT_SESSION_IMPL *session, const char *file_prefix, char ***filesp,
-  u_int *countp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_needs_recovery(WT_SESSION_IMPL *session, WT_LSN *ckp_lsn, bool *recp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_log_openfile(WT_SESSION_IMPL *session, uint32_t id, uint32_t flags, WT_FH **fhp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_log_printf(WT_SESSION_IMPL *session, const char *format, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -370,7 +370,7 @@ __log_remove_once_int(
     u_int i;
 
     for (i = 0; i < logcount; i++) {
-        WT_RET(__wt_log_extract_lognum(session, logfiles[i], &lognum));
+        WT_RET(__wti_log_extract_lognum(session, logfiles[i], &lognum));
         if (lognum < min_lognum)
             WT_RET(__wti_log_remove(session, WT_LOG_FILENAME, lognum));
     }
@@ -636,7 +636,7 @@ __log_file_server(void *arg)
          */
         WT_ACQUIRE_READ_WITH_BARRIER(close_fh, log->log_close_fh);
         if (close_fh != NULL) {
-            WT_ERR(__wt_log_extract_lognum(session, close_fh->name, &filenum));
+            WT_ERR(__wti_log_extract_lognum(session, close_fh->name, &filenum));
             /*
              * The closing file handle should have a correct close LSN.
              */

--- a/src/log/log_private.h
+++ b/src/log/log_private.h
@@ -296,6 +296,8 @@ extern int __wti_log_allocfile(WT_SESSION_IMPL *session, uint32_t lognum, const 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_log_close(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_log_extract_lognum(WT_SESSION_IMPL *session, const char *name, uint32_t *id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_log_fill(WT_SESSION_IMPL *session, WTI_MYSLOT *myslot, bool force, WT_ITEM *record,
   WT_LSN *lsnp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_log_force_write(WT_SESSION_IMPL *session, bool retry, bool *did_work)

--- a/test/catch2/live_restore/api/test_live_restore_fh_extent_import_export.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fh_extent_import_export.cpp
@@ -29,14 +29,16 @@ TEST_CASE("Live Restore extent import", "[live_restore],[live_restore_extent_imp
     std::string source_file = env.source_file_path(file_name);
     std::string dest_file = env.dest_file_path(file_name);
     SECTION(
-      "When opening a file instantiates a new destination file it will have a single hole which "
-      "matches it's size without importing a string")
+      "When opening a file instantiates a new destination file it will have a single hole created "
+      "when importing an empty string")
     {
         WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh;
         create_file(source_file.c_str(), 4096);
         // This call creates the file in destination and a hole in that file the same size as the
         // source file.
         testutil_check(open_lr_fh(env, dest_file.c_str(), &lr_fh, WT_FS_OPEN_CREATE));
+        REQUIRE(__wt_live_restore_fh_import_extents_from_string(
+                  session, (WT_FILE_HANDLE *)lr_fh, nullptr) == 0);
         REQUIRE(extent_list_str(lr_fh) == "(0-4096)");
         REQUIRE(lr_fh->iface.close(reinterpret_cast<WT_FILE_HANDLE *>(lr_fh), wt_session) == 0);
     }

--- a/test/catch2/live_restore/utils_live_restore.cpp
+++ b/test/catch2/live_restore/utils_live_restore.cpp
@@ -47,7 +47,7 @@ open_lr_fh(const live_restore_test_env &env, const std::string &dest_file,
     // Make sure we're always opening the file in the destination directory.
     REQUIRE(strncmp(dest_file.c_str(), env.DB_DEST.c_str(), env.DB_DEST.size()) == 0);
     return lr_fs->iface.fs_open_file(reinterpret_cast<WT_FILE_SYSTEM *>(lr_fs), wt_session,
-      dest_file.c_str(), WT_FS_OPEN_FILE_TYPE_REGULAR, flags,
+      dest_file.c_str(), WT_FS_OPEN_FILE_TYPE_DATA, flags,
       reinterpret_cast<WT_FILE_HANDLE **>(lr_fhp));
 }
 


### PR DESCRIPTION
The log copy stage was added because tracking extents on log files and similar things seemed ugly, and for a while that was valid. During the development of the bitmap change it became clear that a simpler path existed: treat all "regular", i.e. log files and non b-tree files as copy-on-open. That way only b-trees have hole lists that need tracking.

Furthermore to avoid wondering the what the impact of a crash during copy of these files would be the copy has been made atomic by doing a copy followed by rename.