### PR TITLE
WT-14870 Solve __capacity_config() TSAN warning

### DIFF
--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -400,7 +400,7 @@ __wt_capacity_throttle(WT_SESSION_IMPL *session, uint64_t bytes, WT_THROTTLE_TYP
      * consider one subsystem may be turned off at some point in the future. If this subsystem is
      * not throttled there's nothing to do.
      */
-    if (__wt_atomic_load64(&cap->total) == 0 || capacity == 0 ||
+    if (total_capacity == 0 || capacity == 0 ||
       F_ISSET_ATOMIC_32(conn, WT_CONN_RECOVERING))
         return;
 

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -400,8 +400,7 @@ __wt_capacity_throttle(WT_SESSION_IMPL *session, uint64_t bytes, WT_THROTTLE_TYP
      * consider one subsystem may be turned off at some point in the future. If this subsystem is
      * not throttled there's nothing to do.
      */
-    if (total_capacity == 0 || capacity == 0 ||
-      F_ISSET_ATOMIC_32(conn, WT_CONN_RECOVERING))
+    if (total_capacity == 0 || capacity == 0 || F_ISSET_ATOMIC_32(conn, WT_CONN_RECOVERING))
         return;
 
     /*

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -31,10 +31,10 @@ __capacity_config(WT_SESSION_IMPL *session, const char *cfg[])
     WT_CAPACITY *cap;
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
-    uint64_t chunkcache, total;
+    uint64_t chunkcache, ckpt, evict, log, read, total;
 
     conn = S2C(session);
-    chunkcache = total = 0;
+    chunkcache = ckpt = evict = log = read = total = 0;
 
     WT_RET(__wt_config_gets(session, cfg, "io_capacity.total", &cval));
     if (cval.val != 0) {
@@ -70,24 +70,26 @@ __capacity_config(WT_SESSION_IMPL *session, const char *cfg[])
         /*
          * We've been given a total capacity, set the capacity of all the subsystems.
          */
-        cap->ckpt = WT_CAPACITY_SYS(total, WT_CAP_CKPT);
-        cap->evict = WT_CAPACITY_SYS(total, WT_CAP_EVICT);
-        cap->log = WT_CAPACITY_SYS(total, WT_CAP_LOG);
-        cap->read = WT_CAPACITY_SYS(total, WT_CAP_READ);
+        ckpt = WT_CAPACITY_SYS(total, WT_CAP_CKPT);
+        evict = WT_CAPACITY_SYS(total, WT_CAP_EVICT);
+        log = WT_CAPACITY_SYS(total, WT_CAP_LOG);
+        read = WT_CAPACITY_SYS(total, WT_CAP_READ);
+
+        __wt_atomic_store64(&cap->ckpt, ckpt);
+        __wt_atomic_store64(&cap->evict, evict);
+        __wt_atomic_store64(&cap->log, log);
+        __wt_atomic_store64(&cap->read, read);
 
         /*
          * Set the threshold to the percent of our capacity to periodically asynchronously flush
          * what we've written.
          */
-        cap->threshold = ((cap->ckpt + cap->evict + cap->log) / 100) * WT_CAPACITY_PCT;
+        cap->threshold = ((ckpt + log + evict) / 100) * WT_CAPACITY_PCT;
         if (cap->threshold < WT_CAPACITY_MIN_THRESHOLD)
             cap->threshold = WT_CAPACITY_MIN_THRESHOLD;
         WT_STAT_CONN_SET(session, capacity_threshold, cap->threshold);
     } else
         WT_STAT_CONN_SET(session, capacity_threshold, 0);
-
-    if (chunkcache != 0)
-        cap->chunkcache = chunkcache;
 
     return (0);
 }
@@ -302,7 +304,7 @@ __throttle_chunkcache(WT_SESSION_IMPL *session, WT_CAPACITY *cap, uint64_t bytes
     struct timespec now;
     uint64_t capacity, now_ns, *reservation, res_value, sleep_us;
 
-    capacity = cap->chunkcache;
+    capacity = __wt_atomic_load64(&cap->chunkcache);
     reservation = &cap->reservation_chunkcache;
 
     WT_STAT_CONN_INCRV(session, capacity_bytes_chunkcache, bytes);
@@ -368,25 +370,25 @@ __wt_capacity_throttle(WT_SESSION_IMPL *session, uint64_t bytes, WT_THROTTLE_TYP
         __throttle_chunkcache(session, cap, bytes);
         return;
     case WT_THROTTLE_CKPT:
-        capacity = cap->ckpt;
+        capacity = __wt_atomic_load64(&cap->ckpt);
         reservation = &cap->reservation_ckpt;
         WT_STAT_CONN_INCRV(session, capacity_bytes_ckpt, bytes);
         WT_STAT_CONN_INCRV(session, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_EVICT:
-        capacity = cap->evict;
+        capacity = __wt_atomic_load64(&cap->evict);
         reservation = &cap->reservation_evict;
         WT_STAT_CONN_INCRV(session, capacity_bytes_evict, bytes);
         WT_STAT_CONN_INCRV(session, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_LOG:
-        capacity = cap->log;
+        capacity = __wt_atomic_load64(&cap->log);
         reservation = &cap->reservation_log;
         WT_STAT_CONN_INCRV(session, capacity_bytes_log, bytes);
         WT_STAT_CONN_INCRV(session, capacity_bytes_written, bytes);
         break;
     case WT_THROTTLE_READ:
-        capacity = cap->read;
+        capacity = __wt_atomic_load64(&cap->read);
         reservation = &cap->reservation_read;
         WT_STAT_CONN_INCRV(session, capacity_bytes_read, bytes);
         break;
@@ -432,22 +434,22 @@ again:
         best_res = now_ns - WT_BILLION / 2;
         if (type != WT_THROTTLE_CKPT && (this_res = cap->reservation_ckpt) < best_res) {
             steal = &cap->reservation_ckpt;
-            steal_capacity = cap->ckpt;
+            steal_capacity = __wt_atomic_load64(&cap->ckpt);
             best_res = this_res;
         }
         if (type != WT_THROTTLE_EVICT && (this_res = cap->reservation_evict) < best_res) {
             steal = &cap->reservation_evict;
-            steal_capacity = cap->evict;
+            steal_capacity = __wt_atomic_load64(&cap->evict);
             best_res = this_res;
         }
         if (type != WT_THROTTLE_LOG && (this_res = cap->reservation_log) < best_res) {
             steal = &cap->reservation_log;
-            steal_capacity = cap->log;
+            steal_capacity = __wt_atomic_load64(&cap->log);
             best_res = this_res;
         }
         if (type != WT_THROTTLE_READ && (this_res = cap->reservation_read) < best_res) {
             steal = &cap->reservation_read;
-            steal_capacity = cap->read;
+            steal_capacity = __wt_atomic_load64(&cap->read);
             best_res = this_res;
         }
 

--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -34,7 +34,7 @@ __capacity_config(WT_SESSION_IMPL *session, const char *cfg[])
     uint64_t chunkcache, ckpt, evict, log, read, total;
 
     conn = S2C(session);
-    chunkcache = ckpt = evict = log = read = total = 0;
+    chunkcache = total = 0;
 
     WT_RET(__wt_config_gets(session, cfg, "io_capacity.total", &cval));
     if (cval.val != 0) {
@@ -66,30 +66,32 @@ __capacity_config(WT_SESSION_IMPL *session, const char *cfg[])
     cap = &conn->capacity;
     cap->chunkcache = chunkcache;
     __wt_atomic_store64(&cap->total, total);
-    if (total != 0) {
-        /*
-         * We've been given a total capacity, set the capacity of all the subsystems.
-         */
-        ckpt = WT_CAPACITY_SYS(total, WT_CAP_CKPT);
-        evict = WT_CAPACITY_SYS(total, WT_CAP_EVICT);
-        log = WT_CAPACITY_SYS(total, WT_CAP_LOG);
-        read = WT_CAPACITY_SYS(total, WT_CAP_READ);
-
-        __wt_atomic_store64(&cap->ckpt, ckpt);
-        __wt_atomic_store64(&cap->evict, evict);
-        __wt_atomic_store64(&cap->log, log);
-        __wt_atomic_store64(&cap->read, read);
-
-        /*
-         * Set the threshold to the percent of our capacity to periodically asynchronously flush
-         * what we've written.
-         */
-        cap->threshold = ((ckpt + log + evict) / 100) * WT_CAPACITY_PCT;
-        if (cap->threshold < WT_CAPACITY_MIN_THRESHOLD)
-            cap->threshold = WT_CAPACITY_MIN_THRESHOLD;
-        WT_STAT_CONN_SET(session, capacity_threshold, cap->threshold);
-    } else
+    if (total == 0) {
         WT_STAT_CONN_SET(session, capacity_threshold, 0);
+        return (0);
+    }
+
+    /*
+     * We've been given a total capacity, set the capacity of all the subsystems.
+     */
+    ckpt = WT_CAPACITY_SYS(total, WT_CAP_CKPT);
+    evict = WT_CAPACITY_SYS(total, WT_CAP_EVICT);
+    log = WT_CAPACITY_SYS(total, WT_CAP_LOG);
+    read = WT_CAPACITY_SYS(total, WT_CAP_READ);
+
+    __wt_atomic_store64(&cap->ckpt, ckpt);
+    __wt_atomic_store64(&cap->evict, evict);
+    __wt_atomic_store64(&cap->log, log);
+    __wt_atomic_store64(&cap->read, read);
+
+    /*
+     * Set the threshold to the percent of our capacity to periodically asynchronously flush what
+     * we've written.
+     */
+    cap->threshold = ((ckpt + log + evict) / 100) * WT_CAPACITY_PCT;
+    if (cap->threshold < WT_CAPACITY_MIN_THRESHOLD)
+        cap->threshold = WT_CAPACITY_MIN_THRESHOLD;
+    WT_STAT_CONN_SET(session, capacity_threshold, cap->threshold);
 
     return (0);
 }

--- a/src/include/capacity.h
+++ b/src/include/capacity.h
@@ -47,13 +47,13 @@ typedef enum {
 #define WT_CAP_READ 55
 
 struct __wt_capacity {
-    uint64_t chunkcache;      /* Bytes/sec chunk cache capacity */
-    uint64_t ckpt;            /* Bytes/sec checkpoint capacity */
-    uint64_t evict;           /* Bytes/sec eviction capacity */
-    uint64_t log;             /* Bytes/sec logging capacity */
-    uint64_t read;            /* Bytes/sec read capacity */
-    wt_shared uint64_t total; /* Bytes/sec total capacity */
-    uint64_t threshold;       /* Capacity size period */
+    wt_shared uint64_t chunkcache; /* Bytes/sec chunk cache capacity */
+    wt_shared uint64_t ckpt;       /* Bytes/sec checkpoint capacity */
+    wt_shared uint64_t evict;      /* Bytes/sec eviction capacity */
+    wt_shared uint64_t log;        /* Bytes/sec logging capacity */
+    wt_shared uint64_t read;       /* Bytes/sec read capacity */
+    wt_shared uint64_t total;      /* Bytes/sec total capacity */
+    uint64_t threshold;            /* Capacity size period */
 
     wt_shared volatile uint64_t written; /* Written this period */
     wt_shared volatile bool signalled;   /* Capacity signalled */

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -55,7 +55,6 @@ race:__wt_reconcile
 race:__wti_conn_reconfig
 race:__wt_session_cursor_cache_sweep
 race:__wti_txn_update_pinned_timestamp
-race:__capacity_config
 
 
 # FIXME-WT-13075 Address these warnings separately as they may have perf impacts


### PR DESCRIPTION
This PR protects capacity server related values from the data race by protecting them with the relaxed atomic operations.

The data race could have happened during the WT reconfiguration, since it also could reconfigure the I/O capacity, but doesn't stop threads which could access capacity values (eviction, log, etc.). 

I thought about creating using an RW lock for this case, but I see the following drawbacks:
- We need a place to create this RW lock, since here we deal with the common code for `wiredtigen_open()` and `connection::reconfigure()` it became less straightforward since we need to init it for `open()`, and don't need to touch it during `reconfigure()`.  So we need something (like extra Boolean) to separate this cases.
- When capacity threshold is set, thread could fall asleep for some time. While it still should be possible to release the lock before going to sleep, I would prefer not creating locks even around places where we go to sleep :)