### PR TITLE
WT-14869 pack prepared_id and prepare_ts into cells

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -53,7 +53,14 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
     ++*pp;
 
     flags = 0;
-    if (tw->start_ts != WT_TS_NONE) {
+    const bool pack_prepare_info_to_start = tw->prepare && tw->prepare_ts != WT_TS_NONE && (tw->stop_txn == WT_TXN_MAX || tw->stop_txn == tw->start_txn);
+    const bool pack_prepare_info_to_stop = tw->prepare && tw->prepare_ts != WT_TS_NONE && tw->stop_txn != WT_TXN_MAX;
+
+    // if there is prepare ts and no stop ts -> prepare_ts belongs to  write prepare_ts to start_ts
+    if (pack_prepare_info_to_start) {
+        WT_RET(__wt_vpack_uint(pp, 0, tw->prepare_ts));
+        LF_SET(WT_CELL_TS_START);
+    } else if (tw->start_ts != WT_TS_NONE) {
         WT_RET(__wt_vpack_uint(pp, 0, tw->start_ts));
         LF_SET(WT_CELL_TS_START);
     }
@@ -61,7 +68,14 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         WT_RET(__wt_vpack_uint(pp, 0, tw->start_txn));
         LF_SET(WT_CELL_TXN_START);
     }
-    if (tw->durable_start_ts != WT_TS_NONE) {
+
+    // If we write prepare_ts to start_ts, we write prepared_id to durable_start_ts as well
+    if (pack_prepare_info_to_start) {
+        WT_ASSERT(session, tw->prepared_id != WT_PREPARED_ID_NONE);
+        WT_RET(__wt_vpack_uint(pp, 0, tw->prepared_id));
+        LF_SET(WT_CELL_TS_DURABLE_START);
+    }
+    else if (tw->durable_start_ts != WT_TS_NONE) {
         WT_ASSERT(session, tw->start_ts <= tw->durable_start_ts);
         /* Store differences if any, not absolutes. */
         if (tw->durable_start_ts - tw->start_ts > 0) {
@@ -69,8 +83,12 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
             LF_SET(WT_CELL_TS_DURABLE_START);
         }
     }
-    if (tw->stop_ts != WT_TS_MAX) {
+    if (pack_prepare_info_to_stop) {
+        WT_RET(__wt_vpack_uint(pp, 0, tw->prepare_ts));
+        LF_SET(WT_CELL_TS_STOP);
+    } else if (tw->stop_ts != WT_TS_MAX) {
         /* Store differences, not absolutes. */
+        // If we write prepare_ts to start_ts before, should we write stop_ts - prepare_ts instead?
         WT_RET(__wt_vpack_uint(pp, 0, tw->stop_ts - tw->start_ts));
         LF_SET(WT_CELL_TS_STOP);
     }
@@ -79,7 +97,13 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         WT_RET(__wt_vpack_uint(pp, 0, tw->stop_txn - tw->start_txn));
         LF_SET(WT_CELL_TXN_STOP);
     }
-    if (tw->durable_stop_ts != WT_TS_NONE) {
+    /* If we already written prepared_id to durable_start, do we still need to rewrite this here as well if start_txn == stop_txn? */
+    if (pack_prepare_info_to_stop) {
+        WT_ASSERT(session, tw->prepared_id != WT_PREPARED_ID_NONE);
+        WT_RET(__wt_vpack_uint(pp, 0, tw->prepared_id));
+        LF_SET(WT_CELL_TS_DURABLE_STOP);
+    }
+    else if (tw->durable_stop_ts != WT_TS_NONE) {
         WT_ASSERT(session, tw->stop_ts <= tw->durable_stop_ts);
         /* Store differences if any, not absolutes. */
         if (tw->durable_stop_ts - tw->stop_ts > 0) {
@@ -853,19 +877,25 @@ copy_cell_restart:
 
         if (LF_ISSET(WT_CELL_PREPARE))
             tw->prepare = 1;
-        if (LF_ISSET(WT_CELL_TS_START))
-            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->start_ts));
+        if (LF_ISSET(WT_CELL_TS_START)) {
+            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), tw->prepare && LF_ISSET(WT_CELL_TS_DURABLE_START) ? &tw->prepare_ts : &tw->start_ts));
+        }
         if (LF_ISSET(WT_CELL_TXN_START))
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->start_txn));
         if (LF_ISSET(WT_CELL_TS_DURABLE_START)) {
-            WT_RET(
-              __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->durable_start_ts));
-            tw->durable_start_ts += tw->start_ts;
+            if (tw->prepare) {
+                /* In prepared transaction, durable ts is 0, the only case when there is value here is when we pack prepared_id in place of durable_ts */
+                WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->prepared_id));
+            } else {
+                WT_RET(
+                  __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->durable_start_ts));
+                tw->durable_start_ts += tw->start_ts;
+            }
         } else
             tw->durable_start_ts = tw->start_ts;
 
         if (LF_ISSET(WT_CELL_TS_STOP)) {
-            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->stop_ts));
+            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), tw->prepare && LF_ISSET(WT_CELL_TS_DURABLE_STOP) ? &tw->prepare_ts : &tw->stop_ts));
             tw->stop_ts += tw->start_ts;
         }
         if (LF_ISSET(WT_CELL_TXN_STOP)) {
@@ -873,9 +903,14 @@ copy_cell_restart:
             tw->stop_txn += tw->start_txn;
         }
         if (LF_ISSET(WT_CELL_TS_DURABLE_STOP)) {
-            WT_RET(
-              __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->durable_stop_ts));
-            tw->durable_stop_ts += tw->stop_ts;
+            /* In prepared transaction, durable ts is 0, the only case when there is value here is when we pack prepared_id in place of durable_ts */
+            if (tw->prepare) {
+                WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->prepared_id));
+            } else {
+                WT_RET(
+                __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->durable_stop_ts));
+                tw->durable_stop_ts += tw->stop_ts;
+            }
         } else if (tw->stop_ts != WT_TS_MAX)
             tw->durable_stop_ts = tw->stop_ts;
         else

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -5,7 +5,6 @@
  *
  * See the file LICENSE for redistribution information.
  */
-
 #pragma once
 
 /*
@@ -53,10 +52,23 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
     ++*pp;
 
     flags = 0;
-    const bool pack_prepare_info_to_start = F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
-      tw->prepare && (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
+    /* We pack prepared txn info to stop_ts and durable_stop_ts when:
+     *  - disagg is on
+     *  - txn is prepared
+     *  - transaction is in delete prepared (meaning it has stop_txn defined)
+     */
     const bool pack_prepare_info_to_stop =
       F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && tw->prepare && WT_TIME_WINDOW_HAS_STOP(tw);
+
+    /* We pack prepared txn info to start_ts and durable start_ts when:
+     *  - disagg is on
+     *  - txn is prepared
+     *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
+     * means both start and stop transactions are the same
+     */
+    const bool pack_prepare_info_to_start = F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+      tw->prepare && (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
+
     /*
      * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
      * start or stop)

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -53,12 +53,16 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
     ++*pp;
 
     flags = 0;
-    const bool pack_prepare_info_to_start = tw->prepare && tw->prepare_ts != WT_TS_NONE && (tw->stop_txn == WT_TXN_MAX || tw->stop_txn == tw->start_txn);
-    const bool pack_prepare_info_to_stop = tw->prepare && tw->prepare_ts != WT_TS_NONE && tw->stop_txn != WT_TXN_MAX;
+    const bool pack_prepare_info_to_start = F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+      tw->prepare && tw->prepare_ts != WT_TS_NONE &&
+      (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
+    const bool pack_prepare_info_to_stop = F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+      tw->prepare && tw->prepare_ts != WT_TS_NONE && WT_TIME_WINDOW_HAS_STOP(tw);
+    wt_timestamp_t reference_ts = tw->start_ts;
 
-    // if there is prepare ts and no stop ts -> prepare_ts belongs to  write prepare_ts to start_ts
     if (pack_prepare_info_to_start) {
         WT_RET(__wt_vpack_uint(pp, 0, tw->prepare_ts));
+        reference_ts = tw->prepare_ts;
         LF_SET(WT_CELL_TS_START);
     } else if (tw->start_ts != WT_TS_NONE) {
         WT_RET(__wt_vpack_uint(pp, 0, tw->start_ts));
@@ -69,27 +73,25 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         LF_SET(WT_CELL_TXN_START);
     }
 
-    // If we write prepare_ts to start_ts, we write prepared_id to durable_start_ts as well
+    /* If we write prepare_ts to start_ts, we write prepared_id to durable_start_ts as well */
     if (pack_prepare_info_to_start) {
         WT_ASSERT(session, tw->prepared_id != WT_PREPARED_ID_NONE);
         WT_RET(__wt_vpack_uint(pp, 0, tw->prepared_id));
         LF_SET(WT_CELL_TS_DURABLE_START);
-    }
-    else if (tw->durable_start_ts != WT_TS_NONE) {
-        WT_ASSERT(session, tw->start_ts <= tw->durable_start_ts);
+    } else if (tw->durable_start_ts != WT_TS_NONE) {
+        WT_ASSERT(session, reference_ts <= tw->durable_start_ts);
         /* Store differences if any, not absolutes. */
-        if (tw->durable_start_ts - tw->start_ts > 0) {
-            WT_RET(__wt_vpack_uint(pp, 0, tw->durable_start_ts - tw->start_ts));
+        if (tw->durable_start_ts - reference_ts > 0) {
+            WT_RET(__wt_vpack_uint(pp, 0, tw->durable_start_ts - reference_ts));
             LF_SET(WT_CELL_TS_DURABLE_START);
         }
     }
     if (pack_prepare_info_to_stop) {
-        WT_RET(__wt_vpack_uint(pp, 0, tw->prepare_ts));
+        WT_RET(__wt_vpack_uint(pp, 0, tw->prepare_ts - reference_ts));
         LF_SET(WT_CELL_TS_STOP);
     } else if (tw->stop_ts != WT_TS_MAX) {
         /* Store differences, not absolutes. */
-        // If we write prepare_ts to start_ts before, should we write stop_ts - prepare_ts instead?
-        WT_RET(__wt_vpack_uint(pp, 0, tw->stop_ts - tw->start_ts));
+        WT_RET(__wt_vpack_uint(pp, 0, tw->stop_ts - reference_ts));
         LF_SET(WT_CELL_TS_STOP);
     }
     if (tw->stop_txn != WT_TXN_MAX) {
@@ -97,13 +99,16 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         WT_RET(__wt_vpack_uint(pp, 0, tw->stop_txn - tw->start_txn));
         LF_SET(WT_CELL_TXN_STOP);
     }
-    /* If we already written prepared_id to durable_start, do we still need to rewrite this here as well if start_txn == stop_txn? */
+    /*
+     * We pack the difference if the start is also a prepared. But we pack the full value if only
+     * the stop is prepared. For the latter case, the start durable ts is a different type so we
+     * should not pack the difference.
+     */
     if (pack_prepare_info_to_stop) {
         WT_ASSERT(session, tw->prepared_id != WT_PREPARED_ID_NONE);
-        WT_RET(__wt_vpack_uint(pp, 0, tw->prepared_id));
+        WT_RET(__wt_vpack_uint(pp, 0, pack_prepare_info_to_start ? 0 : tw->prepared_id));
         LF_SET(WT_CELL_TS_DURABLE_STOP);
-    }
-    else if (tw->durable_stop_ts != WT_TS_NONE) {
+    } else if (tw->durable_stop_ts != WT_TS_NONE) {
         WT_ASSERT(session, tw->stop_ts <= tw->durable_stop_ts);
         /* Store differences if any, not absolutes. */
         if (tw->durable_stop_ts - tw->stop_ts > 0) {
@@ -874,47 +879,87 @@ copy_cell_restart:
             break;
         flags = *p++; /* skip second descriptor byte */
         WT_CELL_LEN_CHK(p, 0, dsk, end);
+        wt_timestamp_t temp_start_ts, temp_durable_start_ts, temp_stop_ts, temp_durable_stop_ts;
+        temp_start_ts = temp_durable_start_ts = temp_stop_ts = temp_durable_stop_ts = WT_TS_NONE;
 
         if (LF_ISSET(WT_CELL_PREPARE))
             tw->prepare = 1;
         if (LF_ISSET(WT_CELL_TS_START)) {
-            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), tw->prepare && LF_ISSET(WT_CELL_TS_DURABLE_START) ? &tw->prepare_ts : &tw->start_ts));
+            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_start_ts));
         }
         if (LF_ISSET(WT_CELL_TXN_START))
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->start_txn));
-        if (LF_ISSET(WT_CELL_TS_DURABLE_START)) {
-            if (tw->prepare) {
-                /* In prepared transaction, durable ts is 0, the only case when there is value here is when we pack prepared_id in place of durable_ts */
-                WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->prepared_id));
-            } else {
-                WT_RET(
-                  __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->durable_start_ts));
-                tw->durable_start_ts += tw->start_ts;
-            }
-        } else
-            tw->durable_start_ts = tw->start_ts;
+        if (LF_ISSET(WT_CELL_TS_DURABLE_START))
+            WT_RET(
+              __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_durable_start_ts));
 
         if (LF_ISSET(WT_CELL_TS_STOP)) {
-            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), tw->prepare && LF_ISSET(WT_CELL_TS_DURABLE_STOP) ? &tw->prepare_ts : &tw->stop_ts));
-            tw->stop_ts += tw->start_ts;
+            WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_stop_ts));
         }
         if (LF_ISSET(WT_CELL_TXN_STOP)) {
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->stop_txn));
             tw->stop_txn += tw->start_txn;
         }
-        if (LF_ISSET(WT_CELL_TS_DURABLE_STOP)) {
-            /* In prepared transaction, durable ts is 0, the only case when there is value here is when we pack prepared_id in place of durable_ts */
-            if (tw->prepare) {
-                WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->prepared_id));
+        if (LF_ISSET(WT_CELL_TS_DURABLE_STOP))
+            WT_RET(
+              __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_durable_stop_ts));
+
+        /* Load temporary values to the right fields */
+        if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && tw->prepare) {
+            if (tw->start_txn == tw->stop_txn) {
+                /*
+                 * This is a special case where both transaction start and stop are in prepared
+                 * state (same prepared id), so the same prepared id is packed to
+                 * WT_CELL_TS_DURABLE_START and 0 is packed into WT_CELL_TS_DURABLE_STOP since we
+                 * only store the difference.
+                 */
+                WT_ASSERT(session, temp_stop_ts == 0 && temp_durable_stop_ts == 0);
+                WT_ASSERT(session,
+                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
+                    LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
+                tw->prepare_ts = temp_start_ts;
+                tw->prepared_id = temp_durable_start_ts;
+            } else if (tw->stop_txn != WT_TXN_MAX) {
+                /*
+                 * This case happens where the transaction is done, but the transaction stop is
+                 * prepared. In this case, we store the start timestamp and durable start timestamp
+                 * in WT_CELL_TS_START and WT_CELL_TS_DURABLE_START, prepare ts in WT_CELL_TS_STOP
+                 * prepared id in WT_CELL_TS_DURABLE_STOP.
+                 */
+                WT_ASSERT(session,
+                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
+                    LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
+                tw->start_ts = temp_start_ts;
+                tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
+                tw->prepare_ts = tw->start_ts + temp_stop_ts;
+                tw->prepared_id = temp_durable_stop_ts;
             } else {
-                WT_RET(
-                __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->durable_stop_ts));
-                tw->durable_stop_ts += tw->stop_ts;
+                /*
+                 * This case happens when only transaction start is prepared, and there is no
+                 * transaction stop. In this case, we store the prepare ts in WT_CELL_TS_START and
+                 * prepared id in WT_CELL_TS_DURABLE_START.
+                 */
+                WT_ASSERT(session,
+                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
+                    !LF_ISSET(WT_CELL_TS_STOP) && !LF_ISSET(WT_CELL_TS_DURABLE_STOP));
+                tw->prepare_ts = temp_start_ts;
+                tw->prepared_id = temp_durable_start_ts;
             }
-        } else if (tw->stop_ts != WT_TS_MAX)
-            tw->durable_stop_ts = tw->stop_ts;
-        else
-            tw->durable_stop_ts = WT_TS_NONE;
+        } else {
+            if (LF_ISSET(WT_CELL_TS_START))
+                tw->start_ts = temp_start_ts;
+            if (LF_ISSET(WT_CELL_TS_DURABLE_START))
+                tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
+            else
+                tw->durable_start_ts = tw->start_ts;
+
+            if (LF_ISSET(WT_CELL_TS_STOP))
+                tw->stop_ts = temp_stop_ts + tw->start_ts;
+            if (LF_ISSET(WT_CELL_TS_DURABLE_STOP))
+                tw->durable_stop_ts = temp_durable_stop_ts + tw->durable_stop_ts;
+            else if (tw->stop_ts != WT_TS_MAX)
+                tw->durable_stop_ts = tw->stop_ts;
+        }
 
         WT_RET(__cell_check_value_validity(session, tw, end != NULL));
         break;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -54,10 +54,14 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
 
     flags = 0;
     const bool pack_prepare_info_to_start = F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
-      tw->prepare && tw->prepare_ts != WT_TS_NONE &&
-      (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
-    const bool pack_prepare_info_to_stop = F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
-      tw->prepare && tw->prepare_ts != WT_TS_NONE && WT_TIME_WINDOW_HAS_STOP(tw);
+      tw->prepare && (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
+    const bool pack_prepare_info_to_stop =
+      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && tw->prepare && WT_TIME_WINDOW_HAS_STOP(tw);
+    /* Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
+     * start or stop) */
+    WT_ASSERT(session,
+      (tw->prepare_ts != WT_TS_NONE) == (pack_prepare_info_to_start || pack_prepare_info_to_stop));
+
     wt_timestamp_t reference_ts = tw->start_ts;
 
     if (pack_prepare_info_to_start) {
@@ -893,9 +897,9 @@ copy_cell_restart:
             WT_RET(
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_durable_start_ts));
 
-        if (LF_ISSET(WT_CELL_TS_STOP)) {
+        if (LF_ISSET(WT_CELL_TS_STOP))
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_stop_ts));
-        }
+
         if (LF_ISSET(WT_CELL_TXN_STOP)) {
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->stop_txn));
             tw->stop_txn += tw->start_txn;
@@ -956,7 +960,7 @@ copy_cell_restart:
             if (LF_ISSET(WT_CELL_TS_STOP))
                 tw->stop_ts = temp_stop_ts + tw->start_ts;
             if (LF_ISSET(WT_CELL_TS_DURABLE_STOP))
-                tw->durable_stop_ts = temp_durable_stop_ts + tw->durable_stop_ts;
+                tw->durable_stop_ts = temp_durable_stop_ts + tw->stop_ts;
             else if (tw->stop_ts != WT_TS_MAX)
                 tw->durable_stop_ts = tw->stop_ts;
         }

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -58,7 +58,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in delete prepared (meaning it has stop_txn defined)
      */
     const bool pack_prepare_info_to_stop =
-      F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare && WT_TIME_WINDOW_HAS_STOP(tw);
+      F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare &&
+      WT_TIME_WINDOW_HAS_STOP(tw);
 
     /* We pack prepared txn info to start_ts and durable start_ts when:
      *  - disagg is on
@@ -66,8 +67,9 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
      * means both start and stop transactions are the same
      */
-    const bool pack_prepare_info_to_start = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-      tw->prepare && (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
+    const bool pack_prepare_info_to_start =
+      F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare &&
+      (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
 
     /*
      * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -58,7 +58,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in delete prepared (meaning it has stop_txn defined)
      */
     const bool pack_prepare_info_to_stop =
-      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && tw->prepare && WT_TIME_WINDOW_HAS_STOP(tw);
+      F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare && WT_TIME_WINDOW_HAS_STOP(tw);
 
     /* We pack prepared txn info to start_ts and durable start_ts when:
      *  - disagg is on
@@ -66,7 +66,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
      * means both start and stop transactions are the same
      */
-    const bool pack_prepare_info_to_start = F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
+    const bool pack_prepare_info_to_start = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
       tw->prepare && (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
 
     /*
@@ -925,7 +925,7 @@ copy_cell_restart:
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_durable_stop_ts));
 
         /* Load temporary values to the right fields */
-        if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && tw->prepare) {
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
             if (tw->start_txn == tw->stop_txn) {
                 /*
                  * This is a special case where both transaction start and stop are in prepared
@@ -939,6 +939,8 @@ copy_cell_restart:
                     LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
                 tw->prepare_ts = temp_start_ts;
                 tw->prepared_id = temp_durable_start_ts;
+                tw->start_ts = tw->prepare_ts;
+                tw->stop_ts = tw->prepare_ts;
             } else if (tw->stop_txn != WT_TXN_MAX) {
                 /*
                  * This case happens where the transaction is done, but the transaction stop is
@@ -953,6 +955,7 @@ copy_cell_restart:
                 tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
                 tw->prepare_ts = tw->start_ts + temp_stop_ts;
                 tw->prepared_id = temp_durable_stop_ts;
+                tw->stop_ts = tw->prepare_ts;
             } else {
                 /*
                  * This case happens when only transaction start is prepared, and there is no
@@ -964,6 +967,7 @@ copy_cell_restart:
                     !LF_ISSET(WT_CELL_TS_STOP) && !LF_ISSET(WT_CELL_TS_DURABLE_STOP));
                 tw->prepare_ts = temp_start_ts;
                 tw->prepared_id = temp_durable_start_ts;
+                tw->start_ts = tw->prepare_ts;
             }
         } else {
             if (LF_ISSET(WT_CELL_TS_START))

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -57,8 +57,10 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
       tw->prepare && (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
     const bool pack_prepare_info_to_stop =
       F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && tw->prepare && WT_TIME_WINDOW_HAS_STOP(tw);
-    /* Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
-     * start or stop) */
+    /*
+     * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
+     * start or stop)
+     */
     WT_ASSERT(session,
       (tw->prepare_ts != WT_TS_NONE) == (pack_prepare_info_to_start || pack_prepare_info_to_stop));
 
@@ -70,6 +72,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         LF_SET(WT_CELL_TS_START);
     } else if (tw->start_ts != WT_TS_NONE) {
         WT_RET(__wt_vpack_uint(pp, 0, tw->start_ts));
+        reference_ts = tw->start_ts;
         LF_SET(WT_CELL_TS_START);
     }
     if (tw->start_txn != WT_TXN_NONE) {
@@ -884,7 +887,8 @@ copy_cell_restart:
         flags = *p++; /* skip second descriptor byte */
         WT_CELL_LEN_CHK(p, 0, dsk, end);
         wt_timestamp_t temp_start_ts, temp_durable_start_ts, temp_stop_ts, temp_durable_stop_ts;
-        temp_start_ts = temp_durable_start_ts = temp_stop_ts = temp_durable_stop_ts = WT_TS_NONE;
+        temp_start_ts = temp_durable_start_ts = temp_durable_stop_ts = WT_TS_NONE;
+        temp_stop_ts = WT_TS_MAX;
 
         if (LF_ISSET(WT_CELL_PREPARE))
             tw->prepare = 1;

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -509,9 +509,7 @@ __wt_time_value_validate(
               __wt_time_window_to_string(tw, time_string[0]));
 
         if (WT_TIME_WINDOW_HAS_STOP(tw)) {
-            /*
-             * Validate that prepared timestamp field is valid
-             */
+            /* Validate that prepared timestamp field is valid */
             if (tw->stop_ts != WT_TS_MAX || tw->durable_stop_ts != WT_TS_NONE)
                 WT_TIME_VALIDATE_RET(session,
                   "value time window is prepared but has a stop timestamp or durable stop "

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -509,18 +509,30 @@ __wt_time_value_validate(
               __wt_time_window_to_string(tw, time_string[0]));
 
         if (WT_TIME_WINDOW_HAS_STOP(tw)) {
-            /* Validate that prepared timestamp field is valid */
-            if (tw->stop_ts != WT_TS_MAX || tw->durable_stop_ts != WT_TS_NONE)
+            if (tw->stop_ts != tw->prepare_ts)
                 WT_TIME_VALIDATE_RET(session,
-                  "value time window is prepared but has a stop timestamp or durable stop "
-                  "timestamp; time window %s",
+                  "value time window is stop prepared but has different stop_ts and prepared_ts; "
+                  "time window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
+            
+            if (tw->durable_stop_ts != WT_TS_NONE)
+                  WT_TIME_VALIDATE_RET(session,
+                  "value time window is stop prepared but has non-empty durable_stop_ts; "
+                  "time window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+
             if (tw->start_txn == tw->stop_txn) {
-                if (tw->start_ts != WT_TS_NONE || tw->durable_start_ts != WT_TS_NONE)
+              /* both start and stop are prepared, they must be in the same transaction */
+                if (tw->durable_start_ts != WT_TS_NONE)
                     WT_TIME_VALIDATE_RET(session,
-                      "value time window is prepared but has a start timestamp or "
-                      "durable start timestamps; time window %s",
+                      "value time window is start and stop prepared but has non-empty durable start timestamps; time window %s",
                       __wt_time_window_to_string(tw, time_string[0]));
+                if (tw->start_ts != tw->prepare_ts)
+                WT_TIME_VALIDATE_RET(session,
+                  "value time window is start prepared but has different start_ts and prepared_ts; "
+                  "time window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+
             } else if (tw->start_ts >= tw->prepare_ts) {
                 WT_TIME_VALIDATE_RET(session,
                   "value time window is prepared delete but has a start timestamp greater "
@@ -528,9 +540,15 @@ __wt_time_value_validate(
                   __wt_time_window_to_string(tw, time_string[0]));
             }
         } else {
-            if (tw->start_ts != WT_TS_NONE || tw->durable_start_ts != WT_TS_NONE)
+          /* this means time window is start prepared */
+            if (tw->start_ts != tw->prepare_ts)
                 WT_TIME_VALIDATE_RET(session,
-                  "value time window is prepared but has a start or durable start timestamps; "
+                  "value time window is start prepared but has different start_ts and prepared_ts; "
+                  "time window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            if (tw->durable_start_ts != WT_TS_NONE)
+                  WT_TIME_VALIDATE_RET(session,
+                  "value time window is start prepared but has non-empty durable_start_ts; "
                   "time window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
         }

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -507,8 +507,19 @@ __wt_time_value_validate(
               "value time window is prepared and has preserve_prepared enabled but has no prepared "
               "id; time window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        /* should i also check whether prepare_ts is larger than start_ts? */
     }
+    /* Validate that we only have either prepare_ts or start_ts */
+    if (tw->prepare_ts != WT_TS_NONE && tw->start_ts != WT_TS_NONE) {
+        WT_TIME_VALIDATE_RET(session,
+          "value time window has both prepare_ts and start_ts set; time window %s",
+          __wt_time_window_to_string(tw, time_string[0]));
+    }
+    if (tw->prepare_ts == WT_TS_NONE && tw->start_ts == WT_TS_NONE) {
+        WT_TIME_VALIDATE_RET(session,
+          "value time window has neither prepare_ts nor start_ts set; time window %s",
+          __wt_time_window_to_string(tw, time_string[0]));
+    }
+
     /*
      * Optionally validate the time window against a parent's time window.
      *

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -514,24 +514,25 @@ __wt_time_value_validate(
                   "value time window is stop prepared but has different stop_ts and prepared_ts; "
                   "time window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
-            
+
             if (tw->durable_stop_ts != WT_TS_NONE)
-                  WT_TIME_VALIDATE_RET(session,
+                WT_TIME_VALIDATE_RET(session,
                   "value time window is stop prepared but has non-empty durable_stop_ts; "
                   "time window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
 
             if (tw->start_txn == tw->stop_txn) {
-              /* both start and stop are prepared, they must be in the same transaction */
+                /* both start and stop are prepared, they must be in the same transaction */
                 if (tw->durable_start_ts != WT_TS_NONE)
                     WT_TIME_VALIDATE_RET(session,
-                      "value time window is start and stop prepared but has non-empty durable start timestamps; time window %s",
+                      "value time window is start and stop prepared but has non-empty durable "
+                      "start timestamps; time window %s",
                       __wt_time_window_to_string(tw, time_string[0]));
                 if (tw->start_ts != tw->prepare_ts)
-                WT_TIME_VALIDATE_RET(session,
-                  "value time window is start prepared but has different start_ts and prepared_ts; "
-                  "time window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
+                    WT_TIME_VALIDATE_RET(session,
+                      "value time window is start prepared but has different start_ts and "
+                      "prepared_ts; time window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
 
             } else if (tw->start_ts >= tw->prepare_ts) {
                 WT_TIME_VALIDATE_RET(session,
@@ -540,14 +541,14 @@ __wt_time_value_validate(
                   __wt_time_window_to_string(tw, time_string[0]));
             }
         } else {
-          /* this means time window is start prepared */
+            /* this means time window is start prepared */
             if (tw->start_ts != tw->prepare_ts)
                 WT_TIME_VALIDATE_RET(session,
                   "value time window is start prepared but has different start_ts and prepared_ts; "
                   "time window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
             if (tw->durable_start_ts != WT_TS_NONE)
-                  WT_TIME_VALIDATE_RET(session,
+                WT_TIME_VALIDATE_RET(session,
                   "value time window is start prepared but has non-empty durable_start_ts; "
                   "time window %s",
                   __wt_time_window_to_string(tw, time_string[0]));

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -507,17 +507,43 @@ __wt_time_value_validate(
               "value time window is prepared and has preserve_prepared enabled but has no prepared "
               "id; time window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-    }
-    /* Validate that we only have either prepare_ts or start_ts */
-    if (tw->prepare_ts != WT_TS_NONE && tw->start_ts != WT_TS_NONE) {
-        WT_TIME_VALIDATE_RET(session,
-          "value time window has both prepare_ts and start_ts set; time window %s",
-          __wt_time_window_to_string(tw, time_string[0]));
-    }
-    if (tw->prepare_ts == WT_TS_NONE && tw->start_ts == WT_TS_NONE) {
-        WT_TIME_VALIDATE_RET(session,
-          "value time window has neither prepare_ts nor start_ts set; time window %s",
-          __wt_time_window_to_string(tw, time_string[0]));
+
+        if (WT_TIME_WINDOW_HAS_STOP(tw)) {
+            /*
+             * Validate that prepared timestamp field is valid
+             */
+            if (tw->stop_ts != WT_TS_MAX || tw->durable_stop_ts != WT_TS_NONE)
+                WT_TIME_VALIDATE_RET(session,
+                  "value time window is prepared but has a stop timestamp or durable stop "
+                  "timestamp; time window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            if (tw->start_txn == tw->stop_txn) {
+                if (tw->start_ts != WT_TS_NONE || tw->durable_start_ts != WT_TS_NONE)
+                    WT_TIME_VALIDATE_RET(session,
+                      "value time window is prepared but has a start timestamp or "
+                      "durable start timestamps; time window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+            } else if (tw->start_ts >= tw->prepare_ts) {
+                WT_TIME_VALIDATE_RET(session,
+                  "value time window is prepared delete but has a start timestamp greater "
+                  "than or equal to the prepared delete timestamp; time window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            }
+        } else {
+            if (tw->start_ts != WT_TS_NONE || tw->durable_start_ts != WT_TS_NONE)
+                WT_TIME_VALIDATE_RET(session,
+                  "value time window is prepared but has no stop time point with non-none start or "
+                  "durable start timestamps; time window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+        }
+    } else {
+        /* Validate that prepare_ts and prepared_id must be none */
+        if (tw->prepare_ts != WT_TS_NONE || tw->start_ts != WT_TS_NONE) {
+            WT_TIME_VALIDATE_RET(session,
+              "None-prepared value time window but contains prepared ts and prepared id; time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
     }
 
     /*

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -538,9 +538,9 @@ __wt_time_value_validate(
         }
     } else {
         /* Validate that prepare_ts and prepared_id must be none */
-        if (tw->prepare_ts != WT_TS_NONE || tw->start_ts != WT_TS_NONE) {
+        if (tw->prepare_ts != WT_TS_NONE || tw->prepared_id != WT_PREPARED_ID_NONE) {
             WT_TIME_VALIDATE_RET(session,
-              "None-prepared value time window but contains prepared ts and prepared id; time "
+              "Non-prepared value time window but contains prepared ts and prepared id; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
         }

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -496,6 +496,19 @@ __wt_time_value_validate(
           "value time window has a durable start time after its durable stop time; time window %s",
           __wt_time_window_to_string(tw, time_string[0]));
 
+    if (tw->prepare && F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
+        if (tw->prepare_ts == WT_TS_NONE)
+            WT_TIME_VALIDATE_RET(session,
+              "value time window is prepared and has preserve_prepared enabled but has no prepare "
+              "timestamp; time window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        if (tw->prepared_id == WT_PREPARED_ID_NONE)
+            WT_TIME_VALIDATE_RET(session,
+              "value time window is prepared and has preserve_prepared enabled but has no prepared "
+              "id; time window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        /* should i also check whether prepare_ts is larger than start_ts? */
+    }
     /*
      * Optionally validate the time window against a parent's time window.
      *

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -532,8 +532,8 @@ __wt_time_value_validate(
         } else {
             if (tw->start_ts != WT_TS_NONE || tw->durable_start_ts != WT_TS_NONE)
                 WT_TIME_VALIDATE_RET(session,
-                  "value time window is prepared but has no stop time point with non-none start or "
-                  "durable start timestamps; time window %s",
+                  "value time window is prepared but has a start or durable start timestamps; "
+                  "time window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
         }
     } else {

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -52,6 +52,11 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
     scenarios = make_scenarios(types, txn_end)
 
     def test_prepare_discover01(self):
+        # Currently this test will fail because we haven't added support for
+        # packing/unpacking prepare_ts and prepared_id on checkpoint yet, so it
+        # will fail cell validation when trying to read prepared_id from disk. Re-enable this test
+        # when the feature is supported.
+        self.skipTest('FIXME-WT-14941 Enable when packing/unpacking prepare_ts and prepared_id on checkpoint is supported')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
         self.session.create(self.uri, self.s_config)
@@ -69,39 +74,33 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         c[5] = "prepare ts=100"
         # Prepare with a timestamp greater than current stable
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +',prepared_id=123')
-
-        # FIXME-WT-14941: Currently this test will fail because we haven't added support for
-        # packing/unpacking prepare_ts and prepared_id on checkpoint yet, so it
-        # will fail cell validation when trying to read prepared_id from disk. Re-enable this test
-        # when the feature is supported.
-
         # Move the stable timestamp to include the prepared transaction
-        # self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
         # Create a checkpoint
-        # session2 = self.conn.open_session()
-        # session2.checkpoint()
+        session2 = self.conn.open_session()
+        session2.checkpoint()
 
         # Creating backup that will preserve artifacts
-        # backup_dir = 'bkp'
-        # self.backup(backup_dir, session2)
+        backup_dir = 'bkp'
+        self.backup(backup_dir, session2)
 
-        # # Opening backup database
-        # conn2 = self.wiredtiger_open(backup_dir)
+        # Opening backup database
+        conn2 = self.wiredtiger_open(backup_dir)
 
-        # c2s1 = conn2.open_session()
+        c2s1 = conn2.open_session()
 
-        # # Opening prepared discover cursor
-        # prepared_discover_cursor = c2s1.open_cursor("prepared_discover:")
+        # Opening prepared discover cursor
+        prepared_discover_cursor = c2s1.open_cursor("prepared_discover:")
 
-        # # Walking through prepared discover cursor
-        # c2s2 = conn2.open_session()
-        # count = 0
-        # while prepared_discover_cursor.next() == 0:
-        #     count += 1
-        #     prepared_id = prepared_discover_cursor.get_key()
-        #     self.assertEqual(prepared_id, 100)
-        #     c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
-        #     c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
-        # self.assertEqual(count, 1)
+        # Walking through prepared discover cursor
+        c2s2 = conn2.open_session()
+        count = 0
+        while prepared_discover_cursor.next() == 0:
+            count += 1
+            prepared_id = prepared_discover_cursor.get_key()
+            self.assertEqual(prepared_id, 100)
+            c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
+            c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
+        self.assertEqual(count, 1)
 
-        # prepared_discover_cursor.close()
+        prepared_discover_cursor.close()

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -69,7 +69,7 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         c[5] = "prepare ts=100"
         # Prepare with a timestamp greater than current stable
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +',prepared_id=123')
-        
+
         # FIXME-WT-14941: Currently this test will fail because we haven't added support for
         # packing/unpacking prepare_ts and prepared_id on checkpoint yet, so it
         # will fail cell validation when trying to read prepared_id from disk. Re-enable this test

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -56,7 +56,7 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         # packing/unpacking prepare_ts and prepared_id on checkpoint yet, so it
         # will fail cell validation when trying to read prepared_id from disk. Re-enable this test
         # when the feature is supported.
-        # self.skipTest('FIXME-WT-14941 Enable when packing/unpacking prepare_ts and prepared_id on checkpoint is supported')
+        self.skipTest('FIXME-WT-14941 Enable when packing/unpacking prepare_ts and prepared_id on checkpoint is supported')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
         self.session.create(self.uri, self.s_config)

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -69,34 +69,39 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         c[5] = "prepare ts=100"
         # Prepare with a timestamp greater than current stable
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +',prepared_id=123')
+        
+        # FIXME-WT-14941: Currently this test will fail because we haven't added support for
+        # packing/unpacking prepare_ts and prepared_id on checkpoint yet, so it
+        # will fail cell validation when trying to read prepared_id from disk. Re-enable this test
+        # when the feature is supported.
 
         # Move the stable timestamp to include the prepared transaction
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
+        # self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
         # Create a checkpoint
-        session2 = self.conn.open_session()
-        session2.checkpoint()
+        # session2 = self.conn.open_session()
+        # session2.checkpoint()
 
         # Creating backup that will preserve artifacts
-        backup_dir = 'bkp'
-        self.backup(backup_dir, session2)
+        # backup_dir = 'bkp'
+        # self.backup(backup_dir, session2)
 
-        # Opening backup database
-        conn2 = self.wiredtiger_open(backup_dir)
+        # # Opening backup database
+        # conn2 = self.wiredtiger_open(backup_dir)
 
-        c2s1 = conn2.open_session()
+        # c2s1 = conn2.open_session()
 
-        # Opening prepared discover cursor
-        prepared_discover_cursor = c2s1.open_cursor("prepared_discover:")
+        # # Opening prepared discover cursor
+        # prepared_discover_cursor = c2s1.open_cursor("prepared_discover:")
 
-        # Walking through prepared discover cursor
-        c2s2 = conn2.open_session()
-        count = 0
-        while prepared_discover_cursor.next() == 0:
-            count += 1
-            prepared_id = prepared_discover_cursor.get_key()
-            self.assertEqual(prepared_id, 100)
-            c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
-            c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
-        self.assertEqual(count, 1)
+        # # Walking through prepared discover cursor
+        # c2s2 = conn2.open_session()
+        # count = 0
+        # while prepared_discover_cursor.next() == 0:
+        #     count += 1
+        #     prepared_id = prepared_discover_cursor.get_key()
+        #     self.assertEqual(prepared_id, 100)
+        #     c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
+        #     c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
+        # self.assertEqual(count, 1)
 
-        prepared_discover_cursor.close()
+        # prepared_discover_cursor.close()

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -56,7 +56,7 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         # packing/unpacking prepare_ts and prepared_id on checkpoint yet, so it
         # will fail cell validation when trying to read prepared_id from disk. Re-enable this test
         # when the feature is supported.
-        self.skipTest('FIXME-WT-14941 Enable when packing/unpacking prepare_ts and prepared_id on checkpoint is supported')
+        # self.skipTest('FIXME-WT-14941 Enable when packing/unpacking prepare_ts and prepared_id on checkpoint is supported')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
         self.session.create(self.uri, self.s_config)


### PR DESCRIPTION
This PR updates the cell packing/unpacking code to pack and extract prepare_ts and prepared_id from wt_time_window into wt_cell correctly. To avoid data format changes, prepared_id is packed down to durable start/stop timestamp and prepare_ts is packed down to start/stop_ts field, and hide this feature behind PRESERVE_PREPARED config flag