### PR TITLE
WT-14149 Specify bazel version 7.5.0 when building TCMalloc

### DIFF
--- a/test/evergreen/tcmalloc_install_or_build.sh
+++ b/test/evergreen/tcmalloc_install_or_build.sh
@@ -53,6 +53,25 @@ fi
 # From this point onward: any and all errors are fatal, and will cause the build to FAIL.
 set -e
 
+# Fetch the operating system and hardware architecture to download bazelisk binaries. The bazelisk
+# binary is used to specifically obtain the bazel 7.5.0 version. Note: We do not spport TCMalloc
+# with Windows.
+RUN_OS=$(uname -s)
+ARCH=$(uname -m)
+os=$(echo "$RUN_OS" | tr '[:upper:]' '[:lower:]')
+arch_tag=""
+if [[ $ARCH = "x86_64" ]]; then
+    arch_tag="amd64"
+else
+    arch_tag="arm64"
+fi
+
+BAZELISK_URL="https://github.com/bazelbuild/bazelisk/releases/download/v1.25.0/bazelisk-${os}-${arch_tag}"
+curl --retry 5 -L $BAZELISK_URL -sS --max-time 120 --fail --output bazelisk
+chmod 755 bazelisk
+export USE_BAZEL_VERSION="7.5.0"
+./bazelisk
+
 # Download and unpack. Allow a generous 2 minutes for the download to complete.
 curl --retry 5 -L $PATCHED_TGZ_URL -sS --max-time 120 --fail --output ${PATCHED_TGZ}
 rm -rf ${PATCHED_SRC_DIR}
@@ -73,13 +92,9 @@ cc_shared_library(
 )
 EOF
 
+# Install tcmalloc library.
 (cd $PATCHED_SRC_DIR ;
-
- # FIXME-WT-12775 When DEVPROD upgrades to using Bazel 7+, and the corresponding
- # Evergreen sandboxing is fixed. The bazel invocation should be reviewed and
- # hopefully simplified.
- mkdir -p /data/tmp/bazel-working-directory/_main ;
- PATH=/opt/mongodbtoolchain/v4/bin:$PATH bazel build --enable_workspace --sandbox_debug --sandbox_writable_path=/data/tmp/bazel-working-directory --sandbox_writable_path=/data/tmp/bazel-working-directory/_main --verbose_failures libtcmalloc )
+ PATH=/opt/mongodbtoolchain/v4/bin:$PATH bazel build --verbose_failures libtcmalloc )
 
 # Package and upload. If the upload fails: fail the WT build, even though
 # there is an available binary. This is to ensure any problem becomes

--- a/test/evergreen/tcmalloc_install_or_build.sh
+++ b/test/evergreen/tcmalloc_install_or_build.sh
@@ -79,7 +79,7 @@ EOF
  # Evergreen sandboxing is fixed. The bazel invocation should be reviewed and
  # hopefully simplified.
  mkdir -p /data/tmp/bazel-working-directory/_main ;
- PATH=/opt/mongodbtoolchain/v4/bin:$PATH bazel build --sandbox_debug --sandbox_writable_path=/data/tmp/bazel-working-directory --sandbox_writable_path=/data/tmp/bazel-working-directory/_main --verbose_failures libtcmalloc )
+ PATH=/opt/mongodbtoolchain/v4/bin:$PATH bazel build --enable_workspace --sandbox_debug --sandbox_writable_path=/data/tmp/bazel-working-directory --sandbox_writable_path=/data/tmp/bazel-working-directory/_main --verbose_failures libtcmalloc )
 
 # Package and upload. If the upload fails: fail the WT build, even though
 # there is an available binary. This is to ensure any problem becomes


### PR DESCRIPTION
Since bazel 8.0, they have disabled using the workspace file by default follow here:
```
WARNING: --enable_bzlmod is set, but no MODULE.bazel file was found at the workspace root. Bazel will create an empty MODULE.bazel file. Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel. For more details, please refer to https://github.com/bazelbuild/bazel/issues/18958.
ERROR: error loading package 'tcmalloc': Unable to find package for @@[unknown repo 'rules_fuzzing' requested from @@]//fuzzing:cc_defs.bzl: The repository '@@[unknown repo 'rules_fuzzing' requested from @@]' could not be resolved: No repository visible as '@rules_fuzzing' from main repository. Was the repository introduced in WORKSPACE? The WORKSPACE file is disabled by default in Bazel 8 (late 2024) and will be removed in Bazel 9 (late 2025), please migrate to Bzlmod. See https://bazel.build/external/migration.
ERROR: /data/wiredtiger/tcmalloc-mongo-SERVER-85737/BUILD:3:18: error loading package 'tcmalloc': Unable to find package for @@[unknown repo 'rules_fuzzing' requested from @@]//fuzzing:cc_defs.bzl: The repository '@@[unknown repo 'rules_fuzzing' requested from @@]' could not be resolved: No repository visible as '@rules_fuzzing' from main repository. Was the repository introduced in WORKSPACE? The WORKSPACE file is disabled by default in Bazel 8 (late 2024) and will be removed in Bazel 9 (late 2025), please migrate to Bzlmod. See https://bazel.build/external/migration. and referenced by '//:libtcmalloc'
ERROR: Analysis of target '//:libtcmalloc' failed; build aborted: Analysis failed
INFO: Elapsed time: 4.636s, Critical Path: 0.03s
INFO: 1 process: 1 internal.
```
To build TCMalloc successfully on a machine, we need to specify the bazel version. 

Also since we now build on bazel 7.1+, I have tested without the sandbox commands, the FIXME can be removed now. I have verified that the tests pass within the ticket.