### PR TITLE
WT-14355 inc backup csuite test no longer leaves test artefacts

### DIFF
--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -758,8 +758,8 @@ main(int argc, char *argv[])
          */
 
         /*
-         * TODO: WT-14558 - incr_backup test artefacts are generated and retained in a nested manner
-         * (WT_TEST.incr_backup/WT_TEST.incr_backup...) when preserve is true. These artefacts
+         * TODO: WT-14558 - incr_backup test artifacts are generated and retained in a nested manner
+         * (WT_TEST.incr_backup/WT_TEST.incr_backup...) when preserve is true. These artifacts
          * should instead be alongside the WT_TEST directory.
          */
         rnd.v = 0x9b1bde3f111fe316;

--- a/test/csuite/incr_backup/main.c
+++ b/test/csuite/incr_backup/main.c
@@ -756,6 +756,12 @@ main(int argc, char *argv[])
          * Whereas a seed of 0x9b1bde3f111fe316 will succeed even if the WT-10551 fix is commented
          * out because that seed doesn't generate the right set of steps to hit the issue.
          */
+
+        /*
+         * TODO: WT-14558 - incr_backup test artefacts are generated and retained in a nested manner
+         * (WT_TEST.incr_backup/WT_TEST.incr_backup...) when preserve is true. These artefacts
+         * should instead be alongside the WT_TEST directory.
+         */
         rnd.v = 0x9b1bde3f111fe316;
         run_test(working_dir, &rnd, preserve);
 


### PR DESCRIPTION
The `incr_backup` csuite test no longer leaves enormous amounts of test artefacts when the `-p` preserve flag is not set.

This is avoided by saving the starting directory into `cwd_start` and `chdir` into it at the end so that we delete the top directory of the nested test artefacts.

Prior to this change, we retain nested artefacts:
```
(venv) ubuntu in ~/wiredtiger/build on (WT-14355-inc-backup-to-clean-test-artefacts)
$ du -ah /home/ubuntu/wiredtiger | sort -rh | head -n 40
...
1.2G    /home/ubuntu/wiredtiger/build/test/csuite
1.1G    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup
1.1G    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup
...
637M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup
450M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup
...
250M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_HOME
222M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_HOME
218M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/backup.9
201M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/backup.4
...
144M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/backup.9/t32-0.wt
144M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/backup.4/t45-0.wt
144M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_HOME/t45-0.wt
144M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_HOME/t32-0.wt
141M    /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_HOME
...
80M     /home/ubuntu/wiredtiger/build/test/csuite/incr_backup/WT_TEST.incr_backup/WT_TEST.incr_backup/WT_HOME/t50-0.wt
...
```