### PR TITLE
WT-14403 Remove the partial logic and rewrite __live_restore_can_service_read

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -602,14 +602,16 @@ __live_restore_can_service_read(
     /* Iterate through all set bits(1s) first. */
     while (current_bit < read_end_bit && __bit_test(lr_fh->bitmap, current_bit))
         current_bit++;
-    /*
-     * If we got here we either traversed the full hole list and didn't find a hole, or the read is
-     * prior to any holes.
-     */
-    __wt_verbose_debug3(
-      session, WT_VERB_LIVE_RESTORE, "CAN SERVICE %s: No hole found", lr_fh->iface.name);
-    if (current_bit == read_end_bit)
+
+    if (current_bit == read_end_bit) {
+        /*
+         * If we got here we either traversed the full hole list and didn't find a hole, or the read
+         * is prior to any holes.
+         */
+        __wt_verbose_debug3(
+          session, WT_VERB_LIVE_RESTORE, "CAN SERVICE %s: No hole found", lr_fh->iface.name);
         return (true);
+    }
 
     /* Otherwise, some bits are unset(0s), iterate through those next. */
     while (current_bit < read_end_bit && !__bit_test(lr_fh->bitmap, current_bit))

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -760,7 +760,7 @@ __live_restore_fh_read(
         WT_RET(__live_restore_fh_read_destination(session, lr_fh->destination, offset, len, buf));
 
     __wt_readlock(session, &lr_fh->lock);
-    wt_off_t hole_begin_off;
+    wt_off_t hole_begin_off = offset;
     if (__live_restore_can_service_read(session, lr_fh, offset, len, &hole_begin_off)) {
         /* Read the full read from the destination. */
         WT_ERR(

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -583,6 +583,7 @@ static bool
 __live_restore_can_service_read(WT_SESSION_IMPL *session, WTI_LIVE_RESTORE_FILE_HANDLE *lr_fh,
   wt_off_t offset, size_t len, wt_off_t *hole_begin_off)
 {
+    *hole_begin_off = offset;
     /*
      * The read will be serviced out of the destination if the read is beyond the length of the
      * source file.
@@ -760,7 +761,7 @@ __live_restore_fh_read(
         WT_RET(__live_restore_fh_read_destination(session, lr_fh->destination, offset, len, buf));
 
     __wt_readlock(session, &lr_fh->lock);
-    wt_off_t hole_begin_off = offset;
+    wt_off_t hole_begin_off;
     if (__live_restore_can_service_read(session, lr_fh, offset, len, &hole_begin_off)) {
         /* Read the full read from the destination. */
         WT_ERR(

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -772,21 +772,21 @@ __live_restore_fh_read(
         /*
          * If a portion of the read region is serviceable then it is a partial read, add a check
          * here to ensure partial reads always identical to the reads from the source.
-         * /
+         */
         /*
-        *!!!
-        *              <--read len--->
-        * read:        |-------------|
-        *      bitmap: |####|----hole----|
-        *              ^    ^        |
-        *              |    |        |
-        *           read off|        |
-        *                hole off    |
-        * read dest:   |----|
-        * read source:      |--------|
-        *
-        *
-        */
+         *!!!
+         *              <--read len--->
+         * read:        |-------------|
+         *      bitmap: |####|----hole----|
+         *              ^    ^        |
+         *              |    |        |
+         *           read off|        |
+         *                hole off    |
+         * read dest:   |----|
+         * read source:      |--------|
+         *
+         *
+         */
         if (hole_begin_off > offset) {
             WT_ERR(__wt_calloc(session, 1, len, &tmp_buf));
             size_t dest_partial_read_len = (size_t)(hole_begin_off - offset);

--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -769,6 +769,7 @@ __live_restore_fh_read(
         /* Otherwise from the source. */
         WT_ERR(__live_restore_fh_read_source(session, lr_fh->source, offset, len, read_data));
 
+#ifdef HAVE_DIAGNOSTIC
         /*
          * If a portion of the read region is serviceable then it is a partial read, add a check
          * here to ensure partial reads always identical to the reads from the source.
@@ -802,6 +803,7 @@ __live_restore_fh_read(
             WT_ASSERT_ALWAYS(session, WT_STRING_MATCH(read_data, tmp_buf, len),
               "Live restore partial reads should always match reads from the source!");
         }
+#endif
     }
 
 err:


### PR DESCRIPTION
This PR is to remove the partial logic and rewrite the function `__live_restore_can_service_read`. The main changes include:
1. Rewrite the logic to check varies scenarios during the iteration from `read_start_bit` to `read_end_bit`.
2. Remove the PARTIAL logic, now the read is either read from source or dest. The reason behind that is since wiredtiger always read/write one page at a time, when a read range is partial, it means there's an in progress background migration on that page but there are no writes on the page yet, thus read the entire page from source should be safe.