### PR TITLE
WT-13884 Update obsolete cleanup min value (v8.0) (#11571)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -561,7 +561,7 @@ connection_runtime_config = [
             ''', choices=['none', 'reclaim_space']),
         Config('wait', '300', r'''
             seconds to wait between each checkpoint cleanup''',
-            min='60', max='100000'),
+            min='1', max='100000'),
         ]),
     Config('debug_mode', '', r'''
         control the settings of various extended debugging features''',

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -199,7 +199,7 @@ static const char *confchk_method_choices[] = {
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_checkpoint_cleanup_subconfigs[] = {
   {"method", "string", NULL, "choices=[\"none\",\"reclaim_space\"]", NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_STRING, 196, INT64_MIN, INT64_MAX, confchk_method_choices},
-  {"wait", "int", NULL, "min=60,max=100000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 194, 60,
+  {"wait", "int", NULL, "min=1,max=100000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 194, 1,
     100000, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2236,7 +2236,7 @@ struct __wt_connection {
      * to none\, which means no additional work is done to find obsolete content., a string\, chosen
      * from the following options: \c "none"\, \c "reclaim_space"; default \c none.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait, seconds to wait between each checkpoint cleanup., an
-     * integer between \c 60 and \c 100000; default \c 300.}
+     * integer between \c 1 and \c 100000; default \c 300.}
      * @config{ ),,}
      * @config{chunk_cache = (, chunk cache reconfiguration options., a set of related configuration
      * options defined as follows.}
@@ -3050,7 +3050,7 @@ struct __wt_connection {
  * means no additional work is done to find obsolete content., a string\, chosen from the following
  * options: \c "none"\, \c "reclaim_space"; default \c none.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;wait,
- * seconds to wait between each checkpoint cleanup., an integer between \c 60 and \c 100000; default
+ * seconds to wait between each checkpoint cleanup., an integer between \c 1 and \c 100000; default
  * \c 300.}
  * @config{ ),,}
  * @config{checkpoint_sync, flush files to stable storage when closing or writing checkpoints., a

--- a/test/suite/test_cc01.py
+++ b/test/suite/test_cc01.py
@@ -77,12 +77,12 @@ class test_cc_base(wttest.WiredTigerTestCase):
         session.rollback_transaction()
         self.assertEqual(count, nrows)
 
-    def populate(self, uri, start_key, num_keys, value):
+    def populate(self, uri, start_key, num_keys, value, ts = None):
         c = self.session.open_cursor(uri, None)
         for k in range(start_key, num_keys):
             self.session.begin_transaction()
             c[k] = value
-            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(k + 1))
+            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(ts if ts else k + 1))
         c.close()
 
     # Trigger checkpoint cleanup. The function waits for checkpoint cleanup to make progress before

--- a/test/suite/test_cc10.py
+++ b/test/suite/test_cc10.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+from test_cc01 import test_cc_base
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# test_cc10.py
+# Test that the obsolete cleanup thread can be configured to run at different intervals.
+class test_cc10(test_cc_base):
+    waiting_time = [
+        ('1sec', dict(conn_config=f'checkpoint_cleanup=[wait=1]')),
+        ('2sec', dict(conn_config=f'checkpoint_cleanup=[wait=2]')),
+        ('3sec', dict(conn_config=f'checkpoint_cleanup=[wait=3]')),
+    ]
+    scenarios = make_scenarios(waiting_time)
+
+    def test_cc10(self):
+        # Create a table.
+        create_params = 'key_format=i,value_format=S'
+        nrows = 1000
+        uri = "table:cc02"
+
+        # Create and populate a table.
+        self.session.create(uri, create_params)
+
+        old_value = "a"
+        old_ts = 1
+        self.populate(uri, 0, nrows, old_value, old_ts)
+
+        # Pin oldest and stable to timestamp 1.
+        self.conn.set_timestamp(f'oldest_timestamp={self.timestamp_str(old_ts)},stable_timestamp={self.timestamp_str(old_ts)}')
+
+        # Update each record with a newer timestamp.
+        new_value = "b"
+        new_ts = 10
+        self.populate(uri, 0, nrows, new_value, new_ts)
+
+        # Make the updates stable and checkpoint to write everything in the DS and HS.
+        # The most recent updates with the ts 10 should be in the DS while the ones with ts 1 should
+        # be in the HS.
+        self.conn.set_timestamp(f'stable_timestamp={new_ts}')
+        self.session.checkpoint()
+
+        # Make the updates in the HS obsolete.
+        self.conn.set_timestamp(f'oldest_timestamp={new_ts}')
+
+        # Wait for obsolete cleanup to occur, this should clean the history store.
+        # We don't use the debug option to force cleanup as the thread should be running in the
+        # background.
+        time.sleep(5)
+        self.wait_for_cc_to_run()
+
+        c = self.session.open_cursor('statistics:')
+        visited = c[stat.conn.checkpoint_cleanup_pages_visited][2]
+        obsolete_evicted = c[stat.conn.checkpoint_cleanup_pages_evict][2]
+        obsolete_on_disk = c[stat.conn.checkpoint_cleanup_pages_removed][2]
+        c.close()
+
+        # We should always visit pages for cleanup.
+        self.assertGreater(visited, 0)
+
+        # We should have performed some cleanup.
+        self.assertGreater(obsolete_evicted + obsolete_on_disk, 0)


### PR DESCRIPTION
The changes make it possible to trigger the obsolete cleanup thread more often. The current minimum value is 60 seconds, the changes set this limit to 1 second.

(cherry picked from commit 47e5efc0ca77bd34adbd43aa2d7ae765246a4027)