### PR TITLE
WT-14079 Treat nbits -1 as a file completion state & WT-14044 Support the WT util running on a partially live restored database.

### DIFF
--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -22,6 +22,8 @@ Specify an encryption secret key for the ::wiredtiger_open function.
 Specify a database home directory.
 @par \c -L
 Forcibly turn off logging subsystem for debugging purposes.
+@par \c -l directory
+Open a database that is in the process of being live restored. This parameter takes the path to the source directory as an argument.
 @par \c -m
 Verify the WiredTiger metadata as part of opening the database.
 @par \c -R

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -16,6 +16,10 @@
  */
 struct __wt_live_restore_fh_meta {
     char *bitmap_str;
+    /*
+     * The number of bits in the bitmap. We use -1 as a special case to identify when a file has
+     * finished migration and no longer needs a bitmap.
+     */
     int64_t nbits;
     uint32_t allocsize;
 };

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -16,7 +16,7 @@
  */
 struct __wt_live_restore_fh_meta {
     char *bitmap_str;
-    uint64_t nbits;
+    int64_t nbits;
     uint32_t allocsize;
 };
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1146,7 +1146,7 @@ __wt_live_restore_metadata_to_fh(
     lr_fh->allocsize = lr_fh_meta->allocsize;
     /*
      * !!!
-     * While the live restore is in progress the bit count reported by in the live restore meta data
+     * While the live restore is in progress, the bit count reported by in the live restore metadata
      * can hold three states:
      *  (0)         : This means file has not yet had a bitmap representation written to the k
      *                metadata file and therefore no application writes have gone to the
@@ -1218,6 +1218,7 @@ __wt_live_restore_fh_to_metadata(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh, W
           "%s: Appending live restore bitmap (%s, %" PRIu64 ") to metadata", fh->name,
           (char *)buf.data, lr_fh->destination.nbits);
     } else {
+        /* -1 indicates the file has completed migration. */
         WT_ERR(__wt_buf_catfmt(session, meta_string, ",live_restore=(bitmap=,nbits=-1)"));
         __wt_verbose_debug3(
           session, WT_VERB_LIVE_RESTORE, "%s: Appending empty live restore metadata", fh->name);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1171,7 +1171,11 @@ __wt_live_restore_metadata_to_fh(
           session, lr_fh_meta->bitmap_str, (uint64_t)lr_fh_meta->nbits, lr_fh));
     } else {
         lr_fh->destination.complete = true;
-        WT_ASSERT(session, lr_fh_meta->nbits == -1);
+        /*
+         * Zero here is only valid if the file has gone through schema create. We can't test for
+         * that.
+         */
+        WT_ASSERT(session, lr_fh_meta->nbits <= 0);
     }
 
     if (0) {

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1170,7 +1170,7 @@ __wt_live_restore_metadata_to_fh(
         __wt_readunlock(session, &lr_fh->bitmap_lock);
         return (0);
     }
-    if (lr_fh_meta->nbits != 0) {
+    if (lr_fh_meta->nbits > 0) {
         /* We shouldn't be reconstructing a bitmap if the live restore has finished. */
         WT_ASSERT(session, !__wti_live_restore_migration_complete(session));
         __wt_verbose_debug3(session, WT_VERB_LIVE_RESTORE,
@@ -1179,8 +1179,10 @@ __wt_live_restore_metadata_to_fh(
         /* Reconstruct a pre-existing bitmap. */
         WT_ERR(
           __live_restore_decode_bitmap(session, lr_fh_meta->bitmap_str, (uint64_t)lr_fh_meta->nbits, lr_fh));
-    } else
+    } else {
         lr_fh->destination.complete = true;
+        WT_ASSERT(session, lr_fh_meta->nbits == -1);
+    }
 
     if (0) {
 err:

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1167,8 +1167,8 @@ __wt_live_restore_metadata_to_fh(
           "Reconstructing bitmap for %s, bitmap_sz %" PRId64 ", bitmap_str %s", fh->name,
           lr_fh_meta->nbits, lr_fh_meta->bitmap_str);
         /* Reconstruct a pre-existing bitmap. */
-        WT_ERR(
-          __live_restore_decode_bitmap(session, lr_fh_meta->bitmap_str, (uint64_t)lr_fh_meta->nbits, lr_fh));
+        WT_ERR(__live_restore_decode_bitmap(
+          session, lr_fh_meta->bitmap_str, (uint64_t)lr_fh_meta->nbits, lr_fh));
     } else {
         lr_fh->destination.complete = true;
         WT_ASSERT(session, lr_fh_meta->nbits == -1);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1137,16 +1137,6 @@ __wt_live_restore_metadata_to_fh(
         return (0);
     }
 
-    /*
-     * FIXME-WT-14079 there is a tricky scenario here:
-     *   - Open a file that exists in the source, a.wt.
-     *   - Create a new file in the destination to begin migrating the file to.
-     *   - Crash.
-     *   - Open the file a.wt again, we will see an a.wt in the destination and not create the
-     *   necessary file length hole. We will also get an empty extent list string indicating a.wt is
-     *   complete.
-     */
-
     if (lr_fh->destination.bitmap != NULL) {
         WT_ASSERT_ALWAYS(session, false, "Bitmap not empty while trying to parse");
         return (0);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1146,12 +1146,14 @@ __wt_live_restore_metadata_to_fh(
     lr_fh->allocsize = lr_fh_meta->allocsize;
     /*
      * !!!
-     * While the live restore is in progress the bit count reported by in the live restore meta can
-     * hold three states:
-     *  (0)     : This means file has not yet had a bitmap written to the metadata file and
-     *            therefore no relevant writes have gone to the destination.
-     *  (-1)    : This indicates the file has finished migration and the bitmap is therefore empty.
-     *  (nbits) : The number of bits in the bitmap.
+     * While the live restore is in progress the bit count reported by in the live restore meta data
+     * can hold three states:
+     *  (0)         : This means file has not yet had a bitmap representation written to the k
+     *                metadata file and therefore no application writes have gone to the
+     *                destination. In theory background thread writes may have happened but unless
+     *                the tree was dirtied the metadata update was not written out.
+     *  (-1)        : This indicates the file has finished migration and the bitmap is empty.
+     *  (nbits > 0) : The number of bits in the bitmap.
      */
     if (lr_fh_meta->nbits == 0 && lr_fh->source_size > 0) {
         uint64_t nbits = lr_fh->source_size / lr_fh_meta->allocsize;

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -47,7 +47,6 @@ struct __wti_live_restore_file_handle {
         /* Number of bits in the bitmap, should be equivalent to source file size / alloc_size. */
         uint64_t nbits;
         uint8_t *bitmap;
-        bool newly_created;
     } destination;
 
     uint32_t allocsize;

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -133,9 +133,10 @@ __wt_meta_checkpoint(WT_SESSION_IMPL *session, const char *fname, const char *ch
             WT_CONFIG_ITEM cval;
             WT_ERR_NOTFOUND_OK(__wt_config_subgets(session, &v, "bitmap", &cval), true);
             if (ret != WT_NOTFOUND) {
-                WT_ERR(__wt_strndup(session, cval.str, cval.len, &lr_fh_meta->bitmap_str));
                 WT_ERR(__wt_config_subgets(session, &v, "nbits", &cval));
-                lr_fh_meta->nbits = (uint64_t)cval.val;
+                lr_fh_meta->nbits = cval.val;
+                if (lr_fh_meta->nbits > 0)
+                    WT_ERR(__wt_strndup(session, cval.str, cval.len, &lr_fh_meta->bitmap_str));
             }
         }
         /* All code paths that exist today overwrite ret but to be defensive we clear it here. */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -131,12 +131,13 @@ __wt_meta_checkpoint(WT_SESSION_IMPL *session, const char *fname, const char *ch
         WT_ERR_NOTFOUND_OK(__wt_config_getones(session, config, "live_restore", &v), true);
         if (ret != WT_NOTFOUND) {
             WT_CONFIG_ITEM cval;
-            WT_ERR_NOTFOUND_OK(__wt_config_subgets(session, &v, "bitmap", &cval), true);
+            WT_ERR_NOTFOUND_OK(__wt_config_subgets(session, &v, "nbits", &cval), true);
             if (ret != WT_NOTFOUND) {
-                WT_ERR(__wt_config_subgets(session, &v, "nbits", &cval));
                 lr_fh_meta->nbits = cval.val;
-                if (lr_fh_meta->nbits > 0)
+                if (lr_fh_meta->nbits > 0) {
+                    WT_ERR(__wt_config_subgets(session, &v, "bitmap", &cval));
                     WT_ERR(__wt_strndup(session, cval.str, cval.len, &lr_fh_meta->bitmap_str));
+                }
             }
         }
         /* All code paths that exist today overwrite ret but to be defensive we clear it here. */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -137,7 +137,8 @@ __wt_meta_checkpoint(WT_SESSION_IMPL *session, const char *fname, const char *ch
                 if (lr_fh_meta->nbits > 0) {
                     WT_ERR(__wt_config_subgets(session, &v, "bitmap", &cval));
                     WT_ERR(__wt_strndup(session, cval.str, cval.len, &lr_fh_meta->bitmap_str));
-                }
+                } else
+                    lr_fh_meta->bitmap_str = NULL;
             }
         }
         /* All code paths that exist today overwrite ret but to be defensive we clear it here. */

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -46,8 +46,8 @@ usage(void)
 {
     static const char *options[] = {"-B", "maintain release 3.3 log file compatibility",
       "-C config", "wiredtiger_open configuration", "-E key", "secret encryption key", "-h home",
-      "database directory", "-L", "turn logging off for debug-mode", "-m", "run verify on metadata",
-      "-p",
+      "database directory", "-L", "turn logging off for debug-mode", "-l",
+      "run live restore using the path specified.", "-m", "run verify on metadata", "-p",
       "disable pre-fetching on the connection (use this option when dumping/verifying corrupted "
       "data)",
       "-R", "run recovery (if recovery configured)", "-r",
@@ -83,8 +83,8 @@ main(int argc, char *argv[])
     size_t len;
     int ch, major_v, minor_v, tret, (*func)(WT_SESSION *, int, char *[]);
     char *p, *secretkey;
-    const char *cmd_config, *conn_config, *p1, *p2, *p3, *readonly_config, *rec_config,
-      *salvage_config, *session_config;
+    const char *cmd_config, *conn_config, *live_restore_path, *p1, *p2, *p3, *readonly_config,
+      *rec_config, *salvage_config, *session_config;
     bool backward_compatible, disable_prefetch, logoff, meta_verify, readonly, recover, salvage;
 
     conn = NULL;
@@ -106,7 +106,8 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     }
 
-    cmd_config = conn_config = readonly_config = salvage_config = session_config = secretkey = NULL;
+    cmd_config = conn_config = live_restore_path = readonly_config = salvage_config =
+      session_config = secretkey = NULL;
     /*
      * We default to returning an error if recovery needs to be run. Generally we expect this to be
      * run after a clean shutdown. The printlog command disables logging entirely. If recovery is
@@ -117,7 +118,7 @@ main(int argc, char *argv[])
       false;
     /* Check for standard options. */
     __wt_optwt = 1; /* enable WT-specific behavior */
-    while ((ch = __wt_getopt(progname, argc, argv, "BC:E:h:LmpRrSVv?")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "BC:E:h:l:LmpRrSVv?")) != EOF)
         switch (ch) {
         case 'B': /* backward compatibility */
             backward_compatible = true;
@@ -141,6 +142,9 @@ main(int argc, char *argv[])
         case 'L': /* no logging */
             rec_config = REC_LOGOFF;
             logoff = true;
+            break;
+        case 'l':
+            live_restore_path = __wt_optarg;
             break;
         case 'm': /* verify metadata on connection open */
             cmd_config = "verify_metadata=true";
@@ -290,6 +294,11 @@ open:
         len += strlen(conn_config);
     if (cmd_config != NULL)
         len += strlen(cmd_config);
+    len += strlen("live_restore=(enabled=,threads_max=0,path=)");
+    if (live_restore_path != NULL)
+        len += strlen(live_restore_path) + strlen("true");
+    else
+        len += strlen("false");
     if (readonly_config != NULL)
         len += strlen(readonly_config);
     if (salvage_config != NULL)
@@ -305,8 +314,11 @@ open:
         (void)util_err(NULL, errno, NULL);
         goto err;
     }
-    if ((ret = __wt_snprintf(p, len, "error_prefix=wt,%s,%s,%s,%s,%s%s%s%s",
+    if ((ret = __wt_snprintf(p, len,
+           "error_prefix=wt,%s,%s,live_restore=(enabled=%s,threads_max=0,path=%s),%s,%s,%s%s%s%s",
            conn_config == NULL ? "" : conn_config, cmd_config == NULL ? "" : cmd_config,
+           live_restore_path == NULL ? "false" : "true",
+           live_restore_path == NULL ? "" : live_restore_path,
            readonly_config == NULL ? "" : readonly_config, rec_config,
            salvage_config == NULL ? "" : salvage_config, p1, p2, p3)) != 0) {
         (void)util_err(NULL, ret, NULL);

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -47,7 +47,7 @@ usage(void)
     static const char *options[] = {"-B", "maintain release 3.3 log file compatibility",
       "-C config", "wiredtiger_open configuration", "-E key", "secret encryption key", "-h home",
       "database directory", "-L", "turn logging off for debug-mode", "-l",
-      "run live restore using the path specified.", "-m", "run verify on metadata", "-p",
+      "run live restore using the source path specified.", "-m", "run verify on metadata", "-p",
       "disable pre-fetching on the connection (use this option when dumping/verifying corrupted "
       "data)",
       "-R", "run recovery (if recovery configured)", "-r",

--- a/test/suite/test_live_restore02.py
+++ b/test/suite/test_live_restore02.py
@@ -93,6 +93,8 @@ class test_live_restore02(wttest.WiredTigerTestCase):
         # Build in a 2 minute timeout. Once we see the complete state exit the loop.
         while (iteration_count < timeout):
             state = self.get_stat(stat.conn.live_restore_state)
+            # Stress the file create path in the meantime, this checks some assert conditions.
+            self.session.create('file:abc' + str(iteration_count), 'key_format=' + self.key_format + ',value_format=' + self.value_format)
             self.pr("Looping until finish, live restore state is: " + str(state))
             # State 2 means the live restore has completed.
             if (state == 2):

--- a/test/suite/test_live_restore04.py
+++ b/test/suite/test_live_restore04.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import filecmp, os, glob, wiredtiger, wttest
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from helper import copy_wiredtiger_home
+from suite_subprocess import suite_subprocess
+
+
+# test_live_restore04.py
+# Test using the wt utility with live restore.
+@wttest.skip_for_hook("tiered", "using multiple WT homes")
+class test_live_restore04(wttest.WiredTigerTestCase, suite_subprocess):
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        ('row_integer', dict(key_format='i', value_format='S')),
+    ]
+    scenarios = make_scenarios(format_values)
+    nrows = 10000
+    ntables = 3
+    conn_config = 'log=(enabled)'
+
+    def get_stat(self, statistic):
+        stat_cursor = self.session.open_cursor("statistics:")
+        val = stat_cursor[statistic][2]
+        stat_cursor.close()
+        return val
+
+    def test_live_restore04(self):
+        # Live restore is not supported on Windows.
+        if os.name == 'nt':
+            self.skipTest('Unix specific test skipped on Windows')
+
+        # Create a folder to save the wt utility output.
+        util_out_path = 'UTIL'
+        os.mkdir(util_out_path)
+
+        uris = []
+        for i in range(self.ntables):
+            uri = f'file:collection-{i}'
+            uris.append(uri)
+            ds = SimpleDataSet(self, uri, self.nrows, key_format=self.key_format,
+                               value_format=self.value_format)
+            ds.populate()
+
+        # Dump file data for later comparison.
+        for i in range(self.ntables):
+            dump_out = os.path.join(util_out_path, f'{uris[i]}.out')
+            self.runWt(['dump', '-x', uris[i]], outfilename=dump_out)
+
+        # Close the default connection.
+        self.close_conn()
+
+        copy_wiredtiger_home(self, '.', "SOURCE")
+
+        # Remove everything but SOURCE / stderr / stdout / util output folder.
+        for f in glob.glob("*"):
+            if not f == "SOURCE" and not f == "UTIL" and not f == "stderr.txt" and not f == "stdout.txt":
+                os.remove(f)
+
+        # Open a live restore connection with no background migration threads to leave it in an
+        # unfinished state.
+        self.open_conn(config="log=(enabled),statistics=(all),live_restore=(enabled=true,path=\"SOURCE\",threads_max=0)")
+        self.close_conn()
+
+        # Check that opening the wt utility without a proper live restore path gives an error.
+        self.runWt(['dump', '-x', uris[0]],
+                   outfilename=f'{uris[0]}.lr.out',
+                   errfilename='wterr.txt',
+                   reopensession=False,
+                   failure=True)
+        self.check_non_empty_file('wterr.txt')
+
+        # Check the printlog command works as expected.
+        self.runWt(['-l', 'SOURCE', 'printlog'],
+            outfilename='printlog.txt',
+            reopensession=False,
+            failure=False)
+        self.check_non_empty_file('printlog.txt')
+
+        # Open a live restore connection through the wt utility. Check that both dump and verify
+        # work as expected for each file.
+        for i in range(self.ntables):
+            lr_dump_out = os.path.join(util_out_path, f'{uris[i]}.lr.out')
+            self.runWt(['-l', 'SOURCE', 'dump', '-x', uris[i]],
+                       outfilename=lr_dump_out,
+                       reopensession=False,
+                       failure=False)
+
+            # Check the dump contents is identical to the original dump.
+            assert(filecmp.cmp(
+                os.path.join(util_out_path, f'{uris[i]}.lr.out'),
+                os.path.join(util_out_path, f'{uris[i]}.out')
+            ))
+
+            self.runWt(['-l', 'SOURCE', 'verify', uris[i]],
+                reopensession=False,
+                failure=False)

--- a/test/suite/test_live_restore04.py
+++ b/test/suite/test_live_restore04.py
@@ -90,8 +90,9 @@ class test_live_restore04(wttest.WiredTigerTestCase, suite_subprocess):
         self.close_conn()
 
         # Check that opening the wt utility without a proper live restore path gives an error.
+        lr_dump_out = os.path.join(util_out_path, f'{uris[i]}-error.lr.out')
         self.runWt(['dump', '-x', uris[0]],
-                   outfilename=f'{uris[0]}.lr.out',
+                   outfilename=lr_dump_out,
                    errfilename='wterr.txt',
                    reopensession=False,
                    failure=True)

--- a/test/suite/test_live_restore04.py
+++ b/test/suite/test_live_restore04.py
@@ -53,7 +53,7 @@ class test_live_restore04(wttest.WiredTigerTestCase, suite_subprocess):
         return val
 
     def test_live_restore04(self):
-        # Live restore is not supported on Windows.
+        # FIXME-WT-14051: Live restore is not supported on Windows.
         if os.name == 'nt':
             self.skipTest('Unix specific test skipped on Windows')
 


### PR DESCRIPTION
Handle a scenario in live restore that results in a descriptor read error, or potentially other block checksum errors.