### PR TITLE
WT-14980 Avoid table ID namespacing without disagg

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1288,6 +1288,10 @@ __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
     WT_ASSERT(session, btree_id != 0);
 
+    /* No table ID namespacing. */
+    if (!__wt_conn_is_disagg(session))
+        return (1);
+
     /*
      * Map the history store ID into the URI. The current implementation does this simply using
      * table ID namespaces, but keep the notion of HS ID and namespace ID separate to ensure that we

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1288,7 +1288,7 @@ __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
     WT_ASSERT(session, btree_id != 0);
 
-    /* No table ID namespacing. */
+    /* No table ID namespaces. */
     if (!__wt_conn_is_disagg(session))
         return (1);
 


### PR DESCRIPTION
These ID changes were incorrectly being applied on a non-disagg connection. My current understanding is that we do not intend to be able to directly run a disagg WT using files generated by a non-disagg WT, so this simple check is enough.