### PR TITLE
WT-14858 Forbid to prepare a transaction before the stable timestamp if the preserve_prepare config is on

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -694,8 +694,13 @@ __wt_txn_config(WT_SESSION_IMPL *session, WT_CONF *conf)
      * rounded up.
      */
     WT_ERR(__wt_conf_gets_def(session, conf, Roundup_timestamps.prepared, 0, &cval));
-    if (cval.val)
+    if (cval.val) {
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
+            WT_ERR_MSG(session, EINVAL,
+              "cannot round up prepare timestamp to the oldest timestamp when the preserve prepare "
+              "config is on");
         F_SET(txn, WT_TXN_TS_ROUND_PREPARED);
+    }
 
     /* Check if read timestamp needs to be rounded up. */
     WT_ERR(__wt_conf_gets_def(session, conf, Roundup_timestamps.read, 0, &cval));

--- a/test/suite/test_timestamp27.py
+++ b/test/suite/test_timestamp27.py
@@ -107,8 +107,7 @@ class test_timestamp27_preserve_prepared_on(wttest.WiredTigerTestCase):
             '/commit timestamp and rollback timestamp should not be set together/')
 
     def test_prepare_timestamp_before_stable_timestamp(self):
-        self.session.begin_transaction("roundup_timestamps=(prepare=true)")
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
-        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50)),
+        self.session.begin_transaction("roundup_timestamps=(prepare=true)"),
             '/cannot round up prepare timestamp to the oldest timestamp when the preserve prepare config is on/')

--- a/test/suite/test_timestamp27.py
+++ b/test/suite/test_timestamp27.py
@@ -105,3 +105,10 @@ class test_timestamp27_preserve_prepared_on(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
         self.session.timestamp_transaction('rollback_timestamp=' + self.timestamp_str(100) + ",durable_timestamp=" + self.timestamp_str(100)),
             '/commit timestamp and rollback timestamp should not be set together/')
+
+    def test_prepare_timestamp_before_stable_timestamp(self):
+        self.session.begin_transaction("roundup_timestamps=(prepare=true)")
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50)),
+            '/cannot round up prepare timestamp to the oldest timestamp when the preserve prepare config is on/')

--- a/test/suite/test_timestamp27.py
+++ b/test/suite/test_timestamp27.py
@@ -106,8 +106,7 @@ class test_timestamp27_preserve_prepared_on(wttest.WiredTigerTestCase):
         self.session.timestamp_transaction('rollback_timestamp=' + self.timestamp_str(100) + ",durable_timestamp=" + self.timestamp_str(100)),
             '/commit timestamp and rollback timestamp should not be set together/')
 
-    def test_prepare_timestamp_before_stable_timestamp(self):
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
+    def test_roundup_prepare_timestamp(self):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
         self.session.begin_transaction("roundup_timestamps=(prepare=true)"),
             '/cannot round up prepare timestamp to the oldest timestamp when the preserve prepare config is on/')


### PR DESCRIPTION
When the preserve_prepare config is enabled, we cannot prepare a transaction older than or equal to the stable timestamp. Otherwise, we cannot ensure we will write a complete transaction to the checkpoint. Throw an error in this case.

The change doesn't impact the existing versions as it is behind a feature flag. A python test is added to validate the above case.