### PR TITLE
WT-14360 Fixup random generator (follow-up WT-13310)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1204,6 +1204,7 @@ rle
 rmw
 rnd
 rng
+rol
 rotN
 rotn
 rpc

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -43,11 +43,11 @@
  * we would like to preserve its current behavior.
  */
 #undef M_V
-#define M_V(r) r.v
+#define M_V(r) r->v
 #undef M_W
-#define M_W(r) r.x.w
+#define M_W(r) r->x.w
 #undef M_Z
-#define M_Z(r) r.x.z
+#define M_Z(r) r->x.z
 
 #ifdef ENABLE_ANTITHESIS
 #include "instrumentation.h"
@@ -56,6 +56,14 @@
 #define DEFAULT_SEED_W 521288629
 #define DEFAULT_SEED_Z 362436069
 
+/* Circular shift is converted by compilers to a "rol"-like CPU instruction. */
+#define WT_LEFT_CIRCULAR_SHIFT32(x, nbits) (((x) << (nbits)) | ((x) >> (32 - (nbits))))
+
+/* Make a seed from session id, time (in nanoseconds) and pid. */
+#define MAKE_SEED(id, t, pid)                                                           \
+    (((uint64_t)WT_LEFT_CIRCULAR_SHIFT32((uint64_t)(id) + 1, 3)) ^ ((t) / WT_BILLION) ^ \
+      ((t) % WT_BILLION) ^ (uint64_t)(pid))
+
 /*
  * __wt_random_init_default --
  *     Initialize a 32-bit pseudo-random number with a default seed.
@@ -63,12 +71,8 @@
 void
 __wt_random_init_default(WT_RAND_STATE *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    WT_RAND_STATE rnd;
-
-    M_W(rnd) = DEFAULT_SEED_W;
-    M_Z(rnd) = DEFAULT_SEED_Z;
-
-    *rnd_state = rnd;
+    M_W(rnd_state) = DEFAULT_SEED_W;
+    M_Z(rnd_state) = DEFAULT_SEED_Z;
 }
 
 /*
@@ -79,19 +83,19 @@ void
 __wt_random_init_seed(WT_RAND_STATE *rnd_state, uint64_t v)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    WT_RAND_STATE rnd;
-
     /*
      * XOR the provided seed with the initial seed. With high probability, this would provide a
      * random-looking seed which has about 50% of the bits turned on. We don't need to check whether
      * W or Z becomes 0, because we would handle it the first time we use this state to generate a
      * random number.
      */
-    M_V(rnd) = v;
-    M_W(rnd) ^= DEFAULT_SEED_W;
-    M_Z(rnd) ^= DEFAULT_SEED_Z;
-
-    *rnd_state = rnd;
+    M_V(rnd_state) = v;
+    /*
+     * These circular shift operations guarantee that the bits of the seed are mixed into the
+     * initial state. It guarantees good randomness even if the seeds are very close to each other.
+     */
+    M_W(rnd_state) ^= (uint32_t)(WT_LEFT_CIRCULAR_SHIFT32(v, 29) ^ DEFAULT_SEED_W);
+    M_Z(rnd_state) ^= (uint32_t)(WT_LEFT_CIRCULAR_SHIFT32(v, 27) ^ DEFAULT_SEED_Z);
 }
 
 /*
@@ -117,8 +121,8 @@ __wt_session_rng_init_once(WT_SESSION_IMPL *session) WT_GCC_FUNC_ATTRIBUTE((visi
     __wt_random_init_default(&session->rnd_skiplist);
 
     uint64_t t = __wt_clock(session);
-    __wt_random_init_seed(&session->rnd_random,
-      ((uint64_t)session->id + 1) * t / WT_BILLION + (t % WT_BILLION) + (uint64_t)getpid());
+    uint64_t seed = MAKE_SEED(session->id, t, getpid());
+    __wt_random_init_seed(&session->rnd_random, seed);
 }
 
 /*
@@ -131,18 +135,10 @@ __wt_random(WT_RAND_STATE *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility("default
 #ifdef ENABLE_ANTITHESIS
     return (uint32_t)(fuzz_get_random());
 #else
-    WT_RAND_STATE rnd;
     uint32_t w, z;
 
-    /*
-     * Generally, every thread should have their own RNG state, but it's not guaranteed. Take a copy
-     * of the random state so we can ensure that the calculation operates on the state consistently
-     * regardless of concurrent calls with the same random state.
-     */
-    rnd = *rnd_state;
-    WT_ACQUIRE_BARRIER();
-    w = M_W(rnd);
-    z = M_Z(rnd);
+    w = M_W(rnd_state);
+    z = M_Z(rnd_state);
 
     /*
      * Check if either of the two values goes to 0 (from which we won't recover), and reset it to
@@ -162,9 +158,8 @@ __wt_random(WT_RAND_STATE *rnd_state) WT_GCC_FUNC_ATTRIBUTE((visibility("default
     if (z == 0)
         z = DEFAULT_SEED_Z;
 
-    M_W(rnd) = w = 18000 * (w & 65535) + (w >> 16);
-    M_Z(rnd) = z = 36969 * (z & 65535) + (z >> 16);
-    *rnd_state = rnd;
+    M_W(rnd_state) = w = 18000 * (w & 65535) + (w >> 16);
+    M_Z(rnd_state) = z = 36969 * (z & 65535) + (z >> 16);
 
     return ((z << 16) + (w & 65535));
 #endif
@@ -182,6 +177,7 @@ __wt_random_init(WT_SESSION_IMPL *session, WT_RAND_STATE *rnd_state)
         __wt_random_init_seed(rnd_state, __wt_random(&session->rnd_random));
     else {
         uint64_t t = __wt_clock(session);
-        __wt_random_init_seed(rnd_state, t / WT_BILLION + (t % WT_BILLION) + (uint64_t)getpid());
+        uint64_t seed = MAKE_SEED(0, t, getpid());
+        __wt_random_init_seed(rnd_state, seed);
     }
 }

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -116,7 +116,8 @@ __wt_random_init_seed(WT_RAND_STATE *rnd_state, uint64_t v)
  *
  * session->id is used to seed the RNG. Since session objects have infinite lifetime, each session's
  *     RNG is seeded with a different value. This is mixed with the current time and the process ID
- *     to ensure that the RNG is different across runs.
+ *     to ensure that the RNG is different across runs. When the session is reset, the RNG is
+ *     preserved.
  *
  */
 void

--- a/src/support/rand.c
+++ b/src/support/rand.c
@@ -61,8 +61,8 @@
 
 /* Make a seed from session id, time (in nanoseconds) and pid. */
 #define MAKE_SEED(id, t, pid)                                                           \
-    (((uint64_t)WT_LEFT_CIRCULAR_SHIFT32((uint64_t)(id) + 1, 3)) ^ ((t) / WT_BILLION) ^ \
-      ((t) % WT_BILLION) ^ (uint64_t)(pid))
+    (((uint64_t)WT_LEFT_CIRCULAR_SHIFT32((uint64_t)(id) + 1, 3)) + ((t) / WT_BILLION) + \
+      ((t) % WT_BILLION) + (uint64_t)(pid))
 
 /*
  * __wt_random_init_default --

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -136,7 +136,7 @@ main(int argc, char *argv[])
         number = __wt_random(&((WT_SESSION_IMPL *)session)->rnd_random);
         testutil_check(session->close(session, NULL));
         if (opts.verbose)
-            printf("single: %3d: %5u %10u\n", i, (unsigned)number % 2048, (unsigned)number);
+            printf("single: %3d: %5u %10u\n", i, (u_int)number % 2048, (unsigned)number);
         if (i > 0) {
             if (number != prev_number)
                 diffs++;
@@ -169,7 +169,8 @@ main(int argc, char *argv[])
         for (int i = 0; i < N_SESSIONS; i++) {
             numbers[i] = number = __wt_random(&sessions[i]->rnd_random);
             if (opts.verbose)
-                printf("multi: %3d:%3d: %5u %10u\n", cycle, i, (unsigned)number % 2048, (unsigned)number);
+                printf(
+                  "multi: %3d:%3d: %5u %10u\n", cycle, i, (u_int)number % 2048, (unsigned)number);
         }
 
         /* The very first session is special because it's reused after the 'single' test above. */

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -136,7 +136,7 @@ main(int argc, char *argv[])
         number = __wt_random(&((WT_SESSION_IMPL *)session)->rnd_random);
         testutil_check(session->close(session, NULL));
         if (opts.verbose)
-            printf("single: %3d: %5u %10u\n", i, (u_int)number % 2048, (unsigned)number);
+            printf("single: %3d: %5u %10u\n", i, (u_int)number % 2048, (u_int)number);
         if (i > 0) {
             if (number != prev_number)
                 diffs++;
@@ -169,8 +169,7 @@ main(int argc, char *argv[])
         for (int i = 0; i < N_SESSIONS; i++) {
             numbers[i] = number = __wt_random(&sessions[i]->rnd_random);
             if (opts.verbose)
-                printf(
-                  "multi: %3d:%3d: %5u %10u\n", cycle, i, (u_int)number % 2048, (unsigned)number);
+                printf("multi: %3d:%3d: %5u %10u\n", cycle, i, (u_int)number % 2048, (u_int)number);
         }
 
         /* The very first session is special because it's reused after the 'single' test above. */

--- a/test/csuite/random_session/main.c
+++ b/test/csuite/random_session/main.c
@@ -39,7 +39,7 @@ static TEST_OPTS opts;
 
 /*
  * test_rng_seq --
- *     Test5 that 2 sequences are different.
+ *     Test that 2 sequences are different.
  */
 static void
 test_rng_seq(void)
@@ -66,7 +66,7 @@ test_rng_seq(void)
 
 /*
  * test_rng_init --
- *     Test5 that initialization with different seeds yields different starting points.
+ *     Test that initialization with different seeds yields different starting points.
  */
 static void
 test_rng_init(void)


### PR DESCRIPTION
This is a follow-up to **WT-13310**, addressing two key issues:
* Lack of randomness in the seed, which could lead to predictable or poor-quality sequences.
* Insufficient randomness in the low bits of the generated numbers, which affects randomness of selection via modulo.

Multiple tests were performed and added in this PR to ensure:
* Good randomness of each sequence
* Good randomness across sessions
* Good randomness across executions
* Good randomness in low bits (modulo 2048, 256, etc)