### PR TITLE
WT-14172 Compile many-collections-test with --config=opt

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -224,7 +224,7 @@ functions:
         echo "startup --output_user_root=${workdir}/bazel-output-root" >> ~/.bazelrc
         echo "BAZELISK_HOME=${workdir}/bazelisk_home" >> ~/.bazeliskrc
 
-        bazel build --mongo_toolchain_version=v4 --build_enterprise=False install-mongod
+        bazel build --mongo_toolchain_version=v4 --config=opt --build_enterprise=False install-mongod
   "configure wiredtiger": &configure_wiredtiger
     command: shell.exec
     params:


### PR DESCRIPTION
When migrating from mongo's old scons buildscripts to bazel the optimization level changed, causing large drops in our many-collections performance tests. Compile mongo using the optimized profile to return us to our original performance numbers.