### PR TITLE
WT-14840 Fix failing unit tests by filter out all WT_VERB_SWEEP messages

### DIFF
--- a/test/suite/test_sweep03.py
+++ b/test/suite/test_sweep03.py
@@ -58,6 +58,12 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(types)
 
+    # We enabled verbose log level DEBUG_3 in this test to catch an invalid pointer in dhandle.
+    # However, this also causes the log line 'session dhandle name' to appear, which we want to ignore.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ignoreStdoutPattern('WT_VERB_SWEEP')
+
     # Wait for the sweep server to run - let it run twice, since the statistic
     # is incremented at the start of a sweep and the test relies on sweep
     # completing it's work.
@@ -100,7 +106,6 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         close1 = stat_cursor[stat.conn.dh_sweep_dead_close][2]
         stat_cursor.close()
-        self.ignoreStdoutPatternIfExists('sweep-server')
         # We expect nothing to have been closed.
         self.assertEqual(close1, 0)
 
@@ -138,7 +143,6 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(close2, 1)
         # Ensure that any space was reclaimed from cache.
         self.assertLess(cache2, cache1)
-        self.ignoreStdoutPatternIfExists('sweep-server')
 
     @wttest.skip_for_hook("tiered", "Fails with tiered storage")
     def test_disable_idle_timeout_drop(self):
@@ -172,7 +176,6 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(close2, close1)
         # Ensure that any space was reclaimed from cache.
         self.assertLess(cache2, cache1)
-        self.ignoreStdoutPatternIfExists('sweep-server')
 
     # FIXME - WT11133 Uncomment and re-enable this test after fixing this ticket.
     # def test_force_drop_and_sweep(self):

--- a/test/suite/test_sweep05.py
+++ b/test/suite/test_sweep05.py
@@ -43,6 +43,12 @@ class test_sweep05(wttest.WiredTigerTestCase):
     table_numkv = 10
     table_uri_format = 'table:test_sweep05_%s'
 
+    # We enabled verbose log level DEBUG_3 in this test to catch an invalid pointer in dhandle.
+    # However, this also causes the log line 'session dhandle name' to appear, which we want to ignore.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ignoreStdoutPattern('WT_VERB_SWEEP')
+
     def get_stats(self):
         r = dict()
         stat_cursor = self.session.open_cursor('statistics:', None, None)

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -51,6 +51,12 @@ class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(cursor_caching)
 
+    # We enabled verbose log level DEBUG_3 in this test to catch an invalid pointer in dhandle.
+    # However, this also causes the log line 'session dhandle name' to appear, which we want to ignore.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ignoreStdoutPattern('WT_VERB_SWEEP')
+
     def insert(self, i, start, rows):
         session = self.conn.open_session()
         uri = self.uri + str(i)
@@ -90,7 +96,3 @@ class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
         # The expectation is that no dhandles have been closed.
         self.assertEqual(close1, 0)
         self.assertEqual(close2, 0)
-
-        # We enabled verbose log level DEBUG_3 in this test to catch an invalid pointer in dhandle.
-        # However, this also causes the log line 'session dhandle name' to appear, which we want to ignore.
-        self.ignoreStdoutPatternIfExists('sweep-server')


### PR DESCRIPTION
The build failure was due to `ignoreStdoutPattern` only ignore one occurence of `WT_VERB_SWEEP` at a time. This PR consistently filter all WT_VERB_SWEEP messages to prevent the pipeline from failing