### PR TITLE
WT-13627 Add detailed message for debugging out-of-order timestamp assert

### DIFF
--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -347,14 +347,14 @@ __rec_hs_cursor_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btr
      * If we find a key with a timestamp larger than or equal to the specified timestamp then the
      * specified timestamp must be mixed mode.
      */
-    char tp_string[4][WT_TS_INT_STRING_SIZE];
+    char ts_string[4][WT_TS_INT_STRING_SIZE];
     WT_ASSERT_ALWAYS(session, ts == 1 || ts == WT_TS_NONE,
       "out-of-order timestamp update detected, found an existing update with "
       "hs_start_ts=%s, start_ts=%s, stop_ts=%s, that exists later than specified ts=%s",
-      __wt_timestamp_to_string(hs_start_ts, tp_string[0]),
-      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->start_ts, tp_string[1]),
-      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->stop_ts, tp_string[2]),
-      __wt_timestamp_to_string(ts, tp_string[3]));
+      __wt_timestamp_to_string(hs_start_ts, ts_string[0]),
+      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->start_ts, ts_string[1]),
+      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->stop_ts, ts_string[2]),
+      __wt_timestamp_to_string(ts, ts_string[3]));
     return (ret);
 }
 


### PR DESCRIPTION
This PR adds more information to debug the timestamp of the history store update that is out-of-order when this assertion fails