### PR TITLE
WT-14387 Update vcvars64.bat path in Windows buildscript

### DIFF
--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -1,7 +1,7 @@
 param (
     [bool]$configure = $false,
     [bool]$build = $false,
-    [string]$vcvars_bat = "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
+    [string]$vcvars_bat = "C:\Program Files\Microsoft Visual Studio\2022\VC\Auxiliary\Build\vcvars64.bat"
 )
 
 function Die-On-Failure {


### PR DESCRIPTION
Our windows machines have been updated and removed the old vcvard64.bat path on our Windows hosts. This uses the new path