### PR TITLE
WT-14842 Remove tiered storage tests from PR builds

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3151,7 +3151,7 @@ tasks:
           python_binary: $(pwd)/venv/bin/python3
           tiered_storage_test_name: tiered
   - name: s3-tiered-test-small
-    tags: ["pull_request", "python"]
+    tags: ["python"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -3163,7 +3163,7 @@ tasks:
           python_binary: $(pwd)/venv/bin/python3
           tiered_storage_test_name: tiered06
   - name: s3-tiered-catch2-unittest-test
-    tags: ["pull_request", "tiered_unittest"]
+    tags: ["tiered_unittest"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -3197,7 +3197,7 @@ tasks:
           python_binary: $(pwd)/venv/bin/python3
           tiered_storage_test_name: tiered
   - name: azure-gcp-tiered-catch2-unittest-test
-    tags: ["pull_request", "tiered_unittest"]
+    tags: ["tiered_unittest"]
     commands:
       - func: "get project"
       - func: "install gcp dependencies"
@@ -3239,7 +3239,7 @@ tasks:
             ext/storage_sources/gcp_store/test/run_gcp_unit_tests
 
   - name: azure-gcp-tiered-test-small
-    tags: ["pull_request", "python"]
+    tags: ["python"]
     commands:
       - func: "get project"
       - func: "install gcp dependencies"


### PR DESCRIPTION
This PR removes most of tiered storage tests from PR builds so that we can take a quick-win on PR build turnaround time. Only one quick tiered storage test/task (i.e. `unit-test-hook-tiered-timestamp-quick`) is retained in PR builds to provide a minimal coverage avoiding obvious breakage.

For context, the PR builds took ~25 mins to finish lately, with the below 2 tiered storage tests/tasks ran over 20 mins and topped other tasks in the build (the 2nd runner-up took less than 16 mins). 
- azure-gcp-tiered-test-small
- azure-gcp-tiered-catch2-unittest-test
