### PR TITLE
WT-14113 Don't start the background migration server when live restore is already past the migration stage

### DIFF
--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -27,10 +27,11 @@ __live_restore_worker_check(WT_SESSION_IMPL *session)
  *     Clean up live restore metadata once background migration has completed. This will be called
  *     by the last background migration thread. In most cases, we'll enter this function on
  *     completion of background migration, but we also need to handle the case where we restart part
- *     way though the clean up.
+ *     way though the clean up. This function may be called by a thread using the default session.
+ *     We also provide a real session to perform the checkpoint.
  */
 static int
-__live_restore_clean_up(WT_SESSION_IMPL *session, WT_THREAD *ctx)
+__live_restore_clean_up(WT_SESSION_IMPL *session, WT_SESSION_IMPL *checkpoint_session)
 {
     WTI_LIVE_RESTORE_FS *lr_fs = (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system;
     const char *force_ckpt_cfg[] = {
@@ -49,7 +50,7 @@ __live_restore_clean_up(WT_SESSION_IMPL *session, WT_THREAD *ctx)
          * marking background migration complete. All empty bitmaps must be written to the metadata
          * durably first with the checkpoint.
          */
-        WT_RET(__wt_checkpoint_db(ctx->session, force_ckpt_cfg, true));
+        WT_RET(__wt_checkpoint_db(checkpoint_session, force_ckpt_cfg, true));
 
         uint64_t time_diff_ms;
         __wt_timer_evaluate_ms(session, &server->start_timer, &time_diff_ms);
@@ -76,7 +77,7 @@ __live_restore_clean_up(WT_SESSION_IMPL *session, WT_THREAD *ctx)
          * Run a second forced checkpoint now that clean up has finished. Checkpointing files on or
          * after the clean up stage will remove any bitmap strings from the metadata file.
          */
-        WT_RET(__wt_checkpoint_db(ctx->session, force_ckpt_cfg, true));
+        WT_RET(__wt_checkpoint_db(checkpoint_session, force_ckpt_cfg, true));
         WT_RET(__wti_live_restore_set_state(session, lr_fs, WTI_LIVE_RESTORE_STATE_COMPLETE));
 
         /* FALLTHROUGH */
@@ -110,14 +111,7 @@ __live_restore_worker_stop(WT_SESSION_IMPL *session, WT_THREAD *ctx)
              * If all the threads are stopped and the queue is empty, background migration is done.
              */
             if (TAILQ_EMPTY(&server->work_queue))
-                /*
-                 * FIXME-WT-14113 This is currently the only location where we call live restore
-                 * clean up, but it requires us to start up the background migration threads first.
-                 * When WiredTiger starts in a post-background migration state, we should call live
-                 * restore clean up directly instead of spinning up the server to eventually trigger
-                 * clean up.
-                 */
-                WT_ERR(__live_restore_clean_up(session, ctx));
+                WT_ERR(__live_restore_clean_up(session, ctx->session));
 
             /*
              * Future proofing: in general unless the conn is closing the queue must be empty if
@@ -362,6 +356,26 @@ __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char *cfg[])
         return (0);
 
     WT_CONNECTION_IMPL *conn = S2C(session);
+
+    /*
+     * We're currently using the default session. Create a real one for the clean up logic to
+     * perform checkpoints.
+     */
+    WT_SESSION_IMPL *checkpoint_session = NULL;
+
+    /*
+     * If background migration has already complete we don't need to start the background threads.
+     * Run the clean up logic regardless in case we've previously closed the connection at the exact
+     * time we finish migration, but before we call clean up.
+     */
+    if (__wti_live_restore_migration_complete(session)) {
+        WT_RET(__wt_open_internal_session(
+          conn, "live_restore_cleanup", false, 0, 0, &checkpoint_session));
+        WT_ERR(__live_restore_clean_up(session, checkpoint_session));
+        WT_ERR(__wt_session_close_internal(checkpoint_session));
+        return (0);
+    }
+
     WT_ERR(__wt_calloc_one(session, &conn->live_restore_server));
 
     /* Read the threads_max config, zero threads is valid in which case we don't do anything. */
@@ -401,6 +415,8 @@ __wt_live_restore_server_create(WT_SESSION_IMPL *session, const char *cfg[])
 
     if (0) {
 err:
+        if (checkpoint_session != NULL)
+            WT_TRET(__wt_session_close_internal(checkpoint_session));
         __wt_free(session, conn->live_restore_server);
     }
     return (ret);


### PR DESCRIPTION
If we start WiredTiger in live restore mode and the live restore state is already past the migration stage (i.e. CLEAN_UP or COMPLETE) the background migration server will spin up background threads just to immediately kill them. 
This change stops spawning the background threads when they aren't required.