### PR TITLE
WT-13310 Random Cursor

### DIFF
--- a/bench/tiered/push_pull.c
+++ b/bench/tiered/push_pull.c
@@ -64,7 +64,7 @@ static void compute_wt_file_size(const char *, const char *, uint64_t *);
 static void compute_tiered_file_size(const char *, const char *, uint64_t *);
 static void fill_random_data(void);
 static void get_file_size(const char *, uint64_t *);
-static void populate(WT_SESSION *, uint32_t);
+static void populate(WT_SESSION *, uint32_t, uint32_t);
 static void recover_validate(const char *, uint32_t, uint64_t, uint32_t);
 static void run_test_clean(const char *, uint32_t);
 static void run_test(const char *, uint32_t, uint32_t);
@@ -285,7 +285,7 @@ recover_validate(const char *home, uint32_t num_records, uint64_t file_size, uin
     char buf[1024], pwd[1024];
     double diff_sec;
     size_t val_1_size, val_2_size;
-    uint64_t key, i;
+    uint64_t key, i, v;
 
     WT_CONNECTION *conn;
     WT_CURSOR *cursor;
@@ -315,11 +315,12 @@ recover_validate(const char *home, uint32_t num_records, uint64_t file_size, uin
     testutil_wiredtiger_open(opts, home, buf, NULL, &conn, true, true);
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
+    /* Seed the random number generator */
+    v = (uint32_t)getpid() + num_records + (2 * counter);
+    __wt_random_init_seed(&rnd, v);
+
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
     val_1_size = MAX_VALUE_SIZE;
-
-    /* Seed the random number generator */
-    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     gettimeofday(&start, 0);
 
@@ -377,7 +378,7 @@ run_test(const char *home, uint32_t num_records, uint32_t counter)
 
     gettimeofday(&start, 0);
 
-    populate(session, num_records);
+    populate(session, num_records, counter);
     testutil_check(session->checkpoint(session, buf));
 
     gettimeofday(&end, 0);
@@ -405,14 +406,15 @@ run_test(const char *home, uint32_t num_records, uint32_t counter)
  *     Populate the table.
  */
 static void
-populate(WT_SESSION *session, uint32_t num_records)
+populate(WT_SESSION *session, uint32_t num_records, uint32_t counter)
 {
     WT_CURSOR *cursor;
     WT_ITEM item;
-    uint64_t i;
+    uint64_t v, i;
 
     /* Seed the random number generator */
-    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
+    v = (uint32_t)getpid() + num_records + (2 * counter);
+    __wt_random_init_seed(&rnd, v);
 
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
     for (i = 0; i < num_records; i++) {

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -360,7 +360,7 @@ get_dir_num_files(const std::string &dir)
  * This function generates a random table name which is alphanumeric and 5 chars long.
  */
 static void
-gen_random_table_name(char *name, workgen_random_state volatile *rand_state)
+gen_random_table_name(char *name, workgen_random_state *rand_state)
 {
     ASSERT(name != NULL);
 

--- a/bench/workgen/workgen_func.c
+++ b/bench/workgen/workgen_func.c
@@ -75,7 +75,7 @@ workgen_epoch(struct timespec *tsp)
 }
 
 uint32_t
-workgen_random(workgen_random_state volatile *rnd_state)
+workgen_random(workgen_random_state *rnd_state)
 {
     return (__wt_random(&rnd_state->state));
 }
@@ -90,7 +90,7 @@ workgen_random_alloc(WT_SESSION *session, workgen_random_state **rnd_state)
         *rnd_state = NULL;
         return (ENOMEM);
     }
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &state->state);
+    __wt_random_init((WT_SESSION_IMPL *)session, &state->state);
     *rnd_state = state;
     return (0);
 }

--- a/bench/workgen/workgen_func.h
+++ b/bench/workgen/workgen_func.h
@@ -35,7 +35,7 @@ extern uint64_t workgen_atomic_add64(uint64_t *vp, uint64_t v);
 extern uint32_t workgen_atomic_sub32(uint32_t *vp, uint32_t v);
 extern void workgen_clock(uint64_t *tsp);
 extern void workgen_epoch(struct timespec *tsp);
-extern uint32_t workgen_random(struct workgen_random_state volatile *rnd_state);
+extern uint32_t workgen_random(struct workgen_random_state *rnd_state);
 extern int workgen_random_alloc(WT_SESSION *session, struct workgen_random_state **rnd_state);
 extern void workgen_random_free(struct workgen_random_state *rnd_state);
 extern void workgen_u64_to_string_zf(uint64_t n, char *buf, size_t len);

--- a/bench/wt2853_perf/main.c
+++ b/bench/wt2853_perf/main.c
@@ -232,7 +232,7 @@ thread_insert(void *arg)
 
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
     __wt_seconds((WT_SESSION_IMPL *)session, &prevtime);
 
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &maincur));

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -2886,7 +2886,7 @@ start_threads(WTPERF *wtperf, WORKLOAD *workp, WTPERF_THREAD *base, u_int num,
         /*
          * We don't want the threads executing in lock-step, seed each one differently.
          */
-        __wt_random_init_seed(NULL, &thread->rnd);
+        __wt_random_init(NULL, &thread->rnd);
 
         /*
          * Every thread gets a key/data buffer because we don't bother to distinguish between

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -706,7 +706,7 @@ __cursor_reposition_timing_stress(WT_SESSION_IMPL *session)
     conn = S2C(session);
 
     if (FLD_ISSET(conn->timing_stress_flags, WT_TIMING_STRESS_EVICT_REPOSITION) &&
-      __wt_random(&session->rnd) % 10 == 0)
+      __wt_random(&session->rnd_random) % 10 == 0)
         return (true);
 
     return (false);

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -33,7 +33,7 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     TAILQ_INIT(&conn->pfqh);                  /* Pre-fetch reference list */
 
     /* Random numbers. */
-    __wt_random_init(&session->rnd);
+    __wt_session_rng_init_once(session);
 
     /* Configuration. */
     WT_RET(__wt_conn_config_init(session));

--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -1036,9 +1036,9 @@ __curfile_create(WT_SESSION_IMPL *session, WT_CURSOR *owner, const char *cfg[], 
     if (cval.val != 0) {
         WT_ERR(__wt_config_gets_def(session, cfg, "next_random_seed", 0, &cval));
         if (cval.val != 0)
-            __wt_random_init_custom_seed(&cbt->rnd, (uint64_t)cval.val);
+            __wt_random_init_seed(&cbt->rnd, (uint64_t)cval.val);
         else
-            __wt_random_init_seed(session, &cbt->rnd);
+            __wt_random_init(session, &cbt->rnd);
 
         if (WT_CURSOR_RECNO(cursor))
             WT_ERR_MSG(

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1530,7 +1530,7 @@ __evict_walk_choose_dhandle(WT_SESSION_IMPL *session, WT_DATA_HANDLE **dhandle_p
      * from the list in that case.
      */
     if (conn->dhandle_count < conn->dh_hash_size / 4) {
-        rnd_dh = __wt_random(&session->rnd) % conn->dhandle_count;
+        rnd_dh = __wt_random(&session->rnd_random) % conn->dhandle_count;
         dhandle = TAILQ_FIRST(&conn->dhqh);
         for (; rnd_dh > 0; rnd_dh--)
             dhandle = TAILQ_NEXT(dhandle, q);
@@ -1542,14 +1542,14 @@ __evict_walk_choose_dhandle(WT_SESSION_IMPL *session, WT_DATA_HANDLE **dhandle_p
      * Keep picking up a random bucket until we find one that is not empty.
      */
     do {
-        rnd_bucket = __wt_random(&session->rnd) & (conn->dh_hash_size - 1);
+        rnd_bucket = __wt_random(&session->rnd_random) & (conn->dh_hash_size - 1);
     } while ((dh_bucket_count = conn->dh_bucket_count[rnd_bucket]) == 0);
 
     /* We can't pick up an empty bucket with a non zero bucket count. */
     WT_ASSERT(session, !TAILQ_EMPTY(&conn->dhhash[rnd_bucket]));
 
     /* Pick a random dhandle in the chosen bucket. */
-    rnd_dh = __wt_random(&session->rnd) % dh_bucket_count;
+    rnd_dh = __wt_random(&session->rnd_random) % dh_bucket_count;
     dhandle = TAILQ_FIRST(&conn->dhhash[rnd_bucket]);
     for (; rnd_dh > 0; rnd_dh--)
         dhandle = TAILQ_NEXT(dhandle, hashq);
@@ -2181,7 +2181,7 @@ rand_next:
                 /* Ensure internal pages indexes remain valid */
                 WT_WITH_PAGE_INDEX(session,
                   ret = __wt_random_descent(
-                    session, &btree->evict_ref, WT_READ_EVICT_READ_FLAGS, &session->rnd));
+                    session, &btree->evict_ref, WT_READ_EVICT_READ_FLAGS, &session->rnd_random));
                 if (ret != WT_RESTART)
                     break;
                 WT_STAT_CONN_INCR(session, eviction_walk_restart);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -914,7 +914,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
         if (!WT_SESSION_BTREE_SYNC(session) &&
           (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) ||
             (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
-              __wt_random(&session->rnd) % 3 == 0)))
+              __wt_random(&session->rnd_random) % 3 == 0)))
             LF_SET(WT_REC_SCRUB);
     }
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1988,7 +1988,8 @@ __wt_skip_choose_depth(WT_SESSION_IMPL *session)
         probability = 0xe6666665; /* ~90% of the value of uint32 max. */
 #endif
 
-    for (depth = 1; depth < WT_SKIP_MAXDEPTH && __wt_random(&session->rnd) < probability; depth++)
+    for (depth = 1; depth < WT_SKIP_MAXDEPTH && __wt_random(&session->rnd_skiplist) < probability;
+         depth++)
         ;
     return (depth);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1430,7 +1430,7 @@ extern uint32_t __wt_checksum_with_seed_sw(uint32_t seed, const void *chunk, siz
 extern uint32_t __wt_log2_int(uint32_t n) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_nlpo2(uint32_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_nlpo2_round(uint32_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern uint32_t __wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_DECL_ATTRIBUTE(
+extern uint32_t __wt_random(WT_RAND_STATE *rnd_state) WT_GCC_FUNC_DECL_ATTRIBUTE(
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_rduppo2(uint32_t n, uint32_t po2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1522,11 +1522,11 @@ extern void __wt_optrack_record_funcid(
   WT_SESSION_IMPL *session, const char *func, uint16_t *func_idp);
 extern void __wt_os_stdio(WT_SESSION_IMPL *session);
 extern void __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep);
-extern void __wt_random_init(WT_RAND_STATE volatile *rnd_state)
+extern void __wt_random_init(WT_SESSION_IMPL *session, WT_RAND_STATE *rnd_state)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_random_init_custom_seed(WT_RAND_STATE volatile *rnd_state, uint64_t v)
+extern void __wt_random_init_default(WT_RAND_STATE *rnd_state)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_state)
+extern void __wt_random_init_seed(WT_RAND_STATE *rnd_state, uint64_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l);
 extern void __wt_readunlock(WT_SESSION_IMPL *session, WT_RWLOCK *l);
@@ -1542,6 +1542,8 @@ extern void __wt_session_dhandle_writeunlock(WT_SESSION_IMPL *session);
 extern void __wt_session_gen_enter(WT_SESSION_IMPL *session, int which);
 extern void __wt_session_gen_leave(WT_SESSION_IMPL *session, int which);
 extern void __wt_session_reset_last_error(WT_SESSION_IMPL *session);
+extern void __wt_session_rng_init_once(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_session_set_last_error(
   WT_SESSION_IMPL *session, int err, int sub_level_err, const char *fmt, ...);
 extern void __wt_stash_discard(WT_SESSION_IMPL *session);

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -264,7 +264,7 @@ __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session)
      * means we'll hit the maximum roughly every 1K calls.
      */
     for (i = 0;;)
-        if (__wt_random(&session->rnd) & 0x1 || ++i > max)
+        if (__wt_random(&session->rnd_random) & 0x1 || ++i > max)
             break;
 
     if (i == 0)
@@ -292,7 +292,7 @@ __wt_failpoint(WT_SESSION_IMPL *session, uint64_t conn_flag, u_int probability)
     /* Assert that the given probability is sane. */
     WT_ASSERT(session, probability <= 10 * WT_THOUSAND);
 
-    return (__wt_random(&session->rnd) % (10 * WT_THOUSAND) <= probability);
+    return (__wt_random(&session->rnd_random) % (10 * WT_THOUSAND) <= probability);
 }
 
 /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -323,13 +323,19 @@ struct __wt_session_impl {
  * All of the following fields live at the end of the structure so it's easier to clear everything
  * but the fields that persist.
  */
-#define WT_SESSION_CLEAR_SIZE (offsetof(WT_SESSION_IMPL, rnd))
+#define WT_SESSION_CLEAR_SIZE (offsetof(WT_SESSION_IMPL, rnd_random))
 
     /*
      * The random number state persists past session close because we don't want to repeatedly use
-     * the same values for skiplist depth when the application isn't caching sessions.
+     * the same values. This RNG is used for general purpose random number generation.
      */
-    wt_shared WT_RAND_STATE rnd; /* Random number generation state */
+    wt_shared WT_RAND_STATE rnd_random;
+    /*
+     * The random number state persists past session close because we don't want to repeatedly use
+     * the same values for skiplist depth when the application isn't caching sessions. This RNG
+     * supposedly uses a specially crafted seed suitable for skiplists.
+     */
+    wt_shared WT_RAND_STATE rnd_skiplist;
 
     /*
      * Hash tables are allocated lazily as sessions are used to keep the size of this structure from

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1567,7 +1567,7 @@ retry:
          * on every random 100th iteration when this is enabled.
          */
         if (FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_HS_SEARCH) &&
-          __wt_random(&session->rnd) % 100 == 0)
+          __wt_random(&session->rnd_random) % 100 == 0)
             __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
 
         WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1220,7 +1220,7 @@ __ckpt_blkmod_to_meta(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_CKPT *ckpt)
          * versions of WiredTiger
          */
         if (FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_BACKUP_RENAME) &&
-          !F_ISSET(blk, WT_CKPT_BLOCK_MODS_RENAME) && __wt_random(&session->rnd) % 10 == 0)
+          !F_ISSET(blk, WT_CKPT_BLOCK_MODS_RENAME) && __wt_random(&session->rnd_random) % 10 == 0)
             skip_rename = true;
 
         WT_RET(__wt_raw_to_hex(session, blk->bitstring.data, blk->bitstring.size, &bitstring));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2421,8 +2421,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
      * problem because sessions are long-lived and will diverge into different parts of the value
      * space, and what we care about are small values, that is, the low-order bits.
      */
-    if (WT_SESSION_FIRST_USE(session_ret))
-        __wt_random_init(&session_ret->rnd);
+    __wt_session_rng_init_once(session_ret);
 
     __wt_event_handler_set(
       session_ret, event_handler == NULL ? session->event_handler : event_handler);

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -112,8 +112,9 @@ __wt_session_rng_init_once(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((visi
      */
     __wt_random_init_default(&session->rnd_skiplist);
 
+    uint64_t t = __wt_clock(session);
     __wt_random_init_seed(&session->rnd_random,
-      ((uint64_t)session->id + 1) * __wt_clock(session) / WT_BILLION + (uint64_t)getpid());
+      ((uint64_t)session->id + 1) * t / WT_BILLION + (t % WT_BILLION) + (uint64_t)getpid());
 }
 
 /*

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -100,6 +100,10 @@ __wt_random_init_seed(WT_RAND_STATE *rnd_state, uint64_t v)
  *
  * This function requires session->id to be already set!
  *
+ * session->id is used to seed the RNG. Since session objects have infinite lifetime, each session's
+ *     RNG is seeded with a different value. This is mixed with the current time and the process ID
+ *     to ensure that the RNG is different across runs.
+ *
  */
 void
 __wt_session_rng_init_once(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -55,14 +55,13 @@
 
 #define DEFAULT_SEED_W 521288629
 #define DEFAULT_SEED_Z 362436069
-#define WT_LEFT_CIRCULAR_SHIFT32(x, nbits) (((x) << (nbits)) | ((x) >> (32 - (nbits))))
 
 /*
- * __wt_random_init --
- *     Initialize return of a 32-bit pseudo-random number.
+ * __wt_random_init_default --
+ *     Initialize a 32-bit pseudo-random number with a default seed.
  */
 void
-__wt_random_init(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+__wt_random_init_default(WT_RAND_STATE *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
     WT_RAND_STATE rnd;
 
@@ -73,11 +72,11 @@ __wt_random_init(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visib
 }
 
 /*
- * __wt_random_init_custom_seed --
- *     Initialize the state of a 32-bit pseudo-random number with custom seed.
+ * __wt_random_init_seed --
+ *     Initialize the state of a 32-bit pseudo-random number with a seed value.
  */
 void
-__wt_random_init_custom_seed(WT_RAND_STATE volatile *rnd_state, uint64_t v)
+__wt_random_init_seed(WT_RAND_STATE *rnd_state, uint64_t v)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
     WT_RAND_STATE rnd;
@@ -96,45 +95,25 @@ __wt_random_init_custom_seed(WT_RAND_STATE volatile *rnd_state, uint64_t v)
 }
 
 /*
- * __wt_random_init_seed --
- *     Initialize the state of a 32-bit pseudo-random number.
+ * __wt_session_rng_init_once --
+ *     Initialize session's RNGs.
+ *
+ * This function requires session->id to be already set!
+ *
  */
 void
-__wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_state)
-  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+__wt_session_rng_init_once(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    struct timespec ts;
-    WT_RAND_STATE rnd;
-    uintmax_t threadid;
-
-    __wt_epoch(session, &ts);
-    __wt_thread_id(&threadid);
+    if (!WT_SESSION_FIRST_USE(session))
+        return;
 
     /*
-     * Use this, instead of __wt_random_init, to vary the initial state of the RNG. This is
-     * (currently) only used by test programs, where, for example, an initial set of test data is
-     * created by a single thread, and we want more variability in the initial state of the RNG.
-     *
-     * Take the seconds and nanoseconds from the clock together with the thread ID to generate a
-     * 64-bit seed, then smear that value using algorithm "xor" from Marsaglia, "Xorshift RNGs".
+     * Session's skiplist RNG is initialized with the special default seed.
      */
-    M_W(rnd) =
-      (uint32_t)ts.tv_sec ^ (uint32_t)WT_LEFT_CIRCULAR_SHIFT32(ts.tv_nsec, 29) ^ DEFAULT_SEED_W;
-    M_Z(rnd) =
-      (uint32_t)ts.tv_nsec ^ (uint32_t)WT_LEFT_CIRCULAR_SHIFT32(ts.tv_sec, 27) ^ DEFAULT_SEED_Z;
-/*
- * Some system clocks do not have a high enough resolution between each tick cycle. Perform an extra
- * xor against the machine's timestamp counter.
- */
-#ifdef _WIN32
-    rnd.v ^= __wt_rdtsc();
-#endif
-    rnd.v ^= (uint64_t)threadid;
-    rnd.v ^= rnd.v << 13;
-    rnd.v ^= rnd.v >> 7;
-    rnd.v ^= rnd.v << 17;
+    __wt_random_init_default(&session->rnd_skiplist);
 
-    *rnd_state = rnd;
+    __wt_random_init_seed(&session->rnd_random,
+      ((uint64_t)session->id + 1) * __wt_clock(session) / WT_BILLION + (uint64_t)getpid());
 }
 
 /*
@@ -142,7 +121,7 @@ __wt_random_init_seed(WT_SESSION_IMPL *session, WT_RAND_STATE volatile *rnd_stat
  *     Return a 32-bit pseudo-random number.
  */
 uint32_t
-__wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+__wt_random(WT_RAND_STATE *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
 #ifdef ENABLE_ANTITHESIS
     return (uint32_t)(fuzz_get_random());
@@ -184,4 +163,20 @@ __wt_random(WT_RAND_STATE volatile *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility
 
     return ((z << 16) + (w & 65535));
 #endif
+}
+
+/*
+ * __wt_random_init --
+ *     Initialize the state of a 32-bit pseudo-random number by a session's rng.
+ */
+void
+__wt_random_init(WT_SESSION_IMPL *session, WT_RAND_STATE *rnd_state)
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    if (session != NULL)
+        __wt_random_init_seed(rnd_state, __wt_random(&session->rnd_random));
+    else {
+        uint64_t t = __wt_clock(session);
+        __wt_random_init_seed(rnd_state, t / WT_BILLION + (t % WT_BILLION) + (uint64_t)getpid());
+    }
 }

--- a/test/bloom/test_bloom.c
+++ b/test/bloom/test_bloom.c
@@ -234,7 +234,7 @@ populate_entries(void)
     uint32_t i, j;
     uint8_t **entries;
 
-    __wt_random_init_seed(NULL, &g.rand);
+    __wt_random_init_default(&g.rand);
 
     entries = dcalloc(g.c_ops, sizeof(uint8_t *));
 

--- a/test/catch2/block/unit/test_block_session_bms.cpp
+++ b/test/catch2/block/unit/test_block_session_bms.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Block session: __wti_block_ext_prealloc with null block manager", "[b
     {
         WT_BLOCK_MGR_SESSION *bms = nullptr;
 
-        __wt_random_init(&session->get_wt_session_impl()->rnd);
+        __wt_random_init_default(&session->get_wt_session_impl()->rnd_random);
 
         REQUIRE(__wti_block_ext_prealloc(session->get_wt_session_impl(), 0) == 0);
         bms = static_cast<WT_BLOCK_MGR_SESSION *>(session->get_wt_session_impl()->block_manager);

--- a/test/catch2/block/unit/test_block_session_ext.cpp
+++ b/test/catch2/block/unit/test_block_session_ext.cpp
@@ -22,7 +22,7 @@
 TEST_CASE("Block session: __block_ext_alloc", "[block_session_ext]")
 {
     std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
-    __wt_random_init(&session->get_wt_session_impl()->rnd);
+    __wt_random_init_default(&session->get_wt_session_impl()->rnd_random);
 
     WT_EXT *ext = nullptr;
     REQUIRE(__ut_block_ext_alloc(session->get_wt_session_impl(), &ext) == 0);

--- a/test/catch2/wrappers/mock_session.cpp
+++ b/test/catch2/wrappers/mock_session.cpp
@@ -68,7 +68,8 @@ WT_BLOCK_MGR_SESSION *
 mock_session::setup_block_manager_session()
 {
     // Initialize rnd state because block manager requires it.
-    __wt_random_init(&_session_impl->rnd);
+    __wt_random_init_default(&_session_impl->rnd_random);
+    __wt_random_init_default(&_session_impl->rnd_skiplist);
     utils::throw_if_non_zero(
       __wt_calloc(nullptr, 1, sizeof(WT_BLOCK_MGR_SESSION), &_session_impl->block_manager));
     _session_impl->block_manager_cleanup = __ut_block_manager_session_cleanup;

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -71,6 +71,14 @@ define_c_test(
 )
 
 define_c_test(
+    TARGET test_random_session
+    SOURCES random_session/main.c
+    DIR_NAME random_session
+    ARGUMENTS
+    DEPENDS "WT_POSIX"
+)
+
+define_c_test(
     TARGET test_rwlock
     SOURCES rwlock/main.c
     DIR_NAME rwlock

--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -748,7 +748,7 @@ main(int argc, char *argv[])
         rnd.v = 123456789;
         run_test(working_dir, &rnd, preserve);
 
-        __wt_random_init_seed(NULL, &rnd);
+        __wt_random_init_default(&rnd);
         run_test(working_dir, &rnd, preserve);
     } else {
         rnd.v = seed_param;

--- a/test/csuite/random/main.c
+++ b/test/csuite/random/main.c
@@ -50,7 +50,7 @@ test_random(bool verbose)
     i = 0;
     count = 0;
 
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
 
     if (verbose)
         printf("%2s  %11s  %10s\n", "#", "count", "random");

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -136,7 +136,7 @@ thread_run(void *arg)
     char large[128 * 1024];
     bool columnar_table;
 
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
     for (i = 0; i < MAX_RECORD_FILES; i++)
         memset(fname[i], 0, sizeof(fname[i]));
     memset(buf, 0, sizeof(buf));
@@ -734,7 +734,7 @@ main(int argc, char *argv[])
             testutil_lazyfs_setup(&lazyfs, home);
 
         /* Set up the rest of the test. */
-        __wt_random_init_seed(NULL, &rnd);
+        __wt_random_init_default(&rnd);
         if (rand_time) {
             timeout = __wt_random(&rnd) % MAX_TIME;
             if (timeout < MIN_TIME)

--- a/test/csuite/random_directio/main.c
+++ b/test/csuite/random_directio/main.c
@@ -497,7 +497,7 @@ thread_run(void *arg)
     char *buf1, *buf2;
     char large[LARGE_WRITE_SIZE];
 
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
     lsize = sizeof(large);
     memset(large, 0, lsize);
 
@@ -1293,7 +1293,7 @@ main(int argc, char *argv[])
             testutil_mkdir(buf);
         }
 
-        __wt_random_init_seed(NULL, &rnd);
+        __wt_random_init_default(&rnd);
         if (rand_time) {
             timeout = __wt_random(&rnd) % MAX_TIME;
             if (timeout < MIN_TIME)

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
 
     /* Test one session. */
 
-    for (int retry = 0; (++retry) <= N_RETRIES;) {
+    for (int retry = 1; (++retry) <= N_RETRIES;) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */
         __wt_sleep(0, 10);
 
@@ -96,7 +96,7 @@ retry_single:;
 
     /* Test multiple sessions. */
 
-    for (int retry = 0; (++retry) <= N_RETRIES;) {
+    for (int retry = 1; (++retry) <= N_RETRIES;) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */
         __wt_sleep(0, 10);
 

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
 
     /* Test one session. */
 
-    for (int cycle = 0; (++cycle) <= N_RETRIES;) {
+    for (int retry = 0; (++retry) <= N_RETRIES;) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */
         __wt_sleep(0, 10);
 
@@ -81,21 +81,22 @@ main(int argc, char *argv[])
             testutil_check(conn->open_session(conn, NULL, NULL, &session));
             number = __wt_random(&((WT_SESSION_IMPL *)session)->rnd_random);
             testutil_check(session->close(session, NULL));
-            if (cycle > 1 && prev_number == number) {
-                if (cycle < N_RETRIES)
+            if (retry > 1 && prev_number == number) {
+                if (retry < N_RETRIES)
                     /* To eliminate flakiness, give it another go. */
                     goto retry_single;
-                fprintf(stderr, "Random numbers repeated for %d cycles in single session\n", cycle);
+                fprintf(stderr, "Random numbers repeated for %d cycles in single session\n", retry);
                 random_numbers_repeated = true;
             }
             prev_number = number;
         }
+        break;
 retry_single:;
     }
 
     /* Test multiple sessions. */
 
-    for (int cycle = 0; (++cycle) <= N_RETRIES;) {
+    for (int retry = 0; (++retry) <= N_RETRIES;) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */
         __wt_sleep(0, 10);
 
@@ -110,25 +111,25 @@ retry_single:;
         for (int i = 0; i < N_SESSIONS; i++) {
             numbers[i] = number = __wt_random(&sessions[i]->rnd_random);
             if (i > 0 && prev_number == number) {
-                if (cycle < N_RETRIES)
+                if (retry < N_RETRIES)
                     /* To eliminate flakiness, give it another go. */
                     goto retry_multi;
                 fprintf(
-                  stderr, "Random numbers repeated for %d cycles in subsequent sessions\n", cycle);
+                  stderr, "Random numbers repeated for %d cycles in subsequent sessions\n", retry);
                 random_numbers_repeated = true;
             }
             prev_number = number;
         }
 
-        /* Check is any random numbers repeat. */
+        /* Check if any random numbers repeat. */
         __wt_qsort(numbers, N_SESSIONS, sizeof(uint64_t), compare_uint64_t);
         for (int i = 1; i < N_SESSIONS; i++) {
             if (numbers[i] == numbers[i - 1]) {
-                if (cycle < N_RETRIES)
+                if (retry < N_RETRIES)
                     /* To eliminate flakiness, give it another go. */
                     goto retry_multi;
                 fprintf(
-                  stderr, "Random numbers repeated for %d cycles in multiple sessions\n", cycle);
+                  stderr, "Random numbers repeated for %d cycles in multiple sessions\n", retry);
                 random_numbers_repeated = true;
             }
         }

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
 
     /* Test one session. */
 
-    for (int retry = 1; (++retry) <= N_RETRIES;) {
+    for (int retry = 1; retry <= N_RETRIES; ++retry) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */
         __wt_sleep(0, 10);
 
@@ -96,7 +96,7 @@ retry_single:;
 
     /* Test multiple sessions. */
 
-    for (int retry = 1; (++retry) <= N_RETRIES;) {
+    for (int retry = 1; retry <= N_RETRIES; ++retry) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */
         __wt_sleep(0, 10);
 

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -114,7 +114,7 @@ retry_single:;
                     /* To eliminate flakiness, give it another go. */
                     goto retry_multi;
                 fprintf(
-                  stderr, "Random numbers repeated for %d cycles in consequent sessions\n", cycle);
+                  stderr, "Random numbers repeated for %d cycles in subsequent sessions\n", cycle);
                 random_numbers_repeated = true;
             }
             prev_number = number;

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -70,7 +70,12 @@ main(int argc, char *argv[])
 
     testutil_check(wiredtiger_open(home, NULL, conn_config, &conn));
 
-    /* Test one session. */
+    /*
+     * Test one session.
+     *
+     * The test generates a random number in N sessions sequentially, with only one session open at
+     * a time.
+     */
 
     for (int retry = 1; retry <= N_RETRIES; ++retry) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */
@@ -94,7 +99,11 @@ main(int argc, char *argv[])
 retry_single:;
     }
 
-    /* Test multiple sessions. */
+    /*
+     * Test multiple sessions.
+     *
+     * The test generates random numbers with N sessions open simultaneously.
+     */
 
     for (int retry = 1; retry <= N_RETRIES; ++retry) {
         /* Reset the thread's timeslice to raise the probability quicker execution. */

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -1,0 +1,154 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include "test_util.h"
+
+#include <stdlib.h>
+
+#define N_SESSIONS 10
+#define N_RETRIES 10
+
+/* Constants and variables declaration. */
+static const char conn_config[] = "create,cache_size=1MB,statistics=(all)";
+
+/*
+ * compare_uint64_t --
+ *     Compare uint64_t.
+ */
+static int
+compare_uint64_t(const void *a, const void *b)
+{
+    return (*(uint64_t *)a > *(uint64_t *)b) - (*(uint64_t *)a < *(uint64_t *)b);
+}
+
+/*
+ * main --
+ *     The main method.
+ */
+int
+main(int argc, char *argv[])
+{
+    TEST_OPTS *opts, _opts;
+    WT_CONNECTION *conn;
+    WT_SESSION_IMPL *(sessions[N_SESSIONS]);
+    uint64_t numbers[N_SESSIONS], number = 0, prev_number = 0;
+    char home[1024];
+    bool random_numbers_repeated = false;
+
+    opts = &_opts;
+    memset(opts, 0, sizeof(*opts));
+    testutil_check(testutil_parse_opts(argc, argv, opts));
+
+    /* Initialize database. */
+
+    testutil_work_dir_from_path(home, sizeof(home), "WT_TEST.random_session");
+    testutil_recreate_dir(home);
+
+    testutil_check(wiredtiger_open(home, NULL, conn_config, &conn));
+
+    /* Test one session. */
+
+    for (int cycle = 0; (++cycle) <= N_RETRIES;) {
+        /* Reset the thread's timeslice to raise the probability quicker execution. */
+        __wt_sleep(0, 10);
+
+        for (int i = 0; i < N_SESSIONS; i++) {
+            WT_SESSION *session;
+            testutil_check(conn->open_session(conn, NULL, NULL, &session));
+            number = __wt_random(&((WT_SESSION_IMPL *)session)->rnd_random);
+            testutil_check(session->close(session, NULL));
+            if (cycle > 1 && prev_number == number) {
+                if (cycle < N_RETRIES)
+                    /* To eliminate flakiness, give it another go. */
+                    goto retry_single;
+                fprintf(stderr, "Random numbers repeated for %d cycles in single session\n", cycle);
+                random_numbers_repeated = true;
+            }
+            prev_number = number;
+        }
+retry_single:;
+    }
+
+    /* Test multiple sessions. */
+
+    for (int cycle = 0; (++cycle) <= N_RETRIES;) {
+        /* Reset the thread's timeslice to raise the probability quicker execution. */
+        __wt_sleep(0, 10);
+
+        /* Open sessions as quickly as possible. */
+        for (int i = 0; i < N_SESSIONS; i++) {
+            WT_SESSION *session;
+            testutil_check(conn->open_session(conn, NULL, NULL, &session));
+            sessions[i] = (WT_SESSION_IMPL *)session;
+        }
+
+        /* Generate a random number. */
+        for (int i = 0; i < N_SESSIONS; i++) {
+            numbers[i] = number = __wt_random(&sessions[i]->rnd_random);
+            if (i > 0 && prev_number == number) {
+                if (cycle < N_RETRIES)
+                    /* To eliminate flakiness, give it another go. */
+                    goto retry_multi;
+                fprintf(
+                  stderr, "Random numbers repeated for %d cycles in consequent sessions\n", cycle);
+                random_numbers_repeated = true;
+            }
+            prev_number = number;
+        }
+
+        /* Check is any random numbers repeat. */
+        __wt_qsort(numbers, N_SESSIONS, sizeof(uint64_t), compare_uint64_t);
+        for (int i = 1; i < N_SESSIONS; i++) {
+            if (numbers[i] == numbers[i - 1]) {
+                if (cycle < N_RETRIES)
+                    /* To eliminate flakiness, give it another go. */
+                    goto retry_multi;
+                fprintf(
+                  stderr, "Random numbers repeated for %d cycles in multiple sessions\n", cycle);
+                random_numbers_repeated = true;
+            }
+        }
+        break;
+
+retry_multi:
+        /* Close sessions. */
+        for (int i = 0; i < N_SESSIONS; i++)
+            testutil_check(sessions[i]->iface.close(&sessions[i]->iface, NULL));
+    }
+
+    /* Finish the test and clean up. */
+
+    testutil_check(conn->close(conn, NULL));
+
+    if (!opts->preserve)
+        testutil_remove(home);
+    testutil_cleanup(opts);
+
+    testutil_assert(!random_numbers_repeated);
+
+    return (EXIT_SUCCESS);
+}

--- a/test/csuite/wt10897_compact_quick_interrupt/main.c
+++ b/test/csuite/wt10897_compact_quick_interrupt/main.c
@@ -106,7 +106,7 @@ populate(WT_SESSION *session, uint64_t start, uint64_t end)
 
     uint64_t i, str_len, val;
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     str_len = sizeof(data_str) / sizeof(data_str[0]);
     for (i = 0; i < str_len - 1; i++)

--- a/test/csuite/wt11126_compile_config/main.c
+++ b/test/csuite/wt11126_compile_config/main.c
@@ -247,7 +247,7 @@ do_config_run(WT_SESSION *session, uint32_t variant, const char *compiled,
     bool roundup_prepared, roundup_read, no_timestamp;
 
     /* Initialize the RNG. */
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
 
     __wt_epoch(NULL, &before);
     for (i = 0; i < N_CALLS; ++i) {

--- a/test/csuite/wt11440_config_check/main.c
+++ b/test/csuite/wt11440_config_check/main.c
@@ -172,7 +172,7 @@ do_config_run(TEST_OPTS *opts, u_int variant, bool check, uint64_t *nsec)
     init_data = impls[variant].init_data;
 
     /* Initialize the RNG. */
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
 
     __wt_epoch(NULL, &before);
     for (i = 0; i < N_CALLS; ++i) {

--- a/test/csuite/wt13867_interrupt_eviction_handler/main.c
+++ b/test/csuite/wt13867_interrupt_eviction_handler/main.c
@@ -125,7 +125,7 @@ populate(WT_SESSION *session, uint64_t count)
     WT_RAND_STATE rnd;
 
     /* Use a static seed for better reproducible results. */
-    __wt_random_init_custom_seed(&rnd, 0);
+    __wt_random_init_seed(&rnd, 0);
 
     uint64_t str_len = sizeof(data_str) / sizeof(data_str[0]);
     for (uint64_t i = 0; i < str_len - 1; i++)

--- a/test/csuite/wt2695_checksum/main.c
+++ b/test/csuite/wt2695_checksum/main.c
@@ -91,7 +91,7 @@ main(int argc, char *argv[])
       "create,statistics=(all),statistics_log=(json,on_close,wait=1)", &opts->conn));
 
     /* Initialize the RNG. */
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
 
     /* Allocate aligned memory for the data. */
     data = dcalloc(DATASIZE, sizeof(uint8_t));

--- a/test/csuite/wt2719_reconfig/main.c
+++ b/test/csuite/wt2719_reconfig/main.c
@@ -178,7 +178,7 @@ main(int argc, char *argv[])
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
 
     /* Initialize the RNG. */
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
 
     /* Allocate memory for the config. */
     len = WT_ELEMENTS(list) * 64;

--- a/test/csuite/wt2909_checkpoint_integrity/main.c
+++ b/test/csuite/wt2909_checkpoint_integrity/main.c
@@ -584,7 +584,7 @@ subtest_populate(TEST_OPTS *opts, bool close_test)
     bool failed;
 
     failed = false;
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
     CHECK(create_big_string(&bigref), false);
     nrecords = opts->nrecords;
 

--- a/test/csuite/wt3338_partial_update/main.c
+++ b/test/csuite/wt3338_partial_update/main.c
@@ -170,7 +170,7 @@ modify_run(TEST_OPTS *opts)
     verbose = opts->verbose;
 
     /* Initialize the RNG. */
-    __wt_random_init_seed(session, &rnd);
+    __wt_random_init(session, &rnd);
 
     /* Set up replacement information. */
     modify_repl_init();

--- a/test/csuite/wt3363_checkpoint_op_races/main.c
+++ b/test/csuite/wt3363_checkpoint_op_races/main.c
@@ -224,7 +224,7 @@ do_ops(void *args)
     WT_RAND_STATE rnd;
     time_t now, start;
 
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
     (void)time(&start);
     (void)time(&now);
 

--- a/test/csuite/wt4333_handle_locks/main.c
+++ b/test/csuite/wt4333_handle_locks/main.c
@@ -172,7 +172,7 @@ wthread(void *arg)
     memset(cursor_list, 0, sizeof(cursor_list));
 
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     for (next = 0; !done;) {
         if (++next == WT_ELEMENTS(cursor_list))
@@ -201,7 +201,7 @@ vthread(void *arg)
     memset(cursor_list, 0, sizeof(cursor_list));
 
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     for (next = 0; !done;) {
         if (++next == WT_ELEMENTS(cursor_list))
@@ -357,7 +357,7 @@ run(int argc, char *argv[])
     bool default_home, preserve;
 
     (void)testutil_set_progname(argv);
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
 
     default_home = true;
     preserve = false;

--- a/test/csuite/wt6185_modify_ts/main.c
+++ b/test/csuite/wt6185_modify_ts/main.c
@@ -336,7 +336,7 @@ main(int argc, char *argv[])
     (void)testutil_set_progname(argv);
     custom_die = trace_die;
 
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
     modify_repl_init();
 
     no_checkpoint = no_eviction = preserve = false;

--- a/test/csuite/wt6616_checkpoint_oldest_ts/main.c
+++ b/test/csuite/wt6616_checkpoint_oldest_ts/main.c
@@ -98,7 +98,7 @@ thread_ckpt_run(void *arg)
     char ts_string[WT_TS_HEX_STRING_SIZE];
     bool first_ckpt;
 
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
 
     conn = (WT_CONNECTION *)arg;
     /* Keep a separate file with the records we wrote for checking. */
@@ -306,7 +306,7 @@ main(int argc, char *argv[])
     testutil_work_dir_from_path(home, sizeof(home), working_dir);
     testutil_recreate_dir(home);
 
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
     if (rand_time) {
         timeout = __wt_random(&rnd) % MAX_TIME;
         if (timeout < MIN_TIME)

--- a/test/csuite/wt7989_compact_checkpoint/main.c
+++ b/test/csuite/wt7989_compact_checkpoint/main.c
@@ -263,7 +263,7 @@ thread_func_checkpoint(void *arg)
 
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     if (!td->stress_test) {
         /* Wait until both checkpoint and compact threads are ready to go. */
@@ -321,7 +321,7 @@ populate(WT_SESSION *session, const char *uri)
     WT_RAND_STATE rnd;
     uint64_t i, str_len, val;
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     str_len = sizeof(data_str) / sizeof(data_str[0]);
     for (i = 0; i < str_len - 1; i++)

--- a/test/csuite/wt8057_compact_stress/main.c
+++ b/test/csuite/wt8057_compact_stress/main.c
@@ -261,7 +261,7 @@ workload_compact(const char *home, const char *table_config)
     testutil_check(wiredtiger_open(home, &event_handler, conn_config, &conn));
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     /* Create and populate table. Checkpoint the data after that. */
     testutil_check(session->create(session, uri1, table_config));
@@ -346,7 +346,7 @@ populate(WT_SESSION *session, uint64_t start, uint64_t end)
 
     uint64_t i, str_len, val;
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     str_len = sizeof(data_str) / sizeof(data_str[0]);
     for (i = 0; i < str_len - 1; i++)

--- a/test/csuite/wt8246_compact_rts_data_correctness/main.c
+++ b/test/csuite/wt8246_compact_rts_data_correctness/main.c
@@ -324,7 +324,7 @@ large_updates(WT_SESSION *session, const char *uri, char *value, int commit_ts)
     char tscfg[64];
 
     retry_attempts = 0;
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
     testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
     testutil_snprintf(tscfg, sizeof(tscfg), "commit_timestamp=%d", commit_ts);
@@ -366,7 +366,7 @@ populate(WT_SESSION *session, const char *uri)
 
     printf("Populating table...\n");
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     str_len = sizeof(data_str) / sizeof(data_str[0]);
     for (i = 0; i < str_len - 1; i++)

--- a/test/csuite/wt8963_insert_stress/main.c
+++ b/test/csuite/wt8963_insert_stress/main.c
@@ -152,7 +152,7 @@ thread_insert_race(void *arg)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     testutil_check(session->open_cursor(session, opts->uri, NULL, NULL, &cursor));
 
-    __wt_random_init_seed((WT_SESSION_IMPL *)session, &rnd);
+    __wt_random_init((WT_SESSION_IMPL *)session, &rnd);
 
     /* Wait until all the threads are ready to go. */
     (void)__wt_atomic_add64(&ready_counter, 1);

--- a/test/cursor_order/cursor_order_ops.c
+++ b/test/cursor_order/cursor_order_ops.c
@@ -210,7 +210,7 @@ reverse_scan(void *arg)
     s = &run_info[id];
     cfg = s->cfg;
     testutil_check(__wt_thread_str(tid, sizeof(tid)));
-    __wt_random_init(&s->rnd);
+    __wt_random_init_default(&s->rnd);
 
     printf(" reverse scan thread %2" PRIuMAX " starting: tid: %s, file: %s\n", id, tid, s->name);
 
@@ -284,7 +284,7 @@ append_insert(void *arg)
     s = &run_info[id];
     cfg = s->cfg;
     testutil_check(__wt_thread_str(tid, sizeof(tid)));
-    __wt_random_init(&s->rnd);
+    __wt_random_init_default(&s->rnd);
 
     printf("write thread %2" PRIuMAX " starting: tid: %s, file: %s\n", id, tid, s->name);
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2630,11 +2630,6 @@ tasks:
             cd dist
             bash -x s_all -E 2>&1
 
-            # Run s_string with the "-r" option to remove no-longer-needed words from s_string.ok
-            # This is run separately from s_all as it can be too proactive when run as part of
-            # developers local workflow, but needs to be run in PR builds before the code is merged.
-            bash s_string -r 2>&1
-
   - name: s-outdated-fixmes
     # Detect any FIXME comments in the codebase tied to closed Jira tickets.
     # This will send a GET request to JIRA for each FIXME ticket so we don't

--- a/test/fops/fops.c
+++ b/test/fops/fops.c
@@ -98,7 +98,7 @@ fop(void *arg)
     __wt_yield(); /* Get all the threads created. */
 
     s = &run_stats[id];
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
 
     for (i = 0; i < nops; ++i, __wt_yield())
         switch (__wt_random(&rnd) % 9) {

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -249,8 +249,8 @@ main(int argc, char *argv[])
      * reading configuration. There may be random seeds in the configuration, however, so we will
      * reinitialize the RNGs later.
      */
-    __wt_random_init_seed(NULL, &g.data_rnd);
-    __wt_random_init_seed(NULL, &g.extra_rnd);
+    __wt_random_init_default(&g.data_rnd);
+    __wt_random_init_default(&g.extra_rnd);
 
     /* Initialize lock to ensure single threading during failure handling. */
     testutil_check(pthread_rwlock_init(&g.death_lock, NULL));

--- a/test/manydbs/manydbs.c
+++ b/test/manydbs/manydbs.c
@@ -200,7 +200,7 @@ main(int argc, char *argv[])
      */
     testutil_work_dir_from_path(home, HOME_SIZE, working_dir);
     testutil_recreate_dir(home);
-    __wt_random_init(&rnd);
+    __wt_random_init_default(&rnd);
     for (i = 0; i < dbs; ++i) {
         testutil_snprintf(hometmp, HOME_SIZE, "%s%c%s.%d", home, DIR_DELIM, HOME_BASE, i);
         testutil_recreate_dir(hometmp);

--- a/test/model/src/core/random.cpp
+++ b/test/model/src/core/random.cpp
@@ -37,7 +37,7 @@ namespace model {
  */
 random::random(uint64_t seed) noexcept
 {
-    __wt_random_init_custom_seed(&_random_state, seed);
+    __wt_random_init_seed(&_random_state, seed);
 }
 
 /*

--- a/test/thread/rw.c
+++ b/test/thread/rw.c
@@ -189,7 +189,7 @@ reader(void *arg)
     id = (int)(uintptr_t)arg;
     s = &run_info[id];
     testutil_check(__wt_thread_str(tid, sizeof(tid)));
-    __wt_random_init(&s->rnd);
+    __wt_random_init_default(&s->rnd);
 
     printf(" read thread %2d starting: tid: %s, file: %s\n", id, tid, s->name);
 
@@ -277,7 +277,7 @@ writer(void *arg)
     id = (int)(uintptr_t)arg;
     s = &run_info[id];
     testutil_check(__wt_thread_str(tid, sizeof(tid)));
-    __wt_random_init(&s->rnd);
+    __wt_random_init_default(&s->rnd);
 
     printf("write thread %2d starting: tid: %s, file: %s\n", id, tid, s->name);
 

--- a/test/utility/thread.c
+++ b/test/utility/thread.c
@@ -172,7 +172,7 @@ op_bulk_unique(void *arg)
 
     args = (TEST_PER_THREAD_OPTS *)arg;
     opts = args->testopts;
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
 
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
 
@@ -287,7 +287,7 @@ op_create_unique(void *arg)
 
     args = (TEST_PER_THREAD_OPTS *)arg;
     opts = args->testopts;
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
 
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
 
@@ -328,7 +328,7 @@ op_drop(void *arg)
 
     args = (TEST_PER_THREAD_OPTS *)arg;
     opts = args->testopts;
-    __wt_random_init_seed(NULL, &rnd);
+    __wt_random_init_default(&rnd);
 
     testutil_check(opts->conn->open_session(opts->conn, NULL, NULL, &session));
 

--- a/test/utility/util_random.c
+++ b/test/utility/util_random.c
@@ -40,7 +40,7 @@ testutil_random(WT_RAND_STATE *rnd)
     if (rnd != NULL) {
         return __wt_random(rnd);
     } else {
-        __wt_random_init_seed(NULL, &rnd_inner); /* The session argument is not required. */
+        __wt_random_init_default(&rnd_inner); /* The session argument is not required. */
         return __wt_random(&rnd_inner);
     }
 }
@@ -98,7 +98,7 @@ testutil_random_init(WT_RAND_STATE *rnd, uint64_t *seedp, uint32_t n)
          * time on some systems, and that leaves us with the same random seed. So we factor in a "n"
          * value from the caller to get up to 4 different random seeds.
          */
-        __wt_random_init_seed(NULL, rnd);
+        __wt_random_init_default(rnd);
         shift = 8 * (n % 4);
         *seedp = ((rnd->v >> shift) & 0xffffff);
     }


### PR DESCRIPTION
This PR fixes the issue where the session RNG returns the same sequence of numbers.

1. Because the session's `rnd` uses a carefully crafted initial seed to work best with skiplists, this PR introduces another per-session random generator for general purposes. To avoid confusion, these generators are given specific names: `rnd_skiplist` and `rnd_random`.

2. Functions have been renamed for better clarity and readability:
   * `__wt_random_init_seed` is renamed to `__wt_session_rng_init_once`, and its implementation is modified:
       * It will initialize the session's RNG at most once (using `WT_SESSION_FIRST_USE()`).
       * It requires `session->id` to be set before the call to this function.
       * `rnd_skiplist` is initialized the same way as before, maintaining the specialized seed.
       * `rnd_random` is initialized with a uniquely selected seed to ensure it never overlaps within the same application.
   * `__wt_random_init` is renamed to `__wt_random_init_default` to highlight that it uses the default seed.
   * `__wt_random_init_custom_seed` is renamed to `__wt_random_init_seed` for conciseness - since the user-supplied seed is always a "custom" one.

3. Removed unnecessary `volatile` keywords.

4. Other cleanup of no longer used code and macros.

The new test `test/csuite/random_session/test_random_session` attempts to reproduce the bug in two different ways:
1. It opens a session, generates a random number with its RNG and closes the session (in a loop). In this mode, in fact, the issue doesn't show up because the session's RNG is only initialized once and the same session object is getting reused.
2. Rapidly creates a bunch of sessions and generates a random number with their RNGs. This actually reproduces the issue in the `develop` branch but this PR fixes it.