### PR TITLE
Revert "WT-14387 Update vcvars64.bat path in Windows buildscript"

### DIFF
--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -1,7 +1,7 @@
 param (
     [bool]$configure = $false,
     [bool]$build = $false,
-    [string]$vcvars_bat = "C:\Program Files\Microsoft Visual Studio\2022\VC\Auxiliary\Build\vcvars64.bat"
+    [string]$vcvars_bat = "C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat"
 )
 
 function Die-On-Failure {


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#11853

We made this change to fix some platform issues on our Evergreen Windows hosts. Those changes have been reverted so we need to revert back to the original path.