### PR TITLE
WT-14334 remove unused variable from txn_log

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1405,7 +1405,7 @@ extern int __wti_tree_walk_skip(WT_SESSION_IMPL *session, WT_REF **refp, uint64_
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_txn_checkpoint_logread(WT_SESSION_IMPL *session, const uint8_t **pp,
   const uint8_t *end, WT_LSN *ckpt_lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_txn_log_commit(WT_SESSION_IMPL *session, const char *cfg[])
+extern int __wti_txn_log_commit(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -767,7 +767,7 @@ __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)
 
     if (ret == 0 && cval.len != 0) {
         session->isolation = txn->isolation = WT_CONFIG_LIT_MATCH("snapshot", cval) ?
-          WT_ISO_SNAPSHOT :
+                                                          WT_ISO_SNAPSHOT :
           WT_CONFIG_LIT_MATCH("read-uncommitted", cval) ? WT_ISO_READ_UNCOMMITTED :
                                                           WT_ISO_READ_COMMITTED;
     }
@@ -1247,9 +1247,9 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
           __wt_txn_timestamp_usage_check(session, op, txn->commit_timestamp, upd->prev_durable_ts));
 
     for (first_committed_upd = upd; first_committed_upd != NULL &&
-      (first_committed_upd->txnid == WT_TXN_ABORTED ||
-        first_committed_upd->prepare_state == WT_PREPARE_INPROGRESS);
-      first_committed_upd = first_committed_upd->next)
+         (first_committed_upd->txnid == WT_TXN_ABORTED ||
+           first_committed_upd->prepare_state == WT_PREPARE_INPROGRESS);
+         first_committed_upd = first_committed_upd->next)
         ;
 
     /*
@@ -1353,8 +1353,8 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
         if (!commit) {
             if (first_committed_upd->type == WT_UPDATE_TOMBSTONE) {
                 for (upd_followed_tombstone = first_committed_upd->next;
-                  upd_followed_tombstone != NULL;
-                  upd_followed_tombstone = upd_followed_tombstone->next)
+                     upd_followed_tombstone != NULL;
+                     upd_followed_tombstone = upd_followed_tombstone->next)
                     if (upd_followed_tombstone->txnid != WT_TXN_ABORTED)
                         break;
                 /* We may not find a full update following the tombstone if it is obsolete. */

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -767,7 +767,7 @@ __wt_txn_reconfigure(WT_SESSION_IMPL *session, const char *config)
 
     if (ret == 0 && cval.len != 0) {
         session->isolation = txn->isolation = WT_CONFIG_LIT_MATCH("snapshot", cval) ?
-                                                          WT_ISO_SNAPSHOT :
+          WT_ISO_SNAPSHOT :
           WT_CONFIG_LIT_MATCH("read-uncommitted", cval) ? WT_ISO_READ_UNCOMMITTED :
                                                           WT_ISO_READ_COMMITTED;
     }
@@ -1247,9 +1247,9 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
           __wt_txn_timestamp_usage_check(session, op, txn->commit_timestamp, upd->prev_durable_ts));
 
     for (first_committed_upd = upd; first_committed_upd != NULL &&
-         (first_committed_upd->txnid == WT_TXN_ABORTED ||
-           first_committed_upd->prepare_state == WT_PREPARE_INPROGRESS);
-         first_committed_upd = first_committed_upd->next)
+      (first_committed_upd->txnid == WT_TXN_ABORTED ||
+        first_committed_upd->prepare_state == WT_PREPARE_INPROGRESS);
+      first_committed_upd = first_committed_upd->next)
         ;
 
     /*
@@ -1353,8 +1353,8 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
         if (!commit) {
             if (first_committed_upd->type == WT_UPDATE_TOMBSTONE) {
                 for (upd_followed_tombstone = first_committed_upd->next;
-                     upd_followed_tombstone != NULL;
-                     upd_followed_tombstone = upd_followed_tombstone->next)
+                  upd_followed_tombstone != NULL;
+                  upd_followed_tombstone = upd_followed_tombstone->next)
                     if (upd_followed_tombstone->txnid != WT_TXN_ABORTED)
                         break;
                 /* We may not find a full update following the tombstone if it is obsolete. */
@@ -1759,7 +1759,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
          */
         __wt_readlock(session, &txn_global->visibility_rwlock);
         locked = true;
-        WT_ERR(__wti_txn_log_commit(session, cfg));
+        WT_ERR(__wti_txn_log_commit(session));
     }
 
     /* Process updates. */

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -305,11 +305,10 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
  *     Write the operations of a transaction to the log at commit time.
  */
 int
-__wti_txn_log_commit(WT_SESSION_IMPL *session, const char *cfg[])
+__wti_txn_log_commit(WT_SESSION_IMPL *session)
 {
     WT_TXN *txn;
 
-    WT_UNUSED(cfg);
     txn = session->txn;
     /*
      * If there are no log records there is nothing to do.


### PR DESCRIPTION
[WT-14334](https://jira.mongodb.org/browse/WT-14334) This change removes the unused variable `cfg` from `__wti_txn_log_commit`.