### PR TITLE
WT-14561 Build fixes for GCC 15

### DIFF
--- a/src/include/intpack_inline.h
+++ b/src/include/intpack_inline.h
@@ -88,9 +88,6 @@
  * This is a GCC compiler bug referenced in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117829.
  */
 #pragma GCC diagnostic ignored "-Warray-bounds"
-#elif __GNUC__ >= 15
-#pragma message( \
-  "Building with GCC 15 or later. Please check if we can close WT-14292 and remove suppression.")
 #endif
 #endif
 /*

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -562,7 +562,7 @@ flcs_encode_value(size_t offset, char digit)
 static void
 flcs_decode_value(uint8_t value, size_t *offsetp, char *digitp)
 {
-    static const char digits[4] = "2357";
+    static const char digits[] = "2357";
 
     value -= FLCS_OFFSET;
 


### PR DESCRIPTION
The `-Warray-bounds` thing appears to have been fixed in GCC 15, so I removed the message.

There's also a new "unterminated string" warning when a string doesn't have a terminating null. test/checkpoint hit this, but it's OK because we don't actually use it as a string, just an array of characters. The alternative to removing the digit count would have been to mark it with `__attribute((nonstring))` or however it's spelled.