### PR TITLE
WT-14414 Skip session verify in disagg

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1735,6 +1735,12 @@ __session_verify(WT_SESSION *wt_session, const char *uri, const char *config)
     SESSION_API_CALL(session, ret, verify, config, cfg);
     WT_ERR(__wt_inmem_unsupported_op(session, NULL));
 
+    /* FIXME-WT-14553: Implement verify for disagg. */
+    if (__wt_conn_is_disagg(session)) {
+        __wt_verbose_warning(session, WT_VERB_VERIFY, "%s", "skipped verify due to disagg");
+        goto err;
+    }
+
     /* Block out checkpoints to avoid spurious EBUSY errors. */
     WT_WITH_CHECKPOINT_LOCK(session,
       WT_WITH_SCHEMA_LOCK(session,

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1735,12 +1735,6 @@ __session_verify(WT_SESSION *wt_session, const char *uri, const char *config)
     SESSION_API_CALL(session, ret, verify, config, cfg);
     WT_ERR(__wt_inmem_unsupported_op(session, NULL));
 
-    /* FIXME-WT-14553: Implement verify for disagg. */
-    if (__wt_conn_is_disagg(session)) {
-        __wt_verbose_info(session, WT_VERB_VERIFY, "%s", "skipped verify due to disagg");
-        goto err;
-    }
-
     /* Block out checkpoints to avoid spurious EBUSY errors. */
     WT_WITH_CHECKPOINT_LOCK(session,
       WT_WITH_SCHEMA_LOCK(session,
@@ -1752,6 +1746,17 @@ err:
         WT_STAT_CONN_INCR(session, session_table_verify_fail);
     else
         WT_STAT_CONN_INCR(session, session_table_verify_success);
+
+    /*
+     * FIXME-WT-14553: Implement verify for disagg. For now we are skipping the expected ENOTSUP
+     * error.
+     */
+    if (__wt_conn_is_disagg(session) && ret == ENOTSUP) {
+        __wt_verbose_info(
+          session, WT_VERB_VERIFY, "%s", "silenced ENOTSUP from verify due to disagg");
+        ret = 0;
+    }
+
     API_END_RET_NOTFOUND_MAP(session, ret);
 }
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1737,7 +1737,7 @@ __session_verify(WT_SESSION *wt_session, const char *uri, const char *config)
 
     /* FIXME-WT-14553: Implement verify for disagg. */
     if (__wt_conn_is_disagg(session)) {
-        __wt_verbose_warning(session, WT_VERB_VERIFY, "%s", "skipped verify due to disagg");
+        __wt_verbose_info(session, WT_VERB_VERIFY, "%s", "skipped verify due to disagg");
         goto err;
     }
 


### PR DESCRIPTION
For the time being, skip verify in disagg instead of returning `ENOTSUP`, so the server can call verify without getting any error back. WT-14553 will implement verify.