### PR TITLE
WT-14793 Track metrics when we are looping in evict_app_assist_worker

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -3027,8 +3027,8 @@ err:
  * __wt_evict_page_urgent --
  *     Push a page into the urgent eviction queue.
  *
- *     It is called by the eviction server if pages require immediate eviction or by the
- * application threads as part of forced eviction when directly evicting pages is not feasible.
+ *     It is called by the eviction server if pages require immediate eviction or by the application
+ *     threads as part of forced eviction when directly evicting pages is not feasible.
  *
  *     Input parameters:
  *       `ref`: A reference to the page that is being added to the urgent eviction queue.
@@ -3107,13 +3107,13 @@ done:
 
 /* !!!
  * __wt_evict_priority_set --
- *     Set a tree's eviction priority. A higher priority indicates less likelihood for the tree
- * to be considered for eviction. The eviction server skips the eviction of trees with a
- * non-zero priority unless eviction is in an aggressive state and the Btree is significantly
- * utilizing the cache.
+ *     Set a tree's eviction priority. A higher priority indicates less likelihood for the tree to
+ *     be considered for eviction. The eviction server skips the eviction of trees with a non-
+ *     zero priority unless eviction is in an aggressive state and the Btree is significantly
+ *     utilizing the cache.
  *
- *     At present, it is exclusively called for metadata and bloom filter files, as these are
- * meant to be retained in the cache.
+ *     At present, it is exclusively called for metadata and bloom filter files, as these are meant
+ *     to be retained in the cache.
  *
  *     Input parameter:
  *       `v`: An integer that denotes the priority level.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2927,6 +2927,26 @@ __wti_evict_app_assist_worker(
                 break;
         }
 
+        /* Update cache metrics if we are stalling to detect a timeout quicker.*/
+        if (time_start != 0) {
+            uint64_t time_stop = __wt_clock(session);
+            uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
+            WT_STAT_CONN_INCR(session, application_cache_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
+            if (!interruptible) {
+                WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
+                WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
+                WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
+            } else {
+                WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
+                WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
+                WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
+            }
+            session->cache_wait_us += elapsed;
+            time_start = time_stop;
+        }
+
         /*
          * Check if we have become busy.
          *
@@ -3007,8 +3027,8 @@ err:
  * __wt_evict_page_urgent --
  *     Push a page into the urgent eviction queue.
  *
- *     It is called by the eviction server if pages require immediate eviction or by the application
- *     threads as part of forced eviction when directly evicting pages is not feasible.
+ *     It is called by the eviction server if pages require immediate eviction or by the
+ * application threads as part of forced eviction when directly evicting pages is not feasible.
  *
  *     Input parameters:
  *       `ref`: A reference to the page that is being added to the urgent eviction queue.
@@ -3087,13 +3107,13 @@ done:
 
 /* !!!
  * __wt_evict_priority_set --
- *     Set a tree's eviction priority. A higher priority indicates less likelihood for the tree to
- *     be considered for eviction. The eviction server skips the eviction of trees with a non-zero
- *     priority unless eviction is in an aggressive state and the Btree is significantly utilizing
- *     the cache.
+ *     Set a tree's eviction priority. A higher priority indicates less likelihood for the tree
+ * to be considered for eviction. The eviction server skips the eviction of trees with a
+ * non-zero priority unless eviction is in an aggressive state and the Btree is significantly
+ * utilizing the cache.
  *
- *     At present, it is exclusively called for metadata and bloom filter files, as these are meant
- *     to be retained in the cache.
+ *     At present, it is exclusively called for metadata and bloom filter files, as these are
+ * meant to be retained in the cache.
  *
  *     Input parameter:
  *       `v`: An integer that denotes the priority level.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -3108,9 +3108,9 @@ done:
 /* !!!
  * __wt_evict_priority_set --
  *     Set a tree's eviction priority. A higher priority indicates less likelihood for the tree to
- *     be considered for eviction. The eviction server skips the eviction of trees with a non-
- *     zero priority unless eviction is in an aggressive state and the Btree is significantly
- *     utilizing the cache.
+ *     be considered for eviction. The eviction server skips the eviction of trees with a non-zero
+ *     priority unless eviction is in an aggressive state and the Btree is significantly utilizing
+ *     the cache.
  *
  *     At present, it is exclusively called for metadata and bloom filter files, as these are meant
  *     to be retained in the cache.

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2927,6 +2927,26 @@ __wti_evict_app_assist_worker(
                 break;
         }
 
+        /* Update cache metrics if we are stalling to detect a timeout quicker.*/
+        if (time_start != 0) {
+            uint64_t time_stop = __wt_clock(session);
+            uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
+            WT_STAT_CONN_INCR(session, application_cache_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
+            if (!interruptible) {
+                WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
+                WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
+                WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
+            } else {
+                WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
+                WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
+                WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
+            }
+            session->cache_wait_us += elapsed;
+            time_start = time_stop;
+        }
+
         /*
          * Check if we have become busy.
          *
@@ -2962,14 +2982,25 @@ __wti_evict_app_assist_worker(
             evict->app_waits++;
         } else if (ret != EBUSY)
             WT_ERR(ret);
-
-        /* Update cache metrics if we are stalling to detect a timeout quicker.*/
-        time_start = __update_cache_metrics(session, time_start, interruptible);
     }
 
 err:
     if (time_start != 0) {
-        time_start = __update_cache_metrics(session, time_start, interruptible);
+        uint64_t time_stop = __wt_clock(session);
+        uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
+        WT_STAT_CONN_INCR(session, application_cache_ops);
+        WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
+        WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
+        if (!interruptible) {
+            WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
+        } else {
+            WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
+        }
+        session->cache_wait_us += elapsed;
         /*
          * Check if a rollback is required only if there has not been an error. Returning an error
          * takes precedence over asking for a rollback. We can not do both.
@@ -3102,43 +3133,6 @@ void
 __wt_evict_priority_clear(WT_SESSION_IMPL *session)
 {
     S2BT(session)->evict_priority = 0;
-}
-
-/*
- * __update_cache_metrics --
- *     Update the cache metrics.
- */
-int
-__update_cache_metrics(WT_SESSION_IMPL *session, uint64_t time_start, bool interruptible)
-{
-    if (time_start != 0) {
-        uint64_t time_stop = __wt_clock(session);
-        uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
-
-        WT_STAT_CONN_INCR(session, application_cache_ops);
-        WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
-        WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
-
-        if (!interruptible) {
-            /* Handle uninterruptible operations. */
-            WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
-            WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
-            WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
-        } else {
-            /* Handle interruptible operations. */
-            WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
-            WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
-            WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
-        }
-
-        /* Update session cache wait time. */
-        session->cache_wait_us += elapsed;
-
-        /* Return the updated time_stop to the caller for reuse. */
-        return (time_stop);
-    }
-    /* No update if time_start is 0. */
-    return (time_start);
 }
 
 /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2927,26 +2927,6 @@ __wti_evict_app_assist_worker(
                 break;
         }
 
-        /* Update cache metrics if we are stalling to detect a timeout quicker.*/
-        if (time_start != 0) {
-            uint64_t time_stop = __wt_clock(session);
-            uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
-            WT_STAT_CONN_INCR(session, application_cache_ops);
-            WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
-            WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
-            if (!interruptible) {
-                WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
-                WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
-                WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
-            } else {
-                WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
-                WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
-                WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
-            }
-            session->cache_wait_us += elapsed;
-            time_start = time_stop;
-        }
-
         /*
          * Check if we have become busy.
          *
@@ -2982,25 +2962,14 @@ __wti_evict_app_assist_worker(
             evict->app_waits++;
         } else if (ret != EBUSY)
             WT_ERR(ret);
+
+        /* Update cache metrics if we are stalling to detect a timeout quicker.*/
+        time_start = __update_cache_metrics(session, time_start, interruptible);
     }
 
 err:
     if (time_start != 0) {
-        uint64_t time_stop = __wt_clock(session);
-        uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
-        WT_STAT_CONN_INCR(session, application_cache_ops);
-        WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
-        WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
-        if (!interruptible) {
-            WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
-            WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
-            WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
-        } else {
-            WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
-            WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
-            WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
-        }
-        session->cache_wait_us += elapsed;
+        time_start = __update_cache_metrics(session, time_start, interruptible);
         /*
          * Check if a rollback is required only if there has not been an error. Returning an error
          * takes precedence over asking for a rollback. We can not do both.
@@ -3133,6 +3102,43 @@ void
 __wt_evict_priority_clear(WT_SESSION_IMPL *session)
 {
     S2BT(session)->evict_priority = 0;
+}
+
+/*
+ * __update_cache_metrics --
+ *     Update the cache metrics.
+ */
+int
+__update_cache_metrics(WT_SESSION_IMPL *session, uint64_t time_start, bool interruptible)
+{
+    if (time_start != 0) {
+        uint64_t time_stop = __wt_clock(session);
+        uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
+
+        WT_STAT_CONN_INCR(session, application_cache_ops);
+        WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
+        WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
+
+        if (!interruptible) {
+            /* Handle uninterruptible operations. */
+            WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
+        } else {
+            /* Handle interruptible operations. */
+            WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
+            WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
+            WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
+        }
+
+        /* Update session cache wait time. */
+        session->cache_wait_us += elapsed;
+
+        /* Return the updated time_stop to the caller for reuse. */
+        return (time_stop);
+    }
+    /* No update if time_start is 0. */
+    return (time_start);
 }
 
 /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2927,26 +2927,6 @@ __wti_evict_app_assist_worker(
                 break;
         }
 
-        /* Update cache metrics if we are stalling to detect a timeout quicker.*/
-        if (time_start != 0) {
-            uint64_t time_stop = __wt_clock(session);
-            uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
-            WT_STAT_CONN_INCR(session, application_cache_ops);
-            WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
-            WT_STAT_SESSION_INCRV(session, cache_time, elapsed);
-            if (!interruptible) {
-                WT_STAT_CONN_INCR(session, application_cache_uninterruptible_ops);
-                WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
-                WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
-            } else {
-                WT_STAT_CONN_INCR(session, application_cache_interruptible_ops);
-                WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
-                WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
-            }
-            session->cache_wait_us += elapsed;
-            time_start = time_stop;
-        }
-
         /*
          * Check if we have become busy.
          *
@@ -2982,6 +2962,22 @@ __wti_evict_app_assist_worker(
             evict->app_waits++;
         } else if (ret != EBUSY)
             WT_ERR(ret);
+
+        /* Update elapsed cache metrics. */
+        if (time_start != 0) {
+            uint64_t time_stop = __wt_clock(session);
+            uint64_t elapsed = WT_CLOCKDIFF_US(time_stop, time_start);
+            WT_STAT_CONN_INCRV(session, application_cache_time, elapsed);
+            if (!interruptible) {
+                WT_STAT_CONN_INCRV(session, application_cache_uninterruptible_time, elapsed);
+                WT_STAT_SESSION_INCRV(session, cache_time_mandatory, elapsed);
+            } else {
+                WT_STAT_CONN_INCRV(session, application_cache_interruptible_time, elapsed);
+                WT_STAT_SESSION_INCRV(session, cache_time_interruptible, elapsed);
+            }
+            session->cache_wait_us += elapsed;
+            time_start = time_stop;
+        }
     }
 
 err:


### PR DESCRIPTION
When we are in __wti_evict_app_assist_worker, we do not report cache metrics while it is stuck for x amount of time, and we report the total once this exits. The problem is, if we are not updating while it is stuck, our metrics are unable to tell we are in a cache stuck state to alleviate the cache pressure (cache pressure thread in server) and we won't be able to alert our thread until after it exits.

We want to update the metrics within the [while loop](https://github.com/wiredtiger/wiredtiger/blob/develop/src/evict/evict_lru.c#L2897-L2965) where it can get stuck.

We have FTDC data to show that these metrics make a difference. 

We don't double count cause we update the time_start. 