### PR TITLE
SLS-1580 Fix missing stats on disagg block read path

### DIFF
--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -443,6 +443,17 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     else
         WT_STAT_CONN_INCRV(session, block_byte_read_leaf_disk, ip->size);
 
+    WT_STAT_CONN_DSRC_INCR(session, cache_read);
+    if (WT_SESSION_IS_CHECKPOINT(session))
+        WT_STAT_CONN_DSRC_INCR(session, cache_read_checkpoint);
+    if (F_ISSET(dsk, WT_PAGE_COMPRESSED))
+        WT_STAT_DSRC_INCR(session, compress_read);
+
+    /* TODO: How do we want to account for deltas in these statistics? */
+    WT_STAT_CONN_DSRC_INCRV(session, cache_bytes_read, dsk->mem_size);
+    WT_STAT_SESSION_INCRV(session, bytes_read, dsk->mem_size);
+    (void)__wt_atomic_add64(&S2C(session)->cache->bytes_read, dsk->mem_size);
+
     if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
         WT_ERR(__wt_scr_alloc(session, 0, &etmp));
         WT_ERR(__read_decrypt(session, ip, etmp, addr, addr_size, false));


### PR DESCRIPTION
Update wt_block_read_multi to include stats related to pages and bytes read into the cache. These stats are part of the non-disagg read path and should be update on the disagg path, as well.