### PR TITLE
Revert "WT-14276 Force checkpoints in live restore mode (#11725)"

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2041,19 +2041,6 @@ __checkpoint_lock_dirty_tree(
     }
 
     /*
-     * Force every checkpoint when using a live restore file system. Live restore needs to write
-     * metadata for each file being restored, but it doesn't necessarily dirty the btree during
-     * background migration. By forcing checkpoints we ensure that all open btrees will have their
-     * metadata updated.
-     *
-     * There were two alternative solutions here, which we list for posterity:
-     * - Periodically dirtying the btree by calling __wt_tree_modify_set from the background thread.
-     * - Perform a forced checkpoint on completion of migration for every file migrated.
-     */
-    if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
-        force = true;
-
-    /*
      * This is a complicated test to determine if we can avoid the expensive call of getting the
      * list of checkpoints for this file. We want to avoid that for clean files. But on clean files
      * we want to periodically check if we need to delete old checkpoints that may have been in use
@@ -2727,12 +2714,8 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
     if (final && !metadata)
         return (__wt_evict_file(session, WT_SYNC_DISCARD));
 
-    /*
-     * Evict the unmodified file without taking a checkpoint when closing the handle. If we're using
-     * a live restore file system we'll need to checkpoint anyway to ensure we write the live
-     * restore metadata.
-     */
-    if (!btree->modified && !bulk && !F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+    /* Closing an unmodified file. */
+    if (!btree->modified && !bulk)
         return (__wt_evict_file(session, WT_SYNC_DISCARD));
 
     /*

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -945,6 +945,7 @@ __wti_live_restore_fs_restore_file(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)
               " seconds. Currently copying offset %" PRId64 " of file size %" PRId64,
               lr_fh->iface.name, time_diff_ms / WT_THOUSAND, read_offset, WTI_BITMAP_END(lr_fh));
             msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
+            __wt_tree_modify_set(session);
         }
 
         /*
@@ -960,6 +961,7 @@ __wti_live_restore_fs_restore_file(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)
         __wt_verbose_debug1(session, WT_VERB_LIVE_RESTORE,
           "%s: Finished background restoration, closing source file", fh->name);
         WT_ERR(__live_restore_fh_close_source(session, lr_fh, true));
+        __wt_tree_modify_set(session);
     }
 err:
     __wt_free(session, buf);


### PR DESCRIPTION
This reverts commit 7a0234ff0171a7323fea1f8bb98f7f19a0e7d12a.

Reverting due to test fallout. Checkpoints are mistakenly taken during verify.
