### PR TITLE
WT-14294 Remove outdated fixme in test_tiered07.py

### DIFF
--- a/test/suite/test_tiered07.py
+++ b/test/suite/test_tiered07.py
@@ -38,10 +38,9 @@ class test_tiered07(wttest.WiredTigerTestCase, TieredConfigMixin):
 
     storage_sources = gen_tiered_storage_sources(wttest.getss_random_prefix(), 'test_tiered07', tiered_only=True)
 
-    # FIXME-WT-8897 Disabled S3 (only indexing dirstore in storage sources) as S3 directory listing
+    # Disabled S3 (only indexing dirstore in storage sources) as S3 directory listing
     # is interpreting a directory to end in a '/', whereas the code in the tiered storage doesn't
-    # expect that. Enable when fixed.
-    # Make scenarios for different cloud service providers
+    # expect that.
     flush_obj = [('ckpt', dict(first_ckpt=True)),
                  ('no_ckpt', dict(first_ckpt=False)),
                 ]


### PR DESCRIPTION
Remove an outdated FIXME for WT-8897 in test_tiered07.py.
We closed the Jira ticket as Won't Do since tiered storage is now deprecated.