### PR TITLE
WT-14150 Fix WT_SESSION::create documentation

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -1392,8 +1392,8 @@ methods = {
 'WT_SESSION.create' : Method(file_config + tiered_config +
         source_meta + index_only_config + table_only_config + [
     Config('exclusive', 'false', r'''
-        fail if the object exists. When false (the default), if the object exists, check that its
-        settings match the specified configuration''',
+        explicitly fail with EEXIST if the object exists. When false (the default), if the object 
+        exists, silently fail without creating a new object.''',
         type='boolean'),
     Config('import', '', r'''
         configure import of an existing object into the currently running database''',

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1213,9 +1213,9 @@ struct __wt_session {
      * WT_CONNECTION::add_encryptor.  See @ref encryption for more information., a string; default
      * \c none.}
      * @config{ ),,}
-     * @config{exclusive, fail if the object exists.  When false (the default)\, if the object
-     * exists\, check that its settings match the specified configuration., a boolean flag; default
-     * \c false.}
+     * @config{exclusive, explicitly fail with EEXIST if the object exists.  When false (the
+     * default)\, if the object exists\, silently fail without creating a new object., a boolean
+     * flag; default \c false.}
      * @config{format, the file format., a string\, chosen from the following options: \c "btree";
      * default \c btree.}
      * @config{ignore_in_memory_cache_size, allow update and insert operations to proceed even if


### PR DESCRIPTION
Fix the `WT_SESSION::create` incorrectly stated that the configuration was validated upon recreating an object with an existing URI. This is outdated and the current implementation silently fails in this situtation.