### PR TITLE
WT-14147 Fix the eviction updates trigger config log to reflect correct metric

### DIFF
--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -149,7 +149,7 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
     if (evict->eviction_updates_trigger < DBL_EPSILON) {
         WT_CONFIG_DEBUG(session,
           "config eviction_updates_trigger (%f) cannot be zero. Setting "
-          "to 50%% of eviction_updates_trigger (%f).",
+          "to 50%% of eviction_dirty_trigger (%f).",
           evict->eviction_updates_trigger, evict->eviction_dirty_trigger / 2);
         evict->eviction_updates_trigger = evict->eviction_dirty_trigger / 2;
     }

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -141,7 +141,7 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
     if (evict->eviction_updates_target < DBL_EPSILON) {
         WT_CONFIG_DEBUG(session,
           "config eviction_updates_target (%f) cannot be zero. Setting "
-          "to 50%% of eviction_updates_target (%f).",
+          "to 50%% of eviction_dirty_target (%f).",
           evict->eviction_updates_target, evict->eviction_dirty_target / 2);
         evict->eviction_updates_target = evict->eviction_dirty_target / 2;
     }

--- a/test/suite/test_config12.py
+++ b/test/suite/test_config12.py
@@ -36,8 +36,8 @@ from contextlib import contextmanager
 
 class test_config12(wttest.WiredTigerTestCase):
     default_warning_message = ['config eviction_checkpoint_target=.*cannot be less than eviction_dirty_target=.*Setting eviction_checkpoint_target to.*',
-                                                                     'config eviction_updates_target.*cannot be zero.*Setting to.*of eviction_updates_target.*',
-                                                                     'config eviction_updates_trigger.*cannot be zero.*Setting to.*of eviction_updates_trigger.*']
+                                                                     'config eviction_updates_target.*cannot be zero.*Setting to.*of eviction_dirty_target.*',
+                                                                     'config eviction_updates_trigger.*cannot be zero.*Setting to.*of eviction_dirty_trigger.*']
 
     @contextmanager
     def expect_verbose(self, config, patterns, expect_output = True):


### PR DESCRIPTION
When trying to check the `eviction_updates_trigger` for invalid configuration, the log incorrectly states we set the default value to half of the `eviction_updates_trigger` value instead of the `eviction_dirty_trigger`. Also, found a similar error in the same function in`evict_conn.c`, the error message should say setting to 50% of `eviction_dirty_target` not `eviction_updates_target`. 

Solution: fixed inconsistencies in `__evict_validate_config` config log to reflect the correct metrics and fixed pattern matching error in `test_config12.py`.