### PR TITLE
WT-14191 Add counter to track total uncommitted updates size

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -274,6 +274,7 @@ conn_stats = [
     CacheStat('cache_bytes_max', 'maximum bytes configured', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_other', 'bytes not belonging to page images in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_updates', 'bytes allocated for updates', 'no_clear,no_scale,size'),
+    CacheStat('cache_bytes_updates_txn_uncommitted', 'bytes allocated for updates in uncommitted transactions', 'no_clear,no_scale,size'),
     CacheStat('cache_hazard_checks', 'hazard pointer check calls'),
     CacheStat('cache_hazard_max', 'hazard pointer maximum array length', 'max_aggregate,no_scale'),
     CacheStat('cache_hazard_walks', 'hazard pointer check entries walked'),
@@ -1181,6 +1182,6 @@ session_stats = [
     SessionStat('lock_dhandle_wait', 'dhandle lock wait time (usecs)'),
     SessionStat('lock_schema_wait', 'schema lock wait time (usecs)'),
     SessionStat('read_time', 'page read from disk to cache time (usecs)'),
-    SessionStat('txn_bytes_dirty', 'dirty bytes in this txn'),
+    SessionStat('txn_bytes_dirty', 'dirty bytes in this txn', 'no_clear,no_scale,size'),
     SessionStat('write_time', 'page write from cache to disk time (usecs)'),
 ]

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -285,7 +285,7 @@ conn_stats = [
     CacheStat('cache_read_app_count', 'application threads page read from disk to cache count'),
     CacheStat('cache_read_app_time', 'application threads page read from disk to cache time (usecs)'),
     CacheStat('cache_updates_txn_uncommitted_bytes', 'updates in uncommitted txn - bytes', 'no_clear,no_scale,size'),
-    CacheStat('cache_updates_txn_uncommitted_n', 'updates in uncommitted txn - count', 'no_clear,no_scale,size'),
+    CacheStat('cache_updates_txn_uncommitted_count', 'updates in uncommitted txn - count', 'no_clear,no_scale,size'),
     CacheStat('cache_write_app_count', 'application threads page write from cache to disk count'),
     CacheStat('cache_write_app_time', 'application threads page write from cache to disk time (usecs)'),
     CacheStat('npos_evict_walk_max', 'eviction walk restored - had to walk this many pages', 'max_aggregate,no_scale'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -274,7 +274,6 @@ conn_stats = [
     CacheStat('cache_bytes_max', 'maximum bytes configured', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_other', 'bytes not belonging to page images in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_updates', 'bytes allocated for updates', 'no_clear,no_scale,size'),
-    CacheStat('cache_bytes_updates_txn_uncommitted', 'bytes allocated for updates in uncommitted transactions', 'no_clear,no_scale,size'),
     CacheStat('cache_hazard_checks', 'hazard pointer check calls'),
     CacheStat('cache_hazard_max', 'hazard pointer maximum array length', 'max_aggregate,no_scale'),
     CacheStat('cache_hazard_walks', 'hazard pointer check entries walked'),
@@ -285,6 +284,8 @@ conn_stats = [
     CacheStat('cache_pages_inuse', 'pages currently held in the cache', 'no_clear,no_scale'),
     CacheStat('cache_read_app_count', 'application threads page read from disk to cache count'),
     CacheStat('cache_read_app_time', 'application threads page read from disk to cache time (usecs)'),
+    CacheStat('cache_updates_txn_uncommitted_bytes', 'updates in uncommitted txn - bytes', 'no_clear,no_scale,size'),
+    CacheStat('cache_updates_txn_uncommitted_n', 'updates in uncommitted txn - count', 'no_clear,no_scale,size'),
     CacheStat('cache_write_app_count', 'application threads page write from cache to disk count'),
     CacheStat('cache_write_app_time', 'application threads page write from cache to disk time (usecs)'),
     CacheStat('npos_evict_walk_max', 'eviction walk restored - had to walk this many pages', 'max_aggregate,no_scale'),
@@ -1183,5 +1184,6 @@ session_stats = [
     SessionStat('lock_schema_wait', 'schema lock wait time (usecs)'),
     SessionStat('read_time', 'page read from disk to cache time (usecs)'),
     SessionStat('txn_bytes_dirty', 'dirty bytes in this txn', 'no_clear,no_scale,size'),
+    SessionStat('txn_updates', 'number of updates in this txn', 'no_clear,no_scale,size'),
     SessionStat('write_time', 'page write from cache to disk time (usecs)'),
 ]

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -616,7 +616,7 @@ __instantiate_row(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE_DELETED *page_d
         WT_ASSERT(session, WT_ROW_INSERT(page, rip) == NULL);
     }
 
-    __wt_cache_page_inmem_incr(session, page, total_size);
+    __wt_cache_page_inmem_incr(session, page, total_size, false);
 
     /*
      * Note that the label is required by the alloc-and-swap macro. There isn't anything we need to

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -110,7 +110,7 @@ err:
     }
 
     /* Increment the cache statistics. */
-    __wt_cache_page_inmem_incr(session, page, size);
+    __wt_cache_page_inmem_incr(session, page, size, false);
     (void)__wt_atomic_add64(&S2C(session)->cache->pages_inmem, 1);
     page->cache_create_gen = __wt_atomic_load64(&S2C(session)->evict->evict_pass_gen);
 
@@ -317,7 +317,7 @@ __wti_page_inmem_prepare(WT_SESSION_IMPL *session, WT_REF *ref)
      * updates to avoid reconciling the page every time.
      */
     __wt_page_modify_clear(session, page);
-    __wt_cache_page_inmem_incr(session, page, total_size);
+    __wt_cache_page_inmem_incr(session, page, total_size, false);
 
     if (0) {
 err:
@@ -444,7 +444,7 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     }
 
     /* Update the page's cache statistics. */
-    __wt_cache_page_inmem_incr(session, page, size);
+    __wt_cache_page_inmem_incr(session, page, size, false);
 
     if (LF_ISSET(WT_PAGE_DISK_ALLOC))
         __wt_cache_page_image_incr(session, page);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -493,7 +493,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
         for (child_refp = child_pindex->index, j = 0; j < slots; ++child_refp, ++root_refp, ++j)
             WT_ERR(__split_ref_move(session, root, root_refp, &root_decr, child_refp, &child_incr));
 
-        __wt_cache_page_inmem_incr(session, child, child_incr);
+        __wt_cache_page_inmem_incr(session, child, child_incr, false);
     }
     WT_ASSERT(session, alloc_refp - alloc_index->index == (ptrdiff_t)alloc_index->entries);
     WT_ASSERT(session, root_refp - pindex->index == (ptrdiff_t)pindex->entries);
@@ -558,7 +558,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
     root_decr += size;
 
     /* Adjust the root's memory footprint. */
-    __wt_cache_page_inmem_incr(session, root, root_incr);
+    __wt_cache_page_inmem_incr(session, root, root_incr, false);
     __wt_cache_page_inmem_decr(session, root, root_decr);
 
     WT_STAT_CONN_DSRC_INCR(session, cache_eviction_deepen);
@@ -856,7 +856,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     parent_decr += size;
 
     /* Adjust the parent's memory footprint. */
-    __wt_cache_page_inmem_incr(session, parent, parent_incr);
+    __wt_cache_page_inmem_incr(session, parent, parent_incr, false);
     __wt_cache_page_inmem_decr(session, parent, parent_decr);
 
     /*
@@ -1040,7 +1040,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
         for (child_refp = child_pindex->index, j = 0; j < slots; ++child_refp, ++page_refp, ++j)
             WT_ERR(__split_ref_move(session, page, page_refp, &page_decr, child_refp, &child_incr));
 
-        __wt_cache_page_inmem_incr(session, child, child_incr);
+        __wt_cache_page_inmem_incr(session, child, child_incr, false);
     }
     WT_ASSERT(session, alloc_refp - alloc_index->index == (ptrdiff_t)alloc_index->entries);
     WT_ASSERT(session, page_refp - pindex->index == (ptrdiff_t)pindex->entries);
@@ -1113,7 +1113,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
     page_decr += size;
 
     /* Adjust the page's memory footprint. */
-    __wt_cache_page_inmem_incr(session, page, page_incr);
+    __wt_cache_page_inmem_incr(session, page, page_incr, false);
     __wt_cache_page_inmem_decr(session, page, page_decr);
 
     WT_STAT_CONN_DSRC_INCR(session, cache_eviction_split_internal);
@@ -1987,7 +1987,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
      * Update the page accounting.
      */
     __wt_cache_page_inmem_decr(session, page, page_decr);
-    __wt_cache_page_inmem_incr(session, right, right_incr);
+    __wt_cache_page_inmem_incr(session, right, right_incr, false);
 
     /*
      * The act of splitting into the parent releases the pages for eviction; ensure the page
@@ -2031,7 +2031,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     ins_head->tail[0] = moved_ins;
 
     /* Fix up accounting for the page size. */
-    __wt_cache_page_inmem_incr(session, page, page_decr);
+    __wt_cache_page_inmem_incr(session, page, page_decr, false);
 
 err:
     if (split_ref[0] != NULL) {

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -350,7 +350,7 @@ next:
          * on failure, free the allocated memory.
          */
         if (__wt_atomic_cas_ptr((void *)&WT_ROW_KEY_COPY(rip), copy, ikey))
-            __wt_cache_page_inmem_incr(session, page, sizeof(WT_IKEY) + ikey->size);
+            __wt_cache_page_inmem_incr(session, page, sizeof(WT_IKEY) + ikey->size, false);
         else
             __wt_free(session, ikey);
     }
@@ -390,7 +390,7 @@ __wti_row_ikey_incr(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t cell_offse
 {
     WT_RET(__wti_row_ikey(session, cell_offset, key, size, ref));
 
-    __wt_cache_page_inmem_incr(session, page, sizeof(WT_IKEY) + size);
+    __wt_cache_page_inmem_incr(session, page, sizeof(WT_IKEY) + size, false);
 
     return (0);
 }

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -29,7 +29,7 @@ __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
      * another thread did the work.
      */
     if (__wt_atomic_cas_ptr(&page->modify, NULL, modify))
-        __wt_cache_page_inmem_incr(session, page, sizeof(*modify));
+        __wt_cache_page_inmem_incr(session, page, sizeof(*modify), false);
     else
 err:
         __wt_free(session, modify);

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1653,15 +1653,15 @@ struct __wt_insert {
 /*
  * Atomically allocate and swap a structure or array into place.
  */
-#define WT_PAGE_ALLOC_AND_SWAP(s, page, dest, v, count)                      \
-    do {                                                                     \
-        if (((v) = (dest)) == NULL) {                                        \
-            WT_ERR(__wt_calloc_def(s, count, &(v)));                         \
-            if (__wt_atomic_cas_ptr(&(dest), NULL, v))                       \
-                __wt_cache_page_inmem_incr(s, page, (count) * sizeof(*(v))); \
-            else                                                             \
-                __wt_free(s, v);                                             \
-        }                                                                    \
+#define WT_PAGE_ALLOC_AND_SWAP(s, page, dest, v, count)                             \
+    do {                                                                            \
+        if (((v) = (dest)) == NULL) {                                               \
+            WT_ERR(__wt_calloc_def(s, count, &(v)));                                \
+            if (__wt_atomic_cas_ptr(&(dest), NULL, v))                              \
+                __wt_cache_page_inmem_incr(s, page, (count) * sizeof(*(v)), false); \
+            else                                                                    \
+                __wt_free(s, v);                                                    \
+        }                                                                           \
     } while (0)
 
 /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -270,7 +270,7 @@ __wt_btree_bytes_updates(WT_SESSION_IMPL *session)
  *     Increment a page's memory footprint in the cache.
  */
 static WT_INLINE void
-__wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
+__wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size, bool new_update)
 {
     WT_BTREE *btree;
     WT_CACHE *cache;
@@ -295,16 +295,7 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
     (void)__wt_atomic_addsize(&page->memory_footprint, size);
 
     if (page->modify != NULL) {
-        /*
-         * For application threads, track the transaction bytes added to cache usage. We want to
-         * capture only the application's own changes to page data structures. Exclude changes to
-         * internal pages or changes that are the result of the application thread being co-opted
-         * into eviction work.
-         */
-        if (!F_ISSET(session, WT_SESSION_INTERNAL) &&
-          F_ISSET(session->txn, WT_TXN_RUNNING | WT_TXN_HAS_ID) &&
-          __wt_session_gen(session, WT_GEN_EVICT) == 0)
-            __txn_incr_bytes_dirty(session, size);
+        __txn_incr_bytes_dirty(session, size, new_update);
         if (!WT_PAGE_IS_INTERNAL(page)) {
             (void)__wt_atomic_add64(&cache->bytes_updates, size);
             (void)__wt_atomic_add64(&btree->bytes_updates, size);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -304,7 +304,7 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
         if (!F_ISSET(session, WT_SESSION_INTERNAL) &&
           F_ISSET(session->txn, WT_TXN_RUNNING | WT_TXN_HAS_ID) &&
           __wt_session_gen(session, WT_GEN_EVICT) == 0)
-            WT_STAT_SESSION_INCRV(session, txn_bytes_dirty, size);
+            __txn_incr_bytes_dirty(session, size);
         if (!WT_PAGE_IS_INTERNAL(page)) {
             (void)__wt_atomic_add64(&cache->bytes_updates, size);
             (void)__wt_atomic_add64(&btree->bytes_updates, size);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2085,7 +2085,7 @@ static WT_INLINE void __wt_cache_page_image_incr(WT_SESSION_IMPL *session, WT_PA
 static WT_INLINE void __wt_cache_page_inmem_decr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
 static WT_INLINE void __wt_cache_page_inmem_incr(
-  WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
+  WT_SESSION_IMPL *session, WT_PAGE *page, size_t size, bool new_update);
 static WT_INLINE void __wt_cell_get_ta(WT_CELL_UNPACK_ADDR *unpack_addr, WT_TIME_AGGREGATE **tap);
 static WT_INLINE void __wt_cell_get_tw(WT_CELL_UNPACK_KV *unpack_value, WT_TIME_WINDOW **twp);
 static WT_INLINE void __wt_cell_type_reset(

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -178,7 +178,7 @@ __wt_col_append_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT_HEAD *
      * we added cannot be discarded while visible to any running transaction, and we're a running
      * transaction, which means there can be no corresponding delete until we complete.
      */
-    __wt_cache_page_inmem_incr(session, page, new_ins_size);
+    __wt_cache_page_inmem_incr(session, page, new_ins_size, true);
 
     /* Mark the page dirty after updating the footprint. */
     __wt_page_modify_set(session, page);
@@ -230,7 +230,7 @@ __wt_insert_serial(WT_SESSION_IMPL *session, WT_PAGE *page, WT_INSERT_HEAD *ins_
      * we added cannot be discarded while visible to any running transaction, and we're a running
      * transaction, which means there can be no corresponding delete until we complete.
      */
-    __wt_cache_page_inmem_incr(session, page, new_ins_size);
+    __wt_cache_page_inmem_incr(session, page, new_ins_size, true);
 
     /* Mark the page dirty after updating the footprint. */
     __wt_page_modify_set(session, page);
@@ -281,7 +281,7 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_PAGE *page
      * structures we added cannot be discarded while visible to any running transaction, and we're a
      * running transaction, which means there can be no corresponding delete until we complete.
      */
-    __wt_cache_page_inmem_incr(session, page, upd_size);
+    __wt_cache_page_inmem_incr(session, page, upd_size, true);
 
     /* Mark the page dirty after updating the footprint. */
     __wt_page_modify_set(session, page);

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -230,12 +230,16 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
     WT_STAT_DECRV_BASE(session, S2C(session)->stats[(session)->stat_conn_bucket], fld, value)
 #define WT_STAT_CONN_DECR_ATOMIC(session, fld) \
     WT_STAT_DECRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_conn_bucket], fld, 1)
+#define WT_STAT_CONN_DECRV_ATOMIC(session, fld, value) \
+    WT_STAT_DECRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_conn_bucket], fld, value)
 #define WT_STAT_CONN_DECR(session, fld) WT_STAT_CONN_DECRV(session, fld, 1)
 
 #define WT_STAT_CONN_INCRV(session, fld, value) \
     WT_STAT_INCRV_BASE(session, S2C(session)->stats[(session)->stat_conn_bucket], fld, value)
 #define WT_STAT_CONN_INCR_ATOMIC(session, fld) \
     WT_STAT_INCRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_conn_bucket], fld, 1)
+#define WT_STAT_CONN_INCRV_ATOMIC(session, fld, value) \
+    WT_STAT_INCRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_conn_bucket], fld, value)
 #define WT_STAT_CONN_INCR(session, fld) WT_STAT_CONN_INCRV(session, fld, 1)
 
 #define WT_STATP_CONN_SET(session, stats, fld, value)                           \

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -185,6 +185,7 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
     __wt_stats_aggregate_conn(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld))
 #define WT_STAT_DSRC_READ(stats, fld) \
     __wt_stats_aggregate_dsrc(stats, WT_STATS_FIELD_TO_OFFSET(stats, fld))
+#define WT_STAT_SESSION_READ(stats, fld) ((stats)->fld)
 #define WT_STAT_WRITE(session, stats, fld, v) \
     do {                                      \
         if (WT_STAT_ENABLED(session))         \
@@ -487,6 +488,7 @@ struct __wt_connection_stats {
     int64_t cache_write_app_count;
     int64_t cache_write_app_time;
     int64_t cache_bytes_updates;
+    int64_t cache_bytes_updates_txn_uncommitted;
     int64_t cache_bytes_image;
     int64_t cache_bytes_hs;
     int64_t cache_bytes_inuse;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -488,7 +488,6 @@ struct __wt_connection_stats {
     int64_t cache_write_app_count;
     int64_t cache_write_app_time;
     int64_t cache_bytes_updates;
-    int64_t cache_bytes_updates_txn_uncommitted;
     int64_t cache_bytes_image;
     int64_t cache_bytes_hs;
     int64_t cache_bytes_inuse;
@@ -655,6 +654,8 @@ struct __wt_connection_stats {
     int64_t cache_pages_dirty;
     int64_t cache_eviction_blocked_uncommitted_truncate;
     int64_t cache_eviction_clean;
+    int64_t cache_updates_txn_uncommitted_bytes;
+    int64_t cache_updates_txn_uncommitted_n;
     int64_t fsync_all_fh_total;
     int64_t fsync_all_fh;
     int64_t fsync_all_time;
@@ -1435,6 +1436,7 @@ struct __wt_session_stats {
     int64_t bytes_write;
     int64_t lock_dhandle_wait;
     int64_t txn_bytes_dirty;
+    int64_t txn_updates;
     int64_t read_time;
     int64_t write_time;
     int64_t lock_schema_wait;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -655,7 +655,7 @@ struct __wt_connection_stats {
     int64_t cache_eviction_blocked_uncommitted_truncate;
     int64_t cache_eviction_clean;
     int64_t cache_updates_txn_uncommitted_bytes;
-    int64_t cache_updates_txn_uncommitted_n;
+    int64_t cache_updates_txn_uncommitted_count;
     int64_t fsync_all_fh_total;
     int64_t fsync_all_fh;
     int64_t fsync_all_time;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1624,16 +1624,16 @@ retry:
  *     being moved). (2) Exclusively belongs to the current transaction.
  *
  * There are two types of "dirty" data in the system for the purpose of this function: (1) Dirty
- *     data associated with a specific transaction. (2) Dirty data that isn’t tied to a single
+ *     data associated with a specific transaction. (2) Dirty data that isn't tied to a single
  *     transaction (e.g., a page with updates from multiple transactions).
  *
  * Examples:
  *
  * 1. A page can be dirty with multiple updates, each belonging to different transactions. In this
- *     case: (a) The updates are tied to specific transactions. (b) The page itself isn’t
+ *     case: (a) The updates are tied to specific transactions. (b) The page itself isn't
  *     exclusively tied to any one transaction.
  *
- * 2. During a page split, updates move between pages. However, this movement doesn’t create new
+ * 2. During a page split, updates move between pages. However, this movement doesn't create new
  *     dirty data, so the "new_update" flag would be set to false.
  */
 static void

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1682,8 +1682,6 @@ __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
 
     WT_ASSERT(session, !F_ISSET(txn, WT_TXN_RUNNING));
 
-    __txn_clear_bytes_dirty(session);
-
     WT_RET(__wt_txn_config(session, conf));
 
     /*
@@ -1711,6 +1709,8 @@ __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
 
     WT_ASSERT_ALWAYS(
       session, txn->mod_count == 0, "The mod count should be 0 when beginning a transaction");
+
+    __txn_clear_bytes_dirty(session);
 
     return (0);
 }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1623,8 +1623,10 @@ retry:
 static void
 __txn_incr_bytes_dirty(WT_SESSION_IMPL *session, size_t size)
 {
-    WT_STAT_CONN_INCRV(session, cache_bytes_updates_txn_uncommitted, (int64_t)size);
+    WT_STAT_CONN_INCRV(session, cache_updates_txn_uncommitted_bytes, (int64_t)size);
+    WT_STAT_CONN_INCRV(session, cache_updates_txn_uncommitted_n, 1);
     WT_STAT_SESSION_INCRV(session, txn_bytes_dirty, (int64_t)size);
+    WT_STAT_SESSION_INCRV(session, txn_updates, 1);
 }
 
 /*
@@ -1634,10 +1636,18 @@ __txn_incr_bytes_dirty(WT_SESSION_IMPL *session, size_t size)
 static void
 __txn_clear_bytes_dirty(WT_SESSION_IMPL *session)
 {
-    int64_t txn_bytes_dirty = WT_STAT_SESSION_READ(&(session)->stats, txn_bytes_dirty);
-    if (txn_bytes_dirty != 0) {
-        WT_STAT_CONN_DECRV(session, cache_bytes_updates_txn_uncommitted, txn_bytes_dirty);
+    int64_t val;
+
+    val = WT_STAT_SESSION_READ(&(session)->stats, txn_bytes_dirty);
+    if (val != 0) {
+        WT_STAT_CONN_DECRV(session, cache_updates_txn_uncommitted_bytes, val);
         WT_STAT_SESSION_SET(session, txn_bytes_dirty, 0);
+    }
+
+    val = WT_STAT_SESSION_READ(&(session)->stats, txn_updates);
+    if (val != 0) {
+        WT_STAT_CONN_DECRV(session, cache_updates_txn_uncommitted_n, val);
+        WT_STAT_SESSION_SET(session, txn_updates, 0);
     }
 }
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1624,7 +1624,7 @@ static void
 __txn_incr_bytes_dirty(WT_SESSION_IMPL *session, size_t size)
 {
     WT_STAT_CONN_INCRV(session, cache_updates_txn_uncommitted_bytes, (int64_t)size);
-    WT_STAT_CONN_INCRV(session, cache_updates_txn_uncommitted_n, 1);
+    WT_STAT_CONN_INCRV(session, cache_updates_txn_uncommitted_count, 1);
     WT_STAT_SESSION_INCRV(session, txn_bytes_dirty, (int64_t)size);
     WT_STAT_SESSION_INCRV(session, txn_updates, 1);
 }
@@ -1646,7 +1646,7 @@ __txn_clear_bytes_dirty(WT_SESSION_IMPL *session)
 
     val = WT_STAT_SESSION_READ(&(session)->stats, txn_updates);
     if (val != 0) {
-        WT_STAT_CONN_DECRV(session, cache_updates_txn_uncommitted_n, val);
+        WT_STAT_CONN_DECRV(session, cache_updates_txn_uncommitted_count, val);
         WT_STAT_SESSION_SET(session, txn_updates, 0);
     }
 }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1620,8 +1620,21 @@ retry:
  * __txn_incr_bytes_dirty --
  *     Increment the number of bytes dirty in the transaction.
  *
- * The "new_update" flag indicates whether the associated data will be released when the transaction
- *     is committed or rolled back.
+ * The "new_update" argument indicates whether a piece of data is: (1) Newly created (not just data
+ *     being moved). (2) Exclusively belongs to the current transaction.
+ *
+ * There are two types of "dirty" data in the system for the purpose of this function: (1) Dirty
+ *     data associated with a specific transaction. (2) Dirty data that isn’t tied to a single
+ *     transaction (e.g., a page with updates from multiple transactions).
+ *
+ * Examples:
+ *
+ * 1. A page can be dirty with multiple updates, each belonging to different transactions. In this
+ *     case: (a) The updates are tied to specific transactions. (b) The page itself isn’t
+ *     exclusively tied to any one transaction.
+ *
+ * 2. During a page split, updates move between pages. However, this movement doesn’t create new
+ *     dirty data, so the "new_update" flag would be set to false.
  */
 static void
 __txn_incr_bytes_dirty(WT_SESSION_IMPL *session, size_t size, bool new_update)

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5574,1597 +5574,1599 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1073
 /*! cache: bytes allocated for updates */
 #define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1074
-/*! cache: bytes allocated for updates in uncommitted transactions */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_TXN_UNCOMMITTED	1075
 /*! cache: bytes belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1076
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1075
 /*! cache: bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS			1077
+#define	WT_STAT_CONN_CACHE_BYTES_HS			1076
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1078
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1077
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1079
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1078
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1080
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1079
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1081
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1080
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1082
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1081
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1083
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1082
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1084
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1083
 /*! cache: evict page attempts by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1085
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1084
 /*! cache: evict page attempts by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1086
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1085
 /*! cache: evict page failures by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1087
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1086
 /*! cache: evict page failures by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1088
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1087
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1089
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1088
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1090
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1089
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1091
+#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1090
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1092
+#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1091
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1093
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1092
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1094
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1093
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1095
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1094
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1096
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1095
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1097
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1096
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1098
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1097
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1099
+#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1098
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1100
+#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1099
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1101
+#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1100
 /*! cache: eviction server skips dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1102
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1101
 /*! cache: eviction server skips internal pages as it has an active child. */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1103
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1102
 /*! cache: eviction server skips metadata pages with history */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1104
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1103
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1105
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1104
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1106
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1105
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1107
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1106
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1108
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1107
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1109
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1108
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1110
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1109
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1111
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1110
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1112
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1111
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1113
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1112
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1114
+#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1113
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_EVICTION_SLOW			1115
+#define	WT_STAT_CONN_EVICTION_SLOW			1114
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1116
+#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1115
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1117
+#define	WT_STAT_CONN_EVICTION_STATE			1116
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1118
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1117
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1119
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1118
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1120
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1119
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1121
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1120
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1122
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1121
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1123
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1122
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1124
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1123
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1124
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1126
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1125
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1127
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1126
 /*! cache: eviction walk target strategy both clean and dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1128
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1127
 /*! cache: eviction walk target strategy only clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1129
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1128
 /*! cache: eviction walk target strategy only dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1130
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1129
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1131
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1130
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1132
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1131
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1133
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1132
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1134
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1133
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1135
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1134
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1136
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1135
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1137
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1136
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1138
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1137
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1139
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1138
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1140
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1139
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1141
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1140
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1142
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1141
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1143
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1142
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1144
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1143
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1145
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1144
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1146
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1145
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1147
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1146
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1148
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1147
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1149
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1148
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1150
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1149
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1151
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1150
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1152
+#define	WT_STAT_CONN_EVICTION_FORCE			1151
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1153
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1152
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1154
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1153
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1155
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1154
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1156
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1155
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1157
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1156
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1158
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1157
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1159
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1158
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1160
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1159
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1161
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1160
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1162
+#define	WT_STAT_CONN_CACHE_HS_READ			1161
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1163
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1162
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1164
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1163
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1165
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1164
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1166
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1165
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1167
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1166
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1168
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1167
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1169
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1168
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1170
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1169
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1171
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1170
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1172
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1171
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1173
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1172
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1174
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1173
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1175
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1174
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1176
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1175
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1177
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1176
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1178
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1177
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1179
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1178
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1180
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1179
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1181
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1180
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1182
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1181
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1183
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1182
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1184
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1183
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1185
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1184
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1186
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1185
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1187
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1186
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1188
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1187
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1189
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1188
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1190
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1189
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1191
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1190
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1192
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1191
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1193
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1192
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1194
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1193
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1195
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1194
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1196
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1195
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1197
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1196
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1198
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1197
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1199
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1198
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1200
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1199
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1201
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1200
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1202
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1201
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1203
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1202
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1204
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1203
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1205
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1204
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1206
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1205
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1207
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1206
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1208
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1207
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1209
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1208
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1210
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1209
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1211
+#define	WT_STAT_CONN_CACHE_READ				1210
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1212
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1211
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1213
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1212
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1214
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1213
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1215
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1214
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1216
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1215
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1217
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1216
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1218
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1217
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1219
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1218
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1220
+#define	WT_STAT_CONN_EVICTION_FAIL			1219
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1221
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1220
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1222
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1221
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1223
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1222
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1224
+#define	WT_STAT_CONN_EVICTION_WALK			1223
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1225
+#define	WT_STAT_CONN_CACHE_WRITE			1224
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1226
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1225
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1227
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1226
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1228
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1227
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1229
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1228
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1230
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1229
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1231
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1230
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1232
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1231
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1233
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1232
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1234
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1233
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1235
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1234
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1236
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1235
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1237
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1236
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1238
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1237
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1239
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1238
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1240
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1239
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1241
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1240
+/*! cache: updates in uncommitted txn - bytes */
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1241
+/*! cache: updates in uncommitted txn - count */
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_N	1242
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1242
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1243
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1243
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1244
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1244
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1245
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1245
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1246
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1246
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1247
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1247
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1248
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1248
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1249
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1249
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1250
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1250
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1251
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1251
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1252
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1252
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1253
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1253
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1254
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1254
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1255
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1255
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1256
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1256
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1257
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1257
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1258
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1258
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1259
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1259
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1260
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1260
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1261
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1261
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1262
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1262
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1263
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1263
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1264
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1264
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1265
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1265
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1266
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1266
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1267
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1267
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1268
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1268
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1269
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1269
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1270
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1270
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1271
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1271
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1272
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1272
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1273
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1273
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1274
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1274
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1275
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1275
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1276
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1276
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1277
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1277
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1278
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1278
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1279
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1279
+#define	WT_STAT_CONN_CHECKPOINTS_API			1280
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1280
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1281
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1281
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1282
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1282
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1283
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1283
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1284
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1284
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1285
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1285
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1286
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1286
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1287
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1287
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1288
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1288
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1289
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1289
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1290
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1290
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1291
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1291
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1292
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1292
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1293
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1293
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1294
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1294
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1295
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1295
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1296
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1296
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1297
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1297
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1298
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1298
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1299
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1299
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1300
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1300
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1301
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1301
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1302
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1302
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1303
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1303
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1304
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1304
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1305
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1305
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1306
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1306
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1307
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1307
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1308
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1308
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1309
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1309
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1310
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1310
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1311
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1311
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1312
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1312
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1313
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1313
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1314
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1314
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1315
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1315
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1316
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1316
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1317
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1317
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1318
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1318
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1319
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1319
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1320
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1320
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1321
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1321
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1322
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1322
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1323
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1323
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1324
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1324
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1325
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1325
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1326
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1326
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1327
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1327
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1328
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1328
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1329
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1329
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1330
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1330
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1331
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1331
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1332
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1332
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1333
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1333
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1334
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1334
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1335
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1335
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1336
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1336
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1337
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1337
+#define	WT_STAT_CONN_TIME_TRAVEL			1338
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1338
+#define	WT_STAT_CONN_FILE_OPEN				1339
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1339
+#define	WT_STAT_CONN_BUCKETS_DH				1340
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1340
+#define	WT_STAT_CONN_BUCKETS				1341
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1341
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1342
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1342
+#define	WT_STAT_CONN_MEMORY_FREE			1343
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1343
+#define	WT_STAT_CONN_MEMORY_GROW			1344
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1344
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1345
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1345
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1346
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1346
+#define	WT_STAT_CONN_COND_WAIT				1347
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1347
+#define	WT_STAT_CONN_RWLOCK_READ			1348
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1348
+#define	WT_STAT_CONN_RWLOCK_WRITE			1349
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1349
+#define	WT_STAT_CONN_FSYNC_IO				1350
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1350
+#define	WT_STAT_CONN_READ_IO				1351
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1351
+#define	WT_STAT_CONN_WRITE_IO				1352
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1352
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1353
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1353
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1354
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1354
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1355
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1355
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1356
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1356
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1357
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1357
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1358
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1358
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1359
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1359
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1360
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1360
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1361
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1361
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1362
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1362
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1363
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1363
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1364
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1364
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1365
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1365
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1366
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1366
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1367
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1367
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1368
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1368
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1369
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1369
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1370
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1370
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1371
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1371
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1372
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1372
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1373
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1373
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1374
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1374
+#define	WT_STAT_CONN_CURSOR_CACHE			1375
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1375
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1376
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1376
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1377
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1377
+#define	WT_STAT_CONN_CURSOR_CREATE			1378
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1378
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1379
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1379
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1380
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1380
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1381
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1381
+#define	WT_STAT_CONN_CURSOR_INSERT			1382
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1382
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1383
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1383
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1384
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1384
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1385
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1385
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1386
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1386
+#define	WT_STAT_CONN_CURSOR_MODIFY			1387
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1387
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1388
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1388
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1389
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1389
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1390
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1390
+#define	WT_STAT_CONN_CURSOR_NEXT			1391
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1391
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1392
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1392
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1393
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1393
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1394
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1394
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1395
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1395
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1396
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1396
+#define	WT_STAT_CONN_CURSOR_RESTART			1397
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1397
+#define	WT_STAT_CONN_CURSOR_PREV			1398
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1398
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1399
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1399
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1400
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1400
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1401
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1401
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1402
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1402
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1403
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1403
+#define	WT_STAT_CONN_CURSOR_REMOVE			1404
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1404
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1405
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1405
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1406
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1406
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1407
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1407
+#define	WT_STAT_CONN_CURSOR_RESERVE			1408
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1408
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1409
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1409
+#define	WT_STAT_CONN_CURSOR_RESET			1410
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1410
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1411
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1411
+#define	WT_STAT_CONN_CURSOR_SEARCH			1412
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1412
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1413
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1413
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1414
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1414
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1415
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1415
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1416
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1416
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1417
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1417
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1418
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1418
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1419
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1419
+#define	WT_STAT_CONN_CURSOR_SWEEP			1420
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1420
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1421
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1421
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1422
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1422
+#define	WT_STAT_CONN_CURSOR_UPDATE			1423
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1423
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1424
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1424
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1425
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1425
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1426
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1426
+#define	WT_STAT_CONN_CURSOR_REOPEN			1427
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1427
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1428
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1428
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1429
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1429
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1430
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1430
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1431
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1431
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1432
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1432
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1433
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1433
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1434
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1434
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1435
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1435
+#define	WT_STAT_CONN_DH_SWEEP_REF			1436
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1436
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1437
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1437
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1438
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1438
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1439
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1439
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1440
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1440
+#define	WT_STAT_CONN_DH_SWEEPS				1441
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1441
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1442
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1442
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1443
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1443
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1444
 /*! live-restore: live restore state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1444
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1445
 /*!
  * live-restore: the number of files remaining for live restore
  * completion
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1445
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1446
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1446
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1447
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1447
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1448
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1448
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1449
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1449
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1450
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1450
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1451
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1451
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1452
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1452
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1453
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1453
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1454
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1454
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1455
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1455
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1456
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1456
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1457
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1457
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1458
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1458
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1459
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1459
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1460
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1460
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1461
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1461
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1462
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1462
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1463
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1463
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1464
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1464
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1465
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1465
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1466
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1466
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1467
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1467
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1468
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1468
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1469
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1469
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1470
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1470
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1471
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1471
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1472
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1472
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1473
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1473
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1474
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1474
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1475
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1475
+#define	WT_STAT_CONN_LOG_FLUSH				1476
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1476
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1477
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1477
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1478
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1478
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1479
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1479
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1480
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1480
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1481
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1481
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1482
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1482
+#define	WT_STAT_CONN_LOG_SCANS				1483
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1483
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1484
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1484
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1485
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1485
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1486
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1486
+#define	WT_STAT_CONN_LOG_SYNC				1487
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1487
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1488
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1488
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1489
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1489
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1490
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1490
+#define	WT_STAT_CONN_LOG_WRITES				1491
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1491
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1492
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1492
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1493
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1493
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1494
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1494
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1495
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1495
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1496
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1496
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1497
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1497
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1498
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1498
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1499
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1499
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1500
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1500
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1501
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1501
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1502
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1502
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1503
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1503
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1504
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1504
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1505
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1505
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1506
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1506
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1507
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1507
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1508
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1508
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1509
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1509
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1510
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1510
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1511
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1511
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1512
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1512
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1513
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1513
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1514
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1514
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1515
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1515
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1516
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1516
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1517
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1517
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1518
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1518
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1519
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1519
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1520
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1520
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1521
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1521
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1522
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1522
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1523
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1523
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1524
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1524
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1525
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1525
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1526
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1526
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1527
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1527
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1528
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1528
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1529
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1529
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1530
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1530
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1531
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1531
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1532
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1532
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1533
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1533
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1534
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1534
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1535
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1535
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1536
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1536
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1537
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1537
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1538
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1538
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1539
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1539
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1540
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1540
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1541
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1541
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1542
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1542
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1543
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1543
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1544
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1544
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1545
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1545
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1546
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1546
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1547
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1547
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1548
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1548
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1549
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1549
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1550
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1550
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1551
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1551
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1552
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1552
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1553
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1553
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1554
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1554
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1555
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1555
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1556
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1556
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1557
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1557
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1558
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1558
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1559
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1559
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1560
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1560
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1561
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1561
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1562
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1562
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1563
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1563
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1564
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1564
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1565
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1565
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1566
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1566
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1567
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1567
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1568
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1568
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1569
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1569
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1570
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1570
+#define	WT_STAT_CONN_REC_PAGES				1571
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1571
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1572
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1572
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1573
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1573
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1574
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1574
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1575
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1575
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1576
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1576
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1577
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1577
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1578
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1578
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1579
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1579
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1580
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1580
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1581
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1581
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1582
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1582
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1583
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1583
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1584
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1584
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1585
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1585
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1586
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1586
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1587
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1587
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1588
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1588
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1589
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1589
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1590
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1590
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1591
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1591
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1592
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1592
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1593
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1593
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1594
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1594
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1595
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1595
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1596
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1596
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1597
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1597
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1598
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1598
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1599
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1599
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1600
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1600
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1601
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1601
+#define	WT_STAT_CONN_FLUSH_TIER				1602
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1602
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1603
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1603
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1604
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1604
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1605
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1605
+#define	WT_STAT_CONN_SESSION_OPEN			1606
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1606
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1607
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1607
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1608
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1608
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1609
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1609
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1610
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1610
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1611
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1611
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1612
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1612
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1613
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1613
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1614
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1614
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1615
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1615
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1616
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1616
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1617
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1617
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1618
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1618
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1619
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1619
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1620
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1620
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1621
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1621
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1622
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1622
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1623
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1623
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1624
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1624
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1625
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1625
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1626
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1626
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1627
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1627
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1628
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1628
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1629
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1629
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1630
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1630
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1631
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1631
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1632
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1632
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1633
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1633
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1634
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1634
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1635
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1635
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1636
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1636
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1637
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1637
+#define	WT_STAT_CONN_TIERED_RETENTION			1638
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1638
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1639
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1639
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1640
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1640
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1641
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1641
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1642
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1642
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1643
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1643
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1644
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1644
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1645
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1645
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1646
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1646
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1647
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1647
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1648
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1648
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1649
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1649
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1650
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1650
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1651
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1651
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1652
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1652
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1653
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1653
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1654
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1654
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1655
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1655
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1656
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1656
+#define	WT_STAT_CONN_PAGE_SLEEP				1657
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1657
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1658
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1658
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1659
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1659
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1660
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1660
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1661
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1661
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1662
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1662
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1663
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1663
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1664
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1664
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1665
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1665
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1666
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1666
+#define	WT_STAT_CONN_TXN_PREPARE			1667
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1667
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1668
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1668
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1669
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1669
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1670
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1670
+#define	WT_STAT_CONN_TXN_QUERY_TS			1671
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1671
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1672
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1672
+#define	WT_STAT_CONN_TXN_RTS				1673
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1673
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1674
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1674
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1675
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1675
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1676
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1676
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1677
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1677
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1678
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1678
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1679
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1679
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1680
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1680
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1681
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1681
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1682
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1682
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1683
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1683
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1684
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1684
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1685
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1685
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1686
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1686
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1687
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1687
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1688
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1688
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1689
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1689
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1690
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1690
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1691
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1691
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1692
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1692
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1693
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1693
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1694
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1694
+#define	WT_STAT_CONN_TXN_SET_TS				1695
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1695
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1696
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1696
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1697
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1697
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1698
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1698
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1699
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1699
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1700
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1700
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1701
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1701
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1702
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1702
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1703
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1703
+#define	WT_STAT_CONN_TXN_BEGIN				1704
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1704
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1705
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1705
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1706
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1706
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1707
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1707
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1708
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1708
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1709
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1709
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1710
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1710
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1711
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1711
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1712
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1712
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1713
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1713
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1714
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1714
+#define	WT_STAT_CONN_TXN_COMMIT				1715
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1715
+#define	WT_STAT_CONN_TXN_ROLLBACK			1716
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1716
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1717
 
 /*!
  * @}
@@ -8069,18 +8071,20 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_SESSION_LOCK_DHANDLE_WAIT		4002
 /*! session: dirty bytes in this txn */
 #define	WT_STAT_SESSION_TXN_BYTES_DIRTY			4003
+/*! session: number of updates in this txn */
+#define	WT_STAT_SESSION_TXN_UPDATES			4004
 /*! session: page read from disk to cache time (usecs) */
-#define	WT_STAT_SESSION_READ_TIME			4004
+#define	WT_STAT_SESSION_READ_TIME			4005
 /*! session: page write from cache to disk time (usecs) */
-#define	WT_STAT_SESSION_WRITE_TIME			4005
+#define	WT_STAT_SESSION_WRITE_TIME			4006
 /*! session: schema lock wait time (usecs) */
-#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4006
+#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4007
 /*! session: time waiting for cache (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME			4007
+#define	WT_STAT_SESSION_CACHE_TIME			4008
 /*! session: time waiting for cache interruptible eviction (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME_INTERRUPTIBLE	4008
+#define	WT_STAT_SESSION_CACHE_TIME_INTERRUPTIBLE	4009
 /*! session: time waiting for mandatory cache eviction (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME_MANDATORY		4009
+#define	WT_STAT_SESSION_CACHE_TIME_MANDATORY		4010
 /*! @} */
 /*
  * Statistics section: END

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5574,1595 +5574,1597 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1073
 /*! cache: bytes allocated for updates */
 #define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1074
+/*! cache: bytes allocated for updates in uncommitted transactions */
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_TXN_UNCOMMITTED	1075
 /*! cache: bytes belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1075
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1076
 /*! cache: bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS			1076
+#define	WT_STAT_CONN_CACHE_BYTES_HS			1077
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1077
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1078
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1078
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1079
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1079
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1080
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1080
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1081
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1081
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1082
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1082
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1083
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1083
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1084
 /*! cache: evict page attempts by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1084
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1085
 /*! cache: evict page attempts by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1085
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1086
 /*! cache: evict page failures by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1086
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1087
 /*! cache: evict page failures by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1087
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1088
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1088
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1089
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1089
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1090
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1090
+#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1091
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1091
+#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1092
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1092
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1093
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1093
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1094
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1094
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1095
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1095
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1096
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1096
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1097
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1097
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1098
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1098
+#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1099
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1099
+#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1100
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1100
+#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1101
 /*! cache: eviction server skips dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1101
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1102
 /*! cache: eviction server skips internal pages as it has an active child. */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1102
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1103
 /*! cache: eviction server skips metadata pages with history */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1103
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1104
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1104
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1105
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1105
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1106
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1106
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1107
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1107
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1108
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1108
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1109
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1109
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1110
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1110
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1111
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1111
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1112
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1112
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1113
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1113
+#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1114
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_EVICTION_SLOW			1114
+#define	WT_STAT_CONN_EVICTION_SLOW			1115
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1115
+#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1116
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1116
+#define	WT_STAT_CONN_EVICTION_STATE			1117
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1117
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1118
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1118
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1119
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1119
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1120
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1120
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1121
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1121
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1122
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1122
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1123
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1123
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1124
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1124
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1125
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1126
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1126
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1127
 /*! cache: eviction walk target strategy both clean and dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1127
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1128
 /*! cache: eviction walk target strategy only clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1128
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1129
 /*! cache: eviction walk target strategy only dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1129
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1130
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1130
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1131
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1131
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1132
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1132
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1133
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1133
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1134
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1134
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1135
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1135
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1136
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1136
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1137
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1137
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1138
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1138
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1139
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1139
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1140
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1140
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1141
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1141
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1142
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1142
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1143
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1143
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1144
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1144
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1145
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1145
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1146
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1146
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1147
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1147
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1148
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1148
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1149
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1149
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1150
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1150
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1151
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1151
+#define	WT_STAT_CONN_EVICTION_FORCE			1152
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1152
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1153
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1153
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1154
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1154
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1155
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1155
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1156
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1156
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1157
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1157
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1158
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1158
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1159
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1159
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1160
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1160
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1161
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1161
+#define	WT_STAT_CONN_CACHE_HS_READ			1162
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1162
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1163
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1163
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1164
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1164
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1165
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1165
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1166
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1166
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1167
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1167
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1168
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1168
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1169
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1169
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1170
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1170
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1171
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1171
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1172
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1172
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1173
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1173
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1174
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1174
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1175
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1175
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1176
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1176
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1177
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1177
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1178
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1178
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1179
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1179
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1180
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1180
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1181
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1181
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1182
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1182
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1183
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1183
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1184
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1184
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1185
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1185
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1186
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1186
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1187
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1187
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1188
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1188
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1189
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1189
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1190
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1190
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1191
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1191
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1192
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1192
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1193
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1193
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1194
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1194
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1195
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1195
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1196
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1196
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1197
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1197
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1198
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1198
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1199
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1199
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1200
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1200
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1201
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1201
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1202
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1202
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1203
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1203
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1204
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1204
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1205
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1205
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1206
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1206
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1207
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1207
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1208
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1208
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1209
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1209
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1210
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1210
+#define	WT_STAT_CONN_CACHE_READ				1211
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1211
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1212
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1212
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1213
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1213
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1214
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1214
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1215
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1215
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1216
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1216
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1217
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1217
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1218
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1218
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1219
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1219
+#define	WT_STAT_CONN_EVICTION_FAIL			1220
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1220
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1221
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1221
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1222
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1222
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1223
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1223
+#define	WT_STAT_CONN_EVICTION_WALK			1224
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1224
+#define	WT_STAT_CONN_CACHE_WRITE			1225
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1225
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1226
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1226
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1227
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1227
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1228
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1228
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1229
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1229
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1230
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1230
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1231
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1231
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1232
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1232
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1233
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1233
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1234
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1234
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1235
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1235
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1236
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1236
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1237
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1237
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1238
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1238
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1239
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1239
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1240
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1240
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1241
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1241
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1242
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1242
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1243
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1243
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1244
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1244
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1245
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1245
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1246
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1246
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1247
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1247
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1248
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1248
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1249
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1249
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1250
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1250
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1251
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1251
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1252
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1252
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1253
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1253
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1254
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1254
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1255
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1255
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1256
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1256
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1257
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1257
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1258
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1258
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1259
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1259
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1260
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1260
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1261
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1261
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1262
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1262
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1263
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1263
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1264
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1264
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1265
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1265
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1266
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1266
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1267
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1267
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1268
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1268
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1269
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1269
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1270
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1270
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1271
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1271
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1272
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1272
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1273
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1273
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1274
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1274
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1275
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1275
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1276
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1276
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1277
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1277
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1278
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1278
+#define	WT_STAT_CONN_CHECKPOINTS_API			1279
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1279
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1280
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1280
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1281
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1281
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1282
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1282
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1283
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1283
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1284
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1284
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1285
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1285
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1286
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1286
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1287
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1287
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1288
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1288
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1289
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1289
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1290
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1290
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1291
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1291
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1292
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1292
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1293
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1293
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1294
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1294
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1295
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1295
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1296
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1296
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1297
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1297
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1298
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1298
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1299
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1299
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1300
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1300
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1301
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1301
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1302
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1302
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1303
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1303
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1304
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1304
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1305
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1305
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1306
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1306
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1307
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1307
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1308
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1308
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1309
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1309
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1310
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1310
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1311
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1311
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1312
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1312
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1313
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1313
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1314
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1314
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1315
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1315
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1316
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1316
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1317
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1317
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1318
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1318
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1319
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1319
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1320
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1320
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1321
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1321
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1322
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1322
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1323
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1323
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1324
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1324
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1325
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1325
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1326
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1326
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1327
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1327
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1328
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1328
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1329
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1329
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1330
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1330
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1331
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1331
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1332
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1332
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1333
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1333
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1334
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1334
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1335
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1335
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1336
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1336
+#define	WT_STAT_CONN_TIME_TRAVEL			1337
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1337
+#define	WT_STAT_CONN_FILE_OPEN				1338
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1338
+#define	WT_STAT_CONN_BUCKETS_DH				1339
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1339
+#define	WT_STAT_CONN_BUCKETS				1340
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1340
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1341
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1341
+#define	WT_STAT_CONN_MEMORY_FREE			1342
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1342
+#define	WT_STAT_CONN_MEMORY_GROW			1343
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1343
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1344
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1344
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1345
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1345
+#define	WT_STAT_CONN_COND_WAIT				1346
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1346
+#define	WT_STAT_CONN_RWLOCK_READ			1347
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1347
+#define	WT_STAT_CONN_RWLOCK_WRITE			1348
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1348
+#define	WT_STAT_CONN_FSYNC_IO				1349
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1349
+#define	WT_STAT_CONN_READ_IO				1350
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1350
+#define	WT_STAT_CONN_WRITE_IO				1351
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1351
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1352
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1352
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1353
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1353
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1354
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1354
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1355
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1355
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1356
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1356
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1357
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1357
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1358
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1358
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1359
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1359
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1360
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1360
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1361
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1361
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1362
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1362
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1363
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1363
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1364
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1364
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1365
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1365
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1366
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1366
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1367
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1367
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1368
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1368
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1369
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1369
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1370
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1370
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1371
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1371
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1372
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1372
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1373
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1373
+#define	WT_STAT_CONN_CURSOR_CACHE			1374
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1374
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1375
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1375
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1376
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1376
+#define	WT_STAT_CONN_CURSOR_CREATE			1377
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1377
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1378
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1378
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1379
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1379
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1380
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1380
+#define	WT_STAT_CONN_CURSOR_INSERT			1381
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1381
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1382
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1382
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1383
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1383
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1384
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1384
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1385
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1385
+#define	WT_STAT_CONN_CURSOR_MODIFY			1386
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1386
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1387
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1387
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1388
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1388
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1389
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1389
+#define	WT_STAT_CONN_CURSOR_NEXT			1390
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1390
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1391
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1391
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1392
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1392
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1393
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1393
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1394
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1394
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1395
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1395
+#define	WT_STAT_CONN_CURSOR_RESTART			1396
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1396
+#define	WT_STAT_CONN_CURSOR_PREV			1397
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1397
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1398
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1398
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1399
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1399
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1400
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1400
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1401
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1401
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1402
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1402
+#define	WT_STAT_CONN_CURSOR_REMOVE			1403
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1403
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1404
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1404
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1405
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1405
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1406
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1406
+#define	WT_STAT_CONN_CURSOR_RESERVE			1407
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1407
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1408
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1408
+#define	WT_STAT_CONN_CURSOR_RESET			1409
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1409
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1410
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1410
+#define	WT_STAT_CONN_CURSOR_SEARCH			1411
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1411
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1412
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1412
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1413
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1413
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1414
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1414
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1415
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1415
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1416
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1416
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1417
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1417
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1418
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1418
+#define	WT_STAT_CONN_CURSOR_SWEEP			1419
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1419
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1420
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1420
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1421
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1421
+#define	WT_STAT_CONN_CURSOR_UPDATE			1422
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1422
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1423
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1423
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1424
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1424
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1425
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1425
+#define	WT_STAT_CONN_CURSOR_REOPEN			1426
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1426
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1427
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1427
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1428
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1428
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1429
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1429
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1430
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1430
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1431
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1431
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1432
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1432
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1433
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1433
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1434
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1434
+#define	WT_STAT_CONN_DH_SWEEP_REF			1435
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1435
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1436
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1436
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1437
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1437
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1438
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1438
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1439
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1439
+#define	WT_STAT_CONN_DH_SWEEPS				1440
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1440
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1441
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1441
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1442
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1442
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1443
 /*! live-restore: live restore state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1443
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1444
 /*!
  * live-restore: the number of files remaining for live restore
  * completion
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1444
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1445
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1445
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1446
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1446
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1447
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1447
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1448
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1448
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1449
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1449
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1450
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1450
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1451
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1451
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1452
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1452
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1453
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1453
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1454
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1454
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1455
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1455
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1456
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1456
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1457
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1457
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1458
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1458
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1459
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1459
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1460
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1460
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1461
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1461
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1462
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1462
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1463
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1463
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1464
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1464
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1465
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1465
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1466
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1466
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1467
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1467
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1468
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1468
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1469
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1469
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1470
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1470
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1471
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1471
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1472
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1472
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1473
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1473
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1474
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1474
+#define	WT_STAT_CONN_LOG_FLUSH				1475
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1475
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1476
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1476
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1477
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1477
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1478
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1478
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1479
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1479
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1480
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1480
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1481
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1481
+#define	WT_STAT_CONN_LOG_SCANS				1482
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1482
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1483
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1483
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1484
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1484
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1485
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1485
+#define	WT_STAT_CONN_LOG_SYNC				1486
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1486
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1487
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1487
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1488
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1488
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1489
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1489
+#define	WT_STAT_CONN_LOG_WRITES				1490
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1490
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1491
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1491
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1492
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1492
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1493
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1493
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1494
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1494
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1495
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1495
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1496
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1496
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1497
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1497
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1498
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1498
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1499
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1499
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1500
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1500
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1501
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1501
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1502
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1502
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1503
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1503
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1504
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1504
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1505
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1505
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1506
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1506
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1507
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1507
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1508
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1508
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1509
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1509
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1510
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1510
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1511
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1511
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1512
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1512
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1513
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1513
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1514
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1514
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1515
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1515
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1516
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1516
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1517
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1517
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1518
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1518
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1519
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1519
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1520
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1520
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1521
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1521
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1522
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1522
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1523
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1523
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1524
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1524
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1525
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1525
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1526
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1526
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1527
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1527
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1528
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1528
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1529
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1529
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1530
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1530
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1531
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1531
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1532
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1532
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1533
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1533
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1534
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1534
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1535
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1535
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1536
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1536
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1537
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1537
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1538
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1538
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1539
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1539
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1540
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1540
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1541
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1541
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1542
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1542
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1543
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1543
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1544
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1544
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1545
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1545
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1546
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1546
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1547
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1547
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1548
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1548
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1549
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1549
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1550
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1550
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1551
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1551
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1552
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1552
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1553
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1553
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1554
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1554
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1555
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1555
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1556
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1556
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1557
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1557
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1558
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1558
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1559
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1559
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1560
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1560
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1561
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1561
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1562
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1562
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1563
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1563
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1564
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1564
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1565
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1565
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1566
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1566
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1567
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1567
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1568
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1568
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1569
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1569
+#define	WT_STAT_CONN_REC_PAGES				1570
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1570
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1571
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1571
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1572
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1572
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1573
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1573
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1574
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1574
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1575
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1575
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1576
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1576
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1577
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1577
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1578
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1578
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1579
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1579
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1580
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1580
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1581
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1581
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1582
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1582
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1583
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1583
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1584
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1584
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1585
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1585
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1586
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1586
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1587
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1587
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1588
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1588
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1589
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1589
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1590
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1590
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1591
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1591
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1592
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1592
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1593
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1593
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1594
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1594
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1595
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1595
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1596
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1596
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1597
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1597
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1598
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1598
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1599
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1599
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1600
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1600
+#define	WT_STAT_CONN_FLUSH_TIER				1601
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1601
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1602
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1602
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1603
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1603
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1604
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1604
+#define	WT_STAT_CONN_SESSION_OPEN			1605
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1605
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1606
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1606
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1607
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1607
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1608
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1608
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1609
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1609
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1610
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1610
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1611
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1611
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1612
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1612
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1613
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1613
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1614
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1614
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1615
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1615
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1616
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1616
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1617
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1617
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1618
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1618
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1619
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1619
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1620
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1620
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1621
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1621
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1622
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1622
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1623
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1623
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1624
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1624
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1625
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1625
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1626
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1626
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1627
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1627
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1628
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1628
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1629
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1629
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1630
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1630
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1631
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1631
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1632
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1632
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1633
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1633
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1634
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1634
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1635
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1635
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1636
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1636
+#define	WT_STAT_CONN_TIERED_RETENTION			1637
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1637
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1638
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1638
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1639
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1639
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1640
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1640
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1641
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1641
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1642
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1642
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1643
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1643
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1644
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1644
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1645
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1645
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1646
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1646
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1647
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1647
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1648
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1648
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1649
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1649
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1650
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1650
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1651
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1651
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1652
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1652
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1653
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1653
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1654
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1654
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1655
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1655
+#define	WT_STAT_CONN_PAGE_SLEEP				1656
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1656
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1657
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1657
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1658
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1658
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1659
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1659
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1660
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1660
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1661
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1661
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1662
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1662
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1663
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1663
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1664
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1664
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1665
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1665
+#define	WT_STAT_CONN_TXN_PREPARE			1666
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1666
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1667
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1667
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1668
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1668
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1669
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1669
+#define	WT_STAT_CONN_TXN_QUERY_TS			1670
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1670
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1671
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1671
+#define	WT_STAT_CONN_TXN_RTS				1672
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1672
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1673
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1673
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1674
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1674
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1675
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1675
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1676
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1676
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1677
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1677
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1678
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1678
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1679
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1679
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1680
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1680
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1681
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1681
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1682
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1682
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1683
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1683
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1684
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1684
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1685
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1685
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1686
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1686
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1687
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1687
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1688
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1688
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1689
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1689
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1690
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1690
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1691
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1691
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1692
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1692
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1693
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1693
+#define	WT_STAT_CONN_TXN_SET_TS				1694
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1694
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1695
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1695
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1696
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1696
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1697
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1697
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1698
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1698
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1699
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1699
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1700
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1700
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1701
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1701
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1702
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1702
+#define	WT_STAT_CONN_TXN_BEGIN				1703
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1703
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1704
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1704
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1705
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1705
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1706
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1706
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1707
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1707
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1708
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1708
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1709
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1709
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1710
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1710
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1711
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1711
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1712
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1712
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1713
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1713
+#define	WT_STAT_CONN_TXN_COMMIT				1714
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1714
+#define	WT_STAT_CONN_TXN_ROLLBACK			1715
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1715
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1716
 
 /*!
  * @}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6033,7 +6033,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! cache: updates in uncommitted txn - bytes */
 #define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1241
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_N	1242
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1242
 /*! capacity: background fsync file handles considered */
 #define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1243
 /*! capacity: background fsync file handles synced */

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -482,7 +482,7 @@ __wti_ovfl_reuse_add(WT_SESSION_IMPL *session, WT_PAGE *page, const uint8_t *add
     memcpy(p, value, value_size);
     F_SET(reuse, WT_OVFL_REUSE_INUSE | WT_OVFL_REUSE_JUST_ADDED);
 
-    __wt_cache_page_inmem_incr(session, page, WT_OVFL_SIZE(reuse, WT_OVFL_REUSE));
+    __wt_cache_page_inmem_incr(session, page, WT_OVFL_SIZE(reuse, WT_OVFL_REUSE), false);
 
     /* Insert the new entry into the skiplist. */
     __ovfl_reuse_skip_search_stack(head, stack, value, value_size);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -223,7 +223,7 @@ __rec_append_orig_value(
     /* Append the new entry into the update list. */
     WT_RELEASE_WRITE_WITH_BARRIER(upd->next, append);
 
-    __wt_cache_page_inmem_incr(session, page, total_size, true);
+    __wt_cache_page_inmem_incr(session, page, total_size, false);
 
     if (0) {
 err:

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -223,7 +223,7 @@ __rec_append_orig_value(
     /* Append the new entry into the update list. */
     WT_RELEASE_WRITE_WITH_BARRIER(upd->next, append);
 
-    __wt_cache_page_inmem_incr(session, page, total_size);
+    __wt_cache_page_inmem_incr(session, page, total_size, true);
 
     if (0) {
 err:

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1765,7 +1765,6 @@ __session_begin_transaction(WT_SESSION *wt_session, const char *config)
     SESSION_API_CALL_PREPARE_NOT_ALLOWED_NOCONF(session, ret, begin_transaction);
     SESSION_API_CONF(session, begin_transaction, config, conf);
     WT_STAT_CONN_INCR(session, txn_begin);
-    WT_STAT_SESSION_SET(session, txn_bytes_dirty, 0);
 
     WT_ERR(__wt_txn_context_check(session, false));
 

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1392,7 +1392,6 @@ static const char *const __stats_connection_desc[] = {
   "cache: application threads page write from cache to disk count",
   "cache: application threads page write from cache to disk time (usecs)",
   "cache: bytes allocated for updates",
-  "cache: bytes allocated for updates in uncommitted transactions",
   "cache: bytes belonging to page images in the cache",
   "cache: bytes belonging to the history store table in the cache",
   "cache: bytes currently in the cache",
@@ -1577,6 +1576,8 @@ static const char *const __stats_connection_desc[] = {
   "cache: tracked dirty pages in the cache",
   "cache: uncommitted truncate blocked page eviction",
   "cache: unmodified pages evicted",
+  "cache: updates in uncommitted txn - bytes",
+  "cache: updates in uncommitted txn - count",
   "capacity: background fsync file handles considered",
   "capacity: background fsync file handles synced",
   "capacity: background fsync time (msecs)",
@@ -2177,7 +2178,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_write_app_count = 0;
     stats->cache_write_app_time = 0;
     /* not clearing cache_bytes_updates */
-    /* not clearing cache_bytes_updates_txn_uncommitted */
     /* not clearing cache_bytes_image */
     /* not clearing cache_bytes_hs */
     /* not clearing cache_bytes_inuse */
@@ -2344,6 +2344,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing cache_pages_dirty */
     stats->cache_eviction_blocked_uncommitted_truncate = 0;
     stats->cache_eviction_clean = 0;
+    /* not clearing cache_updates_txn_uncommitted_bytes */
+    /* not clearing cache_updates_txn_uncommitted_n */
     stats->fsync_all_fh_total = 0;
     stats->fsync_all_fh = 0;
     /* not clearing fsync_all_time */
@@ -2916,8 +2918,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_write_app_count += WT_STAT_CONN_READ(from, cache_write_app_count);
     to->cache_write_app_time += WT_STAT_CONN_READ(from, cache_write_app_time);
     to->cache_bytes_updates += WT_STAT_CONN_READ(from, cache_bytes_updates);
-    to->cache_bytes_updates_txn_uncommitted +=
-      WT_STAT_CONN_READ(from, cache_bytes_updates_txn_uncommitted);
     to->cache_bytes_image += WT_STAT_CONN_READ(from, cache_bytes_image);
     to->cache_bytes_hs += WT_STAT_CONN_READ(from, cache_bytes_hs);
     to->cache_bytes_inuse += WT_STAT_CONN_READ(from, cache_bytes_inuse);
@@ -3131,6 +3131,9 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_blocked_uncommitted_truncate +=
       WT_STAT_CONN_READ(from, cache_eviction_blocked_uncommitted_truncate);
     to->cache_eviction_clean += WT_STAT_CONN_READ(from, cache_eviction_clean);
+    to->cache_updates_txn_uncommitted_bytes +=
+      WT_STAT_CONN_READ(from, cache_updates_txn_uncommitted_bytes);
+    to->cache_updates_txn_uncommitted_n += WT_STAT_CONN_READ(from, cache_updates_txn_uncommitted_n);
     to->fsync_all_fh_total += WT_STAT_CONN_READ(from, fsync_all_fh_total);
     to->fsync_all_fh += WT_STAT_CONN_READ(from, fsync_all_fh);
     to->fsync_all_time += WT_STAT_CONN_READ(from, fsync_all_time);
@@ -3677,6 +3680,7 @@ static const char *const __stats_session_desc[] = {
   "session: bytes written from cache",
   "session: dhandle lock wait time (usecs)",
   "session: dirty bytes in this txn",
+  "session: number of updates in this txn",
   "session: page read from disk to cache time (usecs)",
   "session: page write from cache to disk time (usecs)",
   "session: schema lock wait time (usecs)",
@@ -3706,6 +3710,7 @@ __wt_stat_session_clear_single(WT_SESSION_STATS *stats)
     stats->bytes_write = 0;
     stats->lock_dhandle_wait = 0;
     /* not clearing txn_bytes_dirty */
+    /* not clearing txn_updates */
     stats->read_time = 0;
     stats->write_time = 0;
     stats->lock_schema_wait = 0;

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1392,6 +1392,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: application threads page write from cache to disk count",
   "cache: application threads page write from cache to disk time (usecs)",
   "cache: bytes allocated for updates",
+  "cache: bytes allocated for updates in uncommitted transactions",
   "cache: bytes belonging to page images in the cache",
   "cache: bytes belonging to the history store table in the cache",
   "cache: bytes currently in the cache",
@@ -2176,6 +2177,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_write_app_count = 0;
     stats->cache_write_app_time = 0;
     /* not clearing cache_bytes_updates */
+    /* not clearing cache_bytes_updates_txn_uncommitted */
     /* not clearing cache_bytes_image */
     /* not clearing cache_bytes_hs */
     /* not clearing cache_bytes_inuse */
@@ -2914,6 +2916,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_write_app_count += WT_STAT_CONN_READ(from, cache_write_app_count);
     to->cache_write_app_time += WT_STAT_CONN_READ(from, cache_write_app_time);
     to->cache_bytes_updates += WT_STAT_CONN_READ(from, cache_bytes_updates);
+    to->cache_bytes_updates_txn_uncommitted +=
+      WT_STAT_CONN_READ(from, cache_bytes_updates_txn_uncommitted);
     to->cache_bytes_image += WT_STAT_CONN_READ(from, cache_bytes_image);
     to->cache_bytes_hs += WT_STAT_CONN_READ(from, cache_bytes_hs);
     to->cache_bytes_inuse += WT_STAT_CONN_READ(from, cache_bytes_inuse);
@@ -3701,7 +3705,7 @@ __wt_stat_session_clear_single(WT_SESSION_STATS *stats)
     stats->bytes_read = 0;
     stats->bytes_write = 0;
     stats->lock_dhandle_wait = 0;
-    stats->txn_bytes_dirty = 0;
+    /* not clearing txn_bytes_dirty */
     stats->read_time = 0;
     stats->write_time = 0;
     stats->lock_schema_wait = 0;

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2345,7 +2345,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_eviction_blocked_uncommitted_truncate = 0;
     stats->cache_eviction_clean = 0;
     /* not clearing cache_updates_txn_uncommitted_bytes */
-    /* not clearing cache_updates_txn_uncommitted_n */
+    /* not clearing cache_updates_txn_uncommitted_count */
     stats->fsync_all_fh_total = 0;
     stats->fsync_all_fh = 0;
     /* not clearing fsync_all_time */
@@ -3133,7 +3133,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_clean += WT_STAT_CONN_READ(from, cache_eviction_clean);
     to->cache_updates_txn_uncommitted_bytes +=
       WT_STAT_CONN_READ(from, cache_updates_txn_uncommitted_bytes);
-    to->cache_updates_txn_uncommitted_n += WT_STAT_CONN_READ(from, cache_updates_txn_uncommitted_n);
+    to->cache_updates_txn_uncommitted_count +=
+      WT_STAT_CONN_READ(from, cache_updates_txn_uncommitted_count);
     to->fsync_all_fh_total += WT_STAT_CONN_READ(from, fsync_all_fh_total);
     to->fsync_all_fh += WT_STAT_CONN_READ(from, fsync_all_fh);
     to->fsync_all_time += WT_STAT_CONN_READ(from, fsync_all_time);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -838,6 +838,8 @@ __txn_release(WT_SESSION_IMPL *session)
 
     /* Clear operation timer. */
     txn->operation_timeout_us = 0;
+
+    __txn_clear_bytes_dirty(session);
 }
 
 /*
@@ -2119,6 +2121,7 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
             break;
         }
     }
+    __txn_clear_bytes_dirty(session);
     WT_STAT_CONN_INCRV(session, txn_prepared_updates, prepared_updates);
     WT_STAT_CONN_INCRV(session, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
 #ifdef HAVE_DIAGNOSTIC

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -145,6 +145,8 @@ __wt_txn_release_snapshot(WT_SESSION_IMPL *session)
 
     /* Leave the generation after releasing the snapshot. */
     __wt_session_gen_leave(session, WT_GEN_HAS_SNAPSHOT);
+
+    __txn_clear_bytes_dirty(session);
 }
 
 /*
@@ -838,8 +840,6 @@ __txn_release(WT_SESSION_IMPL *session)
 
     /* Clear operation timer. */
     txn->operation_timeout_us = 0;
-
-    __txn_clear_bytes_dirty(session);
 }
 
 /*
@@ -2121,7 +2121,6 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
             break;
         }
     }
-    __txn_clear_bytes_dirty(session);
     WT_STAT_CONN_INCRV(session, txn_prepared_updates, prepared_updates);
     WT_STAT_CONN_INCRV(session, txn_prepared_updates_key_repeated, prepared_updates_key_repeated);
 #ifdef HAVE_DIAGNOSTIC

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -928,7 +928,7 @@ __txn_prepare_rollback_restore_hs_update(
     /* Append the update to the end of the chain. */
     WT_RELEASE_WRITE_WITH_BARRIER(upd_chain->next, upd);
 
-    __wt_cache_page_inmem_incr(session, page, total_size);
+    __wt_cache_page_inmem_incr(session, page, total_size, false);
 
     if (0) {
 err:

--- a/test/suite/test_txn_uncommitted.py
+++ b/test/suite/test_txn_uncommitted.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+from unittest import skip
+import wiredtiger, wttest
+
+# test_txn_uncommitted.py
+#    Stats for uncommitted txn data.
+class test_txn_uncommitted(wttest.WiredTigerTestCase):
+
+    n_sessions = 20
+    n_updates = 20
+    # Leave the cache size on the default setting to avoid filling up the cache
+    # too much and triggering unnecessary rollbacks. But make the value fairly
+    # large to make obvious change to the statistics.
+    conn_config = 'statistics=(all)'
+    entry_value = "abcde" * 400
+
+    def get_sstat(self, stat, session):
+        statc =  session.open_cursor('statistics:session', None, None)
+        val = statc[stat][2]
+        statc.close()
+        return val
+
+    def get_cstat(self, stat):
+        statc =  self.session.open_cursor('statistics:', None, None)
+        val = statc[stat][2]
+        statc.close()
+        return val
+
+    def txn_one(self):
+        session = self.conn.open_session()
+        cursor = session.open_cursor('table:test_txn_uncommitted', None, None)
+
+        session.begin_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session), 0)
+
+        cursor[1] = self.entry_value
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 1)
+        self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), len(self.entry_value))
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session), 1)
+        self.assertGreater(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session), len(self.entry_value))
+
+        session.commit_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session), 0)
+
+        cursor.reset()
+        session.close()
+
+    def txn_two(self):
+        session1 = self.conn.open_session()
+        session2 = self.conn.open_session()
+        cursor1 = session1.open_cursor('table:test_txn_uncommitted', None, None)
+        cursor2 = session2.open_cursor('table:test_txn_uncommitted', None, None)
+
+        session1.begin_transaction()
+        session2.begin_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session2), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session2), 0)
+
+        cursor1[1] = self.entry_value
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 1)
+        self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), len(self.entry_value))
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session1), 1)
+        self.assertGreater(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session1), len(self.entry_value))
+
+        cursor2[2] = self.entry_value
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 2)
+        self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 2*len(self.entry_value))
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session1), 1)
+        self.assertGreater(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session1), len(self.entry_value))
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session2), 1)
+        self.assertGreater(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session2), len(self.entry_value))
+
+        session1.commit_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 1)
+        self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), len(self.entry_value))
+
+        session2.rollback_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session2), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session2), 0)
+
+        session1.close()
+        session2.close()
+
+    def txn_two_seq(self):
+        session1 = self.conn.open_session()
+        session2 = self.conn.open_session()
+        cursor1 = session1.open_cursor('table:test_txn_uncommitted', None, None)
+        cursor2 = session2.open_cursor('table:test_txn_uncommitted', None, None)
+
+        session1.begin_transaction()
+        session2.begin_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session2), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session2), 0)
+
+        cursor1[1] = self.entry_value
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 1)
+        self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), len(self.entry_value))
+
+        session1.rollback_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+
+        cursor2[2] = self.entry_value
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 1)
+        self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), len(self.entry_value))
+
+        session2.commit_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session1), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session2), 0)
+        self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session2), 0)
+
+        session1.close()
+        session2.close()
+
+    def txn_many(self):
+        sessions = [self.conn.open_session() for _ in range(self.n_sessions)]
+        cursors = [session.open_cursor('table:test_txn_uncommitted', None, None) for session in sessions]
+        for session in sessions:
+            session.begin_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+
+        for i, cursor in enumerate(cursors):
+            cursor[i] = self.entry_value
+            self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), i+1)
+            self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), (i+1)*len(self.entry_value))
+
+        for i, session in enumerate(sessions):
+            self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session), 1)
+            self.assertGreater(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session), len(self.entry_value))
+            session.commit_transaction()
+            self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), self.n_sessions-i-1)
+            self.assertGreaterEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), (self.n_sessions-i-1)*len(self.entry_value))
+            self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session), 0)
+            self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session), 0)
+
+        for session in sessions:
+            session.close()
+
+    def txn_many_many(self):
+        sessions = [self.conn.open_session() for _ in range(self.n_sessions)]
+        cursors = [session.open_cursor('table:test_txn_uncommitted', None, None) for session in sessions]
+        for session in sessions:
+            session.begin_transaction()
+
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), 0)
+        self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), 0)
+
+        for i, cursor in enumerate(cursors):
+            for j in range(self.n_updates):
+                cursor[i*self.n_updates + j] = self.entry_value
+            self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), self.n_updates * (i+1))
+            self.assertGreater(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), (i+1)*len(self.entry_value) * self.n_updates)
+
+        for i, session in enumerate(sessions):
+            self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session), self.n_updates)
+            self.assertGreater(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session), self.n_updates * len(self.entry_value))
+            session.commit_transaction()
+            self.assertEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_count), (self.n_sessions-i-1) * self.n_updates)
+            self.assertGreaterEqual(self.get_cstat(wiredtiger.stat.conn.cache_updates_txn_uncommitted_bytes), (self.n_sessions-i-1)*len(self.entry_value) * self.n_updates)
+            self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_updates, session), 0)
+            self.assertEqual(self.get_sstat(wiredtiger.stat.session.txn_bytes_dirty, session), 0)
+
+        for session in sessions:
+            session.close()
+
+    def test_session_stats(self):
+        self.session = self.conn.open_session()
+        self.session.create("table:test_txn_uncommitted", "key_format=i,value_format=S")
+
+        self.txn_one()
+        self.txn_two()
+        self.txn_two_seq()
+        self.txn_many()
+        self.txn_many_many()

--- a/test/suite/test_txn_uncommitted.py
+++ b/test/suite/test_txn_uncommitted.py
@@ -36,9 +36,6 @@ class test_txn_uncommitted(wttest.WiredTigerTestCase):
 
     n_sessions = 20
     n_updates = 20
-    # Leave the cache size on the default setting to avoid filling up the cache
-    # too much and triggering unnecessary rollbacks. But make the value fairly
-    # large to make obvious change to the statistics.
     conn_config = 'statistics=(all)'
     entry_value = "abcde" * 400
 


### PR DESCRIPTION
This change adds a counter for total uncommitted updates size for better detection of situations where uncommitted transactions take too much cache space.