### PR TITLE
WT-14461 Fix workgen test failures on machine ARMV9 using V5 toolchain

### DIFF
--- a/bench/workgen/runner/runner/__init__.py
+++ b/bench/workgen/runner/runner/__init__.py
@@ -59,15 +59,15 @@ def _prepend_env_path(pathvar, s):
 # Initialize the python path so needed modules can be imported.
 # If the path already works, don't change it.
 try:
-    import wiredtiger
+    import workgen
 except:
-    # We'll try hard to make the importing work, we'd like to runners
-    # to be executable directly without having to set environment variables.
     sys.path.insert(0, os.path.join(wt_dir, 'lang', 'python'))
     sys.path.insert(0, os.path.join(wt_builddir, 'lang', 'python'))
+    sys.path.insert(0, os.path.join(workgen_src, 'workgen'))
+    sys.path.insert(0, os.path.join(wt_builddir, 'bench', 'workgen'))
     try:
-        import wiredtiger
-    except:
+        import workgen
+    except: 
         # If the WiredTiger libraries is not in our library search path,
         # we need to set it and retry.  However, the dynamic link
         # library has already cached its value, our only option is
@@ -90,11 +90,13 @@ except:
                 sys.exit(1)
 
 try:
-    import workgen
+    import wiredtiger
 except:
-    sys.path.insert(0, os.path.join(workgen_src, 'workgen'))
-    sys.path.insert(0, os.path.join(wt_builddir, 'bench', 'workgen'))
-    import workgen
-
+    # We'll try hard to make the importing work, we'd like to runners
+    # to be executable directly without having to set environment variables.
+    sys.path.insert(0, os.path.join(wt_dir, 'lang', 'python'))
+    sys.path.insert(0, os.path.join(wt_builddir, 'lang', 'python'))
+    import wiredtiger
+    
 from .core import txn, extensions_config, op_append, op_group_transaction, op_log_like, op_multi_table, op_populate_with_range, sleep, timed
 from .latency import workload_latency

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6226,8 +6226,7 @@ buildvariants:
   batchtime: 1440 # 24 hours
   expansions:
     ENABLE_TCMALLOC: 1
-    # FIXME-WT-14461: Use stable toolchain once workgen tests are fixed.
-    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v4_gcc.cmake
+    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v5_gcc.cmake
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
   tasks:
     - name: ".workgen-test"


### PR DESCRIPTION
The workgen python tests import workgen and wiredtiger shared library which has direct dependency to the libstdc++ library. Digging into a rabbit hole found that the wiredtiger.so library has a dependency on snappy library which has a dependency on the libstdc++ library. For some reason importing the libstdc++ from snappy causes a segmentation fault within workgen python tests.

We have found out that the ordering here matters. This is an odd case and is not a common use case of the wiredtiger.so library. The final discussed solution is to import workgen first and then the wiredtiger.so library. In that way the correct libstdc++ can be symbolised, and will not cause further problems in workgen.