### PR TITLE
WT-14385 Avoid propagating error on exit setting from find_cmake.sh

### DIFF
--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -o errexit  # Exit the script with error if any of the commands fail
 
 # CMake version we fallback to and download when cmake doesn't exist on the
 # host system.
@@ -12,6 +11,10 @@ CMAKE_VERSION=$CMAKE_MAJOR_VER.$CMAKE_MINOR_VER.$CMAKE_PATCH_VER
 #   https://github.com/mongodb/mongo-c-driver/blob/master/.evergreen/find-cmake.sh
 find_cmake ()
 {
+    # Setting a trap so the function ends after the first error occurs.
+    # The trap should be cleaned up after both successful and failed executions.
+    trap 'echo "Error occurred in find_cmake()"; trap - ERR; return 1' ERR
+
     if [ -n "$CMAKE" ]; then
         return 0
     elif [ -f "/opt/mongodbtoolchain/v4/bin/cmake" ]; then
@@ -83,6 +86,8 @@ find_cmake ()
     ${CMAKE} --version
     ${CTEST} --version
     echo "=========================================================="
+
+    trap - ERR
 }
 
 find_cmake

--- a/test/evergreen/find_cmake.sh
+++ b/test/evergreen/find_cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # CMake version we fallback to and download when cmake doesn't exist on the
 # host system.


### PR DESCRIPTION
### Summary

Currently `find_cmake.sh` script contains `set -o errexit` setting which causes exit of the whole script if any issue occurs during its execution. This script is intended to be used in sourcing mode (e.g. . ./find_cmake.sh) and because of that, this setting is not a good choice for this script for two reasons:

- In this mode if any issue occurs this setting exits not only the script, but the shell that was executing this script
- Even if execution was successful this setting is propagated to the shell that was executing this script and stays enabled there even after script execution which causes exit from this shell on the next issue (any unsuccessful shell command).

### Different solutions to consider
#### Use `trap` instead of `set -o errexit` to intercept errors and call return instead of exit
This is current solution that is represented in this PR. AFAIK it provides similar effect of exiting from the function but without calling exit. Also, I managed to remove this trap on exit in both success and failure cases.

The only possible issue is that if before execution of this script trap was already set it will be overwritten and not restored after the execution. It can be solved by remembering the trap that was set before and restoring it after script execution ends, but it does require additional logic so I decided not to do it since the probability of such scenario is quite low from my point of view.

It also requires using `bash` instead of `sh` ERR trap pseudo-signal support.

#### Use `set -o errexit` from a subshell
At first glance, this looks simpler than trapping errors. But the problem is that the main purpose of this script is to set `CMAKE` and `CTEST` variables and all the variables set inside the subshell aren't propagated to the calling shell. So, in this case the only option is to run this subshell inside a bash function and then if cmake is detected report path to cmake using `echo` and then read this output in place where this function was called. This also sounds like a good option for me and doesn't overwrite any trap (as previous option does) but requires more code to be changed and more testing to be done.

#### Manually check error codes for all commands we care about in this script
This option means avoid using `trap` or `set -o errexit` but manual checking of the return codes of some most important parts of the script e.g. by the following way:

```
        curl --retry 5 https://cmake.org/files/v$CMAKE_MAJOR_VER.$CMAKE_MINOR_VER/cmake-$CMAKE_VERSION.tar.gz -sS --max-time 120 --fail --output cmake.tar.gz || return
        tar xzf cmake.tar.gz || return
        cd cmake-$CMAKE_VERSION || return
        ./bootstrap --prefix="${CMAKE_INSTALL_DIR}" || return
        make -j8 || return
        make install || return
```

So, all the lines that contain ` || return` will mean end of the function execution in case of non-zero return code.

For example, mongoDB C driver uses this solution in the corresponding find cmake script: https://github.com/mongodb/mongo-c-driver/blob/fee885a3a4a994175dc29b7f6aee085a634ef280/.evergreen/scripts/find-cmake-version.sh

The only drawback of this option is that we need to manually decide whether we need to check this function error output or not.

