### PR TITLE
WT-14119 Make sure all static functions in live restore check their return values

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -1686,7 +1686,7 @@ __live_restore_setup_lr_fh_file_data(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_
          */
         WT_RET(__live_restore_fs_open_in_source(lr_fs, session, lr_fh, flags));
         if (!dest_exist)
-            __live_restore_fs_create_destination_data_file(session, lr_fs, lr_fh, name);
+            WT_RET(__live_restore_fs_create_destination_data_file(session, lr_fs, lr_fh, name));
     }
     WT_RET(__live_restore_fs_open_in_destination(lr_fs, session, lr_fh, name, flags, !dest_exist));
     return (0);
@@ -1876,7 +1876,7 @@ __live_restore_fs_remove(
      * this file in the future. One such case is when a file is created, removed and then created
      * again with the same name.
      */
-    __live_restore_fs_create_stop_file(fs, session, name, flags);
+    WT_ERR(__live_restore_fs_create_stop_file(fs, session, name, flags));
 
 err:
     __wt_free(session, path);

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -123,7 +123,7 @@ __live_restore_get_state_from_file(
                 WT_ASSERT_ALWAYS(
                   session, false, "failed to parse live restore metadata from the turtle file!");
 
-            __live_restore_state_from_string(session, lr_metadata_string, &state_from_file);
+            WT_ERR(__live_restore_state_from_string(session, lr_metadata_string, &state_from_file));
         }
     }
 


### PR DESCRIPTION
WiredTiger annotates almost all of its functions with `WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result))` to make sure the compiler warns us when a function returns a value but we don't use or check that value.
However, we can't add this attribute to static functions and don't get warnings for mis-use of these functions.
This change is a manual review of all static functions in `src/live_restore` to properly check error returns for non-void static functions.