### PR TITLE
WT-13671 Add info log once background compact completes

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -402,7 +402,7 @@ __wt_background_compact_end(WT_SESSION_IMPL *session)
           session, background_compact_ema, conn->background_compact.bytes_rewritten_ema);
     }
 
-    __wt_verbose_info(session, WT_VERB_COMPACT,
+    __wt_verbose_info(session, WT_VERB_COMPACT_PROGRESS,
       "%s: background compaction finished (status: %s) - reclaimed %" PRIu64 "bytes", uri,
       (compact_stat->prev_compact_success ? "success" : "failure"), (uint64_t)bytes_recovered);
 

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -402,6 +402,10 @@ __wt_background_compact_end(WT_SESSION_IMPL *session)
           session, background_compact_ema, conn->background_compact.bytes_rewritten_ema);
     }
 
+    __wt_verbose_info(session, WT_VERB_COMPACT,
+      "%s: background compaction completed (%s) - reclaimed %" PRIu64 "bytes", uri,
+      (compact_stat->prev_compact_success ? "success" : "failure"), (uint64_t)bytes_recovered);
+
     return (0);
 }
 

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -403,7 +403,7 @@ __wt_background_compact_end(WT_SESSION_IMPL *session)
     }
 
     __wt_verbose_info(session, WT_VERB_COMPACT,
-      "%s: background compaction completed (%s) - reclaimed %" PRIu64 "bytes", uri,
+      "%s: background compaction finished (status: %s) - reclaimed %" PRIu64 "bytes", uri,
       (compact_stat->prev_compact_success ? "success" : "failure"), (uint64_t)bytes_recovered);
 
     return (0);

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -403,7 +403,7 @@ __wt_background_compact_end(WT_SESSION_IMPL *session)
     }
 
     __wt_verbose_info(session, WT_VERB_COMPACT_PROGRESS,
-      "%s: background compaction finished (status: %s) - reclaimed %" PRIu64 "bytes", uri,
+      "%s: background compaction finished (status: %s) - reclaimed %" PRIu64 " bytes", uri,
       (compact_stat->prev_compact_success ? "success" : "failure"), (uint64_t)bytes_recovered);
 
     return (0);


### PR DESCRIPTION
In `wt_background_compact_end`, add log info to let users know when background compaction has compacted a file and how much space it has recovered.



