### PR TITLE
WT-14930 Dhandle timeofdeath synchronization

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -40,7 +40,7 @@ __sweep_file_dhandle_check_and_reset_tod(WT_SESSION_IMPL *session, WT_DATA_HANDL
          * Reset the time of death if the file dhandle exists for the associated table dhandle.
          */
         if (ret == 0) {
-            dhandle->timeofdeath = 0;
+            __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
             session->dhandle = NULL;
             return (ret);
         }
@@ -72,14 +72,15 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
          * of death.
          */
         if (__wt_atomic_loadi32(&dhandle->session_inuse) > 1)
-            dhandle->timeofdeath = 0;
+            __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
 
         /*
          * If the handle is open exclusive or currently in use, or the time of death is already set,
          * move on.
          */
         if (F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE) ||
-          __wt_atomic_loadi32(&dhandle->session_inuse) > 0 || dhandle->timeofdeath != 0)
+          __wt_atomic_loadi32(&dhandle->session_inuse) > 0 ||
+          __wt_atomic_load64(&dhandle->gg_timeofdeath) != 0)
             continue;
 
         /* For table dhandles, skip expiration if associated file dhandles exist. */
@@ -106,7 +107,7 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
         __wt_verbose_level(session, WT_VERB_SWEEP, WT_VERBOSE_DEBUG_3,
           "Sweep server setting the time of death for dhandle %s", dhandle->name);
 
-        dhandle->timeofdeath = now;
+        __wt_atomic_store64(&dhandle->gg_timeofdeath, now);
         WT_STAT_CONN_INCR(session, dh_sweep_tod);
     }
 }
@@ -176,6 +177,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
+    uint64_t timeofdeath;
 
     conn = S2C(session);
 
@@ -186,9 +188,10 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
         if (__wt_atomic_load32(&conn->open_btree_count) < conn->sweep_handles_min)
             break;
 
+        timeofdeath = __wt_atomic_load64(&dhandle->gg_timeofdeath);
         if (WT_IS_METADATA(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
-          __wt_atomic_loadi32(&dhandle->session_inuse) != 0 || dhandle->timeofdeath == 0 ||
-          now - dhandle->timeofdeath <= conn->sweep_idle_time)
+          __wt_atomic_loadi32(&dhandle->session_inuse) != 0 || timeofdeath == 0 ||
+          now - timeofdeath <= conn->sweep_idle_time)
             continue;
 
         /*

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -40,7 +40,7 @@ __sweep_file_dhandle_check_and_reset_tod(WT_SESSION_IMPL *session, WT_DATA_HANDL
          * Reset the time of death if the file dhandle exists for the associated table dhandle.
          */
         if (ret == 0) {
-            __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
+            __wt_atomic_store64(&dhandle->timeofdeath, 0);
             session->dhandle = NULL;
             return (ret);
         }
@@ -72,7 +72,7 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
          * of death.
          */
         if (__wt_atomic_loadi32(&dhandle->session_inuse) > 1)
-            __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
+            __wt_atomic_store64(&dhandle->timeofdeath, 0);
 
         /*
          * If the handle is open exclusive or currently in use, or the time of death is already set,
@@ -80,7 +80,7 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
          */
         if (F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE) ||
           __wt_atomic_loadi32(&dhandle->session_inuse) > 0 ||
-          __wt_atomic_load64(&dhandle->gg_timeofdeath) != 0)
+          __wt_atomic_load64(&dhandle->timeofdeath) != 0)
             continue;
 
         /* For table dhandles, skip expiration if associated file dhandles exist. */
@@ -107,7 +107,7 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
         __wt_verbose_level(session, WT_VERB_SWEEP, WT_VERBOSE_DEBUG_3,
           "Sweep server setting the time of death for dhandle %s", dhandle->name);
 
-        __wt_atomic_store64(&dhandle->gg_timeofdeath, now);
+        __wt_atomic_store64(&dhandle->timeofdeath, now);
         WT_STAT_CONN_INCR(session, dh_sweep_tod);
     }
 }
@@ -188,7 +188,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
         if (__wt_atomic_load32(&conn->open_btree_count) < conn->sweep_handles_min)
             break;
 
-        timeofdeath = __wt_atomic_load64(&dhandle->gg_timeofdeath);
+        timeofdeath = __wt_atomic_load64(&dhandle->timeofdeath);
         if (WT_IS_METADATA(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
           __wt_atomic_loadi32(&dhandle->session_inuse) != 0 || timeofdeath == 0 ||
           now - timeofdeath <= conn->sweep_idle_time)

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -378,8 +378,9 @@ __wt_cursor_dhandle_incr_use(WT_SESSION_IMPL *session)
     dhandle = session->dhandle;
 
     /* If we open a handle with a time of death set, clear it. */
-    if (__wt_atomic_addi32(&dhandle->session_inuse, 1) == 1 && dhandle->timeofdeath != 0)
-        dhandle->timeofdeath = 0;
+    if (__wt_atomic_addi32(&dhandle->session_inuse, 1) == 1 &&
+        __wt_atomic_load64(&dhandle->gg_timeofdeath) != 0)
+        __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
 }
 
 /*
@@ -398,8 +399,9 @@ __wt_cursor_dhandle_decr_use(WT_SESSION_IMPL *session)
      * decrementing the use count, there's a chance that the data handle can be freed.
      */
     WT_ASSERT(session, __wt_atomic_loadi32(&dhandle->session_inuse) > 0);
-    if (dhandle->timeofdeath != 0 && __wt_atomic_loadi32(&dhandle->session_inuse) == 1)
-        dhandle->timeofdeath = 0;
+    if (__wt_atomic_load64(&dhandle->gg_timeofdeath) != 0 &&
+        __wt_atomic_loadi32(&dhandle->session_inuse) == 1)
+        __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
     (void)__wt_atomic_subi32(&dhandle->session_inuse, 1);
 }
 

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -379,8 +379,8 @@ __wt_cursor_dhandle_incr_use(WT_SESSION_IMPL *session)
 
     /* If we open a handle with a time of death set, clear it. */
     if (__wt_atomic_addi32(&dhandle->session_inuse, 1) == 1 &&
-        __wt_atomic_load64(&dhandle->gg_timeofdeath) != 0)
-        __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
+        __wt_atomic_load64(&dhandle->timeofdeath) != 0)
+        __wt_atomic_store64(&dhandle->timeofdeath, 0);
 }
 
 /*
@@ -399,9 +399,9 @@ __wt_cursor_dhandle_decr_use(WT_SESSION_IMPL *session)
      * decrementing the use count, there's a chance that the data handle can be freed.
      */
     WT_ASSERT(session, __wt_atomic_loadi32(&dhandle->session_inuse) > 0);
-    if (__wt_atomic_load64(&dhandle->gg_timeofdeath) != 0 &&
+    if (__wt_atomic_load64(&dhandle->timeofdeath) != 0 &&
         __wt_atomic_loadi32(&dhandle->session_inuse) == 1)
-        __wt_atomic_store64(&dhandle->gg_timeofdeath, 0);
+        __wt_atomic_store64(&dhandle->timeofdeath, 0);
     (void)__wt_atomic_subi32(&dhandle->session_inuse, 1);
 }
 

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -112,7 +112,7 @@ struct __wt_data_handle {
     wt_shared uint32_t references;   /* References to this handle */
     wt_shared int32_t session_inuse; /* Sessions using this handle */
     uint32_t excl_ref;               /* Refs of handle by excl_session */
-    uint64_t timeofdeath;            /* Use count went to 0 */
+    wt_shared uint64_t gg_timeofdeath;  /* Use count went to 0 */
     WT_SESSION_IMPL *excl_session;   /* Session with exclusive use, if any */
 
     WT_DATA_SOURCE *dsrc; /* Data source for this handle */

--- a/src/include/dhandle.h
+++ b/src/include/dhandle.h
@@ -112,7 +112,7 @@ struct __wt_data_handle {
     wt_shared uint32_t references;   /* References to this handle */
     wt_shared int32_t session_inuse; /* Sessions using this handle */
     uint32_t excl_ref;               /* Refs of handle by excl_session */
-    wt_shared uint64_t gg_timeofdeath;  /* Use count went to 0 */
+    wt_shared uint64_t timeofdeath;  /* Use count went to 0 */
     WT_SESSION_IMPL *excl_session;   /* Session with exclusive use, if any */
 
     WT_DATA_SOURCE *dsrc; /* Data source for this handle */

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -793,7 +793,7 @@ __wt_session_dhandle_sweep(WT_SESSION_IMPL *session)
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE *dhandle;
     WT_DATA_HANDLE_CACHE *dhandle_cache, *dhandle_cache_tmp;
-    uint64_t now;
+    uint64_t now, timeofdeath;
 
     conn = S2C(session);
 
@@ -816,9 +816,10 @@ __wt_session_dhandle_sweep(WT_SESSION_IMPL *session)
          * evicted. These checks are not done with any locks in place, other than the data handle
          * reference, so we cannot peer past what is in the dhandle directly.
          */
+        timeofdeath = __wt_atomic_load64(&dhandle->gg_timeofdeath);
         if (dhandle != session->dhandle && __wt_atomic_loadi32(&dhandle->session_inuse) == 0 &&
           (WT_DHANDLE_INACTIVE(dhandle) || F_ISSET(dhandle, WT_DHANDLE_OUTDATED) ||
-            (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time)) &&
+            (timeofdeath != 0 && now - timeofdeath > conn->sweep_idle_time)) &&
           (!WT_DHANDLE_BTREE(dhandle) ||
             FLD_ISSET(dhandle->advisory_flags, WT_DHANDLE_ADVISORY_EVICTED))) {
             WT_STAT_CONN_INCR(session, dh_session_handles);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -816,7 +816,7 @@ __wt_session_dhandle_sweep(WT_SESSION_IMPL *session)
          * evicted. These checks are not done with any locks in place, other than the data handle
          * reference, so we cannot peer past what is in the dhandle directly.
          */
-        timeofdeath = __wt_atomic_load64(&dhandle->gg_timeofdeath);
+        timeofdeath = __wt_atomic_load64(&dhandle->timeofdeath);
         if (dhandle != session->dhandle && __wt_atomic_loadi32(&dhandle->session_inuse) == 0 &&
           (WT_DHANDLE_INACTIVE(dhandle) || F_ISSET(dhandle, WT_DHANDLE_OUTDATED) ||
             (timeofdeath != 0 && now - timeofdeath > conn->sweep_idle_time)) &&

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -34,7 +34,6 @@ race:__wt_free_int
 race:__wt_free_update_list
 race:__wt_page_out
 race:__read_blocked
-race:__sweep_mark
 race:__posix_file_close
 race:__log_newfile
 race:__handle_close


### PR DESCRIPTION
This PR adds relaxed atomic accesses to the `dhandle->timeofdeath` field. When field is set to a non-zero value, it starts counting before the dhandle could be sweeped. If difference between the current time and `timeofdeath` is greater than `conn->sweep_idle_time`, a sweep thread closes the dhandle.

Based on my understanding of the code, that should be fine to perform all these calls as relaxed ones. However, I don't fully get the synchronization model for dhandle and dhandles queue, so I want to clear that out first before merging this PR, so I am marking in as a draft for now. One of the question, is that sweeping leads to calling the `__sweep_close_dhandle_locked` function under `WT_WITH_DHANDLE_WRITE_LOCK_NOWAIT` macro, but AFAIS not all accesses to dhandle are protected by the same lock. Generally speaking it works fine now, but I do want to understand the whole picture before proceeding.
