### PR TITLE
WT-14199 Remove log prints in filesystem calls

### DIFF
--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -313,9 +313,7 @@ __posix_fs_remove(
 
 #ifdef __linux__
     /* Flush the backing directory to guarantee the remove. */
-    WT_RET(__wt_log_printf(session, "REMOVE: posix_directory_sync %s", name));
     WT_RET(__posix_directory_sync(session, name));
-    WT_RET(__wt_log_printf(session, "REMOVE: DONE posix_directory_sync %s", name));
 #endif
     return (0);
 }
@@ -355,9 +353,7 @@ __posix_fs_rename(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const cha
      * not provide the guarantee or only provide the guarantee with specific mount options. Flush
      * both of the from/to directories until it's a performance problem.
      */
-    WT_RET(__wt_log_printf(session, "RENAME: posix_directory_sync %s", from));
     WT_RET(__posix_directory_sync(session, from));
-    WT_RET(__wt_log_printf(session, "RENAME: DONE posix_directory_sync %s", from));
 
     /*
      * In almost all cases, we're going to be renaming files in the same directory, we can at least
@@ -892,11 +888,8 @@ __posix_open_file(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const cha
     /*
      * Durability: some filesystems require a directory sync to be confident the file will appear.
      */
-    if (LF_ISSET(WT_FS_OPEN_DURABLE)) {
-        WT_ERR(__wt_log_printf(session, "OPEN/CREATE: posix_directory_sync %s", name));
+    if (LF_ISSET(WT_FS_OPEN_DURABLE))
         WT_ERR(__posix_directory_sync(session, name));
-        WT_ERR(__wt_log_printf(session, "OPEN/CREATE: DONE posix_directory_sync %s", name));
-    }
 #endif
 
     WT_ERR(__posix_open_file_cloexec(session, pfh->fd, name));


### PR DESCRIPTION
The  `__wt_log_printf` in  `__posix_fs_rename` was the culprit of all the deadlocks seen in evergreen. I've removed this and the other calls to `__wt_log_printf` in `os_fs.c` as they create similar dependencies. Let me know if you think we should keep the others in `open_file` and `remove`. Alternatively, if we want to keep all of them, we can add
```
 if (!F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS))
```
and only print them if we're not in live restore mode.

The deadlock does not reproduce with these removed.