### PR TITLE
WT-14139 Write ARM v9 perf results to their own Atlas charts collection

### DIFF
--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -58,7 +58,7 @@ buildvariants:
    - amazon2023-arm64-latest-large-m8g
   expansions:
     <<: *ubuntu2004-perf-tests-expansions-template
-    collection: AllPerfTestsARM64
+    collection: AllPerfTestsARM64_v9
 
 - <<: *perf-tasks-template
   name: ubuntu2004-perf-tests-arm64-only


### PR DESCRIPTION
We're currently writing both the ARM and ARMv9 perf results to the one collection, so results in our Atlas perf charts are combined into a single graph.
We should write them to their own collections to avoid polluting the data set.
