### PR TITLE
WT-14364 Add missing comma to wt list -f description

### DIFF
--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -22,7 +22,7 @@ usage(void)
     static const char *options[] = {"-c",
       "display checkpoints in human-readable format (by default checkpoints are not displayed)",
       "-f output",
-      "redirect output to the specified file (the default is stdout)"
+      "redirect output to the specified file (the default is stdout)",
       "-v",
       "display the complete schema table (by default only a subset is displayed)", "-?",
       "show this message", NULL, NULL};

--- a/src/utilities/util_list.c
+++ b/src/utilities/util_list.c
@@ -21,9 +21,7 @@ usage(void)
 {
     static const char *options[] = {"-c",
       "display checkpoints in human-readable format (by default checkpoints are not displayed)",
-      "-f output",
-      "redirect output to the specified file (the default is stdout)",
-      "-v",
+      "-f output", "redirect output to the specified file (the default is stdout)", "-v",
       "display the complete schema table (by default only a subset is displayed)", "-?",
       "show this message", NULL, NULL};
 


### PR DESCRIPTION
I missed this comma in the previous PR. Thanks Coverity for noticing this.