### PR TITLE
WT-13813 Cleanup the live restore truncate path and crash if we detect bitmap corruption

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1147,7 +1147,7 @@ __live_restore_fh_truncate(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, wt_off_t 
 
     WT_RET(lr_fh->destination->fh_truncate(lr_fh->destination, wt_session, len));
     /* Only modify the bitmap if we are shortening the file and we have taken the lock. */
-    if (old_len < len && locked) {
+    if (old_len > len && locked) {
         /*
          * Set the relevant bits in the bitmap. This won't be persisted across a crash without a
          * metadata write. We catch this rare scenario with an assertion on file reopen.

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1124,39 +1124,39 @@ __live_restore_fh_sync(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)
 static int
 __live_restore_fh_truncate(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, wt_off_t len)
 {
-    WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh;
-    wt_off_t old_len, truncate_end, truncate_start;
-
-    lr_fh = (WTI_LIVE_RESTORE_FILE_HANDLE *)fh;
+    wt_off_t old_len;
     old_len = 0;
-    /*
-     * If we truncate a range we'll never need to read that range from the source file. Mark it as
-     * such.
-     */
-    WT_RET(__live_restore_fh_size(fh, wt_session, &old_len));
 
+    WT_RET(__live_restore_fh_size(fh, wt_session, &old_len));
+    /* Sometimes we call truncate but don't change the length. Ignore */
     if (old_len == len)
-        /* Sometimes we call truncate but don't change the length. Ignore */
         return (0);
 
     __wt_verbose_debug2((WT_SESSION_IMPL *)wt_session, WT_VERB_LIVE_RESTORE,
       "truncating file %s from %" PRId64 " to %" PRId64, fh->name, old_len, len);
 
-    /*
-     * Truncate can be used to shorten a file or to extend it. In both cases the truncated/extended
-     * range doesn't need to be read from the source directory.
-     */
-    truncate_start = WT_MIN(len, old_len);
-    truncate_end = WT_MAX(len, old_len);
-
     WT_SESSION_IMPL *session = (WT_SESSION_IMPL *)wt_session;
+    WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh = (WTI_LIVE_RESTORE_FILE_HANDLE *)fh;
 
-    WTI_WITH_LIVE_RESTORE_FH_WRITE_LOCK(
-      session, lr_fh,
-      __live_restore_fh_fill_bit_range(
-        lr_fh, session, truncate_start, (size_t)(truncate_end - truncate_start)););
+    bool locked = false;
+    if (!WTI_DEST_COMPLETE(lr_fh)) {
+        /* Lock so we can't race with background threads moving chunks. */
+        __wt_writelock(session, &lr_fh->lock);
+        locked = true;
+    }
 
-    return (lr_fh->destination->fh_truncate(lr_fh->destination, wt_session, len));
+    WT_RET(lr_fh->destination->fh_truncate(lr_fh->destination, wt_session, len));
+    /* Only modify the bitmap if we are shortening the file and we have taken the lock. */
+    if (old_len < len && locked) {
+        /*
+         * Set the relevant bits in the bitmap. This won't be persisted across a crash without a
+         * metadata write. We catch this rare scenario with an assertion on file reopen.
+         */
+        __live_restore_fh_fill_bit_range(lr_fh, session, len, (size_t)(old_len - len));
+    }
+    if (locked)
+        __wt_writeunlock(session, &lr_fh->lock);
+    return (0);
 }
 
 /*
@@ -1212,7 +1212,6 @@ __live_restore_decode_bitmap(WT_SESSION_IMPL *session, const char *bitmap_str, u
     WT_CLEAR(buf);
     WT_ERR(__wt_hex_to_raw(session, bitmap_str, &buf));
     memcpy(lr_fh->bitmap, buf.mem, buf.size);
-    /* FIXME-WT-13813: Add check here for shorter dest than bitmap, set end to 1. */
 err:
     __wt_buf_free(session, &buf);
     return (ret);
@@ -1269,9 +1268,9 @@ __wt_live_restore_metadata_to_fh(
      *  (nbits > 0) : The number of bits in the bitmap. This is set when the file is in the
      *                process of being migrated.
      */
+    uint64_t nbits = 0;
     if (lr_fh_meta->nbits == 0) {
         WT_ASSERT(session, !WTI_DEST_COMPLETE(lr_fh));
-        uint64_t nbits;
         WT_ERR(__live_restore_compute_nbits(session, lr_fh, &nbits));
         WT_ERR(__bit_alloc(session, nbits, &lr_fh->bitmap));
         lr_fh->nbits = nbits;
@@ -1283,6 +1282,13 @@ __wt_live_restore_metadata_to_fh(
         __wt_verbose_debug3(session, WT_VERB_LIVE_RESTORE,
           "Reconstructing bitmap for %s, bitmap_sz %" PRId64 ", bitmap_str %s", fh->name,
           lr_fh_meta->nbits, lr_fh_meta->bitmap_str);
+        WT_ERR(__live_restore_compute_nbits(session, lr_fh, &nbits));
+        /*
+         * Catch rare scenarios like truncating before a crash, we don't handle them but they could
+         * create some kind of data corruption.
+         */
+        WT_ASSERT_ALWAYS(
+          session, (uint64_t)lr_fh_meta->nbits == nbits, "file size doesn't match bitmap size");
         /* Reconstruct a pre-existing bitmap. */
         WT_ERR(__live_restore_decode_bitmap(
           session, lr_fh_meta->bitmap_str, (uint64_t)lr_fh_meta->nbits, lr_fh));

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1124,8 +1124,8 @@ __live_restore_fh_sync(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)
 static int
 __live_restore_fh_truncate(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, wt_off_t len)
 {
-    wt_off_t old_len;
-    old_len = 0;
+    WT_DECL_RET;
+    wt_off_t old_len = 0;
 
     WT_RET(__live_restore_fh_size(fh, wt_session, &old_len));
     /* Sometimes we call truncate but don't change the length. Ignore */
@@ -1145,7 +1145,7 @@ __live_restore_fh_truncate(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, wt_off_t 
         locked = true;
     }
 
-    WT_RET(lr_fh->destination->fh_truncate(lr_fh->destination, wt_session, len));
+    WT_ERR(lr_fh->destination->fh_truncate(lr_fh->destination, wt_session, len));
     /* Only modify the bitmap if we are shortening the file and we have taken the lock. */
     if (old_len > len && locked) {
         /*
@@ -1154,9 +1154,10 @@ __live_restore_fh_truncate(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, wt_off_t 
          */
         __live_restore_fh_fill_bit_range(lr_fh, session, len, (size_t)(old_len - len));
     }
+err:
     if (locked)
         __wt_writeunlock(session, &lr_fh->lock);
-    return (0);
+    return (ret);
 }
 
 /*

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -63,10 +63,12 @@ struct __wti_live_restore_file_handle {
     WT_RWLOCK lock;
     /* Number of bits in the bitmap, should be equivalent to source file size / alloc_size. */
     uint64_t nbits;
-    /* The live restore bitmap is never resized throughout the live restore, this means reads or
-     * writes beyond the end of the bitmap are only relevant to the destination file. The
-     * destination file could shrink to be smaller than the original source file size, in this case
-     * we could shrink the bitmap but we have chosen not to as that is an optimization.
+    /*
+     * The live restore bitmap size is set once on bitmap creation and will never change, which
+     * means it is always the size of the source file. This means reads or writes beyond the end of
+     * the bitmap are only relevant to the destination file. The destination file could shrink to be
+     * smaller than the original source file size, in this case we could shrink the bitmap but we
+     * have chosen not to as that is an optimization.
      */
     uint8_t *bitmap;
     WT_FILE_HANDLE *source;

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -63,6 +63,11 @@ struct __wti_live_restore_file_handle {
     WT_RWLOCK lock;
     /* Number of bits in the bitmap, should be equivalent to source file size / alloc_size. */
     uint64_t nbits;
+    /* The live restore bitmap is never resized throughout the live restore, this means reads or
+     * writes beyond the end of the bitmap are only relevant to the destination file. The
+     * destination file could shrink to be smaller than the original source file size, in this case
+     * we could shrink the bitmap but we have chosen not to as that is an optimization.
+     */
     uint8_t *bitmap;
     WT_FILE_HANDLE *source;
 };

--- a/test/catch2/live_restore/unit/test_live_restore_bitmap_encode_decode.cpp
+++ b/test/catch2/live_restore/unit/test_live_restore_bitmap_encode_decode.cpp
@@ -32,11 +32,6 @@ TEST_CASE("Encode various bitmaps", "[live_restore_bitmap],[live_restore_bitmap_
     std::shared_ptr<mock_session> mock_session = mock_session::build_test_mock_session();
     WT_SESSION_IMPL *session = mock_session->get_wt_session_impl();
 
-    WTI_LIVE_RESTORE_FILE_HANDLE lr_fh;
-    WT_CLEAR(lr_fh);
-    WTI_LIVE_RESTORE_FILE_HANDLE lr_fh2;
-    WT_CLEAR(lr_fh2);
-
     test_data test1 = test_data("00", 8, new uint8_t[1]{0x0});
     test_data test2 = test_data("ab", 8, new uint8_t[1]{0xab});
     test_data test3 = test_data("11", 8, new uint8_t[1]{0x11});
@@ -52,29 +47,42 @@ TEST_CASE("Encode various bitmaps", "[live_restore_bitmap],[live_restore_bitmap_
     WT_ITEM buf;
     WT_CLEAR(buf);
 
-    REQUIRE(__wt_rwlock_init(session, &lr_fh.lock) == 0);
-
+    live_restore_test_env env;
     for (const auto &test : test_bitmaps) {
-        lr_fh.bitmap = test.bitmap;
-        lr_fh.nbits = test.nbits;
-        // We need to have a non NULL pointer here for the encoding to take place.
-        lr_fh.source = reinterpret_cast<WT_FILE_HANDLE *>(0xab);
-        __wt_readlock(session, &lr_fh.lock);
-        REQUIRE(__ut_live_restore_encode_bitmap(session, &lr_fh, &buf) == 0);
-        __wt_readunlock(session, &lr_fh.lock);
+        size_t filesize = test.nbits == 0 ? 4096 : 4096 * test.nbits;
+        create_file(env.source_file_path("file"), filesize);
+
+        WT_FILE_HANDLE *fh;
+        REQUIRE(env.lr_fs->iface.fs_open_file((WT_FILE_SYSTEM *)env.lr_fs,
+                  reinterpret_cast<WT_SESSION *>(env.session), env.dest_file_path("file").c_str(),
+                  WT_FS_OPEN_FILE_TYPE_DATA, 0, &fh) == 0);
+        WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh = (WTI_LIVE_RESTORE_FILE_HANDLE *)fh;
+
+        REQUIRE(testutil_exists(".", env.dest_file_path("file").c_str()));
+
+        lr_fh->bitmap = test.bitmap;
+        lr_fh->nbits = test.nbits;
+
+        __wt_readlock(session, &lr_fh->lock);
+        REQUIRE(__ut_live_restore_encode_bitmap(session, lr_fh, &buf) == 0);
+        __wt_readunlock(session, &lr_fh->lock);
         // In the live restore code we only call decode if nbits is not zero.
         if (test.nbits != 0) {
             REQUIRE(
               std::string(static_cast<const char *>(buf.data)) == std::string(test.bitmap_str));
+            lr_fh->allocsize = 4096;
             REQUIRE(__ut_live_restore_decode_bitmap(
-                      session, test.bitmap_str.c_str(), test.nbits, &lr_fh2) == 0);
+                      session, test.bitmap_str.c_str(), test.nbits, lr_fh) == 0);
         }
         if (test.nbits != 0)
-            REQUIRE(memcmp(lr_fh2.bitmap, test.bitmap, test.nbits / 8) == 0);
+            REQUIRE(memcmp(lr_fh->bitmap, test.bitmap, test.nbits / 8) == 0);
+
+        lr_fh->iface.close((WT_FILE_HANDLE *)lr_fh, (WT_SESSION *)env.session);
+        testutil_remove(env.dest_file_path("file").c_str());
+        testutil_remove(env.source_file_path("file").c_str());
+
         delete[] test.bitmap;
-        __wt_free(session, lr_fh2.bitmap);
         __wt_buf_free(session, &buf);
         WT_CLEAR(buf);
     }
-    __wt_rwlock_destroy(session, &lr_fh.lock);
 }

--- a/test/catch2/live_restore/unit/test_live_restore_bitmap_encode_decode.cpp
+++ b/test/catch2/live_restore/unit/test_live_restore_bitmap_encode_decode.cpp
@@ -50,15 +50,17 @@ TEST_CASE("Encode various bitmaps", "[live_restore_bitmap],[live_restore_bitmap_
     live_restore_test_env env;
     for (const auto &test : test_bitmaps) {
         size_t filesize = test.nbits == 0 ? 4096 : 4096 * test.nbits;
-        create_file(env.source_file_path("file"), filesize);
+        std::string dest_file = env.dest_file_path("file");
+        std::string source_file = env.source_file_path("file");
+        create_file(source_file, filesize);
 
         WT_FILE_HANDLE *fh;
         REQUIRE(env.lr_fs->iface.fs_open_file((WT_FILE_SYSTEM *)env.lr_fs,
-                  reinterpret_cast<WT_SESSION *>(env.session), env.dest_file_path("file").c_str(),
+                  reinterpret_cast<WT_SESSION *>(env.session), dest_file.c_str(),
                   WT_FS_OPEN_FILE_TYPE_DATA, 0, &fh) == 0);
         WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh = (WTI_LIVE_RESTORE_FILE_HANDLE *)fh;
 
-        REQUIRE(testutil_exists(".", env.dest_file_path("file").c_str()));
+        REQUIRE(testutil_exists(".", dest_file.c_str()));
 
         lr_fh->bitmap = test.bitmap;
         lr_fh->nbits = test.nbits;
@@ -78,8 +80,8 @@ TEST_CASE("Encode various bitmaps", "[live_restore_bitmap],[live_restore_bitmap_
             REQUIRE(memcmp(lr_fh->bitmap, test.bitmap, test.nbits / 8) == 0);
 
         lr_fh->iface.close((WT_FILE_HANDLE *)lr_fh, (WT_SESSION *)env.session);
-        testutil_remove(env.dest_file_path("file").c_str());
-        testutil_remove(env.source_file_path("file").c_str());
+        testutil_remove(dest_file.c_str());
+        testutil_remove(source_file.c_str());
 
         delete[] test.bitmap;
         __wt_buf_free(session, &buf);


### PR DESCRIPTION
The assert I added should remain regardless of whether we choose to handle the truncate case, personally I think it is low priority and it adds untestable complexity to the code. So I have opted to not resolve that scenario.