### PR TITLE
WT-14326 Reduce disk space usage in live restore stress testing

### DIFF
--- a/test/format/CONFIG.live_restore
+++ b/test/format/CONFIG.live_restore
@@ -1,7 +1,7 @@
 # FIXME-WT-14312 Remove this file and its associated test at the end of the live restore project
 # A reasonable configuration for stress testing.
 cache.minimum=20
-runs.rows=1000000:5000000
+runs.rows=100000:500000
 runs.tables=3:10
 runs.threads=4:32
 # Backups take place every 20-45 seconds. 6 minutes will give us a good number of number of backups taking before we restart the test

--- a/test/live_restore/long_test.sh
+++ b/test/live_restore/long_test.sh
@@ -12,5 +12,5 @@ run_test "-i 2 -l 2 -b -t 1"
 
 # 5 iterations with 200K operations dying at some point. Followed by an single 200K operation
 # iteration after performing recovery
-run_test "-i 5 -l 2 -o 200000 -t 12 -d"
-run_test "-i 1 -l 2 -r -o 200000 -t 12"
+run_test "-i 5 -l 2 -o 100000 -t 12 -d"
+run_test "-i 1 -l 2 -r -o 100000 -t 12"


### PR DESCRIPTION
Reduce the maximum number of operations performed in our live restore stress tests to reduce disk usage and the risk of hitting an ENOSPC error.