### PR TITLE
WT-12806 Remove debug option table_logging from timestamp_abort

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -128,7 +128,7 @@ extern char *__wt_optarg;
 #define ENV_CONFIG_BASE                                       \
     "cache_size=%" PRIu32                                     \
     "M,create,"                                               \
-    "debug_mode=(table_logging=true,checkpoint_retention=5)," \
+    "debug_mode=(checkpoint_retention=5),"                    \
     "eviction_updates_target=20,eviction_updates_trigger=90," \
     "log=(enabled,file_max=10M,remove=%s),session_max=%d,"    \
     "statistics=(all),statistics_log=(wait=%d,json,on_close)"


### PR DESCRIPTION
The option debug option `table_logging` was enabled in WT-4712 to make debugging easier whenever the test was failing. While it makes sense to enable it to debug an issue, it adds enough contention during the test to make the system perform much slower. The changes disable that specific option. It is worth noting that this option is tested in other tests.