### PR TITLE
WT-14193 Fix type error in printf() in packing-test.c when using the v5 toolchain.

### DIFF
--- a/test/packing/packing-test.c
+++ b/test/packing/packing-test.c
@@ -59,7 +59,7 @@ check(const char *fmt, ...)
 
     printf("%s ", fmt);
     for (p = buf, end = p + len; p < end; p++)
-        printf("%02x", (u_char)*p & 0xff);
+        printf("%02x", (u_char)*p & 0xffu);
     printf("\n");
 
     return (ret);


### PR DESCRIPTION
Make the types consistent in the printf() parameters. By changing 0xff to 0xffu it becomes an unsigned int which, when bit-anded with an unsigned char, gives an unsigned int which is what the printf format string is expecting.
