### PR TITLE
WT-14336 Track the dirty and update bytes of the history store

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -268,6 +268,8 @@ conn_stats = [
     # Cache statistics
     ##########################################
     CacheStat('cache_bytes_hs', 'bytes belonging to the history store table in the cache', 'no_clear,no_scale,size'),
+    CacheStat('cache_bytes_hs_dirty', 'dirty bytes belonging to the history store table in the cache', 'no_clear,no_scale,size'),
+    CacheStat('cache_bytes_hs_updates', 'update bytes belonging to the history store table in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_image', 'bytes belonging to page images in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_internal', 'tracked bytes belonging to internal pages in the cache', 'no_clear,no_scale,size'),
     CacheStat('cache_bytes_leaf', 'tracked bytes belonging to leaf pages in the cache', 'no_clear,no_scale,size'),

--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -111,6 +111,10 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
       __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_dirty_total)));
     WT_STATP_CONN_SET(session, stats, cache_bytes_hs,
       __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_hs)));
+    WT_STATP_CONN_SET(session, stats, cache_bytes_hs_dirty,
+      __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_hs_dirty)));
+    WT_STATP_CONN_SET(session, stats, cache_bytes_hs_updates,
+      __wt_cache_bytes_plus_overhead(cache, __wt_atomic_load64(&cache->bytes_hs_updates)));
     WT_STATP_CONN_SET(session, stats, cache_bytes_image, __wt_cache_bytes_image(cache));
     WT_STATP_CONN_SET(session, stats, cache_pages_inuse, __wt_cache_pages_inuse(cache));
     WT_STATP_CONN_SET(session, stats, cache_bytes_internal, intl);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -698,6 +698,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
     if (F_ISSET_ATOMIC_32(conn, WT_CONN_HS_OPEN) && __wt_hs_get_btree(session, &hs_tree) == 0) {
         __wt_atomic_store64(&cache->bytes_hs, __wt_atomic_load64(&hs_tree->bytes_inmem));
         cache->bytes_hs_dirty = hs_tree->bytes_dirty_intl + hs_tree->bytes_dirty_leaf;
+        cache->bytes_hs_updates = hs_tree->bytes_updates;
     }
 
     /*

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -45,8 +45,9 @@ struct __wt_cache {
      * History store cache usage. TODO: The values for these variables are cached and potentially
      * outdated.
      */
-    wt_shared uint64_t bytes_hs; /* History store bytes inmem */
-    uint64_t bytes_hs_dirty;     /* History store bytes inmem dirty */
+    wt_shared uint64_t bytes_hs;         /* History store bytes inmem */
+    wt_shared uint64_t bytes_hs_dirty;   /* History store bytes inmem dirty */
+    wt_shared uint64_t bytes_hs_updates; /* History store bytes inmem updates */
 
     wt_shared uint64_t pages_dirty_intl;
     wt_shared uint64_t pages_dirty_leaf;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -501,6 +501,7 @@ struct __wt_connection_stats {
     int64_t cache_bytes_write;
     int64_t cache_eviction_blocked_checkpoint;
     int64_t cache_eviction_blocked_checkpoint_hs;
+    int64_t cache_bytes_hs_dirty;
     int64_t eviction_server_evict_attempt;
     int64_t eviction_worker_evict_attempt;
     int64_t eviction_server_evict_fail;
@@ -658,6 +659,7 @@ struct __wt_connection_stats {
     int64_t cache_pages_dirty;
     int64_t cache_eviction_blocked_uncommitted_truncate;
     int64_t cache_eviction_clean;
+    int64_t cache_bytes_hs_updates;
     int64_t cache_updates_txn_uncommitted_bytes;
     int64_t cache_updates_txn_uncommitted_count;
     int64_t fsync_all_fh_total;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5930,1596 +5930,1600 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * eviction
  */
 #define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1083
+/*! cache: dirty bytes belonging to the history store table in the cache */
+#define	WT_STAT_CONN_CACHE_BYTES_HS_DIRTY		1084
 /*! cache: evict page attempts by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1084
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1085
 /*! cache: evict page attempts by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1085
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1086
 /*! cache: evict page failures by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1086
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1087
 /*! cache: evict page failures by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1087
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1088
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1088
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1089
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1089
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1090
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1090
+#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1091
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1091
+#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1092
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1092
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1093
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1093
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1094
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1094
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1095
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1095
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1096
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1096
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1097
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1097
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1098
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1098
+#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1099
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1099
+#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1100
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1100
+#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1101
 /*! cache: eviction server skips dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1101
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1102
 /*! cache: eviction server skips internal pages as it has an active child. */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1102
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1103
 /*! cache: eviction server skips metadata pages with history */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1103
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1104
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1104
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1105
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1105
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1106
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1106
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1107
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1107
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1108
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1108
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1109
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1109
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1110
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1110
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1111
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1111
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1112
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1112
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1113
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1113
+#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1114
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_EVICTION_SLOW			1114
+#define	WT_STAT_CONN_EVICTION_SLOW			1115
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1115
+#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1116
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1116
+#define	WT_STAT_CONN_EVICTION_STATE			1117
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1117
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1118
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1118
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1119
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1119
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1120
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1120
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1121
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1121
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1122
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1122
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1123
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1123
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1124
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1124
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1125
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1126
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1126
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1127
 /*! cache: eviction walk target strategy both clean and dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1127
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_BOTH_CLEAN_AND_DIRTY	1128
 /*! cache: eviction walk target strategy only clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1128
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1129
 /*! cache: eviction walk target strategy only dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1129
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1130
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1130
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1131
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1131
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1132
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1132
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1133
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1133
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1134
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1134
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1135
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1135
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1136
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1136
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1137
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1137
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1138
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1138
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1139
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1139
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1140
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1140
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1141
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1141
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1142
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1142
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1143
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1143
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1144
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1144
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1145
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1145
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1146
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1146
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1147
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1147
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1148
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1148
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1149
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1149
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1150
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1150
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1151
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1151
+#define	WT_STAT_CONN_EVICTION_FORCE			1152
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1152
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1153
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1153
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1154
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1154
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1155
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1155
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1156
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1156
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1157
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1157
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1158
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1158
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1159
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1159
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1160
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1160
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1161
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1161
+#define	WT_STAT_CONN_CACHE_HS_READ			1162
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1162
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1163
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1163
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1164
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1164
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1165
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1165
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1166
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1166
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1167
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1167
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1168
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1168
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1169
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1169
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1170
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1170
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1171
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1171
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1172
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1172
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1173
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1173
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1174
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1174
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1175
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1175
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1176
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1176
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1177
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1177
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1178
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1178
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1179
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1179
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1180
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1180
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1181
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1181
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1182
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1182
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1183
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1183
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1184
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1184
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1185
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1185
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1186
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1186
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1187
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1187
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1188
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1188
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1189
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1189
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1190
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1190
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1191
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1191
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1192
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1192
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1193
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1193
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1194
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1194
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1195
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1195
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1196
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1196
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1197
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1197
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1198
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1198
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1199
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1199
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1200
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1200
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1201
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1201
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1202
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1202
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1203
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1203
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1204
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1204
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1205
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1205
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1206
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1206
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1207
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1207
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1208
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1208
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1209
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1209
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1210
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1210
+#define	WT_STAT_CONN_CACHE_READ				1211
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1211
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1212
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1212
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1213
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1213
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1214
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1214
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1215
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1215
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1216
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1216
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1217
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1217
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1218
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1218
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1219
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1219
+#define	WT_STAT_CONN_EVICTION_FAIL			1220
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1220
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1221
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1221
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1222
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1222
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1223
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1223
+#define	WT_STAT_CONN_EVICTION_WALK			1224
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1224
+#define	WT_STAT_CONN_CACHE_WRITE			1225
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1225
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1226
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1226
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1227
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1227
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1228
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1228
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1229
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1229
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1230
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1230
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1231
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1231
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1232
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1232
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1233
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1233
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1234
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1234
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1235
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1235
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1236
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1236
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1237
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1237
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1238
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1238
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1239
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1239
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1240
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1240
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1241
+/*! cache: update bytes belonging to the history store table in the cache */
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1242
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1241
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1243
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1242
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1244
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1243
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1245
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1244
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1246
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1245
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1247
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1246
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1248
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1247
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1249
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1248
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1250
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1249
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1251
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1250
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1252
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1251
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1253
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1252
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1254
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1253
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1255
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1254
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1256
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1255
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1257
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1256
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1258
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1257
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1259
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1258
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1260
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1259
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1261
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1260
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1262
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1261
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1263
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1262
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1264
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1263
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1265
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1264
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1266
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1265
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1267
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1266
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1268
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1267
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1269
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1268
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1270
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1269
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1271
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1270
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1272
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1271
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1273
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1272
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1274
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1273
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1275
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1274
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1276
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1275
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1277
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1276
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1278
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1277
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1279
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1278
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1280
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1279
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1281
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1280
+#define	WT_STAT_CONN_CHECKPOINTS_API			1282
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1281
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1283
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1282
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1284
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1283
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1285
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1284
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1286
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1285
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1287
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1286
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1288
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1287
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1289
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1288
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1290
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1289
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1291
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1290
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1292
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1291
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1293
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1292
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1294
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1293
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1295
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1294
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1296
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1295
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1297
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1296
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1298
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1297
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1299
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1298
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1300
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1299
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1301
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1300
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1302
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1301
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1303
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1302
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1304
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1303
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1305
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1304
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1306
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1305
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1307
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1306
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1308
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1307
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1309
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1308
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1310
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1309
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1311
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1310
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1312
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1311
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1313
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1312
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1314
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1313
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1315
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1314
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1316
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1315
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1317
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1316
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1318
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1317
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1319
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1318
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1320
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1319
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1321
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1320
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1322
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1321
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1323
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1322
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1324
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1323
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1325
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1324
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1326
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1325
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1327
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1326
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1328
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1327
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1329
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1328
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1330
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1329
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1331
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1330
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1332
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1331
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1333
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1332
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1334
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1333
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1335
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1334
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1336
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1335
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1337
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1336
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1338
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1337
+#define	WT_STAT_CONN_TIME_TRAVEL			1339
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1338
+#define	WT_STAT_CONN_FILE_OPEN				1340
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1339
+#define	WT_STAT_CONN_BUCKETS_DH				1341
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1340
+#define	WT_STAT_CONN_BUCKETS				1342
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1341
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1343
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1342
+#define	WT_STAT_CONN_MEMORY_FREE			1344
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1343
+#define	WT_STAT_CONN_MEMORY_GROW			1345
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1344
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1346
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1345
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1347
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1346
+#define	WT_STAT_CONN_COND_WAIT				1348
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1347
+#define	WT_STAT_CONN_RWLOCK_READ			1349
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1348
+#define	WT_STAT_CONN_RWLOCK_WRITE			1350
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1349
+#define	WT_STAT_CONN_FSYNC_IO				1351
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1350
+#define	WT_STAT_CONN_READ_IO				1352
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1351
+#define	WT_STAT_CONN_WRITE_IO				1353
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1352
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1354
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1353
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1355
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1354
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1356
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1355
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1357
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1356
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1358
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1357
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1359
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1358
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1360
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1359
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1361
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1360
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1362
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1361
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1363
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1362
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1364
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1363
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1365
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1364
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1366
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1365
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1367
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1366
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1368
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1367
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1369
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1368
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1370
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1369
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1371
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1370
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1372
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1371
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1373
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1372
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1374
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1373
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1375
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1374
+#define	WT_STAT_CONN_CURSOR_CACHE			1376
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1375
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1377
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1376
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1378
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1377
+#define	WT_STAT_CONN_CURSOR_CREATE			1379
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1378
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1380
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1379
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1381
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1380
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1382
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1381
+#define	WT_STAT_CONN_CURSOR_INSERT			1383
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1382
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1384
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1383
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1385
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1384
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1386
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1385
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1387
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1386
+#define	WT_STAT_CONN_CURSOR_MODIFY			1388
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1387
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1389
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1388
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1390
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1389
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1391
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1390
+#define	WT_STAT_CONN_CURSOR_NEXT			1392
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1391
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1393
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1392
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1394
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1393
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1395
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1394
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1396
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1395
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1397
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1396
+#define	WT_STAT_CONN_CURSOR_RESTART			1398
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1397
+#define	WT_STAT_CONN_CURSOR_PREV			1399
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1398
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1400
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1399
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1401
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1400
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1402
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1401
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1403
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1402
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1404
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1403
+#define	WT_STAT_CONN_CURSOR_REMOVE			1405
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1404
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1406
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1405
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1407
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1406
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1408
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1407
+#define	WT_STAT_CONN_CURSOR_RESERVE			1409
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1408
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1410
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1409
+#define	WT_STAT_CONN_CURSOR_RESET			1411
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1410
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1412
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1411
+#define	WT_STAT_CONN_CURSOR_SEARCH			1413
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1412
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1414
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1413
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1415
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1414
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1416
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1415
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1417
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1416
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1418
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1417
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1419
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1418
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1420
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1419
+#define	WT_STAT_CONN_CURSOR_SWEEP			1421
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1420
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1422
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1421
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1423
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1422
+#define	WT_STAT_CONN_CURSOR_UPDATE			1424
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1423
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1425
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1424
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1426
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1425
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1427
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1426
+#define	WT_STAT_CONN_CURSOR_REOPEN			1428
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1427
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1429
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1428
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1430
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1429
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1431
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1430
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1432
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1431
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1433
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1432
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1434
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1433
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1435
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1434
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1436
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1435
+#define	WT_STAT_CONN_DH_SWEEP_REF			1437
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1436
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1438
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1437
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1439
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1438
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1440
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1439
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1441
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1440
+#define	WT_STAT_CONN_DH_SWEEPS				1442
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1441
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1443
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1442
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1444
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1443
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1445
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1444
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1446
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1445
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1447
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1446
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1448
 /*! live-restore: source read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1447
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1449
 /*! live-restore: source read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1448
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1450
 /*! live-restore: source read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1449
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1451
 /*! live-restore: source read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1450
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1452
 /*! live-restore: source read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1451
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1453
 /*! live-restore: source read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1452
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1454
 /*! live-restore: source read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1453
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1455
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1454
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1456
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1455
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1457
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1456
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1458
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1457
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1459
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1458
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1460
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1459
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1461
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1460
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1462
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1461
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1463
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1462
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1464
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1463
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1465
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1464
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1466
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1465
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1467
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1466
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1468
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1467
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1469
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1468
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1470
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1469
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1471
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1470
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1472
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1471
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1473
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1472
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1474
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1473
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1475
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1474
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1476
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1475
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1477
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1476
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1478
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1477
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1479
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1478
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1480
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1479
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1481
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1480
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1482
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1481
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1483
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1482
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1484
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1483
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1485
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1484
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1486
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1485
+#define	WT_STAT_CONN_LOG_FLUSH				1487
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1486
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1488
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1487
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1489
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1488
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1490
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1489
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1491
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1490
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1492
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1491
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1493
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1492
+#define	WT_STAT_CONN_LOG_SCANS				1494
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1493
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1495
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1494
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1496
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1495
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1497
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1496
+#define	WT_STAT_CONN_LOG_SYNC				1498
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1497
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1499
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1498
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1500
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1499
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1501
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1500
+#define	WT_STAT_CONN_LOG_WRITES				1502
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1501
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1503
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1502
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1504
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1503
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1505
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1504
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1506
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1505
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1507
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1506
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1508
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1507
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1509
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1508
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1510
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1509
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1511
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1510
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1512
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1511
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1513
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1512
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1514
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1513
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1515
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1514
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1516
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1515
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1517
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1516
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1518
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1517
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1519
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1518
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1520
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1519
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1521
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1520
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1522
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1521
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1523
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1522
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1524
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1523
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1525
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1524
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1526
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1525
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1527
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1526
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1528
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1527
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1529
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1528
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1530
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1529
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1531
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1530
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1532
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1531
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1533
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1532
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1534
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1533
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1535
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1534
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1536
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1535
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1537
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1536
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1538
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1537
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1539
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1538
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1540
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1539
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1541
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1540
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1542
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1541
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1543
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1542
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1544
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1543
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1545
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1544
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1546
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1545
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1547
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1546
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1548
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1547
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1549
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1548
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1550
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1549
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1551
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1550
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1552
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1551
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1553
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1552
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1554
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1553
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1555
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1554
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1556
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1555
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1557
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1556
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1558
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1557
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1559
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1558
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1560
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1559
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1561
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1560
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1562
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1561
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1563
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1562
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1564
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1563
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1565
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1564
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1566
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1565
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1567
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1566
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1568
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1567
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1569
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1568
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1570
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1569
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1571
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1570
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1572
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1571
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1573
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1572
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1574
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1573
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1575
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1574
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1576
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1575
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1577
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1576
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1578
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1577
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1579
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1578
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1580
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1579
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1581
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1580
+#define	WT_STAT_CONN_REC_PAGES				1582
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1581
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1583
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1582
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1584
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1583
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1585
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1584
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1586
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1585
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1587
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1586
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1588
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1587
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1589
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1588
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1590
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1589
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1591
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1590
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1592
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1591
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1593
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1592
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1594
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1593
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1595
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1594
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1596
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1595
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1597
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1596
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1598
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1597
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1599
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1598
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1600
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1599
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1601
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1600
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1602
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1601
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1603
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1602
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1604
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1603
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1605
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1604
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1606
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1605
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1607
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1606
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1608
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1607
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1609
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1608
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1610
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1609
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1611
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1610
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1612
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1611
+#define	WT_STAT_CONN_FLUSH_TIER				1613
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1612
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1614
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1613
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1615
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1614
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1616
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1615
+#define	WT_STAT_CONN_SESSION_OPEN			1617
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1616
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1618
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1617
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1619
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1618
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1620
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1619
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1621
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1620
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1622
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1621
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1623
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1622
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1624
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1623
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1625
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1624
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1626
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1625
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1627
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1626
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1628
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1627
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1629
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1628
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1630
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1629
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1631
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1630
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1632
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1631
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1633
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1632
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1634
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1633
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1635
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1634
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1636
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1635
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1637
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1636
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1638
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1637
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1639
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1638
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1640
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1639
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1641
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1640
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1642
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1641
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1643
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1642
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1644
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1643
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1645
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1644
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1646
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1645
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1647
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1646
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1648
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1647
+#define	WT_STAT_CONN_TIERED_RETENTION			1649
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1648
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1650
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1649
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1651
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1650
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1652
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1651
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1653
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1652
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1654
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1653
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1655
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1654
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1656
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1655
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1657
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1656
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1658
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1657
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1659
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1658
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1660
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1659
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1661
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1660
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1662
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1661
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1663
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1662
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1664
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1663
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1665
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1664
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1666
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1665
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1667
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1666
+#define	WT_STAT_CONN_PAGE_SLEEP				1668
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1667
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1669
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1668
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1670
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1669
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1671
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1670
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1672
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1671
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1673
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1672
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1674
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1673
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1675
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1674
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1676
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1675
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1677
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1676
+#define	WT_STAT_CONN_TXN_PREPARE			1678
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1677
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1679
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1678
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1680
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1679
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1681
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1680
+#define	WT_STAT_CONN_TXN_QUERY_TS			1682
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1681
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1683
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1682
+#define	WT_STAT_CONN_TXN_RTS				1684
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1683
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1685
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1684
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1686
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1685
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1687
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1686
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1688
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1687
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1689
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1688
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1690
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1689
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1691
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1690
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1692
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1691
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1693
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1692
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1694
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1693
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1695
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1694
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1696
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1695
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1697
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1696
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1698
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1697
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1699
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1698
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1700
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1699
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1701
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1700
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1702
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1701
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1703
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1702
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1704
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1703
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1705
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1704
+#define	WT_STAT_CONN_TXN_SET_TS				1706
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1705
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1707
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1706
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1708
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1707
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1709
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1708
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1710
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1709
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1711
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1710
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1712
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1711
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1713
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1712
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1714
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1713
+#define	WT_STAT_CONN_TXN_BEGIN				1715
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1714
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1716
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1715
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1717
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1716
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1718
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1717
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1719
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1718
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1720
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1719
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1721
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1720
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1722
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1721
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1723
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1722
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1724
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1723
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1725
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1724
+#define	WT_STAT_CONN_TXN_COMMIT				1726
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1725
+#define	WT_STAT_CONN_TXN_ROLLBACK			1727
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1726
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1728
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1397,6 +1397,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: bytes written from cache",
   "cache: checkpoint blocked page eviction",
   "cache: checkpoint of history store file blocked non-history store page eviction",
+  "cache: dirty bytes belonging to the history store table in the cache",
   "cache: evict page attempts by eviction server",
   "cache: evict page attempts by eviction worker threads",
   "cache: evict page failures by eviction server",
@@ -1572,6 +1573,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: tracked dirty pages in the cache",
   "cache: uncommitted truncate blocked page eviction",
   "cache: unmodified pages evicted",
+  "cache: update bytes belonging to the history store table in the cache",
   "cache: updates in uncommitted txn - bytes",
   "cache: updates in uncommitted txn - count",
   "capacity: background fsync file handles considered",
@@ -2192,6 +2194,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_bytes_write = 0;
     stats->cache_eviction_blocked_checkpoint = 0;
     stats->cache_eviction_blocked_checkpoint_hs = 0;
+    /* not clearing cache_bytes_hs_dirty */
     stats->eviction_server_evict_attempt = 0;
     stats->eviction_worker_evict_attempt = 0;
     stats->eviction_server_evict_fail = 0;
@@ -2349,6 +2352,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing cache_pages_dirty */
     stats->cache_eviction_blocked_uncommitted_truncate = 0;
     stats->cache_eviction_clean = 0;
+    /* not clearing cache_bytes_hs_updates */
     /* not clearing cache_updates_txn_uncommitted_bytes */
     /* not clearing cache_updates_txn_uncommitted_count */
     stats->fsync_all_fh_total = 0;
@@ -2943,6 +2947,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
       WT_STAT_CONN_READ(from, cache_eviction_blocked_checkpoint);
     to->cache_eviction_blocked_checkpoint_hs +=
       WT_STAT_CONN_READ(from, cache_eviction_blocked_checkpoint_hs);
+    to->cache_bytes_hs_dirty += WT_STAT_CONN_READ(from, cache_bytes_hs_dirty);
     to->eviction_server_evict_attempt += WT_STAT_CONN_READ(from, eviction_server_evict_attempt);
     to->eviction_worker_evict_attempt += WT_STAT_CONN_READ(from, eviction_worker_evict_attempt);
     to->eviction_server_evict_fail += WT_STAT_CONN_READ(from, eviction_server_evict_fail);
@@ -3145,6 +3150,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_blocked_uncommitted_truncate +=
       WT_STAT_CONN_READ(from, cache_eviction_blocked_uncommitted_truncate);
     to->cache_eviction_clean += WT_STAT_CONN_READ(from, cache_eviction_clean);
+    to->cache_bytes_hs_updates += WT_STAT_CONN_READ(from, cache_bytes_hs_updates);
     to->cache_updates_txn_uncommitted_bytes +=
       WT_STAT_CONN_READ(from, cache_updates_txn_uncommitted_bytes);
     to->cache_updates_txn_uncommitted_count +=


### PR DESCRIPTION
Tracking the dirty and update bytes of the history store can show us its effect on the cache and eviction processes.
