### PR TITLE
SLS-1516 Disable test_rollback_to_stable44.py for PR testing

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -168,6 +168,7 @@ test_rollback_to_stable39.py # times out
 test_rollback_to_stable40.py
 test_rollback_to_stable41.py
 test_rollback_to_stable42.py
+test_rollback_to_stable44.py
 test_schema02.py
 test_schema08.py # times out
 test_scrub_eviction_prepare.py


### PR DESCRIPTION
Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
