### PR TITLE
WT-14609 Revert block cache compression calculation

### DIFF
--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -615,6 +615,24 @@ err:
 }
 
 /*
+ * __size_worth_compressing --
+ *     Whether it's likely to be worth the CPU cost of compressing a page with a given
+ *     pre-compression size.
+ *
+ * This works differently for disaggregated storage since we're writing to network-backed storage.
+ *     The network message itself doesn't have a notion of a minimum allocation size, and at the
+ *     same time compression is extra-valuable due to the added bandwidth constraint.
+ */
+static bool
+__size_worth_compressing(WT_BTREE *btree, size_t sz)
+{
+    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+        return (sz > 2 * WT_BLOCK_COMPRESS_SKIP);
+
+    return (sz > btree->allocsize);
+}
+
+/*
  * __wt_blkcache_write --
  *     Write a buffer into a block, returning the block's address cookie.
  */
@@ -657,9 +675,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
      */
     if (btree->compressor == NULL || btree->compressor->compress == NULL || compressed)
         ip = buf;
-    else if (buf->size < 2 * WT_BLOCK_COMPRESS_SKIP) {
-        /* FIXME-WT-14609: the heuristic in the condition above was added for deltas and is likely
-         * to need tweaking. */
+    else if (!__size_worth_compressing(btree, buf->size)) {
         ip = buf;
         WT_STAT_DSRC_INCR(session, compress_write_too_small);
     } else {
@@ -700,7 +716,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
          * output requires), it just means the uncompressed version is as good as it gets, and
          * that's what we use.
          */
-        if (compression_failed || buf->size < 2 * WT_BLOCK_COMPRESS_SKIP) {
+        if (compression_failed || !__size_worth_compressing(btree, buf->size)) {
             /* FIXME-WT-14609: the heuristic in the condition above was added for deltas and is
              * likely to need tweaking. */
             ip = buf;

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -615,24 +615,6 @@ err:
 }
 
 /*
- * __size_worth_compressing --
- *     Whether it's likely to be worth the CPU cost of compressing a page with a given
- *     pre-compression size.
- *
- * This works differently for disaggregated storage since we're writing to network-backed storage.
- *     The network message itself doesn't have a notion of a minimum allocation size, and at the
- *     same time compression is extra-valuable due to the added bandwidth constraint.
- */
-static bool
-__size_worth_compressing(WT_BTREE *btree, size_t sz)
-{
-    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-        return (sz > 2 * WT_BLOCK_COMPRESS_SKIP);
-
-    return (sz > btree->allocsize);
-}
-
-/*
  * __wt_blkcache_write --
  *     Write a buffer into a block, returning the block's address cookie.
  */
@@ -675,7 +657,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
      */
     if (btree->compressor == NULL || btree->compressor->compress == NULL || compressed)
         ip = buf;
-    else if (!__size_worth_compressing(btree, buf->size)) {
+    else if (buf->size <= btree->allocsize) {
         ip = buf;
         WT_STAT_DSRC_INCR(session, compress_write_too_small);
     } else {
@@ -716,9 +698,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
          * output requires), it just means the uncompressed version is as good as it gets, and
          * that's what we use.
          */
-        if (compression_failed || !__size_worth_compressing(btree, buf->size)) {
-            /* FIXME-WT-14609: the heuristic in the condition above was added for deltas and is
-             * likely to need tweaking. */
+        if (compression_failed || buf->size / btree->allocsize <= result_len / btree->allocsize) {
             ip = buf;
             WT_STAT_DSRC_INCR(session, compress_write_fail);
         } else {


### PR DESCRIPTION
This was something of a known issue previously. Ideally we'd have something
a bit fancier that knows how to apply a different heuristic based on whether
we can generate deltas (i.e. in disagg), but since the release process is
kicking off again, this is technically a release blocker. So just do the
simple thing and revert this code to its pre-disagg state.

This doesn't warrant a `FIXME`, since it's not technically broken -- it's
just much less likely to compress a delta now (since they're small). I've
made WT-15032 to cover this.

It also doesn't break any of our tests -- I was sure we had something for
this, but I might be thinking of the server's delta testing code that has a
compression scenario.