### PR TITLE
WT-14900 Fix bugs in disagg garbage collection and cleanup the delta code

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -120,14 +120,14 @@ connection_disaggregated_config_common = [
         disk image if successful''',
         type='boolean', undoc=True),
     Config('internal_page_delta', 'true', r'''
-        When enabled, reconciliation writes deltas for internal pages
+        When enabled, reconciliation may write deltas for internal pages
         instead of writing entire pages every time''',
         type='boolean', undoc=True),
     Config('last_materialized_lsn', '', r'''
         the page LSN indicating that all pages up until this LSN are available for reading''',
         type='int', undoc=True),
     Config('leaf_page_delta', 'true', r'''
-        When enabled, reconciliation writes deltas for leaf pages
+        When enabled, reconciliation may write deltas for leaf pages
         instead of writing entire pages every time''',
         type='boolean', undoc=True),
     Config('lose_all_my_data', 'false', r'''

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -391,8 +391,10 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
 
         /* Search the page and apply the modification. */
         WT_ERR(__wt_row_search(&cbt, &key, true, ref, true, NULL));
-        /* Deltas are applied from newest to oldest, ignore keys that have already got a delta
-         * update. */
+        /*
+         * Deltas are applied from newest to oldest, ignore keys that have already got a delta
+         * update.
+         */
         if (cbt.compare == 0) {
             if (cbt.ins != NULL) {
                 if (cbt.ins->upd != NULL && F_ISSET(cbt.ins->upd, WT_UPDATE_RESTORED_FROM_DELTA))

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -133,7 +133,7 @@ __page_merge_internal_delta_with_base_image(WT_SESSION_IMPL *session, WT_REF *re
     WT_ITEM base_key_buf, delta_key_buf;
     WT_PAGE *page;
     WT_REF **refs;
-    size_t i, j, k, base_entries, estimated_entries, final_entries;
+    size_t base_entries, estimated_entries, final_entries, i, j, k;
     int cmp;
 
     final_entries = i = j = k = 0;
@@ -235,9 +235,9 @@ __page_merge_internal_deltas(WT_SESSION_IMPL *session, WT_CELL_UNPACK_DELTA_INT 
   uint32_t start, uint32_t end, size_t *sizes, WT_CELL_UNPACK_DELTA_INT ***deltas_merged,
   size_t *size)
 {
-    WT_CELL_UNPACK_DELTA_INT **left, **right, **merged;
+    WT_CELL_UNPACK_DELTA_INT **left, **merged, **right;
     size_t left_size, right_size;
-    uint32_t mid, i;
+    uint32_t i, mid;
 
     WT_ASSERT(session, start <= end);
     left = right = merged = NULL;
@@ -370,7 +370,7 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
     WT_ITEM key, value;
     WT_PAGE *page;
     WT_ROW *rip;
-    WT_UPDATE *first_upd, *upd, *standard_value, *tombstone;
+    WT_UPDATE *first_upd, *standard_value, *tombstone, *upd;
     size_t size, tmp_size, total_size;
 
     header = (WT_DELTA_HEADER *)delta->data;
@@ -391,9 +391,8 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
 
         /* Search the page and apply the modification. */
         WT_ERR(__wt_row_search(&cbt, &key, true, ref, true, NULL));
-        /*
-         * We apply deltas from newest to oldest, ignore keys that have already got a delta update.
-         */
+        /* Deltas are applied from newest to oldest, ignore keys that have already got a delta
+         * update. */
         if (cbt.compare == 0) {
             if (cbt.ins != NULL) {
                 if (cbt.ins->upd != NULL && F_ISSET(cbt.ins->upd, WT_UPDATE_RESTORED_FROM_DELTA))

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1616,7 +1616,7 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
      * disaggregated storage.
      */
     WT_ASSERT(session,
-      !F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) || multi->supd_entries == 0 ||
+      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) || multi->supd_entries == 0 ||
         multi->supd_restore);
 
     if (!multi->supd_restore)

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -660,6 +660,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     size_t parent_decr, size;
     uint64_t split_gen;
     uint32_t deleted_entries, *deleted_refs, hint, i, j, parent_entries, result_entries;
+    uint16_t ref_changes;
     bool empty_parent;
 
 #ifdef HAVE_DIAGNOSTIC
@@ -709,8 +710,12 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
              * which seems like asking for trouble.) Don't discard any ref has the prefetch flag,
              * the prefetch thread would crash if it sees a freed ref.
              */
-            if ((!F_ISSET(btree, WT_BTREE_DISAGGREGATED) || next_ref->ref_changes == 0) &&
-              next_ref != ref && WT_REF_GET_STATE(next_ref) == WT_REF_DELETED &&
+            if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+                WT_ACQUIRE_READ(ref_changes, next_ref->ref_changes);
+            else
+                ref_changes = 0;
+            if (ref_changes == 0 && next_ref != ref &&
+              WT_REF_GET_STATE(next_ref) == WT_REF_DELETED &&
               (btree->type != BTREE_COL_VAR || i != 0) &&
               !F_ISSET_ATOMIC_8(next_ref, WT_REF_FLAG_PREFETCH) &&
               __wti_delete_page_skip(session, next_ref, true) &&
@@ -1605,6 +1610,14 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
     WT_SAVE_UPD *supd;
     WT_UPDATE **tmp;
     uint32_t i, slot;
+
+    /*
+     * If we have saved updates, we must have decided to restore them to the new page except for
+     * disaggregated storage.
+     */
+    WT_ASSERT(session,
+      !F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) || multi->supd_entries == 0 ||
+        multi->supd_restore);
 
     if (!multi->supd_restore)
         return;

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -172,17 +172,15 @@ struct __wt_delta_cell_int {
  */
 struct __wt_delta_cell_leaf {
     /*
-     * Maximum of 47 bytes:
+     * Maximum of 65 bytes:
      *  1: cell descriptor byte
-     * 36: 4 timestamps		(uint64_t encoding, max 9 bytes)
+     * 54: 6 timestamps		(uint64_t encoding, max 9 bytes)
      *  5: key length		(uint32_t encoding, max 5 bytes)
-     *  5: key length		(uint32_t encoding, max 5 bytes)
+     *  5: value length		(uint32_t encoding, max 5 bytes)
      *
-     * This calculation is pessimistic: the prefix compression count and 64V value overlap, and the
-     * validity window, 64V value, fast-delete information and data length are all optional in some
-     * or even most cases.
+     * This calculation is pessimistic: the timestamps are optional.
      */
-    uint8_t __chunk[47];
+    uint8_t __chunk[65];
 };
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -174,9 +174,9 @@ struct __wt_delta_cell_leaf {
     /*
      * Maximum of 65 bytes:
      *  1: cell descriptor byte
-     * 54: 6 timestamps		(uint64_t encoding, max 9 bytes)
-     *  5: key length		(uint32_t encoding, max 5 bytes)
-     *  5: value length		(uint32_t encoding, max 5 bytes)
+     * 54: 4 timestamps and 2 transaction ids		(uint64_t encoding, max 9 bytes)
+     *  5: key length		                        (uint32_t encoding, max 5 bytes)
+     *  5: value length		                        (uint32_t encoding, max 5 bytes)
      *
      * This calculation is pessimistic: the timestamps are optional.
      */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1516,7 +1516,8 @@ __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, 
              * we should search the history store.
              */
             if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_HS_OPEN) &&
-              !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
+              !F_ISSET(session->dhandle,
+                WT_DHANDLE_HS | WT_DHANDLE_IS_METADATA | WT_DHANDLE_DISAGG_META)) {
                 __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
                 WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format,
                   recno, cbt->upd_value, &cbt->upd_value->buf));

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -646,7 +646,7 @@ __rec_row_garbage_collect_fixup_update_list(WT_SESSION_IMPL *session, WTI_RECONC
     if ((first_upd = WT_ROW_UPDATE(page, rip)) == NULL)
         return (0);
 
-    for (upd = first_upd; upd->txnid == WT_TXN_ABORTED; upd = first_upd->next)
+    for (upd = first_upd; upd != NULL && upd->txnid == WT_TXN_ABORTED; upd = first_upd->next)
         ;
 
     if (upd == NULL)
@@ -689,7 +689,7 @@ __rec_row_garbage_collect_fixup_insert_list(
     if ((first_upd = ins->upd) == NULL)
         return (0);
 
-    for (upd = first_upd; upd->txnid == WT_TXN_ABORTED; upd = upd->next)
+    for (upd = first_upd; upd != NULL && upd->txnid == WT_TXN_ABORTED; upd = upd->next)
         ;
 
     if (upd == NULL)

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -649,6 +649,9 @@ __rec_row_garbage_collect_fixup_update_list(WT_SESSION_IMPL *session, WTI_RECONC
     for (upd = first_upd; upd->txnid == WT_TXN_ABORTED; upd = first_upd->next)
         ;
 
+    if (upd == NULL)
+        return (0);
+
     if (upd->type == WT_UPDATE_TOMBSTONE)
         return (0);
 
@@ -686,6 +689,9 @@ __rec_row_garbage_collect_fixup_insert_list(
 
     for (upd = first_upd; upd->txnid == WT_TXN_ABORTED; upd = upd->next)
         ;
+
+    if (upd == NULL)
+        return (0);
 
     if (upd->type == WT_UPDATE_TOMBSTONE)
         return (0);

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -664,6 +664,7 @@ __rec_row_garbage_collect_fixup_update_list(WT_SESSION_IMPL *session, WTI_RECONC
 
         WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys);
     }
+
     return (0);
 }
 
@@ -683,6 +684,7 @@ __rec_row_garbage_collect_fixup_insert_list(
 
     if (!F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) || !F_ISSET(r, WT_REC_EVICT))
         return (0);
+
     /* The insert list should have an update, but be paranoid */
     if ((first_upd = ins->upd) == NULL)
         return (0);
@@ -704,6 +706,7 @@ __rec_row_garbage_collect_fixup_insert_list(
 
         WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys);
     }
+
     return (0);
 }
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -634,7 +634,7 @@ __rec_row_garbage_collect_fixup_update_list(WT_SESSION_IMPL *session, WTI_RECONC
     WT_BTREE *btree;
     WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
-    WT_UPDATE *first_upd, *tombstone, **upd_entry;
+    WT_UPDATE *first_upd, *tombstone, *upd, **upd_entry;
 
     btree = S2BT(session);
     page = r->page;
@@ -642,14 +642,18 @@ __rec_row_garbage_collect_fixup_update_list(WT_SESSION_IMPL *session, WTI_RECONC
 
     if (!F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) || !F_ISSET(r, WT_REC_EVICT))
         return (0);
+
     if ((first_upd = WT_ROW_UPDATE(page, rip)) == NULL)
         return (0);
 
-    if (first_upd->type == WT_UPDATE_TOMBSTONE)
+    for (upd = first_upd; upd->txnid == WT_TXN_ABORTED; upd = first_upd->next)
+        ;
+
+    if (upd->type == WT_UPDATE_TOMBSTONE)
         return (0);
 
-    if (WT_TXNID_LT(first_upd->txnid, r->last_running) && r->rec_prune_timestamp != WT_TS_NONE &&
-      first_upd->durable_ts <= r->rec_prune_timestamp) {
+    if (WT_TXNID_LT(upd->txnid, r->last_running) && r->rec_prune_timestamp != WT_TS_NONE &&
+      upd->durable_ts <= r->rec_prune_timestamp) {
         WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
         tombstone->next = first_upd;
         upd_entry = &mod->mod_row_update[WT_ROW_SLOT(page, rip)];
@@ -670,7 +674,7 @@ __rec_row_garbage_collect_fixup_insert_list(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins)
 {
     WT_BTREE *btree;
-    WT_UPDATE *first_upd, *tombstone;
+    WT_UPDATE *first_upd, *tombstone, *upd;
 
     btree = S2BT(session);
 
@@ -680,11 +684,14 @@ __rec_row_garbage_collect_fixup_insert_list(
     if ((first_upd = ins->upd) == NULL)
         return (0);
 
-    if (first_upd->type == WT_UPDATE_TOMBSTONE)
+    for (upd = first_upd; upd->txnid == WT_TXN_ABORTED; upd = upd->next)
+        ;
+
+    if (upd->type == WT_UPDATE_TOMBSTONE)
         return (0);
 
-    if (WT_TXNID_LT(first_upd->txnid, r->last_running) && r->rec_prune_timestamp != WT_TS_NONE &&
-      first_upd->durable_ts <= r->rec_prune_timestamp) {
+    if (WT_TXNID_LT(upd->txnid, r->last_running) && r->rec_prune_timestamp != WT_TS_NONE &&
+      upd->durable_ts <= r->rec_prune_timestamp) {
         WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
         tombstone->next = first_upd;
         ins->upd = tombstone;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -651,12 +651,6 @@ __rec_row_garbage_collect_fixup_update_list(WT_SESSION_IMPL *session, WTI_RECONC
     if (WT_TXNID_LT(first_upd->txnid, r->last_running) && r->rec_prune_timestamp != WT_TS_NONE &&
       first_upd->durable_ts <= r->rec_prune_timestamp) {
         WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
-        /*
-         * Use the transaction ID of the prior update to avoid out-of-order IDs, we know that update
-         * selection further into reconciliation will choose this tombstone and cause the record to
-         * be skipped when creating a page image.
-         */
-        tombstone->txnid = first_upd->txnid;
         tombstone->next = first_upd;
         upd_entry = &mod->mod_row_update[WT_ROW_SLOT(page, rip)];
         *upd_entry = tombstone;
@@ -692,12 +686,6 @@ __rec_row_garbage_collect_fixup_insert_list(
     if (WT_TXNID_LT(first_upd->txnid, r->last_running) && r->rec_prune_timestamp != WT_TS_NONE &&
       first_upd->durable_ts <= r->rec_prune_timestamp) {
         WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
-        /*
-         * Use the transaction ID of the prior update to avoid out-of-order IDs, we know that update
-         * selection further into reconciliation will choose this tombstone and cause the record to
-         * be skipped when creating a page image.
-         */
-        tombstone->txnid = first_upd->txnid;
         tombstone->next = first_upd;
         ins->upd = tombstone;
 
@@ -997,12 +985,22 @@ __wti_rec_row_leaf(
         if (upd == NULL) {
             if (__wt_txn_tw_stop_visible_all(session, twp))
                 upd = &upd_tombstone;
-            else if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
-              WT_TXNID_LT(twp->start_txn, r->last_running) &&
-              r->rec_prune_timestamp != WT_TS_NONE &&
-              twp->durable_start_ts <= r->rec_prune_timestamp) {
-                upd = &upd_tombstone;
-                WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys);
+            else if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
+                if (WT_TIME_WINDOW_HAS_STOP(twp)) {
+                    if (WT_TXNID_LT(twp->stop_txn, r->last_running) &&
+                      r->rec_prune_timestamp != WT_TS_NONE &&
+                      twp->durable_stop_ts <= r->rec_prune_timestamp) {
+                        upd = &upd_tombstone;
+                        WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys);
+                    }
+                } else {
+                    if (WT_TXNID_LT(twp->start_txn, r->last_running) &&
+                      r->rec_prune_timestamp != WT_TS_NONE &&
+                      twp->durable_start_ts <= r->rec_prune_timestamp) {
+                        upd = &upd_tombstone;
+                        WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys);
+                    }
+                }
             }
         }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -874,7 +874,17 @@ __rec_fill_tw_from_upd_select(
          * ends when this tombstone started. (Note: this may have been true at one point, but
          * currently we either append the onpage value and return that, or return the tombstone
          * itself; there is no case that returns no update but sets the time window.)
+         *
+         * If the tombstone is restored from the disk except for disaggregated storage or the
+         * history store, the onpage value and the history store value should have been restored
+         * together. Therefore, we should not end up here.
          */
+        WT_ASSERT_ALWAYS(session,
+          (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+            !F_ISSET(tombstone, WT_UPDATE_RESTORED_FROM_HS)) ||
+            (!F_ISSET(tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS)),
+          "A tombstone written to the disk image except for disaggregated storage or history store "
+          "should be accompanied by the full value.");
         WT_RET(__rec_append_orig_value(session, page, tombstone, vpack));
 
         /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -442,6 +442,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
      */
     mod->rec_max_txn = r->max_txn;
     mod->rec_max_timestamp = r->max_ts;
+    mod->rec_pinned_stable_timestamp = r->rec_start_pinned_stable_ts;
 
     page->old_rec_lsn_max = page->rec_lsn_max;
     /* Track the page's most recent LSN. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -442,7 +442,6 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
      */
     mod->rec_max_txn = r->max_txn;
     mod->rec_max_timestamp = r->max_ts;
-    mod->rec_pinned_stable_timestamp = r->rec_start_pinned_stable_ts;
 
     page->old_rec_lsn_max = page->rec_lsn_max;
     /* Track the page's most recent LSN. */
@@ -2455,6 +2454,227 @@ __rec_set_updates_durable(WT_BTREE *btree, WT_MULTI *multi)
 }
 
 /*
+ * __rec_write_delta --
+ *     Write a delta to storage
+ */
+static int
+__rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chunk, uint8_t *addr,
+  size_t *addr_sizep, size_t *compressed_sizep)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_MULTI *multi;
+    WT_PAGE_BLOCK_META *block_meta;
+    uint64_t checkpoint_id, delta_pct;
+
+    conn = S2C(session);
+    multi = &r->multi[r->multi_next - 1];
+    block_meta = &r->ref->page->block_meta;
+
+    WT_ASSERT(session, block_meta->checkpoint_id >= WT_DISAGG_CHECKPOINT_ID_FIRST);
+    multi->block_meta = *block_meta;
+    WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
+    /* The first delta needs to explicitly initialize the base LSN and checkpoint id. */
+    if (multi->block_meta.delta_count == 0) {
+        multi->block_meta.base_lsn = multi->block_meta.disagg_lsn;
+        multi->block_meta.base_checkpoint_id = multi->block_meta.checkpoint_id;
+    }
+    WT_ASSERT(session,
+      multi->block_meta.base_lsn > 0 ||
+        multi->block_meta.base_checkpoint_id >= WT_DISAGG_CHECKPOINT_ID_FIRST);
+    multi->block_meta.backlink_lsn = block_meta->disagg_lsn;
+    multi->block_meta.backlink_checkpoint_id = multi->block_meta.checkpoint_id;
+    if (checkpoint_id != multi->block_meta.checkpoint_id) {
+        WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
+        multi->block_meta.checkpoint_id = checkpoint_id;
+        multi->block_meta.reconciliation_id = 0;
+    } else
+        ++multi->block_meta.reconciliation_id;
+    ++multi->block_meta.delta_count;
+
+    /* Get the checkpoint ID. */
+    WT_RET(__wt_blkcache_write(session, &r->delta, &multi->block_meta, addr, addr_sizep,
+      compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
+    /* Turn off compression adjustment for delta. */
+    *compressed_sizep = 0;
+
+    delta_pct = (r->delta.size * 100) / chunk->image.size;
+    if (F_ISSET(r->ref, WT_REF_FLAG_INTERNAL)) {
+        WT_STAT_CONN_DSRC_INCR(session, rec_page_delta_internal);
+
+        /*
+         * If we decide to write the delta we packed, track the number of bytes saved by avoiding
+         * writing the full page image.
+         *
+         * Also track how large the delta is compared to the full page image.
+         */
+        WT_STAT_CONN_INCRV(
+          session, block_byte_write_saved_delta_intl, chunk->image.size - r->delta.size);
+
+        if (delta_pct <= 20)
+            WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt20);
+        else if (delta_pct <= 40)
+            WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt40);
+        else if (delta_pct <= 60)
+            WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt60);
+        else if (delta_pct <= 80)
+            WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt80);
+        else if (delta_pct <= 100)
+            WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt100);
+        else
+            WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_gt100);
+
+        /* Increase this count only when we write the first delta. */
+        if (multi->block_meta.delta_count == 1)
+            WT_STAT_CONN_DSRC_INCR(session, rec_pages_with_internal_deltas);
+
+        if (multi->block_meta.delta_count >
+          __wt_atomic_load64(&conn->disaggregated_storage.max_internal_delta_count))
+            __wt_atomic_store64(
+              &conn->disaggregated_storage.max_internal_delta_count, multi->block_meta.delta_count);
+    } else if (F_ISSET(r->ref, WT_REF_FLAG_LEAF)) {
+        WT_STAT_CONN_DSRC_INCR(session, rec_page_delta_leaf);
+        WT_STAT_CONN_INCRV(
+          session, block_byte_write_saved_delta_leaf, chunk->image.size - r->delta.size);
+
+        if (delta_pct <= 20)
+            WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt20);
+        else if (delta_pct <= 40)
+            WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt40);
+        else if (delta_pct <= 60)
+            WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt60);
+        else if (delta_pct <= 80)
+            WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt80);
+        else if (delta_pct <= 100)
+            WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt100);
+        else
+            WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_gt100);
+
+        /* Increase this count only when we write the first delta. */
+        if (multi->block_meta.delta_count == 1)
+            WT_STAT_CONN_DSRC_INCR(session, rec_pages_with_leaf_deltas);
+
+        if (multi->block_meta.delta_count >
+          __wt_atomic_load64(&conn->disaggregated_storage.max_leaf_delta_count))
+            __wt_atomic_store64(
+              &conn->disaggregated_storage.max_leaf_delta_count, multi->block_meta.delta_count);
+    }
+
+    return (0);
+}
+
+/*
+ * __rec_write_image --
+ *     Write a full disk image to storage
+ */
+static int
+__rec_write_image(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chunk, uint8_t *addr,
+  size_t *addr_sizep, size_t *compressed_sizep, bool last_block)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_MULTI *multi;
+    WT_PAGE *page;
+    WT_PAGE_BLOCK_META *block_meta;
+    uint64_t checkpoint_id;
+
+    conn = S2C(session);
+    page = r->page;
+    multi = &r->multi[r->multi_next - 1];
+    block_meta = &page->block_meta;
+
+    /* If we split the page, create a new page id. Otherwise, reuse the existing page id. */
+    if (last_block && r->multi_next == 1 && block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
+        multi->block_meta = *block_meta;
+        /*
+         * Full page's backlink is the previous full page. If the previous page is a delta, use the
+         * base as the new backlink. Otherwise, use the previous page as the backlink.
+         */
+        if (multi->block_meta.delta_count > 0) {
+            WT_ASSERT(session,
+              multi->block_meta.base_lsn > 0 ||
+                multi->block_meta.base_checkpoint_id >= WT_DISAGG_CHECKPOINT_ID_FIRST);
+            multi->block_meta.backlink_checkpoint_id = multi->block_meta.base_checkpoint_id;
+            multi->block_meta.backlink_lsn = multi->block_meta.base_lsn;
+        } else {
+            multi->block_meta.backlink_checkpoint_id = multi->block_meta.checkpoint_id;
+            multi->block_meta.backlink_lsn = multi->block_meta.disagg_lsn;
+        }
+        multi->block_meta.delta_count = 0;
+        multi->block_meta.base_lsn = 0;
+        multi->block_meta.base_checkpoint_id = 0;
+        WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
+        if (checkpoint_id != multi->block_meta.checkpoint_id) {
+            WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
+            multi->block_meta.checkpoint_id = checkpoint_id;
+            multi->block_meta.reconciliation_id = 0;
+        } else
+            ++multi->block_meta.reconciliation_id;
+    } else
+        __wt_page_block_meta_assign(session, &multi->block_meta);
+    WT_RET(__rec_write(session, &chunk->image, &multi->block_meta, addr, addr_sizep,
+      compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
+
+    if (F_ISSET(r->ref, WT_REF_FLAG_INTERNAL))
+        WT_STAT_CONN_INCR(session, rec_page_full_image_internal);
+    else if (F_ISSET(r->ref, WT_REF_FLAG_LEAF))
+        WT_STAT_CONN_INCR(session, rec_page_full_image_leaf);
+
+    return (0);
+}
+
+/*
+ * __rec_copy_prev_addr --
+ *     Copy the address cookie of the previous written page
+ */
+static int
+__rec_copy_prev_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
+{
+    WT_MULTI *multi;
+    WT_PAGE *page;
+    WT_PAGE_MODIFY *mod;
+
+    page = r->page;
+    mod = page->modify;
+    multi = &r->multi[r->multi_next - 1];
+
+    switch (mod->rec_result) {
+    case 0:
+        WT_ASSERT(session, r->ref->addr != NULL);
+        break;
+    case WT_PM_REC_EMPTY: /* Page deleted */
+        WT_ASSERT_ALWAYS(session, false, "write delta for a new page.");
+        break;
+    case WT_PM_REC_REPLACE: /* 1-for-1 page swap */
+        multi->block_meta = page->block_meta;
+        if (mod->mod_replace.block_cookie != NULL) {
+            WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_replace.ta);
+            WT_RET(__wt_memdup(session, mod->mod_replace.block_cookie,
+              mod->mod_replace.block_cookie_size, &multi->addr.block_cookie));
+            multi->addr.block_cookie_size = mod->mod_replace.block_cookie_size;
+            multi->addr.type = mod->mod_replace.type;
+        } else
+            WT_ASSERT(session, r->ref->addr != NULL);
+        break;
+    case WT_PM_REC_MULTIBLOCK: /* Multiple blocks */
+        WT_ASSERT(session, mod->mod_multi_entries == 1);
+        multi->block_meta = mod->mod_multi->block_meta;
+        if (mod->mod_multi->addr.block_cookie != NULL) {
+            WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_multi->addr.ta);
+            WT_RET(__wt_memdup(session, mod->mod_multi->addr.block_cookie,
+              mod->mod_multi->addr.block_cookie_size, &multi->addr.block_cookie));
+            multi->addr.block_cookie_size = mod->mod_multi->addr.block_cookie_size;
+            multi->addr.type = mod->mod_multi->addr.type;
+        } else
+            WT_ASSERT(session, r->ref->addr != NULL);
+        break;
+    default:
+        return (__wt_illegal_value(session, mod->rec_result));
+    }
+    WT_STAT_CONN_DSRC_INCR(session, rec_skip_empty_deltas);
+
+    return (0);
+}
+
+/*
  * __rec_split_write --
  *     Write a disk block out for the split helper functions.
  */
@@ -2462,26 +2682,21 @@ static int
 __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chunk, bool last_block)
 {
     WT_BTREE *btree;
-    WT_CONNECTION_IMPL *conn;
     WT_DELTA_HEADER *header;
     WT_MULTI *multi;
     WT_PAGE *page;
     WT_PAGE_BLOCK_META *block_meta;
-    WT_PAGE_MODIFY *mod;
     size_t addr_size, compressed_size;
-    uint64_t checkpoint_id, delta_pct;
     uint8_t addr[WT_ADDR_MAX_COOKIE];
     bool build_delta;
 #ifdef HAVE_DIAGNOSTIC
     bool verify_image;
 #endif
 
-    conn = S2C(session);
     btree = S2BT(session);
     page = r->page;
-    mod = page->modify;
     build_delta = false;
-    block_meta = &r->ref->page->block_meta;
+    block_meta = &page->block_meta;
 #ifdef HAVE_DIAGNOSTIC
     verify_image = true;
 #endif
@@ -2565,8 +2780,8 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
         r->wrapup_checkpoint = &chunk->image;
 
         /*
-         * We need to assign a new page id for the root every time. We don't support delta for
-         * internal page yet.
+         * We need to assign a new page id for the root every time. We don't support delta for root
+         * page yet.
          */
         __wt_page_block_meta_assign(session, &r->wrapup_checkpoint_block_meta);
 
@@ -2612,7 +2827,10 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
       block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID &&
       block_meta->delta_count < btree->max_consecutive_delta) {
         WT_RET(__rec_build_delta(session, r, chunk->image.mem, &build_delta));
-        /* Discard the delta if it is larger than one tenth of the size of the full image. */
+        /*
+         * Discard the delta if it is larger than the configured percentage of the size of the full
+         * image.
+         */
         if (build_delta && ((r->delta.size * 100) / chunk->image.size) > btree->delta_pct)
             build_delta = false;
     }
@@ -2623,171 +2841,16 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
         /* Avoid writing an empty delta. */
         if (header->u.entries == 0) {
             /* Copy the previous written page's address if we skip writing. */
-            switch (mod->rec_result) {
-            case 0:
-                WT_ASSERT(session, r->ref->addr != NULL);
-                break;
-            case WT_PM_REC_EMPTY: /* Page deleted */
-                WT_ASSERT_ALWAYS(session, false, "write delta for a new page.");
-                break;
-            case WT_PM_REC_REPLACE: /* 1-for-1 page swap */
-                multi->block_meta = page->block_meta;
-                if (mod->mod_replace.block_cookie != NULL) {
-                    WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_replace.ta);
-                    WT_RET(__wt_memdup(session, mod->mod_replace.block_cookie,
-                      mod->mod_replace.block_cookie_size, &multi->addr.block_cookie));
-                    multi->addr.block_cookie_size = mod->mod_replace.block_cookie_size;
-                    multi->addr.type = mod->mod_replace.type;
-                } else
-                    WT_ASSERT(session, r->ref->addr != NULL);
-                break;
-            case WT_PM_REC_MULTIBLOCK: /* Multiple blocks */
-                WT_ASSERT(session, mod->mod_multi_entries == 1);
-                multi->block_meta = mod->mod_multi->block_meta;
-                if (mod->mod_multi->addr.block_cookie != NULL) {
-                    WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_multi->addr.ta);
-                    WT_RET(__wt_memdup(session, mod->mod_multi->addr.block_cookie,
-                      mod->mod_multi->addr.block_cookie_size, &multi->addr.block_cookie));
-                    multi->addr.block_cookie_size = mod->mod_multi->addr.block_cookie_size;
-                    multi->addr.type = mod->mod_multi->addr.type;
-                } else
-                    WT_ASSERT(session, r->ref->addr != NULL);
-                break;
-            default:
-                return (__wt_illegal_value(session, mod->rec_result));
-            }
-            WT_STAT_CONN_DSRC_INCR(session, rec_skip_empty_deltas);
+            WT_RET(__rec_copy_prev_addr(session, r));
             goto copy_image;
         }
 
         /* We must only have one delta. Building deltas for split case is a future thing. */
         WT_ASSERT(session, last_block);
-        WT_ASSERT(session, block_meta->checkpoint_id >= WT_DISAGG_CHECKPOINT_ID_FIRST);
-        multi->block_meta = *block_meta;
-        WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
-        /* The first delta needs to explicitly initialize the base LSN and checkpoint id. */
-        if (multi->block_meta.delta_count == 0) {
-            multi->block_meta.base_lsn = multi->block_meta.disagg_lsn;
-            multi->block_meta.base_checkpoint_id = multi->block_meta.checkpoint_id;
-        }
-        WT_ASSERT(session,
-          multi->block_meta.base_lsn > 0 ||
-            multi->block_meta.base_checkpoint_id >= WT_DISAGG_CHECKPOINT_ID_FIRST);
-        multi->block_meta.backlink_lsn = block_meta->disagg_lsn;
-        multi->block_meta.backlink_checkpoint_id = multi->block_meta.checkpoint_id;
-        if (checkpoint_id != multi->block_meta.checkpoint_id) {
-            WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
-            multi->block_meta.checkpoint_id = checkpoint_id;
-            multi->block_meta.reconciliation_id = 0;
-        } else
-            ++multi->block_meta.reconciliation_id;
-        ++multi->block_meta.delta_count;
-
-        /* Get the checkpoint ID. */
-        WT_RET(__wt_blkcache_write(session, &r->delta, &multi->block_meta, addr, &addr_size,
-          &compressed_size, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
-        /* Turn off compression adjustment for delta. */
-        compressed_size = 0;
-
-        delta_pct = (r->delta.size * 100) / chunk->image.size;
-        if (F_ISSET(r->ref, WT_REF_FLAG_INTERNAL)) {
-            WT_STAT_CONN_DSRC_INCR(session, rec_page_delta_internal);
-
-            /*
-             * If we decide to write the delta we packed, track the number of bytes saved by
-             * avoiding writing the full page image.
-             *
-             * Also track how large the delta is compared to the full page image.
-             */
-            WT_STAT_CONN_INCRV(
-              session, block_byte_write_saved_delta_intl, chunk->image.size - r->delta.size);
-
-            if (delta_pct <= 20)
-                WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt20);
-            else if (delta_pct <= 40)
-                WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt40);
-            else if (delta_pct <= 60)
-                WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt60);
-            else if (delta_pct <= 80)
-                WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt80);
-            else if (delta_pct <= 100)
-                WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_lt100);
-            else
-                WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_gt100);
-
-            /* Increase this count only when we write the first delta. */
-            if (multi->block_meta.delta_count == 1)
-                WT_STAT_CONN_DSRC_INCR(session, rec_pages_with_internal_deltas);
-
-            if (multi->block_meta.delta_count >
-              __wt_atomic_load64(&conn->disaggregated_storage.max_internal_delta_count))
-                __wt_atomic_store64(&conn->disaggregated_storage.max_internal_delta_count,
-                  multi->block_meta.delta_count);
-        } else if (F_ISSET(r->ref, WT_REF_FLAG_LEAF)) {
-            WT_STAT_CONN_DSRC_INCR(session, rec_page_delta_leaf);
-            WT_STAT_CONN_INCRV(
-              session, block_byte_write_saved_delta_leaf, chunk->image.size - r->delta.size);
-
-            if (delta_pct <= 20)
-                WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt20);
-            else if (delta_pct <= 40)
-                WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt40);
-            else if (delta_pct <= 60)
-                WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt60);
-            else if (delta_pct <= 80)
-                WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt80);
-            else if (delta_pct <= 100)
-                WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt100);
-            else
-                WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_gt100);
-
-            /* Increase this count only when we write the first delta. */
-            if (multi->block_meta.delta_count == 1)
-                WT_STAT_CONN_DSRC_INCR(session, rec_pages_with_leaf_deltas);
-
-            if (multi->block_meta.delta_count >
-              __wt_atomic_load64(&conn->disaggregated_storage.max_leaf_delta_count))
-                __wt_atomic_store64(
-                  &conn->disaggregated_storage.max_leaf_delta_count, multi->block_meta.delta_count);
-        }
+        WT_RET(__rec_write_delta(session, r, chunk, addr, &addr_size, &compressed_size));
     } else {
-        /* If we split the page, create a new page id. Otherwise, reuse the existing page id. */
-        if (last_block && r->multi_next == 1 && block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
-            multi->block_meta = *block_meta;
-            /*
-             * Full page's backlink is the previous full page. If the previous page is a delta, use
-             * the base as the new backlink. Otherwise, use the previous page as the backlink.
-             */
-            if (multi->block_meta.delta_count > 0) {
-                WT_ASSERT(session,
-                  multi->block_meta.base_lsn > 0 ||
-                    multi->block_meta.base_checkpoint_id >= WT_DISAGG_CHECKPOINT_ID_FIRST);
-                multi->block_meta.backlink_checkpoint_id = multi->block_meta.base_checkpoint_id;
-                multi->block_meta.backlink_lsn = multi->block_meta.base_lsn;
-            } else {
-                multi->block_meta.backlink_checkpoint_id = multi->block_meta.checkpoint_id;
-                multi->block_meta.backlink_lsn = multi->block_meta.disagg_lsn;
-            }
-            multi->block_meta.delta_count = 0;
-            multi->block_meta.base_lsn = 0;
-            multi->block_meta.base_checkpoint_id = 0;
-            WT_ACQUIRE_READ(checkpoint_id, conn->disaggregated_storage.global_checkpoint_id);
-            if (checkpoint_id != multi->block_meta.checkpoint_id) {
-                WT_ASSERT(session, checkpoint_id > multi->block_meta.checkpoint_id);
-                multi->block_meta.checkpoint_id = checkpoint_id;
-                multi->block_meta.reconciliation_id = 0;
-            } else
-                ++multi->block_meta.reconciliation_id;
-        } else
-            __wt_page_block_meta_assign(session, &multi->block_meta);
-        WT_RET(__rec_write(session, &chunk->image, &multi->block_meta, addr, &addr_size,
-          &compressed_size, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
-
-        if (F_ISSET(r->ref, WT_REF_FLAG_INTERNAL))
-            WT_STAT_CONN_INCR(session, rec_page_full_image_internal);
-        else if (F_ISSET(r->ref, WT_REF_FLAG_LEAF))
-            WT_STAT_CONN_INCR(session, rec_page_full_image_leaf);
-
+        WT_RET(
+          __rec_write_image(session, r, chunk, addr, &addr_size, &compressed_size, last_block));
 #ifdef HAVE_DIAGNOSTIC
         verify_image = true;
 #endif
@@ -2957,8 +3020,6 @@ __rec_split_discard(WT_SESSION_IMPL *session, WT_PAGE *page)
               session, multi->addr.block_cookie, multi->addr.block_cookie_size, false));
             __wt_free(session, multi->addr.block_cookie);
         }
-
-        multi->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
     }
     __wt_free(session, mod->mod_multi);
     mod->mod_multi_entries = 0;

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -176,9 +176,6 @@ struct __wti_reconcile {
     /* Track the pinned timestamp at the time reconciliation started. */
     wt_timestamp_t rec_start_pinned_ts;
 
-    /* Track the pinned stable timestamp at the time reconciliation started. */
-    wt_timestamp_t rec_start_pinned_stable_ts;
-
     /* Track the prune timestamp at the time reconciliation started. */
     wt_timestamp_t rec_prune_timestamp;
 
@@ -455,8 +452,10 @@ typedef struct {
       F_ISSET(&S2C(session)->disaggregated_storage, WT_DISAGG_LEAF_PAGE_DELTA) && \
       (r)->multi_next == 1 && !r->ovfl_items && WT_REC_RESULT_SINGLE_PAGE((session), (r))
 
-/* Called when building the internal page image to indicate should we start to build a delta for the
- * page. We are still building so multi_next should still be 0 instead of 1. */
+/*
+ * Called when building the internal page image to indicate should we start to build a delta for the
+ * page. We are still building so multi_next should still be 0 instead of 1.
+ */
 #define WT_BUILD_DELTA_INT(session, r)                                                   \
     F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&                                    \
       F_ISSET(&S2C(session)->disaggregated_storage, WT_DISAGG_INTERNAL_PAGE_DELTA) &&    \

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -176,6 +176,9 @@ struct __wti_reconcile {
     /* Track the pinned timestamp at the time reconciliation started. */
     wt_timestamp_t rec_start_pinned_ts;
 
+    /* Track the pinned stable timestamp at the time reconciliation started. */
+    wt_timestamp_t rec_start_pinned_stable_ts;
+
     /* Track the prune timestamp at the time reconciliation started. */
     wt_timestamp_t rec_prune_timestamp;
 

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -77,63 +77,63 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
             session.rollback_transaction()
         return count
 
-    # def test_gc_ingest_table(self):
-    #     # Create the oplog
-    #     oplog = Oplog(value_size=500)
+    def test_gc_ingest_table(self):
+        # Create the oplog
+        oplog = Oplog(value_size=500)
 
-    #     # Create the table on leader and tell oplog about it
-    #     self.session.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
-    #     t = oplog.add_uri(self.uri)
+        # Create the table on leader and tell oplog about it
+        self.session.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+        t = oplog.add_uri(self.uri)
 
-    #     # Create the follower and create its table
-    #     # To keep this test relatively easy, we're only using a single URI.
-    #     conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
-    #     session_follow = conn_follow.open_session('')
-    #     session_follow.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+        # Create the follower and create its table
+        # To keep this test relatively easy, we're only using a single URI.
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
 
-    #     # Load the data for oplog
-    #     oplog.insert(t, self.nitems)
+        # Load the data for oplog
+        oplog.insert(t, self.nitems)
 
-    #     # Apply it to the leader WT.
-    #     oplog.apply(self, self.session, 0, self.nitems)
-    #     oplog.check(self, self.session, 0, self.nitems)
+        # Apply it to the leader WT.
+        oplog.apply(self, self.session, 0, self.nitems)
+        oplog.check(self, self.session, 0, self.nitems)
 
-    #     ts = oplog.last_timestamp()
-    #     self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(ts)}')
+        ts = oplog.last_timestamp()
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(ts)}')
 
-    #     # On the follower -
-    #     # Apply all the entries to follower
-    #     oplog.apply(self, session_follow, 0, self.nitems)
-    #     oplog.check(self, session_follow, 0, self.nitems)
+        # On the follower -
+        # Apply all the entries to follower
+        oplog.apply(self, session_follow, 0, self.nitems)
+        oplog.check(self, session_follow, 0, self.nitems)
 
-    #     # Ensure everything is in the ingest table
-    #     count = self.count_ingest(session_follow)
-    #     self.assertEqual(count, self.nitems)
+        # Ensure everything is in the ingest table
+        count = self.count_ingest(session_follow)
+        self.assertEqual(count, self.nitems)
 
-    #     # Hold a cursor open on the layered table, and on the ingest as well.
-    #     session_follow2 = conn_follow.open_session('')
-    #     hold_cursor = session_follow2.open_cursor(self.uri)
-    #     hold_cursor.next()
+        # Hold a cursor open on the layered table, and on the ingest as well.
+        session_follow2 = conn_follow.open_session('')
+        hold_cursor = session_follow2.open_cursor(self.uri)
+        hold_cursor.next()
 
-    #     # Take a checkpoint and advance it, make sure everything is still good
-    #     self.session.checkpoint()
-    #     self.disagg_advance_checkpoint(conn_follow)
-    #     oplog.check(self, session_follow, 0, self.nitems)
+        # Take a checkpoint and advance it, make sure everything is still good
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+        oplog.check(self, session_follow, 0, self.nitems)
 
-    #     # At this point, everything in the ingest table is redundant, as it's
-    #     # also in the stable table on the follower. However, it cannot be removed
-    #     # as there is a cursor open.
-    #     self.evict_ingest(session_follow, ts)
-    #     count = self.count_ingest(session_follow)
-    #     self.assertEqual(count, self.nitems)
+        # At this point, everything in the ingest table is redundant, as it's
+        # also in the stable table on the follower. However, it cannot be removed
+        # as there is a cursor open.
+        self.evict_ingest(session_follow, ts)
+        count = self.count_ingest(session_follow)
+        self.assertEqual(count, self.nitems)
 
-    #     # Close the cursor held open.
-    #     hold_cursor.close()
+        # Close the cursor held open.
+        hold_cursor.close()
 
-    #     # Now eviction should remove all the items from the ingest table.
-    #     self.evict_ingest(session_follow, ts)
-    #     count = self.count_ingest(session_follow)
-    #     self.assertEqual(count, 0)
+        # Now eviction should remove all the items from the ingest table.
+        self.evict_ingest(session_follow, ts)
+        count = self.count_ingest(session_follow)
+        self.assertEqual(count, 0)
 
     def test_gc_ingest_table_with_remove(self):
         # Create the oplog

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -36,7 +36,7 @@ from wtscenario import make_scenarios
 @disagg_test_class
 class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_base_config = ',create,cache_size=10GB,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
-                 + 'disaggregated=(page_log=palm,lose_all_my_data=true),'
+                 + 'disaggregated=(page_log=palm,lose_all_my_data=true),checkpoint=(precise=true),'
 
     disagg_storages = gen_disagg_storages('test_layered38', disagg_only = True)
 
@@ -55,7 +55,7 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
     def evict_ingest(self, session, ts):
         # Trigger eviction on the ingest table
         evict_cursor = session.open_cursor("file:test_layered38.wt_ingest", None, "debug=(release_evict)")
-        for i in (1, self.nitems):
+        for i in range(1, self.nitems):
             session.begin_transaction(f'read_timestamp={self.timestamp_str(ts)}')
             evict_cursor.set_key(str(i))
             ret = evict_cursor.search()
@@ -65,15 +65,77 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         evict_cursor.close()
 
     # Return the number of items in the ingest table.
-    def count_ingest(self, session):
+    def count_ingest(self, session, ts=None):
+        if ts != None:
+            session.begin_transaction(f'read_timestamp={self.timestamp_str(ts)}')
         cursor = session.open_cursor(self.ingest_uri)
         count = 0
         for k,v in cursor:
             count += 1
         cursor.close()
+        if ts != None:
+            session.rollback_transaction()
         return count
 
-    def test_gc_ingest_table(self):
+    # def test_gc_ingest_table(self):
+    #     # Create the oplog
+    #     oplog = Oplog(value_size=500)
+
+    #     # Create the table on leader and tell oplog about it
+    #     self.session.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+    #     t = oplog.add_uri(self.uri)
+
+    #     # Create the follower and create its table
+    #     # To keep this test relatively easy, we're only using a single URI.
+    #     conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+    #     session_follow = conn_follow.open_session('')
+    #     session_follow.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+
+    #     # Load the data for oplog
+    #     oplog.insert(t, self.nitems)
+
+    #     # Apply it to the leader WT.
+    #     oplog.apply(self, self.session, 0, self.nitems)
+    #     oplog.check(self, self.session, 0, self.nitems)
+
+    #     ts = oplog.last_timestamp()
+    #     self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(ts)}')
+
+    #     # On the follower -
+    #     # Apply all the entries to follower
+    #     oplog.apply(self, session_follow, 0, self.nitems)
+    #     oplog.check(self, session_follow, 0, self.nitems)
+
+    #     # Ensure everything is in the ingest table
+    #     count = self.count_ingest(session_follow)
+    #     self.assertEqual(count, self.nitems)
+
+    #     # Hold a cursor open on the layered table, and on the ingest as well.
+    #     session_follow2 = conn_follow.open_session('')
+    #     hold_cursor = session_follow2.open_cursor(self.uri)
+    #     hold_cursor.next()
+
+    #     # Take a checkpoint and advance it, make sure everything is still good
+    #     self.session.checkpoint()
+    #     self.disagg_advance_checkpoint(conn_follow)
+    #     oplog.check(self, session_follow, 0, self.nitems)
+
+    #     # At this point, everything in the ingest table is redundant, as it's
+    #     # also in the stable table on the follower. However, it cannot be removed
+    #     # as there is a cursor open.
+    #     self.evict_ingest(session_follow, ts)
+    #     count = self.count_ingest(session_follow)
+    #     self.assertEqual(count, self.nitems)
+
+    #     # Close the cursor held open.
+    #     hold_cursor.close()
+
+    #     # Now eviction should remove all the items from the ingest table.
+    #     self.evict_ingest(session_follow, ts)
+    #     count = self.count_ingest(session_follow)
+    #     self.assertEqual(count, 0)
+
+    def test_gc_ingest_table_with_remove(self):
         # Create the oplog
         oplog = Oplog(value_size=500)
 
@@ -90,17 +152,24 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Load the data for oplog
         oplog.insert(t, self.nitems)
 
-        # Apply it to the leader WT.
-        oplog.apply(self, self.session, 0, self.nitems)
-        oplog.check(self, self.session, 0, self.nitems)
-
         ts = oplog.last_timestamp()
+
+        # Remove the data
+        oplog.remove(t, self.nitems)
+
+        # Apply the insert to the leader WT.
+        oplog.apply(self, self.session, 0, self.nitems)
+
+        # Apply the delete to the leader WT after checkpoint.
+        oplog.apply(self, self.session, self.nitems, self.nitems)
+        oplog.check(self, self.session, 0, 2 * self.nitems)
+
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(ts)}')
 
         # On the follower -
         # Apply all the entries to follower
-        oplog.apply(self, session_follow, 0, self.nitems)
-        oplog.check(self, session_follow, 0, self.nitems)
+        oplog.apply(self, session_follow, 0, 2 * self.nitems)
+        oplog.check(self, session_follow, 0, 2 * self.nitems)
 
         # Ensure everything is in the ingest table
         count = self.count_ingest(session_follow)
@@ -114,19 +183,49 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Take a checkpoint and advance it, make sure everything is still good
         self.session.checkpoint()
         self.disagg_advance_checkpoint(conn_follow)
-        oplog.check(self, session_follow, 0, self.nitems)
+        oplog.check(self, session_follow, 0, 2 * self.nitems)
 
-        # At this point, everything in the ingest table is redundant, as it's
-        # also in the stable table on the follower.  However, it cannot be removed
-        # as there is a cursor open.
+        # At this point, the inserts in the ingest table are redundant but the delets are not.
         self.evict_ingest(session_follow, ts)
-        count = self.count_ingest(session_follow)
+        count = self.count_ingest(session_follow, ts)
         self.assertEqual(count, self.nitems)
 
         # Close the cursor held open.
         hold_cursor.close()
 
+        # Eviction still cannot remove all the records from the ingest table because the deletes
+        # are not in the stable table.
+        self.evict_ingest(session_follow, ts)
+        count = self.count_ingest(session_follow, ts)
+        self.assertEqual(count, self.nitems)
+
+        # Hold a cursor open on the layered table, and on the ingest as well.
+        hold_cursor = session_follow2.open_cursor(self.uri)
+        hold_cursor.next()
+
+        new_ts = oplog.last_timestamp()
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(new_ts)}')
+
+        # Take a new checkpoint and advance it, make sure everything is still good
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+        oplog.check(self, session_follow, 0, 2 * self.nitems)
+
+        # At this point, everything in the ingest table is redundant, as it's
+        # also in the stable table on the follower. However, it cannot be removed
+        # as there is a cursor open.
+        self.evict_ingest(session_follow, ts)
+        count = self.count_ingest(session_follow, ts)
+        self.assertEqual(count, self.nitems)
+
+        # Close the cursor held open.
+        hold_cursor.close()
+
+        # Trigger advance checkpoint code again to set the prune timestamp to the last
+        # checkpoint timestamp. We couldn't do that because there was a cursor holding the old content.
+        self.disagg_advance_checkpoint(conn_follow)
+
         # Now eviction should remove all the items from the ingest table.
         self.evict_ingest(session_follow, ts)
-        count = self.count_ingest(session_follow)
+        count = self.count_ingest(session_follow, ts)
         self.assertEqual(count, 0)

--- a/test/suite/test_layered41.py
+++ b/test/suite/test_layered41.py
@@ -34,7 +34,7 @@ from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_stora
 from wtscenario import make_scenarios
 
 # test_layered41.py
-#    Test layered table metadata has logging disabled.
+#    Test duplicate key.
 @disagg_test_class
 class test_layered41(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_base_config = ',disaggregated=(page_log=palm),'


### PR DESCRIPTION
This pr fixes a bug in the garbage collection for ingest table.

Refactor to move the code that writes delta to different functions.

Add back some asserts removed in WT-14695.

Other code cleanup that is not addressed in WT-14695.