### PR TITLE
WT-13074 Fix log_newfile related warnings from ex_backup

### DIFF
--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -714,11 +714,11 @@ struct __wt_connection_impl {
     uint32_t stat_flags; /* Options declared in flags.py */
 
     /* Connection statistics */
-    uint64_t rec_maximum_hs_wrapup_milliseconds; /* Maximum milliseconds moving updates to history
-                                                    store took. */
-    uint64_t
+    wt_shared uint64_t rec_maximum_hs_wrapup_milliseconds; /* Maximum milliseconds moving updates to
+                                                    history store took. */
+    wt_shared uint64_t
       rec_maximum_image_build_milliseconds; /* Maximum milliseconds building disk image took. */
-    uint64_t rec_maximum_milliseconds;      /* Maximum milliseconds reconciliation took. */
+    wt_shared uint64_t rec_maximum_milliseconds; /* Maximum milliseconds reconciliation took. */
     WT_CONNECTION_STATS *stats[WT_STAT_CONN_COUNTER_SLOTS];
     WT_CONNECTION_STATS *stat_array;
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1180,7 +1180,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (log_mgr->prealloc > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (__wt_atomic_load32(&log_mgr->prealloc) > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -276,7 +276,7 @@ __log_fsync_file(WT_SESSION_IMPL *session, WT_LSN *min_lsn, const char *method, 
         if (use_own_fh)
             WT_ERR(__log_openfile(session, min_lsn->l.file, 0, &log_fh));
         else
-            log_fh = log->log_fh;
+            log_fh = __wt_atomic_load_pointer(&log->log_fh);
         __wt_verbose(session, WT_VERB_LOG, "%s: sync %s to LSN %" PRIu32 "/%" PRIu32, method,
           log_fh->name, min_lsn->l.file, __wt_lsn_offset(min_lsn));
         time_start = __wt_clock(session);
@@ -1145,7 +1145,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * one is closed. Wait for that to close.
      */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SLOT));
-    for (yield_cnt = 0; log->log_close_fh != NULL;) {
+    for (yield_cnt = 0; __wt_atomic_load_pointer(&log->log_close_fh) != NULL;) {
         WT_STAT_CONN_INCR(session, log_close_yields);
         /*
          * Processing slots will conditionally signal the file close server thread. But if we've
@@ -1165,8 +1165,10 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * Note, the file server worker thread requires the LSN be set once the close file handle is
      * set, force that ordering.
      */
-    if (log->log_fh == NULL)
-        log->log_close_fh = NULL;
+    WT_FH *log_fh_tmp;
+    WT_ACQUIRE_READ(log_fh_tmp, log->log_fh);
+    if (log_fh_tmp == NULL)
+        __wt_atomic_store_pointer(&log->log_close_fh, NULL);
     else {
         WT_ASSIGN_LSN(&log->log_close_lsn, &log->alloc_lsn);
         /* Paired with an acquire read in the log file server path. */
@@ -1180,7 +1182,8 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (__wt_atomic_load32(&log_mgr->prealloc) > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (__wt_atomic_load32(&log_mgr->prealloc) > 0 &&
+      __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 
@@ -1240,7 +1243,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
         WT_SET_LSN(&log->alloc_lsn, log->fileid, log->first_record);
     }
     WT_ASSIGN_LSN(&end_lsn, &log->alloc_lsn);
-    WT_RELEASE_WRITE_WITH_BARRIER(log->log_fh, log_fh);
+    WT_RELEASE_WRITE(log->log_fh, log_fh);
 
     /*
      * If we're called from connection creation code, we need to update the LSNs since we're the
@@ -1364,7 +1367,7 @@ __wti_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WTI_LOGSLOT *slot)
     if (F_ISSET(log, WTI_LOG_FORCE_NEWFILE) || !__log_size_fit(session, &log->alloc_lsn, recsize)) {
         WT_RET(__log_newfile(session, false, &created_log));
         F_CLR(log, WTI_LOG_FORCE_NEWFILE);
-        if (log->log_close_fh != NULL)
+        if (__wt_atomic_load_pointer(&log->log_close_fh) != NULL)
             F_SET_ATOMIC_16(slot, WTI_SLOT_CLOSEFH);
     }
 
@@ -1373,7 +1376,7 @@ __wti_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WTI_LOGSLOT *slot)
      * pre-allocated).
      */
     if (__wt_lsn_offset(&log->alloc_lsn) == log->first_record && created_log)
-        WT_RET(__log_prealloc(session, log->log_fh));
+        WT_RET(__log_prealloc(session, __wt_atomic_load_pointer(&log->log_fh)));
     /*
      * Initialize the slot for activation.
      */
@@ -1748,22 +1751,26 @@ __wti_log_close(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WTI_LOG *log;
+    WT_FH *log_close_fh, *log_fh;
 
     conn = S2C(session);
     log = conn->log_mgr.log;
+    log_close_fh = __wt_atomic_load_pointer(&log->log_close_fh);
+    log_fh = __wt_atomic_load_pointer(&log->log_fh);
 
-    if (log->log_close_fh != NULL && log->log_close_fh != log->log_fh) {
-        __wt_verbose(session, WT_VERB_LOG, "closing old log %s", log->log_close_fh->name);
+    if (log_close_fh != NULL && log_close_fh != log_fh) {
+        __wt_verbose(session, WT_VERB_LOG, "closing old log %s", log_close_fh->name);
         if (!F_ISSET_ATOMIC_32(conn, WT_CONN_READONLY))
-            WT_RET(__wt_fsync(session, log->log_close_fh, true));
-        WT_RET(__wt_close(session, &log->log_close_fh));
+            WT_RET(__wt_fsync(session, log_close_fh, true));
+        WT_RET(__wt_close(session, &log_close_fh));
     }
-    if (log->log_fh != NULL) {
-        __wt_verbose(session, WT_VERB_LOG, "closing log %s", log->log_fh->name);
+    if (log_fh != NULL) {
+        __wt_verbose(session, WT_VERB_LOG, "closing log %s", log_fh->name);
         if (!F_ISSET_ATOMIC_32(conn, WT_CONN_READONLY))
-            WT_RET(__wt_fsync(session, log->log_fh, true));
-        WT_RET(__wt_close(session, &log->log_fh));
-        log->log_fh = NULL;
+            WT_RET(__wt_fsync(session, log_fh, true));
+        WT_RET(__wt_close(session, &log_fh));
+        log_fh = NULL;
+        __wt_atomic_store_pointer(&log->log_fh, log_fh);
     }
     if (log->log_dir_fh != NULL) {
         __wt_verbose(session, WT_VERB_LOG, "closing log directory %s", log->log_dir_fh->name);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1170,7 +1170,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
     else {
         WT_ASSIGN_LSN(&log->log_close_lsn, &log->alloc_lsn);
         /* Paired with an acquire read in the log file server path. */
-        WT_RELEASE_WRITE(log->log_close_fh, log->log_fh);
+        WT_RELEASE_WRITE_WITH_BARRIER(log->log_close_fh, log->log_fh);
     }
     log->fileid++;
 
@@ -1241,7 +1241,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
         WT_SET_LSN(&log->alloc_lsn, log->fileid, log->first_record);
     }
     WT_ASSIGN_LSN(&end_lsn, &log->alloc_lsn);
-    WT_RELEASE_WRITE(log->log_fh, log_fh);
+    WT_RELEASE_WRITE_WITH_BARRIER(log->log_fh, log_fh);
 
     /*
      * If we're called from connection creation code, we need to update the LSNs since we're the

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1166,7 +1166,6 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * set, force that ordering.
      */
     WT_FH *log_fh_tmp;
-    WT_ACQUIRE_READ(log_fh_tmp, log->log_fh);
     if (log_fh_tmp == NULL)
         __wt_atomic_store_pointer(&log->log_close_fh, NULL);
     else {
@@ -1250,7 +1249,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * only write in progress.
      */
     if (conn_open) {
-        WT_RET(__wt_fsync(session, log->log_fh, true));
+        WT_RET(__wt_fsync(session, __wt_atomic_load_pointer(&log->log_fh), true));
         WT_ASSIGN_LSN(&log->sync_lsn, &end_lsn);
         WT_ASSIGN_LSN(&log->write_lsn, &end_lsn);
         WT_ASSIGN_LSN(&log->write_start_lsn, &end_lsn);
@@ -1971,7 +1970,7 @@ __wti_log_release(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot, bool *freep)
         __wt_cond_signal(session, conn->log_mgr.file.cond);
 
     if (F_ISSET_ATOMIC_16(slot, WTI_SLOT_SYNC_DIRTY) && !F_ISSET_ATOMIC_16(slot, WTI_SLOT_SYNC) &&
-      (ret = __wt_fsync(session, log->log_fh, false)) != 0) {
+      (ret = __wt_fsync(session, __wt_atomic_load_pointer(&log->log_fh), false)) != 0) {
         /*
          * Ignore ENOTSUP, but don't try again.
          */

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1170,7 +1170,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
     else {
         WT_ASSIGN_LSN(&log->log_close_lsn, &log->alloc_lsn);
         /* Paired with an acquire read in the log file server path. */
-        WT_RELEASE_WRITE_WITH_BARRIER(log->log_close_fh, log->log_fh);
+        WT_RELEASE_WRITE(log->log_close_fh, log->log_fh);
     }
     log->fileid++;
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1165,8 +1165,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * Note, the file server worker thread requires the LSN be set once the close file handle is
      * set, force that ordering.
      */
-    WT_FH *log_fh_tmp;
-    if (log_fh_tmp == NULL)
+    if (log->log_fh == NULL)
         __wt_atomic_store_pointer(&log->log_close_fh, NULL);
     else {
         WT_ASSIGN_LSN(&log->log_close_lsn, &log->alloc_lsn);

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -523,13 +523,14 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
     WTI_LOG *log;
     WT_LOG_MANAGER *log_mgr;
     u_int i, reccount;
+    uint32_t log_prealloc;
     char **recfiles;
 
     log_mgr = &S2C(session)->log_mgr;
     log = log_mgr->log;
     reccount = 0;
     recfiles = NULL;
-
+    log_prealloc = __wt_atomic_load32(&log_mgr->prealloc);
     /*
      * Allocate up to the maximum number, accounting for any existing files that may not have been
      * used yet.
@@ -542,25 +543,25 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
      * them since we last ran.
      */
     if (log->prep_missed > 0) {
-        log_mgr->prealloc += log->prep_missed;
+        log_prealloc += log->prep_missed;
         __wt_verbose(session, WT_VERB_LOG, "Missed %" PRIu32 ". Now pre-allocating up to %" PRIu32,
-          log->prep_missed, log_mgr->prealloc);
-    } else if (reccount > log_mgr->prealloc / 2 &&
-      log_mgr->prealloc > log_mgr->prealloc_init_count) {
+          log->prep_missed, log_prealloc);
+    } else if (reccount > log_prealloc / 2 &&
+      log_prealloc > log_mgr->prealloc_init_count) {
         /*
          * If we used less than half, then start adjusting down.
          */
-        --log_mgr->prealloc;
+        --log_prealloc;
         __wt_verbose(session, WT_VERB_LOG,
           "Adjust down. Did not use %" PRIu32 ". Now pre-allocating %" PRIu32, reccount,
-          log_mgr->prealloc);
+          log_prealloc);
     }
 
-    WT_STAT_CONN_SET(session, log_prealloc_max, log_mgr->prealloc);
+    WT_STAT_CONN_SET(session, log_prealloc_max, log_prealloc);
     /*
      * Allocate up to the maximum number that we just computed and detected.
      */
-    for (i = reccount; i < (u_int)log_mgr->prealloc; i++) {
+    for (i = reccount; i < (u_int)(log_prealloc); i++) {
         WT_ERR(__wti_log_allocfile(session, ++log->prep_fileid, WTI_LOG_PREPNAME));
         WT_STAT_CONN_INCR(session, log_prealloc_files);
     }
@@ -570,7 +571,7 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
      * keep adding in more.
      */
     log->prep_missed = 0;
-
+    __wt_atomic_store32(&log_mgr->prealloc, log_prealloc);
     if (0)
 err:
         __wt_err(session, ret, "log pre-alloc server error");
@@ -961,7 +962,7 @@ __log_server(void *arg)
             /*
              * Perform log pre-allocation.
              */
-            if (log_mgr->prealloc > 0) {
+            if (__wt_atomic_load32(&log_mgr->prealloc) > 0) {
                 /*
                  * Log file pre-allocation is disabled when a hot backup cursor is open because we
                  * have agreed not to rename or remove any files in the database directory.

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -642,13 +642,13 @@ __log_file_server(void *arg)
          * Writers will set the log close lsn first and then the log close file handle, so we need
          * to read them in the reverse order to see a consistent state.
          */
-        WT_ACQUIRE_READ_WITH_BARRIER(close_fh, log->log_close_fh);
+        WT_ACQUIRE_READ(close_fh, log->log_close_fh);
         if (close_fh != NULL) {
             WT_ERR(__wti_log_extract_lognum(session, close_fh->name, &filenum));
             /*
              * The closing file handle should have a correct close LSN.
              */
-            WT_ASSERT(session, log->log_close_lsn.l.file == filenum);
+            WT_ASSERT(session, __wt_atomic_loadv32(&log->log_close_lsn.l.file) == filenum);
 
             if (__wt_log_cmp(&log->write_lsn, &log->log_close_lsn) >= 0) {
                 /*
@@ -658,7 +658,7 @@ __log_file_server(void *arg)
                  */
                 WT_ASSIGN_LSN(&close_end_lsn, &log->log_close_lsn);
                 WT_FULL_BARRIER();
-                log->log_close_fh = NULL;
+                __wt_atomic_store_pointer(&log->log_close_fh, NULL);
                 /*
                  * Set the close_end_lsn to the LSN immediately after ours. That is, the beginning
                  * of the next log file. We need to know the LSN file number of our own close in

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -546,8 +546,7 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
         log_prealloc += log->prep_missed;
         __wt_verbose(session, WT_VERB_LOG, "Missed %" PRIu32 ". Now pre-allocating up to %" PRIu32,
           log->prep_missed, log_prealloc);
-    } else if (reccount > log_prealloc / 2 &&
-      log_prealloc > log_mgr->prealloc_init_count) {
+    } else if (reccount > log_prealloc / 2 && log_prealloc > log_mgr->prealloc_init_count) {
         /*
          * If we used less than half, then start adjusting down.
          */

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -642,7 +642,7 @@ __log_file_server(void *arg)
          * Writers will set the log close lsn first and then the log close file handle, so we need
          * to read them in the reverse order to see a consistent state.
          */
-        WT_ACQUIRE_READ(close_fh, log->log_close_fh);
+        WT_ACQUIRE_READ_WITH_BARRIER(close_fh, log->log_close_fh);
         if (close_fh != NULL) {
             WT_ERR(__wti_log_extract_lognum(session, close_fh->name, &filenum));
             /*

--- a/src/log/log_private.h
+++ b/src/log/log_private.h
@@ -184,7 +184,7 @@ struct __wti_log {
     uint32_t min_fileid; /* Minimum file number needed */
 #endif
     uint32_t prep_missed;           /* Pre-allocated file misses */
-    WT_FH *log_fh;                  /* Logging file handle */
+    wt_shared WT_FH *log_fh;        /* Logging file handle */
     WT_FH *log_dir_fh;              /* Log directory file handle */
     wt_shared WT_FH *log_close_fh;  /* Logging file handle to close */
     wt_shared WT_LSN log_close_lsn; /* LSN needed to close */

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -75,7 +75,7 @@ __wti_log_slot_activate(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot)
     WT_ASSIGN_LSN(&slot->slot_end_lsn, &slot->slot_start_lsn);
     __wt_atomic_storei64(&slot->slot_start_offset, __wt_lsn_offset(&log->alloc_lsn));
     __wt_atomic_storei64(&slot->slot_last_offset, __wt_lsn_offset(&log->alloc_lsn));
-    slot->slot_fh = log->log_fh;
+    __wt_atomic_store_pointer(&slot->slot_fh, log->log_fh);
     __wt_atomic_storei32(&slot->slot_error, 0);
     WT_DIAGNOSTIC_YIELD;
     /*

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -178,7 +178,7 @@ __wt_verbose_dump_log(WT_SESSION_IMPL *session)
       session, "Running downgraded: %s", F_ISSET(log_mgr, WT_LOG_DOWNGRADED) ? "yes" : "no"));
     WT_RET(
       __wt_msg(session, "Zero fill files: %s", F_ISSET(log_mgr, WT_LOG_ZERO_FILL) ? "yes" : "no"));
-    WT_RET(__wt_msg(session, "Pre-allocate files: %s", log_mgr->prealloc > 0 ? "yes" : "no"));
+    WT_RET(__wt_msg(session, "Pre-allocate files: %s", __wt_atomic_load32(&log_mgr->prealloc) > 0 ? "yes" : "no"));
     WT_RET(__wt_msg(
       session, "Initial number of pre-allocated files: %" PRIu32, log_mgr->prealloc_init_count));
     WT_RET(__wt_msg(session, "Logging directory: %s", log_mgr->log_path));

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -178,7 +178,8 @@ __wt_verbose_dump_log(WT_SESSION_IMPL *session)
       session, "Running downgraded: %s", F_ISSET(log_mgr, WT_LOG_DOWNGRADED) ? "yes" : "no"));
     WT_RET(
       __wt_msg(session, "Zero fill files: %s", F_ISSET(log_mgr, WT_LOG_ZERO_FILL) ? "yes" : "no"));
-    WT_RET(__wt_msg(session, "Pre-allocate files: %s", __wt_atomic_load32(&log_mgr->prealloc) > 0 ? "yes" : "no"));
+    WT_RET(__wt_msg(session, "Pre-allocate files: %s",
+      __wt_atomic_load32(&log_mgr->prealloc) > 0 ? "yes" : "no"));
     WT_RET(__wt_msg(
       session, "Initial number of pre-allocated files: %" PRIu32, log_mgr->prealloc_init_count));
     WT_RET(__wt_msg(session, "Logging directory: %s", log_mgr->log_path));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -402,12 +402,12 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
      */
     WT_ASSERT(session, rec < WT_DAY * WT_THOUSAND);
 
-    if (rec_hs_wrapup > conn->rec_maximum_hs_wrapup_milliseconds)
-        conn->rec_maximum_hs_wrapup_milliseconds = rec_hs_wrapup;
-    if (rec_img_build > conn->rec_maximum_image_build_milliseconds)
-        conn->rec_maximum_image_build_milliseconds = rec_img_build;
-    if (rec > conn->rec_maximum_milliseconds)
-        conn->rec_maximum_milliseconds = rec;
+    if (rec_hs_wrapup > __wt_atomic_load64(&conn->rec_maximum_hs_wrapup_milliseconds))
+        __wt_atomic_store64(&conn->rec_maximum_hs_wrapup_milliseconds, rec_hs_wrapup);
+    if (rec_img_build > __wt_atomic_load64(&conn->rec_maximum_image_build_milliseconds))
+        __wt_atomic_store64(&conn->rec_maximum_image_build_milliseconds, rec_img_build);
+    if (rec > __wt_atomic_load64(&conn->rec_maximum_milliseconds))
+        __wt_atomic_store64(&conn->rec_maximum_milliseconds, rec);
     if (session->reconcile_timeline.total_reentry_hs_eviction_time >
       conn->evict->reentry_hs_eviction_ms)
         conn->evict->reentry_hs_eviction_ms =

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -35,7 +35,7 @@ race:__sweep_mark
 # FIXME-WT-14948 Figure out concurrency control expectations around reconfigure
 race:conn_reconfig.c
 
-# FIXME-WT-13074 This Work has been split out into a separate ticket to keep PR sizes down.
+# FIXME-WT-14958 This Work has been split out into a separate ticket to keep PR sizes down.
 race:__wt_free_int
 race:__wt_free_update_list
 race:__wt_page_out

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -32,7 +32,10 @@ race:__wt_configure_method
 # FIXME-WT-14930 Dhandle timeofdeath synchronization
 race:__sweep_mark
 
-# FIXME-WT-13074 Unresolved warnings for ex_backup
+# FIXME-WT-14948 Figure out concurrency control expectations around reconfigure
+race:conn_reconfig.c
+
+# FIXME-WT-13074 This Work has been split out into a separate ticket to keep PR sizes down.
 race:__wt_free_int
 race:__wt_free_update_list
 race:__wt_page_out

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -37,7 +37,6 @@ race:__wt_free_int
 race:__wt_free_update_list
 race:__wt_page_out
 race:__posix_file_close
-race:__log_newfile
 race:__handle_close
 race:__sweep_remove_handles
 race:__stash_discard
@@ -57,7 +56,6 @@ race:__wti_conn_reconfig
 race:__wt_session_cursor_cache_sweep
 race:__wti_txn_update_pinned_timestamp
 race:__capacity_config
-
 
 # FIXME-WT-13075 Address these warnings separately as they may have perf impacts
 race:hazard.c

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -55,7 +55,6 @@ race:__wt_cache_dirty_decr
 race:__wt_reconcile
 
 # FIXME-WT-14856 Unresolved warnings for ex_all
-race:__wti_conn_reconfig
 race:__wt_session_cursor_cache_sweep
 race:__wti_txn_update_pinned_timestamp
 race:__capacity_config


### PR DESCRIPTION
The pull requests fixes log_newfile related warnings. The log subsystem is used to log and track all WT related records. In particular the concurrency can happen from application threads, and 3 background log threads. Each log thread has their own purpose.  Here is my technical analysis of what I have done:

The interaction of log_close_fh and log_fh is as mentioned:
> If a log file needs to be closed, then the application thread moves its file handle to the \c log->log_close_fh field and signals this thread.

**Note:** log subsystem hasn't gotten a race condition bug over 5 years.

**log_close_fh**: The variable has acquire/release semantics to orchestrate happens-before relationships.
The current method makes sense to me and warrants no risk. Here is a summary:
- __wti_log_close: This function is done at connection->close(), there most likely won't be any interaction with other threads.
- I am not concerned with log_newfile, and  __log_file_server because they have an eventual barrier. I assume that the code knows what is going on and thought it through already.
- I wonder if we need a barrier for __wti_log_acquire?

**log->log_fh**: The variable has previously only had a RELEASE semantics without any ACQUIRE semantics. The current usage is clear and warrants no risk. 
- I have added a relax atomic loads to __log_newfile, __wti_log_acquire, __wti_log_close and __wti_log_release. Through inspection none of these loads have any concerning race conditions. 
- I have thought able adding an WT_ACQUIRE_READ inside log->log_fh. We check if it is NULL first and then store the log_close_fh to NULL. However it is not required because it doesn't matter if log_close_fh is set to NULL when it is not meant to. In the worst case we don't close a file handle that was meant to be closed. We can always do it in the next cycle.

**log_mgr->prealloc**: A configuration to create and prepare log files before they need to be used. This is done to reduce I/O performance overhead of creating/switching to new log files.
- I have added a new local variable and use relaxed store/load atomics to store log_mgr->prealloc variables. Concurrency control doesn't matter here. We only have one background thread that should be calling __log_prealloc_once. 

I have also add atomic_loads to rec_maximum_hs_wrapup_milliseconds, rec_maximum_image_build_milliseconds, and rec_maximum_milliseconds. They are only used for statistics and do not need to be accurate. 

