### PR TITLE
WT-14946 Skip incompatible Python tests with tiered hook and disagg

### DIFF
--- a/test/suite/test_layered17.py
+++ b/test/suite/test_layered17.py
@@ -32,7 +32,7 @@ from wtscenario import make_scenarios
 
 # test_layered17.py
 #    Check timestamps.
-@wttest.skip_for_hook("tiered", "TODO fixme")
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered17(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500

--- a/test/suite/test_layered18.py
+++ b/test/suite/test_layered18.py
@@ -32,7 +32,7 @@ from wtscenario import make_scenarios
 
 # test_layered18.py
 #    Create long delta chains.
-@wttest.skip_for_hook("tiered", "TODO fixme")
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered18(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500

--- a/test/suite/test_layered25.py
+++ b/test/suite/test_layered25.py
@@ -32,6 +32,7 @@ from wtscenario import make_scenarios
 
 # test_layered25.py
 #    Start without local files and test historical reads.
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered25(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500

--- a/test/suite/test_layered26.py
+++ b/test/suite/test_layered26.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 # test_layered26.py
 #    Make sure a secondary picking up a checkpoint adds in the stable
 #    component of the table.
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered26(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 5000

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 
 # test_layered27.py
 # Test draining the ingest table
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered27(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \

--- a/test/suite/test_layered30.py
+++ b/test/suite/test_layered30.py
@@ -32,6 +32,7 @@ from wtscenario import make_scenarios
 
 # test_layered30.py
 #    Test creating empty tables.
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered30(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500

--- a/test/suite/test_layered34.py
+++ b/test/suite/test_layered34.py
@@ -32,6 +32,7 @@ from wtscenario import make_scenarios
 
 # test_layered34.py
 #    Test materialization frontier.
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered34(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_base_config = 'statistics=(all),' \

--- a/test/suite/test_layered36.py
+++ b/test/suite/test_layered36.py
@@ -32,6 +32,7 @@ from wtscenario import make_scenarios
 
 # test_layered36.py
 #    Test creating missing stable tables.
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered36(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 
 # test_layered38.py
 # Test garbage collecting redundant content in the ingest table
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_base_config = ',create,cache_size=10GB,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \

--- a/test/suite/test_layered40.py
+++ b/test/suite/test_layered40.py
@@ -32,6 +32,7 @@ from wtscenario import make_scenarios
 
 # test_layered40.py
 #    Test layered table metadata has logging disabled.
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered40(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_config = 'log=(enabled=true),disaggregated=(page_log=palm,role="leader"),'

--- a/test/suite/test_layered43.py
+++ b/test/suite/test_layered43.py
@@ -33,6 +33,7 @@ from wiredtiger import stat
 
 # test_layered43.py
 #    Test disaggregated storage with block cache.
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered43(wttest.WiredTigerTestCase, DisaggConfigMixin):
     nitems = 500


### PR DESCRIPTION
Skip Python disagg tests that are incompatible when tiered hook is used. This will be address with WT-14938.