### PR TITLE
WT-12808 remove transaction macro WT_TXNID_LT and WT_TXNID_LE

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -853,9 +853,8 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
      * Sanity check that the oldest ID hasn't moved on before we have cleared our entry.
      */
     WT_ASSERT(session,
-      WT_TXNID_LE(
-        __wt_atomic_loadv64(&txn_global->oldest_id), __wt_atomic_loadv64(&txn_shared->id)) &&
-        WT_TXNID_LE(__wt_atomic_loadv64(&txn_global->oldest_id),
+      (__wt_atomic_loadv64(&txn_global->oldest_id) <= __wt_atomic_loadv64(&txn_shared->id)) &&
+        (__wt_atomic_loadv64(&txn_global->oldest_id) <=
           __wt_atomic_loadv64(&txn_shared->pinned_id)));
 
     /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -660,7 +660,7 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     }
 
     /* Check if this is the largest transaction ID to update the page. */
-    if (WT_TXNID_LT(__wt_atomic_load64(&page->modify->update_txn), session->txn->id))
+    if (__wt_atomic_load64(&page->modify->update_txn) < session->txn->id)
         __wt_atomic_store64(&page->modify->update_txn, session->txn->id);
 }
 

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -62,7 +62,6 @@ typedef enum { WT_OPCTX_TRANSACTION, WT_OPCTX_RECONCILATION } WT_OP_CONTEXT;
  * WT_TXN_ABORTED is the largest possible ID (never visible to a running transaction), WT_TXN_NONE
  * is smaller than any possible ID (visible to all running transactions).
  */
-#define WT_TXNID_LE(t1, t2) ((t1) <= (t2))
 
 #define WT_TXNID_LT(t1, t2) ((t1) < (t2))
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -295,7 +295,7 @@ __txn_next_op(WT_SESSION_IMPL *session, WT_TXN_OP **opp)
     txn_id = txn->id;
     WT_ASSERT_ALWAYS(session, txn_id != WT_TXN_ABORTED,
       "Assert failure: session: %s: txn->id == WT_TXN_ABORTED", session->name);
-    while (WT_TXNID_LT(btree_txn_id_prev, txn_id)) {
+    while (btree_txn_id_prev < txn_id) {
         if (__wt_atomic_cas64(&op->btree->max_upd_txn, btree_txn_id_prev, txn_id))
             break;
         btree_txn_id_prev = op->btree->max_upd_txn;
@@ -784,7 +784,7 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
          * active checkpoint, keep changes until checkpoint is finished.
          */
         checkpoint_pinned = __wt_atomic_loadv64(&txn_global->checkpoint_txn_shared.pinned_id);
-        if (checkpoint_pinned == WT_TXN_NONE || WT_TXNID_LT(oldest_id, checkpoint_pinned))
+        if (checkpoint_pinned == WT_TXN_NONE || oldest_id < checkpoint_pinned)
             return (oldest_id);
         return (checkpoint_pinned);
     } else {
@@ -793,7 +793,7 @@ __wt_txn_oldest_id(WT_SESSION_IMPL *session)
          * changes until the recovery is finished.
          */
         recovery_ckpt_snap_min = conn->recovery_ckpt_snap_min;
-        if (recovery_ckpt_snap_min == WT_TXN_NONE || WT_TXNID_LT(oldest_id, recovery_ckpt_snap_min))
+        if (recovery_ckpt_snap_min == WT_TXN_NONE || oldest_id < recovery_ckpt_snap_min)
             return (oldest_id);
         return (recovery_ckpt_snap_min);
     }
@@ -893,7 +893,7 @@ __txn_visible_all_id(WT_SESSION_IMPL *session, uint64_t id)
             txn->snapshot_data.snapshot, txn->snapshot_data.snapshot_count));
     oldest_id = __wt_txn_oldest_id(session);
 
-    return (WT_TXNID_LT(id, oldest_id));
+    return (id < oldest_id);
 }
 
 /*
@@ -1087,7 +1087,7 @@ __wt_txn_visible_id_snapshot(
      */
     if (WT_TXNID_LE(snap_max, id))
         return (false);
-    if (snapshot_count == 0 || WT_TXNID_LT(id, snap_min))
+    if (snapshot_count == 0 || id < snap_min)
         return (true);
 
     WT_BINARY_SEARCH(id, snapshot, snapshot_count, found);
@@ -1174,7 +1174,7 @@ __wt_txn_snap_min_visible(
     WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
 
     /* Transaction snapshot minimum check. */
-    if (!WT_TXNID_LT(id, session->txn->snapshot_data.snap_min))
+    if (id >= session->txn->snapshot_data.snap_min)
         return (false);
 
     /* Transactions read their writes, regardless of timestamps. */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1085,7 +1085,7 @@ __wt_txn_visible_id_snapshot(
      *	ids < snap_min are visible,
      *	everything else is visible unless it is found in the snapshot.
      */
-    if (WT_TXNID_LE(snap_max, id))
+    if (snap_max <= id)
         return (false);
     if (snapshot_count == 0 || id < snap_min)
         return (true);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -655,7 +655,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
             upd_select->upd = upd;
 
         /* Track the selected update transaction id and timestamp. */
-        if (WT_TXNID_LT(max_txn, txnid))
+        if (max_txn < txnid)
             max_txn = txnid;
 
         if (upd->start_ts > max_ts)
@@ -675,7 +675,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
      * reconciliation in the service of checkpoints, it is used to avoid discarding trees from
      * memory when they have changes required to satisfy a snapshot read.
      */
-    if (WT_TXNID_LT(r->max_txn, max_txn))
+    if (r->max_txn < max_txn)
         r->max_txn = max_txn;
 
     /* Update the maximum timestamp. */

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -601,7 +601,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
          * ok to undo the work of the previous reconciliations.
          */
         if (!F_ISSET(upd, WT_UPDATE_SELECT_FOR_DS) && !is_hs_page &&
-          (F_ISSET(r, WT_REC_VISIBLE_ALL) ? WT_TXNID_LE(r->last_running, txnid) :
+          (F_ISSET(r, WT_REC_VISIBLE_ALL) ? (r->last_running <= txnid) :
                                             !__txn_visible_id(session, txnid))) {
             /*
              * Rare case: metadata writes at read uncommitted isolation level, eviction may see a

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -413,7 +413,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
      * Track the tree's maximum transaction ID (used to decide if it's safe to discard the tree) and
      * maximum timestamp.
      */
-    if (WT_TXNID_LT(btree->rec_max_txn, r->max_txn))
+    if (btree->rec_max_txn < r->max_txn)
         btree->rec_max_txn = r->max_txn;
     if (btree->rec_max_timestamp < r->max_ts)
         btree->rec_max_timestamp = r->max_ts;
@@ -632,7 +632,7 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
      */
     if (WT_IS_METADATA(session->dhandle)) {
         WT_ACQUIRE_READ_WITH_BARRIER(ckpt_txn, txn_global->checkpoint_txn_shared.id);
-        if (ckpt_txn != WT_TXN_NONE && WT_TXNID_LT(ckpt_txn, r->last_running))
+        if (ckpt_txn != WT_TXN_NONE && (ckpt_txn < r->last_running))
             r->last_running = ckpt_txn;
     }
     /* When operating on the history store table, we should never try history store eviction. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -139,7 +139,7 @@ __reconcile_save_evict_state(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
      * Check that transaction time always moves forward for a given page. If this check fails,
      * reconciliation can free something that a future reconciliation will need.
      */
-    WT_ASSERT(session, WT_TXNID_LE(mod->last_oldest_id, oldest_id));
+    WT_ASSERT(session, mod->last_oldest_id <= oldest_id);
     mod->last_oldest_id = oldest_id;
 #endif
 }

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -31,10 +31,10 @@
  *     Due to a difference in transaction id based visibility and timestamp visibility the timestamp
  *     comparison is inclusive whereas the transaction id comparison isn't.
  */
-#define WTI_REC_TW_START_VISIBLE_ALL(r, tw)                    \
-    (WT_TXNID_LT((tw)->start_txn, (r)->rec_start_oldest_id) && \
-      ((tw)->durable_start_ts == WT_TS_NONE ||                 \
-        ((r)->rec_start_pinned_ts != WT_TS_NONE &&             \
+#define WTI_REC_TW_START_VISIBLE_ALL(r, tw)          \
+    (((tw)->start_txn < (r)->rec_start_oldest_id) && \
+      ((tw)->durable_start_ts == WT_TS_NONE ||       \
+        ((r)->rec_start_pinned_ts != WT_TS_NONE &&   \
           (tw)->durable_start_ts <= (r)->rec_start_pinned_ts)))
 
 /*

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2193,8 +2193,7 @@ __session_transaction_pinned_range(WT_SESSION *wt_session, uint64_t *prange)
 
     /* Assign pinned to the lesser of id or snap_min */
     if (__wt_atomic_loadv64(&txn_shared->id) != WT_TXN_NONE &&
-      WT_TXNID_LT(
-        __wt_atomic_loadv64(&txn_shared->id), __wt_atomic_loadv64(&txn_shared->pinned_id)))
+      __wt_atomic_loadv64(&txn_shared->id) < __wt_atomic_loadv64(&txn_shared->pinned_id))
         pinned = __wt_atomic_loadv64(&txn_shared->id);
     else
         pinned = __wt_atomic_loadv64(&txn_shared->pinned_id);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -77,7 +77,7 @@ __txn_remove_from_global_table(WT_SESSION_IMPL *session)
     txn_global = &S2C(session)->txn_global;
     txn_shared = WT_SESSION_TXN_SHARED(session);
 
-    WT_ASSERT(session, !WT_TXNID_LT(txn->id, __wt_atomic_loadv64(&txn_global->last_running)));
+    WT_ASSERT(session, txn->id >= __wt_atomic_loadv64(&txn_global->last_running));
     WT_ASSERT(
       session, txn->id != WT_TXN_NONE && __wt_atomic_loadv64(&txn_shared->id) != WT_TXN_NONE);
 #else
@@ -174,7 +174,7 @@ __wt_txn_active(WT_SESSION_IMPL *session, uint64_t txnid)
     __wt_readlock(session, &txn_global->rwlock);
     oldest_id = __wt_atomic_loadv64(&txn_global->oldest_id);
 
-    if (WT_TXNID_LT(txnid, oldest_id)) {
+    if (txnid < oldest_id) {
         active = false;
         goto done;
     }
@@ -277,7 +277,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool update_shared_state)
          *    not be visible to the current snapshot.
          */
         while (s != txn_shared && (id = __wt_atomic_loadv64(&s->id)) != WT_TXN_NONE &&
-          WT_TXNID_LE(prev_oldest_id, id) && WT_TXNID_LT(id, current_id)) {
+          WT_TXNID_LE(prev_oldest_id, id) && (id < current_id)) {
             /*
              * If the transaction is still allocating its ID, then we spin here until it gets its
              * valid ID.
@@ -293,7 +293,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool update_shared_state)
                 WT_ACQUIRE_BARRIER();
                 if (id == __wt_atomic_loadv64(&s->id)) {
                     txn->snapshot_data.snapshot[n++] = id;
-                    if (WT_TXNID_LT(id, pinned_id))
+                    if (id < pinned_id)
                         pinned_id = id;
                     break;
                 }
@@ -426,7 +426,7 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
         /* Update the last running transaction ID. */
         while ((id = __wt_atomic_loadv64(&s->id)) != WT_TXN_NONE &&
-          WT_TXNID_LE(prev_oldest_id, id) && WT_TXNID_LT(id, last_running)) {
+          WT_TXNID_LE(prev_oldest_id, id) && id < last_running) {
             /*
              * If the transaction is still allocating its ID, then we spin here until it gets its
              * valid ID.
@@ -449,8 +449,7 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
         }
 
         /* Update the metadata pinned ID. */
-        if ((id = __wt_atomic_loadv64(&s->metadata_pinned)) != WT_TXN_NONE &&
-          WT_TXNID_LT(id, metadata_pinned))
+        if ((id = __wt_atomic_loadv64(&s->metadata_pinned)) != WT_TXN_NONE && id < metadata_pinned)
             metadata_pinned = id;
 
         /*
@@ -461,19 +460,18 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
          * table.  See the comment in __wt_txn_cursor_op for more
          * details.
          */
-        if ((id = __wt_atomic_loadv64(&s->pinned_id)) != WT_TXN_NONE &&
-          WT_TXNID_LT(id, oldest_id)) {
+        if ((id = __wt_atomic_loadv64(&s->pinned_id)) != WT_TXN_NONE && id < oldest_id) {
             oldest_id = id;
             oldest_session = &WT_CONN_SESSIONS_GET(conn)[i];
         }
     }
     WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
 
-    if (WT_TXNID_LT(last_running, oldest_id))
+    if (last_running < oldest_id)
         oldest_id = last_running;
 
     /* The metadata pinned ID can't move past the oldest ID. */
-    if (WT_TXNID_LT(oldest_id, metadata_pinned))
+    if (oldest_id < metadata_pinned)
         metadata_pinned = oldest_id;
 
     *last_runningp = last_running;
@@ -522,7 +520,7 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
      * behind, avoid scanning.
      */
     if ((prev_oldest_id == current_id && prev_metadata_pinned == current_id) ||
-      (!strict && WT_TXNID_LT(current_id, prev_oldest_id + non_strict_min_threshold)))
+      (!strict && current_id < prev_oldest_id + non_strict_min_threshold))
         return (0);
 
     /* First do a read-only scan. */
@@ -537,9 +535,9 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
      * If the state hasn't changed (or hasn't moved far enough for non-forced updates), give up.
      */
     if ((oldest_id == prev_oldest_id ||
-          (!strict && WT_TXNID_LT(oldest_id, prev_oldest_id + non_strict_min_threshold))) &&
+          (!strict && (oldest_id < prev_oldest_id + non_strict_min_threshold))) &&
       ((last_running == prev_last_running) ||
-        (!strict && WT_TXNID_LT(last_running, prev_last_running + non_strict_min_threshold))) &&
+        (!strict && last_running < prev_last_running + non_strict_min_threshold)) &&
       metadata_pinned == prev_metadata_pinned)
         return (0);
 
@@ -565,11 +563,11 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
     __txn_oldest_scan(session, &oldest_id, &last_running, &metadata_pinned, &oldest_session);
 
     /* Update the public IDs. */
-    if (WT_TXNID_LT(__wt_atomic_loadv64(&txn_global->metadata_pinned), metadata_pinned))
+    if (__wt_atomic_loadv64(&txn_global->metadata_pinned) < metadata_pinned)
         __wt_atomic_storev64(&txn_global->metadata_pinned, metadata_pinned);
-    if (WT_TXNID_LT(__wt_atomic_loadv64(&txn_global->oldest_id), oldest_id))
+    if (__wt_atomic_loadv64(&txn_global->oldest_id) < oldest_id)
         __wt_atomic_storev64(&txn_global->oldest_id, oldest_id);
-    if (WT_TXNID_LT(__wt_atomic_loadv64(&txn_global->last_running), last_running)) {
+    if (__wt_atomic_loadv64(&txn_global->last_running) < last_running) {
         __wt_atomic_storev64(&txn_global->last_running, last_running);
 
         /*


### PR DESCRIPTION
The WT_TXNID_LT and WT_TXNID_LE used to contain special handling for transaction IDs like WT_TXN_ABORTED and WT_TXN_NONE, however these days they just evaluate to `a < b` and `a <= b` respectively. 

This change removed `WT_TXNID_LE` macro entirely in the codebase, and while `WT_TXNID_LT` is still kept, I've removed all usage of it except for the one in `WT_INSERTION_SORT` [here](https://github.com/wiredtiger/wiredtiger/blob/develop/src/include/misc.h#L247) for sorting an array. 

