### PR TITLE
WT-12280 and WT-13283 backport (7.0)

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -779,12 +779,12 @@ __evict_pass(WT_SESSION_IMPL *session)
          */
         if (eviction_progress == cache->eviction_progress) {
             if (WT_CLOCKDIFF_MS(time_now, time_prev) >= 20 && F_ISSET(cache, WT_CACHE_EVICT_HARD)) {
-                if (cache->evict_aggressive_score < 100)
-                    ++cache->evict_aggressive_score;
+                if (cache->evict_aggressive_score < WT_EVICT_SCORE_MAX)
+                    (void)__wt_atomic_addv32(&cache->evict_aggressive_score, 1);
                 oldest_id = txn_global->oldest_id;
                 if (prev_oldest_id == oldest_id && txn_global->current != oldest_id &&
-                  cache->evict_aggressive_score < 100)
-                    ++cache->evict_aggressive_score;
+                  cache->evict_aggressive_score < WT_EVICT_SCORE_MAX)
+                    (void)__wt_atomic_addv32(&cache->evict_aggressive_score, 1);
                 time_prev = time_now;
                 prev_oldest_id = oldest_id;
             }
@@ -793,7 +793,7 @@ __evict_pass(WT_SESSION_IMPL *session)
              * Keep trying for long enough that we should be able to evict a page if the server
              * isn't interfering.
              */
-            if (loop < 100 || cache->evict_aggressive_score < 100) {
+            if (loop < 100 || cache->evict_aggressive_score < WT_EVICT_SCORE_MAX) {
                 /*
                  * Back off if we aren't making progress: walks hold the handle list lock, blocking
                  * other operations that can free space in cache, such as LSM discarding handles.
@@ -811,7 +811,7 @@ __evict_pass(WT_SESSION_IMPL *session)
             break;
         }
         if (cache->evict_aggressive_score > 0)
-            --cache->evict_aggressive_score;
+            (void)__wt_atomic_subv32(&cache->evict_aggressive_score, 1);
         loop = 0;
         eviction_progress = cache->eviction_progress;
     }
@@ -2479,7 +2479,8 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly, d
         if (!F_ISSET(conn, WT_CONN_RECOVERING) && __wt_cache_stuck(session)) {
             ret = __wt_txn_is_blocking(session);
             if (ret == WT_ROLLBACK) {
-                --cache->evict_aggressive_score;
+                if (cache->evict_aggressive_score > 0)
+                    (void)__wt_atomic_subv32(&cache->evict_aggressive_score, 1);
                 WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
                 __wt_verbose_debug1(
                   session, WT_VERB_TRANSACTION, "%s", session->txn->rollback_reason);
@@ -2553,7 +2554,8 @@ err:
          */
         if (ret == 0 && cache_max_wait_us != 0 && session->cache_wait_us > cache_max_wait_us) {
             ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW);
-            --cache->evict_aggressive_score;
+            if (cache->evict_aggressive_score > 0)
+                (void)__wt_atomic_subv32(&cache->evict_aggressive_score, 1);
             WT_STAT_CONN_INCR(session, cache_timed_out_ops);
             __wt_verbose_notice(session, WT_VERB_TRANSACTION, "%s", session->txn->rollback_reason);
         }

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -82,10 +82,13 @@ static inline bool
 __wt_cache_stuck(WT_SESSION_IMPL *session)
 {
     WT_CACHE *cache;
+    uint32_t tmp_evict_aggressive_score;
 
     cache = S2C(session)->cache;
+    tmp_evict_aggressive_score = cache->evict_aggressive_score;
+    WT_ASSERT(session, tmp_evict_aggressive_score <= WT_EVICT_SCORE_MAX);
     return (
-      cache->evict_aggressive_score == WT_EVICT_SCORE_MAX && F_ISSET(cache, WT_CACHE_EVICT_HARD));
+      tmp_evict_aggressive_score == WT_EVICT_SCORE_MAX && F_ISSET(cache, WT_CACHE_EVICT_HARD));
 }
 
 /*

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -394,3 +394,18 @@ union __wt_rand_state {
             WT_ERR(__wt_buf_extend(session, buf, (buf)->size + __len + 1));     \
         }                                                                       \
     } while (0)
+
+/*
+ * __wt_atomic_decrement_if_positive --
+ *     Use compare and swap to atomically decrement value by 1 if it's positive.
+ */
+static inline void
+__wt_atomic_decrement_if_positive(uint32_t *valuep)
+{
+    uint32_t old_value;
+    do {
+        WT_ORDERED_READ(old_value, *valuep);
+        if (old_value == 0)
+            break;
+    } while (!__wt_atomic_cas32(valuep, old_value, old_value - 1));
+}


### PR DESCRIPTION
WT-12280 converts evict_aggressive_score to use atomic operations
WT-13283 applies the compare-and-swap operation to the code to avoid
the value drops to -1.