### PR TITLE
WT-14971 Fix broken cursor function entry macro call

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -378,7 +378,7 @@ __curfile_insert(WT_CURSOR *cursor)
     uint64_t time_start, time_stop;
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, ret, cbt->dhandle);
+    CURSOR_UPDATE_API_CALL_BTREE(cursor, session, ret, insert);
     WT_ERR(__cursor_copy_release(cursor));
 
     if (!F_ISSET(cursor, WT_CURSTD_APPEND))


### PR DESCRIPTION
This changes an argument that is only "stringified" and is used to set a session name while the session is inside an API call.  So basically, the last argument becomes part of some output... like `"WT_CURSOR.cbt->dhandle"`, which is confusing, we want the output to be `"WT_CURSOR.insert"`  See all the other uses of `CURSOR_UPDATE_API_CALL_BTREE` in this function for correct usage.