### PR TITLE
WT-14323 Fix assert in bounded_cursor_stress test, to allow for WT_ROLLBACK result

### DIFF
--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -606,7 +606,11 @@ public:
         }
 
         if (normal_ret == WT_NOTFOUND) {
-            testutil_assert(range_ret == WT_NOTFOUND);
+            /*
+             * It's possible that the bounded cursor operations may return WT_ROLLBACK, so allow
+             * that here in addition to WT_NOTFOUND.
+             */
+            testutil_assert(range_ret == WT_NOTFOUND || range_ret == WT_ROLLBACK);
             return 0;
         }
         if (normal_ret != 0)


### PR DESCRIPTION
WT-14323 Fix assert in bounded_cursor_stress test, to allow for the case where the range cursor operations returns WT_ROLLBACK.

In the bounded cursor stress test, multiple threads are adding, removing and updating random keys, while 'normal' cursors and range bounded cursors access that data. The test checks that the results between the normal and bounded cursor results are consistent. 

The test case already handled the case where the normal cursor returned WT_ROLLBACK. However, the test did not handle the case where the normal cursor returns WT_NOTFOUND and the bounded cursor returns WT_ROLLBACK which is possible due to those simultaneous add/remove/update operations. In this scenario an assert is triggered which is what happened in this Build Failure.

The fix is to update the expression in the assert to also allow the WT_ROLLBACK case when the normal cursor has returned WT_NOTFOUND.
