### PR TITLE
WT-14579 Free tmp_buf in __live_restore_fh_read

### DIFF
--- a/src/live_restore/live_restore_fs.c
+++ b/src/live_restore/live_restore_fs.c
@@ -796,9 +796,11 @@ __live_restore_fh_read(
             WT_ERR(__wt_malloc(session, dest_partial_read_len, &tmp_buf));
 
             /* Read the serviceable portion from the destination. */
-            if ((ret = __live_restore_fh_read_destination(
-                   session, lr_fh->destination, offset, dest_partial_read_len, tmp_buf)) != 0) {
-                __wt_free(session, tmp_buf);
+            ret = __live_restore_fh_read_destination(
+              session, lr_fh->destination, offset, dest_partial_read_len, tmp_buf);
+            __wt_free(session, tmp_buf);
+
+            if (ret != 0) {
                 goto err;
             }
 


### PR DESCRIPTION
The ticket is to add the missing of freeing tmp_buf in __live_restore_fh_read when there is no error.