### PR TITLE
WT-14997 Disable layered tables on truncate tests

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -153,6 +153,7 @@ test_timestamp10.py
 test_timestamp12.py
 test_timestamp20.py
 test_timestamp26.py
+test_truncate02.py
 test_truncate05.py
 test_truncate11.py
 test_truncate12.py

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -153,7 +153,6 @@ test_timestamp10.py
 test_timestamp12.py
 test_timestamp20.py
 test_timestamp26.py
-test_truncate02.py
 test_truncate05.py
 test_truncate11.py
 test_truncate12.py

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -63,6 +63,7 @@ class test_truncate_arguments(test_truncate_base):
     scenarios = make_scenarios(test_truncate_base.disagg_storages, [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
+        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
         # ('layered', dict(type='layered:'))
     ])
 
@@ -107,6 +108,7 @@ class test_truncate_uri(test_truncate_base):
     scenarios = make_scenarios(test_truncate_base.disagg_storages, [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
+        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
         # ('layered', dict(type='layered:'))
     ])
 
@@ -175,6 +177,7 @@ class test_truncate_cursor_end(test_truncate_base):
     types = [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
+        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
         # ('layered', dict(type='layered:'))
     ]
     keyfmt = [
@@ -225,6 +228,7 @@ class test_truncate_empty(test_truncate_base):
     types = [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
+        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
         # ('layered', dict(type='layered:'))
     ]
     keyfmt = [
@@ -265,6 +269,7 @@ class test_truncate_timestamp(test_truncate_base):
     scenarios = make_scenarios(test_truncate_base.disagg_storages, [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
+        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
         # ('layered', dict(type='layered:'))
     ])
 
@@ -308,6 +313,7 @@ class test_truncate_cursor(test_truncate_base):
             config='allocation_size=512,leaf_page_max=512', P=0.25)),
         ('table', dict(type='table:', valuefmt='S',
             config='allocation_size=512,leaf_page_max=512', P=0.5)),
+        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
         # ('layered', dict(type='layered:', valuefmt='S',
         #     config='allocation_size=512,leaf_page_max=512', P=0.25)),
     ]

--- a/test/suite/test_truncate02.py
+++ b/test/suite/test_truncate02.py
@@ -48,8 +48,10 @@ class test_truncate_fast_delete(test_truncate_base):
     types = [
         ('file', dict(type='file:', config=\
             'allocation_size=512,leaf_page_max=512')),
-        ('layered', dict(type='layered:', config=\
-            'allocation_size=512,leaf_page_max=512'))
+        # FIXME-WT-14998 Re-enable the layered table scenario once disaggregated storage works with truncate tests.
+        # Consider whether we need this scenario here if the scenario is already defined in the test truncate base test.
+        # ('layered', dict(type='layered:', config=\
+        #     'allocation_size=512,leaf_page_max=512'))
     ]
 
     # This is all about testing the btree layer, not the schema layer, test
@@ -114,11 +116,6 @@ class test_truncate_fast_delete(test_truncate_base):
 
     # Trigger fast delete and test cursor counts.
     def test_truncate_fast_delete(self):
-        # Make the test more reliable.
-        # FIXME-WT-14977 Remove this constraint once disaggregated storage can handle checkpoint id after restart.
-        if self.type == 'layered:' and (self.keyfmt == 'r' or wttest.islongtest()):
-            return
-
         uri = self.type + self.name
 
         '''


### PR DESCRIPTION
These scenarios were disabled as part of the big merge, but we missed creating a fix me ticket.