### PR TITLE
Add error origin tracing capability

### DIFF
--- a/src/block/block_addr.c
+++ b/src/block/block_addr.c
@@ -165,7 +165,7 @@ __wt_block_addr_invalid(
 
     /* Check if the address is past the end of the file. */
     if (objectid == block->objectid && offset + size > block->size)
-        WT_RET_MSG(session, EINVAL, "address is past the end of the file");
+        WT_RET_MSG(session, WT_E(EINVAL), "address is past the end of the file");
     return (0);
 }
 
@@ -209,7 +209,7 @@ __block_ckpt_unpack(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *ck
 
     ci->version = ckpt[0];
     if (ci->version != WT_BM_CHECKPOINT_VERSION)
-        WT_RET_MSG(session, WT_ERROR, "unsupported checkpoint version");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "unsupported checkpoint version");
 
     /*
      * See the comment above about address cookies and sizes for an explanation.
@@ -289,7 +289,7 @@ __wti_block_ckpt_pack(
     uint64_t a;
 
     if (ci->version != WT_BM_CHECKPOINT_VERSION)
-        WT_RET_MSG(session, WT_ERROR, "unsupported checkpoint version");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "unsupported checkpoint version");
 
     (*pp)[0] = ci->version;
     (*pp)++;

--- a/src/block/block_ckpt.c
+++ b/src/block/block_ckpt.c
@@ -97,7 +97,7 @@ __wt_block_checkpoint_load(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint
         live_open = block->live_open;
         block->live_open = true;
         __wt_spin_unlock(session, &block->live_lock);
-        WT_ERR_ASSERT(session, WT_DIAGNOSTIC_CHECKPOINT_VALIDATE, live_open == false, EBUSY,
+        WT_ERR_ASSERT(session, WT_DIAGNOSTIC_CHECKPOINT_VALIDATE, live_open == false, WT_E(EBUSY),
           "%s: attempt to re-open live file", block->name);
 
         ci = &block->live;
@@ -246,7 +246,7 @@ __wt_block_checkpoint_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
     case WT_CKPT_INPROGRESS:
     case WT_CKPT_PANIC_ON_FAILURE:
     case WT_CKPT_SALVAGE:
-        ret = __wt_panic(session, EINVAL,
+        ret = __wt_panic(session, WT_E(EINVAL),
           "%s: an unexpected checkpoint start: the checkpoint has already started or was "
           "configured for salvage",
           block->name);
@@ -619,7 +619,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
         break;
     case WT_CKPT_NONE:
     case WT_CKPT_PANIC_ON_FAILURE:
-        ret = __wt_panic(session, EINVAL,
+        ret = __wt_panic(session, WT_E(EINVAL),
           "%s: an unexpected checkpoint attempt: the checkpoint was never started or has already "
           "completed",
           block->name);
@@ -684,7 +684,7 @@ __ckpt_process(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase)
          */
         if (next_ckpt->bpriv == NULL && !F_ISSET(next_ckpt, WT_CKPT_ADD)) {
             WT_ERR(__ckpt_extlist_read(session, block, next_ckpt, &local));
-            WT_ERR_ASSERT(session, WT_DIAGNOSTIC_CHECKPOINT_VALIDATE, local == true, WT_PANIC,
+            WT_ERR_ASSERT(session, WT_DIAGNOSTIC_CHECKPOINT_VALIDATE, local == true, WT_E(WT_PANIC),
               "tiered storage checkpoint follows local checkpoint");
         }
     }
@@ -887,7 +887,7 @@ live_update:
         a = &block->live;
     if (a->discard.entries != 0)
         WT_ERR_MSG(
-          session, WT_ERROR, "first checkpoint incorrectly has blocks on the discard list");
+          session, WT_E(WT_ERROR), "first checkpoint incorrectly has blocks on the discard list");
 #endif
 
 err:
@@ -1047,7 +1047,7 @@ __wt_block_checkpoint_resolve(WT_SESSION_IMPL *session, WT_BLOCK *block, bool fa
         goto done;
     case WT_CKPT_NONE:
     case WT_CKPT_SALVAGE:
-        ret = __wt_panic(session, EINVAL,
+        ret = __wt_panic(session, WT_E(EINVAL),
           "%s: an unexpected checkpoint resolution: the checkpoint was never started or completed, "
           "or configured for salvage",
           block->name);
@@ -1057,7 +1057,7 @@ __wt_block_checkpoint_resolve(WT_SESSION_IMPL *session, WT_BLOCK *block, bool fa
         if (!failed)
             break;
         ret = __wt_panic(
-          session, EINVAL, "%s: the checkpoint failed, the system must restart", block->name);
+          session, WT_E(EINVAL), "%s: the checkpoint failed, the system must restart", block->name);
         __wt_bm_set_readonly(session);
         break;
     }

--- a/src/block/block_ckpt_scan.c
+++ b/src/block/block_ckpt_scan.c
@@ -298,8 +298,10 @@ __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **met
         if (ext_off != WT_BLOCK_EXTLIST_MAGIC || ext_size != 0)
             continue;
         for (;;) {
-            if ((ret = __wt_extlist_read_pair(&p, &ext_off, &ext_size)) != 0)
+            if ((ret = __wt_extlist_read_pair(&p, &ext_off, &ext_size)) != 0) {
+                WT_E(ret);
                 break;
+            }
             if (ext_off == WT_BLOCK_INVALID_OFFSET)
                 break;
         }
@@ -361,10 +363,10 @@ __wt_block_checkpoint_last(WT_SESSION_IMPL *session, WT_BLOCK *block, char **met
     }
 
     if (!found)
-        WT_ERR_MSG(session, WT_NOTFOUND, "%s: no final checkpoint found in file scan", block->name);
+        WT_ERR_MSG(session, WT_E(WT_NOTFOUND), "%s: no final checkpoint found in file scan", block->name);
 
     /* Correct the checkpoint. */
-    WT_ERR(__block_checkpoint_update(session, block, best));
+    WT_ERR(WT_E(__block_checkpoint_update(session, block, best))); /* No inner checks. */
 
     /*
      * Copy the information out to our caller. Do the WT_ITEM first, it's the only thing left that

--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -18,7 +18,7 @@ int
 __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
 {
     if (block->compact_session_id != WT_SESSION_ID_INVALID)
-        WT_RET_MSG(session, EBUSY,
+        WT_RET_MSG(session, WT_E(EBUSY),
           "Compaction already happening on data handle %s by session %" PRIu32, block->name,
           session->id);
 
@@ -590,7 +590,7 @@ __compact_page_skip(
         __block_compact_estimate_remaining_work(session, block);
         /* If we're in dry run mode, exit compaction. */
         if (session->compact->dryrun)
-            ret = ECANCELED;
+            ret = WT_E(ECANCELED);
     }
 
     return (ret);

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -375,9 +375,9 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
      */
     if (block->size < allocsize) {
         if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))
-            ret = ENOENT;
+            ret = WT_E(ENOENT);
         else {
-            ret = WT_ERROR;
+            ret = WT_E(WT_ERROR);
             F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
         }
         WT_RET_MSG(session, ret,
@@ -415,7 +415,7 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
      */
     if (desc->magic != WT_BLOCK_MAGIC || !checksum_matched) {
         if (__file_is_wt_internal(block->name))
-            WT_ERR_MSG(session, WT_TRY_SALVAGE,
+            WT_ERR_MSG(session, WT_E(WT_TRY_SALVAGE),
               "%s is corrupted: calculated block checksum of %#" PRIx32
               " doesn't match expected checksum of %#" PRIx32,
               block->name, __wt_checksum(desc, allocsize), checksum_tmp);
@@ -428,15 +428,15 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
             goto err;
 
         if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))
-            ret = ENOENT;
+            ret = WT_E(ENOENT);
         else
             WT_ERR_MSG(
-              session, WT_ERROR, "%s does not appear to be a WiredTiger file", block->name);
+              session, WT_E(WT_ERROR), "%s does not appear to be a WiredTiger file", block->name);
     }
 
     if (desc->majorv > WT_BLOCK_MAJOR_VERSION ||
       (desc->majorv == WT_BLOCK_MAJOR_VERSION && desc->minorv > WT_BLOCK_MINOR_VERSION))
-        WT_ERR_MSG(session, WT_ERROR,
+        WT_ERR_MSG(session, WT_E(WT_ERROR),
           "unsupported WiredTiger file version: this build only supports major/minor versions up "
           "to %d/%d, and the file is version %" PRIu16 "/%" PRIu16,
           WT_BLOCK_MAJOR_VERSION, WT_BLOCK_MINOR_VERSION, desc->majorv, desc->minorv);

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -186,7 +186,7 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
      * test.
      */
     if (size < block->allocsize)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "%s: impossibly small block size of %" PRIu32 "B, less than allocation size of %" PRIu32,
           block->name, size, block->allocsize);
 
@@ -280,6 +280,6 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
     /* Panic if a checksum fails during an ordinary read. */
     F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
     if (block->verify || F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
-        return (WT_ERROR);
-    WT_RET_PANIC(session, WT_ERROR, "%s: fatal read error", block->name);
+        return (WT_E(WT_ERROR));
+    WT_RET_PANIC(session, WT_E(WT_ERROR), "%s: fatal read error", block->name);
 }

--- a/src/block/block_session.c
+++ b/src/block/block_session.c
@@ -128,7 +128,7 @@ __block_ext_discard(WT_SESSION_IMPL *session, u_int max)
     bms->ext_cache = ext;
 
     if (max == 0 && bms->ext_cache_cnt != 0)
-        WT_RET_MSG(session, WT_ERROR, "incorrect count in session handle's block manager cache");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "incorrect count in session handle's block manager cache");
     return (0);
 }
 
@@ -235,7 +235,7 @@ __block_size_discard(WT_SESSION_IMPL *session, u_int max)
     bms->sz_cache = sz;
 
     if (max == 0 && bms->sz_cache_cnt != 0)
-        WT_RET_MSG(session, WT_ERROR, "incorrect count in session handle's block manager cache");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "incorrect count in session handle's block manager cache");
     return (0);
 }
 

--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -68,7 +68,7 @@ __wt_block_verify_start(
 
     /* The file size should be a multiple of the allocation size. */
     if (size % block->allocsize != 0)
-        WT_RET_MSG(session, WT_ERROR, "the file size is not a multiple of the allocation size");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "the file size is not a multiple of the allocation size");
 
     /*
      * Allocate a bit array, where each bit represents a single allocation
@@ -364,7 +364,7 @@ __verify_filefrag_add(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *typ
 
     /* Check each chunk against the total file size. */
     if (offset + size > block->size)
-        WT_RET_MSG(session, WT_ERROR,
+        WT_RET_MSG(session, WT_E(WT_ERROR),
           "fragment %" PRIuMAX "-%" PRIuMAX " references non-existent file blocks",
           (uintmax_t)offset, (uintmax_t)(offset + size));
 
@@ -375,7 +375,7 @@ __verify_filefrag_add(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *typ
     if (nodup)
         for (f = frag, i = 0; i < frags; ++f, ++i)
             if (__bit_test(block->fragfile, f))
-                WT_RET_MSG(session, WT_ERROR,
+                WT_RET_MSG(session, WT_E(WT_ERROR),
                   "file fragment at %" PRIuMAX " referenced multiple times", (uintmax_t)offset);
 
     /* Add fragments to the file's fragment list. */
@@ -436,7 +436,7 @@ __verify_filefrag_chk(WT_SESSION_IMPL *session, WT_BLOCK *block)
         return (0);
 
     __wt_errx(session, "file ranges never verified: %" PRIu64, count);
-    return (block->verify_strict ? WT_ERROR : 0);
+    return (block->verify_strict ? WT_E(WT_ERROR) : 0);
 }
 
 /*
@@ -458,7 +458,7 @@ __verify_ckptfrag_add(WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t offset
      * outside of the checkpoint's stored size.
      */
     if (offset + size > block->verify_size)
-        WT_RET_MSG(session, WT_ERROR,
+        WT_RET_MSG(session, WT_E(WT_ERROR),
           "fragment %" PRIuMAX "-%" PRIuMAX " references file blocks outside the checkpoint",
           (uintmax_t)offset, (uintmax_t)(offset + size));
 
@@ -468,7 +468,7 @@ __verify_ckptfrag_add(WT_SESSION_IMPL *session, WT_BLOCK *block, wt_off_t offset
     /* It is illegal to reference a particular chunk more than once. */
     for (f = frag, i = 0; i < frags; ++f, ++i)
         if (!__bit_test(block->fragckpt, f))
-            WT_RET_MSG(session, WT_ERROR,
+            WT_RET_MSG(session, WT_E(WT_ERROR),
               "fragment at %" PRIuMAX
               " referenced multiple times in a single checkpoint or found in the checkpoint but "
               "not listed in the checkpoint's allocation list",
@@ -522,5 +522,5 @@ __verify_ckptfrag_chk(WT_SESSION_IMPL *session, WT_BLOCK *block)
         return (0);
 
     __wt_errx(session, "checkpoint ranges never verified: %" PRIu64, count);
-    return (block->verify_strict ? WT_ERROR : 0);
+    return (block->verify_strict ? WT_E(WT_ERROR) : 0);
 }

--- a/src/block/block_write.c
+++ b/src/block/block_write.c
@@ -182,7 +182,7 @@ __wt_block_write_size(WT_SESSION_IMPL *session, WT_BLOCK *block, size_t *sizep)
      */
     *sizep = (size_t)WT_ALIGN(*sizep + WT_BLOCK_HEADER_BYTE_SIZE, block->allocsize);
     if (*sizep > UINT32_MAX - 1024)
-        WT_RET_MSG(session, EINVAL, "requested block size is too large");
+        WT_RET_MSG(session, WT_E(EINVAL), "requested block size is too large");
     return (0);
 }
 
@@ -247,11 +247,11 @@ __block_write_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, wt_of
     align_size = WT_ALIGN(buf->size, block->allocsize);
     if (align_size > buf->memsize) {
         WT_ASSERT(session, align_size <= buf->memsize);
-        WT_RET_MSG(session, EINVAL, "buffer size check: write buffer incorrectly allocated");
+        WT_RET_MSG(session, WT_E(EINVAL), "buffer size check: write buffer incorrectly allocated");
     }
     if (align_size > UINT32_MAX) {
         WT_ASSERT(session, align_size <= UINT32_MAX);
-        WT_RET_MSG(session, EINVAL, "buffer size check: write buffer too large to write");
+        WT_RET_MSG(session, WT_E(EINVAL), "buffer size check: write buffer too large to write");
     }
 
     /* Pre-allocate some number of extension structures. */

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -53,7 +53,7 @@ __blkcache_alloc(WT_SESSION_IMPL *session, size_t size, void **retp)
 #ifdef ENABLE_MEMKIND
         *retp = memkind_malloc(blkcache->pmem_kind, size);
 #else
-        WT_RET_MSG(session, EINVAL, "NVRAM block cache type requires libmemkind");
+        WT_RET_MSG(session, WT_E(EINVAL), "NVRAM block cache type requires libmemkind");
 #endif
     }
     return (0);
@@ -582,7 +582,7 @@ __blkcache_init(WT_SESSION_IMPL *session, size_t cache_size, u_int hash_size, u_
         __wt_free(session, nvram_device_path);
 #else
         (void)nvram_device_path;
-        WT_RET_MSG(session, EINVAL, "NVRAM block cache type requires libmemkind");
+        WT_RET_MSG(session, WT_E(EINVAL), "NVRAM block cache type requires libmemkind");
 #endif
     }
 
@@ -713,7 +713,7 @@ __blkcache_reconfig(WT_SESSION_IMPL *session, bool reconfig, size_t cache_size, 
       (nvram_device_path != NULL &&
         strncmp(nvram_device_path, blkcache->nvram_device_path, strlen(nvram_device_path)) != 0)) {
         __wt_err(session, EINVAL, "block cache reconfiguration not supported");
-        return (WT_ERROR);
+        return (WT_E(WT_ERROR));
     }
     return (0);
 }
@@ -784,7 +784,7 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
     nvram_device_path = (char *)"";
 
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED && !reconfig)
-        WT_RET_MSG(session, EINVAL, "block cache setup requested for a configured cache");
+        WT_RET_MSG(session, WT_E(EINVAL), "block cache setup requested for a configured cache");
 
     /* When reconfiguring, check if there are any modifications that we care about. */
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED && reconfig) {
@@ -799,13 +799,13 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 
     WT_RET(__wt_config_gets(session, cfg, "block_cache.size", &cval));
     if ((cache_size = (uint64_t)cval.val) <= 0)
-        WT_RET_MSG(session, EINVAL, "block cache size must be greater than zero");
+        WT_RET_MSG(session, WT_E(EINVAL), "block cache size must be greater than zero");
 
     WT_RET(__wt_config_gets(session, cfg, "block_cache.hashsize", &cval));
     if ((hash_size = (u_int)cval.val) == 0)
         hash_size = WT_BLKCACHE_HASHSIZE_DEFAULT;
     else if (hash_size < WT_BLKCACHE_HASHSIZE_MIN || hash_size > WT_BLKCACHE_HASHSIZE_MAX)
-        WT_RET_MSG(session, EINVAL, "block cache hash size must be between %d and %d entries",
+        WT_RET_MSG(session, WT_E(EINVAL), "block cache hash size must be between %d and %d entries",
           WT_BLKCACHE_HASHSIZE_MIN, WT_BLKCACHE_HASHSIZE_MAX);
 
     WT_RET(__wt_config_gets(session, cfg, "block_cache.type", &cval));
@@ -817,12 +817,12 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
         WT_RET(__wt_config_gets(session, cfg, "block_cache.nvram_path", &cval));
         WT_RET(__wt_strndup(session, cval.str, cval.len, &nvram_device_path));
         if (!__wt_absolute_path(nvram_device_path))
-            WT_RET_MSG(session, EINVAL, "NVRAM device path must be an absolute path");
+            WT_RET_MSG(session, WT_E(EINVAL), "NVRAM device path must be an absolute path");
 #else
-        WT_RET_MSG(session, EINVAL, "NVRAM block cache requires libmemkind");
+        WT_RET_MSG(session, WT_E(EINVAL), "NVRAM block cache requires libmemkind");
 #endif
     } else
-        WT_RET_MSG(session, EINVAL, "Invalid block cache type");
+        WT_RET_MSG(session, WT_E(EINVAL), "Invalid block cache type");
 
     WT_RET(__wt_config_gets(session, cfg, "block_cache.system_ram", &cval));
     system_ram = (uint64_t)cval.val;

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -149,7 +149,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
     if (!blkcache_found || blkcache->type != WT_BLKCACHE_DRAM) {
         if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
             if (encryptor == NULL || encryptor->decrypt == NULL)
-                WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
+                WT_ERR(__blkcache_read_corrupt(session, WT_E(WT_ERROR), addr, addr_size,
                   "encrypted block for which no decryptor configured"));
 
             /*
@@ -163,7 +163,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
 
             ip = etmp;
         } else if (btree->kencryptor != NULL)
-            WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
+            WT_ERR(__blkcache_read_corrupt(session, WT_E(WT_ERROR), addr, addr_size,
               "unencrypted block for which encryption configured"));
     }
 
@@ -174,10 +174,10 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
     dsk = ip->data;
     if (F_ISSET(dsk, WT_PAGE_COMPRESSED)) {
         if (compressor == NULL || compressor->decompress == NULL) {
-            ret = __blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
+            ret = __blkcache_read_corrupt(session, WT_E(WT_ERROR), addr, addr_size,
               "compressed block for which no compression configured");
             /* Odd error handling structure to avoid static analyzer complaints. */
-            WT_ERR(ret == 0 ? WT_ERROR : ret);
+            WT_ERR(ret == 0 ? WT_E(WT_ERROR) : ret);
         }
 
         /* Size the buffer based on the in-memory bytes we're expecting from decompression. */
@@ -197,7 +197,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, const uint8_t *addr, 
           (uint8_t *)buf->mem + WT_BLOCK_COMPRESS_SKIP, dsk->mem_size - WT_BLOCK_COMPRESS_SKIP,
           &result_len);
         if (result_len != dsk->mem_size - WT_BLOCK_COMPRESS_SKIP)
-            WT_TRET(WT_ERROR);
+            WT_TRET(WT_E(WT_ERROR)); /* Update? */
 
         /*
          * If checksums were turned off because we're depending on decompression to fail on any

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -56,7 +56,7 @@ static int
 __bm_readonly(WT_BM *bm, WT_SESSION_IMPL *session)
 {
     WT_RET_MSG(
-      session, ENOTSUP, "%s: write operation on read-only checkpoint handle", bm->block->name);
+      session, WT_E(ENOTSUP), "%s: write operation on read-only checkpoint handle", bm->block->name);
 }
 
 /*

--- a/src/bloom/bloom.c
+++ b/src/bloom/bloom.c
@@ -59,10 +59,10 @@ err:
  *     open.
  */
 static int
-__bloom_setup(WT_BLOOM *bloom, uint64_t n, uint64_t m, uint32_t factor, uint32_t k)
+__bloom_setup(WT_SESSION_IMPL *session, WT_BLOOM *bloom, uint64_t n, uint64_t m, uint32_t factor, uint32_t k)
 {
     if (k < 2)
-        WT_RET_MSG(bloom->session, EINVAL,
+        WT_RET_MSG(bloom->session, WT_E(EINVAL),
           "bloom filter hash values to be set/tested must be greater than 2");
 
     bloom->k = k;
@@ -92,7 +92,7 @@ __wt_bloom_create(WT_SESSION_IMPL *session, const char *uri, const char *config,
     WT_DECL_RET;
 
     WT_RET(__bloom_init(session, uri, config, &bloom));
-    WT_ERR(__bloom_setup(bloom, count, 0, factor, k));
+    WT_ERR(__bloom_setup(session, bloom, count, 0, factor, k));
 
     WT_ERR(__bit_alloc(session, bloom->m, &bloom->bitstring));
 
@@ -159,7 +159,7 @@ __wt_bloom_open(WT_SESSION_IMPL *session, const char *uri, uint32_t factor, uint
     WT_ERR(c->get_key(c, &size));
     WT_ERR(c->reset(c));
 
-    WT_ERR(__bloom_setup(bloom, 0, size, factor, k));
+    WT_ERR(__bloom_setup(session, bloom, 0, size, factor, k));
 
     *bloomp = bloom;
     return (0);

--- a/src/btree/bt_compact.c
+++ b/src/btree/bt_compact.c
@@ -257,7 +257,7 @@ __compact_walk_internal(WT_SESSION_IMPL *session, WT_REF *parent)
         WT_RET(__wt_session_compact_check_interrupted(session));
 
         if (__wt_evict_cache_stuck(session))
-            WT_RET(EBUSY);
+            WT_RET(WT_E(EBUSY));
 
         __wt_sleep(1, 0);
     }
@@ -374,7 +374,7 @@ __wt_compact(WT_SESSION_IMPL *session)
             WT_ERR(__wt_session_compact_check_interrupted(session));
 
             if (__wt_evict_cache_stuck(session))
-                WT_ERR(EBUSY);
+                WT_ERR(WT_E(EBUSY));
 
             first = false;
             i = 0;

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -150,7 +150,7 @@ __cursor_fix_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
 
     if (newpage) {
         if ((cbt->ins = WT_SKIP_LAST(cbt->ins_head)) == NULL)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
     } else {
         /* Move to the previous record in the append list, if any. */
         if (cbt->ins != NULL && cbt->recno <= WT_INSERT_RECNO(cbt->ins))
@@ -188,7 +188,7 @@ __cursor_fix_append_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
          */
         if (cbt->ins == NULL &&
           (cbt->recno == cbt->ref->ref_recno || __col_fix_last_recno(cbt->ref) != 0))
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
     }
 
     /*
@@ -256,14 +256,14 @@ __cursor_fix_prev(WT_CURSOR_BTREE *cbt, bool newpage, bool restart)
         cbt->slot = UINT32_MAX;
         cbt->last_standard_recno = __col_fix_last_recno(cbt->ref);
         if (cbt->last_standard_recno == 0)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
         __cursor_set_recno(cbt, cbt->last_standard_recno);
         goto new_page;
     }
 
     /* Move to the previous entry and return the item. */
     if (cbt->recno == cbt->ref->ref_recno)
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
     __cursor_set_recno(cbt, cbt->recno - 1);
 
 new_page:
@@ -336,7 +336,7 @@ __cursor_var_append_prev(
         WT_RET(__cursor_skip_prev(cbt));
 new_page:
         if (cbt->ins == NULL)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
 
         __cursor_set_recno(cbt, WT_INSERT_RECNO(cbt->ins));
 
@@ -405,7 +405,7 @@ __cursor_var_prev(
         cbt->slot = UINT32_MAX;
         cbt->last_standard_recno = __col_var_last_recno(cbt->ref);
         if (cbt->last_standard_recno == 0)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
         __cursor_set_recno(cbt, cbt->last_standard_recno);
         cbt->cip_saved = NULL;
         F_CLR(cbt, WT_CBT_CACHEABLE_RLE_CELL);
@@ -418,7 +418,7 @@ __cursor_var_prev(
 
 new_page:
         if (cbt->recno < cbt->ref->ref_recno)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
 
 restart_read:
         /*
@@ -436,7 +436,7 @@ restart_read:
 
         /* Find the matching WT_COL slot. */
         if ((cip = __col_var_search(cbt->ref, cbt->recno, &rle_start)) == NULL)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
         cbt->slot = WT_COL_SLOT(page, cip);
 
         /* Check any insert list for a matching record. */
@@ -657,7 +657,7 @@ restart_read_insert:
 
         /* Check for the beginning of the page. */
         if (cbt->row_iteration_slot == 1)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
         --cbt->row_iteration_slot;
 
         /*
@@ -888,7 +888,7 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
               session, &cbt->ref, __wt_btcur_skip_page, &walk_skip_stats, flags));
         else
             WT_ERR(__wt_tree_walk(session, &cbt->ref, flags));
-        WT_ERR_TEST(cbt->ref == NULL, WT_NOTFOUND, false);
+        WT_ERR_TEST(cbt->ref == NULL, WT_E(WT_NOTFOUND), false);
     }
 
 done:

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -299,7 +299,7 @@ __debug_config(WT_SESSION_IMPL *session, WT_DBG *ds, const char *ofile, uint32_t
         ds->f = __dmsg_event;
     } else {
         if ((ds->fp = fopen(ofile, "w")) == NULL)
-            WT_ERR(__wt_set_return(session, EIO));
+            WT_ERR(__wt_set_return(session, WT_E(EIO)));
         __wt_stream_set_line_buffer(ds->fp);
         ds->f = __dmsg_file;
     }

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -101,7 +101,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
      */
     creation = ckpt.raw.size == 0;
     if (!creation && F_ISSET(btree, WT_BTREE_BULK))
-        WT_ERR_MSG(session, EINVAL, "bulk-load is only supported on newly created objects");
+        WT_ERR_MSG(session, WT_E(EINVAL), "bulk-load is only supported on newly created objects");
 
     /* Handle salvage configuration. */
     forced_salvage = false;
@@ -363,7 +363,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
         WT_RET(__wt_struct_check(session, cval.str, cval.len, &fixed, &bitcnt));
         if (fixed) {
             if (bitcnt == 0 || bitcnt > 8)
-                WT_RET_MSG(session, EINVAL,
+                WT_RET_MSG(session, WT_E(EINVAL),
                   "fixed-width field sizes must be greater than 0 and less than or equal to 8");
             btree->bitcnt = (uint8_t)bitcnt;
             btree->type = BTREE_COL_FIX;
@@ -382,7 +382,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     WT_RET(__wt_config_gets(session, cfg, "ignore_in_memory_cache_size", &cval));
     if (cval.val) {
         if (!F_ISSET(conn, WT_CONN_IN_MEMORY))
-            WT_RET_MSG(session, EINVAL,
+            WT_RET_MSG(session, WT_E(EINVAL),
               "ignore_in_memory_cache_size setting is only valid with databases configured to run "
               "in-memory");
         F_SET(btree, WT_BTREE_IGNORE_CACHE);
@@ -458,7 +458,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
 
     ret = __wt_config_gets(session, cfg, "huffman_value", &cval);
     if (ret == 0 && cval.len != 0)
-        WT_RET_MSG(session, ENOTSUP, "Huffman encoding for values is no longer supported.");
+        WT_RET_MSG(session, WT_E(ENOTSUP), "Huffman encoding for values is no longer supported.");
 
     /*
      * Reconciliation configuration:
@@ -885,7 +885,7 @@ __btree_get_last_recno(WT_SESSION_IMPL *session)
     next_walk = NULL;
     WT_RET(__wt_tree_walk(session, &next_walk, flags));
     if (next_walk == NULL)
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
 
     page = next_walk->page;
     last_recno = page->type == WT_PAGE_COL_VAR ? __col_var_last_recno(next_walk) :
@@ -933,7 +933,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
     btree->allocsize = (uint32_t)cval.val;
 
     if (!__wt_ispo2(btree->allocsize))
-        WT_RET_MSG(session, EINVAL, "the allocation size must be a power of two");
+        WT_RET_MSG(session, WT_E(EINVAL), "the allocation size must be a power of two");
 
     /*
      * Get the internal/leaf page sizes. All page sizes must be in units of the allocation size.
@@ -945,7 +945,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
 
     if (btree->maxintlpage < btree->allocsize || btree->maxintlpage % btree->allocsize != 0 ||
       btree->maxleafpage < btree->allocsize || btree->maxleafpage % btree->allocsize != 0)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "page sizes must be a multiple of the page allocation size (%" PRIu32 "B)",
           btree->allocsize);
 
@@ -961,7 +961,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      * set the limit to 128KB.
      */
     if (btree->type == BTREE_COL_FIX && btree->maxleafpage > 128 * WT_KILOBYTE)
-        WT_RET_MSG(session, EINVAL, "page size for fixed-length column store is limited to 128KB");
+        WT_RET_MSG(session, WT_E(EINVAL), "page size for fixed-length column store is limited to 128KB");
 
     /*
      * Default in-memory page image size for compression is 4x the maximum internal or leaf page
@@ -973,7 +973,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
     if (btree->maxmempage_image == 0)
         btree->maxmempage_image = 4 * max;
     else if (btree->maxmempage_image < max)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "in-memory page image size must be larger than the maximum page size (%" PRIu32
           "B < %" PRIu32 "B)",
           btree->maxmempage_image, max);

--- a/src/btree/bt_import.c
+++ b/src/btree/bt_import.c
@@ -54,7 +54,7 @@ __wt_import_repair(WT_SESSION_IMPL *session, const char *uri, char **configp)
     WT_ERR(__wt_config_getones(session, metadata, "block_metadata_encrypted", &v));
     WT_ERR(__wt_btree_config_encryptor(session, cfg, &kencryptor));
     if ((kencryptor == NULL && v.val != 0) || (kencryptor != NULL && v.val == 0))
-        WT_ERR_MSG(session, EINVAL,
+        WT_ERR_MSG(session, WT_E(EINVAL),
           "%s: loaded object's encryption configuration doesn't match the database's encryption "
           "configuration",
           uri);
@@ -127,7 +127,7 @@ __wt_import_repair(WT_SESSION_IMPL *session, const char *uri, char **configp)
         if (ckpt->name == NULL || (ckpt + 1)->name == NULL)
             break;
     if (ckpt->name == NULL)
-        WT_ERR_MSG(session, EINVAL, "no checkpoint information available to import");
+        WT_ERR_MSG(session, WT_E(EINVAL), "no checkpoint information available to import");
     F_SET(ckpt, WT_CKPT_UPDATE);
     WT_ERR(__wt_buf_set(session, &ckpt->raw, checkpoint->data, checkpoint->size));
     WT_ERR(__wt_meta_ckptlist_update_config(session, ckptbase, config_tmp, &config));

--- a/src/btree/bt_random.c
+++ b/src/btree/bt_random.c
@@ -460,7 +460,7 @@ restart:
                 goto restart;
 
             WT_RET(__wt_page_release(session, current, flags));
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
         }
 
         /*
@@ -528,7 +528,7 @@ __wt_btcur_next_random(WT_CURSOR_BTREE *cbt)
      * column-store, if there were any reason to do so.
      */
     if (btree->type != BTREE_ROW)
-        WT_RET_MSG(session, ENOTSUP, "WT_CURSOR.next_random only supported by row-store tables");
+        WT_RET_MSG(session, WT_E(ENOTSUP), "WT_CURSOR.next_random only supported by row-store tables");
 
     WT_STAT_CONN_DSRC_INCR(session, cursor_next);
 

--- a/src/btree/bt_ret.c
+++ b/src/btree/bt_ret.c
@@ -203,7 +203,7 @@ __read_page_cell_data_ref_kv(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UN
     WT_RET(__wt_page_cell_data_ref_kv(session, page, unpack, buf));
     if (unpack->cell != NULL && __wt_cell_type_raw(unpack->cell) == WT_CELL_VALUE_OVFL_RM) {
         WT_STAT_CONN_DSRC_INCR(session, txn_read_overflow_remove);
-        return (WT_RESTART);
+        return (WT_E(WT_RESTART));
     }
     return (0);
 }

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -512,7 +512,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
             if (ss->page_type == WT_PAGE_INVALID)
                 ss->page_type = dsk->type;
             if (ss->page_type != dsk->type)
-                WT_ERR_MSG(session, WT_ERROR,
+                WT_ERR_MSG(session, WT_E(WT_ERROR),
                   "file contains multiple file formats (both %s and %s), and cannot be salvaged",
                   __wt_page_type_string(ss->page_type), __wt_page_type_string(dsk->type));
 
@@ -971,7 +971,7 @@ __slvg_col_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_s
      */
     /* Case #2/8, #10, #11 */
     if (a_trk->col_start > b_trk->col_start)
-        WT_RET_PANIC(session, EINVAL, "unexpected merge array sort order");
+        WT_RET_PANIC(session, WT_E(EINVAL), "unexpected merge array sort order");
 
     if (a_trk->col_start == b_trk->col_start) { /* Case #1, #4 and #9 */
                                                 /*
@@ -1391,7 +1391,7 @@ __slvg_col_ovfl_single(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_CELL_UNPACK_K
             return (__slvg_ovfl_ref(session, ovfl, false));
     }
 
-    WT_RET_PANIC(session, EINVAL, "overflow record at column-store page merge not found");
+    WT_RET_PANIC(session, WT_E(EINVAL), "overflow record at column-store page merge not found");
 }
 
 /*
@@ -1564,7 +1564,7 @@ __slvg_row_range_overlap(WT_SESSION_IMPL *session, uint32_t a_slot, uint32_t b_s
     WT_RET(__wt_compare(session, btree->collator, A_TRK_STOP, B_TRK_STOP, &stop_cmp));
 
     if (start_cmp > 0) /* Case #2/8, #10, #11 */
-        WT_RET_PANIC(session, EINVAL, "unexpected merge array sort order");
+        WT_RET_PANIC(session, WT_E(EINVAL), "unexpected merge array sort order");
 
     if (start_cmp == 0) { /* Case #1, #4, #9 */
                           /*
@@ -1771,7 +1771,7 @@ __slvg_row_trk_update_start(WT_SESSION_IMPL *session, WT_ITEM *stop, uint32_t sl
      * Therefore, this test is safe. (But, it never hurts to check.)
      */
     if (!found)
-        WT_ERR_MSG(session, WT_ERROR, "expected on-page key not found");
+        WT_ERR_MSG(session, WT_E(WT_ERROR), "expected on-page key not found");
     WT_ERR(__slvg_key_copy(session, &trk->row_start, key));
 
     /*
@@ -2051,7 +2051,7 @@ __slvg_row_ovfl_single(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_CELL_UNPACK_K
             return (__slvg_ovfl_ref(session, ovfl, true));
     }
 
-    WT_RET_PANIC(session, EINVAL, "overflow record at row-store page merge not found");
+    WT_RET_PANIC(session, WT_E(EINVAL), "overflow record at row-store page merge not found");
 }
 
 /*
@@ -2110,7 +2110,7 @@ __slvg_reconcile_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, 
         }
     }
 
-    WT_RET_PANIC(session, EINVAL, "overflow record discarded during page reconciliation not %s",
+    WT_RET_PANIC(session, WT_E(EINVAL), "overflow record discarded during page reconciliation not %s",
       i == trk->trk_ovfl_cnt ? "referenced" : "found");
 }
 
@@ -2363,8 +2363,8 @@ __slvg_ovfl_ref(WT_SESSION_IMPL *session, WT_TRACK *trk, bool multi_panic)
 {
     if (F_ISSET(trk, WT_TRACK_OVFL_REFD)) {
         if (!multi_panic)
-            return (__wt_set_return(session, EBUSY));
-        WT_RET_PANIC(session, EINVAL,
+            return (__wt_set_return(session, WT_E(EBUSY)));
+        WT_RET_PANIC(session, WT_E(EINVAL),
           "overflow record unexpectedly referenced multiple times during leaf page merge");
     }
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -428,7 +428,7 @@ __split_root(WT_SESSION_IMPL *session, WT_PAGE *root)
     children = pindex->entries / btree->split_deepen_per_child;
     if (children < WT_SPLIT_DEEPEN_MIN_CREATE_CHILD_PAGES) {
         if (pindex->entries < WT_INTERNAL_SPLIT_MIN_KEYS)
-            return (__wt_set_return(session, EBUSY));
+            return (__wt_set_return(session, WT_E(EBUSY)));
         children = WT_SPLIT_DEEPEN_MIN_CREATE_CHILD_PAGES;
     }
     chunk = pindex->entries / children;
@@ -889,7 +889,7 @@ err:
          * wrong.
          */
         if (empty_parent)
-            ret = __wt_set_return(session, EBUSY);
+            ret = __wt_set_return(session, WT_E(EBUSY));
         break;
     case WT_ERR_IGNORE:
         if (ret != WT_PANIC) {
@@ -954,7 +954,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
     children = pindex->entries / btree->split_deepen_per_child;
     if (children < WT_SPLIT_DEEPEN_MIN_CREATE_CHILD_PAGES) {
         if (pindex->entries < WT_INTERNAL_SPLIT_MIN_KEYS)
-            return (__wt_set_return(session, EBUSY));
+            return (__wt_set_return(session, WT_E(EBUSY)));
         children = WT_SPLIT_DEEPEN_MIN_CREATE_CHILD_PAGES;
     }
     chunk = pindex->entries / children;
@@ -1197,7 +1197,7 @@ __split_internal_lock(WT_SESSION_IMPL *session, WT_REF *ref, bool trylock, WT_PA
      * split the parent, give up to avoid that deadlock.
      */
     if (!trylock && __wt_btree_syncing_by_other_session(session))
-        return (__wt_set_return(session, EBUSY));
+        return (__wt_set_return(session, WT_E(EBUSY)));
 
     /*
      * Get a page-level lock on the parent to single-thread splits into the page because we need to
@@ -2180,7 +2180,7 @@ __split_multi_lock(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
 
     /* Fail 1% of the time to simulate we fail to split the page. */
     if (!closing && __wt_failpoint(session, WT_TIMING_STRESS_FAILPOINT_EVICTION_SPLIT, 100))
-        return (EBUSY);
+        return (WT_E(EBUSY));
 
     /* Lock the parent page, then proceed with the split. */
     WT_RET(__split_internal_lock(session, ref, false, &parent));

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -343,7 +343,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
               !tried_eviction && F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT)) {
                 ret = __wt_page_release_evict(session, walk, 0);
                 walk = NULL;
-                WT_ERR_ERROR_OK(ret, EBUSY, false);
+                WT_ERR_ERROR_OK(ret, WT_E(EBUSY), false);
 
                 walk = prev;
                 prev = NULL;

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -680,7 +680,7 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
 
         /* Check we are still dealing with keys that have the right prefix. */
         if (!WT_PREFIX_MATCH(key, WT_URI_FILE_PREFIX)) {
-            ret = WT_NOTFOUND;
+            ret = WT_E(WT_NOTFOUND);
             break;
         }
 

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -41,7 +41,7 @@ static int __verify_dsk_row_leaf(WT_VERIFY_INFO *);
             /* Easy way to set a breakpoint when tracking corruption */    \
             WT_IGNORE_RET(__wt_session_breakpoint((WT_SESSION *)session)); \
         }                                                                  \
-        return ((ret) == 0 ? WT_ERROR : ret);                              \
+        return ((ret) == 0 ? WT_E_S(session, WT_ERROR) : ret);                              \
     } while (0)
 
 #define WT_RET_VRFY(session, ...) WT_RET_VRFY_RETVAL(session, 0, __VA_ARGS__)
@@ -359,7 +359,7 @@ __verify_row_key_order_check(
     WT_ERR(__wt_scr_alloc(vi->session, 0, &tmp1));
     WT_ERR(__wt_scr_alloc(vi->session, 0, &tmp2));
 
-    ret = WT_ERROR;
+    ret = WT_E_S(vi->session, WT_ERROR);
     WT_ERR_VRFY(vi->session, vi->flags,
       "the %" PRIu32 " and %" PRIu32 " keys on page at %s are incorrectly sorted: %s, %s",
       last_cell_num, cell_num, vi->tag,
@@ -547,7 +547,7 @@ __verify_dsk_row_int(WT_VERIFY_INFO *vi)
     if (0) {
 err:
         if (ret == 0)
-            ret = WT_ERROR;
+            ret = WT_E_S(vi->session, WT_ERROR);
     }
     __wt_scr_free(vi->session, &current);
     __wt_scr_free(vi->session, &last);
@@ -749,7 +749,7 @@ key_compare:
     if (0) {
 err:
         if (ret == 0)
-            ret = WT_ERROR;
+            ret = WT_E_S(vi->session, WT_ERROR);
     }
     __wt_scr_free(vi->session, &current);
     __wt_scr_free(vi->session, &last_pfx);
@@ -792,7 +792,7 @@ __verify_dsk_col_int(WT_VERIFY_INFO *vi)
 
         /* Check if any referenced item is entirely in the file. */
         ret = bm->addr_invalid(bm, vi->session, unpack->data, unpack->size);
-        WT_RET_ERROR_OK(ret, EINVAL);
+        WT_RET_ERROR_OK(ret, WT_E_S(vi->session, EINVAL));
         if (ret == EINVAL)
             return (__err_cell_corrupt_or_eof(ret, vi));
     }
@@ -851,7 +851,7 @@ __verify_dsk_col_fix(WT_VERIFY_INFO *vi)
     /* Validate the offsets in the auxiliary header. */
     if (auxhdr.emptyoffset > auxhdr.dataoffset)
         /* The empty-space offset is the also end of the auxiliary header. */
-        WT_RET_VRFY_RETVAL(vi->session, EINVAL,
+        WT_RET_VRFY_RETVAL(vi->session, WT_E_S(vi->session, EINVAL),
           "%s page at %s auxiliary header overlaps data: header ends at offset %" PRIu32
           " and data begins at offset %" PRIu32,
           __wt_page_type_string(vi->dsk->type), vi->tag, auxhdr.emptyoffset, auxhdr.dataoffset);
@@ -1001,7 +1001,7 @@ __verify_dsk_col_var(WT_VERIFY_INFO *vi)
         /* Check if any referenced item is entirely in the file. */
         if (cell_type == WT_CELL_VALUE_OVFL) {
             ret = bm->addr_invalid(bm, vi->session, unpack->data, unpack->size);
-            WT_RET_ERROR_OK(ret, EINVAL);
+            WT_RET_ERROR_OK(ret, WT_E_S(vi->session, EINVAL));
             if (ret == EINVAL)
                 return (__err_cell_corrupt_or_eof(ret, vi));
         }

--- a/src/checkpoint/checkpoint_conn.c
+++ b/src/checkpoint/checkpoint_conn.c
@@ -48,7 +48,7 @@ __ckpt_server_config(WT_SESSION_IMPL *session, const char **cfg, bool *startp)
         /* Checkpoints are incompatible with in-memory configuration */
         WT_RET(__wt_config_gets(session, cfg, "in_memory", &cval));
         if (cval.val != 0)
-            WT_RET_MSG(session, EINVAL,
+            WT_RET_MSG(session, WT_E(EINVAL),
               "checkpoint configuration incompatible with in-memory configuration");
 
         __wt_log_written_reset(session);

--- a/src/conf/conf_bind.c
+++ b/src/conf/conf_bind.c
@@ -26,7 +26,7 @@ __wt_conf_bind(WT_SESSION_IMPL *session, const char *compiled_str, va_list ap)
 
     conn = S2C(session);
     if (!__wt_conf_get_compiled(conn, compiled_str, &conf))
-        return (EINVAL);
+        return (WT_E(EINVAL));
 
     bound = &session->conf_bindings;
     WT_CLEAR(*bound);

--- a/src/conf/conf_compile.c
+++ b/src/conf/conf_compile.c
@@ -44,27 +44,27 @@ __conf_compile_value(WT_SESSION_IMPL *session, WT_CONF *top_conf, WT_CONFIG_ITEM
         /* We must be doing an explicit compilation. */
         if (!bind_allowed)
             WT_RET_MSG(
-              session, EINVAL, "Value '%.*s' is not valid here", (int)value->len, value->str);
+              session, WT_E(EINVAL), "Value '%.*s' is not valid here", (int)value->len, value->str);
 
         if (value->len < 2)
-            WT_RET_MSG(session, EINVAL, "Percent binding format is incomplete");
+            WT_RET_MSG(session, WT_E(EINVAL), "Percent binding format is incomplete");
 
         if (value->str[1] == 'd') {
             if (check_type != WT_CONFIG_ITEM_NUM && check_type != WT_CONFIG_ITEM_BOOL)
-                WT_RET_MSG(session, EINVAL, "Value '%.*s' is not compatible with %s type",
+                WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' is not compatible with %s type",
                   (int)value->len, value->str, check->type);
         } else if (value->str[1] == 's') {
             if (check_type != WT_CONFIG_ITEM_STRING && check_type != WT_CONFIG_ITEM_STRUCT)
-                WT_RET_MSG(session, EINVAL, "Value '%.*s' is not compatible with %s type",
+                WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' is not compatible with %s type",
                   (int)value->len, value->str, check->type);
         } else
-            WT_RET_MSG(session, EINVAL, "Value '%.*s' does not match %s for binding",
+            WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' does not match %s for binding",
               (int)value->len, value->str, "%d or %s");
 
         bind_offset = top_conf->binding_count++;
 
         if (conf_value->type == CONF_VALUE_BIND_DESC)
-            WT_RET_MSG(session, EINVAL, "Value '%.*s' cannot be used on the same key twice",
+            WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' cannot be used on the same key twice",
               (int)value->len, value->str);
 
         conf_value->type = CONF_VALUE_BIND_DESC;
@@ -78,13 +78,13 @@ __conf_compile_value(WT_SESSION_IMPL *session, WT_CONF *top_conf, WT_CONFIG_ITEM
         switch (check_type) {
         case WT_CONFIG_ITEM_NUM:
             if (value->type != WT_CONFIG_ITEM_NUM)
-                WT_RET_MSG(session, EINVAL, "Value '%.*s' expected to be an integer",
+                WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' expected to be an integer",
                   (int)value->len, value->str);
             break;
         case WT_CONFIG_ITEM_BOOL:
             if (value->type != WT_CONFIG_ITEM_BOOL &&
               (value->type != WT_CONFIG_ITEM_NUM || (value->val != 0 && value->val != 1)))
-                WT_RET_MSG(session, EINVAL, "Value '%.*s' expected to be a boolean",
+                WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' expected to be a boolean",
                   (int)value->len, value->str);
 
             /*
@@ -177,7 +177,7 @@ __conf_compile(WT_SESSION_IMPL *session, const char *api, WT_CONF *top_conf, WT_
         check = (const WT_CONFIG_CHECK *)bsearch(
           &key, &checks[i], check_count - i, sizeof(WT_CONFIG_CHECK), __conf_check_compare);
         if (check == NULL)
-            WT_ERR_MSG(session, EINVAL, "Error compiling '%s', unknown key '%.*s' for method '%s'",
+            WT_ERR_MSG(session, WT_E(EINVAL), "Error compiling '%s', unknown key '%.*s' for method '%s'",
               format, (int)key.len, key.str, api);
 
         /* The key id is an offset into the value_map table. */
@@ -208,7 +208,7 @@ __conf_compile(WT_SESSION_IMPL *session, const char *api, WT_CONF *top_conf, WT_
         if (check_type == WT_CONFIG_ITEM_STRUCT && check->choices != NULL &&
           value.type == WT_CONFIG_ITEM_STRING) {
             if (!__wt_config_get_choice(check->choices, &value))
-                WT_ERR_MSG(session, EINVAL, "Value '%.*s' not a permitted choice for key '%.*s'",
+                WT_ERR_MSG(session, WT_E(EINVAL), "Value '%.*s' not a permitted choice for key '%.*s'",
                   (int)value.len, value.str, (int)key.len, key.str);
             conf_value->type = is_default ? CONF_VALUE_DEFAULT_ITEM : CONF_VALUE_NONDEFAULT_ITEM;
             conf_value->u.item = value;
@@ -220,19 +220,19 @@ __conf_compile(WT_SESSION_IMPL *session, const char *api, WT_CONF *top_conf, WT_
                  * of things. Check for matching pairs of parentheses, etc. and strip them.
                  */
                 if (value.type != WT_CONFIG_ITEM_STRUCT)
-                    WT_ERR_MSG(session, EINVAL, "Value '%.*s' expected to be a category",
+                    WT_ERR_MSG(session, WT_E(EINVAL), "Value '%.*s' expected to be a category",
                       (int)value.len, value.str);
                 if (value.str[0] == '[') {
                     if (value.str[value.len - 1] != ']')
-                        WT_ERR_MSG(session, EINVAL, "Value '%.*s' non-matching []", (int)value.len,
+                        WT_ERR_MSG(session, WT_E(EINVAL), "Value '%.*s' non-matching []", (int)value.len,
                           value.str);
                 } else if (value.str[0] == '(') {
                     if (value.str[value.len - 1] != ')')
-                        WT_ERR_MSG(session, EINVAL, "Value '%.*s' non-matching ()", (int)value.len,
+                        WT_ERR_MSG(session, WT_E(EINVAL), "Value '%.*s' non-matching ()", (int)value.len,
                           value.str);
                 } else
                     WT_ERR_MSG(
-                      session, EINVAL, "Value '%.*s' expected () or []", (int)value.len, value.str);
+                      session, WT_E(EINVAL), "Value '%.*s' expected () or []", (int)value.len, value.str);
 
                 /* Remove the first and last char, they were just checked */
                 ++value.str;
@@ -319,7 +319,7 @@ __wt_conf_compile(
     void *buf;
 
     if (format == NULL || api == NULL)
-        WT_RET_MSG(session, EINVAL, "Missing format or method string");
+        WT_RET_MSG(session, WT_E(EINVAL), "Missing format or method string");
 
     conn = S2C(session);
     conf = NULL;
@@ -328,10 +328,10 @@ __wt_conf_compile(
 
     centry = __wt_conn_config_match(api);
     if (centry == NULL)
-        WT_RET_MSG(session, EINVAL, "Error compiling configuration, unknown method '%s'", api);
+        WT_RET_MSG(session, WT_E(EINVAL), "Error compiling configuration, unknown method '%s'", api);
 
     if (!centry->compilable)
-        WT_RET_MSG(session, ENOTSUP,
+        WT_RET_MSG(session, WT_E(ENOTSUP),
           "Error compiling, method '%s' does not support compiled configurations", centry->method);
 
     /*
@@ -355,7 +355,7 @@ __wt_conf_compile(
      */
     compiled_entry = __wt_atomic_fetch_addv32(&conn->conf_size, 1);
     if (compiled_entry >= conn->conf_max)
-        WT_ERR_MSG(session, EINVAL,
+        WT_ERR_MSG(session, WT_E(EINVAL),
           "Error compiling '%s', overflowed maximum compile slots of %" PRIu32, format,
           conn->conf_max);
     conn->conf_array[compiled_entry] = conf;
@@ -390,7 +390,7 @@ __wt_conf_compile_api_call(WT_SESSION_IMPL *session, const WT_CONFIG_ENTRY *cent
     const char *cfg[3];
 
     if (!centry->compilable)
-        WT_RET_MSG(session, ENOTSUP,
+        WT_RET_MSG(session, WT_E(ENOTSUP),
           "Error compiling, method '%s' does not support compiled configurations", centry->method);
 
     /* Fast path: if there is no configuration, return with the default config for this API. */

--- a/src/conf/conf_get.c
+++ b/src/conf/conf_get.c
@@ -36,7 +36,7 @@ __wt_conf_gets_func(WT_SESSION_IMPL *session, const WT_CONF *orig_conf, uint64_t
 
         conf_value_index = conf->value_map[partkey];
         if (conf_value_index == 0)
-            return (WT_NOTFOUND);
+            return (WT_E(WT_NOTFOUND));
 
         /* The value in value_map is one-based, account for that here. */
         --conf_value_index;
@@ -57,20 +57,20 @@ __wt_conf_gets_func(WT_SESSION_IMPL *session, const WT_CONF *orig_conf, uint64_t
         /* FALLTHROUGH */
         case CONF_VALUE_NONDEFAULT_ITEM:
             if (keys != 0)
-                return (WT_NOTFOUND);
+                return (WT_E(WT_NOTFOUND));
             *value = conf_value->u.item;
             return (0);
 
         case CONF_VALUE_BIND_DESC:
             if (keys != 0)
-                return (WT_NOTFOUND);
+                return (WT_E(WT_NOTFOUND));
             bind_desc = &conf_value->u.bind_desc;
             values_off = bind_desc->offset;
             WT_ASSERT(session,
               bind_desc->offset < orig_conf->binding_count &&
                 values_off <= WT_CONF_BIND_VALUES_LEN);
             if (session->conf_bindings.values[values_off].desc != bind_desc)
-                WT_RET_MSG(session, EINVAL,
+                WT_RET_MSG(session, WT_E(EINVAL),
                   "configuration value(s) have not been bound with bind_configuration");
             *value = session->conf_bindings.values[values_off].item;
             return (0);
@@ -87,5 +87,5 @@ __wt_conf_gets_func(WT_SESSION_IMPL *session, const WT_CONF *orig_conf, uint64_t
             break;
         }
     }
-    return (WT_NOTFOUND);
+    return (WT_E(WT_NOTFOUND));
 }

--- a/src/config/config_api.c
+++ b/src/config/config_api.c
@@ -103,7 +103,7 @@ __config_validate(WT_SESSION *wt_session, WT_EVENT_HANDLER *event_handler, const
      * It's a logic error to specify both a session and an event handler.
      */
     if (session != NULL && event_handler != NULL)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "wiredtiger_config_validate event handler ignored when a session also specified");
 
     /*
@@ -123,9 +123,9 @@ __config_validate(WT_SESSION *wt_session, WT_EVENT_HANDLER *event_handler, const
         conn = S2C(session);
 
     if (name == NULL)
-        WT_RET_MSG(session, EINVAL, "no name specified");
+        WT_RET_MSG(session, WT_E(EINVAL), "no name specified");
     if (config == NULL)
-        WT_RET_MSG(session, EINVAL, "no configuration specified");
+        WT_RET_MSG(session, WT_E(EINVAL), "no configuration specified");
 
     /*
      * If we don't have a real connection, look for a matching name in the static list, otherwise
@@ -143,7 +143,7 @@ __config_validate(WT_SESSION *wt_session, WT_EVENT_HANDLER *event_handler, const
             }
     }
     if (ep == NULL)
-        WT_RET_MSG(session, EINVAL, "unknown or unsupported configuration API: %s", name);
+        WT_RET_MSG(session, WT_E(EINVAL), "unknown or unsupported configuration API: %s", name);
 
     return (__wt_config_check(session, ep, config, 0));
 }
@@ -223,14 +223,14 @@ __config_add_checks(WT_SESSION_IMPL *session, WT_CONFIG_ENTRY *entry, WT_CONFIG_
             if (WT_CONFIG_LIT_MATCH("min", ck)) {
                 cp->min_value = strtoll(cv.str, &endnum, 10);
                 if (endnum != &cv.str[cv.len])
-                    WT_RET_MSG(session, EINVAL, "min value invalid for key '%s'", cp->name);
+                    WT_RET_MSG(session, WT_E(EINVAL), "min value invalid for key '%s'", cp->name);
             } else if (WT_CONFIG_LIT_MATCH("max", ck)) {
                 cp->max_value = strtoll(cv.str, &endnum, 10);
                 if (endnum != &cv.str[cv.len])
-                    WT_RET_MSG(session, EINVAL, "max value invalid for key '%s'", cp->name);
+                    WT_RET_MSG(session, WT_E(EINVAL), "max value invalid for key '%s'", cp->name);
             } else if (WT_CONFIG_LIT_MATCH("choices", ck)) {
                 if (cv.len == 0)
-                    WT_RET_MSG(session, EINVAL, "Key '%s' requires a value", cp->name);
+                    WT_RET_MSG(session, WT_E(EINVAL), "Key '%s' requires a value", cp->name);
                 if (cv.type == WT_CONFIG_ITEM_STRUCT) {
                     /*
                      * Handle the 'verbose' case of a list containing restricted choices. This
@@ -306,9 +306,9 @@ __wt_configure_method(WT_SESSION_IMPL *session, const char *method, const char *
 
     /* Argument checking; we only support a limited number of types. */
     if (config == NULL)
-        WT_RET_MSG(session, EINVAL, "no configuration specified");
+        WT_RET_MSG(session, WT_E(EINVAL), "no configuration specified");
     if (type == NULL)
-        WT_RET_MSG(session, EINVAL, "no configuration type specified");
+        WT_RET_MSG(session, WT_E(EINVAL), "no configuration type specified");
 
     /* Determine the compiled type. */
     WT_NOT_READ(compiled_type, 0);
@@ -322,7 +322,7 @@ __wt_configure_method(WT_SESSION_IMPL *session, const char *method, const char *
         compiled_type = WT_CONFIG_COMPILED_TYPE_STRING;
     else
         WT_RET_MSG(
-          session, EINVAL, "type must be one of \"boolean\", \"int\", \"list\" or \"string\"");
+          session, WT_E(EINVAL), "type must be one of \"boolean\", \"int\", \"list\" or \"string\"");
 
     /*
      * Translate the method name to our configuration names, then find a match.
@@ -331,7 +331,7 @@ __wt_configure_method(WT_SESSION_IMPL *session, const char *method, const char *
         if (strcmp((*epp)->method, method) == 0)
             break;
     if (*epp == NULL || (*epp)->method == NULL)
-        WT_RET_MSG(session, WT_NOTFOUND, "no method matching %s found", method);
+        WT_RET_MSG(session, WT_E(WT_NOTFOUND), "no method matching %s found", method);
 
     /*
      * Technically possible for threads to race, lock the connection while adding the new

--- a/src/config/config_check.c
+++ b/src/config/config_check.c
@@ -111,7 +111,7 @@ __config_check_search(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *checks, u
             return (0);
     }
 
-    WT_RET_MSG(session, EINVAL, "unknown configuration key '%.*s'", (int)item->len, item->str);
+    WT_RET_MSG(session, WT_E(EINVAL), "unknown configuration key '%.*s'", (int)item->len, item->str);
 }
 
 /*
@@ -160,7 +160,7 @@ __config_check(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *checks, u_int ch
     while ((ret = __wt_config_next(&parser, &k, &v)) == 0) {
         if (k.type != WT_CONFIG_ITEM_STRING && k.type != WT_CONFIG_ITEM_ID)
             WT_RET_MSG(
-              session, EINVAL, "Invalid configuration key found: '%.*s'", (int)k.len, k.str);
+              session, WT_E(EINVAL), "Invalid configuration key found: '%.*s'", (int)k.len, k.str);
 
         /* Search for a matching entry. */
         WT_RET(__config_check_search(session, checks, checks_entries, &k, check_jump, &check));
@@ -188,10 +188,10 @@ __config_check(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *checks, u_int ch
         case WT_CONFIG_COMPILED_TYPE_STRING:
             break;
         default:
-            WT_RET_MSG(session, EINVAL, "unknown configuration type: '%s'", check->type);
+            WT_RET_MSG(session, WT_E(EINVAL), "unknown configuration type: '%s'", check->type);
         }
         if (badtype)
-            WT_RET_MSG(session, EINVAL, "Invalid value for key '%.*s': expected a %s", (int)k.len,
+            WT_RET_MSG(session, WT_E(EINVAL), "Invalid value for key '%.*s': expected a %s", (int)k.len,
               k.str, check->type);
 
         if (check->checkf != NULL)
@@ -203,16 +203,16 @@ __config_check(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *checks, u_int ch
 
         /* The checks string itself is not needed for checking. */
         if (v.val < check->min_value)
-            WT_RET_MSG(session, EINVAL, "Value too small for key '%.*s' the minimum is %" PRIi64,
+            WT_RET_MSG(session, WT_E(EINVAL), "Value too small for key '%.*s' the minimum is %" PRIi64,
               (int)k.len, k.str, check->min_value);
 
         if (v.val > check->max_value)
-            WT_RET_MSG(session, EINVAL, "Value too large for key '%.*s' the maximum is %" PRIi64,
+            WT_RET_MSG(session, WT_E(EINVAL), "Value too large for key '%.*s' the maximum is %" PRIi64,
               (int)k.len, k.str, check->max_value);
 
         if ((choices = check->choices) != NULL) {
             if (v.len == 0)
-                WT_RET_MSG(session, EINVAL, "Key '%.*s' requires a value", (int)k.len, k.str);
+                WT_RET_MSG(session, WT_E(EINVAL), "Key '%.*s' requires a value", (int)k.len, k.str);
             if (v.type == WT_CONFIG_ITEM_STRUCT) {
                 /* Handle the 'verbose' case of a list containing restricted choices. */
                 __wt_config_subinit(session, &sparser, &v);
@@ -224,7 +224,7 @@ __config_check(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *checks, u_int ch
                 found = __wt_config_get_choice(choices, &v);
 
             if (!found)
-                WT_RET_MSG(session, EINVAL, "Value '%.*s' not a permitted choice for key '%.*s'",
+                WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' not a permitted choice for key '%.*s'",
                   (int)v.len, v.str, (int)k.len, k.str);
         }
     }

--- a/src/config/config_collapse.c
+++ b/src/config/config_collapse.c
@@ -37,7 +37,7 @@ __wt_config_collapse(WT_SESSION_IMPL *session, const char **cfg, char **config_r
     __wt_config_init(session, &cparser, cfg[0]);
     while ((ret = __wt_config_next(&cparser, &k, &v)) == 0) {
         if (k.type != WT_CONFIG_ITEM_STRING && k.type != WT_CONFIG_ITEM_ID)
-            WT_ERR_MSG(session, EINVAL, "Invalid configuration key found: '%s'", k.str);
+            WT_ERR_MSG(session, WT_E(EINVAL), "Invalid configuration key found: '%s'", k.str);
         WT_ERR(__wti_config_get(session, cfg, &k, &v));
         /* Include the quotes around string keys/values. */
         if (k.type == WT_CONFIG_ITEM_STRING)
@@ -115,7 +115,7 @@ __config_merge_scan(
     __wt_config_init(session, &cparser, value);
     while ((ret = __wt_config_next(&cparser, &k, &v)) == 0) {
         if (k.type != WT_CONFIG_ITEM_STRING && k.type != WT_CONFIG_ITEM_ID)
-            WT_ERR_MSG(session, EINVAL, "Invalid configuration key found: '%s'", k.str);
+            WT_ERR_MSG(session, WT_E(EINVAL), "Invalid configuration key found: '%s'", k.str);
 
         /* Include the quotes around string keys/values. */
         if (k.type == WT_CONFIG_ITEM_STRING)
@@ -136,7 +136,7 @@ __config_merge_scan(
          */
         for (len = 0; len < k.len; ++len)
             if (k.str[len] == SEPC)
-                WT_ERR_MSG(session, EINVAL, "key %.*s contains a '%c' separator character",
+                WT_ERR_MSG(session, WT_E(EINVAL), "key %.*s contains a '%c' separator character",
                   (int)k.len, (char *)k.str, SEPC);
 
         /* Build the key/value strings. */

--- a/src/config/config_ext.c
+++ b/src/config/config_ext.c
@@ -26,7 +26,7 @@ __wt_ext_config_get(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, WT_CONFIG_
         session = conn->default_session;
 
     if ((cfg = (const char **)cfg_arg) == NULL)
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
     return (__wt_config_gets(session, cfg, key, cval));
 }
 

--- a/src/conn/conn_cache_pool.c
+++ b/src/conn/conn_cache_pool.c
@@ -69,12 +69,12 @@ __cache_pool_config(WT_SESSION_IMPL *session, const char **cfg)
              * pool.
              */
             if (__wt_config_gets(session, &cfg[1], "shared_cache.size", &cval) != WT_NOTFOUND)
-                WT_RET_MSG(session, EINVAL, "Shared cache configuration requires a pool name");
+                WT_RET_MSG(session, WT_E(EINVAL), "Shared cache configuration requires a pool name");
             return (0);
         }
 
         if (__wt_config_gets(session, &cfg[1], "cache_size", &cval_cache_size) != WT_NOTFOUND)
-            WT_RET_MSG(session, EINVAL,
+            WT_RET_MSG(session, WT_E(EINVAL),
               "Only one of cache_size and shared_cache can be in the configuration");
 
         /*
@@ -102,7 +102,7 @@ __cache_pool_config(WT_SESSION_IMPL *session, const char **cfg)
     } else if (!updating && strcmp(__wt_process.cache_pool->name, pool_name) != 0)
         /* Only a single cache pool is supported. */
         WT_ERR_MSG(
-          session, WT_ERROR, "Attempting to join a cache pool that does not exist: %s", pool_name);
+          session, WT_E(WT_ERROR), "Attempting to join a cache pool that does not exist: %s", pool_name);
 
     /*
      * At this point we have a cache pool to use. We need to take its lock. We need to drop the
@@ -183,7 +183,7 @@ __cache_pool_config(WT_SESSION_IMPL *session, const char **cfg)
     if (updating)
         used_cache -= conn->cache->cp_reserved;
     if (used_cache + reserve > size)
-        WT_ERR_MSG(session, EINVAL,
+        WT_ERR_MSG(session, WT_E(EINVAL),
           "Shared cache unable to accommodate this configuration. Shared cache size: %" PRIu64
           ", requested min: %" PRIu64,
           size, used_cache + reserve);

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -39,7 +39,7 @@ __capacity_config(WT_SESSION_IMPL *session, const char *cfg[])
     WT_RET(__wt_config_gets(session, cfg, "io_capacity.total", &cval));
     if (cval.val != 0) {
         if (cval.val < WT_THROTTLE_MIN)
-            WT_RET_MSG(session, EINVAL, "total I/O capacity value %" PRId64 " below minimum %d",
+            WT_RET_MSG(session, WT_E(EINVAL), "total I/O capacity value %" PRId64 " below minimum %d",
               cval.val, WT_THROTTLE_MIN);
         total = (uint64_t)cval.val;
     }
@@ -48,14 +48,14 @@ __capacity_config(WT_SESSION_IMPL *session, const char *cfg[])
     if (cval.val != 0) {
         chunkcache = (uint64_t)cval.val;
         if (chunkcache < WT_THROTTLE_MIN)
-            WT_RET_MSG(session, EINVAL,
+            WT_RET_MSG(session, WT_E(EINVAL),
               "chunk cache I/O capacity value %" PRIu64 " below minimum %d", chunkcache,
               WT_THROTTLE_MIN);
         if (total < chunkcache)
-            WT_RET_MSG(session, EINVAL,
+            WT_RET_MSG(session, WT_E(EINVAL),
               "chunk cache I/O capacity value %" PRIu64 " below total %" PRIu64, chunkcache, total);
         if ((total - chunkcache) < WT_THROTTLE_MIN)
-            WT_RET_MSG(session, EINVAL,
+            WT_RET_MSG(session, WT_E(EINVAL),
               "chunk cache I/O capacity value %" PRIu64
               " leaves insufficient capacity for other subsystems (total %" PRIu64
               ", remaining %" PRIu64 ")",

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -50,7 +50,7 @@ __conn_dhandle_config_set(WT_SESSION_IMPL *session)
      */
     if ((ret = __wt_metadata_search(session, dhandle->name, &metaconf)) != 0) {
         if (ret == WT_NOTFOUND)
-            ret = __wt_set_return(session, ENOENT);
+            ret = __wt_set_return(session, WT_E(ENOENT));
         WT_RET(ret);
     }
 
@@ -203,7 +203,7 @@ __wt_conn_dhandle_alloc(WT_SESSION_IMPL *session, const char *uri, const char *c
         dhandle = (WT_DATA_HANDLE *)tiered;
         __wt_atomic_store_enum(&dhandle->type, WT_DHANDLE_TYPE_TIERED);
     } else
-        WT_RET_PANIC(session, EINVAL, "illegal handle allocation URI %s", uri);
+        WT_RET_PANIC(session, WT_E(EINVAL), "illegal handle allocation URI %s", uri);
 
     /* Btree handles keep their data separate from the interface. */
     if (WT_DHANDLE_BTREE(dhandle)) {
@@ -283,7 +283,7 @@ __wt_conn_dhandle_find(WT_SESSION_IMPL *session, const char *uri, const char *ch
             }
         }
 
-    return (WT_NOTFOUND);
+    return (WT_E(WT_NOTFOUND));
 }
 
 /*
@@ -324,7 +324,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
         WT_ASSERT_ALWAYS(session, btree->max_upd_txn != WT_TXN_ABORTED,
           "Assert failure: session: %s: btree->max_upd_txn == WT_TXN_ABORTED", session->name);
         if (check_visibility && !__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
-            WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,
+            WT_RET_SUB(session, WT_E(EBUSY), WT_UNCOMMITTED_DATA,
               "the table has uncommitted data and cannot be dropped yet");
 
         /* Turn off eviction. */
@@ -622,7 +622,7 @@ err:
 
     if (ret == ENOENT && F_ISSET(dhandle, WT_DHANDLE_IS_METADATA)) {
         F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
-        return (WT_ERROR);
+        return (WT_E(WT_ERROR));
     }
 
     return (ret);
@@ -842,7 +842,7 @@ __conn_dhandle_remove(WT_SESSION_IMPL *session, bool final)
     if (!final &&
       (__wt_atomic_loadi32(&dhandle->session_inuse) != 0 ||
         __wt_atomic_load32(&dhandle->references) != 0))
-        return (__wt_set_return(session, EBUSY));
+        return (__wt_set_return(session, WT_E(EBUSY)));
 
     WT_CONN_DHANDLE_REMOVE(conn, dhandle, bucket);
     return (0);

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -179,7 +179,7 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
      * are close to hitting the eviction clean trigger.
      */
     if (__wt_evict_clean_pressure(session))
-        return (EBUSY);
+        return (WT_E(EBUSY));
 
     WT_RET(__wt_calloc_one(session, &pe));
     pe->ref = ref;
@@ -190,7 +190,7 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
     /* Don't queue pages for trees that have eviction disabled. */
     if (S2BT(session)->evict_disabled > 0) {
         __wt_spin_unlock(session, &conn->prefetch_lock);
-        WT_ERR(EBUSY);
+        WT_ERR(WT_E(EBUSY));
     }
 
     /* We should never add a ref that is already in the prefetch queue. */

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -171,7 +171,7 @@ __statlog_config(WT_SESSION_IMPL *session, const char **cfg, bool *runp)
         for (cnt = 0; (ret = __wt_config_next(&objectconf, &k, &v)) == 0; ++cnt) {
             /* Only allow "file:" for now, it works because it's been converted to data handles. */
             if (!WT_PREFIX_MATCH(k.str, "file:"))
-                WT_ERR_MSG(session, EINVAL,
+                WT_ERR_MSG(session, WT_E(EINVAL),
                   "statistics_log sources configuration only supports objects of type \"file\"");
             WT_ERR(__wt_strndup(session, k.str, k.len, &sources[cnt]));
         }
@@ -422,7 +422,7 @@ __statlog_log_one(WT_SESSION_IMPL *session, WT_ITEM *path, WT_ITEM *tmp)
 
     /* Create the logging path name for this time of day. */
     if (strftime(tmp->mem, tmp->memsize, conn->stat_path, &localt) == 0)
-        WT_RET_MSG(session, ENOMEM, "strftime path conversion");
+        WT_RET_MSG(session, WT_E(ENOMEM), "strftime path conversion");
 
     /* If the path has changed, cycle the log file. */
     if (conn->stat_fs == NULL || path == NULL || strcmp(tmp->mem, path->mem) != 0) {
@@ -436,7 +436,7 @@ __statlog_log_one(WT_SESSION_IMPL *session, WT_ITEM *path, WT_ITEM *tmp)
 
     /* Create the entry prefix for this time of day. */
     if (strftime(tmp->mem, tmp->memsize, conn->stat_format, &localt) == 0)
-        WT_RET_MSG(session, ENOMEM, "strftime timestamp conversion");
+        WT_RET_MSG(session, WT_E(ENOMEM), "strftime timestamp conversion");
     conn->stat_stamp = tmp->mem;
     WT_RET(__statlog_print_header(session));
 
@@ -474,7 +474,7 @@ __statlog_on_close(WT_SESSION_IMPL *session)
         return (0);
 
     if (FLD_ISSET(conn->server_flags, WT_CONN_SERVER_STATISTICS))
-        WT_RET_MSG(session, EINVAL, "Attempt to log statistics while a server is running");
+        WT_RET_MSG(session, WT_E(EINVAL), "Attempt to log statistics while a server is running");
 
     WT_RET(__wt_scr_alloc(session, strlen(conn->stat_path) + 128, &tmp));
     WT_ERR(__wt_buf_setstr(session, tmp, ""));

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -24,7 +24,7 @@ __sweep_check_file_handle_exists(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhand
     WT_DECL_RET;
     WT_TABLE *table;
 
-    ret = WT_NOTFOUND;
+    ret = WT_E(WT_NOTFOUND);
     /*
      * The sweep server's algorithm is altered to prevent unnecessary table dhandle closures. This
      * is done by checking for associated file dhandles before marking table dhandles for sweeping.
@@ -263,7 +263,7 @@ __sweep_remove_one(WT_SESSION_IMPL *session)
      * If there are no longer any references to the handle in any sessions, attempt to discard it.
      */
     if (!WT_DHANDLE_CAN_DISCARD(session->dhandle))
-        WT_ERR(EBUSY);
+        WT_ERR(WT_E(EBUSY));
 
     ret = __wti_conn_dhandle_discard_single(session, false, true);
 

--- a/src/cursor/cur_backup_incr.c
+++ b/src/cursor/cur_backup_incr.c
@@ -19,7 +19,7 @@ __wt_backup_load_incr(
     if (blkcfg->len != 0)
         WT_RET(__wt_nhex_to_raw(session, blkcfg->str, blkcfg->len, bitstring));
     if (bitstring->size != (nbits >> 3))
-        WT_RET_MSG(session, WT_ERROR, "corrupted modified block list");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "corrupted modified block list");
     return (0);
 }
 
@@ -190,7 +190,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
                     __wt_cursor_set_key(cursor, 0, size, WT_BACKUP_FILE);
                     goto done;
                 }
-                WT_ERR(WT_NOTFOUND);
+                WT_ERR(WT_E(WT_NOTFOUND));
             }
         }
         /* We have initialized incremental information. */
@@ -235,7 +235,7 @@ __curbackup_incr_next(WT_CURSOR *cursor)
 
         /* We either have this object's incremental information or we're done. */
         if (!found)
-            WT_ERR(WT_NOTFOUND);
+            WT_ERR(WT_E(WT_NOTFOUND));
         WT_ASSERT(session, cb->granularity != 0);
         WT_ASSERT(session, total_len != 0);
         __wt_verbose_debug2(session, WT_VERB_BACKUP,

--- a/src/cursor/cur_bulk.c
+++ b/src/cursor/cur_bulk.c
@@ -21,7 +21,7 @@ __bulk_col_keycmp_err(WT_CURSOR_BULK *cbulk)
     cursor = &cbulk->cbt.iface;
     session = CUR2S(cbulk);
 
-    WT_RET_MSG(session, EINVAL,
+    WT_RET_MSG(session, WT_E(EINVAL),
       "bulk-load presented with out-of-order keys: %" PRIu64
       " is less than or equal to the previously inserted key %" PRIu64,
       cursor->recno, cbulk->recno);
@@ -200,7 +200,7 @@ __bulk_row_keycmp_err(WT_CURSOR_BULK *cbulk)
     WT_ERR(__wt_scr_alloc(session, 512, &a));
     WT_ERR(__wt_scr_alloc(session, 512, &b));
 
-    WT_ERR_MSG(session, EINVAL,
+    WT_ERR_MSG(session, WT_E(EINVAL),
       "bulk-load presented with out-of-order keys: %s is less than or equal to the previously "
       "inserted "
       "key %s",

--- a/src/cursor/cur_ds.c
+++ b/src/cursor/cur_ds.c
@@ -133,7 +133,7 @@ __curds_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
      * Confirm both cursors refer to the same source and have keys, then compare them.
      */
     if (strcmp(a->internal_uri, b->internal_uri) != 0)
-        WT_ERR_MSG(session, EINVAL, "Cursors must reference the same object");
+        WT_ERR_MSG(session, WT_E(EINVAL), "Cursors must reference the same object");
 
     WT_ERR(__cursor_needkey(a));
     WT_ERR(__cursor_needkey(b));

--- a/src/cursor/cur_dump.c
+++ b/src/cursor/cur_dump.c
@@ -132,10 +132,10 @@ str2recno(WT_SESSION_IMPL *session, const char *p, uint64_t *recnop)
     errno = 0;
     recno = __wt_strtouq(p, &endptr, 0);
     if (recno == ULLONG_MAX && errno == ERANGE)
-        WT_RET_MSG(session, ERANGE, "%s: invalid record number", p);
+        WT_RET_MSG(session, WT_E(ERANGE), "%s: invalid record number", p);
     if (endptr[0] != '\0')
 format:
-        WT_RET_MSG(session, EINVAL, "%s: invalid record number", p);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s: invalid record number", p);
 
     *recnop = recno;
     return (0);

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -453,7 +453,7 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
          */
         if (F_ISSET(hs_cursor, WT_HS_CUR_BTREE_ID_SET) &&
           !F_ISSET(std_cursor, WT_CURSTD_HS_READ_ACROSS_BTREE) && btree_id != hs_cursor->btree_id) {
-            ret = WT_NOTFOUND;
+            ret = WT_E(WT_NOTFOUND);
             goto err;
         }
 
@@ -464,7 +464,7 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
         if (F_ISSET(hs_cursor, WT_HS_CUR_KEY_SET)) {
             WT_ERR(__wt_compare(session, NULL, datastore_key, hs_cursor->datastore_key, &cmp));
             if (cmp != 0) {
-                ret = WT_NOTFOUND;
+                ret = WT_E(WT_NOTFOUND);
                 goto err;
             }
         }
@@ -505,7 +505,7 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
              * for this entire key.
              */
             if (F_ISSET(hs_cursor, WT_HS_CUR_KEY_SET)) {
-                ret = WT_NOTFOUND;
+                ret = WT_E(WT_NOTFOUND);
                 goto err;
             } else
                 continue;
@@ -556,7 +556,7 @@ __curhs_next_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
          */
         if (F_ISSET(hs_cursor, WT_HS_CUR_BTREE_ID_SET) &&
           !F_ISSET(std_cursor, WT_CURSTD_HS_READ_ACROSS_BTREE) && btree_id != hs_cursor->btree_id) {
-            ret = WT_NOTFOUND;
+            ret = WT_E(WT_NOTFOUND);
             goto err;
         }
 
@@ -567,7 +567,7 @@ __curhs_next_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
         if (F_ISSET(hs_cursor, WT_HS_CUR_KEY_SET)) {
             WT_ERR(__wt_compare(session, NULL, datastore_key, hs_cursor->datastore_key, &cmp));
             if (cmp != 0) {
-                ret = WT_NOTFOUND;
+                ret = WT_E(WT_NOTFOUND);
                 goto err;
             }
         }
@@ -769,7 +769,7 @@ __curhs_search_near(WT_CURSOR *cursor, int *exactp)
                      */
                     WT_ERR(__wt_compare(session, NULL, &file_cursor->key, srch_key, &cmp));
                     if (cmp < 0) {
-                        ret = WT_NOTFOUND;
+                        ret = WT_E(WT_NOTFOUND);
                         goto err;
                     }
                 }
@@ -779,7 +779,7 @@ __curhs_search_near(WT_CURSOR *cursor, int *exactp)
                  * in the specified btree range.
                  */
                 if (btree_id < hs_cursor->btree_id) {
-                    ret = WT_NOTFOUND;
+                    ret = WT_E(WT_NOTFOUND);
                     goto err;
                 }
             }
@@ -848,7 +848,7 @@ __curhs_search_near(WT_CURSOR *cursor, int *exactp)
                      */
                     WT_ERR(__wt_compare(session, NULL, &file_cursor->key, srch_key, &cmp));
                     if (cmp > 0) {
-                        ret = WT_NOTFOUND;
+                        ret = WT_E(WT_NOTFOUND);
                         goto err;
                     }
                 }
@@ -858,7 +858,7 @@ __curhs_search_near(WT_CURSOR *cursor, int *exactp)
                  * in the specified btree range.
                  */
                 if (btree_id > hs_cursor->btree_id) {
-                    ret = WT_NOTFOUND;
+                    ret = WT_E(WT_NOTFOUND);
                     goto err;
                 }
             }

--- a/src/cursor/cur_index.c
+++ b/src/cursor/cur_index.c
@@ -42,7 +42,7 @@ __curindex_set_valuev(WT_CURSOR *cursor, va_list ap)
     WT_UNUSED(ap);
 
     CURSOR_API_CALL(cursor, session, ret, set_value, NULL);
-    WT_ERR_MSG(session, ENOTSUP, "WT_CURSOR.set_value not supported for index cursors");
+    WT_ERR_MSG(session, WT_E(ENOTSUP), "WT_CURSOR.set_value not supported for index cursors");
 
 err:
     cursor->saved_err = ret;
@@ -80,7 +80,7 @@ __curindex_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
 
     /* Check both cursors are "index:" type. */
     if (!WT_PREFIX_MATCH(a->uri, "index:") || strcmp(a->uri, b->uri) != 0)
-        WT_ERR_MSG(session, EINVAL, "Cursors must reference the same object");
+        WT_ERR_MSG(session, WT_E(EINVAL), "Cursors must reference the same object");
 
     WT_ERR(__cursor_checkkey(a));
     WT_ERR(__cursor_checkkey(b));
@@ -255,7 +255,7 @@ __curindex_search(WT_CURSOR *cursor)
      */
     found_key = child->key;
     if (found_key.size < cursor->key.size)
-        WT_ERR(WT_NOTFOUND);
+        WT_ERR(WT_E(WT_NOTFOUND));
 
     /*
      * Custom collators expect to see complete keys, pass an item containing all the visible fields
@@ -269,7 +269,7 @@ __curindex_search(WT_CURSOR *cursor)
 
     WT_ERR(__wt_compare(session, cindex->index->collator, &cursor->key, &found_key, &cmp));
     if (cmp != 0) {
-        ret = WT_NOTFOUND;
+        ret = WT_E(WT_NOTFOUND);
         goto err;
     }
 
@@ -451,7 +451,7 @@ __curindex_bound(WT_CURSOR *cursor, const char *config)
          */
         if (!__increment_bound_array(&child->lower_bound)) {
             WT_ERR(__wt_cursor_bounds_restore(session, child, &saved_bounds));
-            WT_ERR_MSG(session, EINVAL,
+            WT_ERR_MSG(session, WT_E(EINVAL),
               "Cannot set index cursors with the max possible key as the lower bound");
         }
     }
@@ -595,13 +595,13 @@ __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
 
     tablename = uri;
     if (!WT_PREFIX_SKIP(tablename, "index:") || (idxname = strchr(tablename, ':')) == NULL)
-        WT_RET_MSG(session, EINVAL, "Invalid cursor URI: '%s'", uri);
+        WT_RET_MSG(session, WT_E(EINVAL), "Invalid cursor URI: '%s'", uri);
     namesize = (size_t)(idxname - tablename);
     ++idxname;
 
     if ((ret = __wt_schema_get_table(session, tablename, namesize, false, 0, &table)) != 0) {
         if (ret == WT_NOTFOUND)
-            WT_RET_MSG(session, EINVAL, "Cannot open cursor '%s' on unknown table", uri);
+            WT_RET_MSG(session, WT_E(EINVAL), "Cannot open cursor '%s' on unknown table", uri);
         return (ret);
     }
 
@@ -636,7 +636,7 @@ __wt_curindex_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
      * that for now.
      */
     if (WT_CURSOR_RECNO(cursor))
-        WT_ERR_MSG(session, WT_ERROR,
+        WT_ERR_MSG(session, WT_E(WT_ERROR),
           "Column store indexes based on a record number primary key are not supported");
 
     /* Handle projections. */

--- a/src/cursor/cur_metadata.c
+++ b/src/cursor/cur_metadata.c
@@ -246,7 +246,7 @@ __curmetadata_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
     CURSOR_API_CALL(a, session, ret, compare, CUR2BT(a_file_cursor));
 
     if (b->compare != __curmetadata_compare)
-        WT_ERR_MSG(session, EINVAL, "Can only compare cursors of the same type");
+        WT_ERR_MSG(session, WT_E(EINVAL), "Can only compare cursors of the same type");
 
     WT_MD_CURSOR_NEEDKEY(a);
     WT_MD_CURSOR_NEEDKEY(b);
@@ -328,7 +328,7 @@ __curmetadata_prev(WT_CURSOR *cursor)
     CURSOR_API_CALL(cursor, session, ret, prev, CUR2BT(file_cursor));
 
     if (F_ISSET(mdc, WT_MDC_ONMETADATA)) {
-        ret = WT_NOTFOUND;
+        ret = WT_E(WT_NOTFOUND);
         goto err;
     }
 

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -213,7 +213,7 @@ __curstat_next(WT_CURSOR *cursor)
     else if (cst->next_set != NULL)
         WT_ERR((*cst->next_set)(session, cst, true, false));
     else
-        WT_ERR(WT_NOTFOUND);
+        WT_ERR(WT_E(WT_NOTFOUND));
 
     cst->v = (uint64_t)cst->stats[WT_STAT_KEY_OFFSET(cst)];
     F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
@@ -256,7 +256,7 @@ __curstat_prev(WT_CURSOR *cursor)
     else if (cst->next_set != NULL)
         WT_ERR((*cst->next_set)(session, cst, false, false));
     else
-        WT_ERR(WT_NOTFOUND);
+        WT_ERR(WT_E(WT_NOTFOUND));
 
     cst->v = (uint64_t)cst->stats[WT_STAT_KEY_OFFSET(cst)];
     F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
@@ -317,7 +317,7 @@ __curstat_search(WT_CURSOR *cursor)
     }
 
     if (cst->key < WT_STAT_KEY_MIN(cst) || cst->key > WT_STAT_KEY_MAX(cst))
-        WT_ERR(WT_NOTFOUND);
+        WT_ERR(WT_E(WT_NOTFOUND));
 
     cst->v = (uint64_t)cst->stats[WT_STAT_KEY_OFFSET(cst)];
     F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
@@ -582,7 +582,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], 
         WT_ERR_NOTFOUND_OK(ret, false);
         if ((ret = __wt_config_subgets(session, &cval, "fast", &sval)) == 0 && sval.val != 0) {
             if (F_ISSET(cst, WT_STAT_TYPE_ALL))
-                WT_ERR_MSG(session, EINVAL,
+                WT_ERR_MSG(session, WT_E(EINVAL),
                   "Only one of all, fast, none configuration values should be specified");
             F_SET(cst, WT_STAT_TYPE_FAST);
         }
@@ -609,14 +609,14 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], 
 
         if ((ret = __wt_config_subgets(session, &cval, "size", &sval)) == 0 && sval.val != 0) {
             if (F_ISSET(cst, WT_STAT_TYPE_FAST | WT_STAT_TYPE_ALL))
-                WT_ERR_MSG(session, EINVAL,
+                WT_ERR_MSG(session, WT_E(EINVAL),
                   "Only one of all, fast, none configuration values should be specified");
             F_SET(cst, WT_STAT_TYPE_SIZE);
         }
         WT_ERR_NOTFOUND_OK(ret, false);
         if ((ret = __wt_config_subgets(session, &cval, "clear", &sval)) == 0 && sval.val != 0) {
             if (F_ISSET(cst, WT_STAT_TYPE_SIZE))
-                WT_ERR_MSG(session, EINVAL, "clear is incompatible with size statistics");
+                WT_ERR_MSG(session, WT_E(EINVAL), "clear is incompatible with size statistics");
             F_SET(cst, WT_STAT_CLEAR);
         }
         WT_ERR_NOTFOUND_OK(ret, false);
@@ -670,7 +670,7 @@ __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], 
 
     if (0) {
 config_err:
-        WT_ERR_MSG(session, EINVAL,
+        WT_ERR_MSG(session, WT_E(EINVAL),
           "cursor's statistics configuration doesn't match the database statistics configuration");
     }
 

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -242,7 +242,7 @@ __curtable_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
      * object's comparison routine.
      */
     if (strcmp(a->internal_uri, b->internal_uri) != 0)
-        WT_ERR_MSG(session, EINVAL, "comparison method cursors must reference the same object");
+        WT_ERR_MSG(session, WT_E(EINVAL), "comparison method cursors must reference the same object");
     WT_ERR(__cursor_checkkey(WT_CURSOR_PRIMARY(a)));
     WT_ERR(__cursor_checkkey(WT_CURSOR_PRIMARY(b)));
 
@@ -851,7 +851,7 @@ __curtable_complete(WT_SESSION_IMPL *session, WT_TABLE *table)
     /* If the table is incomplete, wait on the table lock and recheck. */
     WT_WITH_TABLE_READ_LOCK(session, complete = table->cg_complete);
     if (!complete)
-        WT_RET_MSG(session, EINVAL, "'%s' not available until all column groups are created",
+        WT_RET_MSG(session, WT_E(EINVAL), "'%s' not available until all column groups are created",
           table->iface.name);
     return (0);
 }
@@ -911,7 +911,7 @@ __curtable_open_indices(WT_CURSOR_TABLE *ctable)
     /* Check for bulk cursors. */
     primary = *ctable->cg_cursors;
     if (F_ISSET(primary, WT_CURSTD_BULK))
-        WT_RET_MSG(session, ENOTSUP, "Bulk load is not supported for tables with indices");
+        WT_RET_MSG(session, WT_E(ENOTSUP), "Bulk load is not supported for tables with indices");
 
     WT_RET(__wt_calloc_def(session, table->nindices, &ctable->idx_cursors));
     for (i = 0, cp = ctable->idx_cursors; i < table->nindices; i++, cp++)

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -184,7 +184,7 @@ __curversion_next_int(WT_CURSOR *cursor)
 
     /* The cursor should be positioned, otherwise the next call will fail. */
     if (!F_ISSET(file_cursor, WT_CURSTD_KEY_INT))
-        WT_ERR_SUB(session, WT_ROLLBACK, WT_NONE,
+        WT_ERR_SUB(session, WT_E(WT_ROLLBACK), WT_NONE,
           "rolling back version_cursor->next due to no initial position");
 
     if (!F_ISSET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED)) {
@@ -283,7 +283,7 @@ __curversion_next_int(WT_CURSOR *cursor)
             if (cbt->ins != NULL) {
                 F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
                 F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
-                WT_ERR(WT_NOTFOUND);
+                WT_ERR(WT_E(WT_NOTFOUND));
             }
             break;
         case WT_PAGE_COL_FIX:
@@ -294,7 +294,7 @@ __curversion_next_int(WT_CURSOR *cursor)
             if (cbt->recno >= cbt->ref->ref_recno + page->entries) {
                 F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
                 F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
-                WT_ERR(WT_NOTFOUND);
+                WT_ERR(WT_E(WT_NOTFOUND));
             }
             break;
         case WT_PAGE_COL_VAR:
@@ -302,7 +302,7 @@ __curversion_next_int(WT_CURSOR *cursor)
             if (page->entries == 0) {
                 F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
                 F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
-                WT_ERR(WT_NOTFOUND);
+                WT_ERR(WT_E(WT_NOTFOUND));
             }
             break;
         default:
@@ -406,7 +406,7 @@ __curversion_next_int(WT_CURSOR *cursor)
     }
 
     if (!upd_found)
-        ret = WT_NOTFOUND;
+        ret = WT_E(WT_NOTFOUND);
     else {
         cbt->upd_value->type = WT_UPDATE_STANDARD;
         __wt_value_return(cbt, cbt->upd_value);
@@ -505,13 +505,13 @@ __curversion_search(WT_CURSOR *cursor)
      * We need to run with snapshot isolation to ensure that the globally visibility does not move.
      */
     if (txn->isolation != WT_ISO_SNAPSHOT)
-        WT_ERR_SUB(session, WT_ROLLBACK, WT_NONE,
+        WT_ERR_SUB(session, WT_E(WT_ROLLBACK), WT_NONE,
           "version cursor can only be called with snapshot isolation");
 
     WT_ERR(__cursor_checkkey(file_cursor));
     if (F_ISSET(file_cursor, WT_CURSTD_KEY_INT))
         WT_ERR_SUB(
-          session, WT_ROLLBACK, WT_NONE, "version cursor cannot be called when it is positioned");
+          session, WT_E(WT_ROLLBACK), WT_NONE, "version cursor cannot be called when it is positioned");
 
     /* Do a search and position on the key if it is found */
     F_SET(file_cursor, WT_CURSTD_KEY_ONLY);

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -35,11 +35,11 @@ __evict_config_abs_to_pct(
          * percentage setting and do not allow an absolute size setting.
          */
         if (shared)
-            WT_RET_MSG(session, EINVAL,
+            WT_RET_MSG(session, WT_E(EINVAL),
               "Shared cache configuration requires a percentage value for %s", param_name);
         /* An absolute value can't exceed the cache size. */
         if (input > cache_size)
-            WT_RET_MSG(session, EINVAL, "%s should not exceed cache size", param_name);
+            WT_RET_MSG(session, WT_E(EINVAL), "%s should not exceed cache size", param_name);
 
         *param = (input * 100.0) / cache_size;
     }
@@ -162,12 +162,12 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* The target size must be lower than the trigger size or we will never get any work done. */
     if (evict->eviction_target >= evict->eviction_trigger)
-        WT_RET_MSG(session, EINVAL, "eviction target must be lower than the eviction trigger");
+        WT_RET_MSG(session, WT_E(EINVAL), "eviction target must be lower than the eviction trigger");
     if (evict->eviction_dirty_target >= evict->eviction_dirty_trigger)
         WT_RET_MSG(
-          session, EINVAL, "eviction dirty target must be lower than the eviction dirty trigger");
+          session, WT_E(EINVAL), "eviction dirty target must be lower than the eviction dirty trigger");
     if (evict->eviction_updates_target >= evict->eviction_updates_trigger)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "eviction updates target must be lower than the eviction updates trigger");
 
     return (0);
@@ -212,7 +212,7 @@ __wt_evict_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 
     if (evict_threads_min > evict_threads_max)
         WT_RET_MSG(
-          session, EINVAL, "eviction=(threads_min) cannot be greater than eviction=(threads_max)");
+          session, WT_E(EINVAL), "eviction=(threads_min) cannot be greater than eviction=(threads_max)");
     conn->evict_threads_max = evict_threads_max;
     conn->evict_threads_min = evict_threads_min;
 

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -70,7 +70,7 @@ __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
 
     WT_ERR(__wt_config_gets(session, cfg, "history_store.file_max", &cval));
     if (cval.val != 0 && cval.val < WT_HS_FILE_MIN)
-        WT_ERR_MSG(session, EINVAL, "max history store size %" PRId64 " below minimum %d", cval.val,
+        WT_ERR_MSG(session, WT_E(EINVAL), "max history store size %" PRId64 " below minimum %d", cval.val,
           WT_HS_FILE_MIN);
 
     /* The history store is not available for in-memory configurations. */

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -74,7 +74,7 @@ __hs_verify_id(
         if (ds_cbt->compare != 0) {
             F_SET(S2C(session), WT_CONN_DATA_CORRUPTION);
             /* Note that we are reformatting the HS key here. */
-            WT_ERR_PANIC(session, WT_PANIC,
+            WT_ERR_PANIC(session, WT_E(WT_PANIC),
               "the associated history store key %s was not found in the data store %s",
               __wt_key_string(session, key.data, key.size, CUR2BT(ds_cbt)->key_format, &key),
               session->dhandle->name);

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -235,7 +235,7 @@
 
 #define API_END_RET_NOTFOUND_MAP(s, ret) \
     API_END(s, ret);                     \
-    return ((ret) == WT_NOTFOUND ? ENOENT : (ret))
+    return ((ret) == WT_NOTFOUND ? WT_EMAP(ENOENT) : (ret))
 
 /*
  * Used in cases where transaction error should not be set, but the error is returned from the API.
@@ -244,7 +244,7 @@
  */
 #define API_END_RET_NO_TXN_ERROR(s, ret) \
     API_END(s, 0);                       \
-    return ((ret) == WT_NOTFOUND ? ENOENT : (ret))
+    return ((ret) == WT_NOTFOUND ? WT_EMAP(ENOENT) : (ret))
 
 #define API_USER_ENTRY(s) (s)->api_call_counter == 1
 
@@ -345,7 +345,7 @@
     SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name);                                  \
     if (F_ISSET(S2C(s), WT_CONN_IN_MEMORY) && !F_ISSET(CUR2BT(cur), WT_BTREE_IGNORE_CACHE) && \
       __wt_cache_full(s))                                                                     \
-        WT_ERR(WT_CACHE_FULL);
+        WT_ERR(WT_E(WT_CACHE_FULL));
 
 #define CURSOR_UPDATE_API_CALL(cur, s, ret, func_name)  \
     (s) = CUR2S(cur);                                   \
@@ -354,14 +354,14 @@
 
 #define CURSOR_UPDATE_API_END_RETRY(s, ret, retry) \
     if ((ret) == WT_PREPARE_CONFLICT)              \
-        (ret) = WT_ROLLBACK;                       \
+        (ret) = WT_E(WT_ROLLBACK);                       \
     TXN_API_END(s, ret, retry)
 
 #define CURSOR_UPDATE_API_END(s, ret) CURSOR_UPDATE_API_END_RETRY(s, ret, true)
 
 #define CURSOR_UPDATE_API_END_RETRY_STAT(s, ret, retry, api) \
     if ((ret) == WT_PREPARE_CONFLICT)                        \
-        (ret) = WT_ROLLBACK;                                 \
+        (ret) = WT_E(WT_ROLLBACK);                                 \
     API_END_STAT(s, ret, api);                               \
     TXN_API_END(s, ret, retry)
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2115,9 +2115,9 @@ __wt_page_swap_func(WT_SESSION_IMPL *session, WT_REF *held, WT_REF *want, uint32
      * to handle.
      */
     if (LF_ISSET(WT_READ_NOTFOUND_OK) && ret == WT_NOTFOUND)
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
     if (LF_ISSET(WT_READ_RESTART_OK) && ret == WT_RESTART)
-        return (WT_RESTART);
+        return (WT_E(WT_RESTART));
 
     /* Discard the original held page on either success or error. */
     acquired = ret == 0;
@@ -2140,9 +2140,9 @@ __wt_page_swap_func(WT_SESSION_IMPL *session, WT_REF *held, WT_REF *want, uint32
      * case.
      */
     if (LF_ISSET(WT_READ_NOTFOUND_OK) && ret == WT_NOTFOUND)
-        WT_RET_MSG(session, EINVAL, "page-release WT_NOTFOUND error mapped to EINVAL");
+        WT_RET_MSG(session, WT_E(EINVAL), "page-release WT_NOTFOUND error mapped to EINVAL");
     if (LF_ISSET(WT_READ_RESTART_OK) && ret == WT_RESTART)
-        WT_RET_MSG(session, EINVAL, "page-release WT_RESTART error mapped to EINVAL");
+        WT_RET_MSG(session, WT_E(EINVAL), "page-release WT_RESTART error mapped to EINVAL");
 
     return (ret);
 }
@@ -2169,7 +2169,7 @@ __wt_btcur_bounds_early_exit(
       session, &cbt->iface, &cbt->iface.key, cbt->recno, next, key_out_of_boundsp));
 
     if (*key_out_of_boundsp)
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
 
     return (0);
 }

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -20,7 +20,7 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, bool e
 
     if ((ret = __wt_time_value_validate(session, tw, NULL, false)) != 0)
         return (expected_error ?
-            WT_ERROR :
+            WT_E(WT_ERROR) :
             __wt_panic(session, ret, "value timestamp window failed validation"));
 #else
     WT_UNUSED(session);
@@ -106,7 +106,7 @@ __wt_check_addr_validity(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE *ta, bool e
 
     if ((ret = __wt_time_aggregate_validate(session, ta, NULL, false)) != 0)
         return (expected_error ?
-            WT_ERROR :
+            WT_E(WT_ERROR) :
             __wt_panic(session, ret, "address timestamp window failed validation"));
 #else
     WT_UNUSED(session);
@@ -690,7 +690,7 @@ __wt_cell_leaf_value_parse(WT_PAGE *page, WT_CELL *cell)
         if ((end) != NULL &&                                    \
           ((uint8_t *)(start) < (uint8_t *)(dsk) ||             \
             (((uint8_t *)(start)) + (len)) > (uint8_t *)(end))) \
-            return (WT_ERROR);                                  \
+            return (WT_E(WT_ERROR));                                  \
     } while (0)
 
 /*
@@ -800,7 +800,7 @@ copy_cell_restart:
     case WT_CELL_ADDR_LEAF_NO:
         /* Return an error if we're not unpacking a cell of this type. */
         if (unpack_addr == NULL)
-            return (WT_ERROR);
+            return (WT_E(WT_ERROR));
 
         if ((cell->__chunk[0] & WT_CELL_SECOND_DESC) == 0)
             break;
@@ -844,7 +844,7 @@ copy_cell_restart:
     case WT_CELL_VALUE_OVFL_RM:
         /* Return an error if we're not unpacking a cell of this type. */
         if (unpack_value == NULL)
-            return (WT_ERROR);
+            return (WT_E(WT_ERROR));
 
         if ((cell->__chunk[0] & WT_CELL_SECOND_DESC) == 0)
             break;
@@ -913,7 +913,7 @@ copy_cell_restart:
     case WT_CELL_VALUE_COPY:
         /* Return an error if we're not unpacking a cell of this type. */
         if (unpack_value == NULL)
-            return (WT_ERROR);
+            return (WT_E(WT_ERROR));
 
         copy_cell = true;
 
@@ -970,7 +970,7 @@ copy_cell_restart:
         unpack->__len = WT_PTRDIFF32(p, cell);
         break;
     default:
-        return (WT_ERROR); /* Unknown cell type. */
+        return (WT_E(WT_ERROR)); /* Unknown cell type. */
     }
 
 done:

--- a/src/include/conf_inline.h
+++ b/src/include/conf_inline.h
@@ -68,7 +68,7 @@ __wt_conf_check_choice(
         if (len == 0)
             *result = __WT_CONFIG_CHOICE_NULL;
         else
-            WT_RET_MSG(session, EINVAL, "Value '%.*s' is not a valid choice", (int)len, str);
+            WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' is not a valid choice", (int)len, str);
     }
     return (0);
 }
@@ -97,11 +97,11 @@ __wt_conf_check_one(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *check, WT_C
           __wt_conf_check_choice(session, check->choices, value->str, value->len, &value->str));
 
         if (value->val < check->min_value)
-            WT_RET_MSG(session, EINVAL, "Value '%.*s' too small, the minimum is %" PRIi64,
+            WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' too small, the minimum is %" PRIi64,
               (int)value->len, value->str, check->min_value);
 
         if (value->val > check->max_value)
-            WT_RET_MSG(session, EINVAL, "Value '%.*s' too large, the maximum is %" PRIi64,
+            WT_RET_MSG(session, WT_E(EINVAL), "Value '%.*s' too large, the maximum is %" PRIi64,
               (int)value->len, value->str, check->max_value);
     }
     return (0);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -262,7 +262,7 @@ struct __wt_name_flag {
  * WT_CONN_CHECK_PANIC --
  *	Check if we've panicked and return the appropriate error.
  */
-#define WT_CONN_CHECK_PANIC(conn) (F_ISSET(conn, WT_CONN_PANIC) ? WT_PANIC : 0)
+#define WT_CONN_CHECK_PANIC(conn) (F_ISSET(conn, WT_CONN_PANIC) ? WT_E(WT_PANIC) : 0)
 #define WT_SESSION_CHECK_PANIC(session) WT_CONN_CHECK_PANIC(S2C(session))
 
 /*

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -169,15 +169,15 @@ __wt_tret_error_ok(int *pret, int a, int e)
     } while (0)
 #endif /* INLINE_FUNCTIONS_INSTEAD_OF_MACROS */
 
-#define WT_TRET_BUSY_OK(a) WT_TRET_ERROR_OK(a, EBUSY)
-#define WT_TRET_NOTFOUND_OK(a) WT_TRET_ERROR_OK(a, WT_NOTFOUND)
+#define WT_TRET_BUSY_OK(a) WT_TRET_ERROR_OK(a, WT_E(EBUSY))
+#define WT_TRET_NOTFOUND_OK(a) WT_TRET_ERROR_OK(a, WT_E(WT_NOTFOUND))
 
 /* Return WT_PANIC regardless of earlier return codes. */
 #define WT_RET_PANIC(session, v, ...) return (__wt_panic(session, v, __VA_ARGS__))
 
 /* Called on unexpected code path: locate the failure. */
 #define __wt_illegal_value(session, v)             \
-    __wt_panic(session, EINVAL, "%s: 0x%" PRIxMAX, \
+    __wt_panic(session, WT_E(EINVAL), "%s: 0x%" PRIxMAX, \
       "encountered an illegal file format or internal value", (uintmax_t)(v))
 
 /*
@@ -341,3 +341,8 @@ __wt_tret_error_ok(int *pret, int a, int e)
             WT_STAT_CONN_INCR(session, stat);  \
         WT_ASSERT(session, exp);               \
     } while (0)
+
+#define WT_E(err) __wt_ret_origin_func(session, err, #err, __func__, __FILE__, __LINE__)
+#define WT_EMAP(err) __wt_ret_origin_mod_func(session, err)
+#define WT_E_S(session, err) __wt_ret_origin_func(session, err, #err, __func__, __FILE__, __LINE__)
+#define WT_EMAP_S(session, err) __wt_ret_origin_mod_func(session, err)

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -9,6 +9,54 @@
 #pragma once
 
 /*
+ * __wt_ret_origin_func --
+ *     Set error origin helper function.
+ */
+static WT_INLINE int
+__wt_ret_origin_func(WT_SESSION_IMPL *session, int err, const char *err_str,
+    const char *func, const char *file, int line)
+{
+    if (session != NULL) {
+        session->last_err.code = err;
+        session->last_err.code_str = err_str;
+        session->last_err.location.func = func;
+        session->last_err.location.file = file;
+        session->last_err.location.line = line;
+    }
+    return (err);
+}
+
+/*
+ * __wt_ret_origin_mod_func --
+ *     Alter the error code but leave the origin information alone.
+ */
+static WT_INLINE int
+__wt_ret_origin_mod_func(WT_SESSION_IMPL *session, int err)
+{
+    if (session != NULL) {
+        if (session->last_err.code == 0) {
+            session->last_err.code_str = NULL;
+            session->last_err.location.func = NULL;
+            session->last_err.location.file = NULL;
+            session->last_err.location.line = 0;
+        }
+        session->last_err.code = err;
+    }
+    return (err);
+}
+
+/*
+ * __wt_ret_origin_func --
+ *     Set error origin helper function.
+ */
+static WT_INLINE void
+__wt_ret_origin_clear(WT_SESSION_IMPL *session)
+{
+    if (session != NULL)
+        session->last_err.code = 0;
+}
+
+/*
  * __wt_cond_wait --
  *     Wait on a mutex, optionally timing out.
  */
@@ -107,6 +155,7 @@ __wt_snprintf(char *buf, size_t size, const char *fmt, ...)
     WT_RET(ret);
 
     /* It's an error if the buffer couldn't hold everything. */
+    // return (len >= size ? WT_E(ERANGE) : 0); // TODO::
     return (len >= size ? ERANGE : 0);
 }
 
@@ -124,6 +173,7 @@ __wt_vsnprintf(char *buf, size_t size, const char *fmt, va_list ap)
     WT_RET(__wt_vsnprintf_len_incr(buf, size, &len, fmt, ap));
 
     /* It's an error if the buffer couldn't hold everything. */
+    // return (len >= size ? WT_E(ERANGE) : 0); // TODO::
     return (len >= size ? ERANGE : 0);
 }
 

--- a/src/include/mutex_inline.h
+++ b/src/include/mutex_inline.h
@@ -82,7 +82,7 @@ __wt_spin_trylock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
         t->session_id = WT_SPIN_SESSION_ID_SAFE(session);
         return (0);
     } else
-        return (EBUSY);
+        return (WT_E(EBUSY));
 }
 
 /*
@@ -257,7 +257,7 @@ __wt_spin_trylock(WT_SESSION_IMPL *session, WT_SPINLOCK *t)
 
     BOOL b = TryEnterCriticalSection(&t->lock);
     if (b == 0)
-        return (EBUSY);
+        return (WT_E(EBUSY));
     t->session_id = WT_SPIN_SESSION_ID_SAFE(session);
     return (0);
 }

--- a/src/include/os_fhandle_inline.h
+++ b/src/include/os_fhandle_inline.h
@@ -80,7 +80,7 @@ __wt_fextend(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset)
         return (handle->fh_extend_nolock(handle, (WT_SESSION *)session, offset));
     if (handle->fh_extend != NULL)
         return (handle->fh_extend(handle, (WT_SESSION *)session, offset));
-    return (__wt_set_return(session, ENOTSUP));
+    return (__wt_set_return(session, WT_E(ENOTSUP)));
 }
 
 /*
@@ -172,7 +172,7 @@ __wt_ftruncate(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset)
 #endif
     if (handle->fh_truncate != NULL)
         return (handle->fh_truncate(handle, (WT_SESSION *)session, offset));
-    return (__wt_set_return(session, ENOTSUP));
+    return (__wt_set_return(session, WT_E(ENOTSUP)));
 }
 
 /*

--- a/src/include/os_fs_inline.h
+++ b/src/include/os_fs_inline.h
@@ -144,7 +144,7 @@ __wt_fs_remove(WT_SESSION_IMPL *session, const char *name, bool durable, bool lo
      * WiredTiger doesn't have the handle open.
      */
     if (__wt_handle_is_open(session, name, locked))
-        WT_RET_MSG(session, EINVAL, "%s: file-remove: file has open handles", name);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s: file-remove: file has open handles", name);
 #else
     WT_UNUSED(locked);
 #endif
@@ -181,9 +181,9 @@ __wt_fs_rename(WT_SESSION_IMPL *session, const char *from, const char *to, bool 
      * WiredTiger doesn't have the handle open.
      */
     if (__wt_handle_is_open(session, from, false))
-        WT_RET_MSG(session, EINVAL, "%s: file-rename: file has open handles", from);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s: file-rename: file has open handles", from);
     if (__wt_handle_is_open(session, to, false))
-        WT_RET_MSG(session, EINVAL, "%s: file-rename: file has open handles", to);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s: file-rename: file has open handles", to);
 #endif
 
     from_path = to_path = NULL;

--- a/src/include/packing_inline.h
+++ b/src/include/packing_inline.h
@@ -63,7 +63,7 @@ static WT_INLINE int
 __pack_initn(WT_SESSION_IMPL *session, WT_PACK *pack, const char *fmt, size_t len)
 {
     if (*fmt == '@' || *fmt == '<' || *fmt == '>')
-        return (EINVAL);
+        return (WT_E(EINVAL));
     if (*fmt == '.') {
         ++fmt;
         if (len > 0)
@@ -341,7 +341,7 @@ __pack_size(WT_SESSION_IMPL *session, WT_PACK_VALUE *pv, size_t *vp)
         return (0);
     }
 
-    WT_RET_MSG(session, EINVAL, "unknown pack-value type: %c", (int)pv->type);
+    WT_RET_MSG(session, WT_E(EINVAL), "unknown pack-value type: %c", (int)pv->type);
 }
 
 /*
@@ -481,7 +481,7 @@ __pack_write(WT_SESSION_IMPL *session, WT_PACK_VALUE *pv, uint8_t **pp, size_t m
         *pp += sizeof(uint64_t);
         break;
     default:
-        WT_RET_MSG(session, EINVAL, "unknown pack-value type: %c", (int)pv->type);
+        WT_RET_MSG(session, WT_E(EINVAL), "unknown pack-value type: %c", (int)pv->type);
     }
 
     return (0);
@@ -572,7 +572,7 @@ __unpack_read(WT_SESSION_IMPL *session, WT_PACK_VALUE *pv, const uint8_t **pp, s
         *pp += sizeof(uint64_t);
         break;
     default:
-        WT_RET_MSG(session, EINVAL, "unknown pack-value type: %c", (int)pv->type);
+        WT_RET_MSG(session, WT_E(EINVAL), "unknown pack-value type: %c", (int)pv->type);
     }
 
     return (0);

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -42,7 +42,7 @@ __insert_simple_func(
          */
         WT_ACQUIRE_READ_WITH_BARRIER(old_ins, *ins_stack[i]);
         if (old_ins != new_ins->next[i] || !__wt_atomic_cas_ptr(ins_stack[i], old_ins, new_ins))
-            return (i == 0 ? WT_RESTART : 0);
+            return (i == 0 ? WT_E(WT_RESTART) : 0);
     }
 
     return (0);
@@ -85,7 +85,7 @@ __insert_serial_func(WT_SESSION_IMPL *session, WT_INSERT_HEAD *ins_head, WT_INSE
          */
         WT_ACQUIRE_READ_WITH_BARRIER(old_ins, *ins_stack[i]);
         if (old_ins != new_ins->next[i] || !__wt_atomic_cas_ptr(ins_stack[i], old_ins, new_ins))
-            return (i == 0 ? WT_RESTART : 0);
+            return (i == 0 ? WT_E(WT_RESTART) : 0);
         if (ins_head->tail[i] == NULL || ins_stack[i] == &ins_head->tail[i]->next[i])
             ins_head->tail[i] = new_ins;
     }

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -73,6 +73,12 @@ struct __wt_error_info {
 #define WT_ERROR_INFO_EMPTY ""
 #define WT_ERROR_INFO_SUCCESS "last API call was successful"
 
+typedef struct __wt_location_info {
+    const char *func; /* Function name */
+    const char *file; /* File name */
+    int line;         /* Line number */
+} WT_LOCATION_INFO;
+
 /* Get the connection implementation for a session */
 #define S2C(session) ((WT_CONNECTION_IMPL *)((WT_SESSION_IMPL *)(session))->iface.connection)
 
@@ -220,6 +226,13 @@ struct __wt_session_impl {
 
     WT_ITEM err; /* Error buffer */
     WT_ERROR_INFO err_info;
+
+    /* Last error origin info. */
+    struct {
+        int code;                  /* Error code. */
+        const char *code_str;            /* Error code string literal. */
+        WT_LOCATION_INFO location; /* Location. */
+    } last_err;
 
     WT_TXN_ISOLATION isolation;
     WT_TXN *txn; /* Transaction state */

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -564,8 +564,8 @@ typedef uint64_t wt_timestamp_t;
 #include "cache_inline.h"
 #include "../evict/evict_inline.h" /* required by misc_inline.h */
 #include "ctype_inline.h"          /* required by packing_inline.h */
-#include "intpack_inline.h"        /* required by cell_inline.h, packing_inline.h */
 #include "misc_inline.h"           /* required by mutex_inline.h */
+#include "intpack_inline.h"        /* required by cell_inline.h, packing_inline.h */
 
 #include "generation_inline.h" /* required by txn_inline.h */
 #include "buf_inline.h"        /* required by cell_inline.h */

--- a/src/live_restore/live_restore_state.c
+++ b/src/live_restore/live_restore_state.c
@@ -78,7 +78,7 @@ __live_restore_state_from_string(
     else if (WT_STRING_LIT_MATCH("WTI_LIVE_RESTORE_STATE_COMPLETE", state_str, str_len))
         *statep = WTI_LIVE_RESTORE_STATE_COMPLETE;
     else
-        WT_RET_MSG(session, EINVAL, "Invalid state string: '%s' ", state_str);
+        WT_RET_MSG(session, WT_E(EINVAL), "Invalid state string: '%s' ", state_str);
 
     return (0);
 }
@@ -372,11 +372,11 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
       lr_fs->source.home, "", &dirlist_source, &num_source_files));
 
     if (num_source_files == 0)
-        WT_ERR_MSG(session, EINVAL, "Source directory is empty. Nothing to restore!");
+        WT_ERR_MSG(session, WT_E(EINVAL), "Source directory is empty. Nothing to restore!");
 
     for (uint32_t i = 0; i < num_source_files; ++i) {
         if (WT_SUFFIX_MATCH(dirlist_source[i], WTI_LIVE_RESTORE_STOP_FILE_SUFFIX))
-            WT_ERR_MSG(session, EINVAL,
+            WT_ERR_MSG(session, WT_E(EINVAL),
               "Source directory contains live restore stop file: %s. This implies it is a "
               "destination directory that hasn't finished restoration",
               dirlist_source[i]);
@@ -391,7 +391,7 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
      * in the destination, and never copy across the file causing data loss.
      */
     if (!contain_backup_file)
-        WT_ERR_MSG(session, EINVAL, "Source directory is not a valid backup directory");
+        WT_ERR_MSG(session, WT_E(EINVAL), "Source directory is not a valid backup directory");
 
     /* Now check the destination folder */
 
@@ -411,7 +411,7 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
         for (uint32_t i = 0; i < num_dest_files; ++i) {
             if (WT_PREFIX_MATCH(dirlist_dest[i], WT_WIREDTIGER) ||
               WT_SUFFIX_MATCH(dirlist_dest[i], ".wt"))
-                WT_ERR_MSG(session, EINVAL,
+                WT_ERR_MSG(session, WT_E(EINVAL),
                   "Attempting to begin a live restore on a directory that already contains "
                   "WiredTiger files '%s'! It's possible this file will be overwritten.",
                   dirlist_dest[i]);
@@ -424,7 +424,7 @@ __wti_live_restore_validate_directories(WT_SESSION_IMPL *session, WTI_LIVE_RESTO
     case WTI_LIVE_RESTORE_STATE_COMPLETE:
         for (uint32_t i = 0; i < num_dest_files; ++i) {
             if (WT_SUFFIX_MATCH(dirlist_dest[i], WTI_LIVE_RESTORE_STOP_FILE_SUFFIX))
-                WT_ERR_MSG(session, EINVAL,
+                WT_ERR_MSG(session, WT_E(EINVAL),
                   "Live restore is complete but live restore stop file '%s' still exists!",
                   dirlist_dest[i]);
         }
@@ -452,7 +452,7 @@ __wt_live_restore_validate_non_lr_system(WT_SESSION_IMPL *session)
     WTI_LIVE_RESTORE_STATE state;
     WT_RET(__live_restore_get_state_from_file(session, S2C(session)->file_system, &state));
     if (state != WTI_LIVE_RESTORE_STATE_NONE && state != WTI_LIVE_RESTORE_STATE_COMPLETE)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "Cannot start in non-live restore mode while a live restore is in progress!");
 
     return (0);

--- a/src/log/log_auto.c
+++ b/src/log/log_auto.c
@@ -17,7 +17,7 @@
 #ifndef PACKING_COMPATIBILITY_MODE
 #define WT_CHECK_OPTYPE(session, opvar, op) \
     if (opvar != op)                        \
-        WT_RET_MSG(session, EINVAL, "unpacking " #op ": optype mismatch");
+        WT_RET_MSG(session, WT_E(EINVAL), "unpacking " #op ": optype mismatch");
 #else
 #define WT_CHECK_OPTYPE(session, opvar, op)
 #endif
@@ -336,7 +336,7 @@ __wt_logop_col_modify_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_col_modify: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_col_modify: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -475,7 +475,7 @@ __wt_logop_col_put_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const ui
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_col_put: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_col_put: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -611,7 +611,7 @@ __wt_logop_col_remove_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_col_remove: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_col_remove: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -737,7 +737,7 @@ __wt_logop_col_truncate_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, con
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_col_truncate: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_col_truncate: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -865,7 +865,7 @@ __wt_logop_row_modify_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_row_modify: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_row_modify: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -1009,7 +1009,7 @@ __wt_logop_row_put_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const ui
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_row_put: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_row_put: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -1150,7 +1150,7 @@ __wt_logop_row_remove_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_row_remove: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_row_remove: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -1290,7 +1290,7 @@ __wt_logop_row_truncate_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, con
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_row_truncate: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_row_truncate: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -1429,7 +1429,7 @@ __wt_logop_checkpoint_start_unpack(WT_SESSION_IMPL *session, const uint8_t **pp,
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "logop_checkpoint_start: size mismatch: expected %u, got %" PRIuPTR, size,
           WT_PTRDIFF(*pp, pp_orig));
     }
@@ -1544,7 +1544,7 @@ __wt_logop_prev_lsn_unpack(
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_prev_lsn: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_prev_lsn: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -1665,7 +1665,7 @@ __wt_logop_backup_id_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, const 
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL, "logop_backup_id: size mismatch: expected %u, got %" PRIuPTR,
+        WT_RET_MSG(session, WT_E(EINVAL), "logop_backup_id: size mismatch: expected %u, got %" PRIuPTR,
           size, WT_PTRDIFF(*pp, pp_orig));
     }
 #endif
@@ -1807,7 +1807,7 @@ __wt_logop_txn_timestamp_unpack(WT_SESSION_IMPL *session, const uint8_t **pp, co
 
 #if !defined(NO_STRICT_PACKING_CHECK)
     if (WT_PTRDIFF(*pp, pp_orig) != size) {
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "logop_txn_timestamp: size mismatch: expected %u, got %" PRIuPTR, size,
           WT_PTRDIFF(*pp, pp_orig));
     }

--- a/src/log/log_cursor.c
+++ b/src/log/log_cursor.c
@@ -213,7 +213,7 @@ __curlog_next(WT_CURSOR *cursor)
         cl->txnid = 0;
         ret = __wt_log_scan(session, cl->next_lsn, NULL, WT_LOGSCAN_ONE, __curlog_logrec, cl);
         if (ret == ENOENT)
-            ret = WT_NOTFOUND;
+            ret = WT_E(WT_NOTFOUND);
         WT_ERR(ret);
     }
     WT_ASSERT(session, cl->logrec->data != NULL);
@@ -252,7 +252,7 @@ __curlog_search(WT_CURSOR *cursor)
     WT_SET_LSN(&key, key_file, key_offset);
     ret = __wt_log_scan(session, &key, NULL, WT_LOGSCAN_ONE, __curlog_logrec, cl);
     if (ret == ENOENT)
-        ret = WT_NOTFOUND;
+        ret = WT_E(WT_NOTFOUND);
     WT_ERR(ret);
     WT_ERR(__curlog_kv(session, cursor));
     WT_STAT_CONN_DSRC_INCR(session, cursor_search);

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -235,14 +235,14 @@ __wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
       ((enabled && !F_ISSET(&conn->log_mgr, WT_LOG_ENABLED)) ||
         (!enabled && F_ISSET(&conn->log_mgr, WT_LOG_ENABLED))))
         WT_RET_MSG(
-          session, EINVAL, "log manager reconfigure: enabled mismatch with existing setting");
+          session, WT_E(EINVAL), "log manager reconfigure: enabled mismatch with existing setting");
 
     /* Logging is incompatible with in-memory */
     if (enabled) {
         WT_RET(__wt_config_gets(session, cfg, "in_memory", &cval));
         if (cval.val != 0)
             WT_RET_MSG(
-              session, EINVAL, "In-memory configuration incompatible with log=(enabled=true)");
+              session, WT_E(EINVAL), "In-memory configuration incompatible with log=(enabled=true)");
     }
 
     if (enabled)
@@ -337,7 +337,7 @@ __wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
     if (cval.val != 0) {
         if (F_ISSET(conn, WT_CONN_READONLY))
             WT_RET_MSG(
-              session, EINVAL, "Read-only configuration incompatible with zero-filling log files");
+              session, WT_E(EINVAL), "Read-only configuration incompatible with zero-filling log files");
         F_SET(&conn->log_mgr, WT_LOG_ZERO_FILL);
     }
 
@@ -587,7 +587,7 @@ __wt_log_truncate_files(WT_SESSION_IMPL *session, WT_CURSOR *cursor, bool force)
         return (0);
     if (!force && FLD_ISSET(conn->server_flags, WT_CONN_SERVER_LOG) &&
       F_ISSET(&conn->log_mgr, WT_LOG_REMOVE))
-        WT_RET_MSG(session, EINVAL, "Attempt to remove manually while a server is running");
+        WT_RET_MSG(session, WT_E(EINVAL), "Attempt to remove manually while a server is running");
 
     log = conn->log_mgr.log;
 
@@ -670,7 +670,7 @@ __log_file_server(void *arg)
                     WT_WITH_HOTBACKUP_READ_LOCK(session,
                       ret = __wt_ftruncate(session, close_fh, __wt_lsn_offset(&close_end_lsn)),
                       NULL);
-                    WT_ERR_ERROR_OK(ret, ENOTSUP, false);
+                    WT_ERR_ERROR_OK(ret, WT_E(ENOTSUP), false);
                 }
                 WT_SET_LSN(&close_end_lsn, close_end_lsn.l.file + 1, 0);
                 __wt_spin_lock(session, &log->log_sync_lock);
@@ -938,7 +938,7 @@ __log_server(void *arg)
          */
         if (log_mgr->force_write_wait == 0 ||
           force_write_timediff >= log_mgr->force_write_wait * WT_THOUSAND) {
-            WT_ERR_ERROR_OK(__wti_log_force_write(session, false, &did_work), EBUSY, false);
+            WT_ERR_ERROR_OK(__wti_log_force_write(session, false, &did_work), WT_E(EBUSY), false);
             force_write_time_start = __wt_clock(session);
         }
         /*

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -105,7 +105,7 @@ __log_slot_close(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot, bool *releasep, bo
     conn = S2C(session);
     log = conn->log_mgr.log;
     if (slot == NULL)
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
 retry:
     old_state = __wt_atomic_loadiv64(&slot->slot_state);
     /*
@@ -113,7 +113,7 @@ retry:
      * return EBUSY. The caller can decide if retrying is necessary or not.
      */
     if (forced && WTI_LOG_SLOT_INPROGRESS(old_state))
-        return (__wt_set_return(session, EBUSY));
+        return (__wt_set_return(session, WT_E(EBUSY)));
     /*
      * If someone else is switching out this slot we lost. Nothing to do but return. Return
      * WT_NOTFOUND anytime the given slot was processed by another closing thread. Only return 0
@@ -121,7 +121,7 @@ retry:
      */
     if (WTI_LOG_SLOT_CLOSED(old_state)) {
         WT_STAT_CONN_INCR(session, log_slot_close_race);
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
     }
     /*
      * If someone completely processed this slot, we're done.
@@ -129,7 +129,7 @@ retry:
     if (FLD_LOG_SLOT_ISSET(
           (uint64_t)__wt_atomic_loadiv64(&slot->slot_state), WTI_LOG_SLOT_RESERVED)) {
         WT_STAT_CONN_INCR(session, log_slot_close_race);
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
     }
     new_state = (old_state | WTI_LOG_SLOT_CLOSE);
     /*

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -201,7 +201,7 @@ __wt_metadata_insert(WT_SESSION_IMPL *session, const char *key, const char *valu
       __metadata_turtle(key) ? "" : "not ");
 
     if (__metadata_turtle(key))
-        WT_RET_MSG(session, EINVAL, "%s: insert not supported on the turtle file", key);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s: insert not supported on the turtle file", key);
 
     WT_RET(__wt_metadata_cursor(session, &cursor));
     cursor->set_key(cursor, key);
@@ -269,7 +269,7 @@ __wt_metadata_remove(WT_SESSION_IMPL *session, const char *key)
       key, WT_META_TRACKING(session) ? "true" : "false", __metadata_turtle(key) ? "" : "not ");
 
     if (__metadata_turtle(key))
-        WT_RET_MSG(session, EINVAL, "%s: remove not supported on the turtle file", key);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s: remove not supported on the turtle file", key);
 
     /*
      * Take, release, and reacquire the metadata cursor. It's complicated, but that way the

--- a/src/optrack/optrack.c
+++ b/src/optrack/optrack.c
@@ -60,7 +60,7 @@ __optrack_open_file(WT_SESSION_IMPL *session)
     conn = S2C(session);
 
     if (!F_ISSET(conn, WT_CONN_OPTRACK))
-        WT_RET_MSG(session, WT_ERROR, "WT_CONN_OPTRACK not set");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "WT_CONN_OPTRACK not set");
 
     WT_RET(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(__wt_filename_construct(

--- a/src/os_common/filename.c
+++ b/src/os_common/filename.c
@@ -88,7 +88,7 @@ __wt_remove_if_exists(WT_SESSION_IMPL *session, const char *name, bool durable)
     if (exist) {
         /* Modifications are not allowed on a read only database. */
         if (F_ISSET(S2C(session), WT_CONN_READONLY))
-            return (EACCES);
+            return (WT_E(EACCES));
         WT_RET(__wt_fs_remove(session, name, durable, false));
     }
     return (0);

--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -33,7 +33,7 @@ __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp)
         WT_STAT_CONN_INCR(session, memory_allocation);
 
     if ((p = calloc(number, size)) == NULL)
-        WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
+        WT_RET_MSG(session, WT_E(__wt_errno()), "memory allocation of %" WT_SIZET_FMT " bytes failed",
           size * number);
 
     *(void **)retp = p;
@@ -64,7 +64,7 @@ __wt_malloc(WT_SESSION_IMPL *session, size_t bytes_to_allocate, void *retp)
         WT_STAT_CONN_INCR(session, memory_allocation);
 
     if ((p = malloc(bytes_to_allocate)) == NULL)
-        WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
+        WT_RET_MSG(session, WT_E(__wt_errno()), "memory allocation of %" WT_SIZET_FMT " bytes failed",
           bytes_to_allocate);
 
     *(void **)retp = p;
@@ -116,7 +116,7 @@ __realloc_func(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret, size_t byt
     if (session != NULL && FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_REALLOC_MALLOC) &&
       (bytes_allocated_ret != NULL)) {
         if ((p = malloc(bytes_to_allocate)) == NULL)
-            WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
+            WT_RET_MSG(session, WT_E(__wt_errno()), "memory allocation of %" WT_SIZET_FMT " bytes failed",
               bytes_to_allocate);
         if (tmpp != NULL) {
             memcpy(p, tmpp, *bytes_allocated_ret);
@@ -125,7 +125,7 @@ __realloc_func(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret, size_t byt
         }
     } else {
         if ((p = realloc(p, bytes_to_allocate)) == NULL)
-            WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
+            WT_RET_MSG(session, WT_E(__wt_errno()), "memory allocation of %" WT_SIZET_FMT " bytes failed",
               bytes_to_allocate);
     }
 

--- a/src/os_common/os_errno.c
+++ b/src/os_common/os_errno.c
@@ -79,6 +79,6 @@ __wt_ext_map_windows_error(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, uin
 #else
     WT_UNUSED(windows_error);
     WT_RET_PANIC(
-      (WT_SESSION_IMPL *)wt_session, WT_PANIC, "unexpected attempt to map Windows error");
+      (WT_SESSION_IMPL *)wt_session, WT_E_S((WT_SESSION_IMPL*)wt_session, WT_PANIC), "unexpected attempt to map Windows error");
 #endif
 }

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -18,7 +18,7 @@ __fhandle_method_finalize(WT_SESSION_IMPL *session, WT_FILE_HANDLE *handle, bool
 {
 #define WT_HANDLE_METHOD_REQ(name) \
     if (handle->name == NULL)      \
-    WT_RET_MSG(session, EINVAL, "a WT_FILE_HANDLE.%s method must be configured", #name)
+    WT_RET_MSG(session, WT_E(EINVAL), "a WT_FILE_HANDLE.%s method must be configured", #name)
 
     WT_HANDLE_METHOD_REQ(close);
     /* not required: fh_advise */

--- a/src/os_common/os_fs_inmemory.c
+++ b/src/os_common/os_fs_inmemory.c
@@ -69,7 +69,7 @@ __im_handle_remove(
     if (im_fh->ref != 0) {
         __wt_err(session, EBUSY, "%s: file-remove", im_fh->iface.name);
         if (!force)
-            return (__wt_set_return(session, EBUSY));
+            return (__wt_set_return(session, WT_E(EBUSY)));
     }
 
     bucket = im_fh->name_hash & (S2C(session)->hash_size - 1);
@@ -208,7 +208,7 @@ __im_fs_remove(
 
     __wt_spin_lock(session, &im_fs->lock);
 
-    ret = ENOENT;
+    ret = WT_E(ENOENT);
     if ((im_fh = __im_handle_search(session, file_system, name)) != NULL)
         ret = __im_handle_remove(session, file_system, im_fh, false);
 
@@ -238,7 +238,7 @@ __im_fs_rename(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *
 
     __wt_spin_lock(session, &im_fs->lock);
 
-    ret = ENOENT;
+    ret = WT_E(ENOENT);
     if ((im_fh = __im_handle_search(session, file_system, from)) != NULL) {
         WT_ERR(__wt_strdup(session, to, &copy));
         __wt_free(session, im_fh->iface.name);
@@ -275,7 +275,7 @@ __im_fs_size(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *na
 
     /* Search for the handle, then get its size. */
     if ((im_fh = __im_handle_search(session, file_system, name)) == NULL)
-        ret = __wt_set_return(session, ENOENT);
+        ret = __wt_set_return(session, WT_E(ENOENT));
     else
         *sizep = (wt_off_t)im_fh->buf.size;
 
@@ -346,12 +346,12 @@ __im_file_read(
         len = WT_MIN(len, im_fh->buf.size - off);
         memcpy(buf, (uint8_t *)im_fh->buf.mem + off, len);
     } else
-        ret = WT_ERROR;
+        ret = WT_E(WT_ERROR);
 
     __wt_spin_unlock(session, &im_fs->lock);
     if (ret == 0)
         return (0);
-    WT_RET_MSG(session, WT_ERROR,
+    WT_RET_MSG(session, WT_E(WT_ERROR),
       "%s: handle-read: failed to read %" WT_SIZET_FMT " bytes at offset %" WT_SIZET_FMT,
       file_handle->name, len, off);
 }
@@ -459,7 +459,7 @@ __im_file_open(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const char *
     if (im_fh != NULL) {
 
         if (im_fh->ref != 0)
-            WT_ERR_MSG(session, EBUSY, "%s: file-open: already open", name);
+            WT_ERR_MSG(session, WT_E(EBUSY), "%s: file-open: already open", name);
 
         im_fh->ref = 1;
 

--- a/src/os_common/os_fstream.c
+++ b/src/os_common/os_fstream.c
@@ -52,7 +52,7 @@ __fstream_flush(WT_SESSION_IMPL *session, WT_FSTREAM *fstr)
 static int
 __fstream_flush_notsup(WT_SESSION_IMPL *session, WT_FSTREAM *fstr)
 {
-    WT_RET_MSG(session, ENOTSUP, "%s: flush", fstr->name);
+    WT_RET_MSG(session, WT_E(ENOTSUP), "%s: flush", fstr->name);
 }
 
 /*
@@ -113,7 +113,7 @@ static int
 __fstream_getline_notsup(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, WT_ITEM *buf)
 {
     WT_UNUSED(buf);
-    WT_RET_MSG(session, ENOTSUP, "%s: getline", fstr->name);
+    WT_RET_MSG(session, WT_E(ENOTSUP), "%s: getline", fstr->name);
 }
 
 /*
@@ -161,7 +161,7 @@ __fstream_printf_notsup(WT_SESSION_IMPL *session, WT_FSTREAM *fstr, const char *
 {
     WT_UNUSED(fmt);
     WT_UNUSED(ap);
-    WT_RET_MSG(session, ENOTSUP, "%s: printf", fstr->name);
+    WT_RET_MSG(session, WT_E(ENOTSUP), "%s: printf", fstr->name);
 }
 
 /*

--- a/src/os_common/os_fstream_stdio.c
+++ b/src/os_common/os_fstream_stdio.c
@@ -15,7 +15,7 @@
 static int
 __stdio_close(WT_SESSION_IMPL *session, WT_FSTREAM *fs)
 {
-    WT_RET_MSG(session, ENOTSUP, "%s: close", fs->name);
+    WT_RET_MSG(session, WT_E(ENOTSUP), "%s: close", fs->name);
 }
 
 /*
@@ -27,7 +27,7 @@ __stdio_flush(WT_SESSION_IMPL *session, WT_FSTREAM *fs)
 {
     if (fflush(fs->fp) == 0)
         return (0);
-    WT_RET_MSG(session, __wt_errno(), "%s: flush", fs->name);
+    WT_RET_MSG(session, WT_E(__wt_errno()), "%s: flush", fs->name);
 }
 
 /*
@@ -38,7 +38,7 @@ static int
 __stdio_getline(WT_SESSION_IMPL *session, WT_FSTREAM *fs, WT_ITEM *buf)
 {
     WT_UNUSED(buf);
-    WT_RET_MSG(session, ENOTSUP, "%s: getline", fs->name);
+    WT_RET_MSG(session, WT_E(ENOTSUP), "%s: getline", fs->name);
 }
 
 /*
@@ -52,7 +52,7 @@ __stdio_printf(WT_SESSION_IMPL *session, WT_FSTREAM *fs, const char *fmt, va_lis
 
     if (vfprintf(fs->fp, fmt, ap) >= 0)
         return (0);
-    return (EIO);
+    return (WT_E(EIO));
 }
 
 /*

--- a/src/os_posix/os_dir.c
+++ b/src/os_posix/os_dir.c
@@ -53,7 +53,7 @@ __directory_list_worker(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, con
     WT_SYSCALL_RETRY(((dirp = opendir(directory)) == NULL ? -1 : 0), ret);
     if (dirp == NULL || ret != 0) {
         if (ret == 0)
-            ret = EINVAL;
+            ret = WT_E(EINVAL);
         WT_ERR_MSG(session, ret, "%s: directory-list: opendir", directory);
     }
     /*
@@ -95,7 +95,7 @@ __directory_list_worker(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, con
      * special message if readdir failed.
      */
     if (errno != 0) {
-        ret = errno;
+        ret = WT_E(errno);
         __wt_epoch(session, &ts);
         WT_ERR(__wt_buf_fmt(session, readerrmsg,
           "[%" PRIuMAX ":%" PRIuMAX "] readdir failed errno %d (%s) dir fd %d",

--- a/src/os_posix/os_dlopen.c
+++ b/src/os_posix/os_dlopen.c
@@ -22,7 +22,7 @@ __wt_dlopen(WT_SESSION_IMPL *session, const char *path, WT_DLH **dlhp)
     WT_ERR(__wt_strdup(session, path == NULL ? "local" : path, &dlh->name));
 
     if ((dlh->handle = dlopen(path, RTLD_LAZY)) == NULL)
-        WT_ERR_MSG(session, __wt_errno(), "dlopen(%s): %s", path, dlerror());
+        WT_ERR_MSG(session, WT_E(__wt_errno()), "dlopen(%s): %s", path, dlerror());
 
     *dlhp = dlh;
     if (0) {
@@ -45,7 +45,7 @@ __wt_dlsym(WT_SESSION_IMPL *session, WT_DLH *dlh, const char *name, bool fail, v
     *(void **)sym_ret = NULL;
     if ((sym = dlsym(dlh->handle, name)) == NULL) {
         if (fail)
-            WT_RET_MSG(session, __wt_errno(), "dlsym(%s in %s): %s", name, dlh->name, dlerror());
+            WT_RET_MSG(session, WT_E(__wt_errno()), "dlsym(%s in %s): %s", name, dlh->name, dlerror());
         return (0);
     }
 
@@ -70,7 +70,7 @@ __wt_dlclose(WT_SESSION_IMPL *session, WT_DLH *dlh)
  */
 #ifndef __FreeBSD__
     if (dlclose(dlh->handle) != 0) {
-        ret = __wt_errno();
+        ret = WT_E(__wt_errno());
         __wt_err(session, ret, "dlclose: %s", dlerror());
     }
 #endif

--- a/src/os_posix/os_fallocate.c
+++ b/src/os_posix/os_fallocate.c
@@ -57,7 +57,7 @@ __posix_std_fallocate(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_of
     WT_UNUSED(file_handle);
     WT_UNUSED(offset);
 
-    return (__wt_set_return((WT_SESSION_IMPL *)wt_session, ENOTSUP));
+    return (__wt_set_return((WT_SESSION_IMPL *)wt_session, WT_E_S((WT_SESSION_IMPL*)wt_session, ENOTSUP)));
 #endif
 }
 
@@ -74,7 +74,7 @@ __posix_sys_fallocate(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_of
     WT_UNUSED(file_handle);
     WT_UNUSED(offset);
 
-    return (__wt_set_return((WT_SESSION_IMPL *)wt_session, ENOTSUP));
+    return (__wt_set_return((WT_SESSION_IMPL *)wt_session, WT_E_S((WT_SESSION_IMPL*)wt_session, ENOTSUP)));
 #endif
 }
 
@@ -91,7 +91,7 @@ __posix_posix_fallocate(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_
     WT_UNUSED(file_handle);
     WT_UNUSED(offset);
 
-    return (__wt_set_return((WT_SESSION_IMPL *)wt_session, ENOTSUP));
+    return (__wt_set_return((WT_SESSION_IMPL *)wt_session, WT_E_S((WT_SESSION_IMPL*)wt_session, ENOTSUP)));
 #endif
 }
 
@@ -148,5 +148,5 @@ __wti_posix_file_extend(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_
 
     file_handle->fh_extend = NULL;
     WT_RELEASE_BARRIER();
-    return (ENOTSUP);
+    return (WT_E_S((WT_SESSION_IMPL*)wt_session, ENOTSUP));
 }

--- a/src/os_posix/os_fs.c
+++ b/src/os_posix/os_fs.c
@@ -426,7 +426,7 @@ __posix_file_advise(
      */
     if (ret == EINVAL) {
         file_handle->fh_advise = NULL;
-        return (__wt_set_return(session, ENOTSUP));
+        return (__wt_set_return(session, WT_E(ENOTSUP)));
     }
 
     WT_RET_MSG(session, ret, "%s: handle-advise: posix_fadvise", file_handle->name);
@@ -530,7 +530,7 @@ __posix_file_read(
          */
         WT_SYSCALL_RETRY((nr = pread(pfh->fd, addr, chunk, offset)) <= 0 ? -1 : 0, ret);
         if (ret != 0)
-            WT_RET_MSG(session, nr == 0 ? WT_ERROR : ret,
+            WT_RET_MSG(session, nr == 0 ? WT_E(WT_ERROR) : ret,
               "%s: handle-read: pread: failed to read %" WT_SIZET_FMT " bytes at offset %" PRIuMAX,
               file_handle->name, chunk, (uintmax_t)offset);
     }
@@ -690,7 +690,7 @@ __posix_file_write(
     for (addr = buf; len > 0; addr += nw, len -= (size_t)nw, offset += nw) {
         chunk = WT_MIN(len, WT_GIGABYTE);
         if ((nw = pwrite(pfh->fd, addr, chunk, offset)) < 0)
-            WT_RET_MSG(session, __wt_errno(),
+            WT_RET_MSG(session, WT_E(__wt_errno()),
               "%s: handle-write: pwrite: failed to write %" WT_SIZET_FMT
               " bytes at offset %" PRIuMAX,
               file_handle->name, chunk, (uintmax_t)offset);
@@ -786,7 +786,7 @@ __posix_open_file_cloexec(WT_SESSION_IMPL *session, int fd, const char *name)
      * the flag to open if available.
      */
     if ((f = fcntl(fd, F_GETFD)) == -1 || fcntl(fd, F_SETFD, f | FD_CLOEXEC) == -1)
-        WT_RET_MSG(session, __wt_errno(), "%s: handle-open: fcntl(FD_CLOEXEC)", name);
+        WT_RET_MSG(session, WT_E(__wt_errno()), "%s: handle-open: fcntl(FD_CLOEXEC)", name);
     return (0);
 #else
     WT_UNUSED(session);
@@ -875,7 +875,7 @@ __posix_open_file(WT_FILE_SYSTEM *file_system, WT_SESSION *wt_session, const cha
 #elif defined(O_SYNC)
         f |= O_SYNC;
 #else
-        WT_ERR_MSG(session, ENOTSUP, "unsupported log sync mode configured");
+        WT_ERR_MSG(session, WT_E(ENOTSUP), "unsupported log sync mode configured");
 #endif
     }
 

--- a/src/os_posix/os_map.c
+++ b/src/os_posix/os_map.c
@@ -45,7 +45,7 @@ __wti_posix_map(WT_FILE_HANDLE *fh, WT_SESSION *wt_session, void **mapped_region
 #endif
              pfh->mmap_flags,
            pfh->fd, (wt_off_t)0)) == MAP_FAILED)
-        WT_RET_MSG(session, __wt_errno(), "%s: memory-map: mmap", fh->name);
+        WT_RET_MSG(session, WT_E(__wt_errno()), "%s: memory-map: mmap", fh->name);
 
     *mapped_regionp = map;
     *lenp = len;
@@ -156,5 +156,5 @@ __wti_posix_unmap(
     if (munmap(mapped_region, len) == 0)
         return (0);
 
-    WT_RET_MSG(session, __wt_errno(), "%s: memory-unmap: munmap", fh->name);
+    WT_RET_MSG(session, WT_E(__wt_errno()), "%s: memory-unmap: munmap", fh->name);
 }

--- a/src/os_posix/os_time.c
+++ b/src/os_posix/os_time.c
@@ -59,5 +59,5 @@ __wt_localtime(WT_SESSION_IMPL *session, const time_t *timep, struct tm *result)
     if (localtime_r(timep, result) != NULL)
         return (0);
 
-    WT_RET_MSG(session, __wt_errno(), "localtime_r");
+    WT_RET_MSG(session, WT_E(__wt_errno()), "localtime_r");
 }

--- a/src/os_win/os_fs.c
+++ b/src/os_win/os_fs.c
@@ -366,7 +366,7 @@ __win_file_set_end(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t
     largeint.QuadPart = len;
 
     if (win_fh->filehandle_secondary == INVALID_HANDLE_VALUE)
-        WT_RET_MSG(session, EINVAL, "%s: handle-set-end: no secondary handle", file_handle->name);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s: handle-set-end: no secondary handle", file_handle->name);
 
     if (SetFilePointerEx(win_fh->filehandle_secondary, largeint, NULL, FILE_BEGIN) == FALSE) {
         windows_error = __wt_getlasterror();
@@ -378,7 +378,7 @@ __win_file_set_end(WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t
 
     if (SetEndOfFile(win_fh->filehandle_secondary) == FALSE) {
         if (GetLastError() == ERROR_USER_MAPPED_FILE)
-            return (__wt_set_return(session, EBUSY));
+            return (__wt_set_return(session, WT_E(EBUSY)));
         windows_error = __wt_getlasterror();
         ret = __wt_map_windows_error(windows_error);
         __wt_err(session, ret, "%s: handle-set-end: SetEndOfFile: %s", file_handle->name,

--- a/src/os_win/os_futex.c
+++ b/src/os_win/os_futex.c
@@ -38,8 +38,8 @@ __wt_futex_wait(
     }
 
     windows_error = __wt_getlasterror();
-    errno = __wt_map_windows_error(windows_error);
-    return (-1);
+    errno = WT_E(__wt_map_windows_error(windows_error));
+    return (WT_EMAP(-1));
 }
 
 /*

--- a/src/os_win/os_thread.c
+++ b/src/os_win/os_thread.c
@@ -29,7 +29,7 @@ __wt_thread_create(
         return (0);
     }
 
-    WT_RET_MSG(session, __wt_errno(), "thread create: _beginthreadex");
+    WT_RET_MSG(session, WT_E(__wt_errno()), "thread create: _beginthreadex");
 }
 
 /*

--- a/src/os_win/os_winerr.c
+++ b/src/os_win/os_winerr.c
@@ -100,7 +100,7 @@ __wt_map_windows_error(DWORD windows_error)
             return (list[i].posix_error);
 
     /* Untranslatable error, go generic. */
-    return (WT_ERROR);
+    return (WT_E(WT_ERROR));
 }
 
 /*

--- a/src/packing/pack_impl.c
+++ b/src/packing/pack_impl.c
@@ -128,14 +128,14 @@ __wt_struct_repack(WT_SESSION_IMPL *session, const char *infmt, const char *outf
     /* Outfmt should complete before infmt */
     while ((ret = __pack_next(&packout, &pvout)) == 0) {
         if (p >= end)
-            WT_RET(EINVAL);
+            WT_RET(WT_E(EINVAL));
         if (pvout.type == 'x' && pvout.size == 0 && pvout.havesize)
             continue;
         WT_RET(__pack_next(&packin, &pvin));
         before = p;
         WT_RET(__unpack_read(session, &pvin, &p, (size_t)(end - p)));
         if (pvout.type != pvin.type)
-            WT_RET(ENOTSUP);
+            WT_RET(WT_E(ENOTSUP));
         if (start == NULL)
             start = before;
     }

--- a/src/packing/pack_stream.c
+++ b/src/packing/pack_stream.c
@@ -84,7 +84,7 @@ wiredtiger_pack_item(WT_PACK_STREAM *ps, WT_ITEM *item)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {
@@ -115,7 +115,7 @@ wiredtiger_pack_int(WT_PACK_STREAM *ps, int64_t i)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {
@@ -148,7 +148,7 @@ wiredtiger_pack_str(WT_PACK_STREAM *ps, const char *s)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {
@@ -178,7 +178,7 @@ wiredtiger_pack_uint(WT_PACK_STREAM *ps, uint64_t u)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {
@@ -214,7 +214,7 @@ wiredtiger_unpack_item(WT_PACK_STREAM *ps, WT_ITEM *item)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {
@@ -245,7 +245,7 @@ wiredtiger_unpack_int(WT_PACK_STREAM *ps, int64_t *ip)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {
@@ -277,7 +277,7 @@ wiredtiger_unpack_str(WT_PACK_STREAM *ps, const char **sp)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {
@@ -306,7 +306,7 @@ wiredtiger_unpack_uint(WT_PACK_STREAM *ps, uint64_t *up)
 
     /* Lower-level packing routines treat a length of zero as unchecked. */
     if (ps->p >= ps->end)
-        return (ENOMEM);
+        return (WT_E(ENOMEM));
 
     WT_RET(__pack_next(&ps->pack, &pv));
     switch (pv.type) {

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -87,7 +87,7 @@ __rec_child_deleted(
     if (!visible) {
         WT_ASSERT(session, !visible_all);
         if (F_ISSET(r, WT_REC_VISIBILITY_ERR))
-            WT_RET_PANIC(session, EINVAL, "reconciliation illegally skipped an update");
+            WT_RET_PANIC(session, WT_E(EINVAL), "reconciliation illegally skipped an update");
         /*
          * In addition to the WT_REC_CLEAN_AFTER_REC case, fail if we're trying to evict an internal
          * page and we can't see the update to it. There's not much point continuing; unlike with a
@@ -96,7 +96,7 @@ __rec_child_deleted(
          * internal pages shouldn't leave them dirty.
          */
         if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
-            return (__wt_set_return(session, EBUSY));
+            return (__wt_set_return(session, WT_E(EBUSY)));
         cmsp->state = WTI_CHILD_ORIGINAL;
         r->leave_dirty = true;
         return (0);
@@ -152,7 +152,7 @@ __rec_child_deleted(
              * should see the original page and which should see the deleted page).
              */
             if (F_ISSET(r, WT_REC_EVICT))
-                return (__wt_set_return(session, EBUSY));
+                return (__wt_set_return(session, WT_E(EBUSY)));
 
             /*
              * It is wrong to leave the page clean after checkpoint if we cannot write the deleted
@@ -243,7 +243,7 @@ __wti_rec_child_modify(
              * We should never be here during eviction, active child pages in an evicted page's
              * subtree fails the eviction attempt.
              */
-            WT_RET_ASSERT(session, WT_DIAGNOSTIC_EVICTION_CHECK, !F_ISSET(r, WT_REC_EVICT), EBUSY,
+            WT_RET_ASSERT(session, WT_DIAGNOSTIC_EVICTION_CHECK, !F_ISSET(r, WT_REC_EVICT), WT_E(EBUSY),
               "unexpected WT_REF_LOCKED child state during eviction reconciliation");
 
             /* If the page is being read from disk, it's not modified by definition. */
@@ -266,7 +266,7 @@ __wti_rec_child_modify(
              * We should never be here during eviction, active child pages in an evicted page's
              * subtree fails the eviction attempt.
              */
-            WT_RET_ASSERT(session, WT_DIAGNOSTIC_EVICTION_CHECK, !F_ISSET(r, WT_REC_EVICT), EBUSY,
+            WT_RET_ASSERT(session, WT_DIAGNOSTIC_EVICTION_CHECK, !F_ISSET(r, WT_REC_EVICT), WT_E(EBUSY),
               "unexpected WT_REF_MEM child state during eviction reconciliation");
 
             /*
@@ -370,10 +370,10 @@ __wti_rec_child_modify(
              * checkpoint, all splits in process will have completed before we walk any pages for
              * checkpoint.
              */
-            WT_RET_ASSERT(session, WT_DIAGNOSTIC_EVICTION_CHECK, false, EBUSY,
+            WT_RET_ASSERT(session, WT_DIAGNOSTIC_EVICTION_CHECK, false, WT_E(EBUSY),
               "unexpected WT_REF_SPLIT child state during reconciliation");
             /* NOTREACHED */
-            return (EBUSY);
+            return (WT_E(EBUSY));
 
         default:
             return (__wt_illegal_value(session, r->tested_ref_state));

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -98,7 +98,7 @@ __wt_bulk_insert_fix_bitmap(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     cursor = &cbulk->cbt.iface;
 
     if (((r->recno - 1) * btree->bitcnt) & 0x7)
-        WT_RET_MSG(session, EINVAL, "Bulk bitmap load not aligned on a byte boundary");
+        WT_RET_MSG(session, WT_E(EINVAL), "Bulk bitmap load not aligned on a byte boundary");
     for (data = cursor->value.data, entries = (uint32_t)cursor->value.size; entries > 0;
          entries -= page_entries, data += page_size) {
         WT_RET(__rec_col_fix_bulk_insert_split_check(cbulk));
@@ -602,7 +602,7 @@ __wti_rec_col_fix(
         auxspace *= 2;
 
         if (rawbitmapsize + auxspace > UINT32_MAX || salvage->take + salvage->missing > UINT32_MAX)
-            WT_RET_PANIC(session, WT_PANIC,
+            WT_RET_PANIC(session, WT_E(WT_PANIC),
               "%s page too large (%" PRIu64 "); cannot split it during salvage",
               __wt_page_type_string(page->type), rawbitmapsize + auxspace);
 

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -99,7 +99,7 @@ __rec_hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor
      * store checkpoint inconsistent.
      */
     if (error_on_ts_ordering) {
-        ret = EBUSY;
+        ret = WT_E(EBUSY);
         __wt_verbose_info(
           session, WT_VERB_HS, "%s", "out-of-order timestamp update detected, aborting eviction");
         WT_STAT_CONN_INCR(session, eviction_fail_checkpoint_no_ts);
@@ -773,7 +773,7 @@ __wti_rec_hs_insert_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_MULTI
                  * make the history store checkpoint inconsistent.
                  */
                 if (error_on_ts_ordering) {
-                    ret = EBUSY;
+                    ret = WT_E(EBUSY);
                     __wt_verbose_info(session, WT_VERB_HS, "%s",
                       "out-of-order timestamp update detected, aborting eviction");
                     WT_STAT_CONN_INCR(session, eviction_fail_checkpoint_no_ts);
@@ -976,7 +976,7 @@ __wti_rec_hs_insert_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_MULTI
             /* Skip updates that are already in the history store. */
             if (F_ISSET(upd, WT_UPDATE_HS)) {
                 if (hs_inserted)
-                    WT_ERR_PANIC(session, WT_PANIC,
+                    WT_ERR_PANIC(session, WT_E(WT_PANIC),
                       "Reinserting updates to the history store may corrupt the data as it may "
                       "clear the history store data newer than it.");
                 continue;
@@ -1055,7 +1055,7 @@ __wti_rec_hs_insert_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_MULTI
     if (max_hs_size != 0) {
         WT_ERR(__wt_block_manager_named_size(session, WT_HS_FILE, &hs_size));
         if ((uint64_t)hs_size > max_hs_size)
-            WT_ERR_PANIC(session, WT_PANIC,
+            WT_ERR_PANIC(session, WT_E(WT_PANIC),
               "WiredTigerHS: file size of %" PRIu64 " exceeds maximum size %" PRIu64,
               (uint64_t)hs_size, max_hs_size);
     }

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -37,7 +37,7 @@ __ovfl_discard_verbose(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell, c
 
     /* Because we dereference the page pointer, it can't be NULL */
     if (page == NULL)
-        WT_RET(EINVAL);
+        WT_RET(WT_E(EINVAL));
 
     WT_RET(__wt_scr_alloc(session, 512, &tmp));
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -88,7 +88,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
      * (e.g., the page could have split).
      */
     if (LF_ISSET(WT_REC_EVICT) && !__wt_page_can_evict(session, ref, NULL))
-        WT_ERR(__wt_set_return(session, EBUSY));
+        WT_ERR(__wt_set_return(session, WT_E(EBUSY)));
 
     /*
      * Reconcile the page. The reconciliation code unlocks the page as soon as possible, and returns
@@ -304,7 +304,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
             F_SET(session->txn, WT_TXN_REFRESH_SNAPSHOT);
 
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_progress);
-        ret = __wt_set_return(session, EBUSY);
+        ret = __wt_set_return(session, WT_E(EBUSY));
     }
     addr = ref->addr;
 
@@ -578,7 +578,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
      */
     r = *(WTI_RECONCILE **)reconcilep;
     if (r != NULL && r->ref != NULL)
-        WT_RET_MSG(session, WT_ERROR, "reconciliation re-entered");
+        WT_RET_MSG(session, WT_E(WT_ERROR), "reconciliation re-entered");
 
     if (r == NULL) {
         WT_RET(__wt_calloc_one(session, &r));
@@ -1463,7 +1463,7 @@ __wti_rec_split(WT_SESSION_IMPL *session, WTI_RECONCILE *r, size_t next_len)
      * page.
      */
     if (r->salvage != NULL)
-        WT_RET_PANIC(session, WT_PANIC, "%s page too large, attempted split during salvage",
+        WT_RET_PANIC(session, WT_E(WT_PANIC), "%s page too large, attempted split during salvage",
           __wt_page_type_string(r->page->type));
 
     /*
@@ -2073,7 +2073,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     if (!last_block && __wt_btree_syncing_by_other_session(session)) {
         WT_STAT_CONN_DSRC_INCR(
           session, cache_eviction_blocked_multi_block_reconciliation_during_checkpoint);
-        return (__wt_set_return(session, EBUSY));
+        return (__wt_set_return(session, WT_E(EBUSY)));
     }
 
     /* Make sure there's enough room for another write. */
@@ -2147,7 +2147,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
          * to allocate a zero-length array.
          */
         if (r->page->type != WT_PAGE_ROW_LEAF && chunk->entries == 0)
-            return (__wt_set_return(session, EBUSY));
+            return (__wt_set_return(session, WT_E(EBUSY)));
 
         /* If we need to restore the page to memory, copy the disk image. */
         if (multi->supd_restore)
@@ -2219,7 +2219,7 @@ __wt_bulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
      * code for a discussion.
      */
     if (!btree->original)
-        WT_RET_MSG(session, EINVAL, "bulk-load is only possible for newly created trees");
+        WT_RET_MSG(session, WT_E(EINVAL), "bulk-load is only possible for newly created trees");
 
     /*
      * Get a reference to the empty leaf page; we have exclusive access so we can take a copy of the
@@ -2820,7 +2820,7 @@ __wti_rec_hs_clear_on_tombstone(
     /* Fail 0.01% of the time. */
     if (F_ISSET(r, WT_REC_EVICT) &&
       __wt_failpoint(session, WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 1))
-        return (EBUSY);
+        return (WT_E(EBUSY));
 
     WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
     WT_STAT_DSRC_INCR(session, cache_hs_key_truncate_onpage_removal);

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -65,9 +65,9 @@ __rts_check(WT_SESSION_IMPL *session)
      * callers should be aware of this limitation.
      */
     if (cookie.ret_cursor_active)
-        WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active file cursors");
+        WT_RET_MSG(session, WT_E(EBUSY), "rollback_to_stable illegal with active file cursors");
     if (cookie.ret_txn_active) {
-        ret = EBUSY;
+        ret = WT_E(EBUSY);
         WT_TRET(__wt_verbose_dump_txn(session));
         WT_RET_MSG(session, ret, "rollback_to_stable illegal with active transactions");
     }

--- a/src/schema/schema_alter.c
+++ b/src/schema/schema_alter.c
@@ -53,7 +53,7 @@ err:
      * entry.
      */
     if (ret == WT_NOTFOUND)
-        ret = __wt_set_return(session, ENOENT);
+        ret = __wt_set_return(session, WT_E(ENOENT));
 
     return (ret);
 }
@@ -302,7 +302,7 @@ __alter_tree(WT_SESSION_IMPL *session, const char *name, const char *newcfg[])
 
     /* Get the data source URI, converting not-found errors to EINVAL for the application. */
     if ((ret = __wt_config_getones(session, value, "source", &cval)) != 0)
-        WT_ERR_MSG(session, ret == WT_NOTFOUND ? EINVAL : ret,
+        WT_ERR_MSG(session, ret == WT_NOTFOUND ? WT_EMAP(EINVAL) : ret,
           "index or column group has no data source: %s", value);
 
     WT_ERR(__wt_scr_alloc(session, 0, &data_source));
@@ -405,7 +405,7 @@ __schema_alter(WT_SESSION_IMPL *session, const char *uri, const char *newcfg[])
     exclusive_refreshed = (bool)cv.val;
 
     if (!exclusive_refreshed && !WT_PREFIX_MATCH(uri, "table:"))
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "option \"exclusive_refreshed\" "
           "is applicable only on simple tables");
 

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -142,7 +142,7 @@ __drop_table(
     if (force && !table->is_simple) {
         __wt_verbose_warning(session, WT_VERB_HANDLEOPS,
           "ENOTSUP: drop table with force=true is not supported for complex tables. uri=%s", uri);
-        WT_ERR(ENOTSUP);
+        WT_ERR(WT_E(ENOTSUP));
     }
 
     /* Drop the column groups. */
@@ -215,7 +215,7 @@ __drop_tiered(
     remove_shared = cval.val != 0;
 
     if (!remove_files && remove_shared)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "drop for tiered storage object must configure removal of underlying files "
           "if forced removal of shared objects is enabled");
 
@@ -389,7 +389,7 @@ __schema_drop(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], bool
      * entry. Map ENOENT to zero if force is set.
      */
     if (ret == WT_NOTFOUND || ret == ENOENT)
-        ret = force ? 0 : ENOENT;
+        ret = force ? 0 : WT_E(ENOENT);
 
     if (F_ISSET(S2C(session), WT_CONN_BACKUP_PARTIAL_RESTORE))
         WT_TRET(__wt_meta_track_off(session, false, ret != 0));

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -80,7 +80,7 @@ __wt_schema_get_table_uri(
     table = (WT_TABLE *)session->dhandle;
     if (!ok_incomplete && !table->cg_complete) {
         WT_ERR(__wt_session_release_dhandle(session));
-        ret = __wt_set_return(session, EINVAL);
+        ret = __wt_set_return(session, WT_E(EINVAL));
         WT_ERR_MSG(session, ret, "'%s' cannot be used until all column groups are created",
           table->iface.name);
     }

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -342,7 +342,7 @@ __schema_open_index(
     }
     WT_ERR_NOTFOUND_OK(ret, false);
     if (idxname != NULL && !match)
-        ret = WT_NOTFOUND;
+        ret = WT_E(WT_NOTFOUND);
 
     /* If we did a full pass, we won't need to do it again. */
     if (idxname == NULL) {
@@ -441,7 +441,7 @@ __schema_open_table(WT_SESSION_IMPL *session)
     WT_RET_NOTFOUND_OK(ret);
 
     if (table->ncolgroups > 0 && table->is_simple)
-        WT_RET_MSG(session, EINVAL, "%s requires a table with named columns", tablename);
+        WT_RET_MSG(session, WT_E(EINVAL), "%s requires a table with named columns", tablename);
 
     if ((ret = __wt_config_gets(session, table_cfg, "shared", &cval)) == 0)
         table->is_tiered_shared = true;
@@ -494,8 +494,8 @@ __wt_schema_get_colgroup(
 
     WT_RET(__wt_schema_release_table(session, &table));
     if (quiet)
-        WT_RET(ENOENT);
-    WT_RET_MSG(session, ENOENT, "%s not found in table", uri);
+        WT_RET(WT_E(ENOENT));
+    WT_RET_MSG(session, WT_E(ENOENT), "%s not found in table", uri);
 }
 
 /*
@@ -545,8 +545,8 @@ err:
         return (0);
 
     if (quiet)
-        WT_RET(ENOENT);
-    WT_RET_MSG(session, ENOENT, "%s not found in table", uri);
+        WT_RET(WT_E(ENOENT));
+    WT_RET_MSG(session, WT_E(ENOENT), "%s not found in table", uri);
 }
 
 /*

--- a/src/schema/schema_plan.c
+++ b/src/schema/schema_plan.c
@@ -62,7 +62,7 @@ cgcols:
     }
 
     if (foundcg == UINT_MAX)
-        return (WT_NOTFOUND);
+        return (WT_E(WT_NOTFOUND));
 
     *cgnump = foundcg;
     if (foundcol < table->nkey_columns) {
@@ -107,7 +107,7 @@ __wti_schema_colcheck(WT_SESSION_IMPL *session, const char *key_format, const ch
     WT_RET_NOTFOUND_OK(ret);
 
     if (ncols != 0 && ncols != kcols + vcols)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "Number of columns in '%.*s' does not match key format '%s' plus value format '%s'",
           (int)colconf->len, colconf->str, key_format, value_format);
 
@@ -145,7 +145,7 @@ __wti_table_check(WT_SESSION_IMPL *session, WT_TABLE *table)
     coltype = '\0';
     while ((ret = __wt_config_next(&conf, &k, &v)) == 0) {
         if (__find_next_col(session, table, &k, &cg, &col, &coltype) != 0)
-            WT_RET_MSG(session, EINVAL, "Column '%.*s' in '%s' does not appear in a column group",
+            WT_RET_MSG(session, WT_E(EINVAL), "Column '%.*s' in '%s' does not appear in a column group",
               (int)k.len, k.str, table->iface.name);
         /*
          * Column groups can't store key columns in their value:
@@ -270,7 +270,7 @@ __find_column_format(WT_SESSION_IMPL *session, WT_TABLE *table, WT_CONFIG_ITEM *
 
         if (k.len == colname->len && strncmp(colname->str, k.str, k.len) == 0) {
             if (value_only && inkey)
-                return (__wt_set_return(session, EINVAL));
+                return (__wt_set_return(session, WT_E(EINVAL)));
             return (0);
         }
     }
@@ -324,9 +324,9 @@ __wt_struct_reformat(WT_SESSION_IMPL *session, WT_TABLE *table, const char *colu
 
         if ((ret = __find_column_format(session, table, &k, value_only, &pv)) != 0) {
             if (value_only && ret == EINVAL)
-                WT_RET_MSG(session, EINVAL,
+                WT_RET_MSG(session, WT_E(EINVAL),
                   "A column group cannot store key column '%.*s' in its value", (int)k.len, k.str);
-            WT_RET_MSG(session, EINVAL, "Column '%.*s' not found", (int)k.len, k.str);
+            WT_RET_MSG(session, WT_E(EINVAL), "Column '%.*s' not found", (int)k.len, k.str);
         }
 
         /*

--- a/src/schema/schema_project.c
+++ b/src/schema/schema_project.c
@@ -127,7 +127,7 @@ __wt_schema_project_in(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *pro
                 break;
 
             default:
-                WT_RET_MSG(session, EINVAL, "unexpected projection plan: %c", (int)*proj);
+                WT_RET_MSG(session, WT_E(EINVAL), "unexpected projection plan: %c", (int)*proj);
             }
         }
     }
@@ -357,7 +357,7 @@ __wt_schema_project_slice(WT_SESSION_IMPL *session, WT_CURSOR **cp, const char *
                 }
                 break;
             default:
-                WT_RET_MSG(session, EINVAL, "unexpected projection plan: %c", (int)*proj);
+                WT_RET_MSG(session, WT_E(EINVAL), "unexpected projection plan: %c", (int)*proj);
             }
         }
     }

--- a/src/schema/schema_truncate.c
+++ b/src/schema/schema_truncate.c
@@ -115,7 +115,7 @@ __wt_schema_truncate(WT_SESSION_IMPL *session, const char *uri, const char *cfg[
         ret = __wt_bad_object_type(session, uri);
 
     /* If we didn't find a metadata entry, map that error to ENOENT. */
-    return (ret == WT_NOTFOUND ? ENOENT : ret);
+    return (ret == WT_NOTFOUND ? WT_E(ENOENT) : ret);
 }
 
 /*

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -32,7 +32,7 @@ __schema_backup_check_int(WT_SESSION_IMPL *session, const char *name)
     }
     for (i = 0; backup_list[i] != NULL; ++i) {
         if (strcmp(backup_list[i], name) == 0)
-            return (__wt_set_return(session, EBUSY));
+            return (__wt_set_return(session, WT_E(EBUSY)));
     }
 
     return (0);
@@ -121,7 +121,7 @@ __str_name_check(WT_SESSION_IMPL *session, const char *name, bool skip_wt)
 {
 
     if (!skip_wt && WT_PREFIX_MATCH(name, "WiredTiger"))
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "%s: the \"WiredTiger\" name space may not be used by applications", name);
 
     /*
@@ -129,7 +129,7 @@ __str_name_check(WT_SESSION_IMPL *session, const char *name, bool skip_wt)
      * but there's no good reason to use them in names and we're not going to do the testing.
      */
     if (strpbrk(name, "{},:[]\\\"'") != NULL)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, WT_E(EINVAL),
           "%s: WiredTiger objects should not include grouping characters in their names", name);
     return (0);
 }

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -100,7 +100,7 @@ __wt_schema_worker(WT_SESSION_IMPL *session, const char *uri,
     is_tiered = WT_PREFIX_MATCH(uri, "object:") || WT_PREFIX_MATCH(uri, "tier:") ||
       WT_PREFIX_MATCH(uri, "tiered:");
     if (is_tiered && (file_func == __wt_salvage || file_func == __wt_verify))
-        WT_ERR(ENOTSUP);
+        WT_ERR(WT_E(ENOTSUP));
 
     /* Get the btree handle(s) and call the underlying function. */
     if (WT_PREFIX_MATCH(uri, "file:")) {
@@ -133,7 +133,7 @@ __wt_schema_worker(WT_SESSION_IMPL *session, const char *uri,
             /* Verify is not implemented for tiered tables. */
             if ((file_func == __wt_salvage || file_func == __wt_verify) &&
               WT_PREFIX_MATCH(colgroup->source, "tiered:"))
-                WT_ERR(ENOTSUP);
+                WT_ERR(WT_E(ENOTSUP));
 
             skip = false;
             if (name_func != NULL)

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -146,6 +146,7 @@ err:
 void
 __wt_session_reset_last_error(WT_SESSION_IMPL *session)
 {
+    __wt_ret_origin_clear(session);
     if (session == NULL || !F_ISSET(session, WT_SESSION_SAVE_ERRORS))
         return;
 

--- a/src/support/crypto.c
+++ b/src/support/crypto.c
@@ -28,7 +28,7 @@ __wt_decrypt(
 
     if (encrypt_len > in->size)
         WT_RET_MSG(
-          session, WT_ERROR, "corrupted encrypted item: padded size less than actual size");
+          session, WT_E(WT_ERROR), "corrupted encrypted item: padded size less than actual size");
     /*
      * We're allocating the number of bytes we're expecting from decryption plus the unencrypted
      * header.

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -540,7 +540,7 @@ __wt_panic_func(WT_SESSION_IMPL *session, int error, const char *func, int line,
 
     /* If the connection has already panicked, just return the error. */
     if (conn != NULL && F_ISSET(conn, WT_CONN_PANIC))
-        return (WT_PANIC);
+        return (WT_EMAP(WT_PANIC));  /* Don't opverwrite the original error location. */
 
     /*
      * Call the error callback function before setting the connection's panic flag, so applications
@@ -586,7 +586,7 @@ __wt_panic_func(WT_SESSION_IMPL *session, int error, const char *func, int line,
      * Reflect, repent, and reboot.
      * Order shall return.
      */
-    return (WT_PANIC);
+    return (WT_EMAP(WT_PANIC)); /* Don't opverwrite the original error location. */
 }
 
 /*
@@ -738,7 +738,7 @@ int
 __wt_inmem_unsupported_op(WT_SESSION_IMPL *session, const char *tag) WT_GCC_FUNC_ATTRIBUTE((cold))
 {
     if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY))
-        WT_RET_MSG(session, ENOTSUP, "%s%snot supported for in-memory configurations",
+        WT_RET_MSG(session, WT_E(ENOTSUP), "%s%snot supported for in-memory configurations",
           tag == NULL ? "" : tag, tag == NULL ? "" : ": ");
     return (0);
 }
@@ -750,7 +750,7 @@ __wt_inmem_unsupported_op(WT_SESSION_IMPL *session, const char *tag) WT_GCC_FUNC
 int
 __wt_object_unsupported(WT_SESSION_IMPL *session, const char *uri) WT_GCC_FUNC_ATTRIBUTE((cold))
 {
-    WT_RET_MSG(session, ENOTSUP, "unsupported object operation: %s", uri);
+    WT_RET_MSG(session, WT_E(ENOTSUP), "unsupported object operation: %s", uri);
 }
 
 /*
@@ -768,9 +768,9 @@ __wt_bad_object_type(WT_SESSION_IMPL *session, const char *uri) WT_GCC_FUNC_ATTR
         return (__wt_object_unsupported(session, uri));
 
     if (WT_PREFIX_MATCH(uri, "lsm:"))
-        WT_RET_MSG(session, ENOTSUP, "lsm object type no longer supported: %s", uri);
+        WT_RET_MSG(session, WT_E(ENOTSUP), "lsm object type no longer supported: %s", uri);
 
-    WT_RET_MSG(session, ENOTSUP, "unknown object type: %s", uri);
+    WT_RET_MSG(session, WT_E(ENOTSUP), "unknown object type: %s", uri);
 }
 
 /*
@@ -781,5 +781,5 @@ int
 __wt_unexpected_object_type(WT_SESSION_IMPL *session, const char *uri, const char *expect)
   WT_GCC_FUNC_ATTRIBUTE((cold))
 {
-    WT_RET_MSG(session, EINVAL, "uri %s doesn't match expected \"%s\"", uri, expect);
+    WT_RET_MSG(session, WT_E(EINVAL), "uri %s doesn't match expected \"%s\"", uri, expect);
 }

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -221,7 +221,7 @@ __wt_hazard_clear(WT_SESSION_IMPL *session, WT_REF *ref)
      * A serious error, we should always find the hazard pointer. Panic, because using a page we
      * didn't have pinned down implies corruption.
      */
-    WT_RET_PANIC(session, EINVAL, "session %p: clear hazard pointer: %p: not found",
+    WT_RET_PANIC(session, WT_E(EINVAL), "session %p: clear hazard pointer: %p: not found",
       (void *)session, (void *)ref);
 }
 

--- a/src/support/hex.c
+++ b/src/support/hex.c
@@ -249,7 +249,7 @@ __wti_hex2byte(const u_char *from, u_char *to)
 static int
 __hex_fmterr(WT_SESSION_IMPL *session)
 {
-    WT_RET_MSG(session, EINVAL, "Invalid format in hexadecimal string");
+    WT_RET_MSG(session, WT_E(EINVAL), "Invalid format in hexadecimal string");
 }
 
 /*

--- a/src/support/json.c
+++ b/src/support/json.c
@@ -230,7 +230,7 @@ __json_unpack_put(WT_SESSION_IMPL *session, void *voidpv, u_char *buf, size_t bu
         return (0);
     }
 
-    WT_RET_MSG(session, EINVAL, "unknown pack-value type: %c", (int)pv->type);
+    WT_RET_MSG(session, WT_E(EINVAL), "unknown pack-value type: %c", (int)pv->type);
 }
 
 /*
@@ -466,7 +466,7 @@ __wt_json_column_init(WT_CURSOR *cursor, const char *uri, const char *keyformat,
             while (__wt_isalnum((u_char) * (in)))                                           \
                 (in)++;                                                                     \
             WT_RET_MSG(                                                                     \
-              session, EINVAL, "unknown keyword \"%.*s\" in JSON", (int)((in)-_bad), _bad); \
+              session, WT_E(EINVAL), "unknown keyword \"%.*s\" in JSON", (int)((in)-_bad), _bad); \
         }                                                                                   \
     } while (0)
 
@@ -522,7 +522,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype, const cha
 
                     uc = (const u_char *)src;
                     if (__wti_hex2byte(&uc[1], &ignored) || __wti_hex2byte(&uc[3], &ignored))
-                        WT_RET_MSG(session, EINVAL, "invalid Unicode within JSON string");
+                        WT_RET_MSG(session, WT_E(EINVAL), "invalid Unicode within JSON string");
                     src += 4;
                 }
                 backslash = false;
@@ -531,7 +531,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype, const cha
         }
         if (result == 's')
             break;
-        WT_RET_MSG(session, EINVAL, "unterminated string in JSON");
+        WT_RET_MSG(session, WT_E(EINVAL), "unterminated string in JSON");
     case '-':
     case '0':
     case '1':
@@ -589,7 +589,7 @@ __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype, const cha
         if (isalph)
             while (*src != '\0' && __wt_isalnum((u_char)*src))
                 src++;
-        WT_RET_MSG(session, EINVAL, "unknown token \"%.*s\" in JSON", (int)(src - bad), bad);
+        WT_RET_MSG(session, WT_E(EINVAL), "unknown token \"%.*s\" in JSON", (int)(src - bad), bad);
         /* NOTREACHED */
     }
     WT_ASSERT(session, result != -1);
@@ -656,7 +656,7 @@ json_string_arg(WT_SESSION_IMPL *session, const char **jstr, WT_ITEM *item)
         item->data = tokstart + 1;
         item->size -= 2;
     } else
-        WT_RET_MSG(session, EINVAL, "expected JSON <string>, got %s", __wt_json_tokname(tok));
+        WT_RET_MSG(session, WT_E(EINVAL), "expected JSON <string>, got %s", __wt_json_tokname(tok));
     return (0);
 }
 
@@ -677,10 +677,10 @@ json_int_arg(WT_SESSION_IMPL *session, const char **jstr, int64_t *ip)
         /* JSON only allows decimal */
         *ip = strtoll(tokstart, &end, 10);
         if (end != tokstart + toksize)
-            WT_RET_MSG(session, EINVAL, "JSON <int> extraneous input");
+            WT_RET_MSG(session, WT_E(EINVAL), "JSON <int> extraneous input");
         *jstr = tokstart + toksize;
     } else
-        WT_RET_MSG(session, EINVAL, "expected JSON <int>, got %s", __wt_json_tokname(tok));
+        WT_RET_MSG(session, WT_E(EINVAL), "expected JSON <int>, got %s", __wt_json_tokname(tok));
     return (0);
 }
 
@@ -701,10 +701,10 @@ json_uint_arg(WT_SESSION_IMPL *session, const char **jstr, uint64_t *up)
         /* JSON only allows decimal */
         *up = strtoull(tokstart, &end, 10);
         if (end != tokstart + toksize)
-            WT_RET_MSG(session, EINVAL, "JSON <int> extraneous input");
+            WT_RET_MSG(session, WT_E(EINVAL), "JSON <int> extraneous input");
         *jstr = tokstart + toksize;
     } else
-        WT_RET_MSG(session, EINVAL, "expected unsigned JSON <int>, got %s", __wt_json_tokname(tok));
+        WT_RET_MSG(session, WT_E(EINVAL), "expected unsigned JSON <int>, got %s", __wt_json_tokname(tok));
     return (0);
 }
 
@@ -713,7 +713,7 @@ json_uint_arg(WT_SESSION_IMPL *session, const char **jstr, uint64_t *up)
         int __tok;                                                                             \
         WT_RET(__wt_json_token((WT_SESSION *)(session), jstr, &__tok, &(start), &(sz)));       \
         if (__tok != (tokval))                                                                 \
-            WT_RET_MSG(session, EINVAL, "expected JSON %s, got %s", __wt_json_tokname(tokval), \
+            WT_RET_MSG(session, WT_E(EINVAL), "expected JSON %s, got %s", __wt_json_tokname(tokval), \
               __wt_json_tokname(__tok));                                                       \
         (jstr) = (start) + (sz);                                                               \
     } while (0)
@@ -801,7 +801,7 @@ __json_pack_size(WT_SESSION_IMPL *session, const char *fmt, WT_CONFIG_ITEM *name
         JSON_EXPECT_TOKEN_GET(session, jstr, 's', tokstart, toksize);
         WT_RET(__pack_name_next(&packname, &name));
         if (toksize - 2 != name.len || strncmp(tokstart + 1, name.str, toksize - 2) != 0)
-            WT_RET_MSG(session, EINVAL, "JSON expected %s name: \"%.*s\"", iskey ? "key" : "value",
+            WT_RET_MSG(session, WT_E(EINVAL), "JSON expected %s name: \"%.*s\"", iskey ? "key" : "value",
               (int)name.len, name.str);
         JSON_EXPECT_TOKEN(session, jstr, ':');
         WT_PACK_JSON_GET(session, pv, jstr);
@@ -902,11 +902,11 @@ __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen, const char
             case 'u':
                 if (__wti_hex2byte((const u_char *)src, &hi) ||
                   __wti_hex2byte((const u_char *)src + 2, &lo))
-                    WT_RET_MSG(session, EINVAL, "invalid Unicode within JSON string");
+                    WT_RET_MSG(session, WT_E_S((WT_SESSION_IMPL*)wt_session, EINVAL), "invalid Unicode within JSON string");
                 src += 4;
                 if (hi != 0)
                     WT_RET_MSG(
-                      session, EINVAL, "Unicode \"%6.6s\" byte out of range in JSON", src - 6);
+                      session, WT_E_S((WT_SESSION_IMPL*)wt_session, EINVAL), "Unicode \"%6.6s\" byte out of range in JSON", src - 6);
                 *dst++ = (char)lo;
                 break;
             case 'f':
@@ -932,7 +932,7 @@ __wt_json_strncpy(WT_SESSION *wt_session, char **pdst, size_t dstlen, const char
             *dst++ = ch;
     }
     if (src != srcend)
-        WT_RET_MSG(session, ENOMEM, "JSON string copy destination buffer too small");
+        WT_RET_MSG(session, WT_E_S((WT_SESSION_IMPL*)wt_session, ENOMEM), "JSON string copy destination buffer too small");
     *pdst = dst;
     while (dst < dstend)
         *dst++ = '\0';

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -431,7 +431,7 @@ __wt_modify_reconstruct_from_upd_list(WT_SESSION_IMPL *session, WT_CURSOR_BTREE 
      * user with a rollback error.
      */
     if (context == WT_OPCTX_TRANSACTION && session->txn->isolation == WT_ISO_READ_UNCOMMITTED)
-        WT_RET_MSG(session, WT_ROLLBACK,
+        WT_RET_MSG(session, WT_E(WT_ROLLBACK),
           "Read-uncommitted readers do not support reconstructing a record with modifies.");
 retry:
     /* Construct full update */

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -137,7 +137,7 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 
     /* This read lock can only be granted if there are no active writers. */
     if (old.u.s.current != old.u.s.next)
-        return (__wt_set_return(session, EBUSY));
+        return (__wt_set_return(session, WT_E(EBUSY)));
 
     /*
      * The replacement lock value is a result of adding an active reader. Check for overflow: if the
@@ -145,10 +145,10 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
      */
     new.u.v = old.u.v;
     if (++new.u.s.readers_active == 0)
-        return (__wt_set_return(session, EBUSY));
+        return (__wt_set_return(session, WT_E(EBUSY)));
 
     /* We rely on this atomic operation to provide a barrier. */
-    WT_RET(__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : EBUSY);
+    WT_RET(__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : WT_E(EBUSY));
 
 #ifdef TSAN_BUILD
     /* Perform a dummy read to inform TSan this function does in fact have acquire semantics. */
@@ -341,7 +341,7 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
      */
     old.u.v = __wt_atomic_loadv64(&l->u.v);
     if (old.u.s.current != old.u.s.next || old.u.s.readers_active != 0)
-        return (__wt_set_return(session, EBUSY));
+        return (__wt_set_return(session, WT_E(EBUSY)));
 
     /*
      * We've checked above that there is no writer active (since
@@ -356,7 +356,7 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
      */
     new.u.v = old.u.v;
     new.u.s.next++;
-    WT_RET(__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : EBUSY);
+    WT_RET(__wt_atomic_casv64(&l->u.v, old.u.v, new.u.v) ? 0 : WT_E(EBUSY));
 
 #ifdef TSAN_BUILD
     /* Perform a dummy write to inform TSan this function does in fact have acquire semantics. */

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -155,7 +155,7 @@ __thread_group_resize(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
         return (0);
 
     if (new_min > new_max)
-        WT_ERR_MSG(session, EINVAL,
+        WT_ERR_MSG(session, WT_E(EINVAL),
           "Illegal thread group resize: %s, from min: %" PRIu32 " -> %" PRIu32 " from max: %" PRIu32
           " -> %" PRIu32,
           group->name, group->min, new_min, group->max, new_max);

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -122,8 +122,8 @@ __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, const char *
 #define WT_TIME_VALIDATE_RET(session, ...)        \
     do {                                          \
         if (silent)                               \
-            return (EINVAL);                      \
-        WT_RET_MSG(session, EINVAL, __VA_ARGS__); \
+            return (WT_E(EINVAL));                      \
+        WT_RET_MSG(session, WT_E(EINVAL), __VA_ARGS__); \
     } while (0)
 
 /*

--- a/src/tiered/tiered_config.c
+++ b/src/tiered/tiered_config.c
@@ -30,7 +30,7 @@ __tiered_confchk(
             *nstoragep = nstorage;
             return (0);
         }
-    WT_RET_MSG(session, EINVAL, "unknown storage source '%.*s'", (int)name->len, name->str);
+    WT_RET_MSG(session, WT_E(EINVAL), "unknown storage source '%.*s'", (int)name->len, name->str);
 }
 
 /*
@@ -82,7 +82,7 @@ __wti_tiered_bucket_config(
         WT_ERR(__wt_config_gets(session, cfg, "tiered_storage.bucket", &bucket));
         if (bucket.len != 0)
             WT_ERR_MSG(
-              session, EINVAL, "tiered_storage.bucket requires tiered_storage.name to be set");
+              session, WT_E(EINVAL), "tiered_storage.bucket requires tiered_storage.name to be set");
         goto done;
     }
     /*
@@ -91,15 +91,15 @@ __wti_tiered_bucket_config(
      */
     if (!WT_CONN_TIERED_STORAGE_ENABLED(conn) && bstoragep != &conn->bstorage)
         WT_ERR_MSG(
-          session, EINVAL, "table tiered storage requires connection tiered storage to be set");
+          session, WT_E(EINVAL), "table tiered storage requires connection tiered storage to be set");
     /* A bucket and bucket_prefix are required, cache_directory and auth_token are not. */
     WT_ERR(__wt_config_gets(session, cfg, "tiered_storage.auth_token", &auth));
     WT_ERR(__wt_config_gets(session, cfg, "tiered_storage.bucket", &bucket));
     if (bucket.len == 0)
-        WT_ERR_MSG(session, EINVAL, "table tiered storage requires bucket to be set");
+        WT_ERR_MSG(session, WT_E(EINVAL), "table tiered storage requires bucket to be set");
     WT_ERR(__wt_config_gets(session, cfg, "tiered_storage.bucket_prefix", &prefix));
     if (prefix.len == 0)
-        WT_ERR_MSG(session, EINVAL, "table tiered storage requires bucket_prefix to be set");
+        WT_ERR_MSG(session, WT_E(EINVAL), "table tiered storage requires bucket_prefix to be set");
     WT_ERR(__wt_config_gets(session, cfg, "tiered_storage.cache_directory", &cachedir));
     WT_ERR_NOTFOUND_OK(__wt_config_gets(session, cfg, "tiered_storage.shared", &shared), false);
 
@@ -109,7 +109,7 @@ __wti_tiered_bucket_config(
      */
     if (WT_CONN_TIERED_STORAGE_ENABLED(conn) && conn->bstorage->tiered_shared == false &&
       shared.val)
-        WT_ERR_MSG(session, EINVAL,
+        WT_ERR_MSG(session, WT_E(EINVAL),
           "table tiered storage shared requires connection tiered storage shared to be set");
 
     hash = __wt_hash_city64(bucket.str, bucket.len);
@@ -187,7 +187,7 @@ __wt_tiered_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfi
 
     /* Check for incompatible configuration options. */
     if (F_ISSET(conn, WT_CONN_IN_MEMORY))
-        WT_ERR_MSG(session, EINVAL,
+        WT_ERR_MSG(session, WT_E(EINVAL),
           "the \"in_memory\" connection configuration is not compatible with tiered storage");
 
     /* Set up the rest of the tiered storage configuration. c*/

--- a/src/tiered/tiered_handle.c
+++ b/src/tiered/tiered_handle.c
@@ -66,7 +66,7 @@ __tiered_name_check(WT_SESSION_IMPL *session, WT_TIERED *tiered)
              */
             __wt_verbose(
               session, WT_VERB_TIERED, "EEXIST %s already exists on shared storage", obj_files[i]);
-            WT_ERR(EEXIST);
+            WT_ERR(WT_E(EEXIST));
         }
     }
 
@@ -100,7 +100,7 @@ __tiered_dhandle_setup(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t i, 
             id = WT_TIERED_INDEX_SHARED;
         else
             WT_ERR_MSG(
-              session, EINVAL, "Unknown or unsupported tiered dhandle type %" PRIu32, type);
+              session, WT_E(EINVAL), "Unknown or unsupported tiered dhandle type %" PRIu32, type);
     } else {
         WT_ASSERT(session, i < WT_TIERED_MAX_TIERS);
         id = i;


### PR DESCRIPTION
Starting point:
```
perl -i -npE 's/(?<!(?:\s[=!]=\s|..\w\s|...[:"<\/]))\b(WT_ROLLBACK|WT_DUPLICATE_KEY|WT_ERROR|WT_NOTFOUND|WT_PANIC|WT_RESTART|WT_RUN_RECOVERY|WT_CACHE_FULL|WT_PREPARE_CONFLICT|WT_TRY_SALVAGE|EACCES|EBUSY|ECANCELED|EEXIST|EFBIG|EINVAL|EIO|EN
OENT|ENOMEM|ENOTSUP|EPERM|ERANGE|ETIMEDOUT|EXIT_FAILURE|errno)\b(?!(?:[}]|\s[=!]=\s))/WT_E($1)/g' `find src -name \*.[ch] | fgrep -v src/utilities`
```

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
