### PR TITLE
WT-14110 Fix code coverage report for v5 toolchain

### DIFF
--- a/test/evergreen/code_coverage/code_coverage_config.json
+++ b/test/evergreen/code_coverage/code_coverage_config.json
@@ -20,7 +20,7 @@
     "// See the README.md file in this directory for details."
   ],
   "setup_actions": [
-    "cmake -DHAVE_UNITTEST=1 -DHAVE_DIAGNOSTIC=0 -DCODE_COVERAGE_MEASUREMENT=1 -DINLINE_FUNCTIONS_INSTEAD_OF_MACROS=1 -DCMAKE_BUILD_TYPE=Coverage -G Ninja ../.",
+    "cmake -DHAVE_UNITTEST=1 -DHAVE_DIAGNOSTIC=0 -DCODE_COVERAGE_MEASUREMENT=1 -DINLINE_FUNCTIONS_INSTEAD_OF_MACROS=1 -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_gcc.cmake -DCMAKE_BUILD_TYPE=Coverage -G Ninja ../.",
     "ninja -j 16",
     "mkdir WT_HOME_COVERAGE",
     "examples/c/ex_hello/ex_hello",

--- a/test/evergreen/code_coverage/code_coverage_config_catch2.json
+++ b/test/evergreen/code_coverage/code_coverage_config_catch2.json
@@ -6,7 +6,7 @@
     "// See the README.md file in this directory for details."
   ],
   "setup_actions" : [
-    "cmake -DHAVE_UNITTEST=1 -DHAVE_DIAGNOSTIC=0 -DCODE_COVERAGE_MEASUREMENT=1 -DINLINE_FUNCTIONS_INSTEAD_OF_MACROS=1 -DCMAKE_BUILD_TYPE=Coverage -G Ninja ../.",
+    "cmake -DHAVE_UNITTEST=1 -DHAVE_DIAGNOSTIC=0 -DCODE_COVERAGE_MEASUREMENT=1 -DINLINE_FUNCTIONS_INSTEAD_OF_MACROS=1 -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_gcc.cmake -G Ninja ../.",
     "ninja"
   ],
   "test_tasks" : [

--- a/test/evergreen/code_coverage/per_test_code_coverage.py
+++ b/test/evergreen/code_coverage/per_test_code_coverage.py
@@ -106,7 +106,8 @@ def run_gcovr(build_dir_base: str, gcovr_dir: str):
                 f"task_info_path = {task_info_path}, coverage_output_dir = {coverage_output_dir}")
             os.mkdir(coverage_output_dir)
             shutil.copy(src=task_info_path, dst=coverage_output_dir)
-            gcovr_command = (f"gcovr {build_copy_name} -f src -j 16 --html-self-contained --html-details "
+            gcovr_command = (f"gcovr {build_copy_name} --gcov-ignore-parse-errors -f src -j 16 "
+                             "--html-self-contained --html-details "
                              f"{coverage_output_dir}/2_coverage_report.html --json-summary-pretty "
                              f"--json-summary {coverage_output_dir}/1_coverage_report_summary.json "
                              f"--json {coverage_output_dir}/full_coverage_report.json")

--- a/test/evergreen/code_coverage_analysis.sh
+++ b/test/evergreen/code_coverage_analysis.sh
@@ -34,9 +34,9 @@ pip3 install lxml==4.8.0 Pygments==2.11.2 Jinja2==3.0.3 gcovr==5.0
 mkdir -p coverage_report
 output_flags="--html-self-contained --html-details coverage_report/2_coverage_report.html --json-summary-pretty --json-summary coverage_report/1_coverage_report_summary.json --json coverage_report/full_coverage_report.json"
 if [ ! -z $combine_coverage_report ]; then
-  gcovr -f $coverage_filter --add-tracefile $first_coverage_file_path --add-tracefile $second_coverage_file_path -j $num_jobs $output_flags
+  gcovr --gcov-ignore-parse-errors -f $coverage_filter --add-tracefile $first_coverage_file_path --add-tracefile $second_coverage_file_path -j $num_jobs $output_flags
 else
-  gcovr -f $coverage_filter -j $num_jobs $output_flags
+  gcovr --gcov-ignore-parse-errors -f $coverage_filter -j $num_jobs $output_flags
   $python_binary test/evergreen/code_coverage_analysis.py -s coverage_report/1_coverage_report_summary.json -t time.txt
 fi
 


### PR DESCRIPTION
The pull request fixes code coverage reports for the v5 toolchain. There were two main problems:
- Fix **ValueError: invalid literal for int() with base 10: 'executed'.** error with adding **--gcov-ignore-parse-errors**.
- Fix code coverage report 0% as code coverage via specifying a mongodbtoolchain when building WT.

To verify these changes I have posted a patch build on the ticket with V5 toolchain enabled.