### PR TITLE
WT-14699 Drop references to discarded pages in the block cache for disagg

### DIFF
--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -554,11 +554,11 @@ err:
 }
 
 /*
- * __wti_blkcache_remove --
+ * __wt_blkcache_remove --
  *     Remove a block from the cache.
  */
 void
-__wti_blkcache_remove(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
+__wt_blkcache_remove(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
 {
     WT_BLKCACHE *blkcache;
     WT_BLKCACHE_ITEM *blkcache_item;

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -490,7 +490,7 @@ __bm_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_
 
     /* Evict the freed block from the block cache */
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED)
-        __wti_blkcache_remove(session, addr, addr_size);
+        __wt_blkcache_remove(session, addr, addr_size);
 
     return (__wt_block_free(session, bm->block, addr, addr_size));
 }

--- a/src/block_disagg/block_disagg_mgr.c
+++ b/src/block_disagg/block_disagg_mgr.c
@@ -80,7 +80,7 @@ __bmd_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
 
     /* Evict the freed block from the block cache */
     if (ret == 0 && blkcache->type != WT_BLKCACHE_UNCONFIGURED)
-        __wti_blkcache_remove(session, addr, addr_size);
+        __wt_blkcache_remove(session, addr, addr_size);
 
     return (ret);
 }

--- a/src/block_disagg/block_disagg_mgr.c
+++ b/src/block_disagg/block_disagg_mgr.c
@@ -71,9 +71,15 @@ __bmd_close(WT_BM *bm, WT_SESSION_IMPL *session)
 static int
 __bmd_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
 {
-    /* FIXME-WT-14699: Drop the page from the block cache. */
-    return (
-      __wti_block_disagg_page_discard(session, (WT_BLOCK_DISAGG *)bm->block, addr, addr_size));
+    WT_DECL_RET;
+
+    ret = __wti_block_disagg_page_discard(session, (WT_BLOCK_DISAGG *)bm->block, addr, addr_size);
+
+    if (ret == 0) {
+        __wt_blkcache_destroy(session);
+    }
+
+    return (ret);
 }
 
 /*

--- a/src/block_disagg/block_disagg_mgr.c
+++ b/src/block_disagg/block_disagg_mgr.c
@@ -71,13 +71,16 @@ __bmd_close(WT_BM *bm, WT_SESSION_IMPL *session)
 static int
 __bmd_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
 {
+    WT_BLKCACHE *blkcache;
     WT_DECL_RET;
+
+    blkcache = &S2C(session)->blkcache;
 
     ret = __wti_block_disagg_page_discard(session, (WT_BLOCK_DISAGG *)bm->block, addr, addr_size);
 
-    if (ret == 0) {
-        __wt_blkcache_destroy(session);
-    }
+    /* Evict the freed block from the block cache */
+    if (ret == 0 && blkcache->type != WT_BLKCACHE_UNCONFIGURED)
+        __wti_blkcache_remove(session, addr, addr_size);
 
     return (ret);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1617,6 +1617,7 @@ extern void __wt_backup_destroy(WT_SESSION_IMPL *session);
 extern void __wt_blkcache_destroy(WT_SESSION_IMPL *session);
 extern void __wt_blkcache_release_handle(
   WT_SESSION_IMPL *session, WT_BLOCK *block, bool *last_release);
+extern void __wt_blkcache_remove(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size);
 extern void __wt_block_compact_get_progress_stats(
   WT_SESSION_IMPL *session, WT_BM *bm, uint64_t *pages_reviewedp);
 extern void __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block);
@@ -1777,7 +1778,6 @@ extern void __wt_writeunlock(WT_SESSION_IMPL *session, WT_RWLOCK *l);
 extern void __wti_blkcache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size,
   WT_BLKCACHE_ITEM **blkcache_retp, bool *foundp, bool *skip_cache_putp);
 extern void __wti_blkcache_get_read_handle(WT_BLOCK *block);
-extern void __wti_blkcache_remove(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size);
 extern void __wti_block_ckpt_destroy(WT_SESSION_IMPL *session, WT_BLOCK_CKPT *ci);
 extern void __wti_block_configure_first_fit(WT_BLOCK *block, bool on);
 extern void __wti_block_disagg_header_byteswap_copy(

--- a/test/suite/test_layered43.py
+++ b/test/suite/test_layered43.py
@@ -29,6 +29,7 @@
 import os, os.path, shutil, time, wiredtiger, wttest
 from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
+from wiredtiger import stat
 
 # test_layered43.py
 #    Test disaggregated storage with block cache.
@@ -64,6 +65,12 @@ class test_layered43(wttest.WiredTigerTestCase, DisaggConfigMixin):
     def early_setup(self):
         os.mkdir('kv_home')
 
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
     # Test long delta chains
     def test_layered43(self):
 
@@ -86,6 +93,9 @@ class test_layered43(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(timestamp1)}')
         self.session.checkpoint()
+
+        # Track block cache stats before evicting
+        prev_block_cache_blocks_removed = self.get_stat(stat.conn.block_cache_blocks_removed)
 
         # Create several updates with small changes
         value_prefix2 = 'bbb'
@@ -120,6 +130,8 @@ class test_layered43(wttest.WiredTigerTestCase, DisaggConfigMixin):
         cursor.reset()
         cursor.close()
         self.session.rollback_transaction()
+
+        self.assertGreater(self.get_stat(stat.conn.block_cache_blocks_removed), prev_block_cache_blocks_removed)
 
         # Remember the relevant statistics
         stat_cursor = self.session.open_cursor('statistics:')


### PR DESCRIPTION
Drop references in block cache when a page is discarded, only drop the reference after a successful discard call. 