### PR TITLE
WT-14317 Create macro which aborts when conn->close() returns an error code

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2765,6 +2765,9 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
     if (need_tracking)
         WT_TRET(__wt_meta_track_off(session, true, ret != 0));
 
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
+#endif
     return (ret);
 }
 

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -959,6 +959,7 @@ restart:
           WT_TRET(__wti_conn_dhandle_discard_single(session, true, F_ISSET(conn, WT_CONN_PANIC))));
     }
     WT_TAILQ_SAFE_REMOVE_END
+
     return (ret);
 }
 

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -893,7 +893,9 @@ __wti_conn_dhandle_discard_single(WT_SESSION_IMPL *session, bool final, bool mar
         WT_TRET(__conn_dhandle_destroy(session, dhandle, final));
         session->dhandle = NULL;
     }
-
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
+#endif
     return (ret);
 }
 
@@ -957,7 +959,6 @@ restart:
           WT_TRET(__wti_conn_dhandle_discard_single(session, true, F_ISSET(conn, WT_CONN_PANIC))));
     }
     WT_TAILQ_SAFE_REMOVE_END
-
     return (ret);
 }
 

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -125,6 +125,8 @@ err:
         if (next_ref != NULL)
             WT_TRET(__wt_page_release(session, next_ref, walk_flags));
     }
-
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
+#endif
     return (ret);
 }

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -846,6 +846,6 @@ struct __wt_sweep_cookie {
  *      Whenever conn->close encounters a non-zero return code, abort the process to track where it
  * came from. This is strictly to be used for debugging purposes.
  */
-#define WT_CONN_CLOSE_ABORT(s, ret)                     \
+#define WT_CONN_CLOSE_ABORT(s, ret)                                          \
     if (F_ISSET(S2C(s), WT_CONN_CLOSING) && (ret != 0) && (ret != WT_PANIC)) \
         __wt_abort(s);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -840,3 +840,12 @@ struct __wt_verbose_dump_cookie {
 struct __wt_sweep_cookie {
     uint64_t now;
 };
+
+/*
+ * WT_CONN_CLOSE_ABORT --
+ *      Whenever conn->close encounters a non-zero return code, abort the process to track where it
+ * came from. This is strictly to be used for debugging purposes.
+ */
+#define WT_CONN_CLOSE_ABORT(s, ret)                     \
+    if (F_ISSET(S2C(s), WT_CONN_CLOSING) && (ret != 0)) \
+        __wt_abort(s);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -847,5 +847,5 @@ struct __wt_sweep_cookie {
  * came from. This is strictly to be used for debugging purposes.
  */
 #define WT_CONN_CLOSE_ABORT(s, ret)                     \
-    if (F_ISSET(S2C(s), WT_CONN_CLOSING) && (ret != 0)) \
+    if (F_ISSET(S2C(s), WT_CONN_CLOSING) && (ret != 0) && (ret != WT_PANIC)) \
         __wt_abort(s);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -279,7 +279,9 @@ __session_close_cursors(WT_SESSION_IMPL *session, WT_CURSOR_LIST *cursors)
         WT_TRET(cursor->close(cursor));
     }
     WT_TAILQ_SAFE_REMOVE_END
-
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
+#endif
     return (ret);
 }
 
@@ -295,6 +297,9 @@ __session_close_cached_cursors(WT_SESSION_IMPL *session)
 
     for (i = 0; i < S2C(session)->hash_size; i++)
         WT_TRET(__session_close_cursors(session, &session->cursor_cache[i]));
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
+#endif
     return (ret);
 }
 
@@ -458,7 +463,9 @@ __wt_session_close_internal(WT_SESSION_IMPL *session)
     if (!internal_session)
         WT_TRET(__wt_call_log_print_return(conn, session, ret, ""));
 #endif
-
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
+#endif
     return (ret);
 }
 
@@ -1968,6 +1975,9 @@ err:
 
 #ifdef HAVE_CALL_LOG
     WT_TRET(__wt_call_log_rollback_transaction(session, config, ret));
+#endif
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
 #endif
     API_END_RET(session, ret);
 }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -464,7 +464,7 @@ __wt_session_close_internal(WT_SESSION_IMPL *session)
         WT_TRET(__wt_call_log_print_return(conn, session, ret, ""));
 #endif
 #ifdef HAVE_DIAGNOSTIC
-    WT_CONN_CLOSE_ABORT(session, ret);
+    WT_CONN_CLOSE_ABORT(&conn->dummy_session, ret);
 #endif
     return (ret);
 }

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -563,6 +563,9 @@ __wt_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_LSN 
     }
 
 err:
+#ifdef HAVE_DIAGNOSTIC
+    WT_CONN_CLOSE_ABORT(session, ret);
+#endif
     __wt_logrec_free(session, &logrec);
     return (ret);
 }


### PR DESCRIPTION
Currently we have BFs that occur due to an EBUSY error code returned from conn->close(). The ticket aims to add diagnostic information for when an EBUSY error code happens again. A new macro has been introduced which will check if the connection is closing and check if the return value is non-zero. If both conditions are met, we abort in an attempt to narrow down where the EBUSY could come from. In the pull request I have identified key areas that the new macro could catch an EBUSY error.