### PR TITLE
WT-13728 Update checkpoint architecture guide

### DIFF
--- a/src/docs/arch-block.dox
+++ b/src/docs/arch-block.dox
@@ -181,6 +181,7 @@ eviction. When a page image is written out the block manager the \c bm->write
 API is called. See \c bt_io.c for more detail.
 
 @subsubsection Checkpoint
+\anchor block-checkpoint
 
 For details on checkpoint at the WiredTiger level see: @ref arch-checkpoint "Checkpoint".
 

--- a/src/docs/arch-checkpoint.dox
+++ b/src/docs/arch-checkpoint.dox
@@ -3,11 +3,13 @@
 # Overview #
 
 A checkpoint is a known point in time from which WiredTiger can recover in the event of a
-crash or unexpected shutdown. WiredTiger checkpoints are created either via the API
+crash or unexpected shutdown. Both checkpoints and @ref arch-logging "logging" provide durability guarantees. During
+recovery WiredTiger can start up from the last known checkpoint and replay the log, recovering the
+lost operations. WiredTiger checkpoints are created either via the API
 WT_SESSION::checkpoint, or internally. Internally checkpoints are created on startup, shutdown
 and during compaction.
 
-A checkpoint is performed within the context of snapshot isolation transaction as such the
+A checkpoint is performed within the context of a @ref arch-snapshot "snapshot isolation" transaction, as such the
 checkpoint has a consistent view of the database from beginning to end. Typically when running a
 checkpoint the configuration \c "use_timestamp=true" is specified. This instructs WiredTiger to set
 the \c checkpoint_timestamp to be the current \c stable_timestamp. As of the latest version of
@@ -19,46 +21,71 @@ WT_CONNECTION::rollback_to_stable.
 
 # The checkpoint algorithm #
 
-A checkpoint can be broken up into 5 main stages:
+The checkpoint algorithm can be considered as a coordinator of multiple aspects of the system. It
+relies on the @ref arch-btree "btree subsystem" for traversing in memory pages, the @ref arch-block "block manager subsystem" for
+handling on-disk blocks and the @ref arch-metadata "metadata subsystem" for constructing and interpreting the metadata
+information.
 
-_The prepare stage:_
+A checkpoint can be broken up into the following stages:
+
+## Locking ##
+
+The first stage of checkpoint is to gather the necessary checkpoint locks. The most important being
+the checkpoint_lock. This lock ensures only one checkpoint takes place at time. More granular locks
+such as, dhandle, schema and flush locks are taken throughout the checkpoint process.
+
+## Eviction ##
+
+Before the checkpoint transaction begins (pinning content), the @ref arch-eviction "eviction server" is leveraged to
+reduce the dirty content in the cache. This has the benefit of utilizing the multi-threaded
+functionality of eviction and reduces the work required during the critical section of the
+checkpoint. The thread performing the checkpoint operation will wait (not forever) for eviction to
+reach the target dirty content ratio.
+
+## Prepare ##
 
 Checkpoint prepare sets up the checkpoint, it begins the checkpoint transaction, updates the global
 checkpoint state and gathers a list of handles to be checkpointed. A global schema lock wraps
 checkpoint prepare to avoid any tables being created or dropped during this phase, additionally the
 global transaction lock is taken during this process as it must modify the global transaction state,
 and to ensure the \c stable_timestamp doesn't move ahead of the snapshot taken by the checkpoint
-transaction. Each handle gathered refers to a specific b-tree. The set of b-trees gathered by the
-checkpoint varies based off configuration. Additionally clean b-trees, i.e. b-trees without any
-modifications are excluded from the list, with an exception for specific checkpoint configuration
-scenarios.
+transaction. The connection dhandle list is walked one handle at a time where each handle gathered
+refers to a specific b-tree. The set of b-trees gathered by the checkpoint varies based off
+configuration. Additionally clean b-trees, i.e. b-trees without any modifications are excluded from
+the list, with an exception for specific checkpoint configuration scenarios. See
+\ref skipping-checkpoints "Skipping checkpoints" for scenarios where b-trees are skipped during
+checkpoint. B-trees included in the checkpoint list then have all earlier checkpoints marked for
+deletion.
 
-_The data files checkpoint:_
+## Data files checkpoint ##
 
 Data files in this instance refer to all the user created files. The main work of checkpoint is done
 here, the array of b-tree's collected in the prepare stage are iterated over. For each b-tree, the
 tree is walked and all the dirty pages are reconciled. Clean pages are skipped to avoid unnecessary
 work. Pages made clean ahead of the checkpoint by eviction are still skipped regardless of whether
 the update written by eviction is visible to the checkpoint transaction. The checkpoint guarantees
-that a clean version of every page in the tree exists and can be written to disk.
+that a clean version of every page in the tree exists and can be written to disk. The
+@ref arch-block "Block Manager" is then responsible for managing the extent lists modified by the
+checkpoint (see \ref block-checkpoint) and deleting old checkpoints.
 
-_The history store checkpoint:_
+ ## History store checkpoint ##
 
-The history store is checkpointed after the data files intentionally as during the reconciliation
+The @ref arch-hs "history store" is checkpointed after the data files intentionally as during the reconciliation
 of the data files additional writes may be created in the history store and its important to include
-them in the checkpoint.
+them in the checkpoint. The history store will follow the same checkpoint process as data files.
 
-_Flushing the files to disk:_
+## Flushing the files to disk ##
 
 All the b-trees checkpointed and the history are flushed to disk at this stage, WiredTiger will wait
 until that process has completed to continue with the checkpoint.
 
-_The metadata checkpoint:_
+## Metadata checkpoint ##
 
 A new entry into the metadata file is created for every data file checkpointed, including the
 history store. As such the metadata file is the last file to be checkpointed. As WiredTiger
 maintains two checkpoints, the location of the most recent checkpoint is written to the turtle file.
 
+\anchor skipping-checkpoints
 # Skipping checkpoints #
 
 It is possible that a checkpoint will be skipped. A checkpoint will be skipped when:
@@ -84,6 +111,16 @@ stop time pair which is globally visible will no longer be required by any reade
 as deleted. This occurs prior to the page being reconciled, allowing for the page to be removed
 during the reconciliation. However this does not mean that the deleted page is available for re-use
 as it may be referenced by older checkpoints, once the older checkpoint is deleted the page is free
-to be used. Given the freed pages exist at the end of the file the file can be truncated. Otherwise
+to be used. If the freed pages exist at the end of the file the file can be truncated. Otherwise
 compaction will need to be initiated to shrink the file, see: WT_SESSION::compact.
+
+# Internal callers #
+WiredTiger may call checkpoint internally at any time. These can occur during:
+- Recovery
+- @ref arch-backup "Backup"
+- @ref arch-compact "Compaction"
+- @ref schema_alter "Schema alter"
+- Internal checkpoint thread (controlled by configuration option to ::wiredtiger_open)
+- Startup/shutdown
+
 */

--- a/src/docs/arch-checkpoint.dox
+++ b/src/docs/arch-checkpoint.dox
@@ -6,7 +6,7 @@ A checkpoint is a known point in time from which WiredTiger can recover in the e
 crash or unexpected shutdown. Both checkpoints and @ref arch-logging "logging" provide durability guarantees. During
 recovery WiredTiger can start up from the last known checkpoint and replay the log, recovering the
 lost operations. WiredTiger checkpoints are created either via the API
-WT_SESSION::checkpoint, or internally. See @ref checkpoint-internal-callers "Internal Callers" for 
+WT_SESSION::checkpoint, or internally. See @ref checkpoint-internal-callers "Internal Callers" for
 when checkpoint can be called internally by WiredTiger.
 
 A checkpoint is performed within the context of a @ref arch-snapshot "snapshot isolation" transaction, as such the

--- a/src/docs/arch-checkpoint.dox
+++ b/src/docs/arch-checkpoint.dox
@@ -6,8 +6,8 @@ A checkpoint is a known point in time from which WiredTiger can recover in the e
 crash or unexpected shutdown. Both checkpoints and @ref arch-logging "logging" provide durability guarantees. During
 recovery WiredTiger can start up from the last known checkpoint and replay the log, recovering the
 lost operations. WiredTiger checkpoints are created either via the API
-WT_SESSION::checkpoint, or internally. Internally checkpoints are created on startup, shutdown
-and during compaction.
+WT_SESSION::checkpoint, or internally. See @ref checkpoint-internal-callers "Internal Callers" for 
+when checkpoint can be called internally by WiredTiger.
 
 A checkpoint is performed within the context of a @ref arch-snapshot "snapshot isolation" transaction, as such the
 checkpoint has a consistent view of the database from beginning to end. Typically when running a
@@ -31,7 +31,7 @@ A checkpoint can be broken up into the following stages:
 ## Locking ##
 
 The first stage of checkpoint is to gather the necessary checkpoint locks. The most important being
-the checkpoint_lock. This lock ensures only one checkpoint takes place at time. More granular locks
+the \c checkpoint_lock. This lock ensures only one checkpoint takes place at time. More granular locks
 such as, dhandle, schema and flush locks are taken throughout the checkpoint process.
 
 ## Eviction ##
@@ -39,8 +39,8 @@ such as, dhandle, schema and flush locks are taken throughout the checkpoint pro
 Before the checkpoint transaction begins (pinning content), the @ref arch-eviction "eviction server" is leveraged to
 reduce the dirty content in the cache. This has the benefit of utilizing the multi-threaded
 functionality of eviction and reduces the work required during the critical section of the
-checkpoint. The thread performing the checkpoint operation will wait (not forever) for eviction to
-reach the target dirty content ratio.
+checkpoint. The thread performing the checkpoint operation will wait for eviction to
+reach the target dirty content ratio unless no progress is made..
 
 ## Prepare ##
 
@@ -55,7 +55,7 @@ configuration. Additionally clean b-trees, i.e. b-trees without any modification
 the list, with an exception for specific checkpoint configuration scenarios. See
 \ref skipping-checkpoints "Skipping checkpoints" for scenarios where b-trees are skipped during
 checkpoint. B-trees included in the checkpoint list then have all earlier checkpoints marked for
-deletion.
+deletion. Previous checkpoints can only be discarded if the associated blocks are no longer used.
 
 ## Data files checkpoint ##
 
@@ -114,6 +114,7 @@ as it may be referenced by older checkpoints, once the older checkpoint is delet
 to be used. If the freed pages exist at the end of the file the file can be truncated. Otherwise
 compaction will need to be initiated to shrink the file, see: WT_SESSION::compact.
 
+\anchor checkpoint-internal-callers
 # Internal callers #
 WiredTiger may call checkpoint internally at any time. These can occur during:
 - Recovery

--- a/src/docs/arch-checkpoint.dox
+++ b/src/docs/arch-checkpoint.dox
@@ -30,17 +30,16 @@ A checkpoint can be broken up into the following stages:
 
 ## Locking ##
 
-The first stage of checkpoint is to gather the necessary checkpoint locks. The most important being
-the \c checkpoint_lock. This lock ensures only one checkpoint takes place at time. More granular locks
+The first stage of checkpoint is to gather the necessary checkpoint locks. The \c checkpoint_lock has the highest precedent ensuring only one checkpoint takes place at time. Other locks
 such as, dhandle, schema and flush locks are taken throughout the checkpoint process.
 
 ## Eviction ##
 
-Before the checkpoint transaction begins (pinning content), the @ref arch-eviction "eviction server" is leveraged to
-reduce the dirty content in the cache. This has the benefit of utilizing the multi-threaded
+Before the checkpoint transaction begins (pinning content), the @ref arch-eviction "eviction subsystem" is leveraged to
+reduce the dirty content in the cache. Using eviction has the benefit of taking advantage of the multi-threaded
 functionality of eviction and reduces the work required during the critical section of the
 checkpoint. The thread performing the checkpoint operation will wait for eviction to
-reach the target dirty content ratio unless no progress is made..
+reach the target dirty content ratio unless no progress is made.
 
 ## Prepare ##
 
@@ -49,23 +48,22 @@ checkpoint state and gathers a list of handles to be checkpointed. A global sche
 checkpoint prepare to avoid any tables being created or dropped during this phase, additionally the
 global transaction lock is taken during this process as it must modify the global transaction state,
 and to ensure the \c stable_timestamp doesn't move ahead of the snapshot taken by the checkpoint
-transaction. The connection dhandle list is walked one handle at a time where each handle gathered
-refers to a specific b-tree. The set of b-trees gathered by the checkpoint varies based off
-configuration. Additionally clean b-trees, i.e. b-trees without any modifications are excluded from
+transaction. The connection dhandle list is walked one handle at a time, where each handle gathered
+refers to a specific btree. Additionally clean btrees, i.e. btrees without any modifications, are excluded from
 the list, with an exception for specific checkpoint configuration scenarios. See
-\ref skipping-checkpoints "Skipping checkpoints" for scenarios where b-trees are skipped during
-checkpoint. B-trees included in the checkpoint list then have all earlier checkpoints marked for
-deletion. Previous checkpoints can only be discarded if the associated blocks are no longer used.
+\ref skipping-checkpoints "Skipping checkpoints" for scenarios where btrees are skipped during
+checkpoint. Btrees included in the checkpoint list then delete earlier checkpoints when possible.
+Previous checkpoints can only be discarded if the associated blocks are no longer used.
 
 ## Data files checkpoint ##
 
 Data files in this instance refer to all the user created files. The main work of checkpoint is done
-here, the array of b-tree's collected in the prepare stage are iterated over. For each b-tree, the
+here, the array of btree's collected in the prepare stage are iterated over. For each btree, the
 tree is walked and all the dirty pages are reconciled. Clean pages are skipped to avoid unnecessary
 work. Pages made clean ahead of the checkpoint by eviction are still skipped regardless of whether
 the update written by eviction is visible to the checkpoint transaction. The checkpoint guarantees
 that a clean version of every page in the tree exists and can be written to disk. The
-@ref arch-block "Block Manager" is then responsible for managing the extent lists modified by the
+@ref arch-block "block manager subsystem" is then responsible for managing the extent lists modified by the
 checkpoint (see \ref block-checkpoint) and deleting old checkpoints.
 
  ## History store checkpoint ##
@@ -76,7 +74,7 @@ them in the checkpoint. The history store will follow the same checkpoint proces
 
 ## Flushing the files to disk ##
 
-All the b-trees checkpointed and the history are flushed to disk at this stage, WiredTiger will wait
+All the btrees checkpointed and the history are flushed to disk at this stage, WiredTiger will wait
 until that process has completed to continue with the checkpoint.
 
 ## Metadata checkpoint ##
@@ -97,16 +95,16 @@ This logic can be overridden by forcing a checkpoint via configuration.
 # Checkpoint generations #
 
 The checkpoint generation indicates which iteration of checkpoint a file has undergone, at the start
-of a checkpoint the generation is incremented. Then after processing any b-tree its
+of a checkpoint the generation is incremented. Then after processing any btree its
 \c checkpoint_gen is set to the latest checkpoint generation. Checkpoint generations impact
-visibility checks within WiredTiger, essentially if a b-tree is behind a checkpoint, i.e. its
+visibility checks within WiredTiger, essentially if a btree is behind a checkpoint, i.e. its
 checkpoint generation is less than the current checkpoint generation, then the checkpoint
 transaction id and checkpoint timestamp are included in certain visibility checks.
-This prevents eviction from evicting updates from a given b-tree ahead of the checkpoint.
+This prevents eviction from evicting updates from a given btree ahead of the checkpoint.
 
 # Garbage collection #
 
-While processing a b-tree, checkpoint can mark pages as obsolete. Any page that has an aggregated
+While processing a btree, checkpoint can mark pages as obsolete. Any page that has an aggregated
 stop time pair which is globally visible will no longer be required by any reader and can be marked
 as deleted. This occurs prior to the page being reconciled, allowing for the page to be removed
 during the reconciliation. However this does not mean that the deleted page is available for re-use

--- a/src/docs/arch-index.dox
+++ b/src/docs/arch-index.dox
@@ -66,6 +66,7 @@ rectangle "**WiredTiger Engine**                                                
   rectangle "[[arch-snapshot.html Snapshots]]" as snapshot
   rectangle "[[arch-cache.html Cache]]" as cache
   rectangle "[[arch-eviction.html Eviction]]" as evict
+  rectangle "[[arch-checkpoint.html Checkpoint]]" as checkpoint
 
   together {
     rectangle "[[arch-block.html Block\nManager]]" as block
@@ -94,28 +95,33 @@ c_api -down-> txn
 
 schema -down-> meta
 schema -down-> btree
+
 cursor -down-> btree
+cursor -down-> history
+
 btree -down-> row
+
 meta -up-> cursor
-' The hidden arrow helps our boxes to line up in a better way.
-meta -[hidden]right-> btree
-cursor -[hidden]right-> txn
+
 txn -down-> snapshot
-row -down-> cache
-cache -down-> history
-evict -down-> history
-history -up-> cursor
-snapshot -down-> evict
-cache -right-> evict
-cache -down-> block
-evict -down-> block
 txn -down-> log
 
-block -[hidden]right-> SPACE_log
-cache -[hidden]down-> SPACE_log
-evict -[hidden]down-> SPACE_log
-SPACE_log -[hidden]right-> log
-log -[hidden]right-> SPACE_log2
+snapshot -down-> evict
+snapshot -down-> checkpoint
+
+row -down-> cache
+
+cache -right-> evict
+cache -down-> block
+
+evict -down-> history
+evict -down-> block
+
+checkpoint -down-> block
+checkpoint -down-> os
+checkpoint -up-> meta
+checkpoint -down-> btree
+checkpoint -down-> history
 
 block -down-> os
 log -down-> os


### PR DESCRIPTION
Updating the checkpoint architecture guide with:
1. More stages that checkpoint goes through (previously undocumented in this guide)
2. Extra context
3. Improved layout
4. Links to other docs
5. Updated the diagram on the index page to include the checkpoint subsystem.