### PR TITLE
WT-14956 Skip test_rollback01 for disagg

### DIFF
--- a/test/suite/test_rollback01.py
+++ b/test/suite/test_rollback01.py
@@ -30,6 +30,7 @@ import time, wiredtiger, wttest
 class test_rollback(wttest.WiredTigerTestCase):
     uri = "table:test_rollback.wt"
 
+    @wttest.skip_for_hook("disagg", "disagg requires an additional condition to evict pages")
     def test_wt_rollback_cursor_next_no_retry(self):
         """
         Try to insert a key value pair while the cache is full, and verify cursor->next() calls


### PR DESCRIPTION
The `test_rollback01` test started to fail under the new `--hook disagg="(role=leader)"` mode after the recent disaggregated storage merges. It turns out disagg requires an additional condition to be met (i.e. page being materialised & available in the Page serice) for page eviction, which cannot be simulated easily with the current test setup. 

This PR skips the `test_rollback01` for disagg testing hook. 