### PR TITLE
WT-14109 Make memory-model-test compatible with the v5 toolchain

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3496,7 +3496,7 @@ tasks:
           script: |
             set -o errexit
             set -o verbose
-            export "PATH=/opt/mongodbtoolchain/v4/bin:$PATH"
+            export "PATH=/opt/mongodbtoolchain/v5/bin:$PATH"
             g++ -o memory_model_test -O2 memory_model_test.cpp -lpthread -std=c++20 -Wall -Werror
             ./memory_model_test -n 100000000
 


### PR DESCRIPTION
Our memory-model test initially had issues when running with the v5 toolchain installation script. Now that the v5 toolchain is pre-installed on our ARM machines, the test is passing successfully. To simplify potential future rollbacks—if we ever need to revert to v4—this PR keeps the change isolated.