### PR TITLE
WT-14156 Allow reconfiguring prepared transactions

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -857,6 +857,7 @@ idx
 ie
 iface
 ifdef's
+iff
 iiSii
 iiiS
 ikey

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -92,14 +92,6 @@ __wt_txn_err_set(WT_SESSION_IMPL *session, int ret)
 
     /* The transaction has to be rolled back. */
     F_SET(txn, WT_TXN_ERROR);
-
-    /*
-     * Check for a prepared transaction, and quit: we can't ignore the error and we can't roll back
-     * a prepared transaction.
-     */
-    if (F_ISSET(txn, WT_TXN_PREPARE))
-        WT_IGNORE_RET(__wt_panic(session, ret,
-          "transactional error logged after transaction was prepared, failing the system"));
 }
 
 /*

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -852,7 +852,8 @@ struct __wt_session {
      *
      * Only configurations listed in the method arguments are modified, other configurations
      * remain in their current state. This method additionally resets the cursors associated
-     * with the session.
+     * with the session. Transaction-related configurations can only be modified when no transaction
+     * is active.
      *
      * @snippet ex_all.c Reconfigure a session
      *

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -852,8 +852,7 @@ struct __wt_session {
      *
      * Only configurations listed in the method arguments are modified, other configurations
      * remain in their current state. This method additionally resets the cursors associated
-     * with the session. WT_SESSION::reconfigure will fail if a transaction is in progress in
-     * the session.
+     * with the session.
      *
      * @snippet ex_all.c Reconfigure a session
      *

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -582,7 +582,15 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
      * Note that this method only checks keys that are passed in by the application: we don't want
      * to reset other session settings to their default values.
      */
-    WT_ERR(__wt_txn_reconfigure(session, config));
+    ret = __wt_txn_reconfigure(session, config);
+    if (ret == EINVAL) {
+        /*
+         * EINVAL is returned iff there is an active transaction and txn is being reconfigured. In
+         * this case, don't want to fail the transaction - same as in SESSION_API_PREPARE_CHECK.
+         */
+        __set_err = false;
+        goto err;
+    }
 
     WT_ERR(__session_config_int(session, config));
 
@@ -1947,6 +1955,14 @@ __session_rollback_transaction(WT_SESSION *wt_session, const char *config)
     F_CLR(session, WT_SESSION_RESOLVING_TXN);
 
 err:
+    /*
+     * Check for a prepared transaction, and quit: we can't ignore the error and we can't roll back
+     * a prepared transaction.
+     */
+    if (ret != 0 && session->txn && F_ISSET(session->txn, WT_TXN_PREPARE))
+        WT_IGNORE_RET(__wt_panic(session, ret,
+          "transactional error logged after transaction was prepared, failing the system"));
+
 #ifdef HAVE_CALL_LOG
     WT_TRET(__wt_call_log_rollback_transaction(session, config, ret));
 #endif

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -573,7 +573,7 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
     WT_SESSION_IMPL *session;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL_PREPARE_NOT_ALLOWED(session, ret, reconfigure, config, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, reconfigure, config, cfg);
     WT_UNUSED(cfg);
 
     WT_ERR(__wt_txn_context_check(session, false));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -576,8 +576,6 @@ __session_reconfigure(WT_SESSION *wt_session, const char *config)
     SESSION_API_CALL_PREPARE_ALLOWED(session, reconfigure, config, cfg);
     WT_UNUSED(cfg);
 
-    WT_ERR(__wt_txn_context_check(session, false));
-
     WT_ERR(__wt_session_reset_cursors(session, false));
 
     /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -759,6 +759,10 @@ __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)
     txn = session->txn;
 
     ret = __wt_config_getones(session, config, "isolation", &cval);
+    if (ret == 0)
+        /* Can only reconfigure this if transaction is not active. */
+        WT_RET(__wt_txn_context_check(session, false));
+
     if (ret == 0 && cval.len != 0) {
         session->isolation = txn->isolation = WT_CONFIG_LIT_MATCH("snapshot", cval) ?
                                                           WT_ISO_SNAPSHOT :

--- a/test/suite/test_prepare02.py
+++ b/test/suite/test_prepare02.py
@@ -37,6 +37,8 @@ import wiredtiger, wttest
 class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
 
     def test_prepare_session_operations(self):
+        msg = "/not permitted in a prepared transaction/"
+        msgRunning = "/not permitted in a running transaction/"
 
         # Test the session methods forbidden after the transaction is prepared.
         self.session.create("table:mytable", "key_format=S,value_format=S")
@@ -44,12 +46,14 @@ class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
         cursor = self.session.open_cursor("table:mytable", None)
         cursor["key"] = "value"
         self.session.prepare_transaction("prepare_timestamp=2a")
-        msg = "/not permitted in a prepared transaction/"
 
         # The operations are listed in the same order as they are declared in the session structure.
         # WT_SESSION.close permitted.
         # WT_SESSION.reconfigure permitted.
         self.session.reconfigure()
+        # WT_SESSION.reconfigure with "isolation" - not permitted.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda:self.session.reconfigure("isolation=snapshot"), msgRunning)
         # WT_SESSION.strerror permitted, but currently broken in the Python API (WT-5399).
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor("table:mytable", None), msg)

--- a/test/suite/test_prepare02.py
+++ b/test/suite/test_prepare02.py
@@ -48,8 +48,8 @@ class test_prepare02(wttest.WiredTigerTestCase, suite_subprocess):
 
         # The operations are listed in the same order as they are declared in the session structure.
         # WT_SESSION.close permitted.
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda:self.session.reconfigure(), msg)
+        # WT_SESSION.reconfigure permitted.
+        self.session.reconfigure()
         # WT_SESSION.strerror permitted, but currently broken in the Python API (WT-5399).
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor("table:mytable", None), msg)


### PR DESCRIPTION
Allow reconfiguring prepared transactions.

This change allows to call `session->reconfigure` on prepared transactions.
The reason why it was not allowed is to allow to only call `commit` or `rollback` when the transaction is prepared.
This change allows to adjust configuration before doing that to change some vital options like `cache_max_wait_ms`. Reconfiguring transaction-related settings when the transaction is started is still prohibited.

Change details:

1. The "`transactional error logged after transaction was prepared, failing the system`" check is moved from `__wt_txn_err_set()` to `__session_rollback_transaction()` since "__wt_txn_err_set" is also called from other places.
2. `WT_ERR(__wt_txn_context_check(session, false))` from `__session_reconfigure()` moved to `__wt_txn_reconfigure()` to allow reconfiguration of non-transaction-related session settings.
3. Failed attempt to reconfigure the session doesn't set the transaction fail flag.