### PR TITLE
WT-13642 Add separate statistics for dirty leaf and internal page byt…

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -842,6 +842,8 @@ conn_dsrc_stats = [
     # Cache and eviction statistics
     ##########################################
     CacheStat('cache_bytes_dirty', 'tracked dirty bytes in the cache', 'no_clear,no_scale,size'),
+    CacheStat('cache_bytes_dirty_internal', 'tracked dirty internal page bytes in the cache', 'no_clear,no_scale,size'),
+    CacheStat('cache_bytes_dirty_leaf', 'tracked dirty leaf page bytes in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_dirty_total', 'bytes dirty in the cache cumulative', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_inuse', 'bytes currently in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_read', 'bytes read into cache', 'size'),

--- a/src/btree/bt_stat.c
+++ b/src/btree/bt_stat.c
@@ -41,6 +41,8 @@ __wt_btree_stat_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
     WT_STAT_SET(session, stats, rec_multiblock_max, btree->rec_multiblock_max);
 
     WT_STAT_SET(session, stats, cache_bytes_dirty, __wt_btree_dirty_inuse(session));
+    WT_STAT_SET(session, stats, cache_bytes_dirty_leaf, __wt_btree_dirty_leaf_inuse(session));
+    WT_STAT_SET(session, stats, cache_bytes_dirty_internal, __wt_btree_dirty_intl_inuse(session));
     WT_STAT_SET(session, stats, cache_bytes_dirty_total,
       __wt_cache_bytes_plus_overhead(S2C(session)->cache, btree->bytes_dirty_total));
     WT_STAT_SET(session, stats, cache_bytes_inuse, __wt_btree_bytes_inuse(session));

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -314,6 +314,8 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(session, stats, cache_overhead, cache->overhead_pct);
 
     WT_STAT_SET(session, stats, cache_bytes_dirty, __wt_cache_dirty_inuse(cache));
+    WT_STAT_SET(session, stats, cache_bytes_dirty_leaf, __wt_cache_dirty_leaf_inuse(cache));
+    WT_STAT_SET(session, stats, cache_bytes_dirty_internal, __wt_cache_dirty_intl_inuse(cache));
     WT_STAT_SET(session, stats, cache_bytes_dirty_total,
       __wt_cache_bytes_plus_overhead(cache, cache->bytes_dirty_total));
     WT_STAT_SET(

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -241,6 +241,22 @@ __wt_btree_dirty_inuse(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wt_btree_dirty_intl_inuse --
+ *     Return the number of bytes in use by dirty internal pages.
+ */
+static inline uint64_t
+__wt_btree_dirty_intl_inuse(WT_SESSION_IMPL *session)
+{
+    WT_BTREE *btree;
+    WT_CACHE *cache;
+
+    btree = S2BT(session);
+    cache = S2C(session)->cache;
+
+    return (__wt_cache_bytes_plus_overhead(cache, btree->bytes_dirty_intl));
+}
+
+/*
  * __wt_btree_dirty_leaf_inuse --
  *     Return the number of bytes in use by dirty leaf pages.
  */

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -159,6 +159,16 @@ __wt_cache_dirty_inuse(WT_CACHE *cache)
 }
 
 /*
+ * __wt_cache_dirty_intl_inuse --
+ *     Return the number of dirty bytes in use by internal pages.
+ */
+static inline uint64_t
+__wt_cache_dirty_intl_inuse(WT_CACHE *cache)
+{
+    return (__wt_cache_bytes_plus_overhead(cache, cache->bytes_dirty_intl));
+}
+
+/*
  * __wt_cache_dirty_leaf_inuse --
  *     Return the number of dirty bytes in use by leaf pages.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2391,6 +2391,8 @@ static inline uint64_t __wt_btree_bytes_inuse(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline uint64_t __wt_btree_bytes_updates(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline uint64_t __wt_btree_dirty_intl_inuse(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline uint64_t __wt_btree_dirty_inuse(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline uint64_t __wt_btree_dirty_leaf_inuse(WT_SESSION_IMPL *session)
@@ -2404,6 +2406,8 @@ static inline uint64_t __wt_cache_bytes_other(WT_CACHE *cache)
 static inline uint64_t __wt_cache_bytes_plus_overhead(WT_CACHE *cache, uint64_t sz)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline uint64_t __wt_cache_bytes_updates(WT_CACHE *cache)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static inline uint64_t __wt_cache_dirty_intl_inuse(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static inline uint64_t __wt_cache_dirty_inuse(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -547,6 +547,8 @@ struct __wt_connection_stats {
     int64_t cache_bytes_internal;
     int64_t cache_bytes_leaf;
     int64_t cache_bytes_dirty;
+    int64_t cache_bytes_dirty_internal;
+    int64_t cache_bytes_dirty_leaf;
     int64_t cache_pages_dirty;
     int64_t cache_eviction_blocked_uncommitted_truncate;
     int64_t cache_eviction_clean;
@@ -1073,6 +1075,8 @@ struct __wt_dsrc_stats {
     int64_t cache_hs_insert_full_update;
     int64_t cache_hs_insert_reverse_modify;
     int64_t cache_bytes_dirty;
+    int64_t cache_bytes_dirty_internal;
+    int64_t cache_bytes_dirty_leaf;
     int64_t cache_eviction_blocked_uncommitted_truncate;
     int64_t cache_eviction_clean;
     int64_t cache_state_gen_avg_gap;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5899,967 +5899,971 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_BYTES_LEAF			1206
 /*! cache: tracked dirty bytes in the cache */
 #define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1207
+/*! cache: tracked dirty internal page bytes in the cache */
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1208
+/*! cache: tracked dirty leaf page bytes in the cache */
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1209
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1208
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1210
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1209
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1211
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1210
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1212
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1211
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1213
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1212
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1214
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1213
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1215
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1214
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1216
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1215
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1217
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1216
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1218
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1217
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1219
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1218
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1220
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1219
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1221
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1220
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1222
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1221
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1223
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1222
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1224
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1223
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1225
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1224
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1226
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CC_PAGES_EVICT			1225
+#define	WT_STAT_CONN_CC_PAGES_EVICT			1227
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CC_PAGES_REMOVED			1226
+#define	WT_STAT_CONN_CC_PAGES_REMOVED			1228
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1227
+#define	WT_STAT_CONN_CC_PAGES_WALK_SKIPPED		1229
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CC_PAGES_VISITED			1228
+#define	WT_STAT_CONN_CC_PAGES_VISITED			1230
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1229
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1231
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1230
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1232
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1231
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1233
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1232
+#define	WT_STAT_CONN_TIME_TRAVEL			1234
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1233
+#define	WT_STAT_CONN_FILE_OPEN				1235
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1234
+#define	WT_STAT_CONN_BUCKETS_DH				1236
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1235
+#define	WT_STAT_CONN_BUCKETS				1237
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1236
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1238
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1237
+#define	WT_STAT_CONN_MEMORY_FREE			1239
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1238
+#define	WT_STAT_CONN_MEMORY_GROW			1240
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1239
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1241
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1240
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1242
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1241
+#define	WT_STAT_CONN_COND_WAIT				1243
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1242
+#define	WT_STAT_CONN_RWLOCK_READ			1244
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1243
+#define	WT_STAT_CONN_RWLOCK_WRITE			1245
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1244
+#define	WT_STAT_CONN_FSYNC_IO				1246
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1245
+#define	WT_STAT_CONN_READ_IO				1247
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1246
+#define	WT_STAT_CONN_WRITE_IO				1248
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1247
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1249
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1248
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1250
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1249
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1251
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1250
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1252
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1251
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1253
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1252
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1254
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1253
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1255
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1254
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1256
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1255
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1257
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1256
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1258
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1257
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1259
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1258
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1260
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1259
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1261
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1260
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1262
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1261
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1263
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1262
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1264
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1263
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1265
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1264
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1266
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1265
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1267
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1266
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1268
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1267
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1269
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1268
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1270
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1269
+#define	WT_STAT_CONN_CURSOR_CACHE			1271
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1270
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1272
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1271
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1273
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1272
+#define	WT_STAT_CONN_CURSOR_CREATE			1274
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1273
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1275
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1274
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1276
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1275
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1277
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1276
+#define	WT_STAT_CONN_CURSOR_INSERT			1278
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1277
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1279
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1278
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1280
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1279
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1281
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1280
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1282
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1281
+#define	WT_STAT_CONN_CURSOR_MODIFY			1283
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1282
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1284
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1283
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1285
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1284
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1286
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1285
+#define	WT_STAT_CONN_CURSOR_NEXT			1287
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1286
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1288
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1287
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1289
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1288
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1290
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1289
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1291
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1290
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1292
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1291
+#define	WT_STAT_CONN_CURSOR_RESTART			1293
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1292
+#define	WT_STAT_CONN_CURSOR_PREV			1294
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1293
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1295
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1294
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1296
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1295
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1297
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1296
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1298
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1297
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1299
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1298
+#define	WT_STAT_CONN_CURSOR_REMOVE			1300
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1299
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1301
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1300
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1302
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1301
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1303
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1302
+#define	WT_STAT_CONN_CURSOR_RESERVE			1304
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1303
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1305
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1304
+#define	WT_STAT_CONN_CURSOR_RESET			1306
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1305
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1307
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1306
+#define	WT_STAT_CONN_CURSOR_SEARCH			1308
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1307
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1309
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1308
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1310
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1309
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1311
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1310
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1312
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1311
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1313
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1312
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1314
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1313
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1315
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1314
+#define	WT_STAT_CONN_CURSOR_SWEEP			1316
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1315
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1317
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1316
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1318
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1317
+#define	WT_STAT_CONN_CURSOR_UPDATE			1319
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1318
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1320
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1319
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1321
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1320
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1322
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1321
+#define	WT_STAT_CONN_CURSOR_REOPEN			1323
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1322
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1324
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1323
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1325
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1324
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1326
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1325
+#define	WT_STAT_CONN_DH_SWEEP_REF			1327
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1326
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1328
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1327
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1329
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1328
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1330
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1329
+#define	WT_STAT_CONN_DH_SWEEPS				1331
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1330
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1332
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1331
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1333
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1332
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1334
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1333
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1335
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1334
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1336
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1335
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1337
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1336
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1338
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1337
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1339
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1338
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1340
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1339
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1341
 /*!
  * lock: durable timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1340
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_APPLICATION	1342
 /*!
  * lock: durable timestamp queue lock internal thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1341
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WAIT_INTERNAL	1343
 /*! lock: durable timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1342
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_READ_COUNT	1344
 /*! lock: durable timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1343
+#define	WT_STAT_CONN_LOCK_DURABLE_TIMESTAMP_WRITE_COUNT	1345
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1344
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1346
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1345
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1347
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1346
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1348
 /*!
  * lock: read timestamp queue lock application thread time waiting
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1347
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_APPLICATION	1349
 /*! lock: read timestamp queue lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1348
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WAIT_INTERNAL	1350
 /*! lock: read timestamp queue read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1349
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_READ_COUNT	1351
 /*! lock: read timestamp queue write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1350
+#define	WT_STAT_CONN_LOCK_READ_TIMESTAMP_WRITE_COUNT	1352
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1351
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1353
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1352
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1354
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1353
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1355
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1354
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1356
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1355
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1357
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1356
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1358
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1357
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1359
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1358
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1360
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1359
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1361
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1360
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1362
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1361
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1363
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1362
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1364
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1363
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1365
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1364
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1366
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1365
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1367
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1366
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1368
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1367
+#define	WT_STAT_CONN_LOG_FLUSH				1369
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1368
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1370
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1369
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1371
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1370
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1372
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1371
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1373
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1372
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1374
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1373
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1375
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1374
+#define	WT_STAT_CONN_LOG_SCANS				1376
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1375
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1377
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1376
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1378
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1377
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1379
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1378
+#define	WT_STAT_CONN_LOG_SYNC				1380
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1379
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1381
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1380
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1382
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1381
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1383
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1382
+#define	WT_STAT_CONN_LOG_WRITES				1384
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1383
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1385
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1384
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1386
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1385
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1387
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1386
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1388
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1387
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1389
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1388
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1390
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1389
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1391
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1390
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1392
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1391
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1393
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1392
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1394
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1393
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1395
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1394
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1396
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1395
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1397
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1396
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1398
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1397
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1399
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1398
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1400
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1399
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1401
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1400
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1402
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1401
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1403
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1402
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1404
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1403
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1405
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1404
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1406
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1405
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1407
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1406
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1408
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1407
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1409
 /*! perf: file system read latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1408
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1410
 /*! perf: file system read latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1409
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1411
 /*! perf: file system read latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1410
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1412
 /*! perf: file system read latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1411
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1413
 /*! perf: file system read latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1412
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1414
 /*! perf: file system read latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1413
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1415
 /*! perf: file system write latency histogram (bucket 1) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1414
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1416
 /*! perf: file system write latency histogram (bucket 2) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1415
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1417
 /*! perf: file system write latency histogram (bucket 3) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1416
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1418
 /*! perf: file system write latency histogram (bucket 4) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1417
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1419
 /*! perf: file system write latency histogram (bucket 5) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1418
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1420
 /*! perf: file system write latency histogram (bucket 6) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1419
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1421
 /*! perf: operation read latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1420
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1422
 /*! perf: operation read latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1421
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1423
 /*! perf: operation read latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1422
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1424
 /*! perf: operation read latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1423
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1425
 /*! perf: operation read latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1424
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1426
 /*! perf: operation write latency histogram (bucket 1) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1425
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1427
 /*! perf: operation write latency histogram (bucket 2) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1426
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1428
 /*! perf: operation write latency histogram (bucket 3) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1427
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1429
 /*! perf: operation write latency histogram (bucket 4) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1428
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1430
 /*! perf: operation write latency histogram (bucket 5) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1429
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1431
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1430
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1432
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1431
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1433
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1432
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1434
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1433
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1435
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1434
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1436
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1435
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1437
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1436
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1438
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1437
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1439
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1438
+#define	WT_STAT_CONN_REC_PAGES				1440
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1439
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1441
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1440
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1442
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1441
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1443
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1442
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1444
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1443
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1445
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1444
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1446
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1445
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1447
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1446
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1448
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1447
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1449
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1448
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1450
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1449
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1451
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1450
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1452
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1451
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1453
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1452
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1454
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1453
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1455
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1454
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1456
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1457
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1458
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1457
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1459
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1458
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1460
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1459
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1461
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1460
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1462
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1461
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1463
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1462
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1464
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1463
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1465
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1464
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1466
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1465
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1467
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1466
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1468
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1467
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1469
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1468
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1470
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1469
+#define	WT_STAT_CONN_FLUSH_TIER				1471
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1470
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1472
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1471
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1473
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1472
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1474
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1473
+#define	WT_STAT_CONN_SESSION_OPEN			1475
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1474
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1476
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1475
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1477
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1476
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1478
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1477
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1479
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1478
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1480
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1479
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1481
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1480
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1482
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1481
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1483
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1482
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1484
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1483
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1485
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1484
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1486
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1485
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1487
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1486
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1488
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1487
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1489
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1488
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1490
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1489
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1491
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1490
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1492
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1491
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1493
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1492
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1494
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1493
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1495
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1494
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1496
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1495
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1497
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1496
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1498
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1497
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1499
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1498
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1500
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1499
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1501
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1500
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1502
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1501
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1503
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1502
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1504
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1503
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1505
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1504
+#define	WT_STAT_CONN_TIERED_RETENTION			1506
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1505
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1507
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1506
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1508
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1507
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1509
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1508
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1510
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1509
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1511
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1510
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1512
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1511
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1513
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1512
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1514
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1513
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1515
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1514
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1516
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1515
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1517
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1516
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1518
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1517
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1519
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1518
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1520
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1519
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1521
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1520
+#define	WT_STAT_CONN_PAGE_SLEEP				1522
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1521
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1523
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1522
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1524
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1523
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1525
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1524
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1526
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1525
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1527
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1526
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1528
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1527
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1529
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1528
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1530
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1529
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1531
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1530
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1532
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1531
+#define	WT_STAT_CONN_TXN_PREPARE			1533
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1532
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1534
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1533
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1535
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1534
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1536
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1535
+#define	WT_STAT_CONN_TXN_QUERY_TS			1537
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1536
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1538
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1537
+#define	WT_STAT_CONN_TXN_RTS				1539
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1538
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1540
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1539
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1541
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1540
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1542
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1541
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1543
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1542
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1544
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1543
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1545
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1544
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1546
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1545
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1547
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1546
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1548
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1547
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1549
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1548
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1550
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1549
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1551
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1550
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1552
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1551
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1553
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1552
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1554
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1553
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1555
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1554
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1556
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1555
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1557
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1556
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1558
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1557
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1559
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1558
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1560
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1559
+#define	WT_STAT_CONN_TXN_SET_TS				1561
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1560
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1562
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1561
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1563
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1562
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1564
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1563
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1565
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1564
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1566
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1565
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1567
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1566
+#define	WT_STAT_CONN_TXN_BEGIN				1568
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1567
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1569
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1568
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1570
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1569
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1571
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1570
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1572
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1571
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1573
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1572
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1574
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1573
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1575
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1574
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1576
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1575
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1577
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1576
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1578
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1577
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1579
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1578
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1580
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1579
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1581
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1580
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1582
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1581
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1583
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1582
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1584
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1583
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1585
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1584
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1586
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1585
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1587
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1586
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1588
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1587
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1589
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1588
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1590
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1589
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1591
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1590
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1592
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1591
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1593
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1592
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1594
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1593
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1595
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1594
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1596
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1595
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1597
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1596
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1598
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1597
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1599
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1598
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1600
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1599
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1601
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1600
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1602
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1601
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1603
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1602
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1604
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1603
+#define	WT_STAT_CONN_TXN_COMMIT				1605
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1604
+#define	WT_STAT_CONN_TXN_ROLLBACK			1606
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1605
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1607
 
 /*!
  * @}
@@ -7215,505 +7219,509 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2119
 /*! cache: tracked dirty bytes in the cache */
 #define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2120
+/*! cache: tracked dirty internal page bytes in the cache */
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2121
+/*! cache: tracked dirty leaf page bytes in the cache */
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2122
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2121
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2123
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2122
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2124
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2123
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2125
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2124
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2126
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2125
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2127
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2126
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2128
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2127
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2129
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2128
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2130
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2129
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2131
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2130
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2132
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2131
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2133
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2132
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2134
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2133
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2135
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2134
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2136
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2135
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2137
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2136
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2138
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2137
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2139
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2138
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2140
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2139
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2141
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2140
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2142
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2141
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2143
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2142
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2144
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2143
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2145
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_DSRC_CC_PAGES_EVICT			2144
+#define	WT_STAT_DSRC_CC_PAGES_EVICT			2146
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_DSRC_CC_PAGES_REMOVED			2145
+#define	WT_STAT_DSRC_CC_PAGES_REMOVED			2147
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_DSRC_CC_PAGES_WALK_SKIPPED		2146
+#define	WT_STAT_DSRC_CC_PAGES_WALK_SKIPPED		2148
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_DSRC_CC_PAGES_VISITED			2147
+#define	WT_STAT_DSRC_CC_PAGES_VISITED			2149
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2148
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2150
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2149
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2151
 /*! compression: compressed pages read */
-#define	WT_STAT_DSRC_COMPRESS_READ			2150
+#define	WT_STAT_DSRC_COMPRESS_READ			2152
 /*! compression: compressed pages written */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2151
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2153
 /*! compression: number of blocks with compress ratio greater than 64 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_MAX		2152
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_MAX		2154
 /*! compression: number of blocks with compress ratio smaller than 16 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_16		2153
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_16		2155
 /*! compression: number of blocks with compress ratio smaller than 2 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_2		2154
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_2		2156
 /*! compression: number of blocks with compress ratio smaller than 32 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_32		2155
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_32		2157
 /*! compression: number of blocks with compress ratio smaller than 4 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_4		2156
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_4		2158
 /*! compression: number of blocks with compress ratio smaller than 64 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_64		2157
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_64		2159
 /*! compression: number of blocks with compress ratio smaller than 8 */
-#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_8		2158
+#define	WT_STAT_DSRC_COMPRESS_HIST_RATIO_8		2160
 /*! compression: page written failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2159
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2161
 /*! compression: page written was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2160
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2162
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2161
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2163
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2162
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2164
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2163
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2165
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2164
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2166
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2165
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2167
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2166
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2168
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2167
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2169
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2168
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2170
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2169
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2171
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2170
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2172
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2171
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2173
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2172
+#define	WT_STAT_DSRC_CURSOR_CACHE			2174
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2173
+#define	WT_STAT_DSRC_CURSOR_CREATE			2175
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2174
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2176
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2175
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2177
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2176
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2178
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2177
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2179
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2178
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2180
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2179
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2181
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2180
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2182
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2181
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2183
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2182
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2184
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2183
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2185
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2184
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2186
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2185
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2187
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2186
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2188
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2187
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2189
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2188
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2190
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2189
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2191
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2190
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2192
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2191
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2193
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2192
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2194
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2193
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2195
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2194
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2196
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2195
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2197
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2196
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2198
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2197
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2199
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2198
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2200
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2199
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2201
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2200
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2202
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2201
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2203
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2202
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2204
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2203
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2205
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2204
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2206
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2205
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2207
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2206
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2208
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2207
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2209
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2208
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2210
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2209
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2211
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2210
+#define	WT_STAT_DSRC_CURSOR_INSERT			2212
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2211
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2213
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2212
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2214
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2213
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2215
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2214
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2216
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2215
+#define	WT_STAT_DSRC_CURSOR_NEXT			2217
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2216
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2218
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2217
+#define	WT_STAT_DSRC_CURSOR_RESTART			2219
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2218
+#define	WT_STAT_DSRC_CURSOR_PREV			2220
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2219
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2221
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2220
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2222
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2221
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2223
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2222
+#define	WT_STAT_DSRC_CURSOR_RESET			2224
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2223
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2225
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2224
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2226
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2225
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2227
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2226
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2228
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2227
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2229
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2228
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2230
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2229
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2231
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2230
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2232
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2231
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2233
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2232
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2234
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2233
+#define	WT_STAT_DSRC_REC_DICTIONARY			2235
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2234
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2236
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2235
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2237
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2236
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2238
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2237
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2239
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2238
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2240
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2239
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2241
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2240
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2242
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2241
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2243
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2242
+#define	WT_STAT_DSRC_REC_PAGES				2244
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2243
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2245
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2244
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2246
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2245
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2247
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2246
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2248
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2247
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2249
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2248
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2250
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2249
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2251
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2250
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2252
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2251
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2253
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2252
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2254
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2253
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2255
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2254
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2256
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2255
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2257
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2256
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2258
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2257
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2259
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2258
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2260
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2259
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2261
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2260
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2262
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2261
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2263
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2262
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2264
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2263
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2265
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2264
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2266
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2265
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2267
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2266
+#define	WT_STAT_DSRC_SESSION_COMPACT			2268
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2267
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2269
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2268
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2270
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2269
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2271
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2270
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2272
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2271
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2273
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2272
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2274
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2273
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2275
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2274
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2276
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2275
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2277
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2276
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2278
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2277
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2279
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2278
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2280
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2279
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2281
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2280
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2282
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2281
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2283
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2282
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2284
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2283
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2285
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2284
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2286
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2285
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2287
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2286
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2288
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2287
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2289
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2288
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2290
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -135,6 +135,8 @@ static const char *const __stats_dsrc_desc[] = {
   "cache: the number of times full update inserted to history store",
   "cache: the number of times reverse modify inserted to history store",
   "cache: tracked dirty bytes in the cache",
+  "cache: tracked dirty internal page bytes in the cache",
+  "cache: tracked dirty leaf page bytes in the cache",
   "cache: uncommitted truncate blocked page eviction",
   "cache: unmodified pages evicted",
   "cache_walk: Average difference between current eviction generation when the page was last "
@@ -473,6 +475,8 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->cache_hs_insert_full_update = 0;
     stats->cache_hs_insert_reverse_modify = 0;
     /* not clearing cache_bytes_dirty */
+    /* not clearing cache_bytes_dirty_internal */
+    /* not clearing cache_bytes_dirty_leaf */
     stats->cache_eviction_blocked_uncommitted_truncate = 0;
     stats->cache_eviction_clean = 0;
     /* not clearing cache_state_gen_avg_gap */
@@ -796,6 +800,8 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->cache_hs_insert_full_update += from->cache_hs_insert_full_update;
     to->cache_hs_insert_reverse_modify += from->cache_hs_insert_reverse_modify;
     to->cache_bytes_dirty += from->cache_bytes_dirty;
+    to->cache_bytes_dirty_internal += from->cache_bytes_dirty_internal;
+    to->cache_bytes_dirty_leaf += from->cache_bytes_dirty_leaf;
     to->cache_eviction_blocked_uncommitted_truncate +=
       from->cache_eviction_blocked_uncommitted_truncate;
     to->cache_eviction_clean += from->cache_eviction_clean;
@@ -1126,6 +1132,8 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->cache_hs_insert_full_update += WT_STAT_READ(from, cache_hs_insert_full_update);
     to->cache_hs_insert_reverse_modify += WT_STAT_READ(from, cache_hs_insert_reverse_modify);
     to->cache_bytes_dirty += WT_STAT_READ(from, cache_bytes_dirty);
+    to->cache_bytes_dirty_internal += WT_STAT_READ(from, cache_bytes_dirty_internal);
+    to->cache_bytes_dirty_leaf += WT_STAT_READ(from, cache_bytes_dirty_leaf);
     to->cache_eviction_blocked_uncommitted_truncate +=
       WT_STAT_READ(from, cache_eviction_blocked_uncommitted_truncate);
     to->cache_eviction_clean += WT_STAT_READ(from, cache_eviction_clean);
@@ -1538,6 +1546,8 @@ static const char *const __stats_connection_desc[] = {
   "cache: tracked bytes belonging to internal pages in the cache",
   "cache: tracked bytes belonging to leaf pages in the cache",
   "cache: tracked dirty bytes in the cache",
+  "cache: tracked dirty internal page bytes in the cache",
+  "cache: tracked dirty leaf page bytes in the cache",
   "cache: tracked dirty pages in the cache",
   "cache: uncommitted truncate blocked page eviction",
   "cache: unmodified pages evicted",
@@ -2194,6 +2204,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing cache_bytes_internal */
     /* not clearing cache_bytes_leaf */
     /* not clearing cache_bytes_dirty */
+    /* not clearing cache_bytes_dirty_internal */
+    /* not clearing cache_bytes_dirty_leaf */
     /* not clearing cache_pages_dirty */
     stats->cache_eviction_blocked_uncommitted_truncate = 0;
     stats->cache_eviction_clean = 0;
@@ -2868,6 +2880,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_bytes_internal += WT_STAT_READ(from, cache_bytes_internal);
     to->cache_bytes_leaf += WT_STAT_READ(from, cache_bytes_leaf);
     to->cache_bytes_dirty += WT_STAT_READ(from, cache_bytes_dirty);
+    to->cache_bytes_dirty_internal += WT_STAT_READ(from, cache_bytes_dirty_internal);
+    to->cache_bytes_dirty_leaf += WT_STAT_READ(from, cache_bytes_dirty_leaf);
     to->cache_pages_dirty += WT_STAT_READ(from, cache_pages_dirty);
     to->cache_eviction_blocked_uncommitted_truncate +=
       WT_STAT_READ(from, cache_eviction_blocked_uncommitted_truncate);


### PR DESCRIPTION
…es (#11141) (v8.0 backport) (#11354)

We currently expose the tracked number of dirty bytes in the cache as a statistic: `cache_bytes_dirty`
However, this does not differentiate between leaf or internal pages. This metric is currently incorrectly interpreted in t2 as the reason for the cache being in the `WT_EVICT_CACHE_DIRTY_HARD` state and causing application threads to evict. This is misleading because the dirty hard state is set based on the dirty leaf page bytes not the total dirty bytes.

The dirty leaf and internal bytes are already tracked in the cache structure as:
`bytes_dirty_intl`
`bytes_dirty_leaf`

This PR exposes these as new statistics.

(cherry picked from commit ca9ffe8305d5815fd44b2cd1ff3c3fc6380c6984)

Co-authored-by: Sean <41533874+Sean04@users.noreply.github.com>
(cherry picked from commit 1416a711395d191efac39820ab59697b4f51942c)