### PR TITLE
WT-14207 Fix Uncommitted data unit test scenario

### DIFF
--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_uncommitted_dirty.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_uncommitted_dirty.cpp
@@ -18,8 +18,8 @@
  * codes and messages are stored.
  */
 
-#define URI "table:test_drop_conflict"
-#define FILE_URI "file:test_drop_conflict.wt"
+#define URI "table:test_drop_uncommitted_dirty"
+#define FILE_URI "file:test_drop_uncommitted_dirty.wt"
 #define UNCOMMITTED_DATA_MSG "the table has uncommitted data and cannot be dropped yet"
 #define DIRTY_DATA_MSG "the table has dirty data and can not be dropped yet"
 
@@ -54,14 +54,18 @@ TEST_CASE("Test WT_UNCOMMITTED_DATA and WT_DIRTY_DATA",
 
     SECTION("Test WT_UNCOMMITTED_DATA is not thrown (with uncommitted txn only)")
     {
-        S2BT(session_impl)->max_upd_txn = 2;
+        // The oldest ID is not pinned by a transaction. Set the value to a high number such
+        // that it can never catch up.
+        S2BT(session_impl)->max_upd_txn = 100;
         REQUIRE(__wt_conn_dhandle_close(session_impl, false, false, false) == 0);
         utils::check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
     }
 
     SECTION("Test WT_UNCOMMITTED_DATA is thrown (with both visibility check and uncommitted txn)")
     {
-        S2BT(session_impl)->max_upd_txn = 2;
+        // The oldest ID is not pinned by a transaction. Set the value to a high number such
+        // that it can never catch up.
+        S2BT(session_impl)->max_upd_txn = 100;
         REQUIRE(__wt_conn_dhandle_close(session_impl, false, false, true) == EBUSY);
         utils::check_error_info(err_info, EBUSY, WT_UNCOMMITTED_DATA, UNCOMMITTED_DATA_MSG);
     }


### PR DESCRIPTION
Inside the `_wt_conn_dhandle_close` we are specifically testing a visibility check performed by `_wt_txn_visible_all`. Within the test, we hardcode the max_upd_txn to equal 3 with the assumption that the oldest transaction ID doesn't move. However since WT finds no active transaction on the system, it can freely move forward the oldest ID forward. Therefore the test becomes flaky as oldest ID can be more than 3. The fix will be instead setting the value to 100