### PR TITLE
WT-14259 Require statistics are enabled when running in live restore mode

### DIFF
--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -312,6 +312,12 @@ __wti_conn_statistics_config(WT_SESSION_IMPL *session, const char *cfg[])
     flags = 0;
     set = 0;
     if ((ret = __wt_config_subgets(session, &cval, "none", &sval)) == 0 && sval.val != 0) {
+        if (F_ISSET(conn, WT_CONN_LIVE_RESTORE_FS))
+            /*
+             * Live restore uses statistics to inform the user when migration has completed. They
+             * must be enabled.
+             */
+            WT_RET_MSG(session, EINVAL, "Statistics must be enabled when live restore is active.");
         flags = 0;
         ++set;
     }

--- a/test/catch2/live_restore/live_restore_test_env.cpp
+++ b/test/catch2/live_restore/live_restore_test_env.cpp
@@ -47,8 +47,8 @@ live_restore_test_env::live_restore_test_env()
     }
 
     testutil_remove(DB_DEST.c_str());
-    static std::string cfg_string =
-      "create=true,live_restore=(enabled=true, path=" + DB_SOURCE + ",threads_max=0)";
+    static std::string cfg_string = "create=true,live_restore=(enabled=true, path=" + DB_SOURCE +
+      ",threads_max=0),statistics=(fast)";
     conn = std::make_unique<connection_wrapper>(DB_DEST.c_str(), cfg_string.c_str());
 
     session = conn->create_session();


### PR DESCRIPTION
Live restore needs statistics to be turned on, otherwise we can't report to the user when live restore has completed and the user can restart in non-live restore mode or start taking new backups.