### PR TITLE
WT-14604 reduce codeowners to the subset of people who work in wiredtiger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Entire team are code-owners for the time being
-# The bot account is here so we can autoassign and supress notifications
-* @svc-bot-sebb @wiredtiger/storage-engines
+* @wiredtiger/wt-engineers


### PR DESCRIPTION
None of the workarounds to do a broad group of people while avoiding notifications seem to work, so lets take a different approach here:
- Encourage people to use draft PRs and explicitly assigning folks before they move them into ready for review
- Shrinking the group to just the subset of Storage Engines that works on wiredtiger regularly
- Enabling automatic assignment to everyone (excluding Leads and Alex G), expecting that people will update the reviewers with more appropriate folks if they forget to assign it and it round robins to the wrong person.