### PR TITLE
WT-14828 Ensure prepare id is set when preparing a transaction if preserve prepare config is on

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2047,6 +2047,11 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
 
     /* Set the prepared id */
     WT_RET(__wt_config_gets(session, cfg, "prepared_id", &cval));
+
+    if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+      (uint64_t)cval.val == WT_PREPARED_ID_NONE) {
+        WT_RET_MSG(session, EINVAL, "prepared_id need to be set with preserve_prepared flag on");
+    }
     session->txn->prepared_id = (uint64_t)cval.val;
 
     if (!F_ISSET(txn, WT_TXN_HAS_TS_PREPARE))

--- a/test/suite/test_prepare30.py
+++ b/test/suite/test_prepare30.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper import simulate_crash_restart
+from wtscenario import make_scenarios
+
+# test_prepare30.py
+# Test that validates that prepare transaction API raises correct errors with preserve_prepared config on
+
+class test_prepare30(wttest.WiredTigerTestCase):
+
+    conn_config_values = [
+        ('preserve_prepared_on', dict(expected_error=True, conn_config=f'preserve_prepared=true')),
+    ]
+
+    scenarios = make_scenarios(conn_config_values)
+
+    def test_prepare30(self):
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
+        uri = 'table:test_prepare31'
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(uri, create_params)
+
+        # Insert some data.
+        ts = 100
+        cursor = self.session.open_cursor(uri)
+        key = 1
+        self.session.begin_transaction()
+        cursor[key] = 'aaa'
+
+        if self.expected_error:
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
+                self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(ts)),
+                        '/prepared_id need to be set with preserve_prepared flag on/')
+
+

--- a/test/suite/test_prepare30.py
+++ b/test/suite/test_prepare30.py
@@ -43,17 +43,11 @@ class test_prepare30(wttest.WiredTigerTestCase):
 
     def test_prepare30(self):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
         uri = 'table:test_prepare31'
         create_params = 'key_format=i,value_format=S'
         self.session.create(uri, create_params)
-
-        # Insert some data.
         ts = 100
-        cursor = self.session.open_cursor(uri)
-        key = 1
         self.session.begin_transaction()
-        cursor[key] = 'aaa'
 
         if self.expected_error:
             self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -68,7 +68,7 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         c[4] = "prepare ts=100"
         c[5] = "prepare ts=100"
         # Prepare with a timestamp greater than current stable
-        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +',prepared_id=123')
 
         # Move the stable timestamp to include the prepared transaction
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))

--- a/test/suite/test_timestamp27.py
+++ b/test/suite/test_timestamp27.py
@@ -72,12 +72,12 @@ class test_timestamp27_preserve_prepared_on(wttest.WiredTigerTestCase):
 
     def test_prepared(self):
         self.session.begin_transaction()
-        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50)+',prepared_id=123')
         self.session.timestamp_transaction('rollback_timestamp=' + self.timestamp_str(100))
 
     def test_rollback_timestamp_lt_stable(self):
         self.session.begin_transaction()
-        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50)+',prepared_id=123')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
         self.session.timestamp_transaction('rollback_timestamp=' + self.timestamp_str(90)),
@@ -85,7 +85,7 @@ class test_timestamp27_preserve_prepared_on(wttest.WiredTigerTestCase):
 
     def test_rollback_timestamp_eq_stable(self):
         self.session.begin_transaction()
-        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50)+',prepared_id=123')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(100))
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
         self.session.timestamp_transaction('rollback_timestamp=' + self.timestamp_str(100)),
@@ -93,14 +93,14 @@ class test_timestamp27_preserve_prepared_on(wttest.WiredTigerTestCase):
 
     def test_rollback_timestamp_with_commit_timestamp(self):
         self.session.begin_transaction()
-        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50)+',prepared_id=123')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
         self.session.timestamp_transaction('rollback_timestamp=' + self.timestamp_str(100) + ",commit_timestamp=" + self.timestamp_str(100)),
             '/commit timestamp and rollback timestamp should not be set together/')
 
     def test_rollback_timestamp_with_commit_timestamp(self):
         self.session.begin_transaction()
-        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50)+',prepared_id=123')
         self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(100))
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda:
         self.session.timestamp_transaction('rollback_timestamp=' + self.timestamp_str(100) + ",durable_timestamp=" + self.timestamp_str(100)),


### PR DESCRIPTION
When preserve prepared flag is on, prepare_transaction API requires a transaction to have a prepare id. This PR checks this condition and raises an error when prepared id is not specified.
