### PR TITLE
WT-14354 Add documentation for wt list -f

### DIFF
--- a/src/docs/command-line.dox
+++ b/src/docs/command-line.dox
@@ -254,7 +254,7 @@ database.  If a URI is specified as an argument, only information about
 that data source is printed.
 
 @subsection util_list_synopsis Synopsis
-`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] list [-cv] [uri]`
+`wt [-BLmRrSVv] [-C config] [-E secretkey ] [-h directory] list [-cv] [-f output] [uri]`
 
 @subsection util_list_options Options
 The following are command-specific options for the \c list command:
@@ -262,6 +262,10 @@ The following are command-specific options for the \c list command:
 @par \c -c
 If the \c -c option is specified, the data source's checkpoints are printed
 in a human-readable format.
+
+@par \c -f
+By default, the \c list command output is written to the standard output;
+the \c -f option re-directs the output to the specified file.
 
 @par \c -v
 If the \c -v option is specified, the data source's complete schema table


### PR DESCRIPTION
`wt list -f` option was added by https://github.com/wiredtiger/wiredtiger/pull/11811. 

This PR is created to document this option on WT docs site.

That's how it looks like in built docs:

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/f27e132f-3799-4c8d-a785-6c019b4a789d" />
