### PR TITLE
WT-13787 Print return value in test/format trace stop messages

### DIFF
--- a/test/format/alter.c
+++ b/test/format/alter.c
@@ -72,7 +72,7 @@ alter(void *arg)
 
         while ((ret = session->alter(session, table->uri, buf)) != 0 && ret != EBUSY)
             testutil_die(ret, "session.alter");
-        trace_msg(session, "Alter #%u URI %s stop", counter, table->uri);
+        trace_msg(session, "Alter #%u URI %s stop, ret=%d", counter, table->uri, ret);
         while (period > 0 && !g.workers_finished) {
             --period;
             __wt_sleep(1, 0);

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -590,7 +590,7 @@ backup(void *arg)
 
             } else
                 testutil_copy_file(session, key);
-            trace_msg(session, "Backup #%u copy file %s stop", counter, key);
+            trace_msg(session, "Backup #%u copy file %s stop, ret=%d", counter, key, ret);
             active_files_add(active_now, key);
         }
         if (ret != WT_NOTFOUND)
@@ -598,9 +598,9 @@ backup(void *arg)
 
         testutil_check(backup_cursor->close(backup_cursor));
         if (config == NULL)
-            trace_msg(session, "Backup #%u stop", counter);
+            trace_msg(session, "Backup #%u stop, ret=%d", counter, ret);
         else
-            trace_msg(session, "Backup #%u stop: (%s)", counter, config);
+            trace_msg(session, "Backup #%u stop: (%s), ret=%d", counter, config, ret);
 
         lock_writeunlock(session, &g.backup_lock);
         active_files_sort(active_now);

--- a/test/format/backup.c
+++ b/test/format/backup.c
@@ -590,7 +590,7 @@ backup(void *arg)
 
             } else
                 testutil_copy_file(session, key);
-            trace_msg(session, "Backup #%u copy file %s stop, ret=%d", counter, key, ret);
+            trace_msg(session, "Backup #%u copy file %s stop", counter, key);
             active_files_add(active_now, key);
         }
         if (ret != WT_NOTFOUND)

--- a/test/format/bulk.c
+++ b/test/format/bulk.c
@@ -223,7 +223,7 @@ table_load(TABLE *base, TABLE *table)
     if (g.transaction_timestamps_config)
         bulk_commit_transaction(session);
 
-    trace_msg(session, "=============== %s bulk load stop", table->uri);
+    trace_msg(session, "=============== %s bulk load stop, ret=%d", table->uri, ret);
     wt_wrap_close_session(session);
 
     /*

--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -150,9 +150,9 @@ checkpoint(void *arg)
         testutil_assert(ret == 0 || (ret == EBUSY && ebusy_ok));
 
         if (ckpt_config == NULL)
-            trace_msg(session, "Checkpoint #%u stop", counter);
+            trace_msg(session, "Checkpoint #%u stop, ret=%d", counter, ret);
         else
-            trace_msg(session, "Checkpoint #%u stop (%s)", counter, ckpt_config);
+            trace_msg(session, "Checkpoint #%u stop (%s), ret=%d", counter, ckpt_config, ret);
 
         if (backup_locked)
             lock_writeunlock(session, &g.backup_lock);


### PR DESCRIPTION
Printing the value of `ret` in several places in `test/format` where we write stop messages to the trace database. This would provide helpful info to developers.