### PR TITLE
WT-14204 Convert RTS related EBUSY messages into sub-level error code

### DIFF
--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -67,7 +67,7 @@ __rts_check(WT_SESSION_IMPL *session)
     if (cookie.ret_cursor_active) {
         ret = EBUSY;
         WT_TRET(__wt_verbose_dump_sessions(session, true));
-        WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active file cursors");
+        WT_RET_MSG(session, ret, "rollback_to_stable illegal with active file cursors");
     }
     if (cookie.ret_txn_active) {
         ret = EBUSY;

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -67,9 +67,8 @@ __rts_check(WT_SESSION_IMPL *session)
      */
     if (cookie.ret_cursor_active)
         WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active file cursors");
-    if (cookie.ret_txn_active) {
+    if (cookie.ret_txn_active)
         WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active transactions");
-    }
     return (0);
 }
 /*

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -17,19 +17,21 @@ static int
 __rts_check_callback(
   WT_SESSION_IMPL *session, WT_SESSION_IMPL *array_session, bool *exit_walkp, void *cookiep)
 {
+    WT_DECL_RET;
     WT_RTS_COOKIE *cookie;
 
     WT_UNUSED(session);
+    WT_UNUSED(exit_walkp);
     cookie = (WT_RTS_COOKIE *)cookiep;
 
     /* Check if a user session has a running transaction. */
     if (F_ISSET(array_session->txn, WT_TXN_RUNNING)) {
         cookie->ret_txn_active = true;
-        *exit_walkp = true;
+        WT_TRET(__wt_verbose_dump_txn(session));
     } else if (array_session->ncursors != 0) {
         /* Check if a user session has an active file cursor. */
         cookie->ret_cursor_active = true;
-        *exit_walkp = true;
+        WT_TRET(__wt_session_dump(session, array_session, true));
     }
     return (0);
 }
@@ -41,7 +43,6 @@ static int
 __rts_check(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_DECL_RET;
     WT_RTS_COOKIE cookie;
 
     WT_CLEAR(cookie);
@@ -67,9 +68,7 @@ __rts_check(WT_SESSION_IMPL *session)
     if (cookie.ret_cursor_active)
         WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active file cursors");
     if (cookie.ret_txn_active) {
-        ret = EBUSY;
-        WT_TRET(__wt_verbose_dump_txn(session));
-        WT_RET_MSG(session, ret, "rollback_to_stable illegal with active transactions");
+        WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active transactions");
     }
     return (0);
 }

--- a/test/suite/test_rollback_to_stable30.py
+++ b/test/suite/test_rollback_to_stable30.py
@@ -75,7 +75,7 @@ class test_rollback_to_stable30(wttest.WiredTigerTestCase):
         cursor.next()
 
         # Roll back to stable should fail because there's an active cursor.
-        msg = '/rollback_to_stable.*active/'
+        msg = '/rollback_to_stable illegal with active file cursors/'
         with self.expectedStdoutPattern('positioned cursors'):
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                     lambda:self.conn.rollback_to_stable('threads=' + str(self.threads)), msg)
@@ -90,8 +90,8 @@ class test_rollback_to_stable30(wttest.WiredTigerTestCase):
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(10))
 
         # Roll back to stable should fail because there's an active transaction.
-        msg = '/rollback_to_stable.*active/'
-        with self.expectedStdoutPattern('transaction state dump'):
+        msg = '/rollback_to_stable illegal with active transactions/'
+        with self.expectedStdoutPattern('transaction'):
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                 lambda:self.conn.rollback_to_stable('threads=' + str(self.threads)), msg)
 

--- a/test/suite/test_rollback_to_stable30.py
+++ b/test/suite/test_rollback_to_stable30.py
@@ -70,7 +70,7 @@ class test_rollback_to_stable30(wttest.WiredTigerTestCase):
             'oldest_timestamp=' + self.timestamp_str(1) +
             ',stable_timestamp=' + self.timestamp_str(1))
 
-        # Write some data and prepare it.
+        # Position a cursor
         cursor = self.session.open_cursor(ds.uri)
         cursor.next()
 
@@ -80,6 +80,7 @@ class test_rollback_to_stable30(wttest.WiredTigerTestCase):
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
                     lambda:self.conn.rollback_to_stable('threads=' + str(self.threads)), msg)
 
+        # Write some data and prepare it.
         self.session.begin_transaction()
 
         # Modify a row.

--- a/test/suite/test_rollback_to_stable30.py
+++ b/test/suite/test_rollback_to_stable30.py
@@ -70,7 +70,7 @@ class test_rollback_to_stable30(wttest.WiredTigerTestCase):
             'oldest_timestamp=' + self.timestamp_str(1) +
             ',stable_timestamp=' + self.timestamp_str(1))
 
-        # Position a cursor
+        # Position a cursor.
         cursor = self.session.open_cursor(ds.uri)
         cursor.next()
 


### PR DESCRIPTION
Adding more debugging information for situations where RTS is blocked by active cursors or transactions and returns an EBUSY error. With these changes, RTS will still return the EBUSY error, but it will also log details about all the active cursors and transactions that are causing the blockage.