### PR TITLE
WT-13368 random_abort shouldn't save in verify-only mode

### DIFF
--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -814,8 +814,9 @@ main(int argc, char *argv[])
     if (chdir(home) != 0)
         testutil_die(errno, "parent chdir: %s", home);
 
-    /* Copy the data to the home directory for debugging purposes given its absolute path */
-    testutil_copy_data();
+    if (!verify_only)
+        /* Copy the data to the home directory for debugging purposes given its absolute path */
+        testutil_copy_data();
 
     /*
      * Clear the cache, if we are using LazyFS. Do this after we save the data for debugging

--- a/test/csuite/random_abort/main.c
+++ b/test/csuite/random_abort/main.c
@@ -815,7 +815,7 @@ main(int argc, char *argv[])
         testutil_die(errno, "parent chdir: %s", home);
 
     if (!verify_only)
-        /* Copy the data to the home directory for debugging purposes given its absolute path */
+        /* Copy the data to the home directory for debugging purposes. */
         testutil_copy_data();
 
     /*

--- a/test/csuite/schema_abort/main.c
+++ b/test/csuite/schema_abort/main.c
@@ -1276,8 +1276,9 @@ main(int argc, char *argv[])
     if (chdir(home) != 0)
         testutil_die(errno, "parent chdir: %s", home);
 
-    /* Copy the data to a separate folder for debugging purposes. */
-    testutil_copy_data();
+    if (!verify_only)
+        /* Copy the data to a separate folder for debugging purposes. */
+        testutil_copy_data();
 
     /*
      * Clear the cache, if we are using LazyFS. Do this after we save the data for debugging

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -1700,9 +1700,6 @@ main(int argc, char *argv[])
         if (chdir(home) != 0)
             testutil_die(errno, "parent chdir: %s", home);
 
-        /* Copy the data to a separate folder for debugging purpose. */
-        testutil_copy_data_opt(BACKUP_BASE);
-
         /* Now do the actual recovery and verification. */
         ret = recover_and_verify(0, 0);
     }


### PR DESCRIPTION
The verify only mode for our random_abort test should not copy the database to a save directory, therefore adding a guard to avoid copying the database for -v mode.