### PR TITLE
WT-14677 Remove redundant arguments

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -693,7 +693,7 @@ __debug_cell_kv(
     if (unpack->raw == WT_CELL_DEL)
         return (0);
 
-    WT_RET(page == NULL ? __wt_dsk_cell_data_ref_kv(session, page_type, unpack, ds->t1) :
+    WT_RET(page == NULL ? __wt_dsk_cell_data_ref_kv(session, unpack, ds->t1) :
                           __wt_page_cell_data_ref_kv(session, page, unpack, ds->t1));
 
     /* Standard key/value cells. */

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -43,11 +43,9 @@ __ovfl_read(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size, WT_
  */
 int
 __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_COMMON *unpack,
-  WT_ITEM *store, bool *decoded)
+  WT_ITEM *store)
 {
     WT_DECL_RET;
-
-    *decoded = false;
 
     /*
      * If no page specified, there's no need to lock and there's no cache to search, we don't care
@@ -63,10 +61,9 @@ __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_COMMON *u
      * with checkpoints doing that work, lock before testing the removed flag.
      */
     __wt_readlock(session, &S2BT(session)->ovfl_lock);
-    if (__wt_cell_type_raw(unpack->cell) == WT_CELL_VALUE_OVFL_RM) {
+    if (__wt_cell_type_raw(unpack->cell) == WT_CELL_VALUE_OVFL_RM)
         ret = __wt_buf_setstr(session, store, "WT_CELL_VALUE_OVFL_RM");
-        *decoded = true;
-    } else
+    else
         ret = __ovfl_read(session, unpack->data, unpack->size, store);
     __wt_readunlock(session, &S2BT(session)->ovfl_lock);
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -869,7 +869,7 @@ __inmem_row_int(WT_SESSION_IMPL *session, WT_PAGE *page, size_t *sizep)
              * Instantiate any overflow keys; WiredTiger depends on this, assuming any overflow key
              * is instantiated, and any keys that aren't instantiated cannot be overflow items.
              */
-            WT_ERR(__wt_dsk_cell_data_ref_addr(session, page->type, &unpack, current));
+            WT_ERR(__wt_dsk_cell_data_ref_addr(session, &unpack, current));
 
             WT_ERR(__wti_row_ikey_incr(session, page, WT_PAGE_DISK_OFFSET(page, unpack.cell),
               current->data, current->size, ref));

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -512,7 +512,7 @@ __verify_dsk_row_int(WT_VERIFY_INFO *vi)
             current->size = unpack->size;
             break;
         case WT_CELL_KEY_OVFL:
-            WT_ERR(__wt_dsk_cell_data_ref_addr(vi->session, vi->dsk->type, unpack, current));
+            WT_ERR(__wt_dsk_cell_data_ref_addr(vi->session, unpack, current));
             break;
         default:
             /* Not a key -- continue with the next cell. */
@@ -665,7 +665,7 @@ __verify_dsk_row_leaf(WT_VERIFY_INFO *vi)
         case WT_CELL_KEY:
             break;
         case WT_CELL_KEY_OVFL:
-            WT_ERR(__wt_dsk_cell_data_ref_kv(vi->session, vi->dsk->type, unpack, current));
+            WT_ERR(__wt_dsk_cell_data_ref_kv(vi->session, unpack, current));
             goto key_compare;
         default:
             /* Not a key -- continue with the next cell. */

--- a/src/btree/row_key.c
+++ b/src/btree/row_key.c
@@ -184,7 +184,7 @@ overflow_retry:
                     __wt_readunlock(session, &btree->ovfl_lock);
                     goto overflow_retry;
                 }
-                ret = __wt_dsk_cell_data_ref_kv(session, WT_PAGE_ROW_LEAF, unpack, keyb);
+                ret = __wt_dsk_cell_data_ref_kv(session, unpack, keyb);
                 __wt_readunlock(session, &btree->ovfl_lock);
                 WT_RET(ret);
                 break;
@@ -220,7 +220,7 @@ overflow_retry:
              *
              * The key doesn't need to be instantiated, just return.
              */
-            WT_RET(__wt_dsk_cell_data_ref_kv(session, WT_PAGE_ROW_LEAF, unpack, keyb));
+            WT_RET(__wt_dsk_cell_data_ref_kv(session, unpack, keyb));
             if (slot_offset == 0)
                 return (0);
             goto switch_and_jump;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1258,27 +1258,15 @@ __wt_cell_get_tw(WT_CELL_UNPACK_KV *unpack_value, WT_TIME_WINDOW **twp)
  *     Set a buffer to reference the data from an unpacked cell.
  */
 static WT_INLINE int
-__cell_data_ref(WT_SESSION_IMPL *session, WT_PAGE *page, int page_type,
-  WT_CELL_UNPACK_COMMON *unpack, WT_ITEM *store)
+__cell_data_ref(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_COMMON *unpack,
+    WT_ITEM *store)
 {
-    bool decoded;
-
     /* Reference the cell's data, optionally decode it. */
     switch (unpack->type) {
     case WT_CELL_KEY:
-        store->data = unpack->data;
-        store->size = unpack->size;
-        if (page_type == WT_PAGE_ROW_INT)
-            return (0);
-        break;
     case WT_CELL_VALUE:
         store->data = unpack->data;
         store->size = unpack->size;
-        break;
-    case WT_CELL_KEY_OVFL:
-        WT_RET(__wt_ovfl_read(session, page, unpack, store, &decoded));
-        if (page_type == WT_PAGE_ROW_INT || decoded)
-            return (0);
         break;
     case WT_CELL_VALUE_OVFL:
         /*
@@ -1286,9 +1274,9 @@ __cell_data_ref(WT_SESSION_IMPL *session, WT_PAGE *page, int page_type,
          * it may be removed by checkpoint concurrently.
          */
         __wt_timing_stress(session, WT_TIMING_STRESS_SLEEP_BEFORE_READ_OVERFLOW_ONPAGE, NULL);
-        WT_RET(__wt_ovfl_read(session, page, unpack, store, &decoded));
-        if (decoded)
-            return (0);
+        /* FALLTHROUGH */
+    case WT_CELL_KEY_OVFL:
+        WT_RET(__wt_ovfl_read(session, page, unpack, store));
         break;
     default:
         return (__wt_illegal_value(session, unpack->type));
@@ -1303,9 +1291,9 @@ __cell_data_ref(WT_SESSION_IMPL *session, WT_PAGE *page, int page_type,
  */
 static WT_INLINE int
 __wt_dsk_cell_data_ref_addr(
-  WT_SESSION_IMPL *session, int page_type, WT_CELL_UNPACK_ADDR *unpack, WT_ITEM *store)
+  WT_SESSION_IMPL *session, WT_CELL_UNPACK_ADDR *unpack, WT_ITEM *store)
 {
-    return (__cell_data_ref(session, NULL, page_type, (WT_CELL_UNPACK_COMMON *)unpack, store));
+    return (__cell_data_ref(session, NULL, (WT_CELL_UNPACK_COMMON *)unpack, store));
 }
 
 /*
@@ -1321,11 +1309,11 @@ __wt_dsk_cell_data_ref_addr(
  */
 static WT_INLINE int
 __wt_dsk_cell_data_ref_kv(
-  WT_SESSION_IMPL *session, int page_type, WT_CELL_UNPACK_KV *unpack, WT_ITEM *store)
+  WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack, WT_ITEM *store)
 {
     WT_ASSERT(session, unpack != NULL);
     WT_ASSERT(session, __wt_cell_type_raw(unpack->cell) != WT_CELL_VALUE_OVFL_RM);
-    return (__cell_data_ref(session, NULL, page_type, (WT_CELL_UNPACK_COMMON *)unpack, store));
+    return (__cell_data_ref(session, NULL, (WT_CELL_UNPACK_COMMON *)unpack, store));
 }
 
 /*
@@ -1336,7 +1324,7 @@ static WT_INLINE int
 __wt_page_cell_data_ref_kv(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_KV *unpack, WT_ITEM *store)
 {
-    return (__cell_data_ref(session, page, page->type, (WT_CELL_UNPACK_COMMON *)unpack, store));
+    return (__cell_data_ref(session, page, (WT_CELL_UNPACK_COMMON *)unpack, store));
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -805,7 +805,7 @@ extern int __wt_os_inmemory(WT_SESSION_IMPL *session)
 extern int __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ovfl_read(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_COMMON *unpack,
-  WT_ITEM *store, bool *decoded) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_ITEM *store) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ovfl_remove(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_KV *unpack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries,
@@ -1909,10 +1909,10 @@ static WT_INLINE int __wt_cursor_localkey(WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_curtable_get_valuev(WT_CURSOR *cursor, va_list ap)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_dsk_cell_data_ref_addr(WT_SESSION_IMPL *session, int page_type,
+static WT_INLINE int __wt_dsk_cell_data_ref_addr(WT_SESSION_IMPL *session,
   WT_CELL_UNPACK_ADDR *unpack, WT_ITEM *store) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_dsk_cell_data_ref_kv(WT_SESSION_IMPL *session, int page_type,
-  WT_CELL_UNPACK_KV *unpack, WT_ITEM *store) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_dsk_cell_data_ref_kv(WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack,
+  WT_ITEM *store) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_extlist_read_pair(const uint8_t **p, wt_off_t *offp, wt_off_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_extlist_write_pair(uint8_t **p, wt_off_t off, wt_off_t size)

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -1407,7 +1407,7 @@ record_loop:
                      * Original is an overflow item; we used it for a key and now we need another
                      * copy; read it into memory.
                      */
-                    WT_ERR(__wt_dsk_cell_data_ref_kv(session, WT_PAGE_COL_VAR, vpack, orig));
+                    WT_ERR(__wt_dsk_cell_data_ref_kv(session, vpack, orig));
                     data = orig->data;
                     size = (uint32_t)orig->size;
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -971,7 +971,7 @@ slow:
              * have to build the key now because we are about to promote it.
              */
             if (key_onpage_ovfl) {
-                WT_ERR(__wt_dsk_cell_data_ref_kv(session, WT_PAGE_ROW_LEAF, kpack, r->cur));
+                WT_ERR(__wt_dsk_cell_data_ref_kv(session, kpack, r->cur));
                 WT_NOT_READ(key_onpage_ovfl, false);
             }
 


### PR DESCRIPTION
I noticed that some interfaces contain arguments that don't change the code logic. This PR removes them for the sake of code clarity.
