### PR TITLE
WT-14687 Reuse WT_BM::free for block discard in disagg

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -50,6 +50,11 @@ __bmd_checkpoint_pack_raw(WT_BLOCK_DISAGG *block_disagg, WT_SESSION_IMPL *sessio
           block_meta->disagg_lsn, block_meta->checkpoint_id, block_meta->reconciliation_id, size,
           checksum));
         ckpt->raw.size = WT_PTRDIFF(endp, ckpt->raw.mem);
+        __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "Checkpoint root page: root_id=%" PRIu64 " lsn=%" PRIu64 " checkpoint_id=%" PRIu64
+          " reconciliation_id=%" PRIu64 " root_size=%" PRIu32 " root_checksum=%" PRIx32,
+          block_meta->page_id, block_meta->disagg_lsn, block_meta->checkpoint_id,
+          block_meta->reconciliation_id, size, checksum);
     }
 
     return (0);

--- a/src/block_disagg/block_disagg_mgr.c
+++ b/src/block_disagg/block_disagg_mgr.c
@@ -71,14 +71,8 @@ __bmd_close(WT_BM *bm, WT_SESSION_IMPL *session)
 static int
 __bmd_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
 {
-    /*
-     * FIX-WT-14611: This should notify the space manager that the page is no longer required.
-     */
-    WT_UNUSED(bm);
-    WT_UNUSED(session);
-    WT_UNUSED(addr);
-    WT_UNUSED(addr_size);
-    return (0);
+    /* TODO: Is this the right place to drop the page from the block cache? */
+    return (__wti_block_disagg_page_discard(session, bm->block, addr, addr_size));
 }
 
 /*

--- a/src/block_disagg/block_disagg_mgr.c
+++ b/src/block_disagg/block_disagg_mgr.c
@@ -71,7 +71,8 @@ __bmd_close(WT_BM *bm, WT_SESSION_IMPL *session)
 static int
 __bmd_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
 {
-    /* TODO: Is this the right place to drop the page from the block cache? */
+    /* FIXME-WT-14699: Drop the page from the block cache. */
+
     return (__wti_block_disagg_page_discard(session, bm->block, addr, addr_size));
 }
 

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -287,5 +287,7 @@ __wti_block_disagg_page_discard(
       page_id, lsn, checkpoint_id, reconciliation_id, size, checksum);
 
     /* FIXME-WT-14532: Implement the page discard logic. */
+    WT_UNUSED(block_disagg);
+
     return (0);
 }

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -262,3 +262,30 @@ __wti_block_disagg_write(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf
 
     return (0);
 }
+
+/*
+ * __wti_block_disagg_page_discard --
+ *     Discard a page.
+ */
+int
+__wti_block_disagg_page_discard(
+  WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr, size_t addr_size)
+{
+    WT_BLOCK_DISAGG *block_disagg;
+    uint64_t checkpoint_id, lsn, page_id, reconciliation_id;
+    uint32_t checksum, size;
+
+    block_disagg = (WT_BLOCK_DISAGG *)block;
+
+    /* Crack the cookie. */
+    WT_RET(__wti_block_disagg_addr_unpack(
+      &addr, addr_size, &page_id, &lsn, &checkpoint_id, &reconciliation_id, &size, &checksum));
+
+    __wt_verbose(session, WT_VERB_BLOCK,
+      "block free: page_id %" PRIu64 ", lsn %" PRIu64 ", checkpoint_id %" PRIu64
+      ", reconciliation_id %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
+      page_id, lsn, checkpoint_id, reconciliation_id, size, checksum);
+
+    /* FIXME-WT-14532: Implement the page discard logic. */
+    return (0);
+}

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -622,7 +622,7 @@ __split_parent_discard_ref(WT_SESSION_IMPL *session, WT_REF *ref, WT_PAGE *paren
     __wt_free(session, ref->page_del);
 
     /* Free the backing block and address. */
-    WT_TRET(__wt_ref_block_free(session, ref));
+    WT_TRET(__wt_ref_block_free(session, ref, false));
 
     /*
      * We cannot discard any ref in the prefetch queue, otherwise, the prefetch thread would read

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1646,7 +1646,7 @@ __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref, bool page_replacement
 
     WT_ERR(__wt_btree_block_free(session, addr.addr, addr.size, page_replacement));
 
-    if (!page_replacement)
+    if (!page_replacement && ref->page != NULL)
         ref->page->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
     /* Clear the address (so we don't free it twice). */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1273,6 +1273,8 @@ extern int __wti_block_disagg_map_discard(WT_BM *bm, WT_SESSION_IMPL *session, v
 extern int __wti_block_disagg_open(WT_SESSION_IMPL *session, const char *filename,
   const char *cfg[], bool forced_salvage, bool readonly, WT_BLOCK **blockp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_block_disagg_page_discard(WT_SESSION_IMPL *session, WT_BLOCK *block,
+  const uint8_t *addr, size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_block_disagg_read(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf,
   WT_PAGE_BLOCK_META *block_meta, const uint8_t *addr, size_t addr_size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1946,7 +1948,7 @@ static WT_INLINE int __wt_btcur_bounds_early_exit(WT_SESSION_IMPL *session, WT_C
 static WT_INLINE int __wt_btcur_skip_page(WT_SESSION_IMPL *session, WT_REF *ref, void *context,
   bool visible_all, bool *skipp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_btree_block_free(WT_SESSION_IMPL *session, const uint8_t *addr,
-  size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  size_t addr_size, bool page_replacement) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_btree_shared(WT_SESSION_IMPL *session, const char *uri,
   const char **bt_cfg, bool *shared) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_btree_shared_base_name(WT_SESSION_IMPL *session, const char **namep,
@@ -2071,8 +2073,8 @@ static WT_INLINE int __wt_page_swap_func(
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_read(WT_SESSION_IMPL *session, WT_FH *fh, wt_off_t offset, size_t len,
   void *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref,
+  bool page_replacement) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_row_leaf_key(WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip,
   WT_ITEM *key, bool instantiate) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_row_leaf_key_instantiate(WT_SESSION_IMPL *session, WT_PAGE *page)

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -33,7 +33,7 @@ __rec_child_deleted(
      * underlying disk blocks and don't write anything in the internal page.
      */
     if (page_del == NULL)
-        return (__wt_ref_block_free(session, ref));
+        return (__wt_ref_block_free(session, ref, false));
 
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
@@ -199,7 +199,7 @@ __rec_child_deleted(
      * is ever a read into this part of the name space again, the cache read function instantiates
      * an entirely new page.)
      */
-    WT_RET(__wt_ref_block_free(session, ref));
+    WT_RET(__wt_ref_block_free(session, ref, false));
 
     /* Globally visible fast-truncate information is never used again, a NULL value is identical. */
     __wt_overwrite_and_free(session, ref->page_del);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2925,10 +2925,6 @@ __rec_split_discard(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (btree->type == BTREE_ROW)
             __wt_free(session, multi->key);
 
-        /*
-         * TODO: We need to tell the PALI interface this page is discarded. Mark it as invalid for
-         * now.
-         */
         multi->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
         __wt_free(session, multi->disk_image);
         __wt_free(session, multi->supd);
@@ -2942,7 +2938,7 @@ __rec_split_discard(WT_SESSION_IMPL *session, WT_PAGE *page)
          */
         if (multi->addr.block_cookie != NULL) {
             WT_RET(__wt_btree_block_free(
-              session, multi->addr.block_cookie, multi->addr.block_cookie_size));
+              session, multi->addr.block_cookie, multi->addr.block_cookie_size, false));
             __wt_free(session, multi->addr.block_cookie);
         }
     }
@@ -3088,6 +3084,9 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              *
              * The exception is root pages are never tracked or free'd, they
              * are checkpoints, and must be explicitly dropped.
+             *
+             * TODO: Does the root work for the same way in disagg? Do we need a separate API to
+             * tell the SLS to drop the checkpoint?
              */
         if (__wt_ref_is_root(ref))
             break;
@@ -3097,7 +3096,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
           r->multi->addr.block_cookie == NULL)
             break;
 
-        WT_RET(__wt_ref_block_free(session, ref));
+        WT_RET(__wt_ref_block_free(session, ref, r->multi_next == 1));
         break;
     case WT_PM_REC_EMPTY: /* Page deleted */
         break;
@@ -3113,10 +3112,13 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                              *
                              * The exception is root pages are never tracked or free'd, they are
                              * checkpoints, and must be explicitly dropped.
+                             *
+                             * TODO: Does the root work for the same way in disagg? Do we need a
+                             * separate API to tell the SLS to drop the checkpoint?
                              */
         if (!__wt_ref_is_root(ref))
-            WT_RET(__wt_btree_block_free(
-              session, mod->mod_replace.block_cookie, mod->mod_replace.block_cookie_size));
+            WT_RET(__wt_btree_block_free(session, mod->mod_replace.block_cookie,
+              mod->mod_replace.block_cookie_size, r->multi_next == 1));
 
         /* Discard the replacement page's address and disk image. */
         __wt_free(session, mod->mod_replace.block_cookie);
@@ -3144,12 +3146,6 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     switch (r->multi_next) {
     case 0: /* Page delete */
         WT_STAT_CONN_DSRC_INCR(session, rec_page_delete);
-
-        /*
-         * TODO: We need to tell the PALI interface this page is discarded. Mark it as invalid for
-         * now.
-         */
-        ref->page->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
         /*
          * If this is the root page, we need to create a sync point. For a page to be empty, it has
@@ -3327,7 +3323,7 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i)
         if (multi->addr.block_cookie != NULL)
             WT_TRET(__wt_btree_block_free(
-              session, multi->addr.block_cookie, multi->addr.block_cookie_size));
+              session, multi->addr.block_cookie, multi->addr.block_cookie_size, false));
 
     WT_TRET(__wti_ovfl_track_wrapup_err(session, page));
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3086,8 +3086,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              * The exception is root pages are never tracked or free'd, they
              * are checkpoints, and must be explicitly dropped.
              *
-             * TODO: Does the root work for the same way in disagg? Do we need a separate API to
-             * tell the SLS to drop the checkpoint?
+             * FIXME-WT-14700: Does the root work for the same way in disagg? Do we need a separate
+             * API to tell the SLS that we are discarding a root page?
              */
         if (__wt_ref_is_root(ref))
             break;
@@ -3114,8 +3114,9 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                              * The exception is root pages are never tracked or free'd, they are
                              * checkpoints, and must be explicitly dropped.
                              *
-                             * TODO: Does the root work for the same way in disagg? Do we need a
-                             * separate API to tell the SLS to drop the checkpoint?
+                             * FIXME-WT-14700: Does the root work for the same way in disagg? Do we
+                             * need a separate API to tell the SLS that we are discarding a root
+                             * page?
                              */
         if (!__wt_ref_is_root(ref))
             WT_RET(__wt_btree_block_free(session, mod->mod_replace.block_cookie,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2925,7 +2925,6 @@ __rec_split_discard(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (btree->type == BTREE_ROW)
             __wt_free(session, multi->key);
 
-        multi->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
         __wt_free(session, multi->disk_image);
         __wt_free(session, multi->supd);
 
@@ -2941,6 +2940,8 @@ __rec_split_discard(WT_SESSION_IMPL *session, WT_PAGE *page)
               session, multi->addr.block_cookie, multi->addr.block_cookie_size, false));
             __wt_free(session, multi->addr.block_cookie);
         }
+
+        multi->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
     }
     __wt_free(session, mod->mod_multi);
     mod->mod_multi_entries = 0;

--- a/test/suite/test_layered44.py
+++ b/test/suite/test_layered44.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+# test_layered44.py
+#    Ensure that we do not read any freed pages.
+@disagg_test_class
+class test_layered44(wttest.WiredTigerTestCase, DisaggConfigMixin):
+
+    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader"),' + \
+                  'verbose=[read:0,block:1],'
+
+    nitems = 10_000
+
+    table_name = 'test_layered44'
+    uri = "layered:" + table_name
+    stable_uri = "file:" + table_name + ".wt_stable"
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        extlist.extension('page_log', 'palm')
+
+    # Custom test case setup
+    def early_setup(self):
+        os.mkdir('follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+
+    # Test records into a layered tree and restarting
+    def test_layered44(self):
+        session_config = 'key_format=S,value_format=S'
+
+        # Ignore all verbose output messages, as we're using them in this test.
+        self.ignoreStdoutPattern("WT_VERB")
+
+        #
+        # Part 1: Create a layered table and a few checkpoints, and check the logged frees.
+        #
+
+        self.session.create(self.uri, session_config)
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            cursor["Key " + str(i)] = str(i)
+        cursor.close()
+
+        self.session.checkpoint()
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 2 == 0:
+                cursor["Key " + str(i)] = str(i) + "_even"
+        cursor.close()
+
+        self.session.checkpoint()
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 100 == 0:
+                cursor["Key " + str(i)] = str(i) + "_hundred"
+        cursor.close()
+
+        self.session.checkpoint()
+
+        # Get the stdout.txt file from the current working directory.
+        stdout_path = os.path.join(os.getcwd(), 'stdout.txt')
+        freed_pages = set()
+        with open(stdout_path, 'r') as file:
+            for line in file:
+                if "WT_VERB_BLOCK" not in line or "block free" not in line \
+                    or self.stable_uri not in line:
+                    continue
+                page_number = int(line.split('page_id')[1].split(',')[0].strip())
+                self.assertNotIn(page_number, freed_pages, f"Page {page_number} freed more than once")
+                freed_pages.add(page_number)
+        self.assertGreater(len(freed_pages), 0)
+
+        #
+        # Part 2: Open a follower, read the data, and check that we do not read any freed pages.
+        #
+
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +
+                                           'verbose=[read:1],' +
+                                           self.conn_base_config + "disaggregated=(role=\"follower\")")
+        self.disagg_advance_checkpoint(conn_follow)
+        session_follow = conn_follow.open_session('')
+
+        cursor_follow = session_follow.open_cursor(self.uri, None, None)
+        item_count = 0
+        while cursor_follow.next() == 0:
+            item_count += 1
+        self.assertEqual(item_count, self.nitems)
+        cursor_follow.close()
+
+        session_follow.close()
+        conn_follow.close()
+
+        num_pages_read = 0
+        with open(stdout_path, 'r') as file:
+            for line in file:
+                if "WT_VERB_READ" not in line or self.stable_uri not in line:
+                    continue
+                num_pages_read += 1
+                page_number = int(line.split('page_id')[1].split(',')[0].strip())
+                self.assertNotIn(page_number, freed_pages, f"Unexpected page read: {page_number}")
+        self.assertGreater(num_pages_read, 0)


### PR DESCRIPTION
The PR allows the disaggregated storage to use `WT_BM::free` for page discard:
* Added a `page_replacement` argument to `__wt_btree_block_free` and `__wt_ref_block_free` to indicate whether this is due to page replacement, in which case we would skip calling `free` for disagg.
* Added a test to ensure that we are not freeing a page that we need.

Most of the PR was done by @quchenhao.

This is a follow-up to #11992, hopefully with all the issues fixed.