### PR TITLE
WT-14970 Split single prepare_ts/id into start_prepare_ts/id and stop_prepare_ts/id

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -420,8 +420,10 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
             standard_value->start_ts = unpack.tw.start_ts;
             standard_value->durable_ts = unpack.tw.durable_start_ts;
             if (WT_TIME_WINDOW_HAS_START_PREPARE(&unpack.tw)) {
-                /* FIXME-WT-14899: Remove prepare flag when we align the code between
-                 * preserve_prepared and non-preserve_prepared connections */
+                /*
+                 * FIXME-WT-14899: Remove prepare flag when we align the code between
+                 * preserve_prepared and non-preserve_prepared connections
+                 */
                 WT_ASSERT(session, unpack.tw.prepare);
                 standard_value->prepared_id = unpack.tw.start_prepared_id;
                 standard_value->prepare_ts = unpack.tw.start_prepare_ts;
@@ -792,7 +794,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
          * Mark the update also as in-progress if the update and tombstone are from same transaction
          * by comparing both the transaction and timestamps as the transaction information gets lost
          * after restart. FIXME-WT-14899: Simplify this check when we align the code between
-         * reserve_prepare vs non-repserve_prepare connection.
+         * reserve_prepare vs non-reserve_prepare connection.
          */
         if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)) ||
           (unpack->tw.start_ts == unpack->tw.stop_ts &&

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -419,7 +419,15 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
             standard_value->txnid = unpack.tw.start_txn;
             standard_value->start_ts = unpack.tw.start_ts;
             standard_value->durable_ts = unpack.tw.durable_start_ts;
-            F_SET(standard_value, WT_UPDATE_DURABLE | WT_UPDATE_RESTORED_FROM_DELTA);
+            if (WT_TIME_WINDOW_HAS_START_PREPARE(&unpack.tw)) {
+                WT_ASSERT(session, unpack.tw.prepare);
+                standard_value->prepared_id = unpack.tw.start_prepared_id;
+                standard_value->prepare_ts = unpack.tw.start_prepare_ts;
+                standard_value->prepare_state = WT_PREPARE_INPROGRESS;
+
+                F_SET(standard_value, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
+            } else
+                F_SET(standard_value, WT_UPDATE_DURABLE | WT_UPDATE_RESTORED_FROM_DELTA);
             size += tmp_size;
 
             if (WT_TIME_WINDOW_HAS_STOP(&unpack.tw)) {
@@ -428,38 +436,19 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
                 tombstone->start_ts = unpack.tw.stop_ts;
                 tombstone->durable_ts = unpack.tw.durable_stop_ts;
 
-                if (unpack.tw.prepare) {
-                    WT_ASSERT(session,
-                      unpack.tw.prepared_id != WT_PREPARED_ID_NONE &&
-                        unpack.tw.prepare_ts != WT_TS_NONE);
-                    tombstone->prepared_id = unpack.tw.prepared_id;
-                    tombstone->prepare_ts = unpack.tw.prepare_ts;
+                if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&unpack.tw)) {
+                    WT_ASSERT(session, unpack.tw.prepare);
+                    tombstone->prepared_id = unpack.tw.stop_prepared_id;
+                    tombstone->prepare_ts = unpack.tw.stop_prepare_ts;
                     tombstone->prepare_state = WT_PREPARE_INPROGRESS;
-
                     F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
-                    if (unpack.tw.start_txn == unpack.tw.stop_txn) {
-                        standard_value->prepared_id = unpack.tw.prepared_id;
-                        standard_value->prepare_ts = unpack.tw.prepare_ts;
-                        standard_value->prepare_state = WT_PREPARE_INPROGRESS;
-                        F_SET(standard_value, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
-                    }
                 } else
                     F_SET(tombstone, WT_UPDATE_DURABLE | WT_UPDATE_RESTORED_FROM_DELTA);
                 size += tmp_size;
                 tombstone->next = standard_value;
                 upd = tombstone;
-            } else {
-                if (unpack.tw.prepare) {
-                    WT_ASSERT(session,
-                      unpack.tw.prepared_id != WT_PREPARED_ID_NONE &&
-                        unpack.tw.prepare_ts != WT_TS_NONE);
-                    standard_value->prepared_id = unpack.tw.prepared_id;
-                    standard_value->prepare_ts = unpack.tw.prepare_ts;
-                    standard_value->prepare_state = WT_PREPARE_INPROGRESS;
-                    F_SET(standard_value, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
-                }
+            } else
                 upd = standard_value;
-            }
         }
 
         WT_ERR(__wt_row_modify(&cbt, &key, NULL, &upd, WT_UPDATE_INVALID, true, true));
@@ -793,8 +782,8 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         tombstone->txnid = unpack->tw.stop_txn;
         tombstone->prepare_state = WT_PREPARE_INPROGRESS;
         tombstone->start_ts = unpack->tw.stop_ts;
-        tombstone->prepare_ts = unpack->tw.prepare_ts;
-        tombstone->prepared_id = unpack->tw.prepared_id;
+        tombstone->prepare_ts = unpack->tw.stop_prepare_ts;
+        tombstone->prepared_id = unpack->tw.stop_prepared_id;
         F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
 
         /*
@@ -805,8 +794,8 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         if ((unpack->tw.start_ts == unpack->tw.stop_ts &&
               unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
               unpack->tw.start_txn == unpack->tw.stop_txn)) {
-            upd->prepared_id = unpack->tw.prepared_id;
-            upd->prepare_ts = unpack->tw.prepare_ts;
+            upd->prepared_id = unpack->tw.start_prepared_id;
+            upd->prepare_ts = unpack->tw.start_prepare_ts;
             upd->durable_ts = WT_TS_NONE;
             upd->prepare_state = WT_PREPARE_INPROGRESS;
             F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
@@ -819,8 +808,8 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         tombstone->next = upd;
         *updp = tombstone;
     } else {
-        upd->prepared_id = unpack->tw.prepared_id;
-        upd->prepare_ts = unpack->tw.prepare_ts;
+        upd->prepared_id = unpack->tw.start_prepared_id;
+        upd->prepare_ts = unpack->tw.start_prepare_ts;
         upd->durable_ts = WT_TS_NONE;
         upd->prepare_state = WT_PREPARE_INPROGRESS;
         F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -790,8 +790,9 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
          * Mark the update also as in-progress if the update and tombstone are from same transaction
          * by comparing both the transaction and timestamps as the transaction information gets lost
          * after restart.
+         * FIXME-WT-14899: Simplify this check when we align the code between reserve_prepare vs non-prepserve_prepare connection.
          */
-        if ((unpack->tw.start_ts == unpack->tw.stop_ts &&
+        if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)) || (unpack->tw.start_ts == unpack->tw.stop_ts &&
               unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
               unpack->tw.start_txn == unpack->tw.stop_txn)) {
             upd->prepared_id = unpack->tw.start_prepared_id;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -792,7 +792,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
          * Mark the update also as in-progress if the update and tombstone are from same transaction
          * by comparing both the transaction and timestamps as the transaction information gets lost
          * after restart. FIXME-WT-14899: Simplify this check when we align the code between
-         * reserve_prepare vs non-prepserve_prepare connection.
+         * reserve_prepare vs non-repserve_prepare connection.
          */
         if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)) ||
           (unpack->tw.start_ts == unpack->tw.stop_ts &&

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -420,7 +420,8 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
             standard_value->start_ts = unpack.tw.start_ts;
             standard_value->durable_ts = unpack.tw.durable_start_ts;
             if (WT_TIME_WINDOW_HAS_START_PREPARE(&unpack.tw)) {
-                /* FIXME-WT-14899: Remove prepare flag when we align the code between preserve_prepared and non-preserve_prepared connections */
+                /* FIXME-WT-14899: Remove prepare flag when we align the code between
+                 * preserve_prepared and non-preserve_prepared connections */
                 WT_ASSERT(session, unpack.tw.prepare);
                 standard_value->prepared_id = unpack.tw.start_prepared_id;
                 standard_value->prepare_ts = unpack.tw.start_prepare_ts;
@@ -790,12 +791,13 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         /*
          * Mark the update also as in-progress if the update and tombstone are from same transaction
          * by comparing both the transaction and timestamps as the transaction information gets lost
-         * after restart.
-         * FIXME-WT-14899: Simplify this check when we align the code between reserve_prepare vs non-prepserve_prepare connection.
+         * after restart. FIXME-WT-14899: Simplify this check when we align the code between
+         * reserve_prepare vs non-prepserve_prepare connection.
          */
-        if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)) || (unpack->tw.start_ts == unpack->tw.stop_ts &&
-              unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
-              unpack->tw.start_txn == unpack->tw.stop_txn)) {
+        if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)) ||
+          (unpack->tw.start_ts == unpack->tw.stop_ts &&
+            unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
+            unpack->tw.start_txn == unpack->tw.stop_txn)) {
             upd->prepared_id = unpack->tw.start_prepared_id;
             upd->prepare_ts = unpack->tw.start_prepare_ts;
             upd->durable_ts = WT_TS_NONE;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -420,6 +420,7 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
             standard_value->start_ts = unpack.tw.start_ts;
             standard_value->durable_ts = unpack.tw.durable_start_ts;
             if (WT_TIME_WINDOW_HAS_START_PREPARE(&unpack.tw)) {
+                /* FIXME-WT-14899: Remove prepare flag when we align the code between preserve_prepared and non-preserve_prepared connections */
                 WT_ASSERT(session, unpack.tw.prepare);
                 standard_value->prepared_id = unpack.tw.start_prepared_id;
                 standard_value->prepare_ts = unpack.tw.start_prepare_ts;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -57,7 +57,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - txn is prepared
      *  - transaction is in delete prepared (meaning it has stop_txn defined)
      */
-    bool pack_prepare_info_to_stop = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+    bool pack_prepare_info_to_stop = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
 
     /* We pack prepared txn info to start_ts and durable start_ts when:
      *  - disagg is on
@@ -65,11 +65,13 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
      * means both start and stop transactions are the same
      */
-    bool pack_prepare_info_to_start = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
+    bool pack_prepare_info_to_start = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_START_PREPARE(tw);
 
     /*
      * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
      * start or stop)
+     * FIXME-WT-14899: Can remove this check when prepare flag is removed from the time
+     * window structure.
      */
     if (tw->prepare && F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
         WT_ASSERT(session, pack_prepare_info_to_start || pack_prepare_info_to_stop);
@@ -927,7 +929,10 @@ copy_cell_restart:
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_durable_stop_ts));
 
         /* Load temporary values to the right fields */
-        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
+            /* We can compare the txn_id only here, but cannot do it everywhere else because when recovering, all transactions id are reset
+             * to WT_TXN_MAX, so we cannot compare the transaction ids.
+             */
             if (tw->start_txn == tw->stop_txn) {
                 /*
                  * This is a special case where both transaction start and stop are in prepared

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -77,9 +77,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
     if (tw->prepare && F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED))
         WT_ASSERT(session, pack_prepare_info_to_start || pack_prepare_info_to_stop);
 
-    if (pack_prepare_info_to_start && pack_prepare_info_to_stop) {
+    if (pack_prepare_info_to_start && pack_prepare_info_to_stop)
         WT_ASSERT(session, tw->start_prepared_id == tw->stop_prepared_id);
-    }
 
     wt_timestamp_t reference_ts = tw->start_ts;
 
@@ -931,7 +930,8 @@ copy_cell_restart:
 
         /* Load temporary values to the right fields */
         if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
-            /* We can compare the txn_id only here, but cannot do it everywhere else because when
+            /*
+             * We can compare the txn_id only here, but cannot do it everywhere else because when
              * recovering, all transaction ids are reset to WT_TXN_NONE, so we cannot compare the
              * transaction ids.
              */

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -932,7 +932,7 @@ copy_cell_restart:
         /* Load temporary values to the right fields */
         if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
             /* We can compare the txn_id only here, but cannot do it everywhere else because when
-             * recovering, all transactions id are reset to WT_TXN_MAX, so we cannot compare the
+             * recovering, all transaction ids are reset to WT_TXN_NONE, so we cannot compare the
              * transaction ids.
              */
             if (tw->start_txn == tw->stop_txn) {
@@ -957,9 +957,7 @@ copy_cell_restart:
                  * in WT_CELL_TS_START and WT_CELL_TS_DURABLE_START, prepare ts in WT_CELL_TS_STOP
                  * prepared id in WT_CELL_TS_DURABLE_STOP.
                  */
-                WT_ASSERT(session,
-                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_STOP) &&
-                    LF_ISSET(WT_CELL_TS_DURABLE_STOP));
+                WT_ASSERT(session, LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
                 tw->start_ts = temp_start_ts;
                 tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
                 tw->stop_prepare_ts = tw->start_ts + temp_stop_ts;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -57,8 +57,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - txn is prepared
      *  - transaction is in delete prepared (meaning it has stop_txn defined)
      */
-    const bool pack_prepare_info_to_stop = F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-      tw->prepare && WT_TIME_WINDOW_HAS_STOP(tw);
+    bool pack_prepare_info_to_stop = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
 
     /* We pack prepared txn info to start_ts and durable start_ts when:
      *  - disagg is on
@@ -66,21 +65,23 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
      * means both start and stop transactions are the same
      */
-    const bool pack_prepare_info_to_start = F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-      tw->prepare && (!WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_txn == tw->start_txn);
+    bool pack_prepare_info_to_start = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
 
     /*
      * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
      * start or stop)
      */
-    WT_ASSERT(session,
-      (tw->prepare_ts != WT_TS_NONE) == (pack_prepare_info_to_start || pack_prepare_info_to_stop));
+    WT_ASSERT(session, (tw->prepare) == (pack_prepare_info_to_start || pack_prepare_info_to_stop));
+
+    if (pack_prepare_info_to_start && pack_prepare_info_to_stop) {
+        WT_ASSERT(session, tw->start_prepared_id == tw->stop_prepared_id);
+    }
 
     wt_timestamp_t reference_ts = tw->start_ts;
 
     if (pack_prepare_info_to_start) {
-        WT_RET(__wt_vpack_uint(pp, 0, tw->prepare_ts));
-        reference_ts = tw->prepare_ts;
+        WT_RET(__wt_vpack_uint(pp, 0, tw->start_prepare_ts));
+        reference_ts = tw->start_prepare_ts;
         LF_SET(WT_CELL_TS_START);
     } else if (tw->start_ts != WT_TS_NONE) {
         WT_RET(__wt_vpack_uint(pp, 0, tw->start_ts));
@@ -94,8 +95,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
 
     /* If we write prepare_ts to start_ts, we write prepared_id to durable_start_ts as well */
     if (pack_prepare_info_to_start) {
-        WT_ASSERT(session, tw->prepared_id != WT_PREPARED_ID_NONE);
-        WT_RET(__wt_vpack_uint(pp, 0, tw->prepared_id));
+        WT_ASSERT(session, tw->start_prepared_id != WT_PREPARED_ID_NONE);
+        WT_RET(__wt_vpack_uint(pp, 0, tw->start_prepared_id));
         LF_SET(WT_CELL_TS_DURABLE_START);
     } else if (tw->durable_start_ts != WT_TS_NONE) {
         WT_ASSERT(session, reference_ts <= tw->durable_start_ts);
@@ -106,7 +107,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         }
     }
     if (pack_prepare_info_to_stop) {
-        WT_RET(__wt_vpack_uint(pp, 0, tw->prepare_ts - reference_ts));
+        WT_RET(__wt_vpack_uint(pp, 0, tw->stop_prepare_ts - reference_ts));
         LF_SET(WT_CELL_TS_STOP);
     } else if (tw->stop_ts != WT_TS_MAX) {
         /* Store differences, not absolutes. */
@@ -124,8 +125,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      * should not pack the difference.
      */
     if (pack_prepare_info_to_stop) {
-        WT_ASSERT(session, tw->prepared_id != WT_PREPARED_ID_NONE);
-        WT_RET(__wt_vpack_uint(pp, 0, pack_prepare_info_to_start ? 0 : tw->prepared_id));
+        WT_ASSERT(session, tw->stop_prepared_id != WT_PREPARED_ID_NONE);
+        WT_RET(__wt_vpack_uint(pp, 0, pack_prepare_info_to_start ? 0 : tw->stop_prepared_id));
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     } else if (tw->durable_stop_ts != WT_TS_NONE) {
         WT_ASSERT(session, tw->stop_ts <= tw->durable_stop_ts);
@@ -937,10 +938,10 @@ copy_cell_restart:
                 WT_ASSERT(session,
                   LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
                     LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
-                tw->prepare_ts = temp_start_ts;
-                tw->prepared_id = temp_durable_start_ts;
-                tw->start_ts = tw->prepare_ts;
-                tw->stop_ts = tw->prepare_ts;
+                tw->start_prepare_ts = temp_start_ts;
+                tw->start_prepared_id = temp_durable_start_ts;
+                tw->stop_prepare_ts = temp_start_ts;
+                tw->stop_prepared_id = temp_durable_start_ts;
             } else if (tw->stop_txn != WT_TXN_MAX) {
                 /*
                  * This case happens where the transaction is done, but the transaction stop is
@@ -949,13 +950,12 @@ copy_cell_restart:
                  * prepared id in WT_CELL_TS_DURABLE_STOP.
                  */
                 WT_ASSERT(session,
-                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
-                    LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
+                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_STOP) &&
+                    LF_ISSET(WT_CELL_TS_DURABLE_STOP));
                 tw->start_ts = temp_start_ts;
                 tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
-                tw->prepare_ts = tw->start_ts + temp_stop_ts;
-                tw->prepared_id = temp_durable_stop_ts;
-                tw->stop_ts = tw->prepare_ts;
+                tw->stop_prepare_ts = tw->start_ts + temp_stop_ts;
+                tw->stop_prepared_id = temp_durable_stop_ts;
             } else {
                 /*
                  * This case happens when only transaction start is prepared, and there is no
@@ -965,9 +965,8 @@ copy_cell_restart:
                 WT_ASSERT(session,
                   LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
                     !LF_ISSET(WT_CELL_TS_STOP) && !LF_ISSET(WT_CELL_TS_DURABLE_STOP));
-                tw->prepare_ts = temp_start_ts;
-                tw->prepared_id = temp_durable_start_ts;
-                tw->start_ts = tw->prepare_ts;
+                tw->start_prepare_ts = temp_start_ts;
+                tw->start_prepared_id = temp_durable_start_ts;
             }
         } else {
             if (LF_ISSET(WT_CELL_TS_START))

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -57,8 +57,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - txn is prepared
      *  - transaction is in delete prepared (meaning it has stop_txn defined)
      */
-    bool pack_prepare_info_to_stop = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-      WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+    bool pack_prepare_info_to_stop =
+      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
 
     /* We pack prepared txn info to start_ts and durable start_ts when:
      *  - disagg is on
@@ -66,15 +66,15 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
      * means both start and stop transactions are the same
      */
-    bool pack_prepare_info_to_start = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-      WT_TIME_WINDOW_HAS_START_PREPARE(tw);
+    bool pack_prepare_info_to_start =
+      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_START_PREPARE(tw);
 
     /*
      * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
      * start or stop) FIXME-WT-14899: Can remove this check when prepare flag is removed from the
      * time window structure.
      */
-    if (tw->prepare && F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
+    if (tw->prepare && F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED))
         WT_ASSERT(session, pack_prepare_info_to_start || pack_prepare_info_to_stop);
 
     if (pack_prepare_info_to_start && pack_prepare_info_to_stop) {
@@ -930,7 +930,7 @@ copy_cell_restart:
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_durable_stop_ts));
 
         /* Load temporary values to the right fields */
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
             /* We can compare the txn_id only here, but cannot do it everywhere else because when
              * recovering, all transaction ids are reset to WT_TXN_NONE, so we cannot compare the
              * transaction ids.

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -57,7 +57,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - txn is prepared
      *  - transaction is in delete prepared (meaning it has stop_txn defined)
      */
-    bool pack_prepare_info_to_stop = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+    bool pack_prepare_info_to_stop = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+      WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
 
     /* We pack prepared txn info to start_ts and durable start_ts when:
      *  - disagg is on
@@ -65,13 +66,13 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
      * means both start and stop transactions are the same
      */
-    bool pack_prepare_info_to_start = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_START_PREPARE(tw);
+    bool pack_prepare_info_to_start = F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+      WT_TIME_WINDOW_HAS_START_PREPARE(tw);
 
     /*
      * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
-     * start or stop)
-     * FIXME-WT-14899: Can remove this check when prepare flag is removed from the time
-     * window structure.
+     * start or stop) FIXME-WT-14899: Can remove this check when prepare flag is removed from the
+     * time window structure.
      */
     if (tw->prepare && F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
         WT_ASSERT(session, pack_prepare_info_to_start || pack_prepare_info_to_stop);
@@ -930,8 +931,9 @@ copy_cell_restart:
 
         /* Load temporary values to the right fields */
         if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
-            /* We can compare the txn_id only here, but cannot do it everywhere else because when recovering, all transactions id are reset
-             * to WT_TXN_MAX, so we cannot compare the transaction ids.
+            /* We can compare the txn_id only here, but cannot do it everywhere else because when
+             * recovering, all transactions id are reset to WT_TXN_MAX, so we cannot compare the
+             * transaction ids.
              */
             if (tw->start_txn == tw->stop_txn) {
                 /*

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -71,7 +71,8 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
      * start or stop)
      */
-    WT_ASSERT(session, (tw->prepare) == (pack_prepare_info_to_start || pack_prepare_info_to_stop));
+    if (tw->prepare && F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED))
+        WT_ASSERT(session, pack_prepare_info_to_start || pack_prepare_info_to_stop);
 
     if (pack_prepare_info_to_start && pack_prepare_info_to_stop) {
         WT_ASSERT(session, tw->start_prepared_id == tw->stop_prepared_id);

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -30,16 +30,14 @@ struct __wt_time_window {
     wt_timestamp_t durable_start_ts; /* default value: WT_TS_NONE */
     wt_timestamp_t start_ts;         /* default value: WT_TS_NONE */
     uint64_t start_txn;              /* default value: WT_TXN_NONE */
+    wt_timestamp_t start_prepare_ts; /* default value: WT_TS_NONE */
+    uint64_t stop_prepared_id;  /* default value: WT_PREPARED_ID_NONE */
 
     wt_timestamp_t durable_stop_ts; /* default value: WT_TS_NONE */
     wt_timestamp_t stop_ts;         /* default value: WT_TS_MAX */
     uint64_t stop_txn;              /* default value: WT_TXN_MAX */
-
-    wt_timestamp_t start_prepare_ts; /* default value: WT_TS_NONE */
     wt_timestamp_t stop_prepare_ts;  /* default value: WT_TS_NONE */
-
     uint64_t start_prepared_id; /* default value: WT_PREPARED_ID_NONE */
-    uint64_t stop_prepared_id;  /* default value: WT_PREPARED_ID_NONE */
     /*
      * Prepare information isn't really part of a time window, but we need to aggregate it to the
      * internal page information in reconciliation, and this is the simplest place to put it.

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -35,8 +35,11 @@ struct __wt_time_window {
     wt_timestamp_t stop_ts;         /* default value: WT_TS_MAX */
     uint64_t stop_txn;              /* default value: WT_TXN_MAX */
 
-    wt_timestamp_t prepare_ts; /* default value: WT_TS_NONE */
-    uint64_t prepared_id;      /* default value: WT_TXN_NONE */
+    wt_timestamp_t start_prepare_ts; /* default value: WT_TS_NONE */
+    wt_timestamp_t stop_prepare_ts;  /* default value: WT_TS_NONE */
+
+    uint64_t start_prepared_id; /* default value: WT_PREPARED_ID_NONE */
+    uint64_t stop_prepared_id;  /* default value: WT_PREPARED_ID_NONE */
     /*
      * Prepare information isn't really part of a time window, but we need to aggregate it to the
      * internal page information in reconciliation, and this is the simplest place to put it.

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -31,13 +31,13 @@ struct __wt_time_window {
     wt_timestamp_t start_ts;         /* default value: WT_TS_NONE */
     uint64_t start_txn;              /* default value: WT_TXN_NONE */
     wt_timestamp_t start_prepare_ts; /* default value: WT_TS_NONE */
-    uint64_t stop_prepared_id;  /* default value: WT_PREPARED_ID_NONE */
+    uint64_t stop_prepared_id;       /* default value: WT_PREPARED_ID_NONE */
 
     wt_timestamp_t durable_stop_ts; /* default value: WT_TS_NONE */
     wt_timestamp_t stop_ts;         /* default value: WT_TS_MAX */
     uint64_t stop_txn;              /* default value: WT_TXN_MAX */
-    wt_timestamp_t stop_prepare_ts;  /* default value: WT_TS_NONE */
-    uint64_t start_prepared_id; /* default value: WT_PREPARED_ID_NONE */
+    wt_timestamp_t stop_prepare_ts; /* default value: WT_TS_NONE */
+    uint64_t start_prepared_id;     /* default value: WT_PREPARED_ID_NONE */
     /*
      * Prepare information isn't really part of a time window, but we need to aggregate it to the
      * internal page information in reconciliation, and this is the simplest place to put it.

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -29,15 +29,15 @@
 struct __wt_time_window {
     wt_timestamp_t durable_start_ts; /* default value: WT_TS_NONE */
     wt_timestamp_t start_ts;         /* default value: WT_TS_NONE */
-    uint64_t start_txn;              /* default value: WT_TXN_NONE */
     wt_timestamp_t start_prepare_ts; /* default value: WT_TS_NONE */
-    uint64_t stop_prepared_id;       /* default value: WT_PREPARED_ID_NONE */
+    uint64_t start_txn;              /* default value: WT_TXN_NONE */
+    uint64_t start_prepared_id;      /* default value: WT_PREPARED_ID_NONE */
 
     wt_timestamp_t durable_stop_ts; /* default value: WT_TS_NONE */
     wt_timestamp_t stop_ts;         /* default value: WT_TS_MAX */
-    uint64_t stop_txn;              /* default value: WT_TXN_MAX */
     wt_timestamp_t stop_prepare_ts; /* default value: WT_TS_NONE */
-    uint64_t start_prepared_id;     /* default value: WT_PREPARED_ID_NONE */
+    uint64_t stop_txn;              /* default value: WT_TXN_MAX */
+    uint64_t stop_prepared_id;      /* default value: WT_PREPARED_ID_NONE */
     /*
      * Prepare information isn't really part of a time window, but we need to aggregate it to the
      * internal page information in reconciliation, and this is the simplest place to put it.

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -14,14 +14,14 @@
         (tw)->durable_start_ts = WT_TS_NONE;           \
         (tw)->start_ts = WT_TS_NONE;                   \
         (tw)->start_txn = WT_TXN_NONE;                 \
+        (tw)->start_prepare_ts = WT_TS_NONE;           \
+        (tw)->start_prepared_id = WT_PREPARED_ID_NONE; \
         (tw)->durable_stop_ts = WT_TS_NONE;            \
         (tw)->stop_ts = WT_TS_MAX;                     \
         (tw)->stop_txn = WT_TXN_MAX;                   \
-        (tw)->prepare = 0;                             \
-        (tw)->start_prepare_ts = WT_TS_NONE;           \
-        (tw)->start_prepared_id = WT_PREPARED_ID_NONE; \
         (tw)->stop_prepare_ts = WT_TS_NONE;            \
         (tw)->stop_prepared_id = WT_PREPARED_ID_NONE;  \
+        (tw)->prepare = 0;                             \
     } while (0)
 
 /* Copy the values from one time window structure to another. */
@@ -31,8 +31,8 @@
 #define WT_TIME_WINDOW_IS_EMPTY(tw)                                                             \
     ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&                    \
       (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE &&                  \
-      (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 &&       \
       (tw)->start_prepare_ts == WT_TS_NONE && (tw)->start_prepared_id == WT_PREPARED_ID_NONE && \
+      (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 &&       \
       (tw)->stop_prepare_ts == WT_TS_NONE && (tw)->stop_prepared_id == WT_PREPARED_ID_NONE)
 
 /* Check if the start time window is set. */
@@ -53,10 +53,11 @@
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                           \
     ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts &&  \
-      (tw1)->start_txn == (tw2)->start_txn && (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && \
+      (tw1)->start_txn == (tw2)->start_txn && (tw1)->start_prepare_ts == (tw2)->start_prepare_ts  \
+    && (tw1)->start_prepared_id == (tw2)->start_prepared_id &&                                     \
+      (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && \
       (tw1)->stop_ts == (tw2)->stop_ts && (tw1)->stop_txn == (tw2)->stop_txn &&                   \
-      (tw1)->prepare == (tw2)->prepare && (tw1)->start_prepare_ts == (tw2)->start_prepare_ts &&   \
-      (tw1)->start_prepared_id == (tw2)->start_prepared_id &&                                     \
+      (tw1)->prepare == (tw2)->prepare &&   \
       (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts &&                                         \
       (tw1)->stop_prepared_id == (tw2)->stop_prepared_id)
 

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -74,17 +74,17 @@
  * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between
  * preserve_prepared and non-preserve_prepared connections.
  */
-#define WT_TIME_WINDOW_SET_START(session, tw, upd)                        \
-    do {                                                                  \
-        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;        \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED)) { \
-            (tw)->start_prepare_ts = (upd)->prepare_ts;                   \
-            (tw)->start_prepared_id = (upd)->prepared_id;                 \
-        }                                                                 \
-                                                                          \
-        if ((upd)->durable_ts != WT_TS_NONE)                              \
-            (tw)->durable_start_ts = (upd)->durable_ts;                   \
-        (tw)->start_txn = (upd)->txnid;                                   \
+#define WT_TIME_WINDOW_SET_START(session, tw, upd)                 \
+    do {                                                           \
+        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts; \
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {    \
+            (tw)->start_prepare_ts = (upd)->prepare_ts;            \
+            (tw)->start_prepared_id = (upd)->prepared_id;          \
+        }                                                          \
+                                                                   \
+        if ((upd)->durable_ts != WT_TS_NONE)                       \
+            (tw)->durable_start_ts = (upd)->durable_ts;            \
+        (tw)->start_txn = (upd)->txnid;                            \
     } while (0)
 
 /*
@@ -93,17 +93,17 @@
  * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between
  * preserve_prepared and non-preserve_prepared connections.
  */
-#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                         \
-    do {                                                                  \
-        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;          \
-        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED)) { \
-            (tw)->stop_prepare_ts = (upd)->prepare_ts;                    \
-            (tw)->stop_prepared_id = (upd)->prepared_id;                  \
-        }                                                                 \
-                                                                          \
-        if ((upd)->durable_ts != WT_TS_NONE)                              \
-            (tw)->durable_stop_ts = (upd)->durable_ts;                    \
-        (tw)->stop_txn = (upd)->txnid;                                    \
+#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                \
+    do {                                                         \
+        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts; \
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {  \
+            (tw)->stop_prepare_ts = (upd)->prepare_ts;           \
+            (tw)->stop_prepared_id = (upd)->prepared_id;         \
+        }                                                        \
+                                                                 \
+        if ((upd)->durable_ts != WT_TS_NONE)                     \
+            (tw)->durable_stop_ts = (upd)->durable_ts;           \
+        (tw)->stop_txn = (upd)->txnid;                           \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -28,12 +28,13 @@
 #define WT_TIME_WINDOW_COPY(dest, source) (*(dest) = *(source))
 
 /* Return true if the time window is equivalent to the default time window. */
-#define WT_TIME_WINDOW_IS_EMPTY(tw)                                                             \
-    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&                    \
-      (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE &&                  \
-      (tw)->start_prepare_ts == WT_TS_NONE && (tw)->start_prepared_id == WT_PREPARED_ID_NONE && \
-      (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 &&       \
-      (tw)->stop_prepare_ts == WT_TS_NONE && (tw)->stop_prepared_id == WT_PREPARED_ID_NONE)
+#define WT_TIME_WINDOW_IS_EMPTY(tw)                                                           \
+    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&                  \
+      (tw)->start_txn == WT_TXN_NONE && (tw)->start_prepare_ts == WT_TS_NONE &&               \
+      (tw)->start_prepared_id == WT_PREPARED_ID_NONE && (tw)->stop_ts == WT_TS_MAX &&         \
+      (tw)->stop_txn == WT_TXN_MAX && (tw)->durable_stop_ts == WT_TS_NONE &&                  \
+      (tw)->stop_prepare_ts == WT_TS_NONE && (tw)->stop_prepared_id == WT_PREPARED_ID_NONE && \
+      (tw)->prepare == 0)
 
 /* Check if the start time window is set. */
 #define WT_TIME_WINDOW_HAS_START(tw) \
@@ -51,15 +52,14 @@
     ((tw)->stop_prepared_id != WT_PREPARED_ID_NONE || (tw)->stop_prepare_ts != WT_TS_NONE)
 
 /* Return true if the time windows are the same. */
-#define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                           \
-    ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts &&  \
-      (tw1)->start_txn == (tw2)->start_txn && (tw1)->start_prepare_ts == (tw2)->start_prepare_ts  \
-    && (tw1)->start_prepared_id == (tw2)->start_prepared_id &&                                     \
-      (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && \
-      (tw1)->stop_ts == (tw2)->stop_ts && (tw1)->stop_txn == (tw2)->stop_txn &&                   \
-      (tw1)->prepare == (tw2)->prepare &&   \
-      (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts &&                                         \
-      (tw1)->stop_prepared_id == (tw2)->stop_prepared_id)
+#define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                          \
+    ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts && \
+      (tw1)->start_txn == (tw2)->start_txn &&                                                    \
+      (tw1)->start_prepare_ts == (tw2)->start_prepare_ts &&                                      \
+      (tw1)->start_prepared_id == (tw2)->start_prepared_id &&                                    \
+      (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && (tw1)->stop_ts == (tw2)->stop_ts &&    \
+      (tw1)->stop_txn == (tw2)->stop_txn && (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts &&  \
+      (tw1)->stop_prepared_id == (tw2)->stop_prepared_id && (tw1)->prepare == (tw2)->prepare)
 
 /* Return true if the stop time windows are the same. */
 #define WT_TIME_WINDOWS_STOP_EQUAL(tw1, tw2)                                                 \
@@ -71,7 +71,8 @@
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
- * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between preserve_prepared and non-preserve_prepared connections.
+ * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between
+ * preserve_prepared and non-preserve_prepared connections.
  */
 #define WT_TIME_WINDOW_SET_START(session, tw, upd)                        \
     do {                                                                  \
@@ -89,7 +90,8 @@
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
- * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between preserve_prepared and non-preserve_prepared connections.
+ * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between
+ * preserve_prepared and non-preserve_prepared connections.
  */
 #define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                         \
     do {                                                                  \

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -71,6 +71,7 @@
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
+ * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between preserve_prepared and non-preserve_prepared connections.
  */
 #define WT_TIME_WINDOW_SET_START(session, tw, upd)                        \
     do {                                                                  \
@@ -88,6 +89,7 @@
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
+ * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between preserve_prepared and non-preserve_prepared connections.
  */
 #define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                         \
     do {                                                                  \

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -9,28 +9,31 @@
 #pragma once
 
 /* Initialize the fields in a time window to their defaults. */
-#define WT_TIME_WINDOW_INIT(tw)                  \
-    do {                                         \
-        (tw)->durable_start_ts = WT_TS_NONE;     \
-        (tw)->start_ts = WT_TS_NONE;             \
-        (tw)->start_txn = WT_TXN_NONE;           \
-        (tw)->durable_stop_ts = WT_TS_NONE;      \
-        (tw)->stop_ts = WT_TS_MAX;               \
-        (tw)->stop_txn = WT_TXN_MAX;             \
-        (tw)->prepare = 0;                       \
-        (tw)->prepare_ts = WT_TS_NONE;           \
-        (tw)->prepared_id = WT_PREPARED_ID_NONE; \
+#define WT_TIME_WINDOW_INIT(tw)                        \
+    do {                                               \
+        (tw)->durable_start_ts = WT_TS_NONE;           \
+        (tw)->start_ts = WT_TS_NONE;                   \
+        (tw)->start_txn = WT_TXN_NONE;                 \
+        (tw)->durable_stop_ts = WT_TS_NONE;            \
+        (tw)->stop_ts = WT_TS_MAX;                     \
+        (tw)->stop_txn = WT_TXN_MAX;                   \
+        (tw)->prepare = 0;                             \
+        (tw)->start_prepare_ts = WT_TS_NONE;           \
+        (tw)->start_prepared_id = WT_PREPARED_ID_NONE; \
+        (tw)->stop_prepare_ts = WT_TS_NONE;            \
+        (tw)->stop_prepared_id = WT_PREPARED_ID_NONE;  \
     } while (0)
 
 /* Copy the values from one time window structure to another. */
 #define WT_TIME_WINDOW_COPY(dest, source) (*(dest) = *(source))
 
 /* Return true if the time window is equivalent to the default time window. */
-#define WT_TIME_WINDOW_IS_EMPTY(tw)                                                       \
-    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&              \
-      (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE &&            \
-      (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 && \
-      (tw)->prepare_ts == WT_TS_NONE && (tw)->prepared_id == WT_PREPARED_ID_NONE)
+#define WT_TIME_WINDOW_IS_EMPTY(tw)                                                             \
+    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&                    \
+      (tw)->start_txn == WT_TXN_NONE && (tw)->durable_stop_ts == WT_TS_NONE &&                  \
+      (tw)->stop_ts == WT_TS_MAX && (tw)->stop_txn == WT_TXN_MAX && (tw)->prepare == 0 &&       \
+      (tw)->start_prepare_ts == WT_TS_NONE && (tw)->start_prepared_id == WT_PREPARED_ID_NONE && \
+      (tw)->stop_prepare_ts == WT_TS_NONE && (tw)->stop_prepared_id == WT_PREPARED_ID_NONE)
 
 /* Check if the start time window is set. */
 #define WT_TIME_WINDOW_HAS_START(tw) \
@@ -39,77 +42,85 @@
 /* Check if the stop time window is set. */
 #define WT_TIME_WINDOW_HAS_STOP(tw) ((tw)->stop_txn != WT_TXN_MAX || (tw)->stop_ts != WT_TS_MAX)
 
+/* Check if the start prepare time window is set. */
+#define WT_TIME_WINDOW_HAS_START_PREPARE(tw) \
+    ((tw)->start_prepared_id != WT_PREPARED_ID_NONE || (tw)->start_prepare_ts != WT_TS_NONE)
+
+/* Check if the stop prepare time window is set. */
+#define WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) \
+    ((tw)->stop_prepared_id != WT_PREPARED_ID_NONE || (tw)->stop_prepare_ts != WT_TS_NONE)
+
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                           \
     ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts &&  \
       (tw1)->start_txn == (tw2)->start_txn && (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && \
       (tw1)->stop_ts == (tw2)->stop_ts && (tw1)->stop_txn == (tw2)->stop_txn &&                   \
-      (tw1)->prepare == (tw2)->prepare && (tw1)->prepare_ts == (tw2)->prepare_ts &&               \
-      (tw1)->prepared_id == (tw2)->prepared_id)
+      (tw1)->prepare == (tw2)->prepare && (tw1)->start_prepare_ts == (tw2)->start_prepare_ts &&   \
+      (tw1)->start_prepared_id == (tw2)->start_prepared_id &&                                     \
+      (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts &&                                         \
+      (tw1)->stop_prepared_id == (tw2)->stop_prepared_id)
 
 /* Return true if the stop time windows are the same. */
 #define WT_TIME_WINDOWS_STOP_EQUAL(tw1, tw2)                                                 \
     ((tw1)->durable_stop_ts == (tw2)->durable_stop_ts && (tw1)->stop_ts == (tw2)->stop_ts && \
-      (tw1)->stop_txn == (tw2)->stop_txn && (tw1)->prepare == (tw2)->prepare)
+      (tw1)->stop_txn == (tw2)->stop_txn && (tw1)->prepare == (tw2)->prepare &&              \
+      (tw1)->stop_prepared_id == (tw2)->stop_prepared_id &&                                  \
+      (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts)
 
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_START(session, tw, upd)                    \
-    do {                                                              \
-        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;    \
-        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&       \
-          (upd)->prepared_id > (tw)->prepared_id) {                   \
-            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts); \
-            (tw)->prepare_ts = (upd)->prepare_ts;                     \
-            (tw)->prepared_id = (upd)->prepared_id;                   \
-        }                                                             \
-                                                                      \
-        if ((upd)->durable_ts != WT_TS_NONE)                          \
-            (tw)->durable_start_ts = (upd)->durable_ts;               \
-        (tw)->start_txn = (upd)->txnid;                               \
+#define WT_TIME_WINDOW_SET_START(session, tw, upd)                        \
+    do {                                                                  \
+        (tw)->durable_start_ts = (tw)->start_ts = (upd)->start_ts;        \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED)) { \
+            (tw)->start_prepare_ts = (upd)->prepare_ts;                   \
+            (tw)->start_prepared_id = (upd)->prepared_id;                 \
+        }                                                                 \
+                                                                          \
+        if ((upd)->durable_ts != WT_TS_NONE)                              \
+            (tw)->durable_start_ts = (upd)->durable_ts;                   \
+        (tw)->start_txn = (upd)->txnid;                                   \
     } while (0)
 
 /*
  * Set the start values of a time window from those in an update structure. Durable timestamp can be
  * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
  */
-#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                     \
-    do {                                                              \
-        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;      \
-        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&       \
-          (upd)->prepared_id > (tw)->prepared_id) {                   \
-            WT_ASSERT(session, (upd)->prepare_ts > (tw)->prepare_ts); \
-            (tw)->prepare_ts = (upd)->prepare_ts;                     \
-            (tw)->prepared_id = (upd)->prepared_id;                   \
-        }                                                             \
-                                                                      \
-        if ((upd)->durable_ts != WT_TS_NONE)                          \
-            (tw)->durable_stop_ts = (upd)->durable_ts;                \
-        (tw)->stop_txn = (upd)->txnid;                                \
+#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                         \
+    do {                                                                  \
+        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->start_ts;          \
+        if (F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED)) { \
+            (tw)->stop_prepare_ts = (upd)->prepare_ts;                    \
+            (tw)->stop_prepared_id = (upd)->prepared_id;                  \
+        }                                                                 \
+                                                                          \
+        if ((upd)->durable_ts != WT_TS_NONE)                              \
+            (tw)->durable_stop_ts = (upd)->durable_ts;                    \
+        (tw)->stop_txn = (upd)->txnid;                                    \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */
-#define WT_TIME_WINDOW_COPY_START(dest, source)                \
-    do {                                                       \
-        (dest)->durable_start_ts = (source)->durable_start_ts; \
-        (dest)->start_ts = (source)->start_ts;                 \
-        (dest)->start_txn = (source)->start_txn;               \
-        (dest)->prepare = (source)->prepare;                   \
-        (dest)->prepare_ts = (source)->prepare_ts;             \
-        (dest)->prepared_id = (source)->prepared_id;           \
+#define WT_TIME_WINDOW_COPY_START(dest, source)                  \
+    do {                                                         \
+        (dest)->durable_start_ts = (source)->durable_start_ts;   \
+        (dest)->start_ts = (source)->start_ts;                   \
+        (dest)->start_txn = (source)->start_txn;                 \
+        (dest)->prepare = (source)->prepare;                     \
+        (dest)->start_prepare_ts = (source)->start_prepare_ts;   \
+        (dest)->start_prepared_id = (source)->start_prepared_id; \
     } while (0)
 
 /* Copy the stop values of a time window from another time window. */
-#define WT_TIME_WINDOW_COPY_STOP(dest, source)               \
-    do {                                                     \
-        (dest)->durable_stop_ts = (source)->durable_stop_ts; \
-        (dest)->stop_ts = (source)->stop_ts;                 \
-        (dest)->stop_txn = (source)->stop_txn;               \
-        (dest)->prepare = (source)->prepare;                 \
-        (dest)->prepare_ts = (source)->prepare_ts;           \
-        (dest)->prepared_id = (source)->prepared_id;         \
+#define WT_TIME_WINDOW_COPY_STOP(dest, source)                 \
+    do {                                                       \
+        (dest)->durable_stop_ts = (source)->durable_stop_ts;   \
+        (dest)->stop_ts = (source)->stop_ts;                   \
+        (dest)->stop_txn = (source)->stop_txn;                 \
+        (dest)->prepare = (source)->prepare;                   \
+        (dest)->stop_prepare_ts = (source)->stop_prepare_ts;   \
+        (dest)->stop_prepared_id = (source)->stop_prepared_id; \
     } while (0)
 
 /*

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -496,68 +496,77 @@ __wt_time_value_validate(
           "value time window has a durable start time after its durable stop time; time window %s",
           __wt_time_window_to_string(tw, time_string[0]));
 
-    if (tw->prepare && F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
-        if (tw->prepare_ts == WT_TS_NONE)
+    if (tw->prepare && F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
+        if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) && !WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
             WT_TIME_VALIDATE_RET(session,
-              "value time window is prepared and has preserve_prepared enabled but has no prepare "
-              "timestamp; time window %s",
+              "Prepared value time window has neither start or stop prepared information; time "
+              "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        if (tw->prepared_id == WT_PREPARED_ID_NONE)
-            WT_TIME_VALIDATE_RET(session,
-              "value time window is prepared and has preserve_prepared enabled but has no prepared "
-              "id; time window %s",
-              __wt_time_window_to_string(tw, time_string[0]));
-
-        if (WT_TIME_WINDOW_HAS_STOP(tw)) {
-            if (tw->stop_ts != tw->prepare_ts)
+        }
+        /* Validate that if start prepare_ts is set, start_prepared_id must be set */
+        if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
+            if (tw->start_prepare_ts == WT_TS_NONE) {
                 WT_TIME_VALIDATE_RET(session,
-                  "value time window is stop prepared but has different stop_ts and prepared_ts; "
-                  "time window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-
-            if (tw->durable_stop_ts != WT_TS_NONE)
-                WT_TIME_VALIDATE_RET(session,
-                  "value time window is stop prepared but has non-empty durable_stop_ts; "
-                  "time window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-
-            if (tw->start_txn == tw->stop_txn) {
-                /* both start and stop are prepared, they must be in the same transaction */
-                if (tw->durable_start_ts != WT_TS_NONE)
-                    WT_TIME_VALIDATE_RET(session,
-                      "value time window is start and stop prepared but has non-empty durable "
-                      "start timestamps; time window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                if (tw->start_ts != tw->prepare_ts)
-                    WT_TIME_VALIDATE_RET(session,
-                      "value time window is start prepared but has different start_ts and "
-                      "prepared_ts; time window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-
-            } else if (tw->start_ts >= tw->prepare_ts) {
-                WT_TIME_VALIDATE_RET(session,
-                  "value time window is prepared delete but has a start timestamp greater "
-                  "than or equal to the prepared delete timestamp; time window %s",
+                  "Start prepared value time window has no start prepare time "
+                  "window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
             }
-        } else {
-            /* this means time window is start prepared */
-            if (tw->start_ts != tw->prepare_ts)
+            if (tw->start_prepared_id == WT_PREPARED_ID_NONE) {
                 WT_TIME_VALIDATE_RET(session,
-                  "value time window is start prepared but has different start_ts and prepared_ts; "
-                  "time window %s",
+                  "Start prepared value time window has no start prepared id; time "
+                  "window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
-            if (tw->durable_start_ts != WT_TS_NONE)
+            }
+            if (tw->start_ts != WT_TS_NONE) {
                 WT_TIME_VALIDATE_RET(session,
-                  "value time window is start prepared but has non-empty durable_start_ts; "
-                  "time window %s",
+                  "Start prepared value time window has a start time set; time "
+                  "window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
+            }
+            if (tw->durable_start_ts != WT_TS_NONE) {
+                WT_TIME_VALIDATE_RET(session,
+                  "Start prepared value time window has a durable start time set; time "
+                  "window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            }
+        }
+        if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+            if (tw->stop_prepare_ts == WT_TS_NONE) {
+                WT_TIME_VALIDATE_RET(session,
+                  "Stop prepared value time window has no stop prepare time "
+                  "window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            }
+            if (tw->stop_prepared_id == WT_PREPARED_ID_NONE) {
+                WT_TIME_VALIDATE_RET(session,
+                  "Stop prepared value time window has no stop prepared id; time "
+                  "window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            }
+            if (tw->stop_ts != WT_TS_MAX) {
+                WT_TIME_VALIDATE_RET(session,
+                  "Stop prepared value time window has a stop time set; time "
+                  "window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            }
+            if (tw->durable_stop_ts != WT_TS_NONE) {
+                WT_TIME_VALIDATE_RET(session,
+                  "Stop prepared value time window has a durable stop time set; time "
+                  "window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+            }
         }
     } else {
         /* Validate that prepare_ts and prepared_id must be none */
-        if (tw->prepare_ts != WT_TS_NONE || tw->prepared_id != WT_PREPARED_ID_NONE) {
+        if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
             WT_TIME_VALIDATE_RET(session,
-              "Non-prepared value time window but contains prepared ts and prepared id; time "
+              "Non-prepared value time window contains start prepared ts and prepared id; time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
+        if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+            WT_TIME_VALIDATE_RET(session,
+              "Non-prepared value time window contains stop prepared ts and prepared id; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
         }

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -502,58 +502,59 @@ __wt_time_value_validate(
               "Prepared value time window has neither start or stop prepared information; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
-        /* Validate that if start prepare_ts is set, start_prepared_id must be set */
-        if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
-            if (tw->start_prepare_ts == WT_TS_NONE) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Start prepared value time window has no start prepare time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
+        } else {
+            /* Validate that if start prepare_ts is set, start_prepared_id must be set */
+            if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
+                if (tw->start_prepare_ts == WT_TS_NONE) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Start prepared value time window has no start prepare time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
+                if (tw->start_prepared_id == WT_PREPARED_ID_NONE) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Start prepared value time window has no start prepared id; time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
+                if (tw->start_ts != WT_TS_NONE) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Start prepared value time window has a start time set; time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
+                if (tw->durable_start_ts != WT_TS_NONE) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Start prepared value time window has a durable start time set; time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
             }
-            if (tw->start_prepared_id == WT_PREPARED_ID_NONE) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Start prepared value time window has no start prepared id; time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-            }
-            if (tw->start_ts != WT_TS_NONE) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Start prepared value time window has a start time set; time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-            }
-            if (tw->durable_start_ts != WT_TS_NONE) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Start prepared value time window has a durable start time set; time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-            }
-        }
-        if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
-            if (tw->stop_prepare_ts == WT_TS_NONE) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Stop prepared value time window has no stop prepare time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-            }
-            if (tw->stop_prepared_id == WT_PREPARED_ID_NONE) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Stop prepared value time window has no stop prepared id; time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-            }
-            if (tw->stop_ts != WT_TS_MAX) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Stop prepared value time window has a stop time set; time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
-            }
-            if (tw->durable_stop_ts != WT_TS_NONE) {
-                WT_TIME_VALIDATE_RET(session,
-                  "Stop prepared value time window has a durable stop time set; time "
-                  "window %s",
-                  __wt_time_window_to_string(tw, time_string[0]));
+            if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+                if (tw->stop_prepare_ts == WT_TS_NONE) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Stop prepared value time window has no stop prepare time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
+                if (tw->stop_prepared_id == WT_PREPARED_ID_NONE) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Stop prepared value time window has no stop prepared id; time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
+                if (tw->stop_ts != WT_TS_MAX) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Stop prepared value time window has a stop time set; time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
+                if (tw->durable_stop_ts != WT_TS_NONE) {
+                    WT_TIME_VALIDATE_RET(session,
+                      "Stop prepared value time window has a durable stop time set; time "
+                      "window %s",
+                      __wt_time_window_to_string(tw, time_string[0]));
+                }
             }
         }
     } else {

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -496,7 +496,7 @@ __wt_time_value_validate(
           "value time window has a durable start time after its durable stop time; time window %s",
           __wt_time_window_to_string(tw, time_string[0]));
 
-    if (tw->prepare && F_ISSET_ATOMIC_32(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
+    if (tw->prepare && F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
         if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) && !WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
             WT_TIME_VALIDATE_RET(session,
               "Prepared value time window has neither start or stop prepared information; time "

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -9,6 +9,7 @@ else()
         misc_tests/test_acquire_release_macros.cpp
         misc_tests/test_binary_search_string.cpp
         misc_tests/test_bitmap.cpp
+        misc_tests/test_cell_prepared_time_window.cpp
         misc_tests/test_crc32.cpp
         misc_tests/test_error.cpp
         misc_tests/test_fnv.cpp

--- a/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
+++ b/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
@@ -6,7 +6,7 @@
  * See the file LICENSE for redistribution information.
  */
 
-// Unit tests for cell packing/unpacking of prepared time windows
+/* Unit tests for cell packing/unpacking of prepared time windows */
 #include <catch2/catch.hpp>
 #include <vector>
 #include "../wrappers/mock_session.h"
@@ -57,7 +57,7 @@ create_test_time_window(wt_timestamp_t start_ts, uint64_t start_txn, wt_timestam
 static std::vector<uint8_t>
 pack_time_window(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    // Allocate enough space for the packed data (conservative estimate)
+    /* Allocate enough space for the packed data (conservative estimate) */
     std::vector<uint8_t> buffer(256, 0);
     uint8_t *p = buffer.data();
     uint8_t *start_p = p;
@@ -65,7 +65,7 @@ pack_time_window(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
     int ret = __cell_pack_value_validity(session, &p, tw);
     REQUIRE(ret == 0);
 
-    // Resize buffer to actual used size
+    /* Resize buffer to actual used size */
     size_t used_size = p - start_p;
     buffer.resize(used_size);
 
@@ -78,7 +78,7 @@ pack_time_window(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 static WT_TIME_WINDOW
 unpack_time_window(WT_SESSION_IMPL *session, const std::vector<uint8_t> &packed_data)
 {
-    // Create a mock cell and page header for unpacking
+    /* Create a mock cell and page header for unpacking */
     WT_CELL cell;
     WT_PAGE_HEADER dsk;
     WT_CELL_UNPACK_KV unpack;
@@ -87,39 +87,43 @@ unpack_time_window(WT_SESSION_IMPL *session, const std::vector<uint8_t> &packed_
     memset(&dsk, 0, sizeof(dsk));
     memset(&unpack, 0, sizeof(unpack));
 
-    // Initialize the page header with a reasonable write generation
-    // This is needed because the unpacking code checks dsk->write_gen
-    dsk.write_gen = 2; // Set to a value > base_write_gen to avoid cleanup
+    /*
+     * Initialize the page header with a reasonable write generation. This is needed because the
+     * unpacking code checks dsk->write_gen.
+     */
+    dsk.write_gen = 2; /* Set to a value > base_write_gen to avoid cleanup */
 
-    // The packed_data contains the validity window packed by __cell_pack_value_validity
-    // We need to create a proper WT_CELL_VALUE with this validity window
+    /*
+     * The packed_data contains the validity window packed by __cell_pack_value_validity. We need to
+     * create a proper WT_CELL_VALUE with this validity window.
+     */
 
     uint8_t *p = cell.__chunk;
     int ret = 0;
     if (packed_data.size() <= 1) {
-        // Empty time window case
+        /* Empty time window case */
         cell.__chunk[0] = WT_CELL_VALUE;
         p = &cell.__chunk[1];
-        // Pack zero data length
+        /* Pack zero data length */
         ret = __wt_vpack_uint(&p, 0, 0);
     } else {
-        // Has validity window
+        /* Has validity window */
         cell.__chunk[0] = WT_CELL_VALUE | WT_CELL_SECOND_DESC;
 
-        // Copy the validity window data (skip the first byte which was the descriptor increment)
+        /* Copy the validity window data (skip the first byte which was the descriptor increment) */
         memcpy(&cell.__chunk[1], packed_data.data() + 1, packed_data.size() - 1);
 
-        // Set pointer to after the validity window data
+        /* Set pointer to after the validity window data */
         p = &cell.__chunk[packed_data.size()];
 
-        // Pack zero data length (WT_CELL_VALUE always expects a data length)
+        /* Pack zero data length (WT_CELL_VALUE always expects a data length) */
         ret = __wt_vpack_uint(&p, 0, 0);
     }
     if (ret != 0) {
         throw std::runtime_error("Failed to pack zero data length");
     }
 
-    // Unpack the cell
+    /* Unpack the cell */
     __wt_cell_unpack_kv(session, &dsk, &cell, &unpack);
 
     return unpack.tw;
@@ -153,17 +157,17 @@ TEST_CASE("Cell Time Window: Empty time window", "[cell][time_window]")
     conn = S2C(session_mock->get_wt_session_impl());
     F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
 
-    // Set up the btree structure that the cell unpacking code needs
+    /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
     WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
-    btree->base_write_gen = 1; // Initialize to a reasonable value
+    btree->base_write_gen = 1; /* Initialize to a reasonable value */
 
     WT_TIME_WINDOW tw;
     WT_TIME_WINDOW_INIT(&tw);
 
-    // Empty time window should pack to minimal size
+    /* Empty time window should pack to minimal size */
     auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
-    CHECK(packed.size() == 1); // Just the increment for empty window
+    CHECK(packed.size() == 1); /* Just the increment for empty window */
 }
 
 TEST_CASE("Cell Time Window: Start prepared only", "[cell][time_window]")
@@ -173,21 +177,21 @@ TEST_CASE("Cell Time Window: Start prepared only", "[cell][time_window]")
     conn = S2C(session_mock->get_wt_session_impl());
     F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
 
-    // Set up the btree structure that the cell unpacking code needs
+    /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
     WT_BTREE *btree = S2BT(session_mock->get_wt_session_impl());
-    btree->base_write_gen = 1; // Initialize to a reasonable value
+    btree->base_write_gen = 1; /* Initialize to a reasonable value */
 
     SECTION("Basic start prepared")
     {
-        auto tw = create_test_time_window(0, // start_ts
-          10,                                // start_txn
-          WT_TS_MAX,                         // stop_ts
-          WT_TXN_MAX,                        // stop_txn
-          true,                              // has_start_prepare
-          false,                             // has_stop_prepare
-          100,                               // start_prepare_ts
-          1                                  // start_prepared_id
+        auto tw = create_test_time_window(0, /* start_ts */
+          10,                                /* start_txn */
+          WT_TS_MAX,                         /* stop_ts */
+          WT_TXN_MAX,                        /* stop_txn */
+          true,                              /* has_start_prepare */
+          false,                             /* has_stop_prepare */
+          100,                               /* start_prepare_ts */
+          1                                  /* start_prepared_id */
         );
 
         auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
@@ -204,23 +208,23 @@ TEST_CASE("Cell Time Window: Stop prepared only", "[cell][time_window]")
     conn = S2C(session_mock->get_wt_session_impl());
     F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
 
-    // Set up the btree structure that the cell unpacking code needs
+    /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
     WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
-    btree->base_write_gen = 1; // Initialize to a reasonable value
+    btree->base_write_gen = 1; /* Initialize to a reasonable value */
 
     SECTION("Basic stop prepared")
     {
-        auto tw = create_test_time_window(50, // start_ts
-          10,                                 // start_txn
-          WT_TS_MAX,                          // stop_ts
-          20,                                 // stop_txn
-          false,                              // has_start_prepare
-          true,                               // has_stop_prepare
-          0,                                  // start_prepare_ts (unused)
-          0,                                  // start_prepared_id (unused)
-          200,                                // stop_prepare_ts
-          3                                   // stop_prepared_id
+        auto tw = create_test_time_window(50, /* start_ts */
+          10,                                 /* start_txn */
+          WT_TS_MAX,                          /* stop_ts */
+          20,                                 /* stop_txn */
+          false,                              /* has_start_prepare */
+          true,                               /* has_stop_prepare */
+          0,                                  /* start_prepare_ts (unused) */
+          0,                                  /* start_prepared_id (unused) */
+          200,                                /* stop_prepare_ts */
+          3                                   /* stop_prepared_id */
         );
 
         auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
@@ -237,23 +241,23 @@ TEST_CASE("Cell Time Window: Both start and stop prepared", "[cell][time_window]
     conn = S2C(session_mock->get_wt_session_impl());
     F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
 
-    // Set up the btree structure that the cell unpacking code needs
+    /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
     WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
-    btree->base_write_gen = 1; // Initialize to a reasonable value
+    btree->base_write_gen = 1; /* Initialize to a reasonable value */
 
     SECTION("Same transaction - both prepared")
     {
-        auto tw = create_test_time_window(0, // start_ts
-          10,                                // start_txn
-          WT_TS_MAX,                         // stop_ts
-          10,                                // stop_txn (same as start)
-          true,                              // has_start_prepare
-          true,                              // has_stop_prepare
-          150,                               // start_prepare_ts
-          2,                                 // start_prepared_id
-          150,                               // stop_prepare_ts (same as start)
-          2                                  // stop_prepared_id (same as start)
+        auto tw = create_test_time_window(0, /* start_ts */
+          10,                                /* start_txn */
+          WT_TS_MAX,                         /* stop_ts */
+          10,                                /* stop_txn (same as start) */
+          true,                              /* has_start_prepare */
+          true,                              /* has_stop_prepare */
+          150,                               /* start_prepare_ts */
+          2,                                 /* start_prepared_id */
+          150,                               /* stop_prepare_ts (same as start) */
+          2                                  /* stop_prepared_id (same as start) */
         );
 
         auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
@@ -264,16 +268,16 @@ TEST_CASE("Cell Time Window: Both start and stop prepared", "[cell][time_window]
 
     SECTION("Both start and stop are prepared - invalid time window")
     {
-        auto tw = create_test_time_window(50, // start_ts
-          10,                                 // start_txn
-          100,                                // stop_ts
-          20,                                 // stop_txn (different from start)
-          true,                               // has_start_prepare
-          true,                               // has_stop_prepare
-          150,                                // start_prepare_ts
-          2,                                  // start_prepared_id
-          200,                                // stop_prepare_ts (different from start)
-          3                                   // stop_prepared_id (different from start)
+        auto tw = create_test_time_window(50, /* start_ts */
+          10,                                 /* start_txn */
+          100,                                /* stop_ts */
+          20,                                 /* stop_txn (different from start) */
+          true,                               /* has_start_prepare */
+          true,                               /* has_stop_prepare */
+          150,                                /* start_prepare_ts */
+          2,                                  /* start_prepared_id */
+          200,                                /* stop_prepare_ts (different from start) */
+          3                                   /* stop_prepared_id (different from start) */
         );
 
         CHECK(
@@ -288,17 +292,17 @@ TEST_CASE("Cell Time Window: Regular (non-prepared) time window", "[cell][time_w
     conn = S2C(session_mock->get_wt_session_impl());
     F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
 
-    // Set up the btree structure that the cell unpacking code needs
+    /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
     WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
-    btree->base_write_gen = 1; // Initialize to a reasonable value
+    btree->base_write_gen = 1; /* Initialize to a reasonable value */
 
-    auto tw = create_test_time_window(50, // start_ts
-      10,                                 // start_txn
-      100,                                // stop_ts
-      20,                                 // stop_txn
-      false,                              // has_start_prepare
-      false                               // has_stop_prepare
+    auto tw = create_test_time_window(50, /* start_ts */
+      10,                                 /* start_txn */
+      100,                                /* stop_ts */
+      20,                                 /* stop_txn */
+      false,                              /* has_start_prepare */
+      false                               /* has_stop_prepare */
     );
 
     auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);

--- a/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
+++ b/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
@@ -265,24 +265,6 @@ TEST_CASE("Cell Time Window: Both start and stop prepared", "[cell][time_window]
 
         compare_time_windows(tw, unpacked);
     }
-
-    SECTION("Both start and stop are prepared - invalid time window")
-    {
-        auto tw = create_test_time_window(50, /* start_ts */
-          10,                                 /* start_txn */
-          100,                                /* stop_ts */
-          20,                                 /* stop_txn (different from start) */
-          true,                               /* has_start_prepare */
-          true,                               /* has_stop_prepare */
-          150,                                /* start_prepare_ts */
-          2,                                  /* start_prepared_id */
-          200,                                /* stop_prepare_ts (different from start) */
-          3                                   /* stop_prepared_id (different from start) */
-        );
-
-        CHECK(
-          __cell_check_value_validity(session_mock->get_wt_session_impl(), &tw, true) == WT_ERROR);
-    }
 }
 
 TEST_CASE("Cell Time Window: Regular (non-prepared) time window", "[cell][time_window]")

--- a/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
+++ b/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
@@ -1,0 +1,308 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+// Unit tests for cell packing/unpacking of prepared time windows
+#include <catch2/catch.hpp>
+#include <vector>
+#include "../wrappers/mock_session.h"
+#include "wt_internal.h"
+
+/*
+ * Helper function to create a test time window with specific prepared information
+ */
+static WT_TIME_WINDOW
+create_test_time_window(wt_timestamp_t start_ts, uint64_t start_txn, wt_timestamp_t stop_ts,
+  uint64_t stop_txn, bool has_start_prepare, bool has_stop_prepare,
+  wt_timestamp_t start_prepare_ts = 100, uint64_t start_prepared_id = 1,
+  wt_timestamp_t stop_prepare_ts = 200, uint64_t stop_prepared_id = 2)
+{
+    WT_TIME_WINDOW tw;
+    WT_TIME_WINDOW_INIT(&tw);
+
+    tw.start_ts = start_ts;
+    tw.start_txn = start_txn;
+    tw.stop_ts = stop_ts;
+    tw.stop_txn = stop_txn;
+
+    if (has_start_prepare || has_stop_prepare) {
+        tw.prepare = 1;
+    }
+    if (tw.start_ts != WT_TS_NONE)
+        tw.durable_start_ts = tw.start_ts;
+
+    if (tw.stop_ts != WT_TS_MAX)
+        tw.durable_stop_ts = tw.stop_ts;
+
+    if (has_start_prepare) {
+        tw.start_prepare_ts = start_prepare_ts;
+        tw.start_prepared_id = start_prepared_id;
+    }
+
+    if (has_stop_prepare) {
+        tw.stop_prepare_ts = stop_prepare_ts;
+        tw.stop_prepared_id = stop_prepared_id;
+    }
+
+    return tw;
+}
+
+/*
+ * Helper function to pack a time window and return the packed data
+ */
+static std::vector<uint8_t>
+pack_time_window(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
+{
+    // Allocate enough space for the packed data (conservative estimate)
+    std::vector<uint8_t> buffer(256, 0);
+    uint8_t *p = buffer.data();
+    uint8_t *start_p = p;
+
+    int ret = __cell_pack_value_validity(session, &p, tw);
+    REQUIRE(ret == 0);
+
+    // Resize buffer to actual used size
+    size_t used_size = p - start_p;
+    buffer.resize(used_size);
+
+    return buffer;
+}
+
+/*
+ * Helper function to unpack time window from packed data
+ */
+static WT_TIME_WINDOW
+unpack_time_window(WT_SESSION_IMPL *session, const std::vector<uint8_t> &packed_data)
+{
+    // Create a mock cell and page header for unpacking
+    WT_CELL cell;
+    WT_PAGE_HEADER dsk;
+    WT_CELL_UNPACK_KV unpack;
+
+    memset(&cell, 0, sizeof(cell));
+    memset(&dsk, 0, sizeof(dsk));
+    memset(&unpack, 0, sizeof(unpack));
+
+    // Initialize the page header with a reasonable write generation
+    // This is needed because the unpacking code checks dsk->write_gen
+    dsk.write_gen = 2; // Set to a value > base_write_gen to avoid cleanup
+
+    // The packed_data contains the validity window packed by __cell_pack_value_validity
+    // We need to create a proper WT_CELL_VALUE with this validity window
+
+    uint8_t *p = cell.__chunk;
+    int ret = 0;
+    if (packed_data.size() <= 1) {
+        // Empty time window case
+        cell.__chunk[0] = WT_CELL_VALUE;
+        p = &cell.__chunk[1];
+        // Pack zero data length
+        ret = __wt_vpack_uint(&p, 0, 0);
+    } else {
+        // Has validity window
+        cell.__chunk[0] = WT_CELL_VALUE | WT_CELL_SECOND_DESC;
+
+        // Copy the validity window data (skip the first byte which was the descriptor increment)
+        memcpy(&cell.__chunk[1], packed_data.data() + 1, packed_data.size() - 1);
+
+        // Set pointer to after the validity window data
+        p = &cell.__chunk[packed_data.size()];
+
+        // Pack zero data length (WT_CELL_VALUE always expects a data length)
+        ret = __wt_vpack_uint(&p, 0, 0);
+    }
+    if (ret != 0) {
+        throw std::runtime_error("Failed to pack zero data length");
+    }
+
+    // Unpack the cell
+    __wt_cell_unpack_kv(session, &dsk, &cell, &unpack);
+
+    return unpack.tw;
+}
+
+/*
+ * Compare two time windows for equality
+ */
+static void
+compare_time_windows(const WT_TIME_WINDOW &expected, const WT_TIME_WINDOW &actual)
+{
+    CHECK(expected.start_ts == actual.start_ts);
+    CHECK(expected.start_txn == actual.start_txn);
+    CHECK(expected.stop_ts == actual.stop_ts);
+    CHECK(expected.stop_txn == actual.stop_txn);
+    CHECK(expected.prepare == actual.prepare);
+    CHECK(expected.start_prepare_ts == actual.start_prepare_ts);
+    CHECK(expected.start_prepared_id == actual.start_prepared_id);
+    CHECK(expected.stop_prepare_ts == actual.stop_prepare_ts);
+    CHECK(expected.stop_prepared_id == actual.stop_prepared_id);
+}
+
+/*
+ * TEST CASES
+ */
+
+TEST_CASE("Cell Time Window: Empty time window", "[cell][time_window]")
+{
+    std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
+    WT_CONNECTION_IMPL *conn;
+    conn = S2C(session_mock->get_wt_session_impl());
+    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+
+    // Set up the btree structure that the cell unpacking code needs
+    session_mock->setup_block_manager_file_operations();
+    WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
+    btree->base_write_gen = 1; // Initialize to a reasonable value
+
+    WT_TIME_WINDOW tw;
+    WT_TIME_WINDOW_INIT(&tw);
+
+    // Empty time window should pack to minimal size
+    auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
+    CHECK(packed.size() == 1); // Just the increment for empty window
+}
+
+TEST_CASE("Cell Time Window: Start prepared only", "[cell][time_window]")
+{
+    std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
+    WT_CONNECTION_IMPL *conn;
+    conn = S2C(session_mock->get_wt_session_impl());
+    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+
+    // Set up the btree structure that the cell unpacking code needs
+    session_mock->setup_block_manager_file_operations();
+    WT_BTREE *btree = S2BT(session_mock->get_wt_session_impl());
+    btree->base_write_gen = 1; // Initialize to a reasonable value
+
+    SECTION("Basic start prepared")
+    {
+        auto tw = create_test_time_window(0, // start_ts
+          10,                                // start_txn
+          WT_TS_MAX,                         // stop_ts
+          WT_TXN_MAX,                        // stop_txn
+          true,                              // has_start_prepare
+          false,                             // has_stop_prepare
+          100,                               // start_prepare_ts
+          1                                  // start_prepared_id
+        );
+
+        auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
+        auto unpacked = unpack_time_window(session_mock->get_wt_session_impl(), packed);
+
+        compare_time_windows(tw, unpacked);
+    }
+}
+
+TEST_CASE("Cell Time Window: Stop prepared only", "[cell][time_window]")
+{
+    std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
+    WT_CONNECTION_IMPL *conn;
+    conn = S2C(session_mock->get_wt_session_impl());
+    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+
+    // Set up the btree structure that the cell unpacking code needs
+    session_mock->setup_block_manager_file_operations();
+    WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
+    btree->base_write_gen = 1; // Initialize to a reasonable value
+
+    SECTION("Basic stop prepared")
+    {
+        auto tw = create_test_time_window(50, // start_ts
+          10,                                 // start_txn
+          WT_TS_MAX,                          // stop_ts
+          20,                                 // stop_txn
+          false,                              // has_start_prepare
+          true,                               // has_stop_prepare
+          0,                                  // start_prepare_ts (unused)
+          0,                                  // start_prepared_id (unused)
+          200,                                // stop_prepare_ts
+          3                                   // stop_prepared_id
+        );
+
+        auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
+        auto unpacked = unpack_time_window(session_mock->get_wt_session_impl(), packed);
+
+        compare_time_windows(tw, unpacked);
+    }
+}
+
+TEST_CASE("Cell Time Window: Both start and stop prepared", "[cell][time_window]")
+{
+    std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
+    WT_CONNECTION_IMPL *conn;
+    conn = S2C(session_mock->get_wt_session_impl());
+    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+
+    // Set up the btree structure that the cell unpacking code needs
+    session_mock->setup_block_manager_file_operations();
+    WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
+    btree->base_write_gen = 1; // Initialize to a reasonable value
+
+    SECTION("Same transaction - both prepared")
+    {
+        auto tw = create_test_time_window(0, // start_ts
+          10,                                // start_txn
+          WT_TS_MAX,                         // stop_ts
+          10,                                // stop_txn (same as start)
+          true,                              // has_start_prepare
+          true,                              // has_stop_prepare
+          150,                               // start_prepare_ts
+          2,                                 // start_prepared_id
+          150,                               // stop_prepare_ts (same as start)
+          2                                  // stop_prepared_id (same as start)
+        );
+
+        auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
+        auto unpacked = unpack_time_window(session_mock->get_wt_session_impl(), packed);
+
+        compare_time_windows(tw, unpacked);
+    }
+
+    SECTION("Both start and stop are prepared - invalid time window")
+    {
+        auto tw = create_test_time_window(50, // start_ts
+          10,                                 // start_txn
+          100,                                // stop_ts
+          20,                                 // stop_txn (different from start)
+          true,                               // has_start_prepare
+          true,                               // has_stop_prepare
+          150,                                // start_prepare_ts
+          2,                                  // start_prepared_id
+          200,                                // stop_prepare_ts (different from start)
+          3                                   // stop_prepared_id (different from start)
+        );
+
+        CHECK(
+          __cell_check_value_validity(session_mock->get_wt_session_impl(), &tw, true) == WT_ERROR);
+    }
+}
+
+TEST_CASE("Cell Time Window: Regular (non-prepared) time window", "[cell][time_window]")
+{
+    std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
+    WT_CONNECTION_IMPL *conn;
+    conn = S2C(session_mock->get_wt_session_impl());
+    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+
+    // Set up the btree structure that the cell unpacking code needs
+    session_mock->setup_block_manager_file_operations();
+    WT_BTREE *btree = (WT_BTREE *)session_mock->get_wt_session_impl()->dhandle->handle;
+    btree->base_write_gen = 1; // Initialize to a reasonable value
+
+    auto tw = create_test_time_window(50, // start_ts
+      10,                                 // start_txn
+      100,                                // stop_ts
+      20,                                 // stop_txn
+      false,                              // has_start_prepare
+      false                               // has_stop_prepare
+    );
+
+    auto packed = pack_time_window(session_mock->get_wt_session_impl(), &tw);
+    auto unpacked = unpack_time_window(session_mock->get_wt_session_impl(), packed);
+
+    compare_time_windows(tw, unpacked);
+}

--- a/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
+++ b/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
@@ -151,7 +151,7 @@ TEST_CASE("Cell Time Window: Empty time window", "[cell][time_window]")
     std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
     WT_CONNECTION_IMPL *conn;
     conn = S2C(session_mock->get_wt_session_impl());
-    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+    F_SET(conn, WT_CONN_PRESERVE_PREPARED);
 
     /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
@@ -171,7 +171,7 @@ TEST_CASE("Cell Time Window: Start prepared only", "[cell][time_window]")
     std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
     WT_CONNECTION_IMPL *conn;
     conn = S2C(session_mock->get_wt_session_impl());
-    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+    F_SET(conn, WT_CONN_PRESERVE_PREPARED);
 
     /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
@@ -202,7 +202,7 @@ TEST_CASE("Cell Time Window: Stop prepared only", "[cell][time_window]")
     std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
     WT_CONNECTION_IMPL *conn;
     conn = S2C(session_mock->get_wt_session_impl());
-    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+    F_SET(conn, WT_CONN_PRESERVE_PREPARED);
 
     /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
@@ -235,7 +235,7 @@ TEST_CASE("Cell Time Window: Both start and stop prepared", "[cell][time_window]
     std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
     WT_CONNECTION_IMPL *conn;
     conn = S2C(session_mock->get_wt_session_impl());
-    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+    F_SET(conn, WT_CONN_PRESERVE_PREPARED);
 
     /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();
@@ -268,7 +268,7 @@ TEST_CASE("Cell Time Window: Regular (non-prepared) time window", "[cell][time_w
     std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
     WT_CONNECTION_IMPL *conn;
     conn = S2C(session_mock->get_wt_session_impl());
-    F_SET_ATOMIC_32(conn, WT_CONN_PRESERVE_PREPARED);
+    F_SET(conn, WT_CONN_PRESERVE_PREPARED);
 
     /* Set up the btree structure that the cell unpacking code needs */
     session_mock->setup_block_manager_file_operations();

--- a/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
+++ b/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
@@ -146,10 +146,6 @@ compare_time_windows(const WT_TIME_WINDOW &expected, const WT_TIME_WINDOW &actua
     CHECK(expected.stop_prepared_id == actual.stop_prepared_id);
 }
 
-/*
- * TEST CASES
- */
-
 TEST_CASE("Cell Time Window: Empty time window", "[cell][time_window]")
 {
     std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();


### PR DESCRIPTION
- Split single prepare_ts/id into start_prepare_ts/id and stop_prepare_ts/id
- Update cell packing/unpacking logic to handle separate prepared information
- Update time window validation to handle new prepared information structure
