### PR TITLE
WT-14901 Enable TSAN testing for all examples

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1582,16 +1582,6 @@ tasks:
         vars:
           directory: examples/c
 
-  - name: examples-c-tsan
-    tags: ["pull_request"]
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "make check directory"
-        vars:
-          directory: examples/c
-          ctest_extra_args: -E "(ex_all|ex_backup|ex_backup_block)" -j ${num_jobs}
-
   - name: examples-c-production-disable-shared-test
     tags: ["pull_request"]
     commands:
@@ -5459,7 +5449,7 @@ buildvariants:
       export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
-    - name: examples-c-tsan
+    - name: examples-c-test
     - name: tsan-warning-metrics
       batchtime: 10080 # 7 days
 
@@ -6282,7 +6272,7 @@ buildvariants:
       export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
-    - name: examples-c-tsan
+    - name: examples-c-test
 
 - name: amazon2023-armv9-msan
   display_name: "(ARMV9) Amazon Linux 2023 MSAN"

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -29,7 +29,7 @@ race:__ref_track_state
 # __wt_configure_method intentionally allows for races between threads to avoid the overhead of taking a lock on each API call.  
 race:__wt_configure_method
 
-# FIXME-WT-13074 This Work has been split out into a separate ticket to keep PR sizes down.
+# FIXME-WT-13074 Unresolved warnings for ex_backup
 race:__wt_free_int
 race:__wt_free_update_list
 race:__wt_page_out
@@ -47,6 +47,15 @@ race:__evict_queue_empty
 race:__evict_get_ref
 race:__evict_clear_all_walks
 race:__session_clear
+race:__rec_row_leaf_insert
+race:__wt_cache_dirty_decr
+
+# FIXME-WT-14856 Unresolved warnings for ex_all
+race:__wti_conn_reconfig
+race:__wt_session_cursor_cache_sweep
+race:__wti_txn_update_pinned_timestamp
+race:__capacity_config
+
 
 # FIXME-WT-13075 Address these warnings separately as they may have perf impacts
 race:hazard.c

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -49,6 +49,7 @@ race:__evict_clear_all_walks
 race:__session_clear
 race:__rec_row_leaf_insert
 race:__wt_cache_dirty_decr
+race:__wt_reconcile
 
 # FIXME-WT-14856 Unresolved warnings for ex_all
 race:__wti_conn_reconfig


### PR DESCRIPTION
Currently some examples aren't included to the regular TSAN CI testing because they generate a lot of warnings. The decision was to suppress all the warnings for now and enable the example to be able to solve these warnings step by step and check the fixes in regular CI by removing the suppressions.

All the warnings should be included into `tsan_warnings.supp` under the corresponding umbrella tickets:

ex_all - https://jira.mongodb.org/browse/WT-14856 
ex_backup - https://jira.mongodb.org/browse/WT-13074 
The idea is to continue resolving warnings from the suppression list iteratively, merging them separately, and creating a new ticket for each PR to reduce the scope of the umbrella tickets.
