### PR TITLE
WT-14459 Move to ARMV9 perf distros

### DIFF
--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -55,7 +55,7 @@ buildvariants:
   name: amazon2023-perf-tests-arm64
   display_name: (ARMV9) Amazon Linux 2023 Performance tests (ARM64)
   run_on:
-   - amazon2023-arm64-latest-large-m8g
+   - amazon2023-arm64-large-m8g-wt
   expansions:
     <<: *ubuntu2004-perf-tests-expansions-template
     collection: AllPerfTestsARM64_v9


### PR DESCRIPTION
In the past, we saw our performance builds have high unexplained variance. This was due to distros being constantly updated producing inconsistent WT performance results. A new performance distro has been created **amazon2023-arm64-large-m8g-wt**
