### PR TITLE
WT-14864 Remove duplicate TSAN warnings from metric script

### DIFF
--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -68,6 +68,10 @@ for tsan_log in os.listdir(current_dir):
                 pattern_to_remove = r"/data/mci/.*/wiredtiger/"
                 cleaned_text = re.sub(pattern_to_remove, "", line).strip()
 
+                # Strip away the column line information.
+                pattern_to_remove = r':(\d+):\d+'
+                cleaned_text = re.sub(pattern_to_remove, r':\1', line).strip()
+
                 tsan_warnings_set.add(cleaned_text)
 
 print("Unique warnings:")

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -70,7 +70,7 @@ for tsan_log in os.listdir(current_dir):
 
                 # Strip away the column line information.
                 pattern_to_remove = r':(\d+):\d+'
-                cleaned_text = re.sub(pattern_to_remove, r':\1', line).strip()
+                cleaned_text = re.sub(pattern_to_remove, r':\1', cleaned_text).strip()
 
                 tsan_warnings_set.add(cleaned_text)
 


### PR DESCRIPTION
A bug has been found the TSAN metric script that doesn't remove duplicate warnings as shown here:

```
[2025/06/07 00:54:59.311] SUMMARY: ThreadSanitizer: data race src/btree/bt_curprev.c:669:15 in __cursor_row_prev
[2025/06/07 00:54:59.311] SUMMARY: ThreadSanitizer: data race src/btree/bt_curprev.c:669 in __cursor_row_prev
```

The pull request aims to fix the duplicate warnings using regex