### PR TITLE
WT-13166 Instrument __wt_rwlock_* calls to be TSan compatible

### DIFF
--- a/src/include/mutex.h
+++ b/src/include/mutex.h
@@ -58,6 +58,17 @@ struct __wt_rwlock { /* Read/write lock */
 
     WT_CONDVAR *cond_readers; /* Blocking readers */
     WT_CONDVAR *cond_writers; /* Blocking writers */
+
+#ifdef TSAN_BUILD
+    /*
+     * Our read/write locks provide thread safety via barriers, but TSan instrumentation doesn't
+     * recognize the assembly instructions our barriers use. As a result TSan reports data races on
+     * memory locations that are correctly protected by locks. To address this each of our rwlock
+     * functions performs a dummy acquire read or release write to this field which communicates the
+     * correct acquire/release semantics to TSan.
+     */
+    uint64_t tsan_sync;
+#endif
 };
 
 /*

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -148,7 +148,14 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
         return (__wt_set_return(session, EBUSY));
 
     /* We rely on this atomic operation to provide a barrier. */
-    return (__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : EBUSY);
+    WT_RET(__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : EBUSY);
+
+#ifdef TSAN_BUILD
+    /* Perform a dummy read to inform TSan this function does in fact have acquire semantics. */
+    (void)__atomic_load_n(&l->tsan_sync, __ATOMIC_ACQUIRE);
+#endif
+
+    return (0);
 }
 
 /*
@@ -270,6 +277,11 @@ stall:
      */
     WT_ACQUIRE_BARRIER();
 
+#ifdef TSAN_BUILD
+    /* Perform a dummy read to inform TSan this function does in fact have acquire semantics. */
+    (void)__atomic_load_n(&l->tsan_sync, __ATOMIC_ACQUIRE);
+#endif
+
     /* Sanity check that we (still) have the lock. */
     WT_ASSERT(session,
       ticket == __wt_atomic_loadv8(&l->u.s.current) &&
@@ -284,6 +296,11 @@ void
 __wt_readunlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 {
     WT_RWLOCK new, old;
+
+#ifdef TSAN_BUILD
+    /* Perform a dummy write to inform TSan this function does in fact have release semantics. */
+    __atomic_store_n(&l->tsan_sync, 1, __ATOMIC_RELEASE);
+#endif
 
     do {
         old.u.v = __wt_atomic_loadv64(&l->u.v);
@@ -339,7 +356,14 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
      */
     new.u.v = old.u.v;
     new.u.s.next++;
-    return (__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : EBUSY);
+    WT_RET(__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : EBUSY);
+
+#ifdef TSAN_BUILD
+    /* Perform a dummy write to inform TSan this function does in fact have acquire semantics. */
+    (void)__atomic_load_n(&l->tsan_sync, __ATOMIC_ACQUIRE);
+#endif
+
+    return (0);
 }
 
 /*
@@ -439,6 +463,11 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
      */
     WT_ACQUIRE_BARRIER();
 
+#ifdef TSAN_BUILD
+    /* Perform a dummy read to inform TSan this function does in fact have acquire semantics. */
+    (void)__atomic_load_n(&l->tsan_sync, __ATOMIC_ACQUIRE);
+#endif
+
     /* Sanity check that we (still) have the lock. */
     WT_ASSERT(session,
       ticket == __wt_atomic_loadv8(&l->u.s.current) &&
@@ -453,6 +482,11 @@ void
 __wt_writeunlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 {
     WT_RWLOCK new, old;
+
+#ifdef TSAN_BUILD
+    /* Perform a dummy write to inform TSan this function does in fact have release semantics. */
+    __atomic_store_n(&l->tsan_sync, 1, __ATOMIC_RELEASE);
+#endif
 
     do {
         old.u.v = __wt_atomic_loadv64(&l->u.v);


### PR DESCRIPTION
This is a re-delivery of #10751 now that we've fixed the null pointer dereference that the new TSan-only code revealed.

This adds dummy atomic reads/writes to our `__wt_rwlock_*` functions that use `__ATOMIC_ACQUIRE` and `__ATOMIC_RELEASE`. Our existing locks are safe, but this additional information allows TSan to understand the semantics and stop reporting false positives.

To verify this I ran `live_restore/short_test.sh` 5 times before and after the code changes. Before the changes we see 20 TSan warnings for `__live_restore_fh_free_bitmap` even though it's protected by the live restore file lock. After these changes we see 0 TSan warnings. We also drop from 85 unique TSan warnings down to 69, although some of this could be chance.