### PR TITLE
WT-14577 add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Entire team are code-owners for the time being
+* @wiredtiger/storage-engines


### PR DESCRIPTION
As part of the wider effort to add code-ownership for compliance and tooling across all of our shipped codebases we need to set this up.

For the time being, I would prefer if we didn't reach for codeowners to create more internal barriers within WT, since I think we're actually in a pretty good place, but this note shouldn't preclude us considering that if/when the time is right.