### PR TITLE
WT-14257 Remove Windows ifdefs in the live restore code

### DIFF
--- a/dist/filelist
+++ b/dist/filelist
@@ -113,9 +113,9 @@ src/evict/evict_stat.c
 src/history/hs_conn.c
 src/history/hs_cursor.c
 src/history/hs_verify.c
-src/live_restore/live_restore_fs.c       POSIX_HOST
-src/live_restore/live_restore_server.c   POSIX_HOST
-src/live_restore/live_restore_state.c    POSIX_HOST
+src/live_restore/live_restore_fs.c
+src/live_restore/live_restore_server.c
+src/live_restore/live_restore_state.c
 src/log/log.c
 src/log/log_auto.c
 src/log/log_cursor.c

--- a/dist/filelist.bzl
+++ b/dist/filelist.bzl
@@ -106,6 +106,9 @@ WT_FILELIST = ['src/block/block_addr.c',
  'src/history/hs_conn.c',
  'src/history/hs_cursor.c',
  'src/history/hs_verify.c',
+ 'src/live_restore/live_restore_fs.c',
+ 'src/live_restore/live_restore_server.c',
+ 'src/live_restore/live_restore_state.c',
  'src/log/log.c',
  'src/log/log_auto.c',
  'src/log/log_cursor.c',
@@ -202,27 +205,6 @@ WT_FILELIST_X86_HOST = ['src/checksum/x86/crc32-x86-alt.c', 'src/checksum/x86/cr
 
 WT_FILELIST_ZSERIES_HOST = ['src/checksum/zseries/crc32-s390x.c', 'src/checksum/zseries/crc32le-vx.S']
 
-WT_FILELIST_POSIX_HOST = ['src/live_restore/live_restore_fs.c',
- 'src/live_restore/live_restore_server.c',
- 'src/live_restore/live_restore_state.c',
- 'src/os_posix/os_dir.c',
- 'src/os_posix/os_dlopen.c',
- 'src/os_posix/os_fallocate.c',
- 'src/os_posix/os_fs.c',
- 'src/os_posix/os_getenv.c',
- 'src/os_posix/os_map.c',
- 'src/os_posix/os_mtx_cond.c',
- 'src/os_posix/os_once.c',
- 'src/os_posix/os_pagesize.c',
- 'src/os_posix/os_path.c',
- 'src/os_posix/os_priv.c',
- 'src/os_posix/os_setvbuf.c',
- 'src/os_posix/os_sleep.c',
- 'src/os_posix/os_snprintf.c',
- 'src/os_posix/os_thread.c',
- 'src/os_posix/os_time.c',
- 'src/os_posix/os_yield.c']
-
 WT_FILELIST_DARWIN_HOST = ['src/os_darwin/os_futex.c']
 
 WT_FILELIST_LINUX_HOST = ['src/os_linux/os_futex.c']
@@ -246,3 +228,21 @@ WT_FILELIST_WINDOWS_HOST = ['src/os_win/os_futex.c',
  'src/os_win/os_utf8.c',
  'src/os_win/os_winerr.c',
  'src/os_win/os_yield.c']
+
+WT_FILELIST_POSIX_HOST = ['src/os_posix/os_dir.c',
+ 'src/os_posix/os_dlopen.c',
+ 'src/os_posix/os_fallocate.c',
+ 'src/os_posix/os_fs.c',
+ 'src/os_posix/os_getenv.c',
+ 'src/os_posix/os_map.c',
+ 'src/os_posix/os_mtx_cond.c',
+ 'src/os_posix/os_once.c',
+ 'src/os_posix/os_pagesize.c',
+ 'src/os_posix/os_path.c',
+ 'src/os_posix/os_priv.c',
+ 'src/os_posix/os_setvbuf.c',
+ 'src/os_posix/os_sleep.c',
+ 'src/os_posix/os_snprintf.c',
+ 'src/os_posix/os_thread.c',
+ 'src/os_posix/os_time.c',
+ 'src/os_posix/os_yield.c']

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -510,7 +510,6 @@ bInheritHandle
 backoff
 bal
 basecfg
-basename
 bb
 bba
 bbb

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -245,16 +245,12 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     }
     WT_ERR(__wt_open(session, filename, WT_FS_OPEN_FILE_TYPE_DATA, flags, &block->fh));
 
-#ifndef _MSC_VER
     /*
      * We need to do this as close to __wt_open as possible as there is a descriptor block read
      * further down which requires the extent lists to be initialized. Even if the extent list is
      * NULL there is bookkeeping to do.
      */
     WT_ERR(__wt_live_restore_metadata_to_fh(session, block->fh->handle, lr_fh_meta));
-#else
-    WT_UNUSED(lr_fh_meta);
-#endif
 
     /* Set the file's size. */
     WT_ERR(__wt_filesize(session, block->fh, &block->size));

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2647,6 +2647,7 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
             WT_RET_MSG(
               session, EINVAL, "Live restore is not compatible with an in-memory connections");
 #ifdef _MSC_VER
+        /* FIXME-WT-14051 Add support for Windows */
         WT_RET_MSG(session, EINVAL, "Live restore is not supported on Windows");
 #endif
     }
@@ -2672,10 +2673,8 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
         }
     }
 
-#ifndef _MSC_VER
     if (!live_restore_enabled)
         WT_RET(__wt_live_restore_validate_non_lr_system(session));
-#endif
 
     return (__conn_chk_file_system(session, F_ISSET(conn, WT_CONN_READONLY)));
 }
@@ -3061,10 +3060,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
 
     WT_ERR(__wt_conf_compile_init(session, cfg));
     WT_ERR(__wti_conn_statistics_config(session, cfg));
-#ifndef _MSC_VER
-    /* FIXME-WT-14051 Add windows support. */
     __wt_live_restore_init_stats(session);
-#endif
     WT_ERR(__wti_sweep_config(session, cfg));
 
     /* Initialize the OS page size for mmap */

--- a/src/conn/conn_open.c
+++ b/src/conn/conn_open.c
@@ -90,9 +90,7 @@ __wti_connection_close(WT_CONNECTION_IMPL *conn)
      * Shut down server threads. Some of these threads access btree handles and eviction, shut them
      * down before the eviction server, and shut all servers down before closing open data handles.
      */
-#ifndef _MSC_VER
     WT_TRET(__wt_live_restore_server_destroy(session));
-#endif
     WT_TRET(__wti_background_compact_server_destroy(session));
     WT_TRET(__wt_checkpoint_server_destroy(session));
     WT_TRET(__wti_statlog_destroy(session, true));
@@ -238,14 +236,12 @@ __wti_connection_workers(WT_SESSION_IMPL *session, const char *cfg[])
      */
     WT_RET(__wt_txn_recover(session, cfg));
 
-#ifndef _MSC_VER
     /*
      * If we're performing a live restore start the server. This is intentionally placed after
      * recovery finishes as we depend on the metadata file containing the list of objects that need
      * live restoration.
      */
     WT_RET(__wt_live_restore_server_create(session, cfg));
-#endif
 
     /* Initialize metadata tracking, required before creating tables. */
     WT_RET(__wt_meta_track_init(session));

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -152,15 +152,10 @@ __wti_conn_compat_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
      * don't rewrite the turtle file if there is an error.
      */
     if (reconfig) {
-#ifdef _MSC_VER
-        /* FIXME-WT-14051 Fix Windows compile support. */
-        WT_WITH_TURTLE_LOCK(session, ret = __wt_metadata_turtle_rewrite(session));
-#else
         if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS))
             ret = __wt_live_restore_turtle_rewrite(session);
         else
             WT_WITH_TURTLE_LOCK(session, ret = __wt_metadata_turtle_rewrite(session));
-#endif
         WT_RET(ret);
     }
 

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -982,10 +982,7 @@ __backup_list_uri_append(WT_SESSION_IMPL *session, const char *name, bool *skip)
     /* Add the metadata entry to the backup file. */
     WT_RET(__wt_metadata_search(session, name, &value));
 
-#ifndef _MSC_VER
-    /* FIXME-WT-14051 Add windows support. */
     WT_ERR(__wt_live_restore_clean_metadata_string(session, value));
-#endif
 
     WT_ERR(__wt_fprintf(session, cb->bfs, "%s\n%s\n", name, value));
     /*

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -9,9 +9,6 @@
 #include "wt_internal.h"
 #include "live_restore_private.h"
 
-/* This is where basename comes from. */
-#include <libgen.h>
-
 static int __live_restore_fs_directory_list_free(
   WT_FILE_SYSTEM *fs, WT_SESSION *wt_session, char **dirlist, uint32_t count);
 
@@ -1857,7 +1854,10 @@ __wt_os_live_restore_fs(
         WT_RET_MSG(session, EINVAL, "live restore is incompatible with readonly mode");
 
     WT_RET(__wt_calloc_one(session, &lr_fs));
+#if defined(__APPLE__) || defined(__linux__)
+    /* FIXME-WT-14051 - Add live restore support to Windows. */
     WT_ERR(__wt_os_posix(session, &lr_fs->os_file_system));
+#endif
 
     /* Initialize the FS jump table. */
     lr_fs->iface.fs_directory_list = __live_restore_fs_directory_list;

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1314,9 +1314,7 @@ __wt_meta_ckptlist_set(
     WT_ERR(__wt_scr_alloc(session, 1024, &buf));
     WT_ERR(__wt_meta_ckptlist_to_meta(session, ckptbase, buf));
 
-#ifndef _MSC_VER
     WT_ERR_NOTFOUND_OK(__meta_live_restore_to_meta(session, dhandle, buf), false);
-#endif
 
     /* Add backup block modifications for any added checkpoint. */
     WT_CKPT_FOREACH (ckptbase, ckpt)

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -54,15 +54,10 @@ __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
     char *existing_config;
     WT_RET(__wti_turtle_read(session, WT_METAFILE_URI, &existing_config));
 
-#ifdef _MSC_VER
-    /* FIXME-WT-14051 - Fix Windows compile support. */
-    WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config));
-#else
     if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
         WT_RET(__wt_live_restore_turtle_update(session, WT_METAFILE_URI, existing_config, false));
     else
         WT_RET(__wt_turtle_update(session, WT_METAFILE_URI, existing_config));
-#endif
 
     __wt_free(session, existing_config);
     return (0);
@@ -236,15 +231,10 @@ __wt_metadata_update(WT_SESSION_IMPL *session, const char *key, const char *valu
       __metadata_turtle(key) ? "" : "not ");
 
     if (__metadata_turtle(key)) {
-#ifdef _MSC_VER
-        /* FIXME-WT-14051 - Fix Windows compile support. */
-        WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value));
-#else
         if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
             ret = __wt_live_restore_turtle_update(session, key, value, true);
         else
             WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, key, value));
-#endif
         return (ret);
     }
 

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -577,16 +577,11 @@ __wt_turtle_init(WT_SESSION_IMPL *session, bool verify_meta, const char *cfg[])
     if (load || load_turtle) {
         /* Create the turtle file. */
         WT_ERR(__metadata_config(session, &metaconf));
-#ifdef _MSC_VER
-        /* FIXME-WT-14051 - Fix Windows compile support. */
-        WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_update(session, WT_METAFILE_URI, metaconf));
-#else
         if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS))
             ret = __wt_live_restore_turtle_update(session, WT_METAFILE_URI, metaconf, true);
         else
             WT_WITH_TURTLE_LOCK(
               session, ret = __wt_turtle_update(session, WT_METAFILE_URI, metaconf));
-#endif
         __wt_free(session, metaconf);
         WT_ERR(ret);
     }
@@ -721,7 +716,6 @@ __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
           "major=%" PRIu16 ",minor=%" PRIu16 "\n",
           WT_METADATA_COMPAT, conn->compat_version.major, conn->compat_version.minor));
 
-#ifndef _MSC_VER
     if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS)) {
         WT_ERR(__wt_scr_alloc(session, WT_LIVE_RESTORE_STATE_STRING_MAX, &state_str));
         WT_ERR(__wt_live_restore_get_state_string(session, state_str));
@@ -731,7 +725,6 @@ __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
           "state=%s\n",
           WT_METADATA_LIVE_RESTORE, (char *)state_str->data));
     }
-#endif
 
     version = wiredtiger_version(&vmajor, &vminor, &vpatch);
     WT_ERR(__wt_fprintf(session, fs,


### PR DESCRIPTION
Previously we needed to #ifdef out live restore code for Windows as live restore used posix-specific libraries such as ioctl fiemap. Now that we persist live restore data to the metadata and turtle files this is no longer necessary and we can clean up the code.

This change only removes pre-processor #ifdefs, live restore is still not supported on Windows.