### PR TITLE
SLS-414 Re-enable skipped WT python tests for disaggregated storage

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -131,6 +131,7 @@ test_prepare13.py # times out
 test_prepare20.py
 test_prepare21.py # times out
 test_prepare23.py # times out
+test_prepare28.py
 test_prepare29.py
 test_prepare_cursor01.py
 test_prepare_hs02.py

--- a/test/suite/test_compact04.py
+++ b/test/suite/test_compact04.py
@@ -112,5 +112,4 @@ class test_compact04(wttest.WiredTigerTestCase):
             else:
                 self.pr(message + ' (FAILURE)')
                 num_failures += 1
-                self.skipTest('disaggregated storage broke compaction behavior')
                 self.assertLessEqual(num_failures, 2)

--- a/test/suite/test_prepare28.py
+++ b/test/suite/test_prepare28.py
@@ -41,7 +41,6 @@ class test_prepare28(wttest.WiredTigerTestCase):
     value3 = 'ccccc'
 
     def test_ignore_prepare(self):
-        self.skipTest('disaggregated storage broke prepared transaction behavior')
         self.session.create(self.uri, 'key_format=i,value_format=S')
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
         cursor = self.session.open_cursor(self.uri)

--- a/test/suite/test_truncate19.py
+++ b/test/suite/test_truncate19.py
@@ -100,7 +100,6 @@ class test_truncate19(wttest.WiredTigerTestCase):
             # Take a checkpoint.
             session2.checkpoint()
             # Ensure the datasize is smaller than 600M
-            self.skipTest('disaggregated storage broke testing for truncation of oplog')
             self.assertGreater(600000000, os.path.getsize("oplog.wt"))
             session3.rollback_transaction()
 


### PR DESCRIPTION
LABS-1188 disabled several python tests that were failing on the disagg branch. These were non-disagg tests, run on WT without any disagg capabilities enabled. 

We have not deliberately fixed these tests, but they are now passing consistently in my testing. So I'm re-enabling them.

A side effect of re-enabling these tests is that they are now eligible to run with the disagg hook. Since we don't support prepared transactions, the `prepared28` test had to be explicitly excluded from disagg hook testing by adding it to `hook_disagg.fail`.