### PR TITLE
WT-14932 Build Framework for Unique WT Verbose IDs

### DIFF
--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -143,6 +143,6 @@ __wt_checksum_with_seed
 __wt_conf_gets
 __wt_verbose_error
 __wt_verbose_level
-__wt_verbose_level_worker
+__wt_verbose_level_id
 __wt_verbose_level_multi
 wt_shared

--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -143,5 +143,6 @@ __wt_checksum_with_seed
 __wt_conf_gets
 __wt_verbose_error
 __wt_verbose_level
+__wt_verbose_level_worker
 __wt_verbose_level_multi
 wt_shared

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1272,7 +1272,7 @@ err:
 
     /* Time since the shutdown has started. */
     __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.shutdown_ms);
-    __wt_verbose_info(session, WT_VERB_RECOVERY_PROGRESS,
+    __wt_verbose_info_id(session, WT_VERB_RECOVERY_PROGRESS, 1493200,
       "shutdown was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the rollback to stable, and %" PRIu64 "ms for the checkpoint.",
       conn->shutdown_timeline.shutdown_ms, conn->shutdown_timeline.rts_ms,

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1272,7 +1272,7 @@ err:
 
     /* Time since the shutdown has started. */
     __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.shutdown_ms);
-    __wt_verbose_info_id(session, WT_VERB_RECOVERY_PROGRESS, 1493200,
+    __wt_verbose_info_id(session, 1493200, WT_VERB_RECOVERY_PROGRESS,
       "shutdown was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the rollback to stable, and %" PRIu64 "ms for the checkpoint.",
       conn->shutdown_timeline.shutdown_ms, conn->shutdown_timeline.rts_ms,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1789,6 +1789,9 @@ extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, 
 extern void __wt_verbose_worker(WT_SESSION_IMPL *session, WT_VERBOSE_CATEGORY category,
   WT_VERBOSE_LEVEL level, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 4, 5)))
   WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
+extern void __wt_verbose_worker_id(
+  WT_SESSION_IMPL *session, const WT_VERBOSE_MESSAGE_INFO *verb_info, const char *fmt, ...)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
 extern void __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l);
 extern void __wt_writeunlock(WT_SESSION_IMPL *session, WT_RWLOCK *l);
 extern void __wti_blkcache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size,

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -201,10 +201,10 @@ struct __wt_verbose_multi_category {
     __wt_verbose_level(session, category, WT_VERBOSE_INFO, fmt, __VA_ARGS__)
 
 /*
- * __wt_verbose_level_worker --
+ * __wt_verbose_level_id --
  *     Check for the verbosity level and invoke the worker with an id.
  */
-#define __wt_verbose_level_worker(session, log_id, verb_category, verb_level, fmt, ...)  \
+#define __wt_verbose_level_id(session, log_id, verb_category, verb_level, fmt, ...)      \
     do {                                                                                 \
         if (WT_VERBOSE_LEVEL_ISSET((session), verb_category, verb_level)) {              \
             WT_VERBOSE_MESSAGE_INFO verb_message_info = {                                \
@@ -215,11 +215,11 @@ struct __wt_verbose_multi_category {
 
 /*
  * __wt_verbose_info_id --
- *     Wrapper to __wt_verbose_level_worker defaulting the verbosity level to WT_VERBOSE_INFO with a
- *     log id.
+ *     Wrapper to __wt_verbose_level_id defaulting the verbosity level to WT_VERBOSE_INFO with a log
+ *     id.
  */
 #define __wt_verbose_info_id(session, log_id, category, fmt, ...) \
-    __wt_verbose_level_worker(session, log_id, category, WT_VERBOSE_INFO, fmt, __VA_ARGS__)
+    __wt_verbose_level_id(session, log_id, category, WT_VERBOSE_INFO, fmt, __VA_ARGS__)
 
 /*
  * __wt_verbose_debug1 --
@@ -257,20 +257,14 @@ struct __wt_verbose_multi_category {
  * __wt_verbose_level_multi_id --
  *     Refer to __wt_verbose_level_multi for details.
  */
-#define __wt_verbose_level_multi_id(session, log_id, multi_category, level, fmt, ...)             \
-    do {                                                                                          \
-        uint32_t __v_idx;                                                                         \
-        /*                                                                                        \
-         * multi_category can be a ternary expression that returns one of two structs. If we call \
-         * it 3 times in this macro then we're evaluating that ternary 3 times and could return a \
-         * different value on a second call. Save it into a local variable to make sure we're     \
-         * working with a constant value.                                                         \
-         */                                                                                       \
-        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                              \
-        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                            \
-            __wt_verbose_level_worker(                                                            \
-              session, log_id, __multi_category.categories[__v_idx], level, fmt, __VA_ARGS__);    \
-        }                                                                                         \
+#define __wt_verbose_level_multi_id(session, log_id, multi_category, level, fmt, ...)          \
+    do {                                                                                       \
+        uint32_t __v_idx;                                                                      \
+        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                           \
+        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                         \
+            __wt_verbose_level_id(                                                             \
+              session, log_id, __multi_category.categories[__v_idx], level, fmt, __VA_ARGS__); \
+        }                                                                                      \
     } while (0)
 
 /*

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -7,6 +7,14 @@
  */
 
 #pragma once
+/*
+ * Structure to bundle verbose message identification details.
+ */
+struct __wt_verbose_message_info {
+    uint32_t id;
+    WT_VERBOSE_CATEGORY category;
+    WT_VERBOSE_LEVEL level;
+};
 
 /* clang-format off */
 #define WT_VERBOSE_CATEGORY_STR_INIT \
@@ -64,6 +72,8 @@
     /* AUTOMATIC VERBOSE ENUM STRING GENERATION STOP */ \
     }
 /* clang-format on */
+
+#define WT_DEFAULT_LOG_ID 1000000 /* Default log ID 1000000 for verbose messages */
 
 /* Convert a verbose level to its string representation. */
 #define WT_VERBOSE_LEVEL_STR(level, level_str) \
@@ -191,6 +201,27 @@ struct __wt_verbose_multi_category {
     __wt_verbose_level(session, category, WT_VERBOSE_INFO, fmt, __VA_ARGS__)
 
 /*
+ * __wt_verbose_level_worker --
+ *     Check for the verbosity level and invoke the worker with an id.
+ */
+#define __wt_verbose_level_worker(session, verb_category, verb_level, log_id, fmt, ...)  \
+    do {                                                                                 \
+        if (WT_VERBOSE_LEVEL_ISSET((session), verb_category, verb_level)) {              \
+            WT_VERBOSE_MESSAGE_INFO verb_message_info = {                                \
+              .id = log_id, .category = verb_category, .level = verb_level};             \
+            __wt_verbose_worker_id((session), (&verb_message_info), (fmt), __VA_ARGS__); \
+        }                                                                                \
+    } while (0)
+
+/*
+ * __wt_verbose_info_id --
+ *     Wrapper to __wt_verbose_info_id defaulting the verbosity level to WT_VERBOSE_INFO with a log
+ *     id.
+ */
+#define __wt_verbose_info_id(session, category, log_id, fmt, ...) \
+    __wt_verbose_level_worker(session, category, WT_VERBOSE_INFO, log_id, fmt, __VA_ARGS__)
+
+/*
  * __wt_verbose_debug1 --
  *     Wrapper to __wt_verbose_level using the default (DEBUG_1) verbosity level.
  */
@@ -221,6 +252,26 @@ struct __wt_verbose_multi_category {
  */
 #define __wt_verbose(session, category, fmt, ...) \
     __wt_verbose_level(session, category, WT_VERBOSE_LEVEL_DEFAULT, fmt, __VA_ARGS__)
+
+/*
+ * __wt_verbose_level_multi_id --
+ *     Refer to __wt_verbose_level_multi for details.
+ */
+#define __wt_verbose_level_multi_id(session, multi_category, level, log_id, fmt, ...)             \
+    do {                                                                                          \
+        uint32_t __v_idx;                                                                         \
+        /*                                                                                        \
+         * multi_category can be a ternary expression that returns one of two structs. If we call \
+         * it 3 times in this macro then we're evaluating that ternary 3 times and could return a \
+         * different value on a second call. Save it into a local variable to make sure we're     \
+         * working with a constant value.                                                         \
+         */                                                                                       \
+        WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                              \
+        for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                            \
+            __wt_verbose_level_worker(                                                            \
+              session, __multi_category.categories[__v_idx], level, log_id, fmt, __VA_ARGS__);    \
+        }                                                                                         \
+    } while (0)
 
 /*
  * __wt_verbose_level_multi --

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -215,7 +215,7 @@ struct __wt_verbose_multi_category {
 
 /*
  * __wt_verbose_info_id --
- *     Wrapper to __wt_verbose_info_id defaulting the verbosity level to WT_VERBOSE_INFO with a log
+ *     Wrapper to __wt_verbose_level_worker defaulting the verbosity level to WT_VERBOSE_INFO with a log
  *     id.
  */
 #define __wt_verbose_info_id(session, category, log_id, fmt, ...) \

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -204,7 +204,7 @@ struct __wt_verbose_multi_category {
  * __wt_verbose_level_worker --
  *     Check for the verbosity level and invoke the worker with an id.
  */
-#define __wt_verbose_level_worker(session, verb_category, verb_level, log_id, fmt, ...)  \
+#define __wt_verbose_level_worker(session, log_id, verb_category, verb_level, fmt, ...)  \
     do {                                                                                 \
         if (WT_VERBOSE_LEVEL_ISSET((session), verb_category, verb_level)) {              \
             WT_VERBOSE_MESSAGE_INFO verb_message_info = {                                \
@@ -215,11 +215,11 @@ struct __wt_verbose_multi_category {
 
 /*
  * __wt_verbose_info_id --
- *     Wrapper to __wt_verbose_level_worker defaulting the verbosity level to WT_VERBOSE_INFO with a log
- *     id.
+ *     Wrapper to __wt_verbose_level_worker defaulting the verbosity level to WT_VERBOSE_INFO with a
+ *     log id.
  */
-#define __wt_verbose_info_id(session, category, log_id, fmt, ...) \
-    __wt_verbose_level_worker(session, category, WT_VERBOSE_INFO, log_id, fmt, __VA_ARGS__)
+#define __wt_verbose_info_id(session, log_id, category, fmt, ...) \
+    __wt_verbose_level_worker(session, log_id, category, WT_VERBOSE_INFO, fmt, __VA_ARGS__)
 
 /*
  * __wt_verbose_debug1 --
@@ -257,7 +257,7 @@ struct __wt_verbose_multi_category {
  * __wt_verbose_level_multi_id --
  *     Refer to __wt_verbose_level_multi for details.
  */
-#define __wt_verbose_level_multi_id(session, multi_category, level, log_id, fmt, ...)             \
+#define __wt_verbose_level_multi_id(session, log_id, multi_category, level, fmt, ...)             \
     do {                                                                                          \
         uint32_t __v_idx;                                                                         \
         /*                                                                                        \
@@ -269,7 +269,7 @@ struct __wt_verbose_multi_category {
         WT_VERBOSE_MULTI_CATEGORY __multi_category = multi_category;                              \
         for (__v_idx = 0; __v_idx < __multi_category.cnt; __v_idx++) {                            \
             __wt_verbose_level_worker(                                                            \
-              session, __multi_category.categories[__v_idx], level, log_id, fmt, __VA_ARGS__);    \
+              session, log_id, __multi_category.categories[__v_idx], level, fmt, __VA_ARGS__);    \
         }                                                                                         \
     } while (0)
 

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -445,6 +445,8 @@ struct __wt_update_vector;
 typedef struct __wt_update_vector WT_UPDATE_VECTOR;
 struct __wt_verbose_dump_cookie;
 typedef struct __wt_verbose_dump_cookie WT_VERBOSE_DUMP_COOKIE;
+struct __wt_verbose_message_info;
+typedef struct __wt_verbose_message_info WT_VERBOSE_MESSAGE_INFO;
 struct __wt_verbose_multi_category;
 typedef struct __wt_verbose_multi_category WT_VERBOSE_MULTI_CATEGORY;
 struct __wt_verify_info;

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1272,7 +1272,7 @@ done:
 
     /* Time since the recovery has started. */
     __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.recovery_ms);
-    __wt_verbose_level_multi(session, WT_VERB_RECOVERY_ALL, WT_VERBOSE_INFO,
+    __wt_verbose_level_multi_id(session, WT_VERB_RECOVERY_ALL, 1493201, WT_VERBOSE_INFO,
       "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64
       "ms for the checkpoint.",

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1272,7 +1272,7 @@ done:
 
     /* Time since the recovery has started. */
     __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.recovery_ms);
-    __wt_verbose_level_multi_id(session, WT_VERB_RECOVERY_ALL, WT_VERBOSE_INFO, 1493201,
+    __wt_verbose_level_multi_id(session, 1493201, WT_VERB_RECOVERY_ALL, WT_VERBOSE_INFO,
       "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64
       "ms for the checkpoint.",

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1272,7 +1272,7 @@ done:
 
     /* Time since the recovery has started. */
     __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.recovery_ms);
-    __wt_verbose_level_multi_id(session, WT_VERB_RECOVERY_ALL, 1493201, WT_VERBOSE_INFO,
+    __wt_verbose_level_multi_id(session, WT_VERB_RECOVERY_ALL, WT_VERBOSE_INFO, 1493201,
       "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64
       "ms for the checkpoint.",

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -43,6 +43,7 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
     expected_json_schema = {
         'category': {'type': str, 'always_expected': True },
         'category_id': {'type': int, 'always_expected': True },
+        'log_id': {'type': int, 'always_expected': True },
         'error_str': {'type': str, 'always_expected': False },
         'error_code': {'type': int, 'always_expected': False },
         'msg': {'type': str, 'always_expected': True },


### PR DESCRIPTION
This pull request introduces a system for adding unique, structured IDs to WiredTiger verbose log messages, enhancing log readability, searchability, and analysis.

Why this change?
Currently, verbose log messages lack unique identifiers, making it challenging to programmatically track specific log events across different log files, especially during debugging. This change addresses that by:

Improving Traceability: Unique IDs allow for easier identification and correlation of specific log events.
Facilitating Automation: Tools can more reliably parse and filter logs based on these consistent identifiers.
Streamlining Debugging: Quicker pinpointing of relevant messages during issue investigation.
How it works
Adopt Server's Approach of using the Jira ticket number followed by 2-digit number.

Introduced a new struct __wt_verbose_message_info to bundle message ID, category, and level.
Added __wt_verbose_worker_id and __wt_verbose_info_id macros/functions to allow log messages to include a unique ID.
Updated the __eventv function to accept and process the new unique ID, including its inclusion in JSON output.
Updated an existing verbose message in src/conn/conn_api.c and src/txn/txn_recover.c to use the new __wt_verbose_info_id/__wt_verbose_level_multi_id with a unique ID.