### PR TITLE
WT-14039 avoid double eviction with scrub eviction

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -732,7 +732,7 @@ __evict_update_work(WT_SESSION_IMPL *session)
         LF_SET(WT_EVICT_CACHE_DIRTY);
 
     /*
-     * Scrub dirty pages and keep them in cache if we are less than half way to the clean, dirty or
+     * Scrub dirty pages and keep them in cache if we are less than half way to the clean, dirty and
      * updates triggers.
      */
     if (bytes_inuse < (uint64_t)((target + trigger) * bytes_max) / 200) {

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -870,6 +870,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
     WT_DECL_RET;
     WT_EVICT *evict;
     uint32_t flags;
+    
     bool closing, is_application_thread_snapshot_refreshed, is_eviction_thread,
       use_snapshot_for_app_thread;
 
@@ -914,12 +915,22 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
          * Scrub and we're supposed to or toss it in sometimes if we are in debugging mode.
          *
          * Note that don't scrub if checkpoint is running on the tree.
+         * 
+         * Scrub only if the page is under the clean eviction target or the page has high read generation.
          */
+        uint64_t bytes_inuse = __wt_cache_bytes_inuse(conn->cache);
+        uint64_t bytes_max = conn->cache_size + 1;
+        WT_PAGE *page = ref->page;
+
         if (!WT_SESSION_BTREE_SYNC(session) &&
           (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) ||
             (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
-              __wt_random(&session->rnd_random) % 3 == 0)))
-            LF_SET(WT_REC_SCRUB);
+              __wt_random(&session->rnd_random) % 3 == 0))) {
+                if (bytes_inuse <= (uint64_t)(evict->eviction_target * bytes_max) / 100 || 
+                    page->read_gen > evict->read_gen) {
+                        LF_SET(WT_REC_SCRUB);
+                }
+              }
     }
 
     /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -870,7 +870,6 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
     WT_DECL_RET;
     WT_EVICT *evict;
     uint32_t flags;
-
     bool closing, is_application_thread_snapshot_refreshed, is_eviction_thread,
       use_snapshot_for_app_thread;
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -916,21 +916,20 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
          *
          * Note that don't scrub if checkpoint is running on the tree.
          */
-        const bool debug_aggressive_scrub_enabled =
+        bool debug_aggressive_scrub_enabled =
           FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
           __wt_random(&session->rnd_random) % 3 == 0;
 
-        const bool can_scrub = !WT_SESSION_BTREE_SYNC(session) &&
+        bool can_scrub = !WT_SESSION_BTREE_SYNC(session) &&
           (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) || debug_aggressive_scrub_enabled);
 
         /*
          * Scrub only if cache is under the clean eviction target or the page has high read
          * generation.
          */
-        const bool is_scrub_candidate = !__wt_evict_clean_needed(session, NULL) ||
-          ref->page->read_gen > __evict_read_gen(session);
-
-        if (can_scrub && is_scrub_candidate) {
+        if (can_scrub &&
+          (!__wt_evict_clean_needed(session, NULL) ||
+            ref->page->read_gen > __evict_read_gen(session))) {
             LF_SET(WT_REC_SCRUB);
         }
     }

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -916,21 +916,20 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
          *
          * Note that don't scrub if checkpoint is running on the tree.
          */
-        bool debug_aggressive_scrub_enabled =
-          FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
-          __wt_random(&session->rnd_random) % 3 == 0;
+        if (!WT_SESSION_BTREE_SYNC(session)) {
+            bool can_scrub = (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) ||
+              (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
+                __wt_random(&session->rnd_random) % 3 == 0));
 
-        bool can_scrub = !WT_SESSION_BTREE_SYNC(session) &&
-          (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) || debug_aggressive_scrub_enabled);
-
-        /*
-         * Scrub only if cache is under the clean eviction target or the page has high read
-         * generation.
-         */
-        if (can_scrub &&
-          (!__wt_evict_clean_needed(session, NULL) ||
-            ref->page->read_gen > __evict_read_gen(session))) {
-            LF_SET(WT_REC_SCRUB);
+            /*
+             * Scrub only if cache is under the clean eviction target or the page has high read
+             * generation (the page is hot and we want to keep it in cache).
+             */
+            if (can_scrub &&
+              (!__wt_evict_clean_needed(session, NULL) ||
+                ref->page->read_gen > __evict_read_gen(session))) {
+                LF_SET(WT_REC_SCRUB);
+            }
         }
     }
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -912,20 +912,26 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
         LF_SET(WT_REC_HS);
 
         /*
-         * Scrub and we're supposed to or toss it in sometimes if we are in debugging mode.
+         * Scrub if we're supposed to or toss it in sometimes if we are in debugging mode.
          *
          * Note that don't scrub if checkpoint is running on the tree.
-         *
-         * Scrub only cache is under clean eviction target or the page has high read generation.
          */
-        if (!WT_SESSION_BTREE_SYNC(session) &&
-          (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) ||
-            (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
-              __wt_random(&session->rnd_random) % 3 == 0))) {
-            if (!(__wt_evict_clean_needed(session, NULL)) ||
-              ref->page->read_gen > __evict_read_gen(session)) {
-                LF_SET(WT_REC_SCRUB);
-            }
+        const bool debug_aggressive_scrub_enabled =
+          FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
+          __wt_random(&session->rnd_random) % 3 == 0;
+
+        const bool can_scrub = !WT_SESSION_BTREE_SYNC(session) &&
+          (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) || debug_aggressive_scrub_enabled);
+
+        /*
+         * Scrub only if cache is under the clean eviction target or the page has high read
+         * generation.
+         */
+        const bool is_scrub_candidate = !__wt_evict_clean_needed(session, NULL) ||
+          ref->page->read_gen > __evict_read_gen(session);
+
+        if (can_scrub && is_scrub_candidate) {
+            LF_SET(WT_REC_SCRUB);
         }
     }
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -870,7 +870,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
     WT_DECL_RET;
     WT_EVICT *evict;
     uint32_t flags;
-    
+
     bool closing, is_application_thread_snapshot_refreshed, is_eviction_thread,
       use_snapshot_for_app_thread;
 
@@ -915,22 +915,18 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
          * Scrub and we're supposed to or toss it in sometimes if we are in debugging mode.
          *
          * Note that don't scrub if checkpoint is running on the tree.
-         * 
-         * Scrub only if the page is under the clean eviction target or the page has high read generation.
+         *
+         * Scrub only cache is under clean eviction target or the page has high read generation.
          */
-        uint64_t bytes_inuse = __wt_cache_bytes_inuse(conn->cache);
-        uint64_t bytes_max = conn->cache_size + 1;
-        WT_PAGE *page = ref->page;
-
         if (!WT_SESSION_BTREE_SYNC(session) &&
           (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) ||
             (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
               __wt_random(&session->rnd_random) % 3 == 0))) {
-                if (bytes_inuse <= (uint64_t)(evict->eviction_target * bytes_max) / 100 || 
-                    page->read_gen > evict->read_gen) {
-                        LF_SET(WT_REC_SCRUB);
-                }
-              }
+            if (!(__wt_evict_clean_needed(session, NULL)) ||
+              ref->page->read_gen > __evict_read_gen(session)) {
+                LF_SET(WT_REC_SCRUB);
+            }
+        }
     }
 
     /*

--- a/test/suite/test_scrub_eviction_conditions.py
+++ b/test/suite/test_scrub_eviction_conditions.py
@@ -74,7 +74,7 @@ class test_scrub_eviction_conditions(wttest.WiredTigerTestCase):
         dirty_after = self.get_stat(stat.dsrc.cache_eviction_dirty)
 
         # Assert scrub eviction happened for dirty page
-        self.assertGreater(scrubbed_after, 0, 
+        self.assertGreater(scrubbed_after, 0,
             "Dirty page should be scrub-evicted.")
 
         self.assertEqual(clean_after, 0,

--- a/test/suite/test_scrub_eviction_conditions.py
+++ b/test/suite/test_scrub_eviction_conditions.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat
+
+class test_scrub_eviction_conditions(wttest.WiredTigerTestCase):
+    def conn_config(self):
+        # Small cache to force eviction, enable all statistics
+        return 'cache_size=1MB,statistics=(all),eviction=(threads_max=4),eviction_target=10'
+
+    def setUp(self):
+        super().setUp()
+        self.uri = 'table:test_scrub_eviction_conditions'
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+
+    def populate_data(self, n=100):
+        c = self.session.open_cursor(self.uri)
+        for i in range(1, n + 1):
+            c[i] = 'x' * 100
+        c.close()
+
+    def evict_page(self, key, use_release_evict=True):
+        config = "debug=(release_evict)" if use_release_evict else ""
+        c = self.session.open_cursor(self.uri, None, config)
+        c.set_key(key)
+        c.search()
+        c.reset()
+        c.close()
+
+    def get_stat(self, stat_key):
+        cursor = self.session.open_cursor("statistics:" + self.uri)
+        value = cursor[stat_key][2]
+        cursor.close()
+        return value
+
+    def read_key(self, key):
+        c = self.session.open_cursor(self.uri)
+        c.set_key(key)
+        self.assertEqual(c.search(), 0)
+        c.close()
+
+    def test_page_eviction_is_scrubbed(self):
+        self.populate_data()
+
+        # Dirty a page
+        c = self.session.open_cursor(self.uri)
+        c[1] = 'dirty-data'
+        c.close()
+
+        # Evict the dirty page
+        self.evict_page(1)
+
+        # Record stats after eviction
+        stat_cursor = self.session.open_cursor('statistics:')
+        scrubbed_after = stat_cursor[stat.conn.cache_write_restore][2]
+        stat_cursor.close()
+        clean_after = self.get_stat(stat.dsrc.cache_eviction_clean)
+        dirty_after = self.get_stat(stat.dsrc.cache_eviction_dirty)
+
+        # Assert scrub eviction happened for dirty page
+        self.assertGreater(scrubbed_after, 0, 
+            "Dirty page should be scrub-evicted.")
+
+        self.assertEqual(clean_after, 0,
+            "Clean eviction should not increase due to dirty page.")
+
+        self.assertGreater(dirty_after, 0,
+            "Expected dirty eviction to increase for the evicted dirty page.")
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
This change updates the code for scrub eviction, to avoid double evicting a page when the cache is under pressure. It is currently possible for a dirty page to be scrub evicted and read back in the cache, then clean evicted afterwards. To avoid this, a condition has been added to skip scrub eviction unless either clean eviction threshold has not been reached, or the page has high read generation. If we're over the clean eviction threshold and the page's read generation is low, we just evict the page.
