### PR TITLE
WT-14333 Fix live restore python tests to checkpoint tables

### DIFF
--- a/test/suite/test_live_restore02.py
+++ b/test/suite/test_live_restore02.py
@@ -74,6 +74,8 @@ class test_live_restore02(backup_base):
           key_format=self.key_format, value_format=self.value_format)
         ds2.populate()
 
+        self.session.checkpoint()
+
         # Close the default connection.
         os.mkdir("SOURCE")
         self.take_full_backup("SOURCE")

--- a/test/suite/test_live_restore03.py
+++ b/test/suite/test_live_restore03.py
@@ -51,6 +51,8 @@ class test_live_restore03(backup_base):
             key_format='i', value_format='S')
             ds.populate()
 
+        self.session.checkpoint()
+
         # Close the default connection.
         os.mkdir("SOURCE")
         self.take_full_backup("SOURCE")

--- a/test/suite/test_live_restore04.py
+++ b/test/suite/test_live_restore04.py
@@ -68,6 +68,8 @@ class test_live_restore04(backup_base):
                                value_format=self.value_format)
             ds.populate()
 
+        self.session.checkpoint()
+
         # Dump file data for later comparison.
         for i in range(self.ntables):
             dump_out = os.path.join(util_out_path, f'{uris[i]}.out')

--- a/test/suite/test_live_restore05.py
+++ b/test/suite/test_live_restore05.py
@@ -61,6 +61,8 @@ class test_live_restore05(backup_base):
                                value_format=self.value_format)
             ds.populate()
 
+        self.session.checkpoint()
+
         # Close the default connection.
         os.mkdir("SOURCE")
         self.take_full_backup("SOURCE")
@@ -88,4 +90,3 @@ class test_live_restore05(backup_base):
                 if index != -1:
                     new_line = line[index+len("live_restore="):]
                     assert(new_line.find("live_restore=") == -1)
-

--- a/test/suite/test_live_restore06.py
+++ b/test/suite/test_live_restore06.py
@@ -54,6 +54,8 @@ class test_live_restore06(backup_base):
             key_format='S', value_format='S')
             ds.populate()
 
+        self.session.checkpoint()
+
         os.mkdir("SOURCE")
         self.take_full_backup("SOURCE")
         self.close_conn()
@@ -117,4 +119,3 @@ class test_live_restore06(backup_base):
             if uri.find("file:") != -1:
                 self.assertTrue("nbits=0," in meta_cursor[uri])
         meta_cursor.close()
-


### PR DESCRIPTION
This adds a checkpoint after the populate phase for each live restore test to ensure the populated data is persisted to disk before taking the backup that is used for live restore.