### PR TITLE
WT-14186 Update compat script to remove BACKUP.copy before copying again.

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -7,6 +7,22 @@ set -e
 set -x
 
 #############################################################
+# bcopy:
+#       arg1: branch name
+#############################################################
+bcopy()
+{
+    # Return true if the branch's format backup generates a BACKUP.copy directory.
+    test "$1" = "mongodb-8.0" && return 1
+    test "$1" = "mongodb-7.0" && return 1
+    test "$1" = "mongodb-6.0" && return 1
+    test "$1" = "mongodb-5.0" && return 1
+    test "$1" = "mongodb-4.4" && return 1
+    # Anything newer than mongodb-8.0 returns false.
+    return 0
+}
+
+#############################################################
 # bflag:
 #       arg1: branch name
 #############################################################
@@ -489,8 +505,15 @@ upgrade_downgrade()
 	    # directory if BACKUP exists. After 8.0 the directory structure
 	    # changed. So copy it for older releases if testing against a
 	    # develop run that is doing backups.
+            need_bcopy1=$(bcopy $1)
+            need_bcopy2=$(bcopy $2)
 	    dir2=$top/$format_dir_branch2/RUNDIR.$am
-	    if [ -e $dir2/BACKUP -a ! -e $dir2/BACKUP.copy ] ; then
+	    # If there is a BACKUP and the older release needs a BACKUP.copy directory and
+	    # the source version does not create one, remove any from an earlier run and
+	    # copy the BACKUP contents for this run.
+	    if [ -e $dir2/BACKUP -a "$need_bcopy1" == "1" -a "$need_bcopy2" == "0" ] ; then
+                echo "Remove any earlier $dir2/BACKUP.copy for older releases"
+		rm -rf $dir2/BACKUP.copy
                 echo "Copying backup directory for older releases"
 		cp -rp $dir2/BACKUP $dir2/BACKUP.copy
 	    fi

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -13,11 +13,11 @@ set -x
 bcopy()
 {
     # Return true if the branch's format backup generates a BACKUP.copy directory.
-    test "$1" = "mongodb-8.0" && return 1
-    test "$1" = "mongodb-7.0" && return 1
-    test "$1" = "mongodb-6.0" && return 1
-    test "$1" = "mongodb-5.0" && return 1
-    test "$1" = "mongodb-4.4" && return 1
+    test "$1" = "mongodb-8.0" && echo "1"
+    test "$1" = "mongodb-7.0" && echo "1"
+    test "$1" = "mongodb-6.0" && echo "1"
+    test "$1" = "mongodb-5.0" && echo "1"
+    test "$1" = "mongodb-4.4" && echo "1"
     # Anything newer than mongodb-8.0 returns false.
     return 0
 }
@@ -511,7 +511,7 @@ upgrade_downgrade()
 	    # If there is a BACKUP and the older release needs a BACKUP.copy directory and
 	    # the source version does not create one, remove any from an earlier run and
 	    # copy the BACKUP contents for this run.
-	    if [ -e $dir2/BACKUP -a "$need_bcopy1" == "1" -a "$need_bcopy2" == "0" ] ; then
+	    if [ -e $dir2/BACKUP -a "$need_bcopy1" == "1" -a -z "$need_bcopy2" ] ; then
                 echo "Remove any earlier $dir2/BACKUP.copy for older releases"
 		rm -rf $dir2/BACKUP.copy
                 echo "Copying backup directory for older releases"


### PR DESCRIPTION
Determine if the release needs copying in a generic way. Remove BACKUP.copy first and then recopy BACKUP in newer releases for older releases.
