### PR TITLE
WT-14947 Suppress perf critical warnings

### DIFF
--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -64,4 +64,9 @@ race:hazard.c
 race:__wt_tree_modify_set
 race:__wt_cond_auto_wait_signal
 race:__wt_ref_addr_copy
-
+race:__wt_row_leaf_key_info
+race:__wt_row_leaf_key
+race:__evict_force_check
+race:__wt_page_evict_clean
+race:__wt_evict_touch_page
+race:__wt_row_search


### PR DESCRIPTION
My assumption is that the recent merges has slowed down the system to the point where the example would perform evictions or need to fetch a page from disk. This causes the new warnings.

All related warnings are under eviction or row search. Both of these are considered perf critical warnings and need deeper investigation. 
