### PR TITLE
WT-14255 Remove long running checkpoint tests from PR testing

### DIFF
--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -44,9 +44,17 @@ define_test_variants(test_checkpoint
         "test_checkpoint_6_row_named_prepare;-t r -T 6 -c TeSt -p"
         "test_checkpoint_row_stress_sweep_timestamps;-t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
         "test_checkpoint_row_sweep_timestamps;-t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+    LABELS
+        check
+        test_checkpoint
+)
+
+define_test_variants(test_checkpoint
+    VARIANTS
         "test_checkpoint_row_server_93028_1;-t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
         "test_checkpoint_row_server_93028_2;-t r -W 50 -r 2 -s 1 -n 100000 -k 100000 -C cache_size=250MB"
     LABELS
         check
         test_checkpoint
+        long_running
 )

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1616,6 +1616,16 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
+          ctest_extra_args: -LE "long_running" ${ctest_extra_args}
+          directory: test/checkpoint
+
+  - name: checkpoint-test-long-running
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "make check directory"
+        vars:
+          ctest_extra_args: -L "long_running" ${ctest_extra_args}
           directory: test/checkpoint
 
   - name: cursor-order-test


### PR DESCRIPTION
We recently added two new tests to checkpoint-test, but their runtimes cause the task to exceed our 25 minute runtime target for PR testing. To fix this move the new tests into a checkpoint-test-long-running task that doesn't run for PR testing.