### PR TITLE
WT-13209 Dead code in __wt_timing_stress_sleep_random

### DIFF
--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -254,8 +254,6 @@ __wt_timing_stress_sleep_random(WT_SESSION_IMPL *session)
         max = 5;
     else
         max = 9;
-    if (pct > 100.0)
-        return;
 
     /*
      * We need a fast way to choose a sleep time. We want to sleep a short period most of the time,


### PR DESCRIPTION
Removing dead code since the value for pct is 100.0 max, the check is not needed.