### PR TITLE
WT-14762 Updated seed generation to ensure variability across runs in test/format

### DIFF
--- a/test/utility/util_random.c
+++ b/test/utility/util_random.c
@@ -98,7 +98,7 @@ testutil_random_init(WT_RAND_STATE *rnd, uint64_t *seedp, uint32_t n)
          * time on some systems, and that leaves us with the same random seed. So we factor in a "n"
          * value from the caller to get up to 4 different random seeds.
          */
-        __wt_random_init_default(rnd);
+        __wt_random_init(NULL, rnd);
         shift = 8 * (n % 4);
         *seedp = ((rnd->v >> shift) & 0xffffff);
     }


### PR DESCRIPTION
While reviewing test behaviour in test/format, I discovered that the seed used for random generation was accidentally being set to the same value on every run. As a result, the test was producing identical random patterns each time, defeating the purpose of randomised coverage.

**Fix:**
Updated seed generation to ensure variability across runs.