### PR TITLE
WT-13994 Reduce PR testing duration

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1329,6 +1329,11 @@ variables:
       ENABLE_TCMALLOC: 0
     tasks:
       - name: compile
+        # This is a special case and should *only* be used for the macOS buildvariant.
+        # The macOS variant can take up to an hour to schedule tasks, but we want PR testing to complete
+        # in under 30 minutes. The compile task also only takes 2 minutes to run so we can bump up priority
+        # with minimal impact on other projects.
+        priority: 5
       - name: make-check-test
       # Use a special version of unit-test for macOS that checks for Python version consistency.
       - name: unit-test-macos


### PR DESCRIPTION
Set the priority of our macOS compile task to 5 by default. 
This task often takes an hour to be scheduled, exceeding our target PR testing time of 30 minutes.
Setting priorities like this should be done very rarely, and only in cases where we know the change won't have negative impacts on other projects getting their tasks scheduled. Since compilation finishes in 2 minutes and potentially improves testing time by 30 minutes this change is considered acceptable.