### PR TITLE
WT-14311 Add heavy testing for live restore

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -825,11 +825,13 @@ functions:
           echo "Using num_jobs '-j ${num_jobs}' for 'unit test'"
           threads_command="-j ${num_jobs}"
         fi
-        if [ ${check_coverage|false} = true ]; then
-            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1 || echo "Ignoring failed test as we are checking test coverage"
-        else
-            ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1
-        fi
+        for i in $(seq ${times|1}); do
+            if [ ${check_coverage|false} = true ]; then
+                ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1 || echo "Ignoring failed test as we are checking test coverage"
+            else
+                ${python_binary|python3} ../test/suite/run.py ${ignore_stdout} ${unit_test_args|-v 2} ${unit_test_variant_args} $threads_command 2>&1
+            fi
+        done
 
   "code coverage analysis":
     command: shell.exec
@@ -2547,6 +2549,62 @@ tasks:
             set -o verbose
             ${PREPARE_TEST_ENV}
             ../test/live_restore/long_test.sh
+
+  # The following tests are temporary so we can heavily test live restore in the final weeks of the project.
+  # They should be deleted when on project completion.
+  # FIXME-WT-14312
+
+  - name: live-restore-short-heavy-testing
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/"
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+
+            # Runtime is approx 20 seconds under ASan. Run for 1 hour
+            for i in $(seq 180); do
+                ../test/live_restore/short_test.sh
+            done
+
+  # Runtime is already 1 hour under ASan. Create a second task to double the testing time.
+  - name: live-restore-long-heavy-testing
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/"
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            ../test/live_restore/long_test.sh
+
+  - name: unit-test-live-restore-heavy-testing
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: live_restore
+          times: 60 # Run time is approx 10 seconds. Loops it for 10 minutes
+
+  - name: format-live-restore-heavy-testing
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "format test script"
+        vars:
+          # 2 hours using a custom config to maximally test live restore
+          format_test_script_args: "-c ../../../test/format/CONFIG.live_restore -t 120"
 
   # End of live restore tests
 
@@ -5434,6 +5492,10 @@ buildvariants:
     - name: csuite-long-running
       batchtime: 1440 # once a day
     - name: live-restore-long
+    - name: live-restore-short-heavy-testing
+    - name: live-restore-long-heavy-testing
+    - name: unit-test-live-restore-heavy-testing
+    - name: format-live-restore-heavy-testing
 
 - name: ubuntu2004-asan
   display_name: "! Ubuntu 20.04 ASAN"
@@ -5457,6 +5519,9 @@ buildvariants:
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: live-restore-long
+    - name: live-restore-short-heavy-testing
+    - name: live-restore-long-heavy-testing
+    - name: format-live-restore-heavy-testing
 
 - name: ubuntu2004-tsan
   display_name: "! Ubuntu 20.04 TSAN"
@@ -5845,6 +5910,10 @@ buildvariants:
       distros: ubuntu2004-arm64-large
     - name: unit-test-zstd
     - name: wtperf-test
+    - name: live-restore-short-heavy-testing
+    - name: live-restore-long-heavy-testing
+    - name: unit-test-live-restore-heavy-testing
+    - name: format-live-restore-heavy-testing
 
 - name: amazon2-arm64
   display_name: "Amazon Linux 2 ARM64"
@@ -5918,6 +5987,10 @@ buildvariants:
     - name: configure-combinations
     - name: format-smoke-test
     - name: s3-tiered-storage-extensions-test
+    - name: live-restore-short-heavy-testing
+    - name: live-restore-long-heavy-testing
+    - name: unit-test-live-restore-heavy-testing
+    - name: format-live-restore-heavy-testing
 
 - name: ubuntu2004-release-arm64
   display_name: "~ Ubuntu 20.04 (ARM64, Release Build)"
@@ -6176,6 +6249,10 @@ buildvariants:
       distros: amazon2023-arm64-latest-large-m8g
     - name: format-smoke-test
     - name: s3-tiered-storage-extensions-test
+    - name: live-restore-short-heavy-testing
+    - name: live-restore-long-heavy-testing
+    - name: unit-test-live-restore-heavy-testing
+    - name: format-live-restore-heavy-testing
 
 - name: amazon2023-armv9
   display_name: "(ARMV9) Amazon Linux 2023 ARM64"

--- a/test/format/CONFIG.live_restore
+++ b/test/format/CONFIG.live_restore
@@ -1,0 +1,12 @@
+# FIXME-WT-14312 Remove this file and its associated test at the end of the live restore project
+# A reasonable configuration for stress testing.
+cache.minimum=20
+runs.rows=1000000:5000000
+runs.tables=3:10
+runs.threads=4:32
+# Backups take place every 20-45 seconds. 6 minutes will give us a good number of number of backups taking before we restart the test
+runs.timer=6
+# Always run live restore. This is the feature we're testing
+backup=1
+backup.incremental=off
+backup.live_restore=1


### PR DESCRIPTION
Turn on additional testing for live restore for the final weeks of the project.
We're writing additional unit tests for live restore, but to help improve confidence in code correctness bump up the amount stress testing for live restore. This change adds approximately 10 hours of additional live restore testing per commit in waterfall.

This increase in testing is temporary. These tests will be removed again at the end of the project to save on compute.