### PR TITLE
WT-14111 Correct the documentation for forced eviction behaviour

### DIFF
--- a/src/docs/arch-eviction.dox
+++ b/src/docs/arch-eviction.dox
@@ -35,16 +35,7 @@ conditions are met; otherwise the page can be evicted by the application thread 
 - The operation has disabled eviction or splitting.
 - The session is preventing from reconciling.
 
-Otherwise, it will attempt to evict it.
-
 Pages in the urgent queue take precedence over the pages from the ordinary eviction queues.
-
-Pages will go into the urgent queue only if the following conditions are met; otherwise,
-the page can be evicted by the application thread itself:
-- The operation has disabled eviction or splitting.
-- The session is preventing from reconciling.
-
-Otherwise, it will attempt to release and evict it.
 
 If there are other threads reading the content, the page cannot be evicted and the
 eviction server/worker threads check for that. Eviction has to lock and get exclusive

--- a/src/docs/arch-eviction.dox
+++ b/src/docs/arch-eviction.dox
@@ -30,8 +30,14 @@ eviction threads.
 
 It is possible to have just the eviction server and no worker threads. In such a case,
 the eviction server walks the tree to find pages to evict and evict these pages from the
-cache. Pages that are being marked for forced eviction go onto the urgent
-queue, and these pages take precedence over the pages from the ordinary eviction queues.
+cache. Pages that are being marked for forced eviction go onto the urgent queue if the following
+conditions are met; otherwise the page can be evicted by the application thread itself:
+- The operation has disabled eviction or splitting.
+- The session is preventing from reconciling.
+
+Otherwise, it will attempt to release and evict it.
+
+Pages in the urgent queue take precedence over the pages from the ordinary eviction queues.
 
 Pages will go into the urgent queue only if the following conditions are met; otherwise,
 the page can be evicted by the application thread itself:

--- a/src/docs/arch-eviction.dox
+++ b/src/docs/arch-eviction.dox
@@ -35,7 +35,7 @@ conditions are met; otherwise the page can be evicted by the application thread 
 - The operation has disabled eviction or splitting.
 - The session is preventing from reconciling.
 
-Otherwise, it will attempt to release and evict it.
+Otherwise, it will attempt to evict it.
 
 Pages in the urgent queue take precedence over the pages from the ordinary eviction queues.
 

--- a/src/docs/arch-eviction.dox
+++ b/src/docs/arch-eviction.dox
@@ -33,6 +33,13 @@ the eviction server walks the tree to find pages to evict and evict these pages 
 cache. Pages that are being marked for forced eviction go onto the urgent
 queue, and these pages take precedence over the pages from the ordinary eviction queues.
 
+Pages will go into the urgent queue only if the following conditions are met; otherwise,
+the page can be evicted by the application thread itself:
+- The operation has disabled eviction or splitting.
+- The session is preventing from reconciling.
+
+Otherwise, it will attempt to release and evict it.
+
 If there are other threads reading the content, the page cannot be evicted and the
 eviction server/worker threads check for that. Eviction has to lock and get exclusive
 access to the page so that after having checked if the page is evictable and starting to


### PR DESCRIPTION
Update the `arch-eviction.dox` to more accurately describe the conditions when pages are added to the urgent eviction queue. Pages will only go into the urgent queue if the operation has disabled eviction or splitting, or if the session is preventing reconciliation. Otherwise the page can be evicted by the application thread itself.
