### PR TITLE
WT-14568 Compat tests: handle absence of stable toolchain file

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -112,10 +112,15 @@ build_branch()
         # Old releases didn't have these enabled, need to make it consistent.
         config+="-DENABLE_LZ4=0 -DENABLE_ZLIB=0 -DENABLE_ZSTD=0 "
         config+="-DWT_STANDALONE_BUILD=0 "
-        # Use the stable MongoDB toolchain for this build.
-        config+="-DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_gcc.cmake "
         # Disable cppsuite - not all versions build with the toolchain
-        config+="-DENABLE_CPPSUITE=0"
+        config+="-DENABLE_CPPSUITE=0 "
+
+        # Use the stable MongoDB toolchain if it exists
+        toolchain="$PWD/cmake/toolchains/mongodbtoolchain_stable_gcc.cmake"
+        if [ ! -f $toolchain ]; then
+            toolchain="$PWD/cmake/toolchains/mongodbtoolchain_v4_gcc.cmake"
+        fi
+        config+="-DCMAKE_TOOLCHAIN_FILE=$toolchain "
 
         (mkdir -p build && cd build &&
             $CMAKE $config ../. && make -j $(grep -c ^processor /proc/cpuinfo)) > /dev/null


### PR DESCRIPTION
Recently a toolchain file for compatibility tests was switched from `mongodbtoolchain_v4_gcc.cmake` to `mongodbtoolchain_stable_gcc.cmake`. Later it turned out that some branches that are randomly picked for a compatibility testing don't contain this file.

This patch fixes it by using the stable toolchain only if it exists. 