### PR TITLE
WT-14576: Reintroduce community-based TCMalloc support on Windows

### DIFF
--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -9,6 +9,34 @@
 #include "wt_internal.h"
 
 /*
+ * On systems with poor default allocators for allocations greater than 16 KB, we provide an option
+ * to use TCMalloc explicitly. This is important on Windows which does not have a builtin mechanism
+ * to replace C run-time memory management functions with alternatives.
+ *
+ * Please note that this feature has community-based support only.
+ */
+#ifdef ENABLE_WINDOWS_TCMALLOC_COMMUNITY_SUPPORT
+/*
+ * Include the TCMalloc header with the "-Wundef" diagnostic flag disabled. Compiling with strict
+ * (where the 'Wundef' diagnostic flag is enabled), generates compilation errors where the
+ * '__cplusplus' CPP macro is not defined. This being employed by the TCMalloc header to
+ * differentiate C & C++ compilation environments. We don't want to define '__cplusplus' when
+ * compiling C sources.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
+#include <gperftools/tcmalloc.h>
+#pragma GCC diagnostic pop
+
+#define calloc tc_calloc
+#define malloc tc_malloc
+#define realloc tc_realloc
+#define posix_memalign tc_posix_memalign
+#define free tc_free
+
+#endif
+
+/*
  * __wt_calloc --
  *     ANSI calloc function.
  */

--- a/src/utilities/util_misc.c
+++ b/src/utilities/util_misc.c
@@ -8,6 +8,20 @@
 
 #include "util.h"
 
+#ifdef ENABLE_WINDOWS_TCMALLOC_COMMUNITY_SUPPORT
+/*
+ * Include the TCMalloc header with the "-Wundef" diagnostic flag disabled. Compiling with strict
+ * (where the 'Wundef' diagnostic flag is enabled), generates compilation errors where the
+ * '__cplusplus' CPP macro is not defined. This being employed by the TCMalloc header to
+ * differentiate C & C++ compilation environments. We don't want to define '__cplusplus' when
+ * compiling C sources.
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
+#include <gperftools/tcmalloc.h>
+#pragma GCC diagnostic pop
+#endif
+
 /*
  * util_cerr --
  *     Report an error for a cursor operation.
@@ -170,7 +184,11 @@ util_usage(const char *usage, const char *tag, const char *list[])
 void *
 util_malloc(size_t len)
 {
+#ifdef ENABLE_WINDOWS_TCMALLOC_COMMUNITY_SUPPORT
+    return (tc_malloc(len));
+#else
     return (malloc(len));
+#endif
 }
 
 /*
@@ -180,7 +198,11 @@ util_malloc(size_t len)
 void *
 util_calloc(size_t members, size_t sz)
 {
+#ifdef ENABLE_WINDOWS_TCMALLOC_COMMUNITY_SUPPORT
+    return (tc_calloc(members, sz));
+#else
     return (calloc(members, sz));
+#endif
 }
 
 /*
@@ -190,7 +212,11 @@ util_calloc(size_t members, size_t sz)
 void *
 util_realloc(void *p, size_t len)
 {
+#ifdef ENABLE_WINDOWS_TCMALLOC_COMMUNITY_SUPPORT
+    return (tc_realloc(p, len));
+#else
     return (realloc(p, len));
+#endif
 }
 
 /*
@@ -201,7 +227,11 @@ util_realloc(void *p, size_t len)
 void
 util_free(void *p)
 {
+#ifdef ENABLE_WINDOWS_TCMALLOC_COMMUNITY_SUPPORT
+    tc_free(p);
+#else
     free(p);
+#endif
 }
 
 /*
@@ -211,7 +241,17 @@ util_free(void *p)
 char *
 util_strdup(const char *s)
 {
+#ifdef ENABLE_WINDOWS_TCMALLOC_COMMUNITY_SUPPORT
+    char *new = util_malloc(strlen(s) + 1);
+    if (new == NULL)
+        return (NULL);
+
+    strcpy(new, s);
+
+    return (new);
+#else
     return (strdup(s));
+#endif
 }
 
 /*


### PR DESCRIPTION
These changes reintroduce replacing a system allocator by TCMalloc symbols explicitly on Windows.

This PR partially reverts changes made in [7b2c59d70a1d25f8090ca334401386900d9f9912](https://github.com/10gen/mongo/commit/7b2c59d70a1d25f8090ca334401386900d9f9912), but only the portion that affects C code. It also renames the guarding macro and introduces additional protection to highlight that this is only for Windows and has community support.

Community support here means that WT doesn't have a build infrastructure to test it, and all the changes made under this macro wouldn't be tested by the CI and therefore should be tested manually.