### PR TITLE
WT-14676 Change eviction stats tests to be more consistent

### DIFF
--- a/test/suite/test_stat12.py
+++ b/test/suite/test_stat12.py
@@ -104,26 +104,26 @@ class test_stat12(wttest.WiredTigerTestCase):
             trigger_count = self.get_stat(wiredtiger.stat.conn.cache_eviction_trigger_reached)
             dirty_trigger_count = self.get_stat(wiredtiger.stat.conn.cache_eviction_trigger_dirty_reached)
             updates_trigger_count = self.get_stat(wiredtiger.stat.conn.cache_eviction_trigger_updates_reached)
+            eviction_triggers = trigger_count + dirty_trigger_count + updates_trigger_count
+
             fill_ratio_lt_25 = self.get_stat(wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_lt_25)
             fill_ratio_25_50 = self.get_stat(wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_25_50)
             fill_ratio_50_75 = self.get_stat(wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_50_75)
             fill_ratio_gt_75 = self.get_stat(wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_gt_75)
             fill_ratio_count = fill_ratio_lt_25 + fill_ratio_25_50 + fill_ratio_50_75 + fill_ratio_gt_75
 
-            if trigger_count != 0 and dirty_trigger_count != 0 and updates_trigger_count != 0 and fill_ratio_count != 0:
+            if eviction_triggers != 0 and fill_ratio_count != 0:
                 break
             # Sleep to allow eviction to process
             time.sleep(1)
 
         # Print or assert their values have increased from 0
-        self.assertGreaterEqual(trigger_count, 1, "Clean trigger was not reached.")
-        self.assertGreaterEqual(dirty_trigger_count, 1, "Dirty trigger was not reached.")
-        self.assertGreaterEqual(updates_trigger_count, 1, "Updates trigger was not reached.")
+        self.assertGreaterEqual(eviction_triggers, 1, "Hard eviction trigger was not reached.")
         self.assertGreaterEqual(fill_ratio_count, 1, "Cache fill ratio at eviction time should be incremented.")
 
         # check that each time application threads evict pages, the fill ratio stats are incremented
         # and that the total fill ratio stats do not exceed eviction trigger stats
         # the reason trigger counts are greater than fill ratio counts is that multiple eviction triggers (clean, dirty, updates)
         # can be reached at once, while fill ratio stats are only incremented once if any application thread evicts a page
-        self.assertGreaterEqual(trigger_count + dirty_trigger_count + updates_trigger_count, fill_ratio_count, "Fill ratio stats should not exceed eviction trigger stats.")
+        self.assertGreaterEqual(eviction_triggers, fill_ratio_count, "Fill ratio stats should not exceed eviction trigger stats.")
 

--- a/test/suite/test_stat12.py
+++ b/test/suite/test_stat12.py
@@ -86,17 +86,17 @@ class test_stat12(wttest.WiredTigerTestCase):
         self.session.create(self.uri, self.create_params)
 
         # Populate enough data to force eviction and thresholds
-        self.populate_data(0, 2000, value_size=2000)  # Big values to fill cache
+        self.populate_data(0, 2000, value_size=5000)  # Big values to fill cache
         self.session.checkpoint()
 
         # Force dirty eviction
-        for i in range(200, 1000):
+        for i in range(200, 2000):
             c = self.session.open_cursor(self.uri)
             c[i] = 'y' * 1000
             c.close()
 
         # Additional reads to touch clean pages (increase memory usage) without dirtying
-        for i in range(200, 2000):
+        for i in range(200, 3000):
             self.read_key(i)
 
         for _ in range(20):


### PR DESCRIPTION
The tests for eviction trigger statistics are non-deterministic as it's hard to control which pages get evicted. We can change the test to check that any eviction happens and increments related stats instead of checking that specific kinds of eviction happens. This should make the test more consistent and still check that eviction related stats are incrementing as they should be when eviction thresholds are met.
