### PR TITLE
Revert "WT-13948 Deprecate rollback_reason API  (#11628)"

### DIFF
--- a/dist/s_void
+++ b/dist/s_void
@@ -90,6 +90,7 @@ func_ok()
         -e '/int __wt_stat_dsrc_desc$/d' \
         -e '/int __wt_stat_session_desc/d' \
         -e '/int __wt_txn_read_upd_list$/d' \
+        -e '/int __wt_txn_rollback_required$/d' \
         -e '/int __wti_win_directory_list_free$/d' \
         -e '/int __ut_ckpt_add_blkmod_entry$/d' \
         -e '/int __ut_ovfl_discard_verbose$/d' \

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -605,6 +605,7 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %exception __wt_connection::get_home;
 %exception __wt_connection::is_new;
 %exception __wt_connection::search_near;
+%exception __wt_session::get_rollback_reason;
 %exception __wt_session::get_last_error;
 %exception __wt_session::strerror;
 %exception __wt_cursor::_set_key;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -184,8 +184,8 @@ __curversion_next_int(WT_CURSOR *cursor)
 
     /* The cursor should be positioned, otherwise the next call will fail. */
     if (!F_ISSET(file_cursor, WT_CURSTD_KEY_INT))
-        WT_ERR_SUB(session, WT_ROLLBACK, WT_NONE,
-          "rolling back version_cursor->next due to no initial position");
+        WT_ERR(__wt_txn_rollback_required(
+          session, "rolling back version_cursor->next due to no initial position"));
 
     if (!F_ISSET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED)) {
         upd = version_cursor->next_upd;
@@ -505,13 +505,13 @@ __curversion_search(WT_CURSOR *cursor)
      * We need to run with snapshot isolation to ensure that the globally visibility does not move.
      */
     if (txn->isolation != WT_ISO_SNAPSHOT)
-        WT_ERR_SUB(session, WT_ROLLBACK, WT_NONE,
-          "version cursor can only be called with snapshot isolation");
+        WT_ERR(__wt_txn_rollback_required(
+          session, "version cursor can only be called with snapshot isolation"));
 
     WT_ERR(__cursor_checkkey(file_cursor));
     if (F_ISSET(file_cursor, WT_CURSTD_KEY_INT))
-        WT_ERR_SUB(
-          session, WT_ROLLBACK, WT_NONE, "version cursor cannot be called when it is positioned");
+        WT_ERR(__wt_txn_rollback_required(
+          session, "version cursor cannot be called when it is positioned"));
 
     /* Do a search and position on the key if it is found */
     F_SET(file_cursor, WT_CURSTD_KEY_ONLY);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2951,7 +2951,7 @@ err:
         if (ret == 0 && cache_max_wait_us != 0 && session->cache_wait_us > cache_max_wait_us) {
             ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW);
             __wt_session_set_last_error(
-              session, ret, WT_CACHE_OVERFLOW, WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW);
+              session, ret, WT_CACHE_OVERFLOW, "Cache capacity has overflown");
             __wt_atomic_decrement_if_positive(&evict->evict_aggressive_score);
 
             WT_STAT_CONN_INCR(session, eviction_timed_out_ops);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2868,9 +2868,8 @@ __wti_evict_app_assist_worker(
                 __wt_atomic_decrement_if_positive(&evict->evict_aggressive_score);
 
                 WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
-                if (F_ISSET(session, WT_SESSION_SAVE_ERRORS))
-                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
-                      session->err_info.err_msg);
+                __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
+                  session->txn->rollback_reason);
             }
             WT_ERR(ret);
         }
@@ -2950,15 +2949,14 @@ err:
          * takes precedence over asking for a rollback. We can not do both.
          */
         if (ret == 0 && cache_max_wait_us != 0 && session->cache_wait_us > cache_max_wait_us) {
-            ret = WT_ROLLBACK;
+            ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW);
             __wt_session_set_last_error(
               session, ret, WT_CACHE_OVERFLOW, WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW);
             __wt_atomic_decrement_if_positive(&evict->evict_aggressive_score);
 
             WT_STAT_CONN_INCR(session, eviction_timed_out_ops);
-            if (F_ISSET(session, WT_SESSION_SAVE_ERRORS))
-                __wt_verbose_notice(
-                  session, WT_VERB_TRANSACTION, "rollback reason: %s", session->err_info.err_msg);
+            __wt_verbose_notice(
+              session, WT_VERB_TRANSACTION, "rollback reason: %s", session->txn->rollback_reason);
         }
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1072,6 +1072,8 @@ extern int __wt_txn_recover(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_txn_rollback_required(WT_SESSION_IMPL *session, const char *reason)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[], bool commit)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_set_timestamp_uint(WT_SESSION_IMPL *session, WT_TS_TXN_TYPE which,

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -21,10 +21,10 @@
  * the session get rollback reason API call. Users of the API could have a dependency on the format
  * of these messages so changing them must be done with care.
  */
-#define WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW "Cache capacity has overflown"
-#define WT_TXN_ROLLBACK_REASON_CONFLICT "Write conflict between concurrent operations"
+#define WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW "transaction rolled back because of cache overflow"
+#define WT_TXN_ROLLBACK_REASON_CONFLICT "conflict between concurrent operations"
 #define WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION \
-    "Transaction has the oldest pinned transaction ID"
+    "oldest pinned transaction ID rolled back for eviction"
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_TXN_LOG_CKPT_CLEANUP 0x01u
@@ -353,6 +353,8 @@ struct __wt_txn {
 
     /* Timeout */
     uint64_t operation_timeout_us;
+
+    const char *rollback_reason; /* If rollback, the reason */
 
 /*
  * WT_TXN_HAS_TS_COMMIT --

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1922,9 +1922,9 @@ __txn_modify_block(
         }
 
         WT_STAT_CONN_DSRC_INCR(session, txn_update_conflict);
-        ret = WT_ROLLBACK;
+        ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_CONFLICT);
         __wt_session_set_last_error(
-          session, ret, WT_WRITE_CONFLICT, WT_TXN_ROLLBACK_REASON_CONFLICT);
+          session, ret, WT_WRITE_CONFLICT, "Write conflict between concurrent operations");
     }
 
     /*
@@ -1986,7 +1986,7 @@ __wt_txn_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE 
         txn_global = &S2C(session)->txn_global;
         if (txn_global->debug_rollback != 0 &&
           ++txn_global->debug_ops % txn_global->debug_rollback == 0)
-            WT_RET_SUB(session, WT_ROLLBACK, WT_NONE, "debug mode simulated conflict");
+            return (__wt_txn_rollback_required(session, "debug mode simulated conflict"));
     }
     return (0);
 }

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -1950,6 +1950,16 @@ struct __wt_session {
     /*! @} */
 
 #ifndef DOXYGEN
+    /*!
+     * Optionally returns the reason for the most recent rollback error returned from the API.
+     *
+     * There is no guarantee a rollback reason will be set and thus the caller
+     * must check for a NULL pointer.
+     *
+     * @param session the session handle
+     * @returns an optional string indicating the reason for the rollback
+     */
+    const char * __F(get_rollback_reason)(WT_SESSION *session);
 
     /*!
      * Call into the library.

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1829,8 +1829,9 @@ __session_commit_transaction(WT_SESSION *wt_session, const char *config)
 
     /* Permit the commit if the transaction failed, but was read-only. */
     if (F_ISSET(txn, WT_TXN_ERROR) && txn->mod_count != 0)
-        WT_ERR_MSG(session, EINVAL, "failed %s transaction requires rollback",
-          F_ISSET(txn, WT_TXN_PREPARE) ? "prepared " : "");
+        WT_ERR_MSG(session, EINVAL, "failed %s transaction requires rollback%s%s",
+          F_ISSET(txn, WT_TXN_PREPARE) ? "prepared " : "", txn->rollback_reason == NULL ? "" : ": ",
+          txn->rollback_reason == NULL ? "" : txn->rollback_reason);
 
 err:
     /*
@@ -2215,6 +2216,20 @@ err:
 }
 
 /*
+ * __session_get_rollback_reason --
+ *     WT_SESSION->get_rollback_reason method.
+ */
+static const char *
+__session_get_rollback_reason(WT_SESSION *wt_session)
+{
+    WT_SESSION_IMPL *session;
+
+    session = (WT_SESSION_IMPL *)wt_session;
+
+    return (session->txn->rollback_reason);
+}
+
+/*
  * __session_get_last_error --
  *     WT_SESSION->get_last_error method.
  */
@@ -2330,7 +2345,8 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __session_begin_transaction, __session_commit_transaction, __session_prepare_transaction,
         __session_rollback_transaction, __session_query_timestamp, __session_timestamp_transaction,
         __session_timestamp_transaction_uint, __session_checkpoint, __session_reset_snapshot,
-        __session_transaction_pinned_range, __session_get_last_error, __wt_session_breakpoint},
+        __session_transaction_pinned_range, __session_get_last_error, __session_get_rollback_reason,
+        __wt_session_breakpoint},
       stds_min = {NULL, NULL, __session_close, __session_reconfigure_notsup, __wt_session_strerror,
         __session_open_cursor, __session_alter_readonly, __session_bind_configuration,
         __session_create_readonly, __wti_session_compact_readonly, __session_drop_readonly,
@@ -2341,7 +2357,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __session_query_timestamp_notsup, __session_timestamp_transaction_notsup,
         __session_timestamp_transaction_uint_notsup, __session_checkpoint_readonly,
         __session_reset_snapshot_notsup, __session_transaction_pinned_range_notsup,
-        __session_get_last_error, __wt_session_breakpoint},
+        __session_get_last_error, __session_get_rollback_reason, __wt_session_breakpoint},
       stds_readonly = {NULL, NULL, __session_close, __session_reconfigure, __wt_session_strerror,
         __session_open_cursor, __session_alter_readonly, __session_bind_configuration,
         __session_create_readonly, __wti_session_compact_readonly, __session_drop_readonly,
@@ -2352,7 +2368,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         __session_query_timestamp, __session_timestamp_transaction,
         __session_timestamp_transaction_uint, __session_checkpoint_readonly,
         __session_reset_snapshot, __session_transaction_pinned_range, __session_get_last_error,
-        __wt_session_breakpoint};
+        __session_get_rollback_reason, __wt_session_breakpoint};
     WT_DECL_RET;
     WT_SESSION_IMPL *session, *session_ret;
     uint32_t i;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -829,6 +829,8 @@ __txn_release(WT_SESSION_IMPL *session)
     __wti_txn_clear_read_timestamp(session);
     txn->isolation = session->isolation;
 
+    txn->rollback_reason = NULL;
+
     /*
      * Ensure the transaction flags are cleared on exit
      *
@@ -2280,6 +2282,18 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[])
 }
 
 /*
+ * __wt_txn_rollback_required --
+ *     Prepare to log a reason if the user attempts to use the transaction to do anything other than
+ *     rollback.
+ */
+int
+__wt_txn_rollback_required(WT_SESSION_IMPL *session, const char *reason)
+{
+    session->txn->rollback_reason = reason;
+    return (WT_ROLLBACK);
+}
+
+/*
  * __wt_txn_init --
  *     Initialize a session's transaction data.
  */
@@ -2677,6 +2691,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
 int
 __wt_txn_is_blocking(WT_SESSION_IMPL *session)
 {
+    WT_DECL_RET;
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     uint64_t global_oldest;
@@ -2715,8 +2730,9 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
      */
     if (__wt_atomic_loadv64(&txn_shared->id) == global_oldest ||
       __wt_atomic_loadv64(&txn_shared->pinned_id) == global_oldest) {
+        ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
         WT_RET_SUB(
-          session, WT_ROLLBACK, WT_OLDEST_FOR_EVICTION, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
+          session, ret, WT_OLDEST_FOR_EVICTION, "Transaction has the oldest pinned transaction ID");
     }
     return (0);
 }
@@ -2798,6 +2814,7 @@ __wt_verbose_dump_txn_one(
         ", read_timestamp: %s"
         ", checkpoint LSN: [%s]"
         ", full checkpoint: %s"
+        ", rollback reason: %s"
         ", flags: 0x%08" PRIx32 ", isolation: %s"
         ", last saved error code: %d"
         ", last saved sub-level error code: %d"
@@ -2810,8 +2827,9 @@ __wt_verbose_dump_txn_one(
         __wt_timestamp_to_string(txn->prepare_timestamp, ts_string[3]),
         __wt_timestamp_to_string(txn_shared->pinned_durable_timestamp, ts_string[4]),
         __wt_timestamp_to_string(txn_shared->read_timestamp, ts_string[5]), ckpt_lsn_str,
-        txn->full_ckpt ? "true" : "false", txn->flags, iso_tag, txn_err_info->err,
-        txn_err_info->sub_level_err, txn_err_info->err_msg));
+        txn->full_ckpt ? "true" : "false", txn->rollback_reason == NULL ? "" : txn->rollback_reason,
+        txn->flags, iso_tag, txn_err_info->err, txn_err_info->sub_level_err,
+        txn_err_info->err_msg));
 
     /*
      * Log a message and return an error if error code and an optional error string has been passed.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -184,19 +184,15 @@ functions:
         set -o errexit
         set -o verbose
         pushd wiredtiger
+        mongo_repo=https://github.com/mongodb/mongo
         # Find the equivalent mongodb branch that matches the same branch version to wiredtiger. In
         # the case of patch builds, it is possible that the developer has a branch name that doesn't
         # adhere to naming rules, therefore derive the base branch name from git.
         branch=$(git branch --contains | grep -e "mongodb" -e "develop" -e "evg-pr-test-")
         if [[ $branch =~ "mongodb-" ]]; then
-          mongo_repo=https://github.com/mongodb/mongo
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
-          # FIXME-WT-14185 Use the public main repo when it is starting to sync with private repo.
-          # The WT-13948 ticket requires changes from the private repository. As a workaround
-          # use a mongodb forked repo with custom branch.
-          mongo_repo=https://github.com/jiechenbo/mongo
-          mongo_branch=wt-13948-workaround
+          mongo_branch=master
         fi
         popd
         git clone $mongo_repo -b $mongo_branch

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -29,6 +29,8 @@
 #include "format.h"
 
 #define SNAP_LIST_SIZE 512
+#define TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION \
+    "oldest pinned transaction ID rolled back for eviction"
 
 /*
  * snap_init --
@@ -630,12 +632,13 @@ static void
 snap_repeat(TINFO *tinfo, SNAP_OPS *snap)
 {
     WT_DECL_RET;
+    WT_SESSION *session;
+    const char *rollback_reason;
 #define MAX_RETRY_ON_ROLLBACK WT_THOUSAND
     u_int max_retry;
 
-    int sub_level_err = 0;
-    const char *err_msg = NULL;
-    WT_SESSION *session = tinfo->session;
+    rollback_reason = NULL;
+    session = tinfo->session;
 
     /* Start a transaction with a read-timestamp and verify the record. */
     for (max_retry = 0; max_retry < MAX_RETRY_ON_ROLLBACK; ++max_retry, __wt_yield()) {
@@ -658,8 +661,7 @@ snap_repeat(TINFO *tinfo, SNAP_OPS *snap)
             break;
         testutil_assertfmt(ret == WT_ROLLBACK, "operation failed: %d", ret);
 
-        sub_level_err = ((WT_SESSION_IMPL *)session)->err_info.sub_level_err;
-        err_msg = ((WT_SESSION_IMPL *)session)->err_info.err_msg;
+        rollback_reason = session->get_rollback_reason(session);
 
         testutil_check(session->rollback_transaction(session, NULL));
     }
@@ -669,9 +671,10 @@ snap_repeat(TINFO *tinfo, SNAP_OPS *snap)
      * This would cause the snapshot read to rollback even we retry many times. Give up and ignore
      * this case.
      */
-    if (max_retry >= MAX_RETRY_ON_ROLLBACK && err_msg != NULL &&
-      sub_level_err == WT_OLDEST_FOR_EVICTION)
-        WARN("%s: %s", "snap repeat exceeds maximum retry", err_msg);
+    if (max_retry >= MAX_RETRY_ON_ROLLBACK && rollback_reason != NULL &&
+      strcmp(rollback_reason, TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION) == 0)
+        WARN(
+          "%s: %s", "snap repeat exceeds maximum retry", TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
     else {
         testutil_assert(max_retry < MAX_RETRY_ON_ROLLBACK);
         testutil_check(session->rollback_transaction(session, NULL));

--- a/test/suite/test_error_info02.py
+++ b/test/suite/test_error_info02.py
@@ -35,6 +35,12 @@ from error_info_util import error_info_util
 class test_error_info02(error_info_util):
     uri = "table:test_error_info.wt"
 
+    def assert_error_equal(self, err_val, sub_level_err_val, err_msg_val):
+        err, sub_level_err, err_msg = self.session.get_last_error()
+        self.assertEqual(err, err_val)
+        self.assertEqual(sub_level_err, sub_level_err_val)
+        self.assertEqual(err_msg, err_msg_val)
+
     def test_wt_rollback_cache_overflow(self):
         """
         Try to insert a key value pair with an unreasonably low cache max wait time and
@@ -70,7 +76,7 @@ class test_error_info02(error_info_util):
 
         self.assert_error_equal(wiredtiger.WT_ROLLBACK, wiredtiger.WT_CACHE_OVERFLOW, "Cache capacity has overflown")
 
-        self.ignoreStdoutPatternIfExists("Cache capacity has overflown")
+        self.ignoreStdoutPatternIfExists("transaction rolled back because of cache overflow")
 
     def test_wt_rollback_write_conflict_update_list(self):
         """

--- a/test/suite/test_error_info04.py
+++ b/test/suite/test_error_info04.py
@@ -55,9 +55,10 @@ class test_error_info04(error_info_util):
         # Configure the lowest cache max wait time so that application attempts eviction.
         self.conn.reconfigure('cache_max_wait_ms=2')
         # Commit all transactions large enough to trigger eviction app worker threads.
-        for temp_session in sessions:
-            self.assertEqual(temp_session.commit_transaction(), 0)
-            self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")
+        with self.expectedStdoutPattern("transaction rolled back because of cache overflow"):
+            for temp_session in sessions:
+                self.assertEqual(temp_session.commit_transaction(), 0)
+                self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")
 
         self.session.checkpoint()
 
@@ -79,6 +80,7 @@ class test_error_info04(error_info_util):
         # Configure the lowest cache max wait time so that application attempts eviction.
         self.conn.reconfigure('cache_max_wait_ms=2')
         # Rollback all transactions large enough to trigger eviction app worker threads.
-        for temp_session in sessions:
-            self.assertEqual(temp_session.rollback_transaction(), 0)
-            self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")
+        with self.expectedStdoutPattern("transaction rolled back because of cache overflow"):
+            for temp_session in sessions:
+                self.assertEqual(temp_session.rollback_transaction(), 0)
+                self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")


### PR DESCRIPTION
This reverts commit 48fa5fc2caadca131d7e62314da659a572ff33ec. It is an anti-pattern for us to use MongoDB forks within our codebase.