### PR TITLE
WT-12244 Add comment on rec_row_zero_len

### DIFF
--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -484,6 +484,9 @@ __rec_row_zero_len(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
      * The item must be globally visible because we're not writing anything on the page. Don't be
      * tempted to check the time window against the default here - the check is subtly different due
      * to the grouping.
+     *
+     * tw->start_ts == WT_TS_NONE && tw->start_txn == WT_TXN_NONE is a simplier check
+     * and can bypass evaluating the more expensive __wt_txn_tw_start_visible_all check.
      */
     return (!WT_TIME_WINDOW_HAS_STOP(tw) &&
       ((tw->start_ts == WT_TS_NONE && tw->start_txn == WT_TXN_NONE) ||

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -485,8 +485,8 @@ __rec_row_zero_len(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
      * tempted to check the time window against the default here - the check is subtly different due
      * to the grouping.
      *
-     * tw->start_ts == WT_TS_NONE && tw->start_txn == WT_TXN_NONE is a simplier check
-     * and can bypass evaluating the more expensive __wt_txn_tw_start_visible_all check.
+     * tw->start_ts == WT_TS_NONE && tw->start_txn == WT_TXN_NONE is a simpler check and can bypass
+     * evaluating the more expensive __wt_txn_tw_start_visible_all check.
      */
     return (!WT_TIME_WINDOW_HAS_STOP(tw) &&
       ((tw->start_ts == WT_TS_NONE && tw->start_txn == WT_TXN_NONE) ||


### PR DESCRIPTION
[WT-12244](https://jira.mongodb.org/browse/WT-12244) ticket was to investigate whether the `__rec_row_zero_len` function can be simplified by removing a check. 

While logically the extra check is not required as `__wt_txn_tw_start_visible_all` check covers it, it is an early exit to the function and can allow the method to skip evaluating the more expensive visible_all check. This pull request adds a comment explaining this. We can keep the code as is close the ticket as won't do. 