### PR TITLE
WT-13985 Disabled the FLCS portion of some tests in service of continuous integration

### DIFF
--- a/test/suite/test_prepare_hs01.py
+++ b/test/suite/test_prepare_hs01.py
@@ -38,7 +38,7 @@ class test_prepare_hs01(wttest.WiredTigerTestCase):
 
     format_values = [
         ('column', dict(key_format='r', value_format='u')),
-        ('column-fix', dict(key_format='r', value_format='8t')),
+        #('column-fix', dict(key_format='r', value_format='8t')),  # FIXME-WT-14972
         ('string-row', dict(key_format='S', value_format='u')),
     ]
 

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -37,7 +37,7 @@ from wtscenario import make_scenarios
 class test_rollback_to_stable01(test_rollback_to_stable_base):
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
-        ('column_fix', dict(key_format='r', value_format='8t')),
+        #('column_fix', dict(key_format='r', value_format='8t')),  # FIXME-WT-14972
         ('row_integer', dict(key_format='i', value_format='S')),
     ]
 

--- a/test/suite/test_rollback_to_stable08.py
+++ b/test/suite/test_rollback_to_stable08.py
@@ -38,7 +38,7 @@ class test_rollback_to_stable08(test_rollback_to_stable_base):
 
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
-        ('column_fix', dict(key_format='r', value_format='8t')),
+        #('column_fix', dict(key_format='r', value_format='8t')),  # FIXME-WT-14972
         ('row_integer', dict(key_format='i', value_format='S')),
     ]
 


### PR DESCRIPTION
This is a test only change, removing a few FLCS scenarios that have popped up as CI-blockers.