### PR TITLE
SLS-1609 Remove the use of "shutdown_checkpoint" from test/model

### DIFF
--- a/test/model/src/core/util.cpp
+++ b/test/model/src/core/util.cpp
@@ -479,7 +479,7 @@ wt_build_dir_path()
  *     Get the config string for disaggregated storage.
  */
 std::string
-wt_disagg_config_string(bool checkpoint_on_shutdown)
+wt_disagg_config_string()
 {
     std::string extension = wt_extension_path("page_log/palm/libwiredtiger_page_log.so");
 
@@ -487,9 +487,7 @@ wt_disagg_config_string(bool checkpoint_on_shutdown)
     config << "checkpoint=(precise=true),";
     config << "extensions=[" << extension << "],";
     /* config << "extensions=[" << extension << "=(config=\"(verbose=1)\")" << "],"; */
-    config << "disaggregated=(page_log=palm,role=follower,";
-    config << "shutdown_checkpoint=" << checkpoint_on_shutdown;
-    config << ")";
+    config << "disaggregated=(page_log=palm,role=follower)";
 
     return config.str();
 }

--- a/test/model/src/include/model/kv_database.h
+++ b/test/model/src/include/model/kv_database.h
@@ -46,11 +46,9 @@ namespace model {
  */
 struct kv_database_config {
 
-    /* Checkpoints. */
-    bool checkpoint_on_shutdown;
-
     /* Disaggregated storage. */
     bool disaggregated;
+    bool leader;
 
     /*
      * kv_database_config::kv_database_config --

--- a/test/model/src/include/model/util.h
+++ b/test/model/src/include/model/util.h
@@ -649,7 +649,7 @@ std::string wt_build_dir_path();
  * wt_disagg_config_string --
  *     Get the config string for disaggregated storage.
  */
-std::string wt_disagg_config_string(bool checkpoint_on_shutdown = true);
+std::string wt_disagg_config_string();
 
 /*
  * wt_disagg_pick_up_latest_checkpoint --

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -182,11 +182,9 @@ run_and_verify(std::shared_ptr<model::kv_workload> workload, const std::string &
             /* Open the WiredTiger database to verify. */
             WT_CONNECTION *conn;
             std::string conn_config_verify = model::kv_workload_runner_wt::k_config_base;
-            if (database.config().disaggregated) {
-                conn_config_verify += ",";
-                conn_config_verify +=
-                  model::wt_disagg_config_string(false /* checkpoint on shutdown */);
-            }
+            if (database.config().disaggregated)
+                conn_config_verify =
+                  model::join(conn_config_verify, model::wt_disagg_config_string(), ",");
             if (conn_config_override != "")
                 conn_config_verify += "," + conn_config_override;
             int ret = wiredtiger_open(


### PR DESCRIPTION
SLS-1568 deprecated the `shutdown_checkpoint` config option and changed WiredTiger's semantics so that only leaders take checkpoints on shutdown. Modify test/model accordingly.