### PR TITLE
WT-12012 Restore original verbose levels if gen_drain becomes unstuck after increasing verbose levels (v7.0 backport)

### DIFF
--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -131,6 +131,19 @@ struct __wt_verbose_multi_category {
 #define WT_VERBOSE_ISSET(session, category) \
     WT_VERBOSE_LEVEL_ISSET(session, category, WT_VERBOSE_LEVEL_DEFAULT)
 
+/* Set the verbose level and save the previous value. */
+#define WT_VERBOSE_SET_AND_SAVE(session, verbose_orig_level, category, level) \
+    do {                                                                      \
+        verbose_orig_level[category] = S2C(session)->verbose[category];       \
+        WT_SET_VERBOSE_LEVEL(session, category, level);                       \
+    } while (0)
+
+/* Restore the original level  */
+#define WT_VERBOSE_RESTORE(session, verbose_orig_level, category)              \
+    do {                                                                       \
+        WT_SET_VERBOSE_LEVEL(session, category, verbose_orig_level[category]); \
+    } while (0)
+
 /*
  * __wt_verbose_level --
  *     Display a verbose message considering a category and a verbosity level.


### PR DESCRIPTION
(cherry picked from commit 8b909411846e25fd119431d57bd990d03e7ba45a)