### PR TITLE
Revert "WT-14278 Clean up live restore bitmap metadata on backup open, not on backup close"

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1251,10 +1251,25 @@ __wt_live_restore_metadata_to_fh(
       "Reading in bitmap information from metadata but bitmap information already exists in "
       "memory");
 
+    /*
+     * Once we're in the clean up stage or later all data has been migrated across to the
+     * destination. There's no need for hole tracking and therefore nothing to reconstruct. The
+     * migration state must be checked before we check the number of bits in the bitmap as we clear
+     * that once it finishes.
+     */
+    if (__wti_live_restore_migration_complete(session)) {
+        /*
+         * Even though the migration has completed we may still have a source file, this indicates
+         * that the live restore finished while this file was being opened.
+         */
+        WT_ERR(__live_restore_fh_close_source(session, lr_fh, true));
+        return (0);
+    }
+
     __wt_writelock(session, &lr_fh->lock);
     lr_fh->allocsize = lr_fh_meta->allocsize;
 
-    /* If there is no source file there is nothing to migrate and therefore no metadata to parse. */
+    /* If there is no source file the migration has completed. */
     if (WTI_DEST_COMPLETE(lr_fh)) {
         __wt_writeunlock(session, &lr_fh->lock);
         return (0);
@@ -1264,10 +1279,12 @@ __wt_live_restore_metadata_to_fh(
      * !!!
      * While the live restore is in progress, the bit count reported by in the live restore metadata
      * can hold three states:
-     *  (0)         : This means the file has not started migration.
+     *  (0)         : This means file has not yet had a bitmap representation written to the
+     *                metadata file and therefore no application writes have gone to the
+     *                destination. In theory background thread writes may have happened but unless
+     *                the tree was dirtied the metadata update was not written out.
      *  (-1)        : This indicates the file has finished migration and the bitmap is empty.
-     *  (nbits > 0) : The number of bits in the bitmap. This is set when the file is in the
-     *                process of being migrated.
+     *  (nbits > 0) : The number of bits in the bitmap.
      */
     if (lr_fh_meta->nbits == 0) {
         WT_ASSERT(session, !WTI_DEST_COMPLETE(lr_fh));
@@ -1288,10 +1305,6 @@ __wt_live_restore_metadata_to_fh(
           session, lr_fh_meta->bitmap_str, (uint64_t)lr_fh_meta->nbits, lr_fh));
     } else {
         WT_ASSERT(session, lr_fh_meta->nbits == -1);
-        /*
-         * Our file open logic always opens the backing source file when it exists, but since we've
-         * completed migration we don't need it.
-         */
         WT_ERR(__live_restore_fh_close_source(session, lr_fh, false));
     }
 
@@ -1313,6 +1326,10 @@ __wt_live_restore_fh_to_metadata(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh, W
 {
     WT_DECL_RET;
     if (!F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+        return (WT_NOTFOUND);
+
+    /* Once we're past the background migration stage there's no need to track hole information. */
+    if (__wti_live_restore_migration_complete(session))
         return (WT_NOTFOUND);
 
     WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh = (WTI_LIVE_RESTORE_FILE_HANDLE *)fh;
@@ -1370,16 +1387,20 @@ __wt_live_restore_clean_metadata_string(WT_SESSION_IMPL *session, char *value)
         WT_ASSERT_ALWAYS(
           session, cval.len == 0, "Found non-empty bitmap when cleaning config string");
 
-        WT_RET(__wt_config_subgets(session, &v, "nbits", &cval));
-
         /*
          * Live restore uses -1 in the nbits field to indicate the file has been fully migrated.
-         * However, if this value is copied into a backup, future live restores using this backup as
-         * a source will see the nbits=-1 value and assume a file that still needs migrating has
-         * already been migrated. Set it to 0 now to indicate it is yet to be migrated.
+         * This value should be updated to 0 when live restore moves past the background migration
+         * phase, but we can only do so if the file is open when we force a checkpoint during clean
+         * up, or if its btree is dirtied after live restore completes but before restarting in
+         * non-live restore mode. If neither of these events take place the metadata won't be
+         * updated on disk and the -1 value persists. A future live restore using this file as a
+         * source will see this value and incorrectly assume the file has already been migrated. To
+         * prevent this manually overwrite the -1 with the correct value 0.
          */
+        WT_RET(__wt_config_subgets(session, &v, "nbits", &cval));
+
+        wt_off_t nbits_val_str_offset = cval.str - value;
         if (WT_STRING_LIT_MATCH("-1", cval.str, 2)) {
-            wt_off_t nbits_val_str_offset = cval.str - value;
             /*
              * We need to overwrite two characters, but only need to write one. Add a redundant
              * comma so we don't need to resize the string. The config parser will ignore it.
@@ -1387,14 +1408,8 @@ __wt_live_restore_clean_metadata_string(WT_SESSION_IMPL *session, char *value)
             value[nbits_val_str_offset] = '0';
             value[nbits_val_str_offset + 1] = ',';
         } else
-            /*
-             * There are only two possible values for nbits here. Either nbits=-1 because the file
-             * underwent a complete live restore, or nbits=0 because we're backing up a database
-             * that didn't undergo live restore. Any other value indicates a file has been partially
-             * live restored and is missing data.
-             */
-            WT_ASSERT_ALWAYS(session, WT_STRING_LIT_MATCH("0", cval.str, 1),
-              "Invalid live restore metadata detected while cleaning string");
+            WT_ASSERT_ALWAYS(session, cval.len == 1 && WT_STRING_LIT_MATCH("0", cval.str, 1),
+              "nbits value other than -1 or 0 found when cleaning metadata string: %s\n", value);
     }
 
     return (0);

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -369,36 +369,20 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
     char **dirlist_source = NULL, **dirlist_dest = NULL;
     uint32_t num_source_files = 0, num_dest_files = 0;
     WTI_LIVE_RESTORE_STATE state_from_file;
-    bool contain_backup_file = false;
 
-    /*
-     * First check that the source doesn't contain any live restore stop files, but does contain a
-     * backup file.
-     */
+    /* First check that the source doesn't contain any live restore metadata files. */
     WT_ERR(lr_fs->os_file_system->fs_directory_list(lr_fs->os_file_system, (WT_SESSION *)session,
       lr_fs->source.home, "", &dirlist_source, &num_source_files));
 
     if (num_source_files == 0)
         WT_ERR_MSG(session, EINVAL, "Source directory is empty. Nothing to restore!");
 
-    for (uint32_t i = 0; i < num_source_files; ++i) {
+    for (uint32_t i = 0; i < num_source_files; ++i)
         if (WT_SUFFIX_MATCH(dirlist_source[i], WTI_LIVE_RESTORE_STOP_FILE_SUFFIX))
             WT_ERR_MSG(session, EINVAL,
               "Source directory contains live restore stop file: %s. This implies it is a "
               "destination directory that hasn't finished restoration",
               dirlist_source[i]);
-
-        if (WT_SUFFIX_MATCH(dirlist_source[i], WT_METADATA_BACKUP))
-            contain_backup_file = true;
-    }
-
-    /*
-     * We rely on the backup process to clean the metadata file in the source and remove instances
-     * of nbits=-1. If we don't live restore could see this nbits=-1, think it applies to the file
-     * in the destination, and never copy across the file causing data loss.
-     */
-    if (!contain_backup_file)
-        WT_ERR_MSG(session, EINVAL, "Source directory is not a valid backup directory");
 
     /* Now check the destination folder */
 

--- a/test/catch2/live_restore/live_restore_test_env.cpp
+++ b/test/catch2/live_restore/live_restore_test_env.cpp
@@ -18,35 +18,26 @@ namespace utils {
  */
 live_restore_test_env::live_restore_test_env()
 {
-    // Clean up any pre-existing folders.
-    testutil_remove(DB_DEST.c_str());
-    testutil_remove(DB_SOURCE.c_str());
+    // Clean up any pre-existing folders. Make sure an empty DB_SOURCE exists
+    // as it need to exist to open the connection in live restore mode.
+    testutil_recreate_dir(DB_DEST.c_str());
+    testutil_recreate_dir(DB_SOURCE.c_str());
 
-    // Live restore requires the source directory to be a valid backup. Create one now.
+    // WiredTiger stores state in the turtle file so we always need to have a valid database in
+    // the source folder. Open and close a connection to initialize the source folder.
     {
         static std::string non_lr_config = "create=true";
-        auto backup_conn =
-          std::make_unique<connection_wrapper>(DB_DEST.c_str(), non_lr_config.c_str());
-
-        backup_conn->get_wt_connection_impl();
-        WT_SESSION *session = (WT_SESSION *)backup_conn->create_session();
-        WT_CURSOR *backup_cursor = nullptr;
-        REQUIRE(session->open_cursor(session, "backup:", nullptr, nullptr, &backup_cursor) == 0);
-
-        testutil_mkdir(DB_SOURCE.c_str());
-        while (backup_cursor->next(backup_cursor) == 0) {
-            const char *uri = nullptr;
-            REQUIRE(backup_cursor->get_key(backup_cursor, &uri) == 0);
-            std::string dest_file = DB_DEST + "/" + uri;
-            std::string source_file = DB_SOURCE + "/" + uri;
-            testutil_copy(dest_file.c_str(), source_file.c_str());
-        }
-
-        backup_cursor->close(backup_cursor);
-        session->close(session, nullptr);
+        conn = std::make_unique<connection_wrapper>(DB_SOURCE.c_str(), non_lr_config.c_str());
+        conn->clear_do_cleanup();
     }
 
-    testutil_remove(DB_DEST.c_str());
+    /*
+     * We're using a connection to set up the file system and let us print WT traces, but all of our
+     * tests will use empty folders where we create files manually. The issue here is
+     * wiredtiger_open will create metadata and turtle files on open and think it needs to remove
+     * them on close. Move these files to a temp location. We'll restore them in destructor before
+     * _conn->close() is called.
+     */
     static std::string cfg_string =
       "create=true,live_restore=(enabled=true, path=" + DB_SOURCE + ",threads_max=0)";
     conn = std::make_unique<connection_wrapper>(DB_DEST.c_str(), cfg_string.c_str());

--- a/test/cppsuite/tests/test_live_restore.cpp
+++ b/test/cppsuite/tests/test_live_restore.cpp
@@ -339,42 +339,6 @@ configure_database(scoped_session &session)
     }
 }
 
-// Take a backup of the provided database and then delete the original db. This backup will be used
-// in the next loop as a source directory.
-static void
-take_backup_and_delete_original(const std::string &home, const std::string &backup_dir)
-{
-    testutil_recreate_dir(backup_dir.c_str());
-    const std::string conn_config = "log=(enabled=true,path=journal)";
-    connection_manager::instance().reopen(conn_config, home);
-
-    {
-        scoped_session backup_session = connection_manager::instance().create_session();
-        scoped_cursor backup_cursor = backup_session.open_scoped_cursor("backup:", "");
-
-        while (backup_cursor->next(backup_cursor.get()) == 0) {
-            char *file_c_str = nullptr;
-            testutil_check(backup_cursor->get_key(backup_cursor.get(), &file_c_str));
-            std::string file = std::string(file_c_str);
-
-            // If the file is a log file prepend the hard-coded journal folder path
-            if (strncmp(file.c_str(), "WiredTigerLog", 13) == 0) {
-                if (!testutil_exists(backup_dir.c_str(), "journal")) {
-                    testutil_mkdir((backup_dir + "/" + std::string("journal")).c_str());
-                }
-                file = "journal/" + file;
-            }
-
-            std::string dest_file = home + "/" + file;
-            std::string source_file = backup_dir + "/" + file;
-            testutil_copy(dest_file.c_str(), source_file.c_str());
-        }
-    }
-
-    connection_manager::instance().close();
-    testutil_remove(home.c_str());
-}
-
 static void
 run_restore(const std::string &home, const std::string &source, const int64_t thread_count,
   const int64_t collection_count, const int64_t op_count, const bool background_thread_mode,
@@ -565,7 +529,7 @@ main(int argc, char *argv[])
 
         // We need to create a database to restore from initially.
         create_db(home_path, thread_count, coll_count, op_count, verbose_level);
-        take_backup_and_delete_original(home_path, std::string(SOURCE_PATH));
+        testutil_move(home_path.c_str(), SOURCE_PATH);
     }
 
     /* When setting up the database we don't want to wait for the background threads to complete. */
@@ -578,7 +542,8 @@ main(int argc, char *argv[])
         logger::log_msg(LOG_INFO, "!!!! Beginning iteration: " + std::to_string(i) + " !!!!");
         run_restore(home_path, SOURCE_PATH, thread_count, coll_count, op_count,
           background_thread_debug_mode, verbose_level, i == death_it, recovery);
-        take_backup_and_delete_original(home_path, std::string(SOURCE_PATH));
+        testutil_remove(SOURCE_PATH);
+        testutil_move(home_path.c_str(), SOURCE_PATH);
     }
 
     return (0);

--- a/test/suite/test_live_restore01.py
+++ b/test/suite/test_live_restore01.py
@@ -28,14 +28,14 @@
 
 import os
 import wiredtiger, wttest
+from helper import copy_wiredtiger_home
 import glob
 import shutil
-from wtbackup import backup_base
 
 # test_live_restore01.py
 # Test live restore compatibility with various other connection options.
 @wttest.skip_for_hook("tiered", "using multiple WT homes")
-class test_live_restore01(backup_base):
+class test_live_restore01(wttest.WiredTigerTestCase):
 
     def expect_success(self, config_str):
         self.open_conn("DEST", config=config_str)
@@ -52,11 +52,9 @@ class test_live_restore01(backup_base):
 
     def test_live_restore01(self):
         # Close the default connection.
-
-        os.mkdir("SOURCE")
-        self.take_full_backup("SOURCE")
         self.close_conn()
 
+        copy_wiredtiger_home(self, '.', "SOURCE")
         # Remove everything but SOURCE / stderr / stdout.
         for f in glob.glob("*"):
             if not f == "SOURCE" and not f == "stderr.txt" and not f == "stdout.txt":

--- a/test/suite/test_live_restore02.py
+++ b/test/suite/test_live_restore02.py
@@ -30,12 +30,12 @@ import os, glob, time, wiredtiger, wttest
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
-from wtbackup import backup_base
+from helper import copy_wiredtiger_home
 
 # test_live_restore02.py
 # Enable background thread migration and loop until it completes
 @wttest.skip_for_hook("tiered", "using multiple WT homes")
-class test_live_restore02(backup_base):
+class test_live_restore02(wttest.WiredTigerTestCase):
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
         ('row_integer', dict(key_format='i', value_format='S')),
@@ -75,9 +75,9 @@ class test_live_restore02(backup_base):
         ds2.populate()
 
         # Close the default connection.
-        os.mkdir("SOURCE")
-        self.take_full_backup("SOURCE")
         self.close_conn()
+
+        copy_wiredtiger_home(self, '.', "SOURCE")
 
         # Remove everything but SOURCE / stderr / stdout.
         for f in glob.glob("*"):

--- a/test/suite/test_live_restore03.py
+++ b/test/suite/test_live_restore03.py
@@ -29,14 +29,14 @@
 import os, glob, wttest
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
-from wtbackup import backup_base
+from helper import copy_wiredtiger_home
 
 # test_live_restore03.py
 # Test that live_restore->fs_size can returns a valid size when the file only exists in the source
 # directory.
 # Note: The block_size statistic corresponds to underlying file size.
 @wttest.skip_for_hook("tiered", "using multiple WT homes")
-class test_live_restore03(backup_base):
+class test_live_restore03(wttest.WiredTigerTestCase):
     nrows = 100
 
     def test_live_restore03(self):
@@ -52,9 +52,9 @@ class test_live_restore03(backup_base):
             ds.populate()
 
         # Close the default connection.
-        os.mkdir("SOURCE")
-        self.take_full_backup("SOURCE")
         self.close_conn()
+
+        copy_wiredtiger_home(self, '.', "SOURCE")
 
         # Remove everything but SOURCE / stderr / stdout.
         for f in glob.glob("*"):

--- a/test/suite/test_live_restore04.py
+++ b/test/suite/test_live_restore04.py
@@ -29,13 +29,14 @@
 import filecmp, os, glob, wiredtiger, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
-from wtbackup import backup_base
+from helper import copy_wiredtiger_home
+from suite_subprocess import suite_subprocess
 
 
 # test_live_restore04.py
 # Test using the wt utility with live restore.
 @wttest.skip_for_hook("tiered", "using multiple WT homes")
-class test_live_restore04(backup_base):
+class test_live_restore04(wttest.WiredTigerTestCase, suite_subprocess):
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
         ('row_integer', dict(key_format='i', value_format='S')),
@@ -74,9 +75,9 @@ class test_live_restore04(backup_base):
             self.runWt(['dump', '-x', uris[i]], outfilename=dump_out)
 
         # Close the default connection.
-        os.mkdir("SOURCE")
-        self.take_full_backup("SOURCE")
         self.close_conn()
+
+        copy_wiredtiger_home(self, '.', "SOURCE")
 
         # Remove everything but SOURCE / stderr / stdout / util output folder.
         for f in glob.glob("*"):

--- a/test/suite/test_live_restore05.py
+++ b/test/suite/test_live_restore05.py
@@ -29,13 +29,14 @@
 import os, glob, wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
-from wtbackup import backup_base
+from helper import copy_wiredtiger_home
+from suite_subprocess import suite_subprocess
 
 
 # test_live_restore05.py
 # Reproduce a live restore edge case that resulted in duplicate metadata entries.
 @wttest.skip_for_hook("tiered", "using multiple WT homes")
-class test_live_restore05(backup_base):
+class test_live_restore05(wttest.WiredTigerTestCase, suite_subprocess):
     format_values = [
         ('row_integer', dict(key_format='i', value_format='S')),
         ('column_store', dict(key_format='r', value_format='S'))
@@ -62,9 +63,9 @@ class test_live_restore05(backup_base):
             ds.populate()
 
         # Close the default connection.
-        os.mkdir("SOURCE")
-        self.take_full_backup("SOURCE")
         self.close_conn()
+
+        copy_wiredtiger_home(self, '.', "SOURCE")
 
         # Remove everything but SOURCE / stderr / stdout / util output folder.
         for f in glob.glob("*"):

--- a/test/suite/test_live_restore06.py
+++ b/test/suite/test_live_restore06.py
@@ -29,11 +29,12 @@
 import os, glob, time, wiredtiger, wttest
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
+from helper import copy_wiredtiger_home
 from wtbackup import backup_base
 
 
 # test_live_restore06.py
-# Ensure WiredTiger cleans all 'nbits=-1' strings from file metadata during backups.
+# Ensure WiredTiger cleans any remaining 'nbits=-1' strings from file metadata during backups.
 @wttest.skip_for_hook("tiered", "using multiple WT homes")
 class test_live_restore06(backup_base):
 
@@ -48,15 +49,14 @@ class test_live_restore06(backup_base):
         if os.name == 'nt':
             return
 
-        # Create an initial DB in SOURCE to be restored
+        # Create a DB in SOURCE to be restored
         for i in range(0, 3):
             ds = SimpleDataSet(self, f'file:collection_{i}', 10_000,
             key_format='S', value_format='S')
             ds.populate()
 
-        os.mkdir("SOURCE")
-        self.take_full_backup("SOURCE")
         self.close_conn()
+        copy_wiredtiger_home(self, '.', "SOURCE")
 
         # Remove everything but SOURCE / stderr / stdout.
         for f in glob.glob("*"):
@@ -88,13 +88,21 @@ class test_live_restore06(backup_base):
             iteration_count += 1
         self.assertEqual(state, wiredtiger.WT_LIVE_RESTORE_COMPLETE)
 
-        # Once live restore has completed the metadata of all files will have nbits=-1
+        # Walk through all the metadata configs to find a file with nbits == -1.
+        # This is the value we need to clean up.
         meta_cursor = self.session.open_cursor('metadata:', None, None)
-        while meta_cursor.next() != 0:
+        neg_one_metadata_file = None
+        while True:
+            ret = meta_cursor.next()
+            if ret != 0:
+                break
             uri = meta_cursor.get_key()
-            if uri.find("file:") != -1:
-                self.assertTrue("nbits=-1" in meta_cursor[uri])
+            if uri.find("file:") != -1 and "nbits=-1" in meta_cursor[uri]:
+                neg_one_metadata_file = uri
+                break
+
         meta_cursor.close()
+        self.assertTrue(neg_one_metadata_file is not None)
 
         # Now take a backup of the destination.
         # This requires opening a new connection in non-live restore mode
@@ -109,12 +117,11 @@ class test_live_restore06(backup_base):
         with open("backup/WiredTiger.backup", "r") as f:
             self.assertTrue("nbits=-1" not in f.read())
 
-        # Now open the backup and check all files have been cleaned and contain nbits=0.
+        # Now open the backup and check the metadata for the nbits=-1 string is not present.
         self.reopen_conn(directory="backup", config="statistics=(all),live_restore=(enabled=false)")
         meta_cursor = self.session.open_cursor('metadata:', None, None)
-        while meta_cursor.next() != 0:
-            uri = meta_cursor.get_key()
-            if uri.find("file:") != -1:
-                self.assertTrue("nbits=0," in meta_cursor[uri])
+        meta_cursor.set_key(neg_one_metadata_file)
+        config = meta_cursor[neg_one_metadata_file]
+        self.assertTrue("nbits=-1" not in config)
         meta_cursor.close()
 

--- a/test/suite/test_live_restore07.py
+++ b/test/suite/test_live_restore07.py
@@ -29,10 +29,10 @@
 import os, wiredtiger, wttest
 from wtscenario import make_scenarios
 
-# test_live_restore07.py
+# test_live_restore06.py
 # Test that restoring from an empty database fails.
 @wttest.skip_for_hook("tiered", "using multiple WT homes")
-class test_live_restore07(wttest.WiredTigerTestCase):
+class test_live_restore02(wttest.WiredTigerTestCase):
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
         ('row_integer', dict(key_format='i', value_format='S')),
@@ -41,7 +41,7 @@ class test_live_restore07(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios(format_values)
 
-    def test_live_restore07(self):
+    def test_live_restore02(self):
         # Live restore is not supported on Windows.
         if os.name == 'nt':
             return


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#11757

This commit didn't update wtperf so all perf tests are failing with `Source directory is not a valid backup directory`