### PR TITLE
WT-14072 Make code coverage fail if Catch2 tests crash

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -856,7 +856,7 @@ functions:
         # Record the start time, in seconds
         date +%s > time.txt
 
-        ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -c ${code_coverage_test_file|test/evergreen/code_coverage/code_coverage_config.json} -b $(pwd)/build_ -j ${num_jobs} -s ${code_cov_extra_args}
+        ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -c ${code_coverage_test_file|test/evergreen/code_coverage/code_coverage_config.json} -b $(pwd)/build_ -j ${num_jobs} -s ${code_cov_extra_args} -v -e
 
         # Record the end time, in seconds
         date +%s >> time.txt

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -856,7 +856,7 @@ functions:
         # Record the start time, in seconds
         date +%s > time.txt
 
-        ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -c ${code_coverage_test_file|test/evergreen/code_coverage/code_coverage_config.json} -b $(pwd)/build_ -j ${num_jobs} -s ${code_cov_extra_args} -v -e
+        ${python_binary|python3} test/evergreen/code_coverage/parallel_code_coverage.py -c ${code_coverage_test_file|test/evergreen/code_coverage/code_coverage_config.json} -b $(pwd)/build_ -j ${num_jobs} -s ${code_cov_extra_args} -v
 
         # Record the end time, in seconds
         date +%s >> time.txt
@@ -3054,6 +3054,7 @@ tasks:
         vars:
           num_jobs: 1
           code_coverage_test_file: test/evergreen/code_coverage/code_coverage_config_catch2.json
+          code_cov_extra_args: --check_errors
       - func: "code coverage analysis"
         vars:
           working_dir: "wiredtiger"

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -74,7 +74,7 @@ def run_task_lists_in_parallel(build_dirs_list, task_list, run_func, optimize_te
                 future.result()
 
         # took to run
-        if (optimize_test_order):
+        if optimize_test_order:
             for future in concurrent.futures.as_completed(futures):
                 data = future.result()
                 analyse_test_timings.append(data)

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -51,7 +51,7 @@ def setup_run_tasks_parallel(init_args):
     return 0
 
 # Execute each list of tasks in parallel
-def run_task_lists_in_parallel(build_dirs_list, task_list, run_func, optimize_test_order):
+def run_task_lists_in_parallel(build_dirs_list, task_list, run_func, optimize_test_order, check_errors):
     parallel = len(build_dirs_list)
     task_start_time = datetime.now()
 
@@ -68,6 +68,11 @@ def run_task_lists_in_parallel(build_dirs_list, task_list, run_func, optimize_te
             futures.append(executor.submit(run_func, index, task))
 
         # Only in analysis mode, do we construct an list of all the tasks and how long they
+        if check_errors:
+            # Check the results of each of the futures. Calling result() will throw an exception for any that failed.
+            for future in concurrent.futures.as_completed(futures):
+                future.result()
+
         # took to run
         if (optimize_test_order):
             for future in concurrent.futures.as_completed(futures):

--- a/test/evergreen/code_coverage/code_coverage_utils.py
+++ b/test/evergreen/code_coverage/code_coverage_utils.py
@@ -56,7 +56,7 @@ def run_task_lists_in_parallel(build_dirs_list, task_list, run_func, optimize_te
     task_start_time = datetime.now()
 
     # Build a shared queue of all the build directories, which will be used to initialize each
-    # process to it's own build directory.
+    # process to its own build directory.
     build_queue = multiprocessing.Queue()
     for build_dir in build_dirs_list:
         build_queue.put(build_dir)
@@ -67,12 +67,12 @@ def run_task_lists_in_parallel(build_dirs_list, task_list, run_func, optimize_te
         for index, task in enumerate(task_list):
             futures.append(executor.submit(run_func, index, task))
 
-        # Only in analysis mode, do we construct an list of all the tasks and how long they
         if check_errors:
             # Check the results of each of the futures. Calling result() will throw an exception for any that failed.
             for future in concurrent.futures.as_completed(futures):
                 future.result()
 
+        # Only in analysis mode, do we construct a list of all the tasks and how long they
         # took to run
         if optimize_test_order:
             for future in concurrent.futures.as_completed(futures):

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -61,7 +61,7 @@ def run_task(index, task):
     end_time = datetime.now()
     diff = end_time - start_time
     logging.debug("Finished task {} in {} : took {} seconds".format(task, build_dir, diff.total_seconds()))
-    return (task, diff.total_seconds())
+    return task, diff.total_seconds()
 
 def main():
     parser = argparse.ArgumentParser()
@@ -95,12 +95,12 @@ def main():
     logging.debug('  Perform setup actions:           {}'.format(setup))
     logging.debug('  Check errors:                    {}'.format(check_errors))
 
-    if (bucket and bucket != "python" and bucket != "other"):
+    if bucket and bucket != "python" and bucket != "other":
         sys.exit("Only buckets options \"python\" and \"other\" are allowed")
 
     # optimize_test_order will rewrite the list of coverage tests. If we use this when running a
     # subset of tests only that subset will be written and we'll lose the unscheduled tests.
-    if (bucket and optimize_test_order):
+    if bucket and optimize_test_order:
         sys.exit("Analysis mode can not be done with bucket")
 
     if parallel_tests < 1:
@@ -136,10 +136,10 @@ def main():
         # To do this we divide the tests into two buckets into either only python tests or
         # non-python tests. If python is set, only include python tests in the task list.
         is_python_test = re.search("python", test)
-        if (not is_python_test and bucket == "python"):
+        if not is_python_test and bucket == "python":
             continue
         # Else if other is set, only include non-python tests in the task list.
-        elif (is_python_test and bucket == "other"):
+        elif is_python_test and bucket == "other":
             continue
         logging.debug("Prepping test {} ".format(test))
         task_list.append(test)

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -57,6 +57,7 @@ def run_task(index, task):
         subprocess.run(split_command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
     except subprocess.CalledProcessError as exception:
         logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
+        sys.exit(f'Exiting because command {exception.cmd} failed with error {exception.returncode}')
     end_time = datetime.now()
     diff = end_time - start_time
     logging.debug("Finished task {} in {} : took {} seconds".format(task, build_dir, diff.total_seconds()))
@@ -72,6 +73,7 @@ def main():
     parser.add_argument('-v', '--verbose', action="store_true", help='Be verbose')
     parser.add_argument('-u', '--bucket', type=str, help='Run on only python tests in code coverage')
     parser.add_argument('-o', '--optimize_test_order', action="store_true", help='Review test runtimes and update the test ordering for faster test execution')
+    parser.add_argument('-e', '--check_errors', action="store_true", help='Check result codes from tasks and exit on failure')
     args = parser.parse_args()
 
     verbose = args.verbose
@@ -82,6 +84,7 @@ def main():
     parallel_tests = args.parallel
     bucket = args.bucket
     setup = args.setup
+    check_errors = args.check_errors
 
     logging.debug('Code Coverage')
     logging.debug('=============')
@@ -90,6 +93,7 @@ def main():
     logging.debug('  Base name for build directories: {}'.format(build_dir_base))
     logging.debug('  Number of parallel tests:        {}'.format(parallel_tests))
     logging.debug('  Perform setup actions:           {}'.format(setup))
+    logging.debug('  Check errors:                    {}'.format(check_errors))
 
     if (bucket and bucket != "python" and bucket != "other"):
         sys.exit("Only buckets options \"python\" and \"other\" are allowed")
@@ -143,7 +147,7 @@ def main():
     logging.debug("task_list: {}".format(task_list))
 
     # Perform task operations in parallel across the build directories
-    analyse_test_timings = run_task_lists_in_parallel(build_dirs_list, task_list, run_func=run_task, optimize_test_order=optimize_test_order)
+    analyse_test_timings = run_task_lists_in_parallel(build_dirs_list, task_list, run_func=run_task, optimize_test_order=optimize_test_order, check_errors=check_errors)
 
     # In analysis mode, we analyze the test and their timings, and sort them in descending order.
     # Running the shortest tests last decreases the amount of time we spend waiting for the

--- a/test/evergreen/code_coverage/per_test_code_coverage.py
+++ b/test/evergreen/code_coverage/per_test_code_coverage.py
@@ -133,6 +133,7 @@ def main():
     parser.add_argument('-s', '--setup', action="store_true",
                         help='Perform setup actions from the config in each build directory')
     parser.add_argument('-v', '--verbose', action="store_true", help='Be verbose')
+    parser.add_argument('-e', '--check_errors', action="store_true", help='Check result codes from tasks and exit on failure')
     args = parser.parse_args()
 
     verbose = args.verbose
@@ -141,6 +142,7 @@ def main():
     gcovr_dir = args.gcovr_dir
     parallel_tests = args.parallel
     setup = args.setup
+    check_errors = args.check_errors
 
     logging.basicConfig(level=logging.DEBUG if verbose else logging.INFO)
 
@@ -152,6 +154,7 @@ def main():
     logging.debug(f'  Number of parallel tests:        {parallel_tests}')
     logging.debug(f'  Perform setup actions:           {setup}')
     logging.debug(f'  Gcovr output directory:          {gcovr_dir}')
+    logging.debug(f'  Check errors:                    {check_errors}')
 
     if parallel_tests < 1:
         sys.exit("Number of parallel tests must be >= 1")
@@ -193,7 +196,7 @@ def main():
     logging.debug("task_list: {}".format(task_list))
 
     # Perform code coverage task operations in parallel across the build directories
-    run_task_lists_in_parallel(build_dirs_list, task_list, run_func=run_coverage_task, optimize_test_order=False)
+    run_task_lists_in_parallel(build_dirs_list, task_list, run_func=run_coverage_task, optimize_test_order=False, check_errors=check_errors)
 
     # Run gcovr if required
     if gcovr_dir:


### PR DESCRIPTION
This change adds support for checking result codes from code coverage tests, and then exiting testing if a failure result occurs. 

Note this is only being used for Catch2 based tests for now, as several Python-based test return errors code when being used for code coverage. 

Some code tidying up was done at the same time.
