### PR TITLE
WT-14277 Intercept turtle_read calls to take the live restore state lock first

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1035,6 +1035,8 @@ extern int __wt_turtle_exists(WT_SESSION_IMPL *session, bool *existp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_init(WT_SESSION_IMPL *session, bool verify_meta, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_turtle_validate_version(WT_SESSION_IMPL *session)
@@ -1400,8 +1402,6 @@ extern int __wti_tiered_storage_destroy(WT_SESSION_IMPL *session, bool final_flu
 extern int __wti_timing_stress_config(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_tree_walk_skip(WT_SESSION_IMPL *session, WT_REF **refp, uint64_t *skipleafcntp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_txn_checkpoint_logread(WT_SESSION_IMPL *session, const uint8_t **pp,
   const uint8_t *end, WT_LSN *ckpt_lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -38,6 +38,8 @@ extern int __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_server_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_live_restore_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_turtle_rewrite(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_turtle_update(WT_SESSION_IMPL *session, const char *key,

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -52,7 +52,7 @@ __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
     WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->turtle_lock);
 
     char *existing_config;
-    WT_RET(__wti_turtle_read(session, WT_METAFILE_URI, &existing_config));
+    WT_RET(__wt_turtle_read(session, WT_METAFILE_URI, &existing_config));
 
     if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
         WT_RET(__wt_live_restore_turtle_update(session, WT_METAFILE_URI, existing_config, false));
@@ -318,7 +318,11 @@ __wt_metadata_search(WT_SESSION_IMPL *session, const char *key, char **valuep)
          * otherwise. The code path is used enough that Coverity complains a lot, add an error check
          * to get some peace and quiet.
          */
-        WT_WITH_TURTLE_LOCK(session, ret = __wti_turtle_read(session, key, valuep));
+        if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+            ret = __wt_live_restore_turtle_read(session, key, valuep);
+        else
+            WT_WITH_TURTLE_LOCK(session, ret = __wt_turtle_read(session, key, valuep));
+
         if (ret != 0)
             __wt_free(session, *valuep);
         return (ret);


### PR DESCRIPTION
Similar to how we intercept turtle file writes, make sure we always take the live restore state lock before taking the turtle lock on the read path. 
I originally only intercepted writes since they call `get_state` to write the live restore state to the turtle file, but the read path can also hit a deadlock since we call `__wti_live_restore_migration_complete` from `__live_restore_setup_lr_fh_file` while opening the turtle file.