### PR TITLE
WT-14192 Ignore pre-c11-compat errors

### DIFF
--- a/cmake/strict/clang_strict.cmake
+++ b/cmake/strict/clang_strict.cmake
@@ -9,6 +9,7 @@ list(APPEND clang_flags "-Weverything")
 list(APPEND clang_flags "-Wno-declaration-after-statement")
 list(APPEND clang_flags "-Wjump-misses-init")
 list(APPEND clang_flags "-Wconditional-uninitialized")
+list(APPEND clang_flags "-Wno-pre-c11-compat")
 list(APPEND clang_flags "-Wno-switch-default")
 
 # In code coverage builds inline functions may not be inlined, which can result in additional


### PR DESCRIPTION
The v5 toolchain enables pre-c11-compact by default and results in a couple of failures when WT runs with v5, this PR adds an ignore flag for these errors.