### PR TITLE
WT-14282 Fix release build compilation errors in V5 toolchain

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -439,6 +439,7 @@ WTI
 WTPERF
 WaitForSingleObject
 WaitOn
+Warray
 Wconditional
 Wduplicated
 WeakHashLen

--- a/src/include/intpack_inline.h
+++ b/src/include/intpack_inline.h
@@ -80,6 +80,19 @@
     } while (0)
 #endif
 
+#ifdef __GNUC__
+#if __GNUC__ == 14
+    /*
+    * !!!
+    * GCC with -Warray-bounds complains about calls to __wt_vunpack_uint in this file.
+    * This is a GCC compiler bug referenced in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117829.
+    */
+    #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#elif __GNUC__ >= 15
+    #pragma message( \
+        "Building with GCC 14 or later. Please check if we can close WT-XXXXX and remove suppression.")
+#endif
+#endif
 /*
  * __wt_vpack_posint --
  *     Packs a positive variable-length integer in the specified location.
@@ -248,10 +261,6 @@ __wt_vpack_int(uint8_t **pp, size_t maxlen, int64_t x)
     return (0);
 }
 
-/*
- * __wt_vunpack_uint --
- *     Variable-sized unpacking for unsigned integers
- */
 static WT_INLINE int
 __wt_vunpack_uint(const uint8_t **pp, size_t maxlen, uint64_t *xp)
 {

--- a/src/include/intpack_inline.h
+++ b/src/include/intpack_inline.h
@@ -87,7 +87,7 @@
  * GCC with -Warray-bounds complains about calls to __wt_vunpack_uint in this file.
  * This is a GCC compiler bug referenced in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117829.
  */
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Warray-bounds"
 #elif __GNUC__ >= 15
 #pragma message( \
   "Building with GCC 15 or later. Please check if we can close WT-14292 and remove suppression.")

--- a/src/include/intpack_inline.h
+++ b/src/include/intpack_inline.h
@@ -82,15 +82,15 @@
 
 #ifdef __GNUC__
 #if __GNUC__ == 14
-    /*
-    * !!!
-    * GCC with -Warray-bounds complains about calls to __wt_vunpack_uint in this file.
-    * This is a GCC compiler bug referenced in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117829.
-    */
-    #pragma GCC diagnostic ignored "-Wformat-nonliteral"
+/*
+ * !!!
+ * GCC with -Warray-bounds complains about calls to __wt_vunpack_uint in this file.
+ * This is a GCC compiler bug referenced in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117829.
+ */
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #elif __GNUC__ >= 15
-    #pragma message( \
-        "Building with GCC 14 or later. Please check if we can close WT-XXXXX and remove suppression.")
+#pragma message( \
+  "Building with GCC 15 or later. Please check if we can close WT-14292 and remove suppression.")
 #endif
 #endif
 /*
@@ -261,6 +261,10 @@ __wt_vpack_int(uint8_t **pp, size_t maxlen, int64_t x)
     return (0);
 }
 
+/*
+ * __wt_vunpack_uint --
+ *     Variable-sized unpacking for unsigned integers
+ */
 static WT_INLINE int
 __wt_vunpack_uint(const uint8_t **pp, size_t maxlen, uint64_t *xp)
 {

--- a/src/utilities/util_load_json.c
+++ b/src/utilities/util_load_json.c
@@ -324,7 +324,7 @@ err:
      * loading files.
      */
     if (cursor != NULL && (tret = cursor->close(cursor)) != 0) {
-        tret = util_err(session, tret, "%s: cursor.close", uri);
+        tret = util_err(session, tret, "%s: cursor.close", uri != NULL ? uri : "NULL");
         if (ret == 0)
             ret = tret;
     }


### PR DESCRIPTION
We encountered compiler bugs when testing v5 toolchain. This ticket aims to fix two compilation issues:
- Inside intpack_inline.h, there is a known gcc bug as follows https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107842. I have applied a mitigation tactic.
- Fixed possible NULL issue inside util_json.c