### PR TITLE
WT-14657 Track stats for oldest id rollback due to cache stuck ( #11986) (v8.1 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -762,6 +762,7 @@ conn_stats = [
     TxnStat('txn_prepared_updates_rolledback', 'Number of prepared updates rolled back'),
     TxnStat('txn_query_ts', 'query timestamp calls'),
     TxnStat('txn_rollback', 'transactions rolled back'),
+    TxnStat('txn_rollback_oldest_id', 'oldest transaction ID rolled back for eviction'),
     TxnStat('txn_rollback_oldest_pinned', 'oldest pinned transaction ID rolled back for eviction'),
     TxnStat('txn_rollback_to_stable_running', 'transaction rollback to stable currently running', 'no_clear,no_scale'),
     TxnStat('txn_rts', 'rollback to stable calls'),

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2862,10 +2862,9 @@ __wti_evict_app_assist_worker(
             ret = __wt_txn_is_blocking(session);
             if (ret == WT_ROLLBACK) {
                 __wt_atomic_decrement_if_positive(&evict->evict_aggressive_score);
-
-                WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
-                __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
-                  session->txn->rollback_reason);
+                if (F_ISSET(session, WT_SESSION_SAVE_ERRORS))
+                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
+                      session->err_info.err_msg);
             }
             WT_ERR(ret);
         }

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1077,6 +1077,7 @@ struct __wt_connection_stats {
     int64_t txn_read_race_prepare_commit;
     int64_t txn_read_overflow_remove;
     int64_t txn_rollback_oldest_pinned;
+    int64_t txn_rollback_oldest_id;
     int64_t txn_prepare;
     int64_t txn_prepare_commit;
     int64_t txn_prepare_active;

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -23,6 +23,8 @@
  */
 #define WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW "transaction rolled back because of cache overflow"
 #define WT_TXN_ROLLBACK_REASON_CONFLICT "conflict between concurrent operations"
+#define WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION \
+    "oldest pinned transaction ID rolled back for eviction"
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_TXN_LOG_CKPT_CLEANUP 0x01u

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -23,8 +23,6 @@
  */
 #define WT_TXN_ROLLBACK_REASON_CACHE_OVERFLOW "transaction rolled back because of cache overflow"
 #define WT_TXN_ROLLBACK_REASON_CONFLICT "conflict between concurrent operations"
-#define WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION \
-    "oldest pinned transaction ID rolled back for eviction"
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_TXN_LOG_CKPT_CLEANUP 0x01u

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7027,145 +7027,147 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! transaction: number of times overflow removed value is read */
 #define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1663
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1720
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1664
+/*! transaction: oldest transaction ID rolled back for eviction */
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1665
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1721
+#define	WT_STAT_CONN_TXN_PREPARE			1666
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1722
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1667
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1723
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1668
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1724
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1669
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1725
+#define	WT_STAT_CONN_TXN_QUERY_TS			1670
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1726
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1671
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1727
+#define	WT_STAT_CONN_TXN_RTS				1672
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1728
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1673
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1729
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1674
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1730
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1675
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1731
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1676
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1732
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1677
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1733
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1678
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1734
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1679
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1735
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1680
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1736
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1681
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1737
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1682
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1738
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1683
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1739
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1684
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1740
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1685
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1741
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1686
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1742
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1687
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1743
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1688
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1744
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1689
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1745
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1690
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1746
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1691
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1747
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1692
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1748
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1693
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1749
+#define	WT_STAT_CONN_TXN_SET_TS				1694
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1750
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1695
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1751
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1696
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1752
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1697
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1753
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1698
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1754
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1699
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1755
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1700
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1756
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1701
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1757
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1702
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1758
+#define	WT_STAT_CONN_TXN_BEGIN				1703
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1759
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1704
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1760
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1705
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1761
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1706
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1762
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1707
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1763
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1708
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1764
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1709
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1765
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1710
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1766
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1711
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1767
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1712
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1768
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1713
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1769
+#define	WT_STAT_CONN_TXN_COMMIT				1714
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1770
+#define	WT_STAT_CONN_TXN_ROLLBACK			1715
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1771
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1716
 
 /*!
  * @}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7027,145 +7027,145 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! transaction: number of times overflow removed value is read */
 #define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1663
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1664
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1720
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1665
+#define	WT_STAT_CONN_TXN_PREPARE			1721
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1666
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1722
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1667
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1723
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1668
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1724
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1669
+#define	WT_STAT_CONN_TXN_QUERY_TS			1725
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1670
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1726
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1671
+#define	WT_STAT_CONN_TXN_RTS				1727
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1672
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1728
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1673
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1729
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1674
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1730
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1675
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1731
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1676
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1732
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1677
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1733
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1678
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1734
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1679
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1735
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1680
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1736
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1681
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1737
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1682
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1738
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1683
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1739
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1684
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1740
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1685
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1741
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1686
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1742
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1687
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1743
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1688
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1744
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1689
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1745
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1690
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1746
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1691
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1747
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1692
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1748
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1693
+#define	WT_STAT_CONN_TXN_SET_TS				1749
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1694
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1750
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1695
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1751
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1696
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1752
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1697
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1753
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1698
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1754
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1699
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1755
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1700
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1756
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1701
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1757
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1702
+#define	WT_STAT_CONN_TXN_BEGIN				1758
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1703
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1759
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1704
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1760
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1705
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1761
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1706
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1762
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1707
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1763
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1708
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1764
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1709
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1765
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1710
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1766
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1711
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1767
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1712
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1768
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1713
+#define	WT_STAT_CONN_TXN_COMMIT				1769
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1714
+#define	WT_STAT_CONN_TXN_ROLLBACK			1770
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1715
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1771
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2004,6 +2004,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: a reader raced with a prepared transaction commit and skipped an update or updates",
   "transaction: number of times overflow removed value is read",
   "transaction: oldest pinned transaction ID rolled back for eviction",
+  "transaction: oldest transaction ID rolled back for eviction",
   "transaction: prepared transactions",
   "transaction: prepared transactions committed",
   "transaction: prepared transactions currently active",
@@ -2766,6 +2767,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->txn_read_race_prepare_commit = 0;
     stats->txn_read_overflow_remove = 0;
     stats->txn_rollback_oldest_pinned = 0;
+    stats->txn_rollback_oldest_id = 0;
     stats->txn_prepare = 0;
     stats->txn_prepare_commit = 0;
     stats->txn_prepare_active = 0;
@@ -3611,6 +3613,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_read_race_prepare_commit += WT_STAT_CONN_READ(from, txn_read_race_prepare_commit);
     to->txn_read_overflow_remove += WT_STAT_CONN_READ(from, txn_read_overflow_remove);
     to->txn_rollback_oldest_pinned += WT_STAT_CONN_READ(from, txn_rollback_oldest_pinned);
+    to->txn_rollback_oldest_id += WT_STAT_CONN_READ(from, txn_rollback_oldest_id);
     to->txn_prepare += WT_STAT_CONN_READ(from, txn_prepare);
     to->txn_prepare_commit += WT_STAT_CONN_READ(from, txn_prepare_commit);
     to->txn_prepare_active += WT_STAT_CONN_READ(from, txn_prepare_active);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2691,7 +2691,6 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
 int
 __wt_txn_is_blocking(WT_SESSION_IMPL *session)
 {
-    WT_DECL_RET;
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     uint64_t global_oldest;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2728,9 +2728,13 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     /*
      * Check if either the transaction's ID or its pinned ID is equal to the oldest transaction ID.
      */
-    if (__wt_atomic_loadv64(&txn_shared->id) == global_oldest ||
+    bool is_txn_id_global_oldest;
+    if (((is_txn_id_global_oldest = __wt_atomic_loadv64(&txn_shared->id) == global_oldest)) ||
       __wt_atomic_loadv64(&txn_shared->pinned_id) == global_oldest) {
-        ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
+        if (is_txn_id_global_oldest)
+            WT_STAT_CONN_INCR(session, txn_rollback_oldest_id);
+        else
+            WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
         WT_RET_SUB(
           session, ret, WT_OLDEST_FOR_EVICTION, "Transaction has the oldest pinned transaction ID");
     }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2691,6 +2691,7 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
 int
 __wt_txn_is_blocking(WT_SESSION_IMPL *session)
 {
+    WT_DECL_RET;
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     uint64_t global_oldest;
@@ -2730,12 +2731,13 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     bool is_txn_id_global_oldest;
     if (((is_txn_id_global_oldest = __wt_atomic_loadv64(&txn_shared->id) == global_oldest)) ||
       __wt_atomic_loadv64(&txn_shared->pinned_id) == global_oldest) {
+        ret = __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
         if (is_txn_id_global_oldest)
             WT_STAT_CONN_INCR(session, txn_rollback_oldest_id);
         else
             WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
         WT_RET_SUB(
-          session, WT_ROLLBACK, WT_OLDEST_FOR_EVICTION, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
+          session, ret, WT_OLDEST_FOR_EVICTION, "Transaction has the oldest pinned transaction ID");
     }
     return (0);
 }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2735,7 +2735,7 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
         else
             WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
         WT_RET_SUB(
-          session, ret, WT_OLDEST_FOR_EVICTION, "Transaction has the oldest pinned transaction ID");
+          session, WT_ROLLBACK, WT_OLDEST_FOR_EVICTION, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
     }
     return (0);
 }


### PR DESCRIPTION
This is [BACKPORT-25241](https://jira.mongodb.org/browse/BACKPORT-25241) that adds [WT-14657](https://jira.mongodb.org/browse/WT-14657) to mongodb 8.1