### PR TITLE
SLS-1231 Use a checkpoint cursor for the stable table.

### DIFF
--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -636,6 +636,8 @@ struct __wt_cursor_layered {
     WT_CURSOR *ingest_cursor;  /* The ingest table */
     WT_CURSOR *stable_cursor;  /* The stable table */
 
+    uint64_t checkpoint_id; /* The id corresponding to the stable table */
+
     int64_t next_random_seed;
     u_int next_random_sample_size;
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -477,6 +477,20 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
         return (__wt_session_get_dhandle(session, uri, NULL, cfg, flags));
     }
 
+    /* For now, open a stable Btree at a checkpoint in a simple way, ignoring history. */
+    if (strstr(uri, ".wt_stable") != NULL) {
+        /*
+         * TODO: we're skipping a lot of good stuff below - in particular, we'd like to get the
+         * shared history file that matches our checkpoint.
+         */
+
+        /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
+        WT_RET(__wt_meta_checkpoint_last_name(session, uri, &checkpoint, NULL, NULL));
+
+        ret = __wt_session_get_dhandle(session, uri, checkpoint, cfg, flags);
+        goto err;
+    }
+
     /*
      * Here and below is only for checkpoints.
      *

--- a/test/suite/test_layered23.py
+++ b/test/suite/test_layered23.py
@@ -57,7 +57,7 @@ class Oplog(object):
 
         # For debugging - when _use_timestamps is false, don't actually
         # use the internally generated timestamps with WT calls.
-        self._use_timestamps = True
+        self._use_timestamps = False   #TODO
 
     def add_uri(self, uri):
         self._uris.append((uri,[]))


### PR DESCRIPTION
Note that in its current state, this change BREAKs the use of history store (reading at timestamp) on the follower.  But it does fix the problem of having multiple Btrees for the stable table.

It's a draft PR until the problems can be solved.