### PR TITLE
WT-14643 Create TSAN metric script

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4207,7 +4207,7 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-            
+
             # Explicitly configure TSAN options.
             export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4199,13 +4199,6 @@ tasks:
           timeout_secs: 43200
       - func: "get project"
       - func: "compile wiredtiger"
-      - command: expansions.update
-        params:
-          updates:
-          - key: additional_env_vars
-            value: |
-              # We intentionally suppress all TSan warnings.
-              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
       - command: shell.exec
         params:
           working_dir: "wiredtiger/cmake_build"
@@ -4214,6 +4207,10 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
+            
+            # Explicitly configure TSAN options.
+            export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
+
             python3 ../test/evergreen/tsan_warnings_analysis.py
 
     ###############################

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1990,9 +1990,6 @@ tasks:
   - name: csuite-tests-fast
     tags: ["pull_request"]
     commands:
-      - command: timeout.update
-        params:
-          timeout_secs: 21600
       - func: "get project"
       - func: "compile wiredtiger"
       - func: "make check directory"
@@ -3504,9 +3501,6 @@ tasks:
 
   - name: format-smoke-test
     commands:
-      - command: timeout.update
-        params:
-          timeout_secs: 21600
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
@@ -4198,43 +4192,29 @@ tasks:
           collection: CodeModularityMetrics
 
   - name: tsan-warning-metrics
-    depends_on:
-    - name: ".unit_test"
-    - name: "format-test"
-    - name: "format-stress-pull-request-test"
-    - name: "format-smoke-test"
-    - name: "csuite-tests-fast"
     commands:
-      - func: "fetch artifacts"
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: csuite-tests-fast
-          destination: wiredtiger/csuite-tests-fast
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: format-test
-          destination: wiredtiger/format-test
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: format-stress-pull-request-test
-          destination: wiredtiger/format-stress-pull-request-test
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: format-smoke-test
-          destination: wiredtiger/format-smoke-test
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: unit-test
-          destination: wiredtiger/unit-test
+      - command: timeout.update
+        params:
+          exec_timeout_secs: 43200
+          timeout_secs: 43200
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - command: expansions.update
+        params:
+          updates:
+          - key: additional_env_vars
+            value: |
+              # We intentionally suppress all TSan warnings.
+              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
       - command: shell.exec
         params:
-          working_dir: "wiredtiger"
+          working_dir: "wiredtiger/cmake_build"
           shell: bash
           script: |
             set -o errexit
             set -o verbose
-            ${PREPARE_PATH}
-            python3 test/evergreen/tsan_warnings_analysis.py
+            ${PREPARE_TEST_ENV}
+            python3 ../test/evergreen/tsan_warnings_analysis.py
 
     ###############################
     # Performance Tests for btree #
@@ -5570,7 +5550,7 @@ buildvariants:
     data_validation_stress_test_args: -t r -m -W 3 -D -p -n 100000 -k 100000 -C cache_size=100MB
     additional_env_vars: |
       # We intentionally suppress all TSan warnings.
-      export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp:exitcode=0:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
+      export TSAN_OPTIONS="detect_deadlocks=0:report_bugs=0:report_atomic_races=0:allocator_may_return_null=1"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     # We don't run C++ memory sanitized testing as it creates false positives. TSan also significantly increases the runtime
     # of some csuite tests, so disable the already long tests as well as tests heavily impacted by TSan.
@@ -5588,7 +5568,6 @@ buildvariants:
     - name: configure-combinations
     - name: syscall-linux
     - name: checkpoint-filetypes-test
-    - name: unit-test
     - name: unit-test-zstd
     - name: unit-test-random-seed
     - name: unit-test-hook-timestamp

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4208,9 +4208,6 @@ tasks:
             set -o verbose
             ${PREPARE_TEST_ENV}
 
-            # Explicitly configure TSAN options.
-            export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
-
             python3 ../test/evergreen/tsan_warnings_analysis.py
 
     ###############################

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5531,6 +5531,7 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: examples-c-tsan
+    - name: tsan-warning-metrics
 
 # FIXME-WT-13256
 # This variant runs all possible tasks under TSan but instructs TSan to not report any issues it
@@ -5580,7 +5581,6 @@ buildvariants:
     - name: catch2-test
     - name: bench-tiered-push-pull
     - name: catch2-assertions
-    - name: tsan-warning-metrics
 
 # Very minimal set without any extensions
 - name: ubuntu2004-minimal

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4193,10 +4193,6 @@ tasks:
 
   - name: tsan-warning-metrics
     commands:
-      - command: timeout.update
-        params:
-          exec_timeout_secs: 43200
-          timeout_secs: 43200
       - func: "get project"
       - func: "compile wiredtiger"
       - command: shell.exec

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1990,6 +1990,9 @@ tasks:
   - name: csuite-tests-fast
     tags: ["pull_request"]
     commands:
+      - command: timeout.update
+        params:
+          timeout_secs: 21600
       - func: "get project"
       - func: "compile wiredtiger"
       - func: "make check directory"
@@ -3501,6 +3504,9 @@ tasks:
 
   - name: format-smoke-test
     commands:
+      - command: timeout.update
+        params:
+          timeout_secs: 21600
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
@@ -4190,6 +4196,45 @@ tasks:
           stats_dir: ./wiredtiger
           test-name: modularity_metrics
           collection: CodeModularityMetrics
+
+  - name: tsan-warning-metrics
+    depends_on:
+    - name: ".unit_test"
+    - name: "format-test"
+    - name: "format-stress-pull-request-test"
+    - name: "format-smoke-test"
+    - name: "csuite-tests-fast"
+    commands:
+      - func: "fetch artifacts"
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: csuite-tests-fast
+          destination: wiredtiger/csuite-tests-fast
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: format-test
+          destination: wiredtiger/format-test
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: format-stress-pull-request-test
+          destination: wiredtiger/format-stress-pull-request-test
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: format-smoke-test
+          destination: wiredtiger/format-smoke-test
+      - func: "fetch artifacts"
+        vars:
+          dependent_task: unit-test
+          destination: wiredtiger/unit-test
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_PATH}
+            python3 test/evergreen/tsan_warnings_analysis.py
 
     ###############################
     # Performance Tests for btree #
@@ -5525,7 +5570,7 @@ buildvariants:
     data_validation_stress_test_args: -t r -m -W 3 -D -p -n 100000 -k 100000 -C cache_size=100MB
     additional_env_vars: |
       # We intentionally suppress all TSan warnings.
-      export TSAN_OPTIONS="detect_deadlocks=0:report_bugs=0:report_atomic_races=0:allocator_may_return_null=1"
+      export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp:exitcode=0:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     # We don't run C++ memory sanitized testing as it creates false positives. TSan also significantly increases the runtime
     # of some csuite tests, so disable the already long tests as well as tests heavily impacted by TSan.
@@ -5543,6 +5588,7 @@ buildvariants:
     - name: configure-combinations
     - name: syscall-linux
     - name: checkpoint-filetypes-test
+    - name: unit-test
     - name: unit-test-zstd
     - name: unit-test-random-seed
     - name: unit-test-hook-timestamp
@@ -5555,6 +5601,7 @@ buildvariants:
     - name: catch2-test
     - name: bench-tiered-push-pull
     - name: catch2-assertions
+    - name: tsan-warning-metrics
 
 # Very minimal set without any extensions
 - name: ubuntu2004-minimal

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5522,6 +5522,7 @@ buildvariants:
   tasks:
     - name: examples-c-tsan
     - name: tsan-warning-metrics
+      batchtime: 10080 # 7 days
 
 # FIXME-WT-13256
 # This variant runs all possible tasks under TSan but instructs TSan to not report any issues it

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4203,7 +4203,6 @@ tasks:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-
             python3 ../test/evergreen/tsan_warnings_analysis.py
 
     ###############################

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -30,7 +30,7 @@ import re, subprocess
 # The script intends to generate warnings from WiredTiger's examples, csuite, python and test/format testing.
 #
 # Running the whole suite causes enormous number of TSAN warnings. The amount of I/O causes slowness in the
-# system leading to non-deterministic results. For now, run only the examples suite.
+# system leading to non-deterministic results. To ensure deterministic results run with only examples suite.
 
 # Configure log path in TSAN options.
 os.environ["TSAN_OPTIONS"] = "$TSAN_OPTIONS:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
@@ -41,6 +41,7 @@ test_tasks = [
 ]
 
 # Run the tasks in list.
+print("Tasks to be executed")
 print(test_tasks)
 for task in test_tasks:
     try:
@@ -68,5 +69,6 @@ for tsan_log in os.listdir(".."):
 
                 tsan_warnings_set.add(cleaned_text)
 
+print("Unique warnings:")
 print("\n".join(tsan_warnings_set))
 print(f"Overall TSAN Warnings: {len(tsan_warnings_set)}")

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -25,9 +25,9 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-import os
+import os, sys
 import re, subprocess
-# The script generate warnings from running WiredTiger's examples, csuite, python and test/format testing.
+# The script intends to generate warnings from WiredTiger's examples, csuite, python and test/format testing.
 #
 # Running the whole suite causes enormous number of TSAN warnings. The amount of I/O causes slowness in the
 # system leading to non-deterministic results. For now, run only the examples suite.
@@ -50,6 +50,7 @@ for task in test_tasks:
         print(f'Command {exception.cmd} failed with error {exception.returncode}')
     except subprocess.TimeoutExpired as exception:
         print(f'Command {exception.cmd} timed out')
+        sys.exit(1)
 
 # Loop through all subdirectories recursively and search tsan logs.
 tsan_warnings_set = set()

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -34,7 +34,8 @@ import re, subprocess
 
 # Configure log path in TSAN options.
 current_dir = os.getcwd()
-os.environ["TSAN_OPTIONS"] = f"$TSAN_OPTIONS:log_path={current_dir}/tsan_logs"
+existing_tsan_options = os.environ.get("TSAN_OPTIONS")
+os.environ["TSAN_OPTIONS"] = f"{existing_tsan_options}:log_path={current_dir}/tsan_logs"
 
 # Start with examples suite.
 test_tasks = [

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -40,7 +40,7 @@ for task in test_tasks:
     try:
         split_command = task.split()
         # Tasks are allowed to run with maximum of three hours.
-        subprocess.run(split_command, check=True, timeout=10800)
+        subprocess.run(split_command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10800)
     except subprocess.CalledProcessError as exception:
         print(f'Command {exception.cmd} failed with error {exception.returncode}')
     except subprocess.TimeoutExpired as exception:

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -29,7 +29,7 @@ import os
 import re, subprocess
 test_tasks = [
     "python3 ../test/suite/run.py -j 8 --ignore-stdout",
-    "ctest --test-dir test/csuite  -j 8 -LE \"long_running\"",
+    "ctest -j 8 -LE \"long_running\"",
     "bash test/format/format.sh -j 8 -t 60 rows=10000 ops=50000"
   ]
 

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+import os
+import re
+# This script must be run from WT root directory or may lead to inconsistent results.
+
+# Loop through all subdirectories recursively and search tsan logs. 
+tsan_warnings_set = set()
+for dirpath, _, filenames in os.walk("."):  
+    for filename in filenames:  
+        # Check if the file starts with "tsan."  
+        if filename.startswith("tsan."):
+            full_path = os.path.join(dirpath, filename)  
+            with open(full_path, "r") as file:
+                for line in file:
+                    if (not line.startswith("SUMMARY:")):
+                        continue
+                    # Strip away the unnecessary information
+                    pattern_to_remove = r"/data/mci/.*/wiredtiger/"  
+                    cleaned_text = re.sub(pattern_to_remove, "", line).strip() 
+
+                    tsan_warnings_set.add(cleaned_text)
+
+print("\n".join(tsan_warnings_set)) 
+print(f"Overall TSAN Warnings: {len(tsan_warnings_set)}")

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -52,7 +52,7 @@ for task in test_tasks:
         print(f'Command {exception.cmd} timed out')
         sys.exit(1)
 
-# Loop through all subdirectories recursively and search tsan logs.
+# Loop through WT root directory and search for tsan logs.
 tsan_warnings_set = set()
 for tsan_log in os.listdir(".."):
     # Check if the file starts with "tsan."

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -33,7 +33,8 @@ import re, subprocess
 # system leading to non-deterministic results. To ensure deterministic results run with only examples suite.
 
 # Configure log path in TSAN options.
-os.environ["TSAN_OPTIONS"] = "$TSAN_OPTIONS:log_path=$(git rev-parse --show-toplevel)/tsan_logs"
+current_dir = os.getcwd()
+os.environ["TSAN_OPTIONS"] = f"$TSAN_OPTIONS:log_path={current_dir}/tsan_logs"
 
 # Start with examples suite.
 test_tasks = [
@@ -55,11 +56,10 @@ for task in test_tasks:
 
 # Loop through WT root directory and search for tsan logs.
 tsan_warnings_set = set()
-for tsan_log in os.listdir(".."):
+for tsan_log in os.listdir(current_dir):
     # Check if the file starts with "tsan."
     if tsan_log.startswith("tsan"):
-        full_path = os.path.join("..", tsan_log)
-        with open(full_path, "r") as file:
+        with open(tsan_log, "r") as file:
             for line in file:
                 if (not line.startswith("SUMMARY:")):
                     continue

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -35,7 +35,7 @@ import re, subprocess
 # Configure log path in TSAN options.
 current_dir = os.getcwd()
 existing_tsan_options = os.environ.get("TSAN_OPTIONS")
-os.environ["TSAN_OPTIONS"] = f"{existing_tsan_options}:log_path={current_dir}/tsan_logs"
+os.environ["TSAN_OPTIONS"] = f"{existing_tsan_options}:log_path={current_dir}/tsan_logs:exitcode=0"
 
 # Start with examples suite.
 test_tasks = [
@@ -58,7 +58,7 @@ for task in test_tasks:
 # Loop through WT root directory and search for tsan logs.
 tsan_warnings_set = set()
 for tsan_log in os.listdir(current_dir):
-    # Check if the file starts with "tsan."
+    # Check if the file starts with "tsan"
     if tsan_log.startswith("tsan"):
         with open(tsan_log, "r") as file:
             for line in file:


### PR DESCRIPTION
The pull request adds a new TSAN metric script which outputs an estimated number of TSAN warnings. Here are technical details of the script:
- Runs csuite, python and test/format test script
- Ignore any errors encountered during these tests
- Has a maximum timeout of up to 3 hours

The csuite and python tests may take too long (+6 hours each). This can be attributed to slow down of running under TSAN or heavy I/O output due to TSAN warnings + test output. Therefore the final TSAN warning number is **not accurate and final**. I would imagine as we fix more and more TSAN warnings, we will be able to run more tests and reveal more TSAN warnings.