### PR TITLE
SLS-414 Re-enable skipped WT python tests for disaggregated storage

### DIFF
--- a/test/suite/test_compact04.py
+++ b/test/suite/test_compact04.py
@@ -112,5 +112,4 @@ class test_compact04(wttest.WiredTigerTestCase):
             else:
                 self.pr(message + ' (FAILURE)')
                 num_failures += 1
-                self.skipTest('disaggregated storage broke compaction behavior')
                 self.assertLessEqual(num_failures, 2)

--- a/test/suite/test_prepare28.py
+++ b/test/suite/test_prepare28.py
@@ -41,7 +41,6 @@ class test_prepare28(wttest.WiredTigerTestCase):
     value3 = 'ccccc'
 
     def test_ignore_prepare(self):
-        self.skipTest('disaggregated storage broke prepared transaction behavior')
         self.session.create(self.uri, 'key_format=i,value_format=S')
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)

--- a/test/suite/test_truncate19.py
+++ b/test/suite/test_truncate19.py
@@ -100,7 +100,6 @@ class test_truncate19(wttest.WiredTigerTestCase):
             # Take a checkpoint.
             session2.checkpoint()
             # Ensure the datasize is smaller than 600M
-            self.skipTest('disaggregated storage broke testing for truncation of oplog')
             self.assertGreater(600000000, os.path.getsize("oplog.wt"))
             session3.rollback_transaction()
 


### PR DESCRIPTION
At one point several python tests, without disaggregated storage enabled, were failing on the disagg branch. Currently these tests are working. So this change re-enables them.
