### PR TITLE
WT-14244 Re-enable the zSeries tasks by removing 'activate: false'

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5709,7 +5709,6 @@ buildvariants:
     ENABLE_TCMALLOC: 0
     posix_configure_flags: -DENABLE_ZSTD=0
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
-  activate: false # Launch only manually for now
   tasks:
     - name: compile
     - name: generate-datafile-big-endian
@@ -5747,7 +5746,6 @@ buildvariants:
     ENABLE_TCMALLOC: 0
     # Use half number of vCPU to avoid OOM kill failure
     num_jobs: $(echo $(grep -c ^processor /proc/cpuinfo) / 2 | bc)
-  activate: false # Launch only manually for now
   tasks:
     - name: compile
     - name: unit-test


### PR DESCRIPTION
Re-enable the zSeries tasks by removing 'activate: false' so they run by default in post-merge testing, effectively reversing the changes in [WT-14194](https://jira.mongodb.org/browse/WT-14194) that temporarily disabled the tests, now that the toolchain config issues have been fixed.


