### PR TITLE
WT-14551 Skip the test SECTION("Test WT_CONFLICT_DHANDLE with tiered storage") on Mac

### DIFF
--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp
@@ -94,9 +94,9 @@ TEST_CASE("Test WT_CONFLICT_BACKUP and WT_CONFLICT_DHANDLE",
 
     /*
      * This section gives us coverage in __drop_tiered. The dir_store extension is only supported
-     * for POSIX systems, so we skip this section on Windows.
+     * Linux systems, so we skip this section on Windows & Mac.
      */
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
     SECTION("Test WT_CONFLICT_DHANDLE with tiered storage")
     {
         /* Set up the connection and session to use tiered storage. */


### PR DESCRIPTION
When running the Catch2 unit tests on my Macbook Pro M3 Max running MacOS 15.4.1 the following error occurs

```
/Users/jeremy.thorp/Git/wiredtiger/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp:100: Failure:
due to unexpected exception with message:
  Error result is 2
```
in 

`SECTION("Test WT_CONFLICT_DHANDLE with tiered storage")`

This test is skipped on Windows, and needs to be disabled on Mac too, which is what this change does.
