### PR TITLE
WT-14325 Skip syscall test if env issues detected

### DIFF
--- a/test/syscall/CMakeLists.txt
+++ b/test/syscall/CMakeLists.txt
@@ -10,3 +10,5 @@ create_test_executable(test_wt2336_base
 )
 
 add_test(NAME test_syscall COMMAND python3 ${CMAKE_CURRENT_BINARY_DIR}/syscall.py)
+
+set_tests_properties(test_syscall PROPERTIES SKIP_RETURN_CODE 3) # skip test in case of env errors

--- a/test/syscall/syscall.py
+++ b/test/syscall/syscall.py
@@ -199,8 +199,7 @@ pwrite_out = r'pwrite'
 env_known_issues = {
     'Darwin' : {
         "dtrace: system integrity protection is on, some features will not be available" :
-            "Impossible to trace system calls since MacOS SIP is enabled. Consider weakening SIP " +
-            "to enable system calls testing"
+            "Test skipped due to the inability to trace system calls since macOS SIP is enabled."
     }
 }
 

--- a/test/syscall/syscall.py
+++ b/test/syscall/syscall.py
@@ -127,7 +127,7 @@
 
 from __future__ import print_function
 import argparse, fnmatch, os, platform, re, shutil, \
-    subprocess, sys
+    subprocess, sys, enum
 
 # A class that represents a context in which predefined constants can be
 # set, and new variables can be assigned.
@@ -195,6 +195,28 @@ headpatterns = [ [ tracepat, 'trace_syscalls', 0],
 pwrite_in = r'pwrite64'
 pwrite_out = r'pwrite'
 
+# Known environments issues and messages with suggestions on how to fix them
+env_known_issues = {
+    'Darwin' : {
+        "dtrace: system integrity protection is on, some features will not be available" :
+            "Impossible to trace system calls since MacOS SIP is enabled. Consider weakening SIP " +
+            "to enable system calls testing"
+    }
+}
+
+# Return codes
+class TestReturnCode(enum.Enum):
+    SUCCESS = 0
+    FAILURE = 1
+    BAD_INPUT = 2
+    ENV_ISSUE = 3
+
+    def is_success(self):
+        return self == TestReturnCode.SUCCESS
+
+    def is_failure(self):
+        return self == TestReturnCode.FAILURE or self == TestReturnCode.BAD_INPUT
+
 # To create breakpoints while debugging this script
 def bp():
     import pdb
@@ -205,7 +227,7 @@ def msg(s):
 
 def die(s):
     msg(s)
-    sys.exit(1)
+    sys.exit(TestReturnCode.FAILURE.value)
 
 # If wttop appears as a prefix of pathname, strip it off.
 def simplify_path(wttop, pathname):
@@ -651,14 +673,25 @@ class Runner:
         self.fail(runline, 'unrecognized pattern in runfile:' + runline)
         return False
 
+    def match_env_error(self, errline):
+        system_known_issues = env_known_issues.get(self.args.systype)
+        if not system_known_issues:
+            return False # no issues to check on this OS
+
+        err_msg = system_known_issues.get(errline)
+        if err_msg:
+            print(err_msg)
+            return True
+
+        return False # no issues detected
+
     def match_lines(self):
         outfile = FileReader(self.wttopdir, self.outfilename, True)
         errfile = FileReader(self.wttopdir, self.errfilename, True)
 
         if outfile.readline():
             self.fail(None, 'output file has content, expected to be empty')
-            return False
-
+            return TestReturnCode.BAD_INPUT
         with outfile, errfile:
             runlines = self.order_runfile(self.runfile)
             errline = errfile.readline()
@@ -677,18 +710,17 @@ class Runner:
                 first_errline = errline
                 while errline and not self.match(runline, errline,
                                                  self.args.verbose, skiplines):
+                    if self.match_env_error(errline):
+                        return TestReturnCode.ENV_ISSUE
                     if skiplines or hasattr(errline, 'skip'):
                         errline = errfile.readline().normalize()
                     else:
-                        self.fail(runline, "expecting " + runline)
-                        self.failrange(errfile, first_errline, errline,
-                                       "does not match")
-                        return False
-                if not errline:
+                        break
+                if not errline or not self.match(runline, errline, self.args.verbose, skiplines):
                     self.fail(runline, "failed to match line: " + runline)
                     self.failrange(errfile, first_errline, errline,
                                    "does not match")
-                    return False
+                    return TestReturnCode.FAILURE
                 errline = errfile.readline()
                 if re.match(dtruss_init_pat, errline):
                     errline = errfile.readline()
@@ -696,8 +728,8 @@ class Runner:
                 skiplines = False
             if errline and not skiplines:
                 self.fail(errline, "extra lines seen starting at " + errline)
-                return False
-            return True
+                return TestReturnCode.FAILURE
+            return TestReturnCode.SUCCESS
 
     def order_runfile(self, f):
         # In OS X, dtruss is implemented using dtrace's apparently buffered
@@ -840,28 +872,28 @@ class SyscallCommand:
         return True
 
     def runone(self, runfilename, exedir, testexe, args):
-        result = True
+        result = TestReturnCode.SUCCESS
         runner = Runner(self.disttop, runfilename, exedir, testexe,
                         self.strace, args, self.variables, self.defines)
         okay, skip = runner.init(args.systype)
         if not okay:
             if not skip:
-                result = False
+                result = TestReturnCode.FAILURE
         else:
             if testexe:
                 print('running ' + testexe)
                 if not runner.run():
-                    result = False
-            if result:
+                    result = TestReturnCode.FAILURE
+            if result.is_success():
                 print('comparing:')
                 print('  ' + simplify_path(self.disttop, runfilename))
                 print('  ' + simplify_path(self.disttop, runner.errfilename))
                 result = runner.match_lines()
-                if not result and args.verbose:
+                if not result.is_success() and args.verbose:
                     printfile(runfilename, "runfile")
                     printfile(runner.errfilename, "trace output")
-        runner.close(not result)
-        if not result:
+        runner.close(result.is_failure())
+        if result.is_failure():
             print('************************ FAILED ************************')
             print('  see results in ' + exedir)
         print('')
@@ -928,12 +960,14 @@ class SyscallCommand:
 
     def execute(self):
         args = self.args
-        result = True
+        result = TestReturnCode.SUCCESS
         if not self.build_system_defines():
             die('cannot build system defines')
         if not self.dorun:
             for testname in args.tests:
-                result = self.runone(testname, None, None, args) and result
+                result = self.runone(testname, None, None, args)
+                if not result.is_success():
+                    break
         else:
             if len(args.tests) > 0:
                 tests = []
@@ -960,7 +994,12 @@ class SyscallCommand:
                             exedir += '.' + str(testnum)
                             testnum += 1
                         result = self.runone(runfilename, exedir,
-                                             testexe, args) and result
+                                             testexe, args)
+                        if not result.is_success():
+                            break
+        if result.is_failure():
+            print('For a HOW TO on debugging, see the top of syscall.py',
+                  file=sys.stderr)
         return result
 
 # Set paths, determining the top of the build.
@@ -987,9 +1026,7 @@ else:
 
 cmd = SyscallCommand(wt_disttop, wt_builddir)
 if not cmd.parse_args(sys.argv):
-    die('bad usage')
-if not cmd.execute():
-    print('For a HOW TO on debugging, see the top of syscall.py',
-          file=sys.stderr)
-    sys.exit(1)
-sys.exit(0)
+    print('Bad usage')
+    sys.exit(TestReturnCode.BAD_INPUT.value)
+
+sys.exit(cmd.execute().value)


### PR DESCRIPTION
Currently running simple `ctest` command on a non-preconfigured macOS system reports `test_syscall` failure because of Apple SIP system (enabled by default since OSX El Capitan) which restricts tracing system calls using `dtrace` tool.

The solution is to mark this test as "skipped" in this case instead of "failed" since generally speaking it is not a test failure (like detection of unexpected system call) but rather an absence of testing due to lack of required permissions. This commit also shows a message about the reason of the test being skipped.


<details>
  <summary>This is how it looked like before:</summary>
  
```
ivan.kochin@M-KXJQD73J73 build % ctest -R test_syscall                                                          
Test project /Users/ivan.kochin/work/git/wiredtiger/build
    Start 107: test_syscall
Password:

1/1 Test #107: test_syscall .....................***Failed    6.41 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   6.42 sec

The following tests FAILED:
	107 - test_syscall (Failed)
Errors while running CTest
Output from these tests are in: /Users/ivan.kochin/work/git/wiredtiger/build/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
ivan.kochin@M-KXJQD73J73 build % python3 ../test/syscall/syscall.py          
running /Users/ivan.kochin/work/git/wiredtiger/build/test/syscall/test_wt2336_base

comparing:
  test/syscall/wt2336_base/base.run
  build/test/syscall/WT_TEST.wt2336_base.0/stderr.txt
test/syscall/wt2336_base/base.run:57: expecting OUTPUT("--------------wiredtiger_open");
build/test/syscall/WT_TEST.wt2336_base.0/stderr.txt:1: does not match
  1: dtrace: system integrity protection is on, some features will not be available

************************ FAILED ************************
  see results in /Users/ivan.kochin/work/git/wiredtiger/build/test/syscall/WT_TEST.wt2336_base.0

For a HOW TO on debugging, see the top of syscall.py
```
  
</details>


<details>
  <summary>This is how it looks now:</summary>

```
ivan.kochin@M-KXJQD73J73 build % ctest -R test_syscall                                            
Test project /Users/ivan.kochin/work/git/wiredtiger/build
    Start 107: test_syscall
Password:

1/1 Test #107: test_syscall .....................***Skipped   5.63 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   5.64 sec

The following tests did not run:
	107 - test_syscall (Skipped)
ivan.kochin@M-KXJQD73J73 build % python3 ../test/syscall/syscall.py                                             
running /Users/ivan.kochin/work/git/wiredtiger/build/test/syscall/test_wt2336_base

comparing:
  test/syscall/wt2336_base/base.run
  build/test/syscall/WT_TEST.wt2336_base.0/stderr.txt
Test skipped due to the inability to trace system calls since macOS SIP is enabled.
```
</details>