### PR TITLE
WT-14152 Enable compressor tests and TCMalloc on ARMV9 machines

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -277,19 +277,6 @@ functions:
           DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
         fi
 
-        # FIXME-WT-14152: Enable LZ4 and snappy compressors once installed on machines.
-        if [[ "${build_variant|}" =~ "amazon2023" ]]; then
-          if [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_LZ4=1) ]]; then
-            DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_LZ4=1/}
-          fi
-          if [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_ZSTD=1) ]]; then
-            DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_ZSTD=1/}
-          fi
-          if [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_SNAPPY=1) ]]; then
-            DEFINED_EVERGREEN_CONFIG_FLAGS=${DEFINED_EVERGREEN_CONFIG_FLAGS/\-DHAVE_BUILTIN_EXTENSION_SNAPPY=1/}
-          fi
-        fi
-
         if [[ "${build_variant|}" =~ "macos-14" ]]; then
           # For mac builds, we want explicitly tell cmake which python to use, as
           # well as the matching library directory and header files. The find_libpython
@@ -6077,7 +6064,7 @@ buildvariants:
   run_on:
   - amazon2023-arm64-latest-small-m8g
   expansions:
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=RelWithDebInfo
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     NONSTANDALONE: -DWT_STANDALONE_BUILD=0
@@ -6100,7 +6087,7 @@ buildvariants:
   run_on:
   - amazon2023-arm64-latest-large-m8g
   expansions:
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     NONSTANDALONE: -DWT_STANDALONE_BUILD=0
     unit_test_variant_args: "--hook nonstandalone"
@@ -6118,8 +6105,7 @@ buildvariants:
     - name: ".stress-test-4"
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
-    # FIXME-WT-14152: Enable stress tests that require snappy compressors
-    - name: ".cppsuite-stress-test !cppsuite-burst-inserts-stress !cppsuite-hs-cleanup-stress !cppsuite-operations-test-stress !cppsuite-reverse-split-stress"
+    - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
 
 - name: amazon2023-release-armv9
@@ -6128,7 +6114,7 @@ buildvariants:
   - amazon2023-arm64-latest-small-m8g
   batchtime: 720 # 12 hours
   expansions:
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=RelWithDebInfo
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
   tasks:
@@ -6153,19 +6139,17 @@ buildvariants:
   - amazon2023-arm64-latest-small-m8g
   batchtime: 1440 # 24 hours
   expansions:
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
   tasks:
-    # FIXME-WT-14152: Enable once LZ4 and snappy compressors are on machines
-    # - name: ".workgen-test"
-    #  batchtime: 1440 # 24 hours
+    - name: ".workgen-test"
+      batchtime: 1440 # 24 hours
     - name: checkpoint-filetypes-test
     - name: chunkcache-test
     - name: compile
     - name: fops
-    # FIXME-WT-14152: Enable once LZ4 and snappy compressors are on machines
-    # - name: format-failure-configs-test
-    #  distros: amazon2023-arm64-latest-large-m8g
+    - name: format-failure-configs-test
+      distros: amazon2023-arm64-latest-large-m8g
     - name: format-smoke-test
     - name: format-stress-pull-request-test
     - name: long-test
@@ -6194,9 +6178,8 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: compile
     - name: fops
-    # FIXME-WT-14152: Enable once LZ4 and snappy compressors are on machines
-    # - name: format-failure-configs-test
-    #  distros: amazon2023-arm64-latest-large-m8g
+    - name: format-failure-configs-test
+      distros: amazon2023-arm64-latest-large-m8g
 
 - name: cppsuite-stress-tests-armv9
   display_name: "(ARMV9) Cppsuite Stress Tests ARM64"
@@ -6204,19 +6187,18 @@ buildvariants:
   run_on:
   - amazon2023-arm64-latest-large-m8g
   expansions:
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: compile
-    # FIXME-WT-14152: Enable stress tests that require snappy compressors
-    - name: ".cppsuite-stress-test !cppsuite-burst-inserts-stress !cppsuite-hs-cleanup-stress !cppsuite-operations-test-stress !cppsuite-reverse-split-stress"
+    - name: ".cppsuite-stress-test"
 
 - name: amazon2023-stress-tests-armv9
   display_name: (ARMV9) Amazon2023 Stress tests ARM64
   run_on:
   - amazon2023-arm64-latest-large-m8g
   expansions:
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: ".stress-test-1"
@@ -6237,7 +6219,7 @@ buildvariants:
   expansions:
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=ASan
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     additional_env_vars: |
       export LSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/asan_leaks.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
@@ -6260,7 +6242,7 @@ buildvariants:
   expansions:
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=TSan
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     additional_env_vars: |
       export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
@@ -6279,7 +6261,7 @@ buildvariants:
     # Use optimisation level -O0 since Clang treats -Og (our default optimisation for non-release
     # builds) as -O1, making test binaries more difficult to debug.
     CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     # We don't run C++ memory sanitized testing as it creates false positives. MSAN also causes
     # some csuite tests to take an extended amount of time. These are excluded from the
     # make-check-test task and are covered by the csuite-long-running task.
@@ -6309,7 +6291,7 @@ buildvariants:
     # Use optimisation level -O0 since Clang treats -Og (our default optimisation for non-release
     # builds) as -O1, making test binaries more difficult to debug.
     CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-    ENABLE_TCMALLOC: 0
+    ENABLE_TCMALLOC: 1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: compile
@@ -6338,6 +6320,5 @@ buildvariants:
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: compile
-    # FIXME-WT-14152: Enable stress tests that require snappy compressors
-    - name: ".cppsuite-stress-test !cppsuite-burst-inserts-stress !cppsuite-hs-cleanup-stress !cppsuite-operations-test-stress !cppsuite-reverse-split-stress"
+    - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6219,7 +6219,7 @@ buildvariants:
   expansions:
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=ASan
-    ENABLE_TCMALLOC: 1
+    ENABLE_TCMALLOC: 0
     additional_env_vars: |
       export LSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/asan_leaks.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
@@ -6242,7 +6242,7 @@ buildvariants:
   expansions:
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=TSan
-    ENABLE_TCMALLOC: 1
+    ENABLE_TCMALLOC: 0
     additional_env_vars: |
       export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
@@ -6261,7 +6261,7 @@ buildvariants:
     # Use optimisation level -O0 since Clang treats -Og (our default optimisation for non-release
     # builds) as -O1, making test binaries more difficult to debug.
     CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-    ENABLE_TCMALLOC: 1
+    ENABLE_TCMALLOC: 0
     # We don't run C++ memory sanitized testing as it creates false positives. MSAN also causes
     # some csuite tests to take an extended amount of time. These are excluded from the
     # make-check-test task and are covered by the csuite-long-running task.
@@ -6291,7 +6291,7 @@ buildvariants:
     # Use optimisation level -O0 since Clang treats -Og (our default optimisation for non-release
     # builds) as -O1, making test binaries more difficult to debug.
     CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-    ENABLE_TCMALLOC: 1
+    ENABLE_TCMALLOC: 0
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: compile

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -51,15 +51,14 @@ buildvariants:
     <<: *ubuntu2004-perf-tests-expansions-template
     collection: AllPerfTestsARM64
 
-# FIXME-WT-14152: Enable once LZ4 and snappy compressors are on machines
-#- <<: *perf-tasks-template
-#  name: amazon2023-perf-tests-arm64
-#  display_name: (ARMV9) Amazon Linux 2023 Performance tests (ARM64)
-#  run_on:
-#    - amazon2023-arm64-latest-large-m8g
-#  expansions:
-#    <<: *ubuntu2004-perf-tests-expansions-template
-#    collection: AllPerfTestsARM64
+- <<: *perf-tasks-template
+  name: amazon2023-perf-tests-arm64
+  display_name: (ARMV9) Amazon Linux 2023 Performance tests (ARM64)
+  run_on:
+   - amazon2023-arm64-latest-large-m8g
+  expansions:
+    <<: *ubuntu2004-perf-tests-expansions-template
+    collection: AllPerfTestsARM64
 
 - <<: *perf-tasks-template
   name: ubuntu2004-perf-tests-arm64-only


### PR DESCRIPTION
During the work of [WT-14122](https://jira.mongodb.org/browse/WT-14122), we have found that armv9 machines do not have lz4, snappy compressors installed on the machine. Additionally due to [WT-14149](https://jira.mongodb.org/browse/WT-14149) we have found that TCMalloc fails to build due the mongo-fork repo being outdated. Since then we have been able to get compressors and TCMalloc working on the machine.

This ticket will be enabling the compressor related tests and enabling TCMalloc on all machines.