### PR TITLE
WT-14268 Disable table_logging for prepare_stress.py

### DIFF
--- a/bench/workgen/runner/prepare_stress.py
+++ b/bench/workgen/runner/prepare_stress.py
@@ -80,7 +80,6 @@ import time
 context = Context()
 conn_config =   "cache_size=1G,checkpoint=(wait=60,log_size=2GB),\
                 eviction=(threads_min=12,threads_max=12),log=(enabled=true),session_max=800,\
-                debug_mode=(table_logging=true),\
                 eviction_target=60,statistics=(fast),statistics_log=(wait=1,json)"# explicitly added
 conn = context.wiredtiger_open("create," + conn_config)
 s = conn.open_session("")


### PR DESCRIPTION
The prepare-stress workload generates 250 threads altogether to perform CRUD operations. The *table_logging** debugging option, explicity triggers all CRUD operations to write to log for debugging purposes. The 250 threads will all write to the logging subsystem. This creates contention within the logging system.

The fix is to disable table_logging, it is only used for debugging purposes and should not be enabled as part of a performance test.