### PR TITLE
WT-14123 Delete the ARMv8 performance build variants in evergreen.yml

### DIFF
--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -43,15 +43,6 @@ buildvariants:
     collection: AllPerfTests
 
 - <<: *perf-tasks-template
-  name: ubuntu2004-perf-tests-arm64
-  display_name: Ubuntu 20.04 Performance tests (ARM64)
-  run_on:
-    - ubuntu2004-arm64-perf-testing
-  expansions:
-    <<: *ubuntu2004-perf-tests-expansions-template
-    collection: AllPerfTestsARM64
-
-- <<: *perf-tasks-template
   name: amazon2023-perf-tests-arm64
   display_name: (ARMV9) Amazon Linux 2023 Performance tests (ARM64)
   run_on:


### PR DESCRIPTION
Removed the ARM V8 perf tests, as we now have perf tests running on ARM v9.

Other (non-perf) ARM V8 tests that are no longer required because they are now running on ARM  V9 will be removed by WT-14124.

