### PR TITLE
WT-14151 Don't clobber existing directories in cppsuite's connection_manager::create

### DIFF
--- a/test/cppsuite/src/main/test.cpp
+++ b/test/cppsuite/src/main/test.cpp
@@ -160,9 +160,12 @@ test::run()
     /* Add the user supplied wiredtiger open config. */
     db_create_config += "," + _args.wt_open_config;
 
+    /* Clean up any pre-existing test artifacts. */
+    std::string home = _args.home.empty() ? DEFAULT_DIR : _args.home;
+    testutil_remove(home.c_str());
+
     /* Create connection. */
-    connection_manager::instance().create(
-      db_create_config, _args.home.empty() ? DEFAULT_DIR : _args.home);
+    connection_manager::instance().create(db_create_config, home);
 
     /* Load each component. They have to be all loaded first before being able to run. */
     for (const auto &it : _components)

--- a/test/cppsuite/src/storage/connection_manager.cpp
+++ b/test/cppsuite/src/storage/connection_manager.cpp
@@ -67,10 +67,10 @@ connection_manager::create(
     }
     logger::log_msg(LOG_INFO, "wiredtiger_open config: " + config);
 
-    // FIXME-WT-14151 Add an assert here that we're not clobbering an existing database.
+    testutil_assert(!testutil_exists(".", home.c_str()));
 
     /* Create the working dir. */
-    testutil_recreate_dir(home.c_str());
+    testutil_mkdir(home.c_str());
     if (create_log_directory)
         testutil_mkdir((home + "/journal").c_str());
 

--- a/test/cppsuite/tests/csuite_style_example_test.cpp
+++ b/test/cppsuite/tests/csuite_style_example_test.cpp
@@ -100,6 +100,9 @@ main(int argc, char *argv[])
     const std::string conn_config = CONNECTION_CREATE + ",cache_size=500MB";
     const std::string home_dir = std::string(DEFAULT_DIR) + '_' + progname;
 
+    /* Clean up any artifacts from prior runs. */
+    testutil_remove(home_dir.c_str());
+
     /* Create connection. */
     connection_manager::instance().create(conn_config, home_dir);
     WT_CONNECTION *conn = connection_manager::instance().get_connection();


### PR DESCRIPTION
I ran into this a few times when implementing a prior live restore test. connection_manager::create will silently delete any existing folder of the same name, so when a destination folder hasn't been copied across to the source it makes it harder to diagnose what went wrong when the eventually crashes. Add a quick safety check to prevent this from happening in future.