### PR TITLE
WT-11271 Don't use transactions with bulk operations in schema_abort test

### DIFF
--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -232,11 +232,11 @@ test_bulk(THREAD_DATA *td)
     WT_DECL_RET;
     WT_SESSION *session;
 
-    testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
-
     /* Bulk operations are incompatible with transactions. */
     if (use_txn)
         return;
+
+    testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
 
     if ((ret = session->create(session, uri, config)) != 0)
         if (ret != EEXIST && ret != EBUSY)
@@ -265,6 +265,10 @@ test_bulk_unique(THREAD_DATA *td, uint64_t unique_id, int force)
     WT_SESSION *session;
     char dropconf[128], new_uri[64];
 
+    /* Bulk operations are incompatible with transactions. */
+    if (use_txn)
+        return;
+
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
 
     /*
@@ -272,10 +276,6 @@ test_bulk_unique(THREAD_DATA *td, uint64_t unique_id, int force)
      * ensures it to be unique.
      */
     testutil_snprintf(new_uri, sizeof(new_uri), "%s.%" PRIu64, uri, unique_id);
-
-    /* Bulk operations are incompatible with transactions. */
-    if (use_txn)
-        return;
 
     testutil_check(session->create(session, new_uri, config));
 

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -234,8 +234,9 @@ test_bulk(THREAD_DATA *td)
 
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
 
+    /* Bulk operations are incompatible with transactions. */
     if (use_txn)
-        testutil_die(ret, "test_bulk should not be used with transactions");
+        return;
 
     if ((ret = session->create(session, uri, config)) != 0)
         if (ret != EEXIST && ret != EBUSY)
@@ -272,8 +273,9 @@ test_bulk_unique(THREAD_DATA *td, uint64_t unique_id, int force)
      */
     testutil_snprintf(new_uri, sizeof(new_uri), "%s.%" PRIu64, uri, unique_id);
 
+    /* Bulk operations are incompatible with transactions. */
     if (use_txn)
-        testutil_die(ret, "test_bulk_unique should not be used with transactions");
+        return;
 
     testutil_check(session->create(session, new_uri, config));
 
@@ -778,13 +780,11 @@ thread_run(void *arg)
             switch (__wt_random(&td->data_rnd) % 20) {
             case 0:
                 WT_RELEASE_WRITE_WITH_BARRIER(th_ts[td->info].op, BULK);
-                if (!use_txn)
-                    test_bulk(td);
+                test_bulk(td);
                 break;
             case 1:
                 WT_RELEASE_WRITE_WITH_BARRIER(th_ts[td->info].op, BULK_UNQ);
-                if (!use_txn)
-                    test_bulk_unique(td, reserved_ts, __wt_random(&td->data_rnd) & 1);
+                test_bulk_unique(td, reserved_ts, __wt_random(&td->data_rnd) & 1);
                 break;
             case 2:
                 WT_RELEASE_WRITE_WITH_BARRIER(th_ts[td->info].op, CREATE);

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -231,20 +231,17 @@ test_bulk(THREAD_DATA *td)
     WT_CURSOR *c;
     WT_DECL_RET;
     WT_SESSION *session;
-    bool create;
 
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
 
     if (use_txn)
         testutil_die(ret, "test_bulk should not be used with transactions");
 
-    create = false;
     if ((ret = session->create(session, uri, config)) != 0)
         if (ret != EEXIST && ret != EBUSY)
             testutil_die(ret, "session.create");
 
     if (ret == 0) {
-        create = true;
         if ((ret = session->open_cursor(session, uri, NULL, "bulk", &c)) == 0) {
             __wt_yield();
             testutil_check(c->close(c));

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -778,12 +778,12 @@ thread_run(void *arg)
             switch (__wt_random(&td->data_rnd) % 20) {
             case 0:
                 WT_RELEASE_WRITE_WITH_BARRIER(th_ts[td->info].op, BULK);
-                if(!use_txn)
+                if (!use_txn)
                     test_bulk(td);
                 break;
             case 1:
                 WT_RELEASE_WRITE_WITH_BARRIER(th_ts[td->info].op, BULK_UNQ);
-                if(!use_txn)
+                if (!use_txn)
                     test_bulk_unique(td, reserved_ts, __wt_random(&td->data_rnd) & 1);
                 break;
             case 2:


### PR DESCRIPTION
Bulk operations should not be used inside transactions. Update schema_abort to avoid trying bulk operations when transactions are enabled.