### PR TITLE
SLS-1434 Skip building internal page deltas for splits

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -801,6 +801,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
 
     /* The split is complete and verified, ignore benign errors. */
     complete = WT_ERR_IGNORE;
+    F_SET(parent->modify, WT_PAGE_MODIFY_PINDEX_UPDATE);
 
     /*
      * The new page index is in place. Threads cursoring in the tree are blocked because the WT_REF
@@ -1073,6 +1074,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 
     /* The split is complete and verified, ignore benign errors. */
     complete = WT_ERR_IGNORE;
+    F_SET(parent->modify, WT_PAGE_MODIFY_PINDEX_UPDATE);
 
     /*
      * We don't care about the page-index we allocated, all we needed was the array of WT_REF

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -801,7 +801,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
 
     /* The split is complete and verified, ignore benign errors. */
     complete = WT_ERR_IGNORE;
-    F_SET(parent->modify, WT_PAGE_MODIFY_PINDEX_UPDATE);
+    F_SET_ATOMIC_16(parent, WT_PAGE_INTL_PINDEX_UPDATE);
 
     /*
      * The new page index is in place. Threads cursoring in the tree are blocked because the WT_REF
@@ -1074,7 +1074,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 
     /* The split is complete and verified, ignore benign errors. */
     complete = WT_ERR_IGNORE;
-    F_SET(parent->modify, WT_PAGE_MODIFY_PINDEX_UPDATE);
+    F_SET_ATOMIC_16(page, WT_PAGE_INTL_PINDEX_UPDATE);
 
     /*
      * We don't care about the page-index we allocated, all we needed was the array of WT_REF

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1074,6 +1074,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 
     /* The split is complete and verified, ignore benign errors. */
     complete = WT_ERR_IGNORE;
+    WT_ASSERT(session, F_ISSET_ATOMIC_16(page, WT_PAGE_INTL_PINDEX_UPDATE));
 
     /*
      * We don't care about the page-index we allocated, all we needed was the array of WT_REF

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1074,7 +1074,6 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
 
     /* The split is complete and verified, ignore benign errors. */
     complete = WT_ERR_IGNORE;
-    F_SET_ATOMIC_16(page, WT_PAGE_INTL_PINDEX_UPDATE);
 
     /*
      * We don't care about the page-index we allocated, all we needed was the array of WT_REF

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -581,8 +581,7 @@ struct __wt_page_modify {
 /* Additional diagnostics fields to catch invalid updates to page_state, even in release builds. */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_PAGE_MODIFY_EXCLUSIVE 0x1u
-#define WT_PAGE_MODIFY_PINDEX_UPDATE 0x2u /* Page index updated */
-#define WT_PAGE_MODIFY_RECONCILING 0x4u
+#define WT_PAGE_MODIFY_RECONCILING 0x2u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 };
@@ -806,11 +805,12 @@ struct __wt_page {
 #define WT_PAGE_EVICT_LRU_URGENT 0x0020u   /* Page is in the urgent queue */
 #define WT_PAGE_EVICT_NO_PROGRESS 0x0040u  /* Eviction doesn't count as progress */
 #define WT_PAGE_INTL_OVERFLOW_KEYS 0x0080u /* Internal page has overflow keys (historic only) */
-#define WT_PAGE_PREFETCH 0x0100u           /* The page is being pre-fetched */
-#define WT_PAGE_REC_FAIL 0x0200u           /* The previous reconciliation failed on the page. */
-#define WT_PAGE_SPLIT_INSERT 0x0400u       /* A leaf page was split for append */
-#define WT_PAGE_UPDATE_IGNORE 0x0800u      /* Ignore updates on page discard */
-#define WT_PAGE_WITH_DELTAS 0x1000u        /* Page was built with deltas */
+#define WT_PAGE_INTL_PINDEX_UPDATE 0x0100u /* Page index updated */
+#define WT_PAGE_PREFETCH 0x0200u           /* The page is being pre-fetched */
+#define WT_PAGE_REC_FAIL 0x0400u           /* The previous reconciliation failed on the page. */
+#define WT_PAGE_SPLIT_INSERT 0x0800u       /* A leaf page was split for append */
+#define WT_PAGE_UPDATE_IGNORE 0x1000u      /* Ignore updates on page discard */
+#define WT_PAGE_WITH_DELTAS 0x2000u        /* Page was built with deltas */
                                            /* AUTOMATIC FLAG VALUE GENERATION STOP 16 */
     wt_shared uint16_t flags_atomic;       /* Atomic flags, use F_*_ATOMIC_16 */
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -581,7 +581,8 @@ struct __wt_page_modify {
 /* Additional diagnostics fields to catch invalid updates to page_state, even in release builds. */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_PAGE_MODIFY_EXCLUSIVE 0x1u
-#define WT_PAGE_MODIFY_RECONCILING 0x2u
+#define WT_PAGE_MODIFY_PINDEX_UPDATE 0x2u /* Page index updated */
+#define WT_PAGE_MODIFY_RECONCILING 0x4u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 };

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -405,8 +405,8 @@ typedef struct {
 
 /* Called when building the internal page image to indicate should we start to build a delta for the
  * page. We are still building so multi_next should still be 0 instead of 1. */
-#define WT_BUILD_DELTA_INT(session, r)                                              \
-    F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && !__wt_ref_is_root(r->ref) &&  \
-      (r)->multi_next == 0 && !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL) && \
-      !F_ISSET(r->ref->page->modify, WT_PAGE_MODIFY_PINDEX_UPDATE) &&               \
+#define WT_BUILD_DELTA_INT(session, r)                                                   \
+    F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && !__wt_ref_is_root(r->ref) &&       \
+      (r)->multi_next == 0 &&                                                            \
+      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INTL_PINDEX_UPDATE) && \
       WT_REC_RESULT_SINGLE_PAGE((session), (r))

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -408,4 +408,5 @@ typedef struct {
 #define WT_BUILD_DELTA_INT(session, r)                                        \
     F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && (r)->multi_next == 0 && \
       !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL) &&                   \
+      !F_ISSET(r->ref->page->modify, WT_PAGE_MODIFY_PINDEX_UPDATE) &&         \
       WT_REC_RESULT_SINGLE_PAGE((session), (r))

--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -405,8 +405,8 @@ typedef struct {
 
 /* Called when building the internal page image to indicate should we start to build a delta for the
  * page. We are still building so multi_next should still be 0 instead of 1. */
-#define WT_BUILD_DELTA_INT(session, r)                                        \
-    F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && (r)->multi_next == 0 && \
-      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL) &&                   \
-      !F_ISSET(r->ref->page->modify, WT_PAGE_MODIFY_PINDEX_UPDATE) &&         \
+#define WT_BUILD_DELTA_INT(session, r)                                              \
+    F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && !__wt_ref_is_root(r->ref) &&  \
+      (r)->multi_next == 0 && !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL) && \
+      !F_ISSET(r->ref->page->modify, WT_PAGE_MODIFY_PINDEX_UPDATE) &&               \
       WT_REC_RESULT_SINGLE_PAGE((session), (r))

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -404,6 +404,8 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WT_RECONCILE *r)
     page = r->page;
     mod = page->modify;
 
+    F_CLR_ATOMIC_16(page, WT_PAGE_INTL_PINDEX_UPDATE);
+
     /*
      * Track the page's maximum transaction ID (used to decide if we can evict a clean page and
      * discard its history).


### PR DESCRIPTION
This PR disallows building deltas whenever the pindex is updated for an internal page. This typically occurs during eviction, where we might split a page into multiple pages or perform reverse splits when entries are deleted, requiring an update to the parent page's pindex.

The changes account for all relevant scenarios, including split_multi, split_insert, split_internal, and reverse_split. We simply detect whether the page index was updated and, during reconciliation, skip building deltas for such pages. 

Once reconciliation is complete, we clear the flag in __rec_write_page_status.
