### PR TITLE
WT-14603 update codeowners to include svc-bot-sebb

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Entire team are code-owners for the time being
-* @wiredtiger/storage-engines
+# The bot account is here so we can autoassign and supress notifications
+* @svc-bot-sebb @wiredtiger/storage-engines


### PR DESCRIPTION
Because codeowners auto-assigns reviewers, and that comes with email notifications we need to include a service account in the code ownership rules so that we can exclude the team from auto assignment and silence the notifications.

When new users are onboarded, we have to make sure they are included in the list of users excluded from auto assignment here: https://github.com/orgs/wiredtiger/teams/storage-engines/edit/review_assignment

This is unfortunate, but seemingly the best option per https://github.com/orgs/community/discussions/35673

