### PR TITLE
WT-14826 Save prepared timestamp and prepared id to disk if preserve prepared config is on

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -155,7 +155,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         tombstone->prepare_state = WT_PREPARE_INPROGRESS;
         tombstone->start_ts = unpack->tw.stop_ts;
         tombstone->prepare_ts = unpack->tw.prepare_ts;
-        tombstone->prepared_id = unpack->tw.prepared_txn;
+        tombstone->prepared_id = unpack->tw.prepared_id;
         F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
 
         /*
@@ -176,6 +176,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         tombstone->next = upd;
         *updp = tombstone;
     } else {
+        upd->prepared_id = unpack->tw.prepared_id;
         upd->durable_ts = WT_TS_NONE;
         upd->prepare_state = WT_PREPARE_INPROGRESS;
         F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -141,7 +141,10 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
     upd->durable_ts = unpack->tw.durable_start_ts;
     upd->start_ts = unpack->tw.start_ts;
     upd->txnid = unpack->tw.start_txn;
-
+    if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
+        upd->prepare_ts = unpack->tw.start_ts;
+    else
+        upd->prepare_ts = WT_TS_NONE;
     /*
      * Instantiate both update and tombstone if the prepared update is a tombstone. This is required
      * to ensure that written prepared delete operation must be removed from the data store, when
@@ -151,9 +154,13 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
         total_size += size;
         tombstone->durable_ts = WT_TS_NONE;
-        tombstone->start_ts = unpack->tw.stop_ts;
         tombstone->txnid = unpack->tw.stop_txn;
         tombstone->prepare_state = WT_PREPARE_INPROGRESS;
+        tombstone->start_ts = unpack->tw.stop_ts;
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
+            tombstone->prepare_ts = unpack->tw.stop_ts;
+        else
+            tombstone->prepare_ts = WT_TS_NONE;
         F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
 
         /*

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -141,10 +141,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
     upd->durable_ts = unpack->tw.durable_start_ts;
     upd->start_ts = unpack->tw.start_ts;
     upd->txnid = unpack->tw.start_txn;
-    if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
-        upd->prepare_ts = unpack->tw.start_ts;
-    else
-        upd->prepare_ts = WT_TS_NONE;
+    upd->prepare_ts = unpack->tw.prepare_ts;
     /*
      * Instantiate both update and tombstone if the prepared update is a tombstone. This is required
      * to ensure that written prepared delete operation must be removed from the data store, when
@@ -157,10 +154,8 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         tombstone->txnid = unpack->tw.stop_txn;
         tombstone->prepare_state = WT_PREPARE_INPROGRESS;
         tombstone->start_ts = unpack->tw.stop_ts;
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
-            tombstone->prepare_ts = unpack->tw.stop_ts;
-        else
-            tombstone->prepare_ts = WT_TS_NONE;
+        tombstone->prepare_ts = unpack->tw.prepare_ts;
+        tombstone->prepared_id = unpack->tw.prepared_txn;
         F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
 
         /*
@@ -168,9 +163,10 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
          * by comparing both the transaction and timestamps as the transaction information gets lost
          * after restart.
          */
-        if (unpack->tw.start_ts == unpack->tw.stop_ts &&
-          unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
-          unpack->tw.start_txn == unpack->tw.stop_txn) {
+        if ((unpack->tw.start_ts == unpack->tw.stop_ts &&
+              unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
+              unpack->tw.start_txn == unpack->tw.stop_txn) ||
+          WT_TIME_WINDOW_HAS_PREPARE(&unpack->tw)) {
             upd->durable_ts = WT_TS_NONE;
             upd->prepare_state = WT_PREPARE_INPROGRESS;
             F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -141,7 +141,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
     upd->durable_ts = unpack->tw.durable_start_ts;
     upd->start_ts = unpack->tw.start_ts;
     upd->txnid = unpack->tw.start_txn;
-    upd->prepare_ts = unpack->tw.prepare_ts;
+
     /*
      * Instantiate both update and tombstone if the prepared update is a tombstone. This is required
      * to ensure that written prepared delete operation must be removed from the data store, when
@@ -165,8 +165,9 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
          */
         if ((unpack->tw.start_ts == unpack->tw.stop_ts &&
               unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
-              unpack->tw.start_txn == unpack->tw.stop_txn) ||
-          WT_TIME_WINDOW_HAS_PREPARE(&unpack->tw)) {
+              unpack->tw.start_txn == unpack->tw.stop_txn)) {
+            upd->prepared_id = unpack->tw.prepared_id;
+            upd->prepare_ts = unpack->tw.prepare_ts;
             upd->durable_ts = WT_TS_NONE;
             upd->prepare_state = WT_PREPARE_INPROGRESS;
             F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
@@ -177,6 +178,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         *updp = tombstone;
     } else {
         upd->prepared_id = unpack->tw.prepared_id;
+        upd->prepare_ts = unpack->tw.prepare_ts;
         upd->durable_ts = WT_TS_NONE;
         upd->prepare_state = WT_PREPARE_INPROGRESS;
         F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -35,6 +35,8 @@ struct __wt_time_window {
     wt_timestamp_t stop_ts;         /* default value: WT_TS_MAX */
     uint64_t stop_txn;              /* default value: WT_TXN_MAX */
 
+    wt_timestamp_t prepare_ts;
+    uint64_t prepared_txn;
     /*
      * Prepare information isn't really part of a time window, but we need to aggregate it to the
      * internal page information in reconciliation, and this is the simplest place to put it.

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -36,7 +36,7 @@ struct __wt_time_window {
     uint64_t stop_txn;              /* default value: WT_TXN_MAX */
 
     wt_timestamp_t prepare_ts; /* default value: WT_TS_NONE */
-    uint64_t prepared_id;      /* default value: WT_TS_NONE */
+    uint64_t prepared_id;      /* default value: WT_TXN_NONE */
     /*
      * Prepare information isn't really part of a time window, but we need to aggregate it to the
      * internal page information in reconciliation, and this is the simplest place to put it.

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -35,8 +35,8 @@ struct __wt_time_window {
     wt_timestamp_t stop_ts;         /* default value: WT_TS_MAX */
     uint64_t stop_txn;              /* default value: WT_TXN_MAX */
 
-    wt_timestamp_t prepare_ts;
-    uint64_t prepared_txn;
+    wt_timestamp_t prepare_ts; /* default value: WT_TS_NONE */
+    uint64_t prepared_id;      /* default value: WT_TS_NONE */
     /*
      * Prepare information isn't really part of a time window, but we need to aggregate it to the
      * internal page information in reconciliation, and this is the simplest place to put it.

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -52,24 +52,28 @@
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_START(tw, upd)                          \
-    do {                                                           \
-        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts; \
-        if ((upd)->durable_ts != WT_TS_NONE)                       \
-            (tw)->durable_start_ts = (upd)->durable_ts;            \
-        (tw)->start_txn = (upd)->txnid;                            \
+#define WT_TIME_WINDOW_SET_START(session, tw, upd)                                            \
+    do {                                                                                      \
+        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                            \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) \
+            (tw)->start_ts = (upd)->prepare_ts;                                               \
+        if ((upd)->durable_ts != WT_TS_NONE)                                                  \
+            (tw)->durable_start_ts = (upd)->durable_ts;                                       \
+        (tw)->start_txn = (upd)->txnid;                                                       \
     } while (0)
 
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_STOP(tw, upd)                         \
-    do {                                                         \
-        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts; \
-        if ((upd)->durable_ts != WT_TS_NONE)                     \
-            (tw)->durable_stop_ts = (upd)->durable_ts;           \
-        (tw)->stop_txn = (upd)->txnid;                           \
+#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                                             \
+    do {                                                                                      \
+        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                              \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) \
+            (tw)->stop_ts = (upd)->prepare_ts;                                                \
+        if ((upd)->durable_ts != WT_TS_NONE)                                                  \
+            (tw)->durable_stop_ts = (upd)->durable_ts;                                        \
+        (tw)->stop_txn = (upd)->txnid;                                                        \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -18,8 +18,8 @@
         (tw)->stop_ts = WT_TS_MAX;           \
         (tw)->stop_txn = WT_TXN_MAX;         \
         (tw)->prepare = 0;                   \
-        (tw)->prepare_ts = WT_TXN_NONE;      \
-        (tw)->prepared_txn = WT_TXN_NONE;    \
+        (tw)->prepare_ts = WT_TS_NONE;       \
+        (tw)->prepared_id = WT_TXN_NONE;     \
     } while (0)
 
 /* Copy the values from one time window structure to another. */
@@ -30,7 +30,7 @@
     ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&              \
       (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE &&            \
       (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 && \
-      (tw)->prepare_ts == WT_TXN_NONE)
+      (tw)->prepare_ts == WT_TS_NONE && (tw)->prepared_id == WT_TXN_NONE)
 
 /* Check if the start time window is set. */
 #define WT_TIME_WINDOW_HAS_START(tw) \
@@ -41,14 +41,15 @@
 
 /* Check if the prepare time window is set. */
 #define WT_TIME_WINDOW_HAS_PREPARE(tw) \
-    ((tw)->prepare == 1 && ((tw)->prepare_ts != WT_TS_NONE || (tw)->prepared_txn != WT_TXN_NONE))
+    ((tw)->prepare == 1 && ((tw)->prepare_ts != WT_TS_NONE || (tw)->prepared_id != WT_TXN_NONE))
 
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                           \
     ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts &&  \
       (tw1)->start_txn == (tw2)->start_txn && (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && \
       (tw1)->stop_ts == (tw2)->stop_ts && (tw1)->stop_txn == (tw2)->stop_txn &&                   \
-      (tw1)->prepare == (tw2)->prepare && (tw1)->prepare_ts == (tw2)->prepare_ts)
+      (tw1)->prepare == (tw2)->prepare && (tw1)->prepare_ts == (tw2)->prepare_ts &&               \
+      (tw1)->prepared_id == (tw2)->prepared_id)
 
 /* Return true if the stop time windows are the same. */
 #define WT_TIME_WINDOWS_STOP_EQUAL(tw1, tw2)                                                 \
@@ -64,7 +65,7 @@
         (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                              \
         if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) { \
             (tw)->prepare_ts = (upd)->prepare_ts;                                               \
-            (tw)->prepared_txn = (upd)->prepared_id;                                            \
+            (tw)->prepared_id = (upd)->prepared_id;                                             \
         }                                                                                       \
         if ((upd)->durable_ts != WT_TS_NONE)                                                    \
             (tw)->durable_start_ts = (upd)->durable_ts;                                         \
@@ -80,7 +81,7 @@
         (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                                \
         if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) { \
             (tw)->prepare_ts = (upd)->prepare_ts;                                               \
-            (tw)->prepared_txn = (upd)->prepared_id;                                            \
+            (tw)->prepared_id = (upd)->prepared_id;                                             \
         }                                                                                       \
         if ((upd)->durable_ts != WT_TS_NONE)                                                    \
             (tw)->durable_stop_ts = (upd)->durable_ts;                                          \
@@ -95,7 +96,7 @@
         (dest)->start_txn = (source)->start_txn;               \
         (dest)->prepare = (source)->prepare;                   \
         (dest)->prepare_ts = (source)->prepare_ts;             \
-        (dest)->prepared_txn = (source)->prepared_txn;         \
+        (dest)->prepared_id = (source)->prepared_id;           \
     } while (0)
 
 /* Copy the stop values of a time window from another time window. */
@@ -106,7 +107,7 @@
         (dest)->stop_txn = (source)->stop_txn;               \
         (dest)->prepare = (source)->prepare;                 \
         (dest)->prepare_ts = (source)->prepare_ts;           \
-        (dest)->prepared_txn = (source)->prepared_txn;       \
+        (dest)->prepared_id = (source)->prepared_id;         \
     } while (0)
 
 /*

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -59,8 +59,8 @@
 #define WT_TIME_WINDOW_SET_START(session, tw, upd)                                        \
     do {                                                                                  \
         (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                        \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&                 \
-          ((upd)->prepare_ts == WT_TS_NONE || (upd)->prepared_id == WT_PREPARED_ID_NONE)) { \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (upd)->prepared_id > (tw)->prepared_id) { \
+            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts);                     \
             (tw)->prepare_ts = (upd)->prepare_ts;                                         \
             (tw)->prepared_id = (upd)->prepared_id;                                       \
         }                                                                                 \
@@ -77,8 +77,8 @@
 #define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                                         \
     do {                                                                                  \
         (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                          \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&                 \
-          ((upd)->prepare_ts == WT_TS_NONE || (upd)->prepared_id == WT_PREPARED_ID_NONE)) { \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (upd)->prepared_id > (tw)->prepared_id) { \
+            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts);                     \
             (tw)->prepare_ts = (upd)->prepare_ts;                                         \
             (tw)->prepared_id = (upd)->prepared_id;                                       \
         }                                                                                 \

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -18,16 +18,18 @@
         (tw)->stop_ts = WT_TS_MAX;           \
         (tw)->stop_txn = WT_TXN_MAX;         \
         (tw)->prepare = 0;                   \
+        (tw)->prepare_ts = WT_TXN_NONE;      \
     } while (0)
 
 /* Copy the values from one time window structure to another. */
 #define WT_TIME_WINDOW_COPY(dest, source) (*(dest) = *(source))
 
 /* Return true if the time window is equivalent to the default time window. */
-#define WT_TIME_WINDOW_IS_EMPTY(tw)                                            \
-    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&   \
-      (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE && \
-      (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0)
+#define WT_TIME_WINDOW_IS_EMPTY(tw)                                                       \
+    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&              \
+      (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE &&            \
+      (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 && \
+      (tw)->prepare_ts == WT_TXN_NONE)
 
 /* Check if the start time window is set. */
 #define WT_TIME_WINDOW_HAS_START(tw) \
@@ -36,12 +38,16 @@
 /* Check if the stop time window is set. */
 #define WT_TIME_WINDOW_HAS_STOP(tw) ((tw)->stop_txn != WT_TXN_MAX || (tw)->stop_ts != WT_TS_MAX)
 
+/* Check if the prepare time window is set. */
+#define WT_TIME_WINDOW_HAS_PREPARE(tw) \
+    ((tw)->prepare == 1 && ((tw)->prepare_ts != WT_TS_NONE || (tw)->start_txn != WT_TXN_NONE))
+
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                           \
     ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts &&  \
       (tw1)->start_txn == (tw2)->start_txn && (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && \
       (tw1)->stop_ts == (tw2)->stop_ts && (tw1)->stop_txn == (tw2)->stop_txn &&                   \
-      (tw1)->prepare == (tw2)->prepare)
+      (tw1)->prepare == (tw2)->prepare && (tw1)->prepare_ts == (tw2)->prepare_ts)
 
 /* Return true if the stop time windows are the same. */
 #define WT_TIME_WINDOWS_STOP_EQUAL(tw1, tw2)                                                 \
@@ -52,28 +58,32 @@
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_START(session, tw, upd)                                            \
-    do {                                                                                      \
-        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                            \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) \
-            (tw)->start_ts = (upd)->prepare_ts;                                               \
-        if ((upd)->durable_ts != WT_TS_NONE)                                                  \
-            (tw)->durable_start_ts = (upd)->durable_ts;                                       \
-        (tw)->start_txn = (upd)->txnid;                                                       \
+#define WT_TIME_WINDOW_SET_START(session, tw, upd)                                              \
+    do {                                                                                        \
+        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                              \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) { \
+            (tw)->prepare_ts = (upd)->prepare_ts;                                               \
+            (tw)->prepared_txn = (upd)->prepared_id;                                            \
+        }                                                                                       \
+        if ((upd)->durable_ts != WT_TS_NONE)                                                    \
+            (tw)->durable_start_ts = (upd)->durable_ts;                                         \
+        (tw)->start_txn = (upd)->txnid;                                                         \
     } while (0)
 
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                                             \
-    do {                                                                                      \
-        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                              \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) \
-            (tw)->stop_ts = (upd)->prepare_ts;                                                \
-        if ((upd)->durable_ts != WT_TS_NONE)                                                  \
-            (tw)->durable_stop_ts = (upd)->durable_ts;                                        \
-        (tw)->stop_txn = (upd)->txnid;                                                        \
+#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                                               \
+    do {                                                                                        \
+        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                                \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) { \
+            (tw)->prepare_ts = (upd)->prepare_ts;                                               \
+            (tw)->prepared_txn = (upd)->prepared_id;                                            \
+        }                                                                                       \
+        if ((upd)->durable_ts != WT_TS_NONE)                                                    \
+            (tw)->durable_stop_ts = (upd)->durable_ts;                                          \
+        (tw)->stop_txn = (upd)->txnid;                                                          \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */
@@ -83,6 +93,8 @@
         (dest)->start_ts = (source)->start_ts;                 \
         (dest)->start_txn = (source)->start_txn;               \
         (dest)->prepare = (source)->prepare;                   \
+        (dest)->prepare_ts = (source)->prepare_ts;             \
+        (dest)->prepared_txn = (source)->prepared_txn;         \
     } while (0)
 
 /* Copy the stop values of a time window from another time window. */
@@ -92,6 +104,8 @@
         (dest)->stop_ts = (source)->stop_ts;                 \
         (dest)->stop_txn = (source)->stop_txn;               \
         (dest)->prepare = (source)->prepare;                 \
+        (dest)->prepare_ts = (source)->prepare_ts;           \
+        (dest)->prepared_txn = (source)->prepared_txn;       \
     } while (0)
 
 /*

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -9,17 +9,17 @@
 #pragma once
 
 /* Initialize the fields in a time window to their defaults. */
-#define WT_TIME_WINDOW_INIT(tw)              \
-    do {                                     \
-        (tw)->durable_start_ts = WT_TS_NONE; \
-        (tw)->start_ts = WT_TS_NONE;         \
-        (tw)->start_txn = WT_TXN_NONE;       \
-        (tw)->durable_stop_ts = WT_TS_NONE;  \
-        (tw)->stop_ts = WT_TS_MAX;           \
-        (tw)->stop_txn = WT_TXN_MAX;         \
-        (tw)->prepare = 0;                   \
-        (tw)->prepare_ts = WT_TS_NONE;       \
-        (tw)->prepared_id = WT_TXN_NONE;     \
+#define WT_TIME_WINDOW_INIT(tw)                  \
+    do {                                         \
+        (tw)->durable_start_ts = WT_TS_NONE;     \
+        (tw)->start_ts = WT_TS_NONE;             \
+        (tw)->start_txn = WT_TXN_NONE;           \
+        (tw)->durable_stop_ts = WT_TS_NONE;      \
+        (tw)->stop_ts = WT_TS_MAX;               \
+        (tw)->stop_txn = WT_TXN_MAX;             \
+        (tw)->prepare = 0;                       \
+        (tw)->prepare_ts = WT_TS_NONE;           \
+        (tw)->prepared_id = WT_PREPARED_ID_NONE; \
     } while (0)
 
 /* Copy the values from one time window structure to another. */
@@ -30,7 +30,7 @@
     ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&              \
       (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE &&            \
       (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 && \
-      (tw)->prepare_ts == WT_TS_NONE && (tw)->prepared_id == WT_TXN_NONE)
+      (tw)->prepare_ts == WT_TS_NONE && (tw)->prepared_id == WT_PREPARED_ID_NONE)
 
 /* Check if the start time window is set. */
 #define WT_TIME_WINDOW_HAS_START(tw) \
@@ -38,10 +38,6 @@
 
 /* Check if the stop time window is set. */
 #define WT_TIME_WINDOW_HAS_STOP(tw) ((tw)->stop_txn != WT_TXN_MAX || (tw)->stop_ts != WT_TS_MAX)
-
-/* Check if the prepare time window is set. */
-#define WT_TIME_WINDOW_HAS_PREPARE(tw) \
-    ((tw)->prepare == 1 && ((tw)->prepare_ts != WT_TS_NONE || (tw)->prepared_id != WT_TXN_NONE))
 
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                           \
@@ -60,32 +56,36 @@
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_START(session, tw, upd)                                              \
-    do {                                                                                        \
-        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                              \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) { \
-            (tw)->prepare_ts = (upd)->prepare_ts;                                               \
-            (tw)->prepared_id = (upd)->prepared_id;                                             \
-        }                                                                                       \
-        if ((upd)->durable_ts != WT_TS_NONE)                                                    \
-            (tw)->durable_start_ts = (upd)->durable_ts;                                         \
-        (tw)->start_txn = (upd)->txnid;                                                         \
+#define WT_TIME_WINDOW_SET_START(session, tw, upd)                                        \
+    do {                                                                                  \
+        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                        \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&                 \
+          ((upd)->prepare_ts == WT_TS_NONE || (upd)->prepared_id == WT_PREPARED_ID_NONE)) { \
+            (tw)->prepare_ts = (upd)->prepare_ts;                                         \
+            (tw)->prepared_id = (upd)->prepared_id;                                       \
+        }                                                                                 \
+                                                                                          \
+        if ((upd)->durable_ts != WT_TS_NONE)                                              \
+            (tw)->durable_start_ts = (upd)->durable_ts;                                   \
+        (tw)->start_txn = (upd)->txnid;                                                   \
     } while (0)
 
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                                               \
-    do {                                                                                        \
-        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                                \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (tw)->prepare == 1) { \
-            (tw)->prepare_ts = (upd)->prepare_ts;                                               \
-            (tw)->prepared_id = (upd)->prepared_id;                                             \
-        }                                                                                       \
-        if ((upd)->durable_ts != WT_TS_NONE)                                                    \
-            (tw)->durable_stop_ts = (upd)->durable_ts;                                          \
-        (tw)->stop_txn = (upd)->txnid;                                                          \
+#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                                         \
+    do {                                                                                  \
+        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                          \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&                 \
+          ((upd)->prepare_ts == WT_TS_NONE || (upd)->prepared_id == WT_PREPARED_ID_NONE)) { \
+            (tw)->prepare_ts = (upd)->prepare_ts;                                         \
+            (tw)->prepared_id = (upd)->prepared_id;                                       \
+        }                                                                                 \
+                                                                                          \
+        if ((upd)->durable_ts != WT_TS_NONE)                                              \
+            (tw)->durable_stop_ts = (upd)->durable_ts;                                    \
+        (tw)->stop_txn = (upd)->txnid;                                                    \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -56,36 +56,38 @@
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_START(session, tw, upd)                                        \
-    do {                                                                                  \
-        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;                        \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (upd)->prepared_id > (tw)->prepared_id) { \
-            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts);                     \
-            (tw)->prepare_ts = (upd)->prepare_ts;                                         \
-            (tw)->prepared_id = (upd)->prepared_id;                                       \
-        }                                                                                 \
-                                                                                          \
-        if ((upd)->durable_ts != WT_TS_NONE)                                              \
-            (tw)->durable_start_ts = (upd)->durable_ts;                                   \
-        (tw)->start_txn = (upd)->txnid;                                                   \
+#define WT_TIME_WINDOW_SET_START(session, tw, upd)                        \
+    do {                                                                  \
+        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;        \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && \
+          (upd)->prepared_id > (tw)->prepared_id) {                       \
+            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts);     \
+            (tw)->prepare_ts = (upd)->prepare_ts;                         \
+            (tw)->prepared_id = (upd)->prepared_id;                       \
+        }                                                                 \
+                                                                          \
+        if ((upd)->durable_ts != WT_TS_NONE)                              \
+            (tw)->durable_start_ts = (upd)->durable_ts;                   \
+        (tw)->start_txn = (upd)->txnid;                                   \
     } while (0)
 
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                                         \
-    do {                                                                                  \
-        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;                          \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && (upd)->prepared_id > (tw)->prepared_id) { \
-            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts);                     \
-            (tw)->prepare_ts = (upd)->prepare_ts;                                         \
-            (tw)->prepared_id = (upd)->prepared_id;                                       \
-        }                                                                                 \
-                                                                                          \
-        if ((upd)->durable_ts != WT_TS_NONE)                                              \
-            (tw)->durable_stop_ts = (upd)->durable_ts;                                    \
-        (tw)->stop_txn = (upd)->txnid;                                                    \
+#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                         \
+    do {                                                                  \
+        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;          \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && \
+          (upd)->prepared_id > (tw)->prepared_id) {                       \
+            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts);     \
+            (tw)->prepare_ts = (upd)->prepare_ts;                         \
+            (tw)->prepared_id = (upd)->prepared_id;                       \
+        }                                                                 \
+                                                                          \
+        if ((upd)->durable_ts != WT_TS_NONE)                              \
+            (tw)->durable_stop_ts = (upd)->durable_ts;                    \
+        (tw)->stop_txn = (upd)->txnid;                                    \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -19,6 +19,7 @@
         (tw)->stop_txn = WT_TXN_MAX;         \
         (tw)->prepare = 0;                   \
         (tw)->prepare_ts = WT_TXN_NONE;      \
+        (tw)->prepared_txn = WT_TXN_NONE;    \
     } while (0)
 
 /* Copy the values from one time window structure to another. */
@@ -40,7 +41,7 @@
 
 /* Check if the prepare time window is set. */
 #define WT_TIME_WINDOW_HAS_PREPARE(tw) \
-    ((tw)->prepare == 1 && ((tw)->prepare_ts != WT_TS_NONE || (tw)->start_txn != WT_TXN_NONE))
+    ((tw)->prepare == 1 && ((tw)->prepare_ts != WT_TS_NONE || (tw)->prepared_txn != WT_TXN_NONE))
 
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                           \

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -12,6 +12,7 @@
 #define WT_TXN_FIRST 1               /* First transaction to run */
 #define WT_TXN_MAX (UINT64_MAX - 10) /* End of time */
 #define WT_TXN_ABORTED UINT64_MAX    /* Update rolled back */
+#define WT_PREPARED_ID_NONE 0        /* Empty prepared id */
 
 #define WT_TS_NONE 0         /* Beginning of time */
 #define WT_TS_MAX UINT64_MAX /* End of time */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1228,7 +1228,7 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
               upd->type == WT_UPDATE_STANDARD))
             return (WT_VISIBLE_TRUE);
 
-        upd_visible = __wt_txn_visible(session, upd->txnid, upd->start_ts, upd->durable_ts);
+        upd_visible = __wt_txn_visible(session, upd->txnid, F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) ? upd->prepare_ts : upd->start_ts, upd->durable_ts);
 
         /*
          * The visibility check is only valid if the update does not change state. If the state does

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1228,7 +1228,10 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
               upd->type == WT_UPDATE_STANDARD))
             return (WT_VISIBLE_TRUE);
 
-        upd_visible = __wt_txn_visible(session, upd->txnid, F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) ? upd->prepare_ts : upd->start_ts, upd->durable_ts);
+        upd_visible = __wt_txn_visible(session, upd->txnid,
+          F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) ? upd->prepare_ts :
+                                                                       upd->start_ts,
+          upd->durable_ts);
 
         /*
          * The visibility check is only valid if the update does not change state. If the state does

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1229,8 +1229,10 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
             return (WT_VISIBLE_TRUE);
 
         upd_visible = __wt_txn_visible(session, upd->txnid,
-          F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) ? upd->prepare_ts :
-                                                                       upd->start_ts,
+          F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+              prepare_state == WT_PREPARE_INPROGRESS ?
+            upd->prepare_ts :
+            upd->start_ts,
           upd->durable_ts);
 
         /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -765,7 +765,7 @@ __rec_fill_tw_from_upd_select(
      * that the value is visible to any timestamp/transaction id ahead of it.
      */
     if (upd->type == WT_UPDATE_TOMBSTONE) {
-        WT_TIME_WINDOW_SET_STOP(select_tw, upd);
+        WT_TIME_WINDOW_SET_STOP(session, select_tw, upd);
         tombstone = upd_select->tombstone = upd;
 
         /* Find the update this tombstone applies to. */
@@ -783,7 +783,7 @@ __rec_fill_tw_from_upd_select(
 
     if (upd != NULL)
         /* The beginning of the validity window is the selected update's time point. */
-        WT_TIME_WINDOW_SET_START(select_tw, upd);
+        WT_TIME_WINDOW_SET_START(session, select_tw, upd);
     else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
         WT_ASSERT_ALWAYS(
           session, tombstone != NULL, "The only contents of the update list is a single tombstone");
@@ -842,7 +842,7 @@ __rec_fill_tw_from_upd_select(
               "Tombstone is globally visible, but the tombstoned update is on the update "
               "chain");
             upd_select->upd = last_upd->next;
-            WT_TIME_WINDOW_SET_START(select_tw, last_upd->next);
+            WT_TIME_WINDOW_SET_START(session, select_tw, last_upd->next);
         } else {
             /*
              * It's possible that onpage value is not appended if the tombstone becomes globally


### PR DESCRIPTION
This PR writes the prepare ts and prepared id to disk, and restore them to in-memory struct if preserve_prepared config is on