### PR TITLE
WT-14554 Remove s_tags from s_all

### DIFF
--- a/dist/s_all
+++ b/dist/s_all
@@ -162,7 +162,6 @@ run --bg "s_longlines" &
 run --bg "s_python" &
 run --bg "s_stat" &
 run --bg "s_string" &
-run --bg "s_tags" &
 run --bg "s_typedef -c" &
 run --bg "s_visibility_checks" &
 run --bg "s_void" &


### PR DESCRIPTION
tag files don't need to be generated as part of s_all.