### PR TITLE
WT-12800 remove dead code in reconciliation

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -593,13 +593,6 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     r->ref = ref;
     r->page = page;
 
-    /*
-     * Save the transaction generations before reading the page. These are all acquire reads, but we
-     * only need one.
-     */
-    r->orig_btree_checkpoint_gen = btree->checkpoint_gen;
-    r->orig_txn_checkpoint_gen = __wt_gen(session, WT_GEN_CHECKPOINT);
-
     WT_ASSERT_ALWAYS(
       session, page->modify->flags == 0, "Illegal page state when initializing reconcile");
 

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -166,13 +166,7 @@ struct __wti_reconcile {
     WT_REF *ref; /* Page being reconciled */
     WT_PAGE *page;
     uint32_t flags; /* Caller's configuration */
-
-    /*
-     * Track start/stop checkpoint generations to decide if history store table records are correct.
-     */
-    uint64_t orig_btree_checkpoint_gen;
-    uint64_t orig_txn_checkpoint_gen;
-
+    
     /* Track the oldest running transaction. */
     uint64_t last_running;
 

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -166,7 +166,7 @@ struct __wti_reconcile {
     WT_REF *ref; /* Page being reconciled */
     WT_PAGE *page;
     uint32_t flags; /* Caller's configuration */
-    
+
     /* Track the oldest running transaction. */
     uint64_t last_running;
 


### PR DESCRIPTION
There's two instantiated values in `__rec_init` that are not being read by anything. This PR cleans up the code and removes the unused values from `__rec_init` and from the definition of `__wti_reconcile`. 