### PR TITLE
WT-12806 Increase wait time for checkpoint file creation timestamp_abort

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -72,7 +72,7 @@ static char home[1024]; /* Program working dir */
 #define MAX_BACKUP_INVL 4 /* Maximum interval between backups */
 #define MAX_CKPT_INVL 5   /* Maximum interval between checkpoints */
 #define MAX_TH 200        /* Maximum configurable threads */
-#define MAX_TIME 40
+#define MAX_TIME 120
 #define MAX_VAL 1024
 #define MIN_TH 5
 #define MIN_TIME 10


### PR DESCRIPTION
WT-3515 introduces this and I was able to reproduce from that commit. The original intention of why that code was added is because of this:
```
The child checkpoint thread got the error on the first checkpoint and never created the file that parent is looking for. So the parent hung. One fix is to have the parent wait up to MAX_TIME for that file to appear and error if it doesn't appear by then.
```

For the checkpoint file to be created it needs to first perform a checkpoint and the stable timestamp has been moved at least once. The expected 40 seconds is too strict when there are 200 threads are multiple intentional delays done inside the test. Here is a breakdown of all things that can slow down the first checkpoint or the setting the stable timestamp:
* Timing stress for prepare_checkpoint_delay
* Before first checkpoint, we can sleep up to 5 seconds
* Wait for transactions to commit so that stable timestamp can move forward
* All 200 threads are waiting to write their entries in the lob subsystem

On top of all the requirements, we are running on the rhel8 machines which are known to be much slower than other machines. 

The original reason why we implemented a 40 seconds wait time is to make sure we don't hang if the first checkpoint file was never created. We do not need to be as strict for the test. Therefore I will be increasing the number of seconds to 120. 
