### PR TITLE
WT-14195 Reduce set_last_error calls in API_INIT

### DIFF
--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -36,9 +36,10 @@ can get more detailed information about the last session API call. The informati
 error code, a sub-level error code and message. The intended usage of the sub-level error code
 is to allow users to programmatically make decisions on the application level.
 
-The sub-level error code is optional and default to WT_NONE. The error message is also optional and
-would default to an empty string if prior API failed or success message when successful. The error
-message string is owned by the session, and is invalidated after each session API call.
+The sub-level error code is optional and defaults to WT_NONE. When the prior API call succeeds, a
+default success message is returned. When the prior API call fails, the error message is optional
+and defaults to an empty message. The error message string is owned by the session, 
+and is invalidated after each session API call.
 
 @section error_list WiredTiger-specific errors
 

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -38,7 +38,7 @@ is to allow users to programmatically make decisions on the application level.
 
 The sub-level error code is optional and defaults to WT_NONE. When the prior API call succeeds, a
 default success message is returned. When the prior API call fails, the error message is optional
-and defaults to an empty message. The error message string is owned by the session, 
+and defaults to an empty message. The error message string is owned by the session,
 and is invalidated after each session API call.
 
 @section error_list WiredTiger-specific errors

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -36,10 +36,10 @@ can get more detailed information about the last session API call. The informati
 error code, a sub-level error code and message. The intended usage of the sub-level error code
 is to allow users to programmatically make decisions on the application level.
 
-The sub-level error code is optional and defaults to WT_NONE. When the prior API call succeeds, a
-default success message is returned. When the prior API call fails, the error message is optional
-and defaults to an empty message. The error message string is owned by the session,
-and is invalidated after each session API call.
+The sub-level error code is optional and defaults to WT_NONE. When the prior API call succeeds or
+no other API call has been made a default success message is returned. When the prior API call
+fails, the error message is optional and defaults to an empty message. The error message string is
+owned by the session, and is invalidated after each session API call.
 
 @section error_list WiredTiger-specific errors
 

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -36,9 +36,9 @@ can get more detailed information about the last session API call. The informati
 error code, a sub-level error code and message. The intended usage of the sub-level error code
 is to allow users to programmatically make decisions on the application level.
 
-The sub-level error code and error messages are optional and default to WT_NONE and an empty
-string respectively. The error message string is owned by the session, and is invalidated after
-each session API call.
+The sub-level error code is optional and default to WT_NONE. The error message is also optional and
+would default to an empty string if prior API failed or success message when successful. The error
+message string is owned by the session, and is invalidated after each session API call.
 
 @section error_list WiredTiger-specific errors
 

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -89,7 +89,7 @@
      * Reset the err_info struct back to default only if the prior API call had an error - passing \
      * NULL sets the message to WT_ERROR_INFO_SUCCESS.                                             \
      */                                                                                            \
-    if ((s)->err_info->err != 0)                                                                   \
+    if ((s)->err_info.err != 0)                                                                    \
         __wt_session_set_last_error((s), 0, WT_NONE, NULL);                                        \
     __wt_verbose((s), WT_VERB_API, "%s", "CALL: " #struct_name ":" #func_name)
 

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -85,8 +85,12 @@
     /* Reset wait time if this isn't an API reentry. */                                            \
     if ((s)->api_call_counter == 1)                                                                \
         (s)->cache_wait_us = 0;                                                                    \
-    /* Initialize the err_info struct - passing NULL sets the message to WT_ERROR_INFO_SUCCESS. */ \
-    __wt_session_set_last_error((s), 0, WT_NONE, NULL);                                            \
+    /*                                                                                             \
+     * Reset the err_info struct back to default only if the prior API call had an error - passing \
+     * NULL sets the message to WT_ERROR_INFO_SUCCESS.                                             \
+     */                                                                                            \
+    if ((s)->err_info->err != 0)                                                                   \
+        __wt_session_set_last_error((s), 0, WT_NONE, NULL);                                        \
     __wt_verbose((s), WT_VERB_API, "%s", "CALL: " #struct_name ":" #func_name)
 
 #define API_CALL_NOCONF(s, struct_name, func_name, dh) \

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -70,27 +70,26 @@
     --(s)->api_call_counter
 
 /* Standard entry points to the API: declares/initializes local variables. */
-#define API_SESSION_INIT(s, struct_name, func_name, dh)                                            \
-    WT_TRACK_OP_DECL;                                                                              \
-    API_SESSION_PUSH(s, struct_name, func_name, dh);                                               \
-    /*                                                                                             \
-     * No code before this line, otherwise error handling won't be                                 \
-     * correct.                                                                                    \
-     */                                                                                            \
-    WT_ERR(WT_SESSION_CHECK_PANIC(s));                                                             \
-    WT_SINGLE_THREAD_CHECK_START(s);                                                               \
-    WT_TRACK_OP_INIT(s);                                                                           \
-    if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL))                            \
-        __wt_op_timer_start(s);                                                                    \
-    /* Reset wait time if this isn't an API reentry. */                                            \
-    if ((s)->api_call_counter == 1)                                                                \
-        (s)->cache_wait_us = 0;                                                                    \
-    /*                                                                                             \
-     * Reset the err_info struct back to default only if the prior API call had an error - passing \
-     * NULL sets the message to WT_ERROR_INFO_SUCCESS.                                             \
-     */                                                                                            \
-    if ((s)->err_info.err != 0)                                                                    \
-        __wt_session_set_last_error((s), 0, WT_NONE, NULL);                                        \
+#define API_SESSION_INIT(s, struct_name, func_name, dh)                                  \
+    WT_TRACK_OP_DECL;                                                                    \
+    API_SESSION_PUSH(s, struct_name, func_name, dh);                                     \
+    /*                                                                                   \
+     * No code before this line, otherwise error handling won't be                       \
+     * correct.                                                                          \
+     */                                                                                  \
+    WT_ERR(WT_SESSION_CHECK_PANIC(s));                                                   \
+    WT_SINGLE_THREAD_CHECK_START(s);                                                     \
+    WT_TRACK_OP_INIT(s);                                                                 \
+    if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL))                  \
+        __wt_op_timer_start(s);                                                          \
+    /* Reset wait time if this isn't an API reentry. */                                  \
+    if ((s)->api_call_counter == 1)                                                      \
+        (s)->cache_wait_us = 0;                                                          \
+    /*                                                                                   \
+     * Reset the err_info struct back to default only if the prior API call had an error \
+     */                                                                                  \
+    if ((s)->err_info.err != 0)                                                          \
+        __wt_session_reset_last_error((s));                                              \
     __wt_verbose((s), WT_VERB_API, "%s", "CALL: " #struct_name ":" #func_name)
 
 #define API_CALL_NOCONF(s, struct_name, func_name, dh) \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1546,6 +1546,7 @@ extern void __wt_session_dhandle_sweep(WT_SESSION_IMPL *session);
 extern void __wt_session_dhandle_writeunlock(WT_SESSION_IMPL *session);
 extern void __wt_session_gen_enter(WT_SESSION_IMPL *session, int which);
 extern void __wt_session_gen_leave(WT_SESSION_IMPL *session, int which);
+extern void __wt_session_reset_last_error(WT_SESSION_IMPL *session);
 extern void __wt_session_set_last_error(
   WT_SESSION_IMPL *session, int err, int sub_level_err, const char *fmt, ...);
 extern void __wt_stash_discard(WT_SESSION_IMPL *session);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2512,7 +2512,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     F_SET(session_ret, WT_SESSION_SAVE_ERRORS);
     session_ret->err_info.err_msg = NULL;
     WT_ERR(__wt_buf_initsize(session, &(session_ret->err_info.err_msg_buf), 128));
-    __wt_session_set_last_error(session_ret, 0, WT_NONE, NULL);
+    __wt_session_reset_last_error(session_ret);
 
     /*
      * Release write to ensure structure fields are set before any other thread will consider the

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2512,7 +2512,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     F_SET(session_ret, WT_SESSION_SAVE_ERRORS);
     session_ret->err_info.err_msg = NULL;
     WT_ERR(__wt_buf_initsize(session, &(session_ret->err_info.err_msg_buf), 128));
-    __wt_session_set_last_error(session_ret, 0, WT_NONE, WT_ERROR_INFO_EMPTY);
+    __wt_session_set_last_error(session_ret, 0, WT_NONE, NULL);
 
     /*
      * Release write to ensure structure fields are set before any other thread will consider the

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -156,9 +156,8 @@ __wt_session_set_last_error(
     if (session == NULL || !F_ISSET(session, WT_SESSION_SAVE_ERRORS))
         return;
 
-    /*
-     * Only update the err_info struct if it has not been previously set in the current API call or
-     * if it is being reset back to default.
+    /* Only update if the err_info struct has not been previously set in the current API call, or
+     * if the err_info struct is being reset.
      */
     if (session->err_info.err != 0 && err != 0)
         return;
@@ -170,14 +169,14 @@ __wt_session_set_last_error(
      * Load error codes and message into err_info. If the message is empty or is NULL (indicating
      * success), use static string buffers. Otherwise, format the message into the buffer.
      *
-     * If err == 0, we are at the start of an API call, in which case fmt should be NULL and err_msg
-     * should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a strcmp to
-     * validate that we never set err = 0 with a custom message.
+     * If err == 0, we are at the start of an API call, in which case fmt should be NULL
+     * and err_msg should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a
+     * strcmp to validate that we never set err = 0 with a custom message.
      */
     WT_ERROR_INFO *err_info = &(session->err_info);
     err_info->err = err;
     err_info->sub_level_err = sub_level_err;
-    if (fmt != NULL)
+    if (fmt != NULL && strlen(fmt) == 0)
         err_info->err_msg = WT_ERROR_INFO_EMPTY;
     else if (err == 0) {
         WT_ASSERT(session, fmt == NULL);

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -168,23 +168,28 @@ __wt_session_set_last_error(
     /*
      * Load error codes and message into err_info. If the message is empty or is NULL (indicating
      * success), use static string buffers. Otherwise, format the message into the buffer.
-     *
-     * When err is 0, it signifies the start of an API call. The fmt needs to be set to NULL, which
-     * sets the err_msg to WT_ERROR_INFO_SUCCESS. The NULL here implies success saving us from an
-     * extra strcmp().
      */
     WT_ERROR_INFO *err_info = &(session->err_info);
     err_info->err = err;
     err_info->sub_level_err = sub_level_err;
-    if (fmt != NULL && strlen(fmt) == 0)
-        err_info->err_msg = WT_ERROR_INFO_EMPTY;
-    else if (err == 0) {
+    if (err == 0) {
+        /*
+         * A successful API call results in having err equal to 0 and the err_msg set to the default
+         * success message.
+         *
+         * The fmt variable doesn't need to be processed because the successful err_msg is fixed. 
+         * Therefore, the fmt variable should be NULL when an API call is successful.
+         */
         WT_ASSERT(session, fmt == NULL);
         err_info->err_msg = WT_ERROR_INFO_SUCCESS;
     } else {
+      if (strlen(fmt) == 0)
+        err_info->err_msg = WT_ERROR_INFO_EMPTY;
+      else {
         WT_ASSERT(session, fmt != NULL);
         WT_VA_ARGS_BUF_FORMAT(session, &(err_info->err_msg_buf), fmt, false);
         err_info->err_msg = err_info->err_msg_buf.data;
+      }
     }
 
     return;

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -169,9 +169,9 @@ __wt_session_set_last_error(
      * Load error codes and message into err_info. If the message is empty or is NULL (indicating
      * success), use static string buffers. Otherwise, format the message into the buffer.
      *
-     * If err == 0, we are at the start of an API call, in which case fmt should be NULL and err_msg
-     * should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a strcmp to
-     * validate that we never set err = 0 with a custom message.
+     * When err is 0, it signifies the start of an API call. The fmt needs to be set to NULL, which
+     * sets the err_msg to WT_ERROR_INFO_SUCCESS. The NULL here implies success saving us from an
+     * extra strcmp().
      */
     WT_ERROR_INFO *err_info = &(session->err_info);
     err_info->err = err;

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -169,9 +169,9 @@ __wt_session_set_last_error(
      * Load error codes and message into err_info. If the message is empty or is NULL (indicating
      * success), use static string buffers. Otherwise, format the message into the buffer.
      *
-     * If err == 0, we are at the start of an API call, in which case fmt should be NULL
-     * and err_msg should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a
-     * strcmp to validate that we never set err = 0 with a custom message.
+     * If err == 0, we are at the start of an API call, in which case fmt should be NULL and err_msg
+     * should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a strcmp to
+     * validate that we never set err = 0 with a custom message.
      */
     WT_ERROR_INFO *err_info = &(session->err_info);
     err_info->err = err;

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -157,7 +157,7 @@ __wt_session_reset_last_error(WT_SESSION_IMPL *session)
 
 /*
  * __wt_session_set_last_error --
- *     Stores information about the last error to occur during this session.
+ *     Record errors that occur in the lifetime of a session API call.
  */
 void
 __wt_session_set_last_error(

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -177,19 +177,19 @@ __wt_session_set_last_error(
          * A successful API call results in having err equal to 0 and the err_msg set to the default
          * success message.
          *
-         * The fmt variable doesn't need to be processed because the successful err_msg is fixed. 
+         * The fmt variable doesn't need to be processed because the successful err_msg is fixed.
          * Therefore, the fmt variable should be NULL when an API call is successful.
          */
         WT_ASSERT(session, fmt == NULL);
         err_info->err_msg = WT_ERROR_INFO_SUCCESS;
     } else {
-      if (strlen(fmt) == 0)
-        err_info->err_msg = WT_ERROR_INFO_EMPTY;
-      else {
-        WT_ASSERT(session, fmt != NULL);
-        WT_VA_ARGS_BUF_FORMAT(session, &(err_info->err_msg_buf), fmt, false);
-        err_info->err_msg = err_info->err_msg_buf.data;
-      }
+        if (strlen(fmt) == 0)
+            err_info->err_msg = WT_ERROR_INFO_EMPTY;
+        else {
+            WT_ASSERT(session, fmt != NULL);
+            WT_VA_ARGS_BUF_FORMAT(session, &(err_info->err_msg_buf), fmt, false);
+            err_info->err_msg = err_info->err_msg_buf.data;
+        }
     }
 
     return;

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -177,8 +177,8 @@ __wt_session_set_last_error(
          * A successful API call results in having err equal to 0 and the err_msg set to the default
          * success message.
          *
-         * The fmt variable doesn't need to be processed because the successful err_msg is fixed.
-         * Therefore, the fmt variable should be NULL when an API call is successful.
+         * Since the successful err_msg is fixed the fmt variable doesn't need to be processed.
+         * Therefore, the fmt variable should equal to NULL whenever an API call is successful.
          */
         WT_ASSERT(session, fmt == NULL);
         err_info->err_msg = WT_ERROR_INFO_SUCCESS;

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -156,8 +156,9 @@ __wt_session_set_last_error(
     if (session == NULL || !F_ISSET(session, WT_SESSION_SAVE_ERRORS))
         return;
 
-    /* Only update if the err_info struct has not been previously set in the current API call, or
-     * if the err_info struct is being reset.
+    /*
+     * Only update the err_info struct if it has not been previously set in the current API call or
+     * if it is being reset back to default.
      */
     if (session->err_info.err != 0 && err != 0)
         return;
@@ -169,15 +170,14 @@ __wt_session_set_last_error(
      * Load error codes and message into err_info. If the message is empty or is NULL (indicating
      * success), use static string buffers. Otherwise, format the message into the buffer.
      *
-     * If err == 0, either: we are opening the session and err_msg should be initialized to
-     * WT_ERROR_INFO_EMPTY; or we are at the start of an API call, in which case fmt should be NULL
-     * and err_msg should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a
-     * strcmp to validate that we never set err = 0 with a custom message.
+     * If err == 0, we are at the start of an API call, in which case fmt should be NULL and err_msg
+     * should be set to WT_ERROR_INFO_SUCCESS. NULL implying success here saves us a strcmp to
+     * validate that we never set err = 0 with a custom message.
      */
     WT_ERROR_INFO *err_info = &(session->err_info);
     err_info->err = err;
     err_info->sub_level_err = sub_level_err;
-    if (fmt != NULL && strlen(fmt) == 0)
+    if (fmt != NULL)
         err_info->err_msg = WT_ERROR_INFO_EMPTY;
     else if (err == 0) {
         WT_ASSERT(session, fmt == NULL);

--- a/test/catch2/sub_level_error/api/test_sub_level_error_session_get_last_error.cpp
+++ b/test/catch2/sub_level_error/api/test_sub_level_error_session_get_last_error.cpp
@@ -38,6 +38,6 @@ TEST_CASE("Session get last error - test getting verbose info about the last err
         /* Test that the API returns expected default values. */
         CHECK(err == 0);
         CHECK(sub_level_err == WT_NONE);
-        CHECK(strcmp(err_msg, WT_ERROR_INFO_EMPTY) == 0);
+        CHECK(strcmp(err_msg, WT_ERROR_INFO_SUCCESS) == 0);
     }
 }

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_compact.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_compact.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Test functions for error handling in compaction workflows",
         // Set database as in-memory and readonly.
         F_SET(conn_impl, WT_CONN_IN_MEMORY | WT_CONN_READONLY);
         CHECK(__wt_background_compact_signal(session_impl, NULL) == ENOTSUP);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
         // Clear in-memory and read only flag as connection close requires them to be cleared.
         F_CLR(conn_impl, WT_CONN_IN_MEMORY | WT_CONN_READONLY);
     }
@@ -44,15 +44,15 @@ TEST_CASE("Test functions for error handling in compaction workflows",
     {
         // New background compaction config string doesn't contain background key.
         CHECK(__wt_background_compact_signal(session_impl, "") == WT_NOTFOUND);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Set new background compaction config string to false.
         CHECK(__wt_background_compact_signal(session_impl, "background=false") == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Set new background compaction config string to true.
         CHECK(__wt_background_compact_signal(session_impl, "background=true") == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 
     SECTION("Test __wt_background_compact_signal - background_compact configuration")
@@ -64,7 +64,7 @@ TEST_CASE("Test functions for error handling in compaction workflows",
           "dryrun=false,exclude=,free_space_target=20MB,run_once=false,timeout=1200";
 
         CHECK(__wt_background_compact_signal(session_impl, "background=true") == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Expect the new configuration not match the already set configuration. Expect an error.
         conn_impl->background_compact.config = "";

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
@@ -155,7 +155,7 @@ TEST_CASE("Test conflicts with checkpoint/schema/table locks", "[sub_level_error
 
         utils::check_error_info(
           err_info_a, EBUSY, WT_CONFLICT_CHECKPOINT_LOCK, CONFLICT_CHECKPOINT_LOCK_MSG);
-        utils::check_error_info(err_info_b, 0, WT_NONE, WT_ERROR_INFO_EMPTY);
+        utils::check_error_info(err_info_b, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 
     SECTION("Test CONFLICT_SCHEMA_LOCK")
@@ -166,7 +166,7 @@ TEST_CASE("Test conflicts with checkpoint/schema/table locks", "[sub_level_error
 
         utils::check_error_info(
           err_info_a, EBUSY, WT_CONFLICT_SCHEMA_LOCK, CONFLICT_SCHEMA_LOCK_MSG);
-        utils::check_error_info(err_info_b, 0, WT_NONE, WT_ERROR_INFO_EMPTY);
+        utils::check_error_info(err_info_b, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 #endif
 
@@ -177,7 +177,7 @@ TEST_CASE("Test conflicts with checkpoint/schema/table locks", "[sub_level_error
                                  REQUIRE(session_a->drop(session_a, URI, "lock_wait=0") == EBUSY););
 
         utils::check_error_info(err_info_a, EBUSY, WT_CONFLICT_TABLE_LOCK, CONFLICT_TABLE_LOCK_MSG);
-        utils::check_error_info(err_info_b, 0, WT_NONE, WT_ERROR_INFO_EMPTY);
+        utils::check_error_info(err_info_b, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 
     /* Drop the table once the tests are completed. */

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
@@ -172,7 +172,7 @@ TEST_CASE("Test functions for error handling in rollback workflows",
           "Transaction has the oldest pinned transaction ID");
 
         // Reset error.
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        __wt_session_reset_last_error(session_impl);
 
         // Set transaction's ID to be equal to the oldest transaction ID.
         txn_shared->id = S2C(session)->txn_global.oldest_id;

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
@@ -126,7 +126,7 @@ TEST_CASE("Test functions for error handling in rollback workflows",
         // Set transaction as prepared. This should cause an early exist so no error is returned.
         F_SET(session_impl->txn, WT_TXN_PREPARE);
         CHECK(__wt_txn_is_blocking(session_impl) == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 
     SECTION("Test WT_OLDEST_FOR_EVICTION in __wt_txn_is_blocking - rollback can't be handled")
@@ -137,22 +137,22 @@ TEST_CASE("Test functions for error handling in rollback workflows",
         // Set the transaction to have 1 modification.
         session_impl->txn->mod_count = 1;
         CHECK(__wt_txn_is_blocking(session_impl) == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Set transaction running to true.
         F_SET(session_impl->txn, WT_TXN_RUNNING);
         CHECK(__wt_txn_is_blocking(session_impl) == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Set operations timers to low value.
         session_impl->operation_start_us = session_impl->operation_timeout_us = 1;
         CHECK(__wt_txn_is_blocking(session_impl) == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Set the transaction to have 0 modifications.
         session_impl->txn->mod_count = 0;
         CHECK(__wt_txn_is_blocking(session_impl) == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 
     SECTION("Test WT_OLDEST_FOR_EVICTION in __wt_txn_is_blocking - transaction ID")
@@ -162,7 +162,7 @@ TEST_CASE("Test functions for error handling in rollback workflows",
 
         // Check if the transaction's ID or its pinned ID is equal to the oldest transaction ID.
         CHECK(__wt_txn_is_blocking(session_impl) == 0);
-        check_error_info(err_info, 0, WT_NONE, "");
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Set transaction's pinned ID to be equal to the oldest transaction ID.
         WT_TXN_SHARED *txn_shared = WT_SESSION_TXN_SHARED(session_impl);

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
@@ -18,7 +18,7 @@
 
 using namespace utils;
 
-TEST_CASE("Session set last error - test storing verbose info about the last error in the session",
+TEST_CASE("Test set_last_error and reset_last_error functions",
   "[sub_level_error_session_set_last_error],[sub_level_error]")
 {
     WT_SESSION *session;
@@ -33,13 +33,13 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
     SECTION("Test with NULL session")
     {
         // Check that function can handle a NULL session without aborting.
-        __wt_session_set_last_error(NULL, 0, WT_NONE, WT_ERROR_INFO_EMPTY);
+        __wt_session_reset_last_error(NULL);
     }
 
     SECTION("Test with initial values")
     {
         const char *err_msg_content = WT_ERROR_INFO_SUCCESS;
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        __wt_session_reset_last_error(session_impl);
         check_error_info(err_info, 0, WT_NONE, err_msg_content);
     }
 
@@ -62,7 +62,7 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
         check_error_info(err_info, EINVAL, WT_NONE, err_msg_content);
 
         // The error message should be reset.
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        __wt_session_reset_last_error(session_impl);
         check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 
@@ -70,7 +70,7 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
     {
         const char *err_msg_content_EINVAL = "Some EINVAL error";
         const char *err_msg_content_EBUSY = "Some EBUSY error";
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        __wt_session_reset_last_error(session_impl);
         check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
         __wt_session_set_last_error(
           session_impl, EINVAL, WT_BACKGROUND_COMPACT_ALREADY_RUNNING, err_msg_content_EINVAL);
@@ -78,18 +78,18 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
           err_info, EINVAL, WT_BACKGROUND_COMPACT_ALREADY_RUNNING, err_msg_content_EINVAL);
 
         // Reset error.
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        __wt_session_reset_last_error(session_impl);
 
         __wt_session_set_last_error(
           session_impl, EBUSY, WT_UNCOMMITTED_DATA, err_msg_content_EBUSY);
         check_error_info(err_info, EBUSY, WT_UNCOMMITTED_DATA, err_msg_content_EBUSY);
 
         // Reset error.
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        __wt_session_reset_last_error(session_impl);
 
         __wt_session_set_last_error(session_impl, EBUSY, WT_DIRTY_DATA, err_msg_content_EBUSY);
         check_error_info(err_info, EBUSY, WT_DIRTY_DATA, err_msg_content_EBUSY);
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        __wt_session_reset_last_error(session_impl);
         check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
 
     SECTION("Test with initial values")
     {
-        const char *err_msg_content = WT_ERROR_INFO_EMPTY;
+        const char *err_msg_content = WT_ERROR_INFO_SUCCESS;
         __wt_session_set_last_error(session_impl, 0, WT_NONE, err_msg_content);
         check_error_info(err_info, 0, WT_NONE, err_msg_content);
     }

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
@@ -70,8 +70,8 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
     {
         const char *err_msg_content_EINVAL = "Some EINVAL error";
         const char *err_msg_content_EBUSY = "Some EBUSY error";
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, WT_ERROR_INFO_EMPTY);
-        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_EMPTY);
+        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
         __wt_session_set_last_error(
           session_impl, EINVAL, WT_BACKGROUND_COMPACT_ALREADY_RUNNING, err_msg_content_EINVAL);
         check_error_info(

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Session set last error - test storing verbose info about the last err
     SECTION("Test with initial values")
     {
         const char *err_msg_content = WT_ERROR_INFO_SUCCESS;
-        __wt_session_set_last_error(session_impl, 0, WT_NONE, err_msg_content);
+        __wt_session_set_last_error(session_impl, 0, WT_NONE, NULL);
         check_error_info(err_info, 0, WT_NONE, err_msg_content);
     }
 

--- a/test/suite/test_error_info01.py
+++ b/test/suite/test_error_info01.py
@@ -113,7 +113,7 @@ class test_error_info01(error_info_util, compact_util):
         codes/message should reflect the result of the most recent API call, regardless of whether
         it failed or succeeded.
         """
-        self.assert_error_equal(0, wiredtiger.WT_NONE, "")
+        self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")
         self.test_success()
         self.test_einval_wt_background_compaction_already_running()
         self.test_ebusy_wt_uncommitted_data()
@@ -129,7 +129,7 @@ class test_error_info01(error_info_util, compact_util):
         Test that successive API calls with the same outcome result in the same error codes and
         message being stored. The codes/message should only change when the result changes.
         """
-        self.assert_error_equal(0, wiredtiger.WT_NONE, "")
+        self.assert_error_equal(0, wiredtiger.WT_NONE, "last API call was successful")
         self.test_success()
         self.test_success()
         self.test_einval_wt_background_compaction_already_running()


### PR DESCRIPTION
As part of [PM-3810](https://jira.mongodb.org/browse/SPM-3810) and [WT-13866](https://jira.mongodb.org/browse/WT-13866), we have introduced a performance regression. The performance regression is due to the number of calls calling set last error within each session API call. Currently, we call the set_last_error function to return the session error info structure to the default state before performing the actual session API work. This was done because of the need to have error state clean before we start tracking errors within WiredTiger.

**Solution**
The solution to this problem is to only perform set_last_error if the previous session error info contains a fail error code. In this case it means that we do not need to perform unnecessary resetting to default and only set it back to default if any of the members inside the error info structure was changed.

This also requires change in the API behaviour. After a success full open session call, the error message will reflect the successful open of a session with a success message. Previously it would be an empty string.