### PR TITLE
WT-14978 Add diagnostic information to durable timestamp error

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -475,7 +475,7 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
           prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
             prev_upd->start_ts == prev_upd->durable_ts || prev_upd->durable_ts >= upd->durable_ts,
           "Durable timestamps cannot be out of order for prepared updates: prev_upd->start_ts=%s, "
-          "prev_upd->durable_ts=%s, upd->durable_ts=%s, upd->flags=%hu",
+          "prev_upd->durable_ts=%s, upd->durable_ts=%s, upd->flags=%" PRIu16,
           __wt_timestamp_to_string(prev_upd->start_ts, ts_string[0]),
           __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]),
           __wt_timestamp_to_string(upd->durable_ts, ts_string[2]), upd->flags);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -470,10 +470,15 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
         if (upd->txnid == WT_TXN_ABORTED)
             continue;
 
+        char ts_string[3][WT_TS_INT_STRING_SIZE];
         WT_ASSERT_ALWAYS(session,
           prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
             prev_upd->start_ts == prev_upd->durable_ts || prev_upd->durable_ts >= upd->durable_ts,
-          "Durable timestamps cannot be out of order for prepared updates");
+          "Durable timestamps cannot be out of order for prepared updates: prev_upd->start_ts=%s, "
+          "prev_upd->durable_ts=%s, upd->durable_ts=%s, upd->flags=%hu",
+          __wt_timestamp_to_string(prev_upd->start_ts, ts_string[0]),
+          __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]),
+          __wt_timestamp_to_string(upd->durable_ts, ts_string[2]), upd->flags);
 
         /* Validate that the updates older than us have older timestamps. */
         if (prev_upd->start_ts < upd->start_ts) {
@@ -510,18 +515,27 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
      * reconciliations ondisk value that we will be comparing against.
      */
     if (vpack != NULL && !vpack->tw.prepare) {
+        char ts_string[3][WT_TS_INT_STRING_SIZE];
         if (WT_TIME_WINDOW_HAS_STOP(&vpack->tw))
             WT_ASSERT_ALWAYS(session,
               prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
                 prev_upd->start_ts == prev_upd->durable_ts ||
                 prev_upd->durable_ts >= vpack->tw.durable_stop_ts,
-              "Stop: Durable timestamps cannot be out of order for prepared updates");
+              "Stop: Durable timestamps cannot be out of order for prepared updates: "
+              "prev_upd->start_ts=%s, prev_upd->durable_ts=%s, vpack->tw.durable_stop_ts=%s",
+              __wt_timestamp_to_string(prev_upd->start_ts, ts_string[0]),
+              __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]),
+              __wt_timestamp_to_string(vpack->tw.durable_stop_ts, ts_string[2]));
         else
             WT_ASSERT_ALWAYS(session,
               prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
                 prev_upd->start_ts == prev_upd->durable_ts ||
                 prev_upd->durable_ts >= vpack->tw.durable_start_ts,
-              "Start: Durable timestamps cannot be out of order for prepared updates");
+              "Start: Durable timestamps cannot be out of order for prepared updates: "
+              "prev_upd->start_ts=%s, prev_upd->durable_ts=%s, vpack->tw.durable_start_ts=%s",
+              __wt_timestamp_to_string(prev_upd->start_ts, ts_string[0]),
+              __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]),
+              __wt_timestamp_to_string(vpack->tw.durable_start_ts, ts_string[2]));
 
         if (prev_upd->start_ts == WT_TS_NONE) {
             if (vpack->tw.start_ts != WT_TS_NONE ||

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -475,9 +475,10 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
           prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
             prev_upd->start_ts == prev_upd->durable_ts || prev_upd->durable_ts >= upd->durable_ts,
           "Durable timestamps cannot be out of order for prepared updates: prev_upd->start_ts=%s, "
-          "prev_upd->durable_ts=%s, upd->durable_ts=%s, upd->flags=%" PRIu16,
+          "prev_upd->durable_ts=%s, prev_upd->flags=%" PRIu16
+          ", upd->durable_ts=%s, upd->flags=%" PRIu16,
           __wt_timestamp_to_string(prev_upd->start_ts, ts_string[0]),
-          __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]),
+          __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]), prev_upd->flags,
           __wt_timestamp_to_string(upd->durable_ts, ts_string[2]), upd->flags);
 
         /* Validate that the updates older than us have older timestamps. */
@@ -522,9 +523,10 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
                 prev_upd->start_ts == prev_upd->durable_ts ||
                 prev_upd->durable_ts >= vpack->tw.durable_stop_ts,
               "Stop: Durable timestamps cannot be out of order for prepared updates: "
-              "prev_upd->start_ts=%s, prev_upd->durable_ts=%s, vpack->tw.durable_stop_ts=%s",
+              "prev_upd->start_ts=%s, prev_upd->durable_ts=%s, prev_upd->flags=%" PRIu16
+              ", vpack->tw.durable_stop_ts=%s",
               __wt_timestamp_to_string(prev_upd->start_ts, ts_string[0]),
-              __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]),
+              __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]), prev_upd->flags,
               __wt_timestamp_to_string(vpack->tw.durable_stop_ts, ts_string[2]));
         else
             WT_ASSERT_ALWAYS(session,
@@ -532,9 +534,10 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
                 prev_upd->start_ts == prev_upd->durable_ts ||
                 prev_upd->durable_ts >= vpack->tw.durable_start_ts,
               "Start: Durable timestamps cannot be out of order for prepared updates: "
-              "prev_upd->start_ts=%s, prev_upd->durable_ts=%s, vpack->tw.durable_start_ts=%s",
+              "prev_upd->start_ts=%s, prev_upd->durable_ts=%s, prev_upd->flags=%" PRIu16
+              ", vpack->tw.durable_start_ts=%s",
               __wt_timestamp_to_string(prev_upd->start_ts, ts_string[0]),
-              __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]),
+              __wt_timestamp_to_string(prev_upd->durable_ts, ts_string[1]), prev_upd->flags,
               __wt_timestamp_to_string(vpack->tw.durable_start_ts, ts_string[2]));
 
         if (prev_upd->start_ts == WT_TS_NONE) {


### PR DESCRIPTION
This change adds some additional logs information to the assertion "Durable timestamps cannot be out of order for prepared updates" to see what the values are when this error is triggered
