### PR TITLE
WT-14327 Evaluate __wt_verbose_multi_* macro arguments once

### DIFF
--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -223,17 +223,23 @@ struct __wt_verbose_multi_category {
  *     Display a verbose message, given a set of multiple verbose categories. A verbose message will
  *     be displayed if at least one category in the set satisfies the required verbosity level.
  */
-#define __wt_verbose_level_multi(session, multi_category, level, fmt, ...)                      \
-    do {                                                                                        \
-        uint32_t __v_idx;                                                                       \
-        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                            \
-        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                          \
-            if (WT_VERBOSE_LEVEL_ISSET(session, __multi_category.categories[__v_idx], level)) { \
-                __wt_verbose_worker(                                                            \
-                  session, __multi_category.categories[__v_idx], level, fmt, __VA_ARGS__);      \
-                break;                                                                          \
-            }                                                                                   \
-        }                                                                                       \
+#define __wt_verbose_level_multi(session, multi_category, level, fmt, ...)                        \
+    do {                                                                                          \
+        uint32_t __v_idx;                                                                         \
+        /*                                                                                        \
+         * multi_category can be a ternary expression that returns one of two structs. If we call \
+         * it 3 times in this macro then we're evaluating that ternary 3 times and could return a \
+         * different value on a second call. Save it into a local variable to make sure we're     \
+         * working with a constant value.                                                         \
+         */                                                                                       \
+        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                              \
+        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                            \
+            if (WT_VERBOSE_LEVEL_ISSET(session, __multi_category.categories[__v_idx], level)) {   \
+                __wt_verbose_worker(                                                              \
+                  session, __multi_category.categories[__v_idx], level, fmt, __VA_ARGS__);        \
+                break;                                                                            \
+            }                                                                                     \
+        }                                                                                         \
     } while (0)
 
 /*
@@ -241,15 +247,21 @@ struct __wt_verbose_multi_category {
  *     Display a verbose message, given a set of multiple verbose categories using the default
  *     verbosity level.
  */
-#define __wt_verbose_multi(session, multi_category, fmt, ...)                      \
-    do {                                                                           \
-        uint32_t __v_idx;                                                          \
-        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;               \
-        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {             \
-            if (WT_VERBOSE_ISSET(session, __multi_category.categories[__v_idx])) { \
-                __wt_verbose_worker(session, __multi_category.categories[__v_idx], \
-                  WT_VERBOSE_LEVEL_DEFAULT, fmt, __VA_ARGS__);                     \
-                break;                                                             \
-            }                                                                      \
-        }                                                                          \
+#define __wt_verbose_multi(session, multi_category, fmt, ...)                                     \
+    do {                                                                                          \
+        uint32_t __v_idx;                                                                         \
+        /*                                                                                        \
+         * multi_category can be a ternary expression that returns one of two structs. If we call \
+         * it 3 times in this macro then we're evaluating that ternary 3 times and could return a \
+         * different value on a second call. Save it into a local variable to make sure we're     \
+         * working with a constant value.                                                         \
+         */                                                                                       \
+        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                              \
+        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                            \
+            if (WT_VERBOSE_ISSET(session, __multi_category.categories[__v_idx])) {                \
+                __wt_verbose_worker(session, __multi_category.categories[__v_idx],                \
+                  WT_VERBOSE_LEVEL_DEFAULT, fmt, __VA_ARGS__);                                    \
+                break;                                                                            \
+            }                                                                                     \
+        }                                                                                         \
     } while (0)

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -223,16 +223,17 @@ struct __wt_verbose_multi_category {
  *     Display a verbose message, given a set of multiple verbose categories. A verbose message will
  *     be displayed if at least one category in the set satisfies the required verbosity level.
  */
-#define __wt_verbose_level_multi(session, multi_category, level, fmt, ...)                    \
-    do {                                                                                      \
-        uint32_t __v_idx;                                                                     \
-        for (__v_idx = 0; __v_idx < multi_category.cnt; __v_idx++) {                          \
-            if (WT_VERBOSE_LEVEL_ISSET(session, multi_category.categories[__v_idx], level)) { \
-                __wt_verbose_worker(                                                          \
-                  session, multi_category.categories[__v_idx], level, fmt, __VA_ARGS__);      \
-                break;                                                                        \
-            }                                                                                 \
-        }                                                                                     \
+#define __wt_verbose_level_multi(session, multi_category, level, fmt, ...)                      \
+    do {                                                                                        \
+        uint32_t __v_idx;                                                                       \
+        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                            \
+        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                          \
+            if (WT_VERBOSE_LEVEL_ISSET(session, __multi_category.categories[__v_idx], level)) { \
+                __wt_verbose_worker(                                                            \
+                  session, __multi_category.categories[__v_idx], level, fmt, __VA_ARGS__);      \
+                break;                                                                          \
+            }                                                                                   \
+        }                                                                                       \
     } while (0)
 
 /*
@@ -240,14 +241,15 @@ struct __wt_verbose_multi_category {
  *     Display a verbose message, given a set of multiple verbose categories using the default
  *     verbosity level.
  */
-#define __wt_verbose_multi(session, multi_category, fmt, ...)                    \
-    do {                                                                         \
-        uint32_t __v_idx;                                                        \
-        for (__v_idx = 0; __v_idx < multi_category.cnt; __v_idx++) {             \
-            if (WT_VERBOSE_ISSET(session, multi_category.categories[__v_idx])) { \
-                __wt_verbose_worker(session, multi_category.categories[__v_idx], \
-                  WT_VERBOSE_LEVEL_DEFAULT, fmt, __VA_ARGS__);                   \
-                break;                                                           \
-            }                                                                    \
-        }                                                                        \
+#define __wt_verbose_multi(session, multi_category, fmt, ...)                      \
+    do {                                                                           \
+        uint32_t __v_idx;                                                          \
+        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;               \
+        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {             \
+            if (WT_VERBOSE_ISSET(session, __multi_category.categories[__v_idx])) { \
+                __wt_verbose_worker(session, __multi_category.categories[__v_idx], \
+                  WT_VERBOSE_LEVEL_DEFAULT, fmt, __VA_ARGS__);                     \
+                break;                                                             \
+            }                                                                      \
+        }                                                                          \
     } while (0)

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -506,6 +506,7 @@ typedef uint64_t wt_timestamp_t;
 #include "dhandle.h"      /* required by btree.h, connection.h */
 #include "timestamp.h"    /* required by reconcile.h */
 #include "thread_group.h" /* required by rollback_to_stable.h */
+#include "verbose.h"      /* required by rollback_to_stable.h */
 
 #include "api.h"
 #include "bitstring.h"
@@ -542,7 +543,6 @@ typedef uint64_t wt_timestamp_t;
 #include "tiered.h"
 #include "truncate.h"
 #include "txn.h"
-#include "verbose.h"
 
 #include "session.h" /* required by connection.h */
 #include "version.h" /* required by connection.h */


### PR DESCRIPTION
We often pass `WT_VERB_RECOVERY_RTS` into the `__wt_verbose_multi_*` macros as the `multi_category` argument, but `WT_VERB_RECOVERY_RTS` is a ternary under the hood so when we substitute `multi_category` into the macro we've evaluating the ternary in three separate locations. 

clang-analyzer raises a warning about this, as when `WT_VERB_RECOVERY_RTS` evaluates differently in different locations we can attempt a read past the end of the array. In the following code
```c
for (__v_idx = 0; __v_idx < multi_category.cnt; __v_idx++) {
    if (WT_VERBOSE_LEVEL_ISSET(session, multi_category.categories[__v_idx], level)) {
```
if `multi_category` first evaluates to a struct with two categories (`cnt == 2`) then `__v_idx` will iterate up to a value of 1. Then if `multi_category` evaluates to a single-category struct in the second occurrence then `multi_category.categories` is an array of length one and `__v_idx == 1` attempts to read past the end of the array.

The solution is to evaluate `multi_category` once and store the result into a local variable.