### PR TITLE
WT-14020 removed unusued hs_dhandle value

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1116,6 +1116,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     struct timespec tsp;
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
+    WT_DATA_HANDLE *hs_dhandle;
     WT_DECL_RET;
     WT_EVICT *evict;
     WT_TXN *txn;
@@ -1312,7 +1313,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * occurred), this will return ENOENT which we ignore and continue.
      */
     WT_ERR_ERROR_OK(__wt_session_get_dhandle(session, WT_HS_URI, NULL, NULL, 0), ENOENT, false);
-    WT_DATA_HANDLE *hs_dhandle = session->dhandle;
+    hs_dhandle = session->dhandle;
 
     /*
      * It is possible that we don't have a history store file in certain recovery scenarios. As such

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1116,7 +1116,6 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     struct timespec tsp;
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
-    WT_DATA_HANDLE *hs_dhandle;
     WT_DECL_RET;
     WT_EVICT *evict;
     WT_TXN *txn;
@@ -1137,7 +1136,6 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     conn = S2C(session);
     evict = conn->evict;
     hs_size = 0;
-    hs_dhandle = NULL;
     txn = session->txn;
     txn_global = &conn->txn_global;
     saved_isolation = session->isolation;
@@ -1314,7 +1312,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * occurred), this will return ENOENT which we ignore and continue.
      */
     WT_ERR_ERROR_OK(__wt_session_get_dhandle(session, WT_HS_URI, NULL, NULL, 0), ENOENT, false);
-    hs_dhandle = session->dhandle;
+    WT_DATA_HANDLE *hs_dhandle = session->dhandle;
 
     /*
      * It is possible that we don't have a history store file in certain recovery scenarios. As such


### PR DESCRIPTION
[WT-14020](https://jira.mongodb.org/browse/WT-14020): Minor change to remove the unused initialisation of `hs_dhandle = NULL` in `/src/checkpoint/checkpoint_txn.c`. Moved the declaration of `hs_dhandle` to where it is first used in the function.