### PR TITLE
WT-14068 Fix misaligned usage of modify variable

### DIFF
--- a/src/include/modify_inline.h
+++ b/src/include/modify_inline.h
@@ -8,29 +8,33 @@
 
 #pragma once
 
-#define WT_MODIFY_FOREACH_BEGIN(mod, p, nentries, napplied)                    \
+#define WT_MODIFY_FOREACH_BEGIN(mod, p, nentries)                              \
     do {                                                                       \
-        const size_t *__p = p;                                                 \
+        const uint8_t *__p = p;                                                \
         const uint8_t *__data = (const uint8_t *)(__p + (size_t)(nentries)*3); \
-        int __i;                                                               \
+        size_t __i;                                                            \
         for (__i = 0; __i < (nentries); ++__i) {                               \
-            memcpy(&(mod).data.size, __p++, sizeof(size_t));                   \
-            memcpy(&(mod).offset, __p++, sizeof(size_t));                      \
-            memcpy(&(mod).size, __p++, sizeof(size_t));                        \
+            memcpy(&(mod).data.size, __p, sizeof(size_t));                     \
+            p += sizeof(size_t);                                               \
+            memcpy(&(mod).offset, __p, sizeof(size_t));                        \
+            p += sizeof(size_t);                                               \
+            memcpy(&(mod).size, __p, sizeof(size_t));                          \
+            p += sizeof(size_t);                                               \
             (mod).data.data = __data;                                          \
-            __data += (mod).data.size;                                         \
-            if (__i < (napplied))                                              \
-                continue;
+            __data += (mod).data.size;
 
-#define WT_MODIFY_FOREACH_REVERSE(mod, p, nentries, napplied, datasz) \
-    do {                                                              \
-        const size_t *__p = (p) + (size_t)(nentries)*3;               \
-        const uint8_t *__data = (const uint8_t *)__p + datasz;        \
-        int __i;                                                      \
-        for (__i = (napplied); __i < (nentries); ++__i) {             \
-            memcpy(&(mod).size, --__p, sizeof(size_t));               \
-            memcpy(&(mod).offset, --__p, sizeof(size_t));             \
-            memcpy(&(mod).data.size, --__p, sizeof(size_t));          \
+#define WT_MODIFY_FOREACH_REVERSE(mod, p, nentries, napplied, datasz)          \
+    do {                                                                       \
+        const uint8_t *__p = (p) + (size_t)(nentries)*3;                       \
+        const uint8_t *__data = (const uint8_t *)__p + datasz;                 \
+        size_t __i;                                                            \
+        for (__i = (napplied); __i < (nentries); ++__i) {                      \
+            p -= sizeof(size_t);                                               \
+            memcpy(&(mod).size, __p, sizeof(size_t));                          \
+            p -= sizeof(size_t);                                               \
+            memcpy(&(mod).offset, __p, sizeof(size_t));                        \
+            p -= sizeof(size_t);                                               \
+            memcpy(&(mod).data.size, __p, sizeof(size_t));                     \
             (mod).data.data = (__data -= (mod).data.size);
 
 #define WT_MODIFY_FOREACH_END \
@@ -46,18 +50,16 @@ static WT_INLINE void
 __wt_modify_max_memsize(const void *modify, size_t base_value_size, size_t *max_memsize)
 {
     WT_MODIFY mod;
-    size_t tmp;
-    const size_t *p;
-    int nentries;
-
+    size_t nentries;
+    const uint8_t *p;
     *max_memsize = base_value_size;
 
     /* Get the number of modify entries. */
-    p = (const size_t *)modify;
-    memcpy(&tmp, p++, sizeof(size_t));
-    nentries = (int)tmp;
+    p = (const uint8_t *)modify;
+    memcpy(&nentries, p, sizeof(size_t));
+    p += sizeof(size_t);
 
-    WT_MODIFY_FOREACH_BEGIN (mod, p, nentries, 0) {
+    WT_MODIFY_FOREACH_BEGIN (mod, p, nentries) {
         *max_memsize = WT_MAX(*max_memsize, mod.offset) + mod.data.size;
     }
     WT_MODIFY_FOREACH_END;
@@ -109,7 +111,6 @@ __wt_modifies_max_memsize(
 {
     WT_UPDATE *upd;
     int i;
-
     *max_memsize = base_value_size;
 
     for (i = (int)modifies->size - 1; i >= 0; --i) {


### PR DESCRIPTION
**Problem statement**
A UBSAN failure has been found when needing to loop through a modify. All modify data is captured within the WT_UPDATE->data variable. The first size_t bytes of the modify refer to the number of entries within one modify. Followingly, the WT_MODIFY_FOREACH_BEGIN and WT_MODIFY_FOREACH_REVERSE loops through the same pointer and captures the metadata of a modify fetching data size, offset ,and size, all of which are size_t bytes. 

The WT_UPDATE structure is packed such that WT_UPDATE->data always starts from the 47th byte. In the general case, this is safe. However, when dealing with modifies, the codebase typecasts the WT_UPDATE->data structure to **size_t*  **. This is problematic as we are starting from an unaligned position (47 % 8 != 0).

**Solution**
The ticket will address the misaligned behaviour by fetching the size_t information under a uint8_t pointer without typecasting it. While addressing this, I encountered further improvements:
- The `napplied` variable is not needed inside WT_MODIFY_FOREACH_BEGIN
- Changed `nentries` and `napplied` to size_t. We need to ensure they can never be negative.
- Removed the `tmp` variable, as it is not required.

