### PR TITLE
WT-14276 Force checkpoints in live restore mode

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -890,7 +890,6 @@ __wti_live_restore_fs_restore_file(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)
               " seconds. Currently copying offset %" PRId64 " of file size %" PRId64,
               lr_fh->iface.name, time_diff_ms / WT_THOUSAND, read_offset, WTI_BITMAP_END(lr_fh));
             msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
-            __wt_tree_modify_set(session);
         }
 
         /*
@@ -906,7 +905,6 @@ __wti_live_restore_fs_restore_file(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)
         __wt_verbose_debug1(session, WT_VERB_LIVE_RESTORE,
           "%s: Finished background restoration, closing source file", fh->name);
         WT_ERR(__live_restore_fh_close_source(session, lr_fh, true));
-        __wt_tree_modify_set(session);
     }
 err:
     __wt_free(session, buf);


### PR DESCRIPTION
This forces checkpoints to run on all files when in live restore mode. We previously dirtied trees that required checkpointing to write their live restore metadata entires, however, this was problematic for newly created tables that took "fake" checkpoints. See [SERVER-99614](https://jira.mongodb.org/browse/SERVER-99614) for further details.