### PR TITLE
WT-13585 wt_cmp_dir - fix handling WT logs output during check execution

### DIFF
--- a/tools/wt_cmp_dir
+++ b/tools/wt_cmp_dir
@@ -56,20 +56,20 @@ init_wt_utility() {
 }
 
 wtfiles() {
-    local tmpa=/tmp/wcd$$a
-    local tmpb=/tmp/wcd$$b
+    local tmpout=/tmp/wcd$$out
+    local tmperr=/tmp/wcd$$err
 
     #TODO: check for corruption
-    $wt -h "$1" list >$tmpa 2>$tmpb
-    if [ "$?" != 0 -o -s $tmpb ]; then
+    $wt -h "$1" list -f $tmpout > /dev/null 2>$tmperr
+    if [ "$?" != 0 -o -s $tmperr ]; then
         echo failed command: $wt -h "$1" list >&2
-        cat $tmpb
-        rm -f $tmpa $tmpb
+        cat $tmperr
+        rm -f $tmpout $tmperr
         exit 1
     fi
     # The uris are a simple list, for example: "colgroup:table1 file:table1.wt table:table1"
-    uris=$(cat $tmpa)
-    rm -f $tmpa $tmpb
+    uris=$(cat $tmpout)
+    rm -f $tmpout $tmperr
     results=""
     for uri in $uris; do
         case "$uri" in


### PR DESCRIPTION
Currently, if some log output occurs during the execution of the wt_cmp_dir script, the script fails because it mixes the output of the `wt list` internal call and the log output. This PR fixes it by redirecting `wt list` output to the specified file and redirecting all the unrelated output during these checks to `/dev/null`.

The original issue doesn't reproduce on the default CI. Please see the corresponding Jira ticket for testing proofs.