### PR TITLE
WT-14243 Fix deadlock between the turtle lock and the live restore state lock

### DIFF
--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -152,7 +152,15 @@ __wti_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
      * don't rewrite the turtle file if there is an error.
      */
     if (reconfig) {
+#ifdef _MSC_VER
+        /* FIXME-WT-14051 Fix Windows compile support. */
         WT_WITH_TURTLE_LOCK(session, ret = __wt_metadata_turtle_rewrite(session));
+#else
+        if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS))
+            ret = __wt_live_restore_turtle_rewrite(session);
+        else
+            WT_WITH_TURTLE_LOCK(session, ret = __wt_metadata_turtle_rewrite(session));
+#endif
         WT_RET(ret);
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1035,6 +1035,8 @@ extern int __wt_turtle_exists(WT_SESSION_IMPL *session, bool *existp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_init(WT_SESSION_IMPL *session, bool verify_meta, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value,
+  WT_ITEM *lr_state_str) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_validate_version(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_activity_drain(WT_SESSION_IMPL *session)
@@ -1400,8 +1402,6 @@ extern int __wti_timing_stress_config(WT_SESSION_IMPL *session, const char *cfg[
 extern int __wti_tree_walk_skip(WT_SESSION_IMPL *session, WT_REF **refp, uint64_t *skipleafcntp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_txn_checkpoint_logread(WT_SESSION_IMPL *session, const uint8_t **pp,
   const uint8_t *end, WT_LSN *ckpt_lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1035,8 +1035,8 @@ extern int __wt_turtle_exists(WT_SESSION_IMPL *session, bool *existp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_init(WT_SESSION_IMPL *session, bool verify_meta, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value,
-  WT_ITEM *lr_state_str) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_validate_version(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_txn_activity_drain(WT_SESSION_IMPL *session)

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -30,6 +30,8 @@ extern int __wt_live_restore_clean_metadata_string(WT_SESSION_IMPL *session, cha
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_fh_to_metadata(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh,
   WT_ITEM *meta_string) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_live_restore_get_state_string(WT_SESSION_IMPL *session, WT_ITEM *lr_state_str)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_metadata_to_fh(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh,
   WT_LIVE_RESTORE_FH_META *lr_fh_meta) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char *cfg[])

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -36,6 +36,8 @@ extern int __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_server_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_live_restore_turtle_rewrite(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_turtle_update(WT_SESSION_IMPL *session, const char *key,
   const char *value, bool take_turtle_lock) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_validate_non_lr_system(WT_SESSION_IMPL *session)

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -30,14 +30,14 @@ extern int __wt_live_restore_clean_metadata_string(WT_SESSION_IMPL *session, cha
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_fh_to_metadata(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh,
   WT_ITEM *meta_string) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_live_restore_get_state_string(WT_SESSION_IMPL *session, WT_ITEM *lr_state_str)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_metadata_to_fh(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh,
   WT_LIVE_RESTORE_FH_META *lr_fh_meta) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_server_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_live_restore_turtle_update(WT_SESSION_IMPL *session, const char *key,
+  const char *value, bool take_turtle_lock) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_validate_non_lr_system(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_os_live_restore_fs(WT_SESSION_IMPL *session, const char *cfg[],

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -53,7 +53,16 @@ __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
 
     char *existing_config;
     WT_RET(__wti_turtle_read(session, WT_METAFILE_URI, &existing_config));
-    WT_RET(__wti_turtle_update(session, WT_METAFILE_URI, existing_config));
+
+#ifdef _MSC_VER
+    /* FIXME-WT-14051 - Fix Windows compile support. */
+    WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config, NULL));
+#else
+    if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+        WT_RET(__wt_live_restore_turtle_update(session, WT_METAFILE_URI, existing_config, false));
+    else
+        WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config, NULL));
+#endif
 
     __wt_free(session, existing_config);
     return (0);
@@ -227,7 +236,17 @@ __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *valu
       __metadata_turtle(key) ? "" : "not ");
 
     if (__metadata_turtle(key)) {
-        WT_WITH_TURTLE_LOCK(session, ret = __wti_turtle_update(session, key, value));
+#ifdef _MSC_VER
+        /* FIXME-WT-14051 - Fix Windows compile support. */
+        WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value, NULL));
+#else
+        if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+            WT_RET(__wt_live_restore_turtle_update(session, key, value, true));
+        else {
+            WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value, NULL));
+            WT_RET(ret);
+        }
+#endif
         return (ret);
     }
 

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -241,11 +241,9 @@ __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *valu
         WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value));
 #else
         if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
-            WT_RET(__wt_live_restore_turtle_update(session, key, value, true));
-        else {
+            ret = __wt_live_restore_turtle_update(session, key, value, true);
+        else
             WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value));
-            WT_RET(ret);
-        }
 #endif
         return (ret);
     }

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -61,7 +61,7 @@ __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
     if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
         WT_RET(__wt_live_restore_turtle_update(session, WT_METAFILE_URI, existing_config, false));
     else
-        WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config, NULL));
+        WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config));
 #endif
 
     __wt_free(session, existing_config);
@@ -238,12 +238,12 @@ __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *valu
     if (__metadata_turtle(key)) {
 #ifdef _MSC_VER
         /* FIXME-WT-14051 - Fix Windows compile support. */
-        WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value, NULL));
+        WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value));
 #else
         if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
             WT_RET(__wt_live_restore_turtle_update(session, key, value, true));
         else {
-            WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value, NULL));
+            WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value));
             WT_RET(ret);
         }
 #endif

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -56,7 +56,7 @@ __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
 
 #ifdef _MSC_VER
     /* FIXME-WT-14051 - Fix Windows compile support. */
-    WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config, NULL));
+    WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config));
 #else
     if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
         WT_RET(__wt_live_restore_turtle_update(session, WT_METAFILE_URI, existing_config, false));

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -579,14 +579,13 @@ __wt_turtle_init(WT_SESSION_IMPL *session, bool verify_meta, const char *cfg[])
         WT_ERR(__metadata_config(session, &metaconf));
 #ifdef _MSC_VER
         /* FIXME-WT-14051 - Fix Windows compile support. */
-        WT_WITH_TURTLE_LOCK(
-          session, ret = __wt_turtle_update(session, WT_METAFILE_URI, metaconf, NULL));
+        WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, WT_METAFILE_URI, metaconf));
 #else
         if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS))
             ret = __wt_live_restore_turtle_update(session, WT_METAFILE_URI, metaconf, true);
         else
             WT_WITH_TURTLE_LOCK(
-              session, ret = __wt_turtle_update(session, WT_METAFILE_URI, metaconf, NULL));
+              session, ret = __wt_turtle_update(session, WT_METAFILE_URI, metaconf));
 #endif
         __wt_free(session, metaconf);
         WT_ERR(ret);
@@ -690,14 +689,15 @@ err:
  *     Update the turtle file.
  */
 int
-__wt_turtle_update(
-  WT_SESSION_IMPL *session, const char *key, const char *value, WT_ITEM *lr_state_str)
+__wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_FSTREAM *fs;
     int vmajor, vminor, vpatch;
     const char *version;
+
+    WT_DECL_ITEM(state_str);
 
     fs = NULL;
     conn = S2C(session);
@@ -721,12 +721,17 @@ __wt_turtle_update(
           "major=%" PRIu16 ",minor=%" PRIu16 "\n",
           WT_METADATA_COMPAT, conn->compat_version.major, conn->compat_version.minor));
 
-    if (lr_state_str != NULL) {
+#ifndef _MSC_VER
+    if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS)) {
+        WT_ERR(__wt_scr_alloc(session, WT_LIVE_RESTORE_STATE_STRING_MAX, &state_str));
+        WT_ERR(__wt_live_restore_get_state_string(session, state_str));
+
         WT_ERR(__wt_fprintf(session, fs,
           "%s\n"
           "state=%s\n",
-          WT_METADATA_LIVE_RESTORE, (char *)lr_state_str->data));
+          WT_METADATA_LIVE_RESTORE, (char *)state_str->data));
     }
+#endif
 
     version = wiredtiger_version(&vmajor, &vminor, &vpatch);
     WT_ERR(__wt_fprintf(session, fs,
@@ -745,6 +750,7 @@ __wt_turtle_update(
 err:
     WT_TRET(__wt_fclose(session, &fs));
     WT_TRET(__wt_remove_if_exists(session, WT_METADATA_TURTLE_SET, false));
+    __wt_scr_free(session, &state_str);
 
     /*
      * An error updating the turtle file means something has gone horribly wrong -- we're done.


### PR DESCRIPTION
This change adds two functions to intercept calls to update or rewrite the turtle file. Ensuring that the live restore state file lock is held before the turtle lock is taken. The consistent order of claiming the two locks removes the possibility of a dead lock when one thread set the live restore at the same time another thread is updating the turtle file.