### PR TITLE
WT-13283 Fix the cache aggressive mode not to show the garbage value (8.0) (#11622)

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -828,8 +828,7 @@ __evict_pass(WT_SESSION_IMPL *session)
             __wt_verbose(session, WT_VERB_EVICTSERVER, "%s", "unable to reach eviction goal");
             break;
         }
-        if (__wt_atomic_load32(&cache->evict_aggressive_score) > 0)
-            (void)__wt_atomic_subv32(&cache->evict_aggressive_score, 1);
+        __wt_atomic_decrement_if_positive(&cache->evict_aggressive_score);
         loop = 0;
         eviction_progress = cache->eviction_progress;
     }
@@ -2524,8 +2523,8 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
         if (!F_ISSET(conn, WT_CONN_RECOVERING) && __wt_cache_stuck(session)) {
             ret = __wt_txn_is_blocking(session);
             if (ret == WT_ROLLBACK) {
-                if (__wt_atomic_load32(&cache->evict_aggressive_score) > 0)
-                    (void)__wt_atomic_subv32(&cache->evict_aggressive_score, 1);
+                __wt_atomic_decrement_if_positive(&cache->evict_aggressive_score);
+
                 WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
                 __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
                   session->txn->rollback_reason);
@@ -2600,8 +2599,7 @@ err:
          */
         if (ret == 0 && cache_max_wait_us != 0 && session->cache_wait_us > cache_max_wait_us) {
             ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW);
-            if (__wt_atomic_load32(&cache->evict_aggressive_score) > 0)
-                (void)__wt_atomic_subv32(&cache->evict_aggressive_score, 1);
+            __wt_atomic_decrement_if_positive(&cache->evict_aggressive_score);
             WT_STAT_CONN_INCR(session, cache_timed_out_ops);
             __wt_verbose_notice(
               session, WT_VERB_TRANSACTION, "rollback reason: %s", session->txn->rollback_reason);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -490,5 +490,18 @@ union __wt_rand_state {
             WT_ERR(__wt_buf_extend(session, buf, (buf)->size + __len + 1));     \
         }                                                                       \
     } while (0)
-
+/*
+ * __wt_atomic_decrement_if_positive --
+ *     Use compare and swap to atomically decrement value by 1 if it's positive.
+ */
+static WT_INLINE void
+__wt_atomic_decrement_if_positive(uint32_t *valuep)
+{
+    uint32_t old_value;
+    do {
+        old_value = __wt_atomic_load32(valuep);
+        if (old_value == 0)
+            break;
+    } while (!__wt_atomic_cas32(valuep, old_value, old_value - 1));
+}
 #endif /* __WT_MISC_H */


### PR DESCRIPTION
We currently do check before decrementing `evict_aggressive_score` to ensure it won't drop below zero. However the check then decrement operations are not implemented atomically which causes race condition. This PR is to apply the compare-and-swap operation to the code to avoid the value drops to -1(which is `int_max` as `evict_aggressive_score` is an unsigned int).

(cherry picked from commit 4a0a6109f05468cdfb1a7964e98bcfb4c351aa88)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
