### PR TITLE
WT-14394 Enable connection level logging in test/model

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1494,8 +1494,19 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * view of the data, make sure that all the logs are flushed to disk before the checkpoint is
      * complete.
      */
-    if (F_ISSET(&conn->log_mgr, WT_LOG_ENABLED))
+    if (F_ISSET(&conn->log_mgr, WT_LOG_ENABLED)) {
+        /* Crash before metadata sync if checkpoint crash point is configured.
+
+         * FIXME-WT-15069: This is a temporary workaround to allow ckpt_crash_before_metadata_sync
+         * crash point with logging enabled. test/model currently expects crash points to result in
+         * only non-recoverable checkpoints. However, from WT perspective, a crash after the txn
+         * commits is still considered a valid recoverable checkpoint.
+         */
+        if (ckpt_crash_before_metadata_sync)
+            __wt_debug_crash(session);
+
         WT_ERR(__wt_log_flush(session, WT_LOG_FSYNC));
+    }
 
     /* Crash before metadata sync if checkpoint crash point is configured. */
     if (ckpt_crash_before_metadata_sync)

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1494,7 +1494,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * view of the data, make sure that all the logs are flushed to disk before the checkpoint is
      * complete.
      */
-    if (F_ISSET(&conn->log_mgr, WT_LOG_ENABLED)) {
+    if (logging) {
         /* FIXME-WT-15069: Remove this if condition as part of this FIXME. This is a temporary
          * workaround to allow ckpt_crash_before_metadata_sync crash point with logging enabled.
          * test/model currently expects crash points to result in only non-recoverable checkpoints.

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1495,13 +1495,13 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * complete.
      */
     if (F_ISSET(&conn->log_mgr, WT_LOG_ENABLED)) {
-        /* Crash before metadata sync if checkpoint crash point is configured.
-
-         * FIXME-WT-15069: This is a temporary workaround to allow ckpt_crash_before_metadata_sync
-         * crash point with logging enabled. test/model currently expects crash points to result in
-         * only non-recoverable checkpoints. However, from WT perspective, a crash after the txn
-         * commits is still considered a valid recoverable checkpoint.
+        /* FIXME-WT-15069: Remove this if condition as part of this FIXME. This is a temporary
+         * workaround to allow ckpt_crash_before_metadata_sync crash point with logging enabled.
+         * test/model currently expects crash points to result in only non-recoverable checkpoints.
+         * However, from WT perspective, a crash after flushing the logs here is still considered
+         * a valid recoverable checkpoint.
          */
+        /* Crash before metadata sync if checkpoint crash point is configured. */
         if (ckpt_crash_before_metadata_sync)
             __wt_debug_crash(session);
 

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -63,7 +63,7 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     /*
      * FIXME-WT-14395 - The last crash point in the checkpoint code (used by test/model's
      * checkpoint_crash) triggers after the checkpoint txn commits but before the turtle file is
-     * updated. This causes inconsistent behaviour when logging is enabled. For now checkpoint_crash
+     * updated. This causes inconsistent behavior when logging is enabled. For now checkpoint_crash
      * has been disabled. Once resolved, return checkpoint_crash probability value to 0.002.
      */
     checkpoint_crash = 0;

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -329,16 +329,15 @@ kv_workload_generator::choose_table(kv_workload_sequence_ptr txn)
 }
 
 /*
- * kv_workload_generator::generate_connection_config --
- *     Generate random WiredTiger connection configurations.
+ * kv_workload_generator::generate_connection_stress_config --
+ *     Generate random time stress configurations.
  */
 std::string
-kv_workload_generator::generate_connection_config()
+kv_workload_generator::generate_connection_stress_config()
 {
     std::string wt_env_config;
     probability_switch(_random.next_float())
     {
-        probability_case(_spec.conn_logging) wt_env_config += "log=(enabled=true)";
         probability_case(_spec.timing_stress_ckpt_slow) wt_env_config +=
           "timing_stress_for_test=[checkpoint_slow]";
         probability_case(_spec.timing_stress_ckpt_evict_page) wt_env_config +=
@@ -359,6 +358,21 @@ kv_workload_generator::generate_connection_config()
           "timing_stress_for_test=[prepare_checkpoint_delay]";
         probability_case(_spec.timing_stress_commit_txn_slow) wt_env_config +=
           "timing_stress_for_test=[commit_transaction_slow]";
+    }
+    return wt_env_config;
+}
+
+/*
+ * kv_workload_generator::generate_connection_log_config --
+ *     Generate random WiredTiger log configurations.
+ */
+std::string
+kv_workload_generator::generate_connection_log_config()
+{
+    std::string wt_env_config;
+    probability_switch(_random.next_float())
+    {
+        probability_case(_spec.conn_logging) wt_env_config += "log=(enabled=true)";
     }
     return wt_env_config;
 }

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -371,7 +371,7 @@ kv_workload_generator::generate_connection_log_config()
 {
     std::string wt_env_config;
 
-    if (_spec.conn_logging < _random.next_float())
+    if (_spec.conn_logging > _random.next_float())
         wt_env_config = model::join(wt_env_config, "log=(enabled=true)");
 
     return wt_env_config;

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -60,13 +60,7 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     truncate = 0.005;
 
     checkpoint = 0.02;
-    /*
-     * FIXME-WT-14395 - The last crash point in the checkpoint code (used by test/model's
-     * checkpoint_crash) triggers after the checkpoint txn commits but before the turtle file is
-     * updated. This causes inconsistent behavior when logging is enabled. For now checkpoint_crash
-     * has been disabled. Once resolved, return checkpoint_crash probability value to 0.002.
-     */
-    checkpoint_crash = 0;
+    checkpoint_crash = 0.002;
     crash = 0.002;
     evict = 0.1;
     restart = 0.002;

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -72,6 +72,8 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     remove_existing = 0.9;
     update_existing = 0.1;
 
+    conn_logging = 0.1;
+
     prepared_transaction = 0.25;
     max_delay_after_prepare = 25; /* FIXME-WT-13232 This must be a small number until it's fixed. */
     use_set_commit_timestamp = 0.25;
@@ -336,6 +338,7 @@ kv_workload_generator::generate_connection_config()
     std::string wt_env_config;
     probability_switch(_random.next_float())
     {
+        probability_case(_spec.conn_logging) wt_env_config += "log=(enabled=true)";
         probability_case(_spec.timing_stress_ckpt_slow) wt_env_config +=
           "timing_stress_for_test=[checkpoint_slow]";
         probability_case(_spec.timing_stress_ckpt_evict_page) wt_env_config +=

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -72,7 +72,7 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     remove_existing = 0.9;
     update_existing = 0.1;
 
-    conn_logging = 0.1;
+    conn_logging = 0.5;
 
     prepared_transaction = 0.25;
     max_delay_after_prepare = 25; /* FIXME-WT-13232 This must be a small number until it's fixed. */
@@ -370,10 +370,10 @@ std::string
 kv_workload_generator::generate_connection_log_config()
 {
     std::string wt_env_config;
-    probability_switch(_random.next_float())
-    {
-        probability_case(_spec.conn_logging) wt_env_config += "log=(enabled=true)";
-    }
+
+    if (_spec.conn_logging < _random.next_float())
+        wt_env_config = model::join(wt_env_config, "log=(enabled=true)");
+
     return wt_env_config;
 }
 

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -60,7 +60,13 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     truncate = 0.005;
 
     checkpoint = 0.02;
-    checkpoint_crash = 0.002;
+    /*
+     * FIXME-WT-14395 - The last crash point in the checkpoint code (used by test/model's
+     * checkpoint_crash) triggers after the checkpoint txn commits but before the turtle file is
+     * updated. This causes inconsistent behaviour when logging is enabled. For now checkpoint_crash
+     * has been disabled. Once resolved, return checkpoint_crash probability value to 0.002.
+     */
+    checkpoint_crash = 0;
     crash = 0.002;
     evict = 0.1;
     restart = 0.002;

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -69,6 +69,9 @@ struct kv_workload_generator_spec {
     /* The probability of allowing the use of "set commit timestamp" in a transaction. */
     float use_set_commit_timestamp;
 
+    /* The probabibility of running with connection level logging */
+    float conn_logging;
+
     /* Probabilities of operations within a transaction. */
     float finish_transaction; /* Commit, prepare, or rollback. */
     float get;

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -69,7 +69,7 @@ struct kv_workload_generator_spec {
     /* The probability of allowing the use of "set commit timestamp" in a transaction. */
     float use_set_commit_timestamp;
 
-    /* The probabibility of running with connection level logging */
+    /* The probability of running with connection level logging */
     float conn_logging;
 
     /* Probabilities of operations within a transaction. */

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -450,10 +450,17 @@ public:
     }
 
     static std::string
-    generate_configurations(uint64_t seed = 0)
+    generate_stress_configurations(uint64_t seed = 0)
     {
         kv_workload_generator generator(_default_spec, seed);
-        return generator.generate_connection_config();
+        return generator.generate_connection_stress_config();
+    }
+
+    static std::string
+    generate_log_configurations(uint64_t seed = 0)
+    {
+        kv_workload_generator generator(_default_spec, seed);
+        return generator.generate_connection_log_config();
     }
 
 protected:
@@ -499,10 +506,16 @@ protected:
     void create_table();
 
     /*
-     * kv_workload_generator::generate_connection_config --
-     *     Generate random WiredTiger timing stress configurations.
+     * kv_workload_generator::generate_connection_stress_config --
+     *     Generate random time stress configurations.
      */
-    std::string generate_connection_config();
+    std::string generate_connection_stress_config();
+
+    /*
+     * kv_workload_generator::generate_connection_log_config --
+     *     Generate random WiredTiger log configurations.
+     */
+    std::string generate_connection_log_config();
 
     /*
      * kv_workload_generator::generate_key --

--- a/test/model/src/include/model/driver/kv_workload_runner_wt.h
+++ b/test/model/src/include/model/driver/kv_workload_runner_wt.h
@@ -46,7 +46,7 @@ class kv_workload_runner_wt {
 
 public:
     /* Base connection configuration applied to every connection. */
-    constexpr static const char *k_config_base = "create=true,log=(enabled=false)";
+    constexpr static const char *k_config_base = "create=true";
 
 protected:
     /*

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -292,6 +292,8 @@ update_spec(model::kv_workload_generator_spec &spec, std::string &conn_config,
         UPDATE_SPEC(remove_existing, float);
         UPDATE_SPEC(update_existing, float);
 
+        UPDATE_SPEC(conn_logging, float);
+
         UPDATE_SPEC(prepared_transaction, float);
         UPDATE_SPEC(max_delay_after_prepare, uint64);
         UPDATE_SPEC(nonprepared_transaction_rollback, float);

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -852,6 +852,9 @@ main(int argc, char *argv[])
         for (uint64_t iteration = 1;; iteration++) {
             uint64_t seed = next_seed;
             std::string wt_conn_config = conn_config;
+            wt_conn_config = model::join(
+              wt_conn_config, model::kv_workload_generator::generate_log_configurations(seed));
+
             next_seed = model::random::next_seed(next_seed);
 
             std::cout << "Iteration " << iteration << ", seed 0x" << std::hex << seed << std::dec
@@ -868,9 +871,10 @@ main(int argc, char *argv[])
 
             /* Generate random timing stress configurations and add it to the WiredTiger config. */
             if (generate_timing_stress_configurations) {
-                std::string rand_env_config;
-                rand_env_config = model::kv_workload_generator::generate_configurations(seed);
-                wt_conn_config = model::join(wt_conn_config, rand_env_config);
+                std::string rand_stress_config;
+                rand_stress_config =
+                  model::kv_workload_generator::generate_stress_configurations(seed);
+                wt_conn_config = model::join(wt_conn_config, rand_stress_config);
             }
 
             /* Add the connection and table configurations to the workload. */

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -871,8 +871,7 @@ main(int argc, char *argv[])
 
             /* Generate random timing stress configurations and add it to the WiredTiger config. */
             if (generate_timing_stress_configurations) {
-                std::string rand_stress_config;
-                rand_stress_config =
+                std::string rand_stress_config =
                   model::kv_workload_generator::generate_stress_configurations(seed);
                 wt_conn_config = model::join(wt_conn_config, rand_stress_config);
             }


### PR DESCRIPTION
Allow connection level logging in test/model with 50% probability.