### PR TITLE
WT-14935 __read_block() synchronization

### DIFF
--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -165,7 +165,7 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
 static bool
 __read_blocked(WT_SESSION_IMPL *session)
 {
-    return (session->current_rwticket != session->current_rwlock->u.s.current);
+    return (session->current_rwticket != __wt_atomic_loadv8(&session->current_rwlock->u.s.current));
 }
 
 /*

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -29,12 +29,13 @@ race:__ref_track_state
 # __wt_configure_method intentionally allows for races between threads to avoid the overhead of taking a lock on each API call.  
 race:__wt_configure_method
 
+# FIXME-WT-14930 Dhandle timeofdeath synchronization
+race:__sweep_mark
+
 # FIXME-WT-13074 Unresolved warnings for ex_backup
 race:__wt_free_int
 race:__wt_free_update_list
 race:__wt_page_out
-race:__read_blocked
-race:__sweep_mark
 race:__posix_file_close
 race:__log_newfile
 race:__handle_close


### PR DESCRIPTION
This patch eliminates the data race detected by TSAN. Read of `&session->current_rwlock->u.s.current` in `__read_blocked()` could be done in a relaxed manner since all the synchronization happens later and by `WT_ACQUIRE_BARRIER` in `__wt_readlock`. 