### PR TITLE
WT-14121 Ignore switch statement (lack of) default warning

### DIFF
--- a/cmake/strict/clang_strict.cmake
+++ b/cmake/strict/clang_strict.cmake
@@ -9,6 +9,7 @@ list(APPEND clang_flags "-Weverything")
 list(APPEND clang_flags "-Wno-declaration-after-statement")
 list(APPEND clang_flags "-Wjump-misses-init")
 list(APPEND clang_flags "-Wconditional-uninitialized")
+list(APPEND clang_flags "-Wno-switch-default")
 
 # In code coverage builds inline functions may not be inlined, which can result in additional
 # unused copies of those functions, so the unused-function warning much be turned off.

--- a/cmake/strict/strict_flags_helpers.cmake
+++ b/cmake/strict/strict_flags_helpers.cmake
@@ -42,6 +42,7 @@ function(get_gnu_base_flags flags)
     # FIXME-WT-11788: Remove the following flag once the violation of the standard C11 7.1.3 has
     # been addressed.
     list(APPEND gnu_flags "-Wno-reserved-identifier")
+    list(APPEND gnu_flags "-Wno-switch-default")
     list(APPEND gnu_flags "-Wpacked")
     list(APPEND gnu_flags "-Wpointer-arith")
     list(APPEND gnu_flags "-Wredundant-decls")
@@ -127,6 +128,7 @@ function(get_clang_base_flags flags)
     # FIXME-WT-11788: Remove the following flag once the violation of the standard C11 7.1.3 has
     # been addressed.
     list(APPEND clang_flags "-Wno-reserved-identifier")
+    list(APPEND clang_flags "-Wno-switch-default")
     list(APPEND clang_flags "-Wno-unsafe-buffer-usage")
     list(APPEND clang_flags "-Wno-zero-length-array")
 


### PR DESCRIPTION
The default switch statement warning is popping up after we test WiredTiger on the v5 toolchain, this PR adds a flag to ignore the error and we have [WT-14128](https://jira.mongodb.org/browse/WT-14128) to add default statements for our switch cases in the future. 