### PR TITLE
WT-14551 Add explicit dependency on wiredtiger_dir_store to the catch2 unittests

### DIFF
--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -110,5 +110,9 @@ target_compile_options(
 
 target_link_libraries(catch2-unittests Catch2::Catch2)
 
+if(WT_POSIX)
+    add_dependencies(catch2-unittests wiredtiger_dir_store)
+endif()
+
 add_test(NAME unittest COMMAND ${CMAKE_CURRENT_BINARY_DIR}/catch2-unittests)
 set_tests_properties(unittest PROPERTIES LABELS "check;unittest")


### PR DESCRIPTION
Add explicit dependency on wiredtiger_dir_store to the catch2 unittests to ensure that CMake will always build wiredtiger_dir_store when building the Catch2 unit tests. 

When running the Catch2 unit tests using CLion on my Macbook Pro M3 Max running MacOS 15.4.1 the following error frequently occurs:

```
/Users/jeremy.thorp/Git/wiredtiger/test/catch2/sub_level_error/unit/test_sub_level_error_drop_conflict.cpp:100: Failure:
due to unexpected exception with message:
  Error result is 2
```
in 

`SECTION("Test WT_CONFLICT_DHANDLE with tiered storage")`

The error is caused by a missing dynamically loaded library, libwiredtiger_dir_store.so, that the test depends on. This library may, or may not, be available depending on how WT has been built. 

Note, the issue was initially thought to be Mac specific, but this is not the case.

If WT is built using 

`cmake -DHAVE_UNITTEST=1 -G "Ninja" ./..`

then libwiredtiger_dir_store.so will be built on Posix systems (including Linux & Mac), and the Catch2 tests will all pass.

However, CLion optimises the build to build only the binaries required to run the executable (eg Catch2 unit tests) requested. The dependency for libwiredtiger_dir_store.so is missing, and so the library will not be built by default, in which case the test will fail.

The fix is to explicitly add that dependency using CMake's add_dependencies() feature.
