### PR TITLE
WT-14140 Unnecessary schema lock taken for active file: dhandles that are not swept

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -14,6 +14,41 @@
       __wt_atomic_load32(&(dhandle)->references) == 0)
 
 /*
+ * __sweep_check_file_handle_exists --
+ *     Check if the file dhandle exists for the table dhandle.
+ */
+static int
+__sweep_check_file_handle_exists(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle)
+{
+    WT_DECL_RET;
+    WT_TABLE *table;
+
+    /*
+     * The sweep server's algorithm is altered to prevent unnecessary table dhandle closures. This
+     * is done by checking for associated file dhandles before marking table dhandles for sweeping.
+     * It resolves schema lock contention caused by repetitive table dhandle operations during
+     * MongoDB cursor activity on simple tables, and ensures table dhandles are retained for active
+     * file dhandles, which is required for file dhandle access.
+     */
+    table = (WT_TABLE *)dhandle;
+    if (table->is_simple && table->cg_complete) {
+        ret = __wt_conn_dhandle_find(session, table->cgroups[0]->source, NULL);
+
+        /*
+         * Reset the time of death if the file dhandle exists for the associated table dhandle.
+         */
+        if (ret == 0) {
+            dhandle->timeofdeath = 0;
+            return (1);
+        }
+        WT_ASSERT_ALWAYS(
+          session, ret == WT_NOTFOUND, "Connection dhandle find has returned an error.");
+    }
+
+    return (ret);
+}
+
+/*
  * __sweep_mark --
  *     Mark idle handles with a time of death, and note if we see dead handles.
  */
@@ -23,7 +58,6 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
-    WT_TABLE *table;
 
     conn = S2C(session);
 
@@ -47,30 +81,18 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
           __wt_atomic_loadi32(&dhandle->session_inuse) > 0 || dhandle->timeofdeath != 0)
             continue;
 
-        /*
-         * The sweep server's algorithm is altered to prevent unnecessary table dhandle closures.
-         * This is done by checking for associated file dhandles before marking table dhandles for
-         * sweeping. It resolves schema lock contention caused by repetitive table dhandle
-         * operations during MongoDB cursor activity on simple tables, and ensures table dhandles
-         * are retained for active file dhandles, which is required for file dhandle access.
-         */
+        /* For table dhandles, skip expiration if associated file dhandles exist. */
         if (dhandle->type == WT_DHANDLE_TYPE_TABLE) {
-            table = (WT_TABLE *)dhandle;
-            if (table->is_simple && table->cgroups != NULL) {
-                const char *uri = table->cgroups[0]->source;
-                WT_WITHOUT_DHANDLE(session,
-                  WT_WITH_HANDLE_LIST_READ_LOCK(
-                    session, (ret = __wt_conn_dhandle_find(session, uri, NULL))));
-
-                /* Continue if the file dhandle exists for the associated table dhandle. */
-                if (ret == 0) {
-                    dhandle->timeofdeath = 0;
-                    continue;
-                }
-                WT_ASSERT_ALWAYS(
-                  session, ret == WT_NOTFOUND, "Connection dhandle find has returned an error.");
-            }
+            WT_WITHOUT_DHANDLE(session,
+              WT_WITH_HANDLE_LIST_READ_LOCK(
+                session, (ret = __sweep_check_file_handle_exists(session, dhandle))));
         }
+
+        /* Continue if the file dhandle exists for the associated table dhandle. */
+        if (ret == 1) {
+            continue;
+        }
+
         /*
          * Never close out the history store handle via sweep. It can cause a deadlock if eviction
          * needs to re-open a handle to the history store while a checkpoint is getting started.

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -59,9 +59,10 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
         if (dhandle->type == WT_DHANDLE_TYPE_TABLE) {
             table = (WT_TABLE *)dhandle;
             if (table->is_simple && table->cgroups != NULL) {
+                const char *uri = table->cgroups[0]->source;
                 WT_WITHOUT_DHANDLE(session,
-                  WT_WITH_HANDLE_LIST_READ_LOCK(session,
-                    (ret = __wt_conn_dhandle_find(session, table->cgroups[0]->source, NULL))));
+                  WT_WITH_HANDLE_LIST_READ_LOCK(
+                    session, (ret = __wt_conn_dhandle_find(session, uri, NULL))));
 
                 /* Continue if the file dhandle exists for the associated table dhandle. */
                 if (ret == 0) {

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -20,9 +20,9 @@
 static void
 __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
 {
-    WT_DECL_RET;
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE *dhandle;
+    WT_DECL_RET;
     WT_TABLE *table;
 
     conn = S2C(session);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -48,12 +48,11 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
             continue;
 
         /*
-         * When MongoDB opens cursors on table URIs, WiredTiger opens and releases table dhandles,
-         * particularly for simple tables. This repetitive dhandle creation and release, handled by
-         * the sweep server, leads to schema lock contention. To prevent this, the below algorithm
-         * modifies the sweep server's behavior. The algorithm now checks if any file dhandles are
-         * associated with the table before marking a table dhandle for sweeping, thus preventing
-         * unnecessary closures.
+         * The sweep server's algorithm is altered to prevent unnecessary table dhandle closures.
+         * This is done by checking for associated file dhandles before marking table dhandles for
+         * sweeping. It resolves schema lock contention caused by repetitive table dhandle
+         * operations during MongoDB cursor activity on simple tables, and ensures table dhandles
+         * are retained for active file dhandles, which is required for file dhandle access.
          */
         if (dhandle->type == WT_DHANDLE_TYPE_TABLE) {
             table = (WT_TABLE *)dhandle;

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -88,9 +88,8 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
                 session, (ret = __sweep_check_file_handle_exists(session, dhandle))));
 
             /* Continue if the file dhandle exists for the associated table dhandle. */
-            if (ret == 0) {
+            if (ret == 0)
                 continue;
-            }
 
             WT_ASSERT_ALWAYS(
               session, ret == WT_NOTFOUND, "Connection dhandle find has returned an error.");

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -6,7 +6,6 @@
  * See the file LICENSE for redistribution information.
  */
 
-#include "wiredtiger.h"
 #include "wt_internal.h"
 
 #define WT_DHANDLE_CAN_DISCARD(dhandle)                           \

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -59,8 +59,8 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
             table = (WT_TABLE *)dhandle;
             if (table->is_simple) {
                 WT_WITHOUT_DHANDLE(session,
-                  WT_WITH_HANDLE_LIST_READ_LOCK(
-                    session, (ret = __wt_conn_dhandle_find(session, dhandle->name, NULL))));
+                  WT_WITH_HANDLE_LIST_READ_LOCK(session,
+                    (ret = __wt_conn_dhandle_find(session, table->cgroups[0]->source, NULL))));
 
                 /* Continue if the file dhandle exists for the associated table dhandle. */
                 if (ret == 0)

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -65,11 +65,11 @@ class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
         session.close()
 
     def test_dhandles(self):
+        if self.cursor_caching:
+            self.session.reconfigure('cache_cursors=true')
         for i in range(1,self.dhandles):
             uri = self.uri + str(i)
             self.session.create(uri, self.format)
-            if self.cursor_caching:
-                self.session.reconfigure('cache_cursors=true')
 
         for i in range(1,100):
             threads = []

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -41,7 +41,7 @@ class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
     tablebase = 'test_sweep06'
     uri = 'table:' + tablebase
     conn_config = 'file_manager=(close_handle_minimum=0,' + \
-                  'close_idle_time=60,close_scan_interval=30),'
+                  'close_idle_time=60,close_scan_interval=30),session_max=512'
 
     cursor_caching = [
         ('cursor_caching_disabled', dict(cursor_caching=False)),

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -36,7 +36,7 @@ from wiredtiger import stat
 from wtscenario import make_scenarios
 
 class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
-    dhandles = 1000
+    dhandles = 500
     format='key_format=i,value_format=S'
     tablebase = 'test_sweep06'
     uri = 'table:' + tablebase

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -32,6 +32,7 @@
 
 from suite_subprocess import suite_subprocess
 import wttest, threading
+from wiredtiger import stat
 
 class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
     dhandles = 1000
@@ -69,3 +70,11 @@ class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
             for thread in threads:
                 thread.join()
 
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        close1 = stat_cursor[stat.conn.dh_sweep_dead_close][2]
+        close2 = stat_cursor[stat.conn.dh_sweep_expired_close][2]
+        stat_cursor.close()
+
+        # The expectation is that no dhandles have been closed.
+        self.assertEqual(close1, 0)
+        self.assertEqual(close2, 0)

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -41,7 +41,7 @@ class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
     tablebase = 'test_sweep06'
     uri = 'table:' + tablebase
     conn_config = 'file_manager=(close_handle_minimum=0,' + \
-                  'close_idle_time=60,close_scan_interval=30),session_max=512'
+                  'close_idle_time=60,close_scan_interval=30),session_max=530'
 
     cursor_caching = [
         ('cursor_caching_disabled', dict(cursor_caching=False)),

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_sweep06.py
+# This test confirms that table dhandles are correctly retained and not
+# marked for sweep server expiry when file data dhandles are present.
+
+from suite_subprocess import suite_subprocess
+import wttest, threading
+
+class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
+    dhandles = 1000
+    format='key_format=i,value_format=S'
+    tablebase = 'test_sweep06'
+    uri = 'table:' + tablebase
+    conn_config = 'file_manager=(close_handle_minimum=0,' + \
+                  'close_idle_time=60,close_scan_interval=30),'
+
+    def insert(self, i, start, rows):
+        session = self.conn.open_session()
+        uri = self.uri + str(i)
+        cursor = session.open_cursor(uri)
+        session.begin_transaction()
+        for i in range(start, rows):
+            cursor.set_key(i)
+            cursor.set_value(str(i))
+            cursor.insert()
+        session.commit_transaction()
+        cursor.close()
+        session.close()
+
+    def test_dhandles(self):
+        for i in range(1,self.dhandles):
+            uri = self.uri + str(i)
+            self.session.create(uri, self.format)
+
+        for i in range(1,100):
+            threads = []
+            for i in range(1,self.dhandles):
+                thread = threading.Thread(target=self.insert, args=(i, 0, 100))
+                thread.start()
+                threads.append(thread)
+
+            for thread in threads:
+                thread.join()
+


### PR DESCRIPTION
This pull request has the changes to enhance sweep server's expiration logic, it will skip marking table dhandles for expiration if corresponding file dhandles exist, after verifying it's a simple table type.