### PR TITLE
WT-14955 Gate test/format precise checkpoint on disagg storage being enabled

### DIFF
--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -784,7 +784,11 @@ wts_open(const char *home, WT_CONNECTION **connp, bool verify_metadata)
             CONFIG_APPEND(p, ",%s", s);
         if (g.config_open != NULL)
             CONFIG_APPEND(p, ",%s", g.config_open);
-        if (GV(CHECKPOINT_PRECISE))
+        /*
+         * FIXME-WT-14979: Precise checkpoints are incompatible with the on-disk block manager.
+         * Ideally we would not gate precise checkpoints on disagg also being enabled.
+         */
+        if (g.disagg_storage_config && GV(CHECKPOINT_PRECISE))
             CONFIG_APPEND(p, ",checkpoint=(precise=true)");
 
 #if WIREDTIGER_VERSION_MAJOR >= 10


### PR DESCRIPTION
I made a ticket to fix the interaction between the on-disk and block manager and precise checkpoints, but that's a bigger job so just dodge this combination in CI for the short term.