### PR TITLE
WT-14833 Fix ENABLE_TCMALLOC propagation

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -74,6 +74,11 @@ functions:
               # DO NOT MOVE:This variable must be set in the same function(shell) that runs a test,
               # and as close as possible to the test execution, since it affects all the binaries.
               export LD_PRELOAD=$WT_TOPDIR/TCMALLOC_LIB/libtcmalloc.so
+
+              if [ ! -f "$LD_PRELOAD" ]; then
+                echo "Error: TCMalloc support was requested, but the library doesn't exist: $LD_PRELOAD"
+                exit 1
+              fi
             fi
 
             ${additional_env_vars}
@@ -1300,9 +1305,8 @@ variables:
     IMPORT_S3_SDK: -DIMPORT_S3_SDK=external
 
   # Configure flags for address sanitizer for stable mongodb toolchain clang (include builtins).
-  - &configure_flags_address_sanitizer_mongodb_stable_clang_with_builtins
+  - &configure_flags_asan_mongodb_stable_clang_with_builtins
     <<: *configure_flags_with_builtins
-    ENABLE_TCMALLOC: 0
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=ASan
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake
     ENABLE_CPPSUITE: -DENABLE_CPPSUITE=0
@@ -1338,8 +1342,8 @@ variables:
 
 #########################################################################################
 # The following stress tests are configured to run for six hours via the "-t 360"
-# argument to format.sh: format-stress-test, format-stress-sanitizer-test, and
-# race-condition-stress-sanitizer-test. The recovery tests run in a loop, with
+# argument to format.sh: format-stress-test, format-stress-asan-test, and
+# race-condition-stress-asan-test. The recovery tests run in a loop, with
 # the number of runs adjusted to provide aproximately six hours of testing.
 #########################################################################################
 
@@ -1354,13 +1358,13 @@ variables:
         vars:
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 360
 
-  - &format-stress-sanitizer-ppc-test
+  - &format-stress-asan-ppc-test
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          <<: *configure_flags_address_sanitizer_mongodb_stable_clang_with_builtins
+          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
       - func: "format test script"
         vars:
           additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
@@ -1368,25 +1372,25 @@ variables:
           # See https://bugzilla.redhat.com/show_bug.cgi?id=1686261#c10 for the potential cause.
           format_test_script_args: -t 360 -- -C "mmap=false,mmap_all=false"
 
-  - &format-stress-sanitizer-test
+  - &format-stress-asan-test
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          <<: *configure_flags_address_sanitizer_mongodb_stable_clang_with_builtins
+          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
           additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
       - func: "format test script"
         vars:
           format_test_script_args: -t 360
 
-  - &race-condition-stress-sanitizer-test
+  - &race-condition-stress-asan-test
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          <<: *configure_flags_address_sanitizer_mongodb_stable_clang_with_builtins
+          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
       - func: "format test script"
         vars:
           additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
@@ -3459,7 +3463,7 @@ tasks:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          <<: *configure_flags_address_sanitizer_mongodb_stable_clang_with_builtins
+          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
       - func: "format test script"
         vars:
           additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
@@ -3886,36 +3890,36 @@ tasks:
   - <<: *format-stress-test
     name: format-stress-test-4
     tags: ["stress-test-4"]
-  - <<: *format-stress-sanitizer-ppc-test
-    name: format-stress-sanitizer-ppc-test-1
+  - <<: *format-stress-asan-ppc-test
+    name: format-stress-asan-ppc-test-1
     tags: ["stress-test-ppc-1"]
-  - <<: *format-stress-sanitizer-ppc-test
-    name: format-stress-sanitizer-ppc-test-2
+  - <<: *format-stress-asan-ppc-test
+    name: format-stress-asan-ppc-test-2
     tags: ["stress-test-ppc-2"]
-  - <<: *format-stress-sanitizer-test
-    name: format-stress-sanitizer-test-1
-    tags: ["stress-test-sanitizer"]
-  - <<: *format-stress-sanitizer-test
-    name: format-stress-sanitizer-test-2
-    tags: ["stress-test-sanitizer"]
-  - <<: *format-stress-sanitizer-test
-    name: format-stress-sanitizer-test-3
-    tags: ["stress-test-sanitizer"]
-  - <<: *format-stress-sanitizer-test
-    name: format-stress-sanitizer-test-4
-    tags: ["stress-test-sanitizer"]
-  - <<: *race-condition-stress-sanitizer-test
-    name: race-condition-stress-sanitizer-test-1
-    tags: ["stress-test-sanitizer"]
-  - <<: *race-condition-stress-sanitizer-test
-    name: race-condition-stress-sanitizer-test-2
-    tags: ["stress-test-sanitizer"]
-  - <<: *race-condition-stress-sanitizer-test
-    name: race-condition-stress-sanitizer-test-3
-    tags: ["stress-test-sanitizer"]
-  - <<: *race-condition-stress-sanitizer-test
-    name: race-condition-stress-sanitizer-test-4
-    tags: ["stress-test-sanitizer"]
+  - <<: *format-stress-asan-test
+    name: format-stress-asan-test-1
+    tags: ["stress-test-asan"]
+  - <<: *format-stress-asan-test
+    name: format-stress-asan-test-2
+    tags: ["stress-test-asan"]
+  - <<: *format-stress-asan-test
+    name: format-stress-asan-test-3
+    tags: ["stress-test-asan"]
+  - <<: *format-stress-asan-test
+    name: format-stress-asan-test-4
+    tags: ["stress-test-asan"]
+  - <<: *race-condition-stress-asan-test
+    name: race-condition-stress-asan-test-1
+    tags: ["stress-test-asan"]
+  - <<: *race-condition-stress-asan-test
+    name: race-condition-stress-asan-test-2
+    tags: ["stress-test-asan"]
+  - <<: *race-condition-stress-asan-test
+    name: race-condition-stress-asan-test-3
+    tags: ["stress-test-asan"]
+  - <<: *race-condition-stress-asan-test
+    name: race-condition-stress-asan-test-4
+    tags: ["stress-test-asan"]
   - <<: *recovery-stress-test
     name: recovery-stress-test-1
     tags: ["stress-test-1", "stress-test-zseries-1"]
@@ -3939,28 +3943,28 @@ tasks:
         vars:
           format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 360
 
-  - name: format-stress-sanitizer-test-no-barrier
-    tags: ["stress-test-sanitizer"]
+  - name: format-stress-asan-test-no-barrier
+    tags: ["stress-test-asan"]
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          <<: *configure_flags_address_sanitizer_mongodb_stable_clang_with_builtins
+          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
           NON_BARRIER_DIAGNOSTIC_YIELDS: -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
       - func: "format test script"
         vars:
           additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
           format_test_script_args: -t 360
 
-  - name: race-condition-stress-sanitizer-test-no-barrier
-    tags: ["stress-test-sanitizer"]
+  - name: race-condition-stress-asan-test-no-barrier
+    tags: ["stress-test-asan"]
     exec_timeout_secs: 25200
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
-          <<: *configure_flags_address_sanitizer_mongodb_stable_clang_with_builtins
+          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
           NON_BARRIER_DIAGNOSTIC_YIELDS: -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
       - func: "format test script"
         vars:
@@ -5602,13 +5606,20 @@ buildvariants:
     - name: ".stress-test-4"
     - name: ".stress-test-no-barrier"
       distros: ubuntu2004-medium
-    - name: ".stress-test-sanitizer"
-      run_on:
-      - ubuntu2004-medium
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
     - name: checkpoint-filetypes-predictable-test
+
+- name: ubuntu2004-stress-tests-asan
+  display_name: Ubuntu 20.04 Stress tests ASAN
+  run_on:
+  - ubuntu2004-medium
+  expansions:
+    ENABLE_TCMALLOC: 0
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+  tasks:
+    - name: ".stress-test-asan"
 
 - name: ubuntu2004-stress-tests-arm64
   display_name: Ubuntu 20.04 Stress tests (ARM64)
@@ -5806,8 +5817,6 @@ buildvariants:
     - name: long-test
       distros: ubuntu2004-arm64-large
     - name: make-check-test
-    - name: memory-model-test
-      batchtime: 40320 # 28 days
     - name: model-test-failure-workloads
       batchtime: 1440 # 24 hours
     - name: model-test-long
@@ -5826,6 +5835,17 @@ buildvariants:
       distros: ubuntu2004-arm64-large
     - name: unit-test-zstd
     - name: wtperf-test
+
+- name: ubuntu2004-arm64-memory-model
+  display_name: "Ubuntu 20.04 ARM64 Memory model test"
+  run_on:
+  - ubuntu2004-arm64-small
+  batchtime: 40320 # 28 days
+  expansions:
+    ENABLE_TCMALLOC: 0
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
+  tasks:
+    - name: memory-model-test
 
 - name: amazon2-arm64
   display_name: "Amazon Linux 2 ARM64"
@@ -6181,8 +6201,6 @@ buildvariants:
     - name: long-test
       distros: amazon2023-arm64-latest-large-m8g
     - name: make-check-test
-    - name: memory-model-test
-      batchtime: 40320 # 28 days
     - name: model-test-failure-workloads
       batchtime: 1440 # 24 hours
     - name: model-test-long
@@ -6233,10 +6251,19 @@ buildvariants:
     - name: ".stress-test-4"
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
-    - name: ".stress-test-sanitizer"
     - name: format-predictable-test
     - name: schema-abort-predictable-test
     - name: checkpoint-filetypes-predictable-test
+
+- name: amazon2023-stress-tests-armv9-asan
+  display_name: (ARMV9) Amazon2023 Stress tests ARM64 ASAN
+  run_on:
+  - amazon2023-arm64-latest-large-m8g
+  expansions:
+    ENABLE_TCMALLOC: 0
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+  tasks:
+    - name: ".stress-test-asan"
 
 - name: amazon2023-armv9-asan
   display_name: "(ARMV9) Amazon Linux 2023 ASAN"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5445,6 +5445,7 @@ buildvariants:
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: live-restore-long
+    - name: ".stress-test-asan"
 
 - name: ubuntu2004-tsan
   display_name: "! Ubuntu 20.04 TSAN"
@@ -5610,16 +5611,6 @@ buildvariants:
     - name: format-predictable-test
     - name: schema-abort-predictable-test
     - name: checkpoint-filetypes-predictable-test
-
-- name: ubuntu2004-stress-tests-asan
-  display_name: Ubuntu 20.04 Stress tests ASAN
-  run_on:
-  - ubuntu2004-medium
-  expansions:
-    ENABLE_TCMALLOC: 0
-    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
-  tasks:
-    - name: ".stress-test-asan"
 
 - name: ubuntu2004-stress-tests-arm64
   display_name: Ubuntu 20.04 Stress tests (ARM64)
@@ -6255,16 +6246,6 @@ buildvariants:
     - name: schema-abort-predictable-test
     - name: checkpoint-filetypes-predictable-test
 
-- name: amazon2023-stress-tests-armv9-asan
-  display_name: (ARMV9) Amazon2023 Stress tests ARM64 ASAN
-  run_on:
-  - amazon2023-arm64-latest-large-m8g
-  expansions:
-    ENABLE_TCMALLOC: 0
-    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
-  tasks:
-    - name: ".stress-test-asan"
-
 - name: amazon2023-armv9-asan
   display_name: "(ARMV9) Amazon Linux 2023 ASAN"
   run_on:
@@ -6287,6 +6268,7 @@ buildvariants:
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: live-restore-long
+    - name: ".stress-test-asan"
 
 - name: amazon2023-armv9-tsan
   display_name: "(ARMV9) Amazon Linux 2023 TSAN"


### PR DESCRIPTION
It turned out that `ENABLE_TCMALLOC` was incorrectly set on some platforms since the only way to set it for `PREPARE_TEST_ENV` is to define it as an `expansions` for a variant. And if a platform define task specific `ENABLE_TCMALLOC` it cannot be propagated to `PREPARE_TEST_ENV`. So, the only way to enable/disable TCMalloc correctly for some tests is to create separate variants, and this is what this PR does.

It also does two changes that I decided not to move to separate PRs:
- Fail the test if ENABLE_TCMALLOC is set, but TCMalloc library does exist on the system
- Rename `*-sanitizer-*` tests to `*-asan-*` since all these tests enables ASAN and "sanitizer" sounds ambiguous from my point of view (also we already have other "asan" tests so it's for consistency too)