### PR TITLE
WT-13736 Fix test_schema_abort generating out of order oldest timestamp

### DIFF
--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -28,7 +28,6 @@
 
 #include "test_util.h"
 
-#include <stdint.h>
 #include <sys/wait.h>
 #include <signal.h>
 
@@ -518,8 +517,8 @@ static bool
 is_set_timestamp_required(uint64_t last_ts, uint64_t oldest_ts)
 {
     /*
-     * The set_timestamp should be invoked only when current_oldest_ts is greater than
-     * last_oldest_ts and the difference is greater than the STABLE_PERIOD.
+     * The set_timestamp should be invoked only when current oldest timestamp is greater than last
+     * oldest timestamp and the difference is greater than the STABLE_PERIOD.
      */
     return ((oldest_ts == stop_timestamp && oldest_ts != last_ts) ||
       (oldest_ts != UINT64_MAX && oldest_ts > last_ts && oldest_ts - last_ts > STABLE_PERIOD));

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -28,6 +28,7 @@
 
 #include "test_util.h"
 
+#include <stdint.h>
 #include <sys/wait.h>
 #include <signal.h>
 
@@ -510,6 +511,18 @@ get_all_committed_ts(void)
 }
 
 /*
+ * is_set_timestamp_required --
+ *     Return if set_timestamp is required.
+ */
+static bool
+is_set_timestamp_required(uint64_t last_ts, uint64_t oldest_ts)
+{
+    int64_t ts_diff = (int64_t)(oldest_ts - last_ts);
+    return ((oldest_ts == stop_timestamp && oldest_ts != last_ts) ||
+      (oldest_ts != UINT64_MAX && ts_diff > STABLE_PERIOD));
+}
+
+/*
  * thread_ts_run --
  *     Runner function for a timestamp thread.
  */
@@ -536,8 +549,7 @@ thread_ts_run(void *arg)
         if (oldest_ts != UINT64_MAX && stop_timestamp != 0 && oldest_ts > stop_timestamp)
             oldest_ts = stop_timestamp;
 
-        if ((oldest_ts == stop_timestamp && oldest_ts != last_ts) ||
-          (oldest_ts != UINT64_MAX && oldest_ts - last_ts > STABLE_PERIOD)) {
+        if (is_set_timestamp_required(last_ts, oldest_ts)) {
             /*
              * Set both the oldest and stable timestamp so that we don't need to maintain read
              * availability at older timestamps.

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -512,14 +512,17 @@ get_all_committed_ts(void)
 
 /*
  * is_set_timestamp_required --
- *     Return if set_timestamp is required.
+ *     Return True if set_timestamp is required.
  */
 static bool
 is_set_timestamp_required(uint64_t last_ts, uint64_t oldest_ts)
 {
-    int64_t ts_diff = (int64_t)(oldest_ts - last_ts);
+    /*
+     * The set_timestamp should be invoked only when current_oldest_ts is greater than
+     * last_oldest_ts and the difference is greater than the STABLE_PERIOD.
+     */
     return ((oldest_ts == stop_timestamp && oldest_ts != last_ts) ||
-      (oldest_ts != UINT64_MAX && ts_diff > STABLE_PERIOD));
+      (oldest_ts != UINT64_MAX && oldest_ts > last_ts && oldest_ts - last_ts > STABLE_PERIOD));
 }
 
 /*


### PR DESCRIPTION
This pull request has the changes to fix a bug in the test_schema_abort where two threads incorrectly compares last_oldest_timestamp with current_oldest_timestamp and proceeds to call the set_timestamp API if the difference exceeds 100. However, this difference can sometimes be negative, leading to unintended calls to the set_timestamp API and triggering the observed failure.