### PR TITLE
WT-14205 - Disable zSeries tasks (with activate: false) temporarily

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5727,6 +5727,7 @@ buildvariants:
     ENABLE_TCMALLOC: 0
     posix_configure_flags: -DENABLE_ZSTD=0
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+  activate: false # Launch only manually for now
   tasks:
     - name: compile
     - name: generate-datafile-big-endian
@@ -5764,6 +5765,7 @@ buildvariants:
     ENABLE_TCMALLOC: 0
     # Use half number of vCPU to avoid OOM kill failure
     num_jobs: $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
+  activate: false # Launch only manually for now
   tasks:
     - name: compile
     - name: unit-test


### PR DESCRIPTION
We are seeing a lot of failures on zSeries machines due to toolchain config issues (see [WT-14194](https://jira.mongodb.org/browse/WT-14194)).

This change uses activate: false to disable the zSeries tasks until [WT-14194](https://jira.mongodb.org/browse/WT-14194) is fixed. Using activate: false means that the tasks are still visible in Evergreen and can be manually launched as required, giving more flexibility compared to commenting them out.


