### PR TITLE
WT-14953 Fix layered table manager initialization

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -511,11 +511,11 @@ __layered_table_manager_thread_run(WT_SESSION_IMPL *session_shared, WT_THREAD *t
 }
 
 /*
- * __wt_layered_table_manager_start --
+ * __layered_table_manager_start --
  *     Start the layered table manager thread
  */
-int
-__wt_layered_table_manager_start(WT_SESSION_IMPL *session)
+static int
+__layered_table_manager_start(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
@@ -545,7 +545,7 @@ __wt_layered_table_manager_start(WT_SESSION_IMPL *session)
 
     WT_STAT_CONN_SET(session, layered_table_manager_running, 1);
     __wt_verbose_level(
-      session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5, "%s", "__wt_layered_table_manager_start");
+      session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5, "%s", "__layered_table_manager_start");
     FLD_SET(conn->server_flags, WT_CONN_SERVER_LAYERED);
 
     manager->state = WT_LAYERED_TABLE_MANAGER_RUNNING;
@@ -764,6 +764,7 @@ __wti_layered_table_manager_destroy(WT_SESSION_IMPL *session)
     __wt_atomic_store32(&manager->state, WT_LAYERED_TABLE_MANAGER_OFF);
     WT_STAT_CONN_SET(session, layered_table_manager_running, 0);
     __wt_spin_unlock(session, &manager->layered_table_lock);
+    __wt_spin_destroy(session, &manager->layered_table_lock);
 
     return (0);
 }
@@ -1059,6 +1060,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
 
     /* FIXME-WT-14965: Exit the function immediately if this check returns false. */
     if (__wt_conn_is_disagg(session)) {
+        WT_ERR(__layered_table_manager_start(session));
 
         /* Initialize the shared metadata table. */
         WT_ERR(__disagg_metadata_table_init(session));
@@ -1123,9 +1125,6 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
         WT_ERR(__wt_config_gets(session, cfg, "disaggregated.lose_all_my_data", &cval));
         if (cval.val != 0)
             F_SET(&conn->disaggregated_storage, WT_DISAGG_NO_SYNC);
-
-        /* Start the layered table manager thread. */
-        WT_ERR(__wt_layered_table_manager_start(session));
     }
 
 err:

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -525,19 +525,9 @@ __wt_layered_table_manager_start(WT_SESSION_IMPL *session)
     conn = S2C(session);
     manager = &conn->layered_table_manager;
 
-    /* It's possible to race - only start the manager if we are the winner */
-    if (!__wt_atomic_cas32(
-          &manager->state, WT_LAYERED_TABLE_MANAGER_OFF, WT_LAYERED_TABLE_MANAGER_STARTING)) {
-        /* This isn't optimal, but it'll do. It's uncommon for multiple threads to be trying to
-         * start the layered table manager at the same time.
-         * It's probably fine for any "loser" to proceed without waiting, but be conservative
-         * and have a semantic where a return from this function indicates a running layered table
-         * manager->
-         */
-        while (__wt_atomic_load32(&manager->state) != WT_LAYERED_TABLE_MANAGER_RUNNING)
-            __wt_sleep(0, 1000);
-        return (0);
-    }
+    WT_ASSERT_ALWAYS(session, manager->state == WT_LAYERED_TABLE_MANAGER_OFF,
+            "Layered table manager initialization conflict");
+    manager->state = WT_LAYERED_TABLE_MANAGER_STARTING; 
 
     WT_RET(__wt_spin_init(session, &manager->layered_table_lock, "layered table manager"));
 
@@ -558,8 +548,7 @@ __wt_layered_table_manager_start(WT_SESSION_IMPL *session)
       session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5, "%s", "__wt_layered_table_manager_start");
     FLD_SET(conn->server_flags, WT_CONN_SERVER_LAYERED);
 
-    /* Now that everything is setup, allow the manager to be used. */
-    __wt_atomic_store32(&manager->state, WT_LAYERED_TABLE_MANAGER_RUNNING);
+    manager->state = WT_LAYERED_TABLE_MANAGER_RUNNING;
     return (0);
 
 err:
@@ -588,8 +577,7 @@ __wt_layered_table_manager_add_table(WT_SESSION_IMPL *session, uint32_t ingest_i
       "Adding a layered tree to tracking without the right dhandle context.");
     layered = (WT_LAYERED_TABLE *)session->dhandle;
 
-    WT_ASSERT_ALWAYS(session,
-      __wt_atomic_load32(&manager->state) == WT_LAYERED_TABLE_MANAGER_RUNNING,
+    WT_ASSERT_ALWAYS(session, manager->state == WT_LAYERED_TABLE_MANAGER_RUNNING,
       "Adding a layered table, but the manager isn't running");
     __wt_spin_lock(session, &manager->layered_table_lock);
 
@@ -668,19 +656,16 @@ void
 __wt_layered_table_manager_remove_table(WT_SESSION_IMPL *session, uint32_t ingest_id)
 {
     WT_LAYERED_TABLE_MANAGER *manager;
-    uint32_t manager_state;
 
     manager = &S2C(session)->layered_table_manager;
 
-    manager_state = __wt_atomic_load32(&manager->state);
-
     /* Shutdown calls this redundantly - ignore cases when the manager is already closed. */
-    if (manager_state == WT_LAYERED_TABLE_MANAGER_OFF)
+    if (manager->state == WT_LAYERED_TABLE_MANAGER_OFF)
         return;
 
     WT_ASSERT_ALWAYS(session,
-      manager_state == WT_LAYERED_TABLE_MANAGER_RUNNING ||
-        manager_state == WT_LAYERED_TABLE_MANAGER_STOPPING,
+      manager->state == WT_LAYERED_TABLE_MANAGER_RUNNING ||
+        manager->state == WT_LAYERED_TABLE_MANAGER_STOPPING,
       "Adding a layered table, but the manager isn't running");
     __wt_spin_lock(session, &manager->layered_table_lock);
     __layered_table_manager_remove_table_inlock(session, ingest_id);
@@ -745,6 +730,7 @@ __wti_layered_table_manager_destroy(WT_SESSION_IMPL *session)
      * Spin until exclusive access is gained. If we got here from the startup path seeing an error,
      * the state might still be "starting" rather than "running".
      */
+    /* FIXME-WT-14963: Check whether we need atomics here. */
     while (!__wt_atomic_cas32(&manager->state, WT_LAYERED_TABLE_MANAGER_RUNNING,
              WT_LAYERED_TABLE_MANAGER_STOPPING) &&
       !__wt_atomic_cas32(
@@ -1071,6 +1057,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
           WT_DISAGG_METADATA_TABLE_ID, &conn->disaggregated_storage.page_log_meta));
     }
 
+    /* FIXME-WT-14965: Exit the function immediately if this check returns false. */
     if (__wt_conn_is_disagg(session)) {
 
         /* Initialize the shared metadata table. */
@@ -1136,6 +1123,9 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
         WT_ERR(__wt_config_gets(session, cfg, "disaggregated.lose_all_my_data", &cval));
         if (cval.val != 0)
             F_SET(&conn->disaggregated_storage, WT_DISAGG_NO_SYNC);
+
+        /* Start the layered table manager thread. */
+        WT_ERR(__wt_layered_table_manager_start(session));
     }
 
 err:
@@ -1557,6 +1547,9 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
     min_ckpt_inuse = ds->ckpt_track_cnt;
     uri_at_checkpoint = NULL;
     uri_alloc = 0;
+
+
+    WT_ASSERT(session, manager->state == WT_LAYERED_TABLE_MANAGER_RUNNING);
 
     __wt_spin_lock(session, &manager->layered_table_lock);
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -527,7 +527,6 @@ __layered_table_manager_start(WT_SESSION_IMPL *session)
 
     WT_ASSERT_ALWAYS(session, manager->state == WT_LAYERED_TABLE_MANAGER_OFF,
       "Layered table manager initialization conflict");
-    manager->state = WT_LAYERED_TABLE_MANAGER_STARTING;
 
     WT_RET(__wt_spin_init(session, &manager->layered_table_lock, "layered table manager"));
 
@@ -663,10 +662,6 @@ __wt_layered_table_manager_remove_table(WT_SESSION_IMPL *session, uint32_t inges
     if (manager->state == WT_LAYERED_TABLE_MANAGER_OFF)
         return;
 
-    WT_ASSERT_ALWAYS(session,
-      manager->state == WT_LAYERED_TABLE_MANAGER_RUNNING ||
-        manager->state == WT_LAYERED_TABLE_MANAGER_STOPPING,
-      "Adding a layered table, but the manager isn't running");
     __wt_spin_lock(session, &manager->layered_table_lock);
     __layered_table_manager_remove_table_inlock(session, ingest_id);
 
@@ -726,25 +721,8 @@ __wti_layered_table_manager_destroy(WT_SESSION_IMPL *session)
     if (__wt_atomic_load32(&manager->state) == WT_LAYERED_TABLE_MANAGER_OFF)
         return (0);
 
-    /*
-     * Spin until exclusive access is gained. If we got here from the startup path seeing an error,
-     * the state might still be "starting" rather than "running".
-     */
-    /* FIXME-WT-14963: Check whether we need atomics here. */
-    while (!__wt_atomic_cas32(&manager->state, WT_LAYERED_TABLE_MANAGER_RUNNING,
-             WT_LAYERED_TABLE_MANAGER_STOPPING) &&
-      !__wt_atomic_cas32(
-        &manager->state, WT_LAYERED_TABLE_MANAGER_STARTING, WT_LAYERED_TABLE_MANAGER_STOPPING)) {
-        /* If someone beat us to it, we are done */
-        if (__wt_atomic_load32(&manager->state) == WT_LAYERED_TABLE_MANAGER_OFF)
-            return (0);
-        __wt_sleep(0, 1000);
-    }
-
     /* Ensure other things that engage with the layered table server know it's gone. */
     FLD_CLR(conn->server_flags, WT_CONN_SERVER_LAYERED);
-
-    __wt_spin_lock(session, &manager->layered_table_lock);
 
     /* Let any running threads finish up. */
     __wt_cond_signal(session, manager->threads.wait_cond);
@@ -761,9 +739,9 @@ __wti_layered_table_manager_destroy(WT_SESSION_IMPL *session)
     manager->open_layered_table_count = 0;
     manager->entries_allocated_bytes = 0;
 
-    __wt_atomic_store32(&manager->state, WT_LAYERED_TABLE_MANAGER_OFF);
+    manager->state = WT_LAYERED_TABLE_MANAGER_OFF;
     WT_STAT_CONN_SET(session, layered_table_manager_running, 0);
-    __wt_spin_unlock(session, &manager->layered_table_lock);
+
     __wt_spin_destroy(session, &manager->layered_table_lock);
 
     return (0);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -526,8 +526,8 @@ __wt_layered_table_manager_start(WT_SESSION_IMPL *session)
     manager = &conn->layered_table_manager;
 
     WT_ASSERT_ALWAYS(session, manager->state == WT_LAYERED_TABLE_MANAGER_OFF,
-            "Layered table manager initialization conflict");
-    manager->state = WT_LAYERED_TABLE_MANAGER_STARTING; 
+      "Layered table manager initialization conflict");
+    manager->state = WT_LAYERED_TABLE_MANAGER_STARTING;
 
     WT_RET(__wt_spin_init(session, &manager->layered_table_lock, "layered table manager"));
 
@@ -1547,7 +1547,6 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
     min_ckpt_inuse = ds->ckpt_track_cnt;
     uri_at_checkpoint = NULL;
     uri_alloc = 0;
-
 
     WT_ASSERT(session, manager->state == WT_LAYERED_TABLE_MANAGER_RUNNING);
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -132,9 +132,9 @@ struct __wt_layered_table_manager_entry {
  */
 struct __wt_layered_table_manager {
 
-#define WT_LAYERED_TABLE_MANAGER_OFF 0      /* The layered table manager is not running */
-#define WT_LAYERED_TABLE_MANAGER_RUNNING 1  /* The layered table manager is running */
-    wt_shared uint32_t state;               /* Atomic: Indicating the manager is already running */
+#define WT_LAYERED_TABLE_MANAGER_OFF 0     /* The layered table manager is not running */
+#define WT_LAYERED_TABLE_MANAGER_RUNNING 1 /* The layered table manager is running */
+    wt_shared uint32_t state;              /* Atomic: Indicating the manager is already running */
 
     WT_SPINLOCK
     layered_table_lock; /* Lock used for managing changes to global layered table state */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -134,7 +134,7 @@ struct __wt_layered_table_manager {
 
 #define WT_LAYERED_TABLE_MANAGER_OFF 0     /* The layered table manager is not running */
 #define WT_LAYERED_TABLE_MANAGER_RUNNING 1 /* The layered table manager is running */
-    wt_shared uint32_t state;              /* Atomic: Indicating the manager is already running */
+    uint32_t state;                        /* Atomic: Indicating the manager is already running */
 
     WT_SPINLOCK
     layered_table_lock; /* Lock used for managing changes to global layered table state */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -134,8 +134,6 @@ struct __wt_layered_table_manager {
 
 #define WT_LAYERED_TABLE_MANAGER_OFF 0      /* The layered table manager is not running */
 #define WT_LAYERED_TABLE_MANAGER_RUNNING 1  /* The layered table manager is running */
-#define WT_LAYERED_TABLE_MANAGER_STARTING 2 /* The layered table manager is being started */
-#define WT_LAYERED_TABLE_MANAGER_STOPPING 3 /* The layered table manager is being shut down */
     wt_shared uint32_t state;               /* Atomic: Indicating the manager is already running */
 
     WT_SPINLOCK

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -134,7 +134,7 @@ struct __wt_layered_table_manager {
 
 #define WT_LAYERED_TABLE_MANAGER_OFF 0     /* The layered table manager is not running */
 #define WT_LAYERED_TABLE_MANAGER_RUNNING 1 /* The layered table manager is running */
-    uint32_t state;                        /* Atomic: Indicating the manager is already running */
+    uint32_t state;                        /* Indicating the manager is already running */
 
     WT_SPINLOCK
     layered_table_lock; /* Lock used for managing changes to global layered table state */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -715,8 +715,6 @@ extern int __wt_json_token(WT_SESSION *wt_session, const char *src, int *toktype
 extern int __wt_key_return(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_layered_table_manager_add_table(WT_SESSION_IMPL *session, uint32_t ingest_id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_layered_table_manager_start(WT_SESSION_IMPL *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_library_init(void) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_malloc(WT_SESSION_IMPL *session, size_t bytes_to_allocate, void *retp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -712,9 +712,6 @@ __wt_schema_open_layered(WT_SESSION_IMPL *session)
       session, ret = __schema_open_layered_ingest(session, layered, layered->ingest_uri));
     WT_RET(ret);
 
-    /* Start the layered table manager thread if it isn't running. */
-    WT_RET(__wt_layered_table_manager_start(session));
-
     WT_RET(__wt_layered_table_manager_add_table(session, layered->ingest_btree_id));
 
     return (0);


### PR DESCRIPTION
Currently, the layered table manager is initialized during the first table opening. However, some parts of the code that are unrelated to tables—for example, reconfiguration—might rely on the manager’s fields before it is even initialized.

To address this, we decided to move the manager initialization routine to __wti_disagg_conn_config(), which is executed as part of wiredtiger_open(). This also eliminates the need to synchronize manager initialization across multiple threads.
