### PR TITLE
Revert "WT-14603 update codeowners to include svc-bot-sebb (#11952)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 # Entire team are code-owners for the time being
-# The bot account is here so we can autoassign and supress notifications
-* @svc-bot-sebb @wiredtiger/storage-engines
+* @wiredtiger/storage-engines


### PR DESCRIPTION
This reverts commit 08d3ad73febac1d784b3a9a4e0d936de043bb54d.

It seems that we can solve this problem by taking advantage of the mana bot being in the storage-engines group and having it auto assign to that user.