### PR TITLE
WT-14753 Check a filename argument content before opening a block manager

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -178,6 +178,8 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
 
     *blockp = NULL;
 
+    WT_ASSERT(session, filename != NULL);
+
     __wt_verbose(session, WT_VERB_BLOCK, "open: %s", filename);
 
     block = NULL;

--- a/src/block_disagg/block_disagg_open.c
+++ b/src/block_disagg/block_disagg_open.c
@@ -79,6 +79,8 @@ __wti_block_disagg_open(WT_SESSION_IMPL *session, const char *filename, const ch
     *blockp = NULL;
     block_disagg = NULL;
 
+    WT_ASSERT(session, filename != NULL);
+
     __wt_verbose(session, WT_VERB_BLOCK, "open: %s", filename);
 
     conn = S2C(session);


### PR DESCRIPTION
This change was inspired by a coverity report which highlighted that passing NULL as the `filename` argument could lead to a NULL dereference. While it is not really dangerous since it would simply fail later, it's still worth adding an assertion to make the reason of failure clearer and more meaningful.
