### PR TITLE
WT-10234 Don't run code with side effects inside asserts

### DIFF
--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -420,7 +420,8 @@ __wti_row_ikey(
          */
         WT_ASSERT(session, oldv == 0 || (oldv & WT_IK_FLAG) != 0);
         WT_ASSERT(session, WT_REF_GET_STATE(ref) != WT_REF_SPLIT);
-        WT_ASSERT(session, __wt_atomic_cas_ptr(&ref->ref_ikey, (WT_IKEY *)oldv, ikey));
+        bool cas_success = __wt_atomic_cas_ptr(&ref->ref_ikey, (WT_IKEY *)oldv, ikey);
+        WT_ASSERT(session, cas_success);
     }
 #else
     ref->ref_ikey = ikey;

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -32,7 +32,8 @@
          * already hold it.                                                       \
          */                                                                       \
         if ((s)->id != 0 && (s)->thread_check.owning_thread != __tmp_api_tid) {   \
-            WT_ASSERT((s), __wt_spin_trylock((s), &(s)->thread_check.lock) == 0); \
+            bool lock_success = __wt_spin_trylock((s), &(s)->thread_check.lock);  \
+            WT_ASSERT((s), lock_success == 0);                                    \
             (s)->thread_check.owning_thread = __tmp_api_tid;                      \
         }                                                                         \
                                                                                   \


### PR DESCRIPTION
Code inside a WT_ASSERT will only run when we compile in HAVE_DIAGNOSTIC mode. In release mode it's entirely compiled out. This carries a risk when the code inside the assert has some side effect, for example setting a field in a struct.
This ticket removes the few cases where we do this. They're already inside of an #ifdef HAVE_DIAGNOSTIC so there's no functional impact, but it protects against the possibility of ever using this code outside of HAVE_DIAGNOSTIC.