### PR TITLE
WT-14455 Update the oldest_id before the drop table active transaction check

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -323,9 +323,12 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
          */
         WT_ASSERT_ALWAYS(session, btree->max_upd_txn != WT_TXN_ABORTED,
           "Assert failure: session: %s: btree->max_upd_txn == WT_TXN_ABORTED", session->name);
-        if (check_visibility && !__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
-            WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,
-              "the table has uncommitted data and cannot be dropped yet");
+        if (check_visibility) {
+            WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
+            if (!__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
+                WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,
+                  "the table has uncommitted data and cannot be dropped yet");
+        }
 
         /* Turn off eviction. */
         WT_RET(__wt_evict_file_exclusive_on(session));

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -324,6 +324,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
         WT_ASSERT_ALWAYS(session, btree->max_upd_txn != WT_TXN_ABORTED,
           "Assert failure: session: %s: btree->max_upd_txn == WT_TXN_ABORTED", session->name);
         if (check_visibility) {
+            /* Bump the oldest ID, we're about to do some visibility checks. */
             WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
             if (!__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
                 WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,

--- a/test/suite/test_drop03.py
+++ b/test/suite/test_drop03.py
@@ -100,8 +100,11 @@ class test_drop03(wttest.WiredTigerTestCase):
         self.verify_value(self.uri, self.session, 'key: bbb', 'value: bbb1')
 
         # Drop call should succeed without the force option.
-        self.prout("drop force=false without active transaction should succeed.")
-        self.dropUntilSuccess(self.session, self.uri, "force=false")
+        self.prout("drop force=false without active transaction should fail as the table is dirty.")
+        self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, "force=false")),
+                        "was expecting drop call to fail with EBUSY")
+        self.prout("drop force=true without active transaction should succeed even if the table is dirty.")
+        self.session.drop(self.uri, "force=true")
 
         # Check that the table is dropped.
         self.prout("Does not exist after successful drop. confirm_does_not_exist().")


### PR DESCRIPTION
Updating the oldest_id transaction before a drop prevents unnecessary EBUSY errors, even when no older transactions exist below the table's last modified transaction.