### PR TITLE
WT-13971 Return ENOENT when live restore attempts to open a directory that doesn't exist in the destination

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1319,7 +1319,7 @@ __live_restore_setup_lr_fh_directory(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_
     WT_RET_NOTFOUND_OK(
       __live_restore_fs_has_file(lr_fs, &lr_fs->destination, session, name, &dest_exist));
 
-    /* WiredTiger never creates directories. The user must do this themself. */
+    /* WiredTiger never creates directories. The user must do this themselves. */
     if (!dest_exist)
         WT_RET_MSG(session, ENOENT, "Directory %s does not exist in the destination", name);
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1398,7 +1398,7 @@ __live_restore_fs_atomic_copy_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS
 
     /* Open both files and create the temporary destination file. */
     WT_ERR(lr_fs->os_file_system->fs_open_file(
-      lr_fs->os_file_system, wt_session, source_path, type, WT_FS_OPEN_EXCLUSIVE, &source_fh));
+      lr_fs->os_file_system, wt_session, source_path, type, 0, &source_fh));
     WT_ERR(lr_fs->os_file_system->fs_open_file(lr_fs->os_file_system, wt_session, tmp_dest_path,
       type, WT_FS_OPEN_CREATE | WT_FS_OPEN_EXCLUSIVE, &dest_fh));
 

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1088,8 +1088,8 @@ __live_restore_fs_open_in_source(WTI_LIVE_RESTORE_FS *lr_fs, WT_SESSION_IMPL *se
     /* Open the file in the layer. */
     WT_ERR(__live_restore_fs_backing_filename(
       &lr_fs->source, session, lr_fs->destination.home, lr_fh->iface.name, &path));
-    WT_ERR(lr_fs->os_file_system->fs_open_file(
-      lr_fs->os_file_system, (WT_SESSION *)session, path, lr_fh->file_type, flags, &fh));
+    WT_ERR(lr_fs->os_file_system->fs_open_file(lr_fs->os_file_system, (WT_SESSION *)session, path,
+      lr_fh->file_type, flags | WT_FS_OPEN_READONLY, &fh));
 
     lr_fh->source = fh;
 
@@ -1350,7 +1350,7 @@ err:
 
 /*
  * __live_restore_setup_lr_fh_directory --
- *     Populate a live restore file handle for a directory. Directories are created the user and
+ *     Populate a live restore file handle for a directory. Directories are created by the user and
  *     therefore must always exist in the destination.
  */
 static int
@@ -1440,7 +1440,7 @@ __live_restore_fs_atomic_copy_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS
 
     /* Open both files and create the temporary destination file. */
     WT_ERR(lr_fs->os_file_system->fs_open_file(
-      lr_fs->os_file_system, wt_session, source_path, type, 0, &source_fh));
+      lr_fs->os_file_system, wt_session, source_path, type, WT_FS_OPEN_READONLY, &source_fh));
     WT_ERR(lr_fs->os_file_system->fs_open_file(lr_fs->os_file_system, wt_session, tmp_dest_path,
       type, WT_FS_OPEN_CREATE | WT_FS_OPEN_EXCLUSIVE, &dest_fh));
 

--- a/test/catch2/live_restore/api/test_live_restore_fs_open_file.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_open_file.cpp
@@ -107,36 +107,38 @@ TEST_CASE("Live Restore fs_open_file", "[live_restore],[live_restore_open_file]"
 
     SECTION("fs_open - Directory")
     {
+        /*
+         * WiredTiger never creates directories. The user must do this outside of WiredTiger. This
+         * means all cases where the directory doesn't exist in the destination we return ENOENT
+         * These cases include when:
+         */
         WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh = nullptr;
 
-        // If the folder doesn't exist return ENOENT.
+        // The directory doesn't exist in the source or destination
         lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY, ENOENT);
         REQUIRE(lr_fh == nullptr);
 
-        // However if we provide the WT_FS_OPEN_CREATE flag it will be created in the destination.
-        lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY, 0, WT_FS_OPEN_CREATE);
-        REQUIRE(testutil_exists(".", env.dest_file_path(subfolder).c_str()));
-        testutil_remove(env.dest_file_path(subfolder).c_str());
-        validate_lr_fh(lr_fh, env, subfolder, true);
-        lr_fh->iface.close((WT_FILE_HANDLE *)lr_fh, (WT_SESSION *)env.session);
+        // The WT_FS_OPEN_CREATE flag is provided
+        lr_fh =
+          open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY, ENOENT, WT_FS_OPEN_CREATE);
+        REQUIRE(lr_fh == nullptr);
 
-        // If the folder only exists in the destination open is successful.
+        // The directory exists in the source
+        testutil_remove(env.dest_file_path(subfolder).c_str());
+        testutil_mkdir(env.source_file_path(subfolder).c_str());
+        lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY, ENOENT);
+        REQUIRE(lr_fh == nullptr);
+
+        // However, when the directory exists in the destination open will be successful when:
+
+        // The directory exists only in the destination
         testutil_mkdir(env.dest_file_path(subfolder).c_str());
         REQUIRE(testutil_exists(".", env.dest_file_path(subfolder).c_str()));
         lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY);
         validate_lr_fh(lr_fh, env, subfolder, true);
         lr_fh->iface.close((WT_FILE_HANDLE *)lr_fh, (WT_SESSION *)env.session);
 
-        // If the folder only exists in the source open is successful and we create a copy in the
-        // destination
-        testutil_remove(env.dest_file_path(subfolder).c_str());
-        testutil_mkdir(env.source_file_path(subfolder).c_str());
-        lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY);
-        REQUIRE(testutil_exists(".", env.dest_file_path(subfolder).c_str()));
-        validate_lr_fh(lr_fh, env, subfolder, true);
-        lr_fh->iface.close((WT_FILE_HANDLE *)lr_fh, (WT_SESSION *)env.session);
-
-        // If the folder exists in both source and destination open is successful.
+        // The directory exists in both the source and destination.
         testutil_remove(env.dest_file_path(subfolder).c_str());
         testutil_remove(env.source_file_path(subfolder).c_str());
 
@@ -146,6 +148,7 @@ TEST_CASE("Live Restore fs_open_file", "[live_restore],[live_restore_open_file]"
         validate_lr_fh(lr_fh, env, subfolder, true);
         lr_fh->iface.close((WT_FILE_HANDLE *)lr_fh, (WT_SESSION *)env.session);
 
-        // We don't consider tombstones for directories. WiredTiger will never delete a folder.
+        // We don't need to consider the presence of stop files. WiredTiger never renames or deletes
+        // directories, so stop files will never exist.
     }
 }

--- a/test/catch2/live_restore/api/test_live_restore_fs_open_file.cpp
+++ b/test/catch2/live_restore/api/test_live_restore_fs_open_file.cpp
@@ -106,31 +106,30 @@ TEST_CASE("Live Restore fs_open_file", "[live_restore],[live_restore_open_file]"
 
     SECTION("fs_open - Directory")
     {
-        /*
-         * WiredTiger never creates directories. The user must do this outside of WiredTiger. This
-         * means all cases where the directory doesn't exist in the destination we return ENOENT
-         * These cases include when:
-         */
         WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh = nullptr;
 
-        // The directory doesn't exist in the source or destination
+        // WiredTiger never creates directories. The user must do this outside of WiredTiger. This
+        // means all cases where the directory doesn't exist in the destination we return ENOENT.
+
+        // The directory doesn't exist in the source or destination. Return ENOENT.
         lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY, ENOENT);
         REQUIRE(lr_fh == nullptr);
 
-        // The WT_FS_OPEN_CREATE flag is provided
+        // The WT_FS_OPEN_CREATE flag is provided but there is no directory in the destination.
+        // Return ENOENT.
         lr_fh =
           open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY, ENOENT, WT_FS_OPEN_CREATE);
         REQUIRE(lr_fh == nullptr);
 
-        // The directory exists in the source
+        // The directory exists in the source but not the destination. Return ENOENT.
         testutil_remove(env.dest_file_path(subfolder).c_str());
         testutil_mkdir(env.source_file_path(subfolder).c_str());
         lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY, ENOENT);
         REQUIRE(lr_fh == nullptr);
 
-        // However, when the directory exists in the destination open will be successful when:
+        // However, when the directory exists in the destination open will be successful.
 
-        // The directory exists only in the destination
+        // The directory exists only in the destination.
         testutil_mkdir(env.dest_file_path(subfolder).c_str());
         REQUIRE(testutil_exists(".", env.dest_file_path(subfolder).c_str()));
         lr_fh = open_file(env, subfolder, WT_FS_OPEN_FILE_TYPE_DIRECTORY);


### PR DESCRIPTION
This change addresses both WT-13971 and WT-13823. 
As we're only opening and migrating file WiredTiger owns we can keep the logic simple. WiredTiger never creates directories so any directory we open must already exist, and files use the default permissions as set in the posix or windows layer which live restore calls into.