### PR TITLE
WT-14163 Explicitly set the number of RTS threads in test/format

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -230,8 +230,8 @@ tinfo_teardown(void)
 static void
 rollback_to_stable(WT_SESSION *session)
 {
-    char cfg[512];
     u_int num_threads;
+    char cfg[512];
 
     /* Rollback-to-stable only makes sense for timestamps. */
     if (!g.transaction_timestamps_config)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -231,14 +231,19 @@ static void
 rollback_to_stable(WT_SESSION *session)
 {
     char cfg[512];
+    u_int num_threads;
 
     /* Rollback-to-stable only makes sense for timestamps. */
     if (!g.transaction_timestamps_config)
         return;
 
-    /* Rollback the system using up to 10 threads. */
-    testutil_snprintf(cfg, sizeof(cfg), "treads=%" PRIu32, mmrand(&g.extra_rnd, 0, 10));
-    testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, cfg));
+    /*
+     * Rollback the system using up to 10 threads. Extend to 11 values to cover the NULL config
+     * case.
+     */
+    num_threads = mmrand(&g.extra_rnd, 0, 11);
+    testutil_snprintf(cfg, sizeof(cfg), "treads=%" PRIu32, num_threads);
+    testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, num_threads > 10 ? NULL : cfg));
 
     /*
      * Get the stable timestamp, and update ours. They should be the same, but there's no point in

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -243,7 +243,7 @@ rollback_to_stable(WT_SESSION *session)
      */
     num_threads = mmrand(&g.extra_rnd, 0, 11);
     testutil_snprintf(cfg, sizeof(cfg), "threads=%" PRIu32, num_threads);
-    testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, num_threads > 10 ? NULL : cfg));
+    testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, num_threads == 11 ? NULL : cfg));
 
     /*
      * Get the stable timestamp, and update ours. They should be the same, but there's no point in

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -242,7 +242,7 @@ rollback_to_stable(WT_SESSION *session)
      * case.
      */
     num_threads = mmrand(&g.extra_rnd, 0, 11);
-    testutil_snprintf(cfg, sizeof(cfg), "treads=%" PRIu32, num_threads);
+    testutil_snprintf(cfg, sizeof(cfg), "threads=%" PRIu32, num_threads);
     testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, num_threads > 10 ? NULL : cfg));
 
     /*

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -231,7 +231,7 @@ static void
 rollback_to_stable(WT_SESSION *session)
 {
     u_int num_threads;
-    char cfg[512];
+    char cfg[32];
 
     /* Rollback-to-stable only makes sense for timestamps. */
     if (!g.transaction_timestamps_config)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -230,12 +230,15 @@ tinfo_teardown(void)
 static void
 rollback_to_stable(WT_SESSION *session)
 {
+    char cfg[512];
+
     /* Rollback-to-stable only makes sense for timestamps. */
     if (!g.transaction_timestamps_config)
         return;
 
-    /* Rollback the system. */
-    testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, NULL));
+    /* Rollback the system using up to 10 threads. */
+    testutil_snprintf(cfg, sizeof(cfg), "treads=%" PRIu64, WT_MIN(10, GV(RUNS_THREADS)));
+    testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, cfg));
 
     /*
      * Get the stable timestamp, and update ours. They should be the same, but there's no point in

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -237,7 +237,7 @@ rollback_to_stable(WT_SESSION *session)
         return;
 
     /* Rollback the system using up to 10 threads. */
-    testutil_snprintf(cfg, sizeof(cfg), "treads=%" PRIu64, WT_MIN(10, GV(RUNS_THREADS)));
+    testutil_snprintf(cfg, sizeof(cfg), "treads=%" PRIu32, mmrand(&g.extra_rnd, 0, 10));
     testutil_check(g.wts_conn->rollback_to_stable(g.wts_conn, cfg));
 
     /*


### PR DESCRIPTION
The changes update test/format to use up to 10 threads when performing RTS.