### PR TITLE
SLS-1364 Don't run tests that use unsupported stats with disagg hook.

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -21,6 +21,7 @@ test_cc02.py # times out
 test_cc03.py
 test_cc04.py # times out
 test_cc05.py # times out
+test_cc06.py # uses statistics we don't support in disagg
 test_checkpoint01.py
 test_checkpoint02.py # times out
 test_checkpoint07.py


### PR DESCRIPTION
Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
