### PR TITLE
WT-13661 Remove dead consecutive_unsuccessful_attempts variable code

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -383,12 +383,10 @@ __wt_background_compact_end(WT_SESSION_IMPL *session)
      * compaction to do work (rewriting bytes) while other operations cause the file to increase in
      * size.
      */
-    if (bytes_recovered <= 0) {
-        compact_stat->consecutive_unsuccessful_attempts++;
+    if (bytes_recovered <= 0)
         compact_stat->prev_compact_success = false;
-    } else {
+    else {
         WT_STAT_CONN_INCRV(session, background_compact_bytes_recovered, bytes_recovered);
-        compact_stat->consecutive_unsuccessful_attempts = 0;
         conn->background_compact.files_compacted++;
         compact_stat->prev_compact_success = true;
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -58,12 +58,11 @@ typedef enum __wt_background_compact_cleanup_stat_type {
  */
 struct __wt_background_compact_stat {
     const char *uri;
-    uint32_t id;                                /* File ID */
-    bool prev_compact_success;                  /* Last compact successfully reclaimed space */
-    uint64_t prev_compact_time;                 /* Start time for last compact attempt */
-    uint64_t skip_count;                        /* Number of times we've skipped this file */
-    uint64_t consecutive_unsuccessful_attempts; /* Number of failed attempts since last success */
-    uint64_t bytes_rewritten;                   /* Bytes rewritten during last compaction call */
+    uint32_t id;                /* File ID */
+    bool prev_compact_success;  /* Last compact successfully reclaimed space */
+    uint64_t prev_compact_time; /* Start time for last compact attempt */
+    uint64_t skip_count;        /* Number of times we've skipped this file */
+    uint64_t bytes_rewritten;   /* Bytes rewritten during last compaction call */
 
     wt_off_t start_size; /* File size before compact last started */
     wt_off_t end_size;   /* File size after compact last ended */


### PR DESCRIPTION
The field `consecutive_unsuccessful_attempts` in `WT_BACKGROUND_COMPACT_STAT` struct is set but never read.
This field is dead code and should be deleted.