### PR TITLE
WT-14267 Fix unsynchronized read for the global generation

### DIFF
--- a/src/include/generation_inline.h
+++ b/src/include/generation_inline.h
@@ -44,7 +44,8 @@ __wt_gen_next(WT_SESSION_IMPL *session, int which, uint64_t *genp)
 static WT_INLINE uint64_t
 __wt_session_gen(WT_SESSION_IMPL *session, int which)
 {
-    /* No need to consider memory ordering for this read as it is always accessed by the same
-     * thread. */
+    /*
+     * No need to consider memory ordering for this read as it is always read by the same thread.
+     */
     return (__wt_atomic_loadv64(&session->generations[which]));
 }

--- a/src/include/generation_inline.h
+++ b/src/include/generation_inline.h
@@ -17,7 +17,10 @@
 static WT_INLINE uint64_t
 __wt_gen(WT_SESSION_IMPL *session, int which)
 {
-    return (__wt_atomic_loadv64(&S2C(session)->generations[which]));
+    uint64_t gen;
+
+    WT_ACQUIRE_READ_WITH_BARRIER(gen, S2C(session)->generations[which]);
+    return (gen);
 }
 
 /*
@@ -41,5 +44,7 @@ __wt_gen_next(WT_SESSION_IMPL *session, int which, uint64_t *genp)
 static WT_INLINE uint64_t
 __wt_session_gen(WT_SESSION_IMPL *session, int which)
 {
+    /* No need to consider memory ordering for this read as it is always accessed by the same
+     * thread. */
     return (__wt_atomic_loadv64(&session->generations[which]));
 }


### PR DESCRIPTION
The read of the global generation value is not synchroized with the write of the value. Therefore, we may read an arbitrarily old value of that. 