### PR TITLE
SLS-1908 Fix read ordering for eviction check

### DIFF
--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -114,11 +114,7 @@ __wt_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *bloc
     page_id = block_meta->page_id;
     /* Get the checkpoint ID. */
     WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
-    /*
-     * TODO: revisit this in SLS-1908. It exists a race that will cause eviction to write with an
-     * old checkpoint id.
-     */
-    WT_ASSERT_ALWAYS(session, checkpoint_id >= block_meta->checkpoint_id,
+    WT_ASSERT_ALWAYS(session, checkpoint_id == block_meta->checkpoint_id,
       "The page checkpoint id doesn't match the current checkpoint id");
     /* Check that we are the leader (only leaders can write). */
     WT_ASSERT_ALWAYS(

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2108,9 +2108,9 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * before we set the checkpoint running flag to false.
      */
     if (modified && F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !WT_SESSION_BTREE_SYNC(session)) {
-        WT_ACQUIRE_READ(checkpoint_gen, &btree->checkpoint_gen);
+        WT_ACQUIRE_READ(checkpoint_gen, btree->checkpoint_gen);
         if (checkpoint_gen == __wt_gen(session, WT_GEN_CHECKPOINT)) {
-            WT_ACQUIRE_READ(checkpoint_running, &S2C(session)->txn_global.checkpoint_running)
+            WT_ACQUIRE_READ(checkpoint_running, S2C(session)->txn_global.checkpoint_running);
             if (checkpoint_running)
                 return (false);
         }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2111,7 +2111,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
         WT_ACQUIRE_READ(checkpoint_gen, &btree->checkpoint_gen);
         if (checkpoint_gen == __wt_gen(session, WT_GEN_CHECKPOINT)) {
             WT_ACQUIRE_READ(checkpoint_running, &S2C(session)->txn_global.checkpoint_running)
-            return (false);
+            if (checkpoint_running)
+                return (false);
         }
     }
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -275,7 +275,7 @@ __checkpoint_update_generation(WT_SESSION_IMPL *session)
     if (WT_IS_METADATA(session->dhandle))
         return;
 
-    WT_RELEASE_WRITE_WITH_BARRIER(btree->checkpoint_gen, __wt_gen(session, WT_GEN_CHECKPOINT));
+    WT_RELEASE_WRITE(btree->checkpoint_gen, __wt_gen(session, WT_GEN_CHECKPOINT));
     WT_STAT_DSRC_SET(session, btree_checkpoint_generation, btree->checkpoint_gen);
 }
 
@@ -1646,7 +1646,7 @@ __txn_checkpoint_wrapper(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
 
-    __wt_atomic_storevbool(&txn_global->checkpoint_running, true);
+    WT_RELEASE_WRITE(&txn_global->checkpoint_running, true);
 
     /*
      * FIXME-WT-11149: Some reading threads rely on the value of checkpoint running flag being
@@ -1657,7 +1657,7 @@ __txn_checkpoint_wrapper(WT_SESSION_IMPL *session, const char *cfg[])
 
     ret = __txn_checkpoint(session, cfg);
 
-    __wt_atomic_storevbool(&txn_global->checkpoint_running, false);
+    WT_RELEASE_WRITE(&txn_global->checkpoint_running, false);
 
     /*
      * Signal the tiered storage thread because it waits for the checkpoint to complete to process

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1646,7 +1646,7 @@ __txn_checkpoint_wrapper(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
 
-    WT_RELEASE_WRITE(&txn_global->checkpoint_running, true);
+    WT_RELEASE_WRITE(txn_global->checkpoint_running, (bool)true);
 
     /*
      * FIXME-WT-11149: Some reading threads rely on the value of checkpoint running flag being
@@ -1657,7 +1657,7 @@ __txn_checkpoint_wrapper(WT_SESSION_IMPL *session, const char *cfg[])
 
     ret = __txn_checkpoint(session, cfg);
 
-    WT_RELEASE_WRITE(&txn_global->checkpoint_running, false);
+    WT_RELEASE_WRITE(txn_global->checkpoint_running, (bool)false);
 
     /*
      * Signal the tiered storage thread because it waits for the checkpoint to complete to process


### PR DESCRIPTION
My brain explodes when thinking about this. I feel what I do is still not enough.

I believe __wt_gen and WT_SESSION_BTREE_SYNC(session) should also use an acquire read internally. However, that will be a bigger change.