### PR TITLE
WT-13074 Fix log_newfile related warnings from ex_backup

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1182,7 +1182,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (WT_IS_LOG_PREALLOC_ENABLED(session) && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (__wt_log_is_prealloc_enabled(session) && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1146,7 +1146,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SLOT));
     WT_ACQUIRE_READ(close_fh, log->log_close_fh);
-    for (yield_cnt = 0; log->log_close_fh != NULL;) {
+    for (yield_cnt = 0; close_fh != NULL;) {
         WT_STAT_CONN_INCR(session, log_close_yields);
         /*
          * Processing slots will conditionally signal the file close server thread. But if we've
@@ -1161,6 +1161,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
         if (++yield_cnt > WT_THOUSAND * 10)
             return (__wt_set_return(session, EBUSY));
         __wt_yield();
+        WT_ACQUIRE_READ(close_fh, log->log_close_fh);
     }
     /*
      * Note, the file server worker thread requires the LSN be set once the close file handle is

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1182,7 +1182,8 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (__wt_log_is_prealloc_enabled(session) && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (__wti_log_is_prealloc_enabled(session) &&
+      __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1366,7 +1366,7 @@ __wti_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WTI_LOGSLOT *slot)
     if (F_ISSET(log, WTI_LOG_FORCE_NEWFILE) || !__log_size_fit(session, &log->alloc_lsn, recsize)) {
         WT_RET(__log_newfile(session, false, &created_log));
         F_CLR(log, WTI_LOG_FORCE_NEWFILE);
-        if (__wt_atomic_load_pointer(&log->log_close_fh) != NULL)
+        if (log->log_close_fh != NULL)
             F_SET_ATOMIC_16(slot, WTI_SLOT_CLOSEFH);
     }
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1180,8 +1180,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (__wt_atomic_load32(&log_mgr->prealloc) > 0 &&
-      __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (log_mgr->prealloc_init_count > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1182,7 +1182,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (log_mgr->prealloc_init_count > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (WT_IS_LOG_PREALLOC_ENABLED(session) && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1128,7 +1128,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_FH *log_fh;
+    WT_FH *log_fh, *close_fh;
     WTI_LOG *log;
     WT_LOG_MANAGER *log_mgr;
     WT_LSN end_lsn, logrec_lsn;
@@ -1145,7 +1145,8 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * one is closed. Wait for that to close.
      */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SLOT));
-    for (yield_cnt = 0; __wt_atomic_load_pointer(&log->log_close_fh) != NULL;) {
+    WT_ACQUIRE_READ(close_fh, log->log_close_fh);
+    for (yield_cnt = 0; log->log_close_fh != NULL;) {
         WT_STAT_CONN_INCR(session, log_close_yields);
         /*
          * Processing slots will conditionally signal the file close server thread. But if we've

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1180,7 +1180,8 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (__wt_atomic_load32(&log_mgr->prealloc) > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (__wt_atomic_load32(&log_mgr->prealloc) > 0 &&
+      __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1145,7 +1145,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * one is closed. Wait for that to close.
      */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SLOT));
-    for (yield_cnt = 0; log->log_close_fh != NULL;) {
+    for (yield_cnt = 0; __wt_atomic_load_pointer(&log->log_close_fh) != NULL;) {
         WT_STAT_CONN_INCR(session, log_close_yields);
         /*
          * Processing slots will conditionally signal the file close server thread. But if we've
@@ -1180,7 +1180,7 @@ __log_newfile(WT_SESSION_IMPL *session, bool conn_open, bool *created)
      * can copy the files in any way they choose, and a log file rename might confuse things.
      */
     create_log = true;
-    if (log_mgr->prealloc > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
+    if (__wt_atomic_load32(&log_mgr->prealloc) > 0 && __wt_atomic_load64(&conn->hot_backup_start) == 0) {
         WT_WITH_HOTBACKUP_READ_LOCK(
           session, ret = __log_alloc_prealloc(session, log->fileid), &skipp);
 
@@ -1364,7 +1364,7 @@ __wti_log_acquire(WT_SESSION_IMPL *session, uint64_t recsize, WTI_LOGSLOT *slot)
     if (F_ISSET(log, WTI_LOG_FORCE_NEWFILE) || !__log_size_fit(session, &log->alloc_lsn, recsize)) {
         WT_RET(__log_newfile(session, false, &created_log));
         F_CLR(log, WTI_LOG_FORCE_NEWFILE);
-        if (log->log_close_fh != NULL)
+        if (__wt_atomic_load_pointer(&log->log_close_fh) != NULL)
             F_SET_ATOMIC_16(slot, WTI_SLOT_CLOSEFH);
     }
 

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -176,6 +176,8 @@ struct __wt_log_manager {
     uint32_t flags; /* Global logging configuration */
 };
 
+#define WT_IS_LOG_PREALLOC_ENABLED(session) S2C(session)->log_mgr.prealloc_init_count > 0
+
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
 extern int __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -324,8 +324,6 @@ extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn);
 extern void __wt_log_written_reset(WT_SESSION_IMPL *session);
 extern void __wt_logmgr_compat_version(WT_SESSION_IMPL *session);
 extern void __wt_logrec_free(WT_SESSION_IMPL *session, WT_ITEM **logrecp);
-static WT_INLINE bool __wt_log_is_prealloc_enabled(WT_SESSION *session)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_log_cmp(WT_LSN *lsn1, WT_LSN *lsn2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_lsn_string(WT_LSN *lsn, size_t len, char *buf)

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -176,8 +176,6 @@ struct __wt_log_manager {
     uint32_t flags; /* Global logging configuration */
 };
 
-#define WT_IS_LOG_PREALLOC_ENABLED(session) S2C(session)->log_mgr.prealloc_init_count > 0
-
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 
 extern int __wt_curlog_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],
@@ -326,6 +324,8 @@ extern void __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn);
 extern void __wt_log_written_reset(WT_SESSION_IMPL *session);
 extern void __wt_logmgr_compat_version(WT_SESSION_IMPL *session);
 extern void __wt_logrec_free(WT_SESSION_IMPL *session, WT_ITEM **logrecp);
+static WT_INLINE bool __wt_log_is_prealloc_enabled(WT_SESSION *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_log_cmp(WT_LSN *lsn1, WT_LSN *lsn2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_lsn_string(WT_LSN *lsn, size_t len, char *buf)

--- a/src/log/log_inline.h
+++ b/src/log/log_inline.h
@@ -93,3 +93,15 @@ __wt_lsn_offset(WT_LSN *lsn)
 {
     return (__wt_atomic_load32(&lsn->l.offset));
 }
+
+/*
+ * __wt_log_is_prealloc_enabled --
+ *     Check if pre-allocation is configured using log_mgr->prealloc_init_count. Use the
+ *     log_mgr->prealloc_init_count variable because the log_mgr->prealloc variable performs
+ *     concurrent writes/reads and may induce race conditions.
+ */
+static WT_INLINE bool
+__wt_log_is_prealloc_enabled(WT_SESSION *session)
+{
+    return (S2C(session)->log_mgr.prealloc_init_count > 0);
+}

--- a/src/log/log_inline.h
+++ b/src/log/log_inline.h
@@ -95,13 +95,13 @@ __wt_lsn_offset(WT_LSN *lsn)
 }
 
 /*
- * __wt_log_is_prealloc_enabled --
+ * __wti_log_is_prealloc_enabled --
  *     Check if pre-allocation is configured using log_mgr->prealloc_init_count. Use the
  *     log_mgr->prealloc_init_count variable because the log_mgr->prealloc variable performs
  *     concurrent writes/reads and may induce race conditions.
  */
 static WT_INLINE bool
-__wt_log_is_prealloc_enabled(WT_SESSION *session)
+__wti_log_is_prealloc_enabled(WT_SESSION_IMPL *session)
 {
     return (S2C(session)->log_mgr.prealloc_init_count > 0);
 }

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -314,7 +314,7 @@ __wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
         WT_RET(__wt_config_gets(session, cfg, "log.prealloc_init_count", &cval));
         log_mgr->prealloc = (uint32_t)cval.val;
         log_mgr->prealloc_init_count = (uint32_t)cval.val;
-        WT_ASSERT(session, log_mgr->prealloc > 0);
+        WT_ASSERT(session, log_mgr->prealloc_init_count > 0);
     }
 
     WT_RET(__wt_config_gets(session, cfg, "log.force_write_wait", &cval));
@@ -647,7 +647,7 @@ __log_file_server(void *arg)
             /*
              * The closing file handle should have a correct close LSN.
              */
-            WT_ASSERT(session, __wt_atomic_loadv32(&log->log_close_lsn.l.file) == filenum);
+            WT_ASSERT(session, log->log_close_lsn.l.file == filenum);
 
             if (__wt_log_cmp(&log->write_lsn, &log->log_close_lsn) >= 0) {
                 /*
@@ -657,7 +657,7 @@ __log_file_server(void *arg)
                  */
                 WT_ASSIGN_LSN(&close_end_lsn, &log->log_close_lsn);
                 WT_FULL_BARRIER();
-                __wt_atomic_store_pointer(&log->log_close_fh, NULL);
+                log->log_close_fh = NULL;
                 /*
                  * Set the close_end_lsn to the LSN immediately after ours. That is, the beginning
                  * of the next log file. We need to know the LSN file number of our own close in
@@ -960,7 +960,7 @@ __log_server(void *arg)
             /*
              * Perform log pre-allocation.
              */
-            if (log_mgr->prealloc > 0) {
+            if (log_mgr->prealloc_init_count > 0) {
                 /*
                  * Log file pre-allocation is disabled when a hot backup cursor is open because we
                  * have agreed not to rename or remove any files in the database directory.

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -314,7 +314,7 @@ __wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
         WT_RET(__wt_config_gets(session, cfg, "log.prealloc_init_count", &cval));
         log_mgr->prealloc = (uint32_t)cval.val;
         log_mgr->prealloc_init_count = (uint32_t)cval.val;
-        WT_ASSERT(session, WT_IS_LOG_PREALLOC_ENABLED(session));
+        WT_ASSERT(session, __wt_log_is_prealloc_enabled(session));
     }
 
     WT_RET(__wt_config_gets(session, cfg, "log.force_write_wait", &cval));
@@ -960,7 +960,7 @@ __log_server(void *arg)
             /*
              * Perform log pre-allocation.
              */
-            if (WT_IS_LOG_PREALLOC_ENABLED(session)) {
+            if (__wt_log_is_prealloc_enabled(session)) {
                 /*
                  * Log file pre-allocation is disabled when a hot backup cursor is open because we
                  * have agreed not to rename or remove any files in the database directory.

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -523,12 +523,14 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
     WTI_LOG *log;
     WT_LOG_MANAGER *log_mgr;
     u_int i, reccount;
+    uint32_t log_prealloc;
     char **recfiles;
 
     log_mgr = &S2C(session)->log_mgr;
     log = log_mgr->log;
     reccount = 0;
     recfiles = NULL;
+    log_prealloc = __wt_atomic_load32(&log_mgr->prealloc);
 
     /*
      * Allocate up to the maximum number, accounting for any existing files that may not have been
@@ -542,25 +544,25 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
      * them since we last ran.
      */
     if (log->prep_missed > 0) {
-        log_mgr->prealloc += log->prep_missed;
+        log_prealloc += log->prep_missed;
         __wt_verbose(session, WT_VERB_LOG, "Missed %" PRIu32 ". Now pre-allocating up to %" PRIu32,
-          log->prep_missed, log_mgr->prealloc);
-    } else if (reccount > log_mgr->prealloc / 2 &&
-      log_mgr->prealloc > log_mgr->prealloc_init_count) {
+          log->prep_missed, log_prealloc);
+    } else if (reccount > log_prealloc / 2 &&
+      log_prealloc > log_mgr->prealloc_init_count) {
         /*
          * If we used less than half, then start adjusting down.
          */
-        --log_mgr->prealloc;
+        --log_prealloc;
         __wt_verbose(session, WT_VERB_LOG,
           "Adjust down. Did not use %" PRIu32 ". Now pre-allocating %" PRIu32, reccount,
-          log_mgr->prealloc);
+          log_prealloc);
     }
 
-    WT_STAT_CONN_SET(session, log_prealloc_max, log_mgr->prealloc);
+    WT_STAT_CONN_SET(session, log_prealloc_max, log_prealloc);
     /*
      * Allocate up to the maximum number that we just computed and detected.
      */
-    for (i = reccount; i < (u_int)log_mgr->prealloc; i++) {
+    for (i = reccount; i < (u_int)log_prealloc; i++) {
         WT_ERR(__wti_log_allocfile(session, ++log->prep_fileid, WTI_LOG_PREPNAME));
         WT_STAT_CONN_INCR(session, log_prealloc_files);
     }
@@ -570,7 +572,7 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
      * keep adding in more.
      */
     log->prep_missed = 0;
-
+    __wt_atomic_store32(&log_mgr->prealloc, log_prealloc);
     if (0)
 err:
         __wt_err(session, ret, "log pre-alloc server error");
@@ -648,7 +650,7 @@ __log_file_server(void *arg)
             /*
              * The closing file handle should have a correct close LSN.
              */
-            WT_ASSERT(session, log->log_close_lsn.l.file == filenum);
+            WT_ASSERT(session, __wt_atomic_loadv32(&log->log_close_lsn.l.file) == filenum);
 
             if (__wt_log_cmp(&log->write_lsn, &log->log_close_lsn) >= 0) {
                 /*
@@ -658,7 +660,7 @@ __log_file_server(void *arg)
                  */
                 WT_ASSIGN_LSN(&close_end_lsn, &log->log_close_lsn);
                 WT_FULL_BARRIER();
-                log->log_close_fh = NULL;
+                __wt_atomic_store_pointer(&log->log_close_fh, NULL);
                 /*
                  * Set the close_end_lsn to the LSN immediately after ours. That is, the beginning
                  * of the next log file. We need to know the LSN file number of our own close in

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -314,7 +314,7 @@ __wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
         WT_RET(__wt_config_gets(session, cfg, "log.prealloc_init_count", &cval));
         log_mgr->prealloc = (uint32_t)cval.val;
         log_mgr->prealloc_init_count = (uint32_t)cval.val;
-        WT_ASSERT(session, log_mgr->prealloc_init_count > 0);
+        WT_ASSERT(session, WT_IS_LOG_PREALLOC_ENABLED(session));
     }
 
     WT_RET(__wt_config_gets(session, cfg, "log.force_write_wait", &cval));
@@ -960,7 +960,7 @@ __log_server(void *arg)
             /*
              * Perform log pre-allocation.
              */
-            if (log_mgr->prealloc_init_count > 0) {
+            if (WT_IS_LOG_PREALLOC_ENABLED(session)) {
                 /*
                  * Log file pre-allocation is disabled when a hot backup cursor is open because we
                  * have agreed not to rename or remove any files in the database directory.

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -314,7 +314,7 @@ __wt_logmgr_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfig)
         WT_RET(__wt_config_gets(session, cfg, "log.prealloc_init_count", &cval));
         log_mgr->prealloc = (uint32_t)cval.val;
         log_mgr->prealloc_init_count = (uint32_t)cval.val;
-        WT_ASSERT(session, __wt_log_is_prealloc_enabled(session));
+        WT_ASSERT(session, __wti_log_is_prealloc_enabled(session));
     }
 
     WT_RET(__wt_config_gets(session, cfg, "log.force_write_wait", &cval));
@@ -960,7 +960,7 @@ __log_server(void *arg)
             /*
              * Perform log pre-allocation.
              */
-            if (__wt_log_is_prealloc_enabled(session)) {
+            if (__wti_log_is_prealloc_enabled(session)) {
                 /*
                  * Log file pre-allocation is disabled when a hot backup cursor is open because we
                  * have agreed not to rename or remove any files in the database directory.

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -547,8 +547,7 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
         log_prealloc += log->prep_missed;
         __wt_verbose(session, WT_VERB_LOG, "Missed %" PRIu32 ". Now pre-allocating up to %" PRIu32,
           log->prep_missed, log_prealloc);
-    } else if (reccount > log_prealloc / 2 &&
-      log_prealloc > log_mgr->prealloc_init_count) {
+    } else if (reccount > log_prealloc / 2 && log_prealloc > log_mgr->prealloc_init_count) {
         /*
          * If we used less than half, then start adjusting down.
          */

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -523,14 +523,12 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
     WTI_LOG *log;
     WT_LOG_MANAGER *log_mgr;
     u_int i, reccount;
-    uint32_t log_prealloc;
     char **recfiles;
 
     log_mgr = &S2C(session)->log_mgr;
     log = log_mgr->log;
     reccount = 0;
     recfiles = NULL;
-    log_prealloc = __wt_atomic_load32(&log_mgr->prealloc);
 
     /*
      * Allocate up to the maximum number, accounting for any existing files that may not have been
@@ -544,24 +542,25 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
      * them since we last ran.
      */
     if (log->prep_missed > 0) {
-        log_prealloc += log->prep_missed;
+        log_mgr->prealloc += log->prep_missed;
         __wt_verbose(session, WT_VERB_LOG, "Missed %" PRIu32 ". Now pre-allocating up to %" PRIu32,
-          log->prep_missed, log_prealloc);
-    } else if (reccount > log_prealloc / 2 && log_prealloc > log_mgr->prealloc_init_count) {
+          log->prep_missed, log_mgr->prealloc);
+    } else if (reccount > log_mgr->prealloc / 2 &&
+      log_mgr->prealloc > log_mgr->prealloc_init_count) {
         /*
          * If we used less than half, then start adjusting down.
          */
-        --log_prealloc;
+        --log_mgr->prealloc;
         __wt_verbose(session, WT_VERB_LOG,
           "Adjust down. Did not use %" PRIu32 ". Now pre-allocating %" PRIu32, reccount,
-          log_prealloc);
+          log_mgr->prealloc);
     }
 
-    WT_STAT_CONN_SET(session, log_prealloc_max, log_prealloc);
+    WT_STAT_CONN_SET(session, log_prealloc_max, log_mgr->prealloc);
     /*
      * Allocate up to the maximum number that we just computed and detected.
      */
-    for (i = reccount; i < (u_int)log_prealloc; i++) {
+    for (i = reccount; i < (u_int)log_mgr->prealloc; i++) {
         WT_ERR(__wti_log_allocfile(session, ++log->prep_fileid, WTI_LOG_PREPNAME));
         WT_STAT_CONN_INCR(session, log_prealloc_files);
     }
@@ -571,7 +570,6 @@ __log_prealloc_once(WT_SESSION_IMPL *session)
      * keep adding in more.
      */
     log->prep_missed = 0;
-    __wt_atomic_store32(&log_mgr->prealloc, log_prealloc);
     if (0)
 err:
         __wt_err(session, ret, "log pre-alloc server error");

--- a/src/log/log_private.h
+++ b/src/log/log_private.h
@@ -328,6 +328,8 @@ extern void __wti_log_slot_free(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot);
 extern void __wti_log_slot_join(
   WT_SESSION_IMPL *session, uint64_t mysize, uint32_t flags, WTI_MYSLOT *myslot);
 extern void __wti_log_wrlsn(WT_SESSION_IMPL *session, int *yield);
+static WT_INLINE bool __wti_log_is_prealloc_enabled(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE void __wti_log_desc_byteswap(WTI_LOG_DESC *desc);
 static WT_INLINE void __wti_log_record_byteswap(WT_LOG_RECORD *record);
 

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -178,7 +178,8 @@ __wt_verbose_dump_log(WT_SESSION_IMPL *session)
       session, "Running downgraded: %s", F_ISSET(log_mgr, WT_LOG_DOWNGRADED) ? "yes" : "no"));
     WT_RET(
       __wt_msg(session, "Zero fill files: %s", F_ISSET(log_mgr, WT_LOG_ZERO_FILL) ? "yes" : "no"));
-    WT_RET(__wt_msg(session, "Pre-allocate files: %s", log_mgr->prealloc > 0 ? "yes" : "no"));
+    WT_RET(
+      __wt_msg(session, "Pre-allocate files: %s", log_mgr->prealloc_init_count > 0 ? "yes" : "no"));
     WT_RET(__wt_msg(
       session, "Initial number of pre-allocated files: %" PRIu32, log_mgr->prealloc_init_count));
     WT_RET(__wt_msg(session, "Logging directory: %s", log_mgr->log_path));

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -179,7 +179,7 @@ __wt_verbose_dump_log(WT_SESSION_IMPL *session)
     WT_RET(
       __wt_msg(session, "Zero fill files: %s", F_ISSET(log_mgr, WT_LOG_ZERO_FILL) ? "yes" : "no"));
     WT_RET(__wt_msg(
-      session, "Pre-allocate files: %s", __wt_log_is_prealloc_enabled(session) ? "yes" : "no"));
+      session, "Pre-allocate files: %s", __wti_log_is_prealloc_enabled(session) ? "yes" : "no"));
     WT_RET(__wt_msg(
       session, "Initial number of pre-allocated files: %" PRIu32, log_mgr->prealloc_init_count));
     WT_RET(__wt_msg(session, "Logging directory: %s", log_mgr->log_path));

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -179,7 +179,7 @@ __wt_verbose_dump_log(WT_SESSION_IMPL *session)
     WT_RET(
       __wt_msg(session, "Zero fill files: %s", F_ISSET(log_mgr, WT_LOG_ZERO_FILL) ? "yes" : "no"));
     WT_RET(
-      __wt_msg(session, "Pre-allocate files: %s", log_mgr->prealloc_init_count > 0 ? "yes" : "no"));
+      __wt_msg(session, "Pre-allocate files: %s", WT_IS_LOG_PREALLOC_ENABLED(session) ? "yes" : "no"));
     WT_RET(__wt_msg(
       session, "Initial number of pre-allocated files: %" PRIu32, log_mgr->prealloc_init_count));
     WT_RET(__wt_msg(session, "Logging directory: %s", log_mgr->log_path));

--- a/src/log/log_sys.c
+++ b/src/log/log_sys.c
@@ -178,8 +178,8 @@ __wt_verbose_dump_log(WT_SESSION_IMPL *session)
       session, "Running downgraded: %s", F_ISSET(log_mgr, WT_LOG_DOWNGRADED) ? "yes" : "no"));
     WT_RET(
       __wt_msg(session, "Zero fill files: %s", F_ISSET(log_mgr, WT_LOG_ZERO_FILL) ? "yes" : "no"));
-    WT_RET(
-      __wt_msg(session, "Pre-allocate files: %s", WT_IS_LOG_PREALLOC_ENABLED(session) ? "yes" : "no"));
+    WT_RET(__wt_msg(
+      session, "Pre-allocate files: %s", __wt_log_is_prealloc_enabled(session) ? "yes" : "no"));
     WT_RET(__wt_msg(
       session, "Initial number of pre-allocated files: %" PRIu32, log_mgr->prealloc_init_count));
     WT_RET(__wt_msg(session, "Logging directory: %s", log_mgr->log_path));

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -32,17 +32,18 @@ race:__wt_configure_method
 # FIXME-WT-14930 Dhandle timeofdeath synchronization
 race:__sweep_mark
 
-# FIXME-WT-13074 Unresolved warnings for ex_backup
+# FIXME-WT-14948 Figure out concurrency control expectations around reconfigure
+race:conn_reconfig.c
+
+# FIXME-WT-14958 This Work has been split out into a separate ticket to keep PR sizes down.
 race:__wt_free_int
 race:__wt_free_update_list
 race:__wt_page_out
 race:__posix_file_close
-race:__log_newfile
 race:__handle_close
 race:__sweep_remove_handles
 race:__stash_discard
 race:__evict_lru_walk
-race:__log_file_server
 race:__tree_walk_internal
 race:__evict_queue_empty
 race:__evict_get_ref

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -44,6 +44,7 @@ race:__handle_close
 race:__sweep_remove_handles
 race:__stash_discard
 race:__evict_lru_walk
+race:__log_file_server
 race:__tree_walk_internal
 race:__evict_queue_empty
 race:__evict_get_ref


### PR DESCRIPTION
The pull request aims to fix the log_newfile related warinings from ex_backup. The only concurrent operations that can touch shared variables is between an application thread and background threads. Applications threads that need to access to the same slot and wants to change the state of the slot needs exclusive access using WTI_WITH_SLOT_LOCK. I have posted the relevant TSAN warnings inside the ticket. 

(1) Inside log_newfile function we wait for the log_close_fh to be NULL. The log_file_server is conditionally signalled for the log_close_fh to be NULL. It is the only concurrency that can happen as log_newfile requires a slot lock. Thus an atomic relax is enough.

(2) The **log->log_close_lsn** needs to be updated correct related to **log->log_close_fh**. In log_newfile perform an WT_RELEASE_WITH_BARRIER to ensure that **log->log_close_lsn** must be written before log->log_close_fh is set. As the same time, we ensure this behaviour with an **WT_ACQUIRE_READ_WITH_BARRIER** inside log_file_server. Therefore an relaxed atomic is okay here.

(3)  The **__log_prealloc_once** function is only called from the background **log_server** thread. It is possible that it contends with an application thread calling **__log_newfile**. This contention is not necessary as the **__log_newfile** only checks if the configuration has been set or not. I have used prealloc_init_count to acommodate for this which is non-changing.

**Note: There has been no critical bug in log system for over 5 years**