### PR TITLE
WT-14102 Add Evergreen tests for currently supported GCC and Clang versions 

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1492,6 +1492,18 @@ tasks:
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=9
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=9
+      - func: "compile wiredtiger"
+        vars:
+          GNU_C_VERSION: -DGNU_C_VERSION=10
+          GNU_CXX_VERSION: -DGNU_CXX_VERSION=10
+      - func: "compile wiredtiger"
+        vars:
+          GNU_C_VERSION: -DGNU_C_VERSION=11
+          GNU_CXX_VERSION: -DGNU_CXX_VERSION=11
+      - func: "compile wiredtiger"
+        vars:
+          GNU_C_VERSION: -DGNU_C_VERSION=12
+          GNU_CXX_VERSION: -DGNU_CXX_VERSION=12
 
   - name: compile-clang
     tags: ["pull_request", "pull_request_compilers"]
@@ -1517,6 +1529,26 @@ tasks:
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=8
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=8
+      - func: "compile wiredtiger"
+        vars:
+          CLANG_C_VERSION: -DCLANG_C_VERSION=9
+          CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=9
+      - func: "compile wiredtiger"
+        vars:
+          CLANG_C_VERSION: -DCLANG_C_VERSION=10
+          CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=10
+      - func: "compile wiredtiger"
+        vars:
+          CLANG_C_VERSION: -DCLANG_C_VERSION=11
+          CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=12
+      - func: "compile wiredtiger"
+        vars:
+          CLANG_C_VERSION: -DCLANG_C_VERSION=13
+          CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=13
+      - func: "compile wiredtiger"
+        vars:
+          CLANG_C_VERSION: -DCLANG_C_VERSION=14
+          CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=14
 
   # Compile WiredTiger with uncommon build flags to make sure we compile code that
   # is often pre-processed out.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1494,16 +1494,8 @@ tasks:
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=9
       - func: "compile wiredtiger"
         vars:
-          GNU_C_VERSION: -DGNU_C_VERSION=10
-          GNU_CXX_VERSION: -DGNU_CXX_VERSION=10
-      - func: "compile wiredtiger"
-        vars:
           GNU_C_VERSION: -DGNU_C_VERSION=11
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=11
-      - func: "compile wiredtiger"
-        vars:
-          GNU_C_VERSION: -DGNU_C_VERSION=12
-          GNU_CXX_VERSION: -DGNU_CXX_VERSION=12
 
   - name: compile-clang
     tags: ["pull_request", "pull_request_compilers"]


### PR DESCRIPTION
This ticket adds new compile tasks for currently installed gcc and g++ binaries on the ubuntu machine.