### PR TITLE
WT-14231 Support taking a backup when live restore is in the complete stage

### DIFF
--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -26,6 +26,8 @@ struct __wt_live_restore_fh_meta {
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
+extern bool __wt_live_restore_migration_complete(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_clean_metadata_string(WT_SESSION_IMPL *session, char *value)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_fh_to_metadata(WT_SESSION_IMPL *session, WT_FILE_HANDLE *fh,

--- a/src/live_restore/live_restore.h
+++ b/src/live_restore/live_restore.h
@@ -26,7 +26,7 @@ struct __wt_live_restore_fh_meta {
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
-extern bool __wt_live_restore_migration_complete(WT_SESSION_IMPL *session)
+extern bool __wt_live_restore_migration_in_progress(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_live_restore_clean_metadata_string(WT_SESSION_IMPL *session, char *value)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -110,7 +110,7 @@ __live_restore_fs_create_stop_file(
     if (!reentrant)
         __wt_spin_lock(session, &lr_fs->state_lock);
 
-    if (__wti_live_restore_migration_complete(session)) {
+    if (__wt_live_restore_migration_complete(session)) {
         if (!reentrant)
             __wt_spin_unlock(session, &lr_fs->state_lock);
         return (0);
@@ -224,7 +224,7 @@ __live_restore_fs_find_layer(WT_FILE_SYSTEM *fs, WT_SESSION_IMPL *session, const
      * moved by the user. We can't depend on stop files here as post-migration clean up may have
      * deleted the stop file already.
      */
-    if (__wti_live_restore_migration_complete(session))
+    if (__wt_live_restore_migration_complete(session))
         return (0);
 
     WT_RET(__live_restore_fs_has_file(lr_fs, &lr_fs->source, session, name, &exists));
@@ -295,7 +295,7 @@ __live_restore_fs_directory_list_worker(WT_FILE_SYSTEM *fs, WT_SESSION *wt_sessi
      * Once we're past the background migration stage we never need to access the source directory
      * again.
      */
-    if (__wti_live_restore_migration_complete(session))
+    if (__wt_live_restore_migration_complete(session))
         goto done;
 
     /* Get files from source. */
@@ -1321,7 +1321,7 @@ __wt_live_restore_metadata_to_fh(
         return (0);
     } else if (lr_fh_meta->nbits > 0) {
         /* We shouldn't be reconstructing a bitmap if the live restore has finished. */
-        WT_ASSERT(session, !__wti_live_restore_migration_complete(session));
+        WT_ASSERT(session, !__wt_live_restore_migration_complete(session));
         __wt_verbose_debug3(session, WT_VERB_LIVE_RESTORE,
           "Reconstructing bitmap for %s, bitmap_sz %" PRId64 ", bitmap_str %s", fh->name,
           lr_fh_meta->nbits, lr_fh_meta->bitmap_str);
@@ -1394,8 +1394,9 @@ __wt_live_restore_clean_metadata_string(WT_SESSION_IMPL *session, char *value)
     WT_CONFIG_ITEM v;
     WT_DECL_RET;
 
-    /* FIXME-WT-14231 Allow taking backups during live restore in the COMPLETE phase. */
-    WT_ASSERT_ALWAYS(session, !F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS),
+    WT_ASSERT_ALWAYS(session,
+      !F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS) ||
+        __wt_live_restore_migration_complete(session),
       "Cleaning the metadata string should only be called for non-live restore file systems");
 
     ret = __wt_config_getones(session, value, "live_restore", &v);
@@ -1547,7 +1548,7 @@ __live_restore_fs_atomic_copy_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS
     char *buf = NULL, *source_path = NULL, *dest_path = NULL, *tmp_dest_path = NULL;
     bool dest_closed = false;
 
-    WT_ASSERT_ALWAYS(session, !__wti_live_restore_migration_complete(session),
+    WT_ASSERT_ALWAYS(session, !__wt_live_restore_migration_complete(session),
       "Attempting to atomically copy a file outside of the migration phase!");
 
     WT_ASSERT(session, type == WT_FS_OPEN_FILE_TYPE_LOG || type == WT_FS_OPEN_FILE_TYPE_REGULAR);
@@ -1749,7 +1750,7 @@ __live_restore_setup_lr_fh_file(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FS *l
      */
 
     bool dest_exist = false, have_stop = false,
-         check_source = !__wti_live_restore_migration_complete(session);
+         check_source = !__wt_live_restore_migration_complete(session);
 
     WT_RET_NOTFOUND_OK(
       __live_restore_fs_has_file(lr_fs, &lr_fs->destination, session, name, &dest_exist));

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -171,6 +171,8 @@ struct __wti_live_restore_server {
 
 extern WTI_LIVE_RESTORE_STATE __wti_live_restore_get_state(WT_SESSION_IMPL *session,
   WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wti_live_restore_migration_complete(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_cleanup_stop_files(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_fs_restore_file(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)

--- a/src/live_restore/live_restore_private.h
+++ b/src/live_restore/live_restore_private.h
@@ -171,8 +171,6 @@ struct __wti_live_restore_server {
 
 extern WTI_LIVE_RESTORE_STATE __wti_live_restore_get_state(WT_SESSION_IMPL *session,
   WTI_LIVE_RESTORE_FS *lr_fs) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern bool __wti_live_restore_migration_complete(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_cleanup_stop_files(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_live_restore_fs_restore_file(WT_FILE_HANDLE *fh, WT_SESSION *wt_session)

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -10,16 +10,32 @@
 #include "live_restore_private.h"
 
 /*
- * __wt_live_restore_migration_complete --
+ * __wti_live_restore_migration_complete --
  *     Return if live restore is past the background migration stage.
  */
 bool
-__wt_live_restore_migration_complete(WT_SESSION_IMPL *session)
+__wti_live_restore_migration_complete(WT_SESSION_IMPL *session)
 {
     WTI_LIVE_RESTORE_FS *lr_fs = (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system;
     WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
 
     return (state == WTI_LIVE_RESTORE_STATE_CLEAN_UP || state == WTI_LIVE_RESTORE_STATE_COMPLETE);
+}
+
+/*
+ * __wt_live_restore_migration_in_progress --
+ *     Return if live restore is in progress stage.
+ */
+bool
+__wt_live_restore_migration_in_progress(WT_SESSION_IMPL *session)
+{
+    /* If live restore is not enabled then no need to check its state. */
+    if (!F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+        return (false);
+    WTI_LIVE_RESTORE_FS *lr_fs = (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system;
+    WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);
+
+    return (state == WTI_LIVE_RESTORE_STATE_BACKGROUND_MIGRATION);
 }
 
 /*

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -29,7 +29,7 @@ __wti_live_restore_migration_complete(WT_SESSION_IMPL *session)
 bool
 __wt_live_restore_migration_in_progress(WT_SESSION_IMPL *session)
 {
-    /* If live restore is not enabled then no need to check its state. */
+    /* If live restore is not enabled then background migration is by definition not in progress. */
     if (!F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
         return (false);
     WTI_LIVE_RESTORE_FS *lr_fs = (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system;

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -10,11 +10,11 @@
 #include "live_restore_private.h"
 
 /*
- * __wti_live_restore_migration_complete --
+ * __wt_live_restore_migration_complete --
  *     Return if live restore is past the background migration stage.
  */
 bool
-__wti_live_restore_migration_complete(WT_SESSION_IMPL *session)
+__wt_live_restore_migration_complete(WT_SESSION_IMPL *session)
 {
     WTI_LIVE_RESTORE_FS *lr_fs = (WTI_LIVE_RESTORE_FS *)S2C(session)->file_system;
     WTI_LIVE_RESTORE_STATE state = __wti_live_restore_get_state(session, lr_fs);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -692,9 +692,9 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
             WT_RET(__wt_curmetadata_open(session, uri, owner, cfg, cursorp));
         break;
     case 'b':
-        /* FIXME-WT-14231 Allow taking backups when live restore is in the COMPLETE phase. */
         if (WT_PREFIX_MATCH(uri, "backup:")) {
-            if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS))
+            if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS) &&
+              !__wt_live_restore_migration_complete(session))
                 WT_RET_SUB(session, EINVAL, WT_CONFLICT_LIVE_RESTORE,
                   "backup cannot be taken when live restore is enabled");
             WT_RET(__wt_curbackup_open(session, uri, other, cfg, cursorp));

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -693,8 +693,7 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
         break;
     case 'b':
         if (WT_PREFIX_MATCH(uri, "backup:")) {
-            if (F_ISSET(S2C(session), WT_CONN_LIVE_RESTORE_FS) &&
-              !__wt_live_restore_migration_complete(session))
+            if (__wt_live_restore_migration_in_progress(session))
                 WT_RET_SUB(session, EINVAL, WT_CONFLICT_LIVE_RESTORE,
                   "backup cannot be taken when live restore is enabled");
             WT_RET(__wt_curbackup_open(session, uri, other, cfg, cursorp));

--- a/test/suite/test_live_restore06.py
+++ b/test/suite/test_live_restore06.py
@@ -99,7 +99,7 @@ class test_live_restore06(backup_base):
         meta_cursor.close()
 
         # Now take a backup of the destination.
-        # Test backups when live restore in the COMPLETE phase
+        # Test backups when live restore is in the COMPLETE phase
         self.do_backup_test("backup0","statistics=(all),live_restore=(enabled=true,path=\"SOURCE\")")
         # Test backups in non-live restore mode
         self.do_backup_test("backup1","statistics=(all),live_restore=(enabled=false)")

--- a/test/suite/test_live_restore06.py
+++ b/test/suite/test_live_restore06.py
@@ -99,20 +99,24 @@ class test_live_restore06(backup_base):
         meta_cursor.close()
 
         # Now take a backup of the destination.
-        # This requires opening a new connection in non-live restore mode
-        # FIXME-WT-14231 Add a testing for taking backups when live restore in the COMPLETE phase
-        self.reopen_conn(directory="DEST", config="statistics=(all),live_restore=(enabled=false)")
-        os.mkdir("backup")
+        # Test backups when live restore in the COMPLETE phase
+        self.do_backup_test("backup0","statistics=(all),live_restore=(enabled=true,path=\"SOURCE\")")
+        # Test backups in non-live restore mode
+        self.do_backup_test("backup1","statistics=(all),live_restore=(enabled=false)")
+
+    def do_backup_test(self, backup_dir, backup_conn_config):
+        self.reopen_conn(directory="DEST", config=backup_conn_config)
+        os.mkdir(backup_dir)
         backup_cursor = self.session.open_cursor("backup:")
-        self.take_full_backup("backup", backup_cursor, home=self.conn.get_home())
+        self.take_full_backup(backup_dir, backup_cursor, home=self.conn.get_home())
 
         # Assert that backup/WiredTiger.backup doesn't contain the nbits=-1 string.
         # The backup file is plain text so we can simply grep for the string
-        with open("backup/WiredTiger.backup", "r") as f:
+        with open(backup_dir + "/WiredTiger.backup", "r") as f:
             self.assertTrue("nbits=-1" not in f.read())
 
         # Now open the backup and check all files have been cleaned and contain nbits=0.
-        self.reopen_conn(directory="backup", config="statistics=(all),live_restore=(enabled=false)")
+        self.reopen_conn(directory=backup_dir, config="statistics=(all),live_restore=(enabled=false)")
         meta_cursor = self.session.open_cursor('metadata:', None, None)
         while meta_cursor.next() != 0:
             uri = meta_cursor.get_key()


### PR DESCRIPTION
This PR did below changes:
1. Allow opening a backup cursor when live restore is in the complete stage.
2. Allow taking backup in `__wt_live_restore_clean_metadata_string()`.
3. Change `__wti_live_restore_migration_complete()` to `__wt_live_restore_migration_complete()` as it is used externally.
4. Add a testing for taking backups when live restore in the COMPLETE phase for `test_live_restore06.py`.