### PR TITLE
WT-15028 Configure hook disagg python file to create layered tables through table: prefix

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2201,7 +2201,7 @@ tasks:
           unit_test_parallel_ignore: test/suite/hook_disagg.fail
           # The timeout for this command is on a test file basis. Make the timeouts long,
           # as there are a few files that contain a large number of slower tests.
-          unit_test_parallel_args: -v 2 --timeout 1800 --hook "disagg=(role=leader,table_type=table)"
+          unit_test_parallel_args: -v 2 --timeout 1800 --hook "disagg=(role=leader,table_prefix=table)"
 
   - name: unit-test-hook-disagg-follower
     tags: ["python"]
@@ -2223,7 +2223,7 @@ tasks:
       - func: "unit test"
         vars:
           # As follower, run a minimal functionality test
-          unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower,table_type=table)" base01
+          unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower,table_prefix=table)" base01
 
   - name: unit-test-hook-timing-stress-log
     tags: ["python"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2189,6 +2189,20 @@ tasks:
           # as there are a few files that contain a large number of slower tests.
           unit_test_parallel_args: -v 2 --timeout 1800 --hook "disagg=(role=leader)"
 
+  - name: unit-test-hook-disagg-leader-table
+    tags: ["pull_request", "python"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test parallel"
+        vars:
+          # As leader, run the set of tests that are not in the fail list.
+          unit_test_parallel_ignore: test/suite/hook_disagg.fail
+          # The timeout for this command is on a test file basis. Make the timeouts long,
+          # as there are a few files that contain a large number of slower tests.
+          unit_test_parallel_args: -v 2 --timeout 1800 --hook "disagg=(role=leader,table_type=table)"
+
   - name: unit-test-hook-disagg-follower
     tags: ["python"]
     depends_on:
@@ -2199,6 +2213,17 @@ tasks:
         vars:
           # As follower, run a minimal functionality test
           unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower)" base01
+
+  - name: unit-test-hook-disagg-follower-table
+    tags: ["pull_request", "python"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          # As follower, run a minimal functionality test
+          unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower,table_type=table)" base01
 
   - name: unit-test-hook-timing-stress-log
     tags: ["python"]

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -175,11 +175,13 @@ def is_layered(uri):
 
 # If the uri has been marked as layered, then transform to a layered uri
 def replace_uri(uri):
+    testcase = WiredTigerTestCase.currentTestCase()
+    disagg_parameters = testcase.platform_api.getDisaggParameters()
     # Handle statistics: or statistics:<uri>
     stat_prefix = 'statistics:'
     if uri.startswith(stat_prefix):
         return 'statistics:' + replace_uri(uri[len(stat_prefix):])
-    if is_layered(uri):
+    if is_layered(uri) and disagg_parameters.table_type != "layered":
         return uri.replace("table:", "layered:")
     else:
         return uri
@@ -208,7 +210,8 @@ def session_compact_replace(orig_session_compact, session_self, uri, config):
 
 # Called to replace Session.create
 def session_create_replace(orig_session_create, session_self, uri, config):
-    new_uri = uri
+    testcase = WiredTigerTestCase.currentTestCase()
+    disagg_parameters = testcase.platform_api.getDisaggParameters()
 
     # If the test isn't creating a table (i.e., it's a column store or lsm) create it as a
     # regular (not layered) object.  Otherwise we get disagg storage from the connection defaults.
@@ -219,9 +222,14 @@ def session_create_replace(orig_session_create, session_self, uri, config):
        and not 'type=lsm' in config \
        and not marked_as_non_layered(uri):
         mark_as_layered(uri)
-        WiredTigerTestCase.verbose(None, 1, f'    Replacing, old uri = "{uri}"')
-        uri = replace_uri(uri)
-        WiredTigerTestCase.verbose(None, 1, f'    Replacing, new uri = "{uri}"')
+        if (disagg_parameters.table_type == "layered"):
+            WiredTigerTestCase.verbose(None, 1, f'    Replacing, old uri = "{uri}"')
+            uri = replace_uri(uri)
+            WiredTigerTestCase.verbose(None, 1, f'    Replacing, new uri = "{uri}"')
+        else:
+            WiredTigerTestCase.verbose(None, 1, f'    Replacing, old config = "\{config}"')
+            config += ',block_manager=disagg,type=layered'
+            WiredTigerTestCase.verbose(None, 1, f'    Replacing, new config = "\{config}"')
 
     # If this is an index create and the main table was already tagged to be layered,
     # there's nothing we can do to "fix" it.  Currently "index:foo" is hardwired to
@@ -392,6 +400,7 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
         self.disagg_config = ''
         self.disagg_page_log = 'palm'
         self.disagg_role = 'leader'
+        self.table_type = 'layered'
 
         for param_key, param_value in params:
             if param_key == 'config':
@@ -400,6 +409,8 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
                 self.disagg_page_log = param_value
             elif param_key == 'role':
                 self.disagg_role = param_value
+            elif param_key == 'table_type':
+                self.table_type = param_value
             else:
                 raise Exception('hook_disagg: unknown parameter {}'.format(param_key))
 
@@ -438,6 +449,7 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
         result.config = self.disagg_config
         result.role = self.disagg_role
         result.page_log = self.disagg_page_log
+        result.table_type = self.table_type
         return result
 
 # Every hook file must have a top level initialize function,

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -181,7 +181,7 @@ def replace_uri(uri):
     stat_prefix = 'statistics:'
     if uri.startswith(stat_prefix):
         return 'statistics:' + replace_uri(uri[len(stat_prefix):])
-    if is_layered(uri) and disagg_parameters.table_type != "layered":
+    if is_layered(uri) and disagg_parameters.table_prefix != "layered":
         return uri.replace("table:", "layered:")
     else:
         return uri
@@ -222,7 +222,7 @@ def session_create_replace(orig_session_create, session_self, uri, config):
        and not 'type=lsm' in config \
        and not marked_as_non_layered(uri):
         mark_as_layered(uri)
-        if (disagg_parameters.table_type == "layered"):
+        if (disagg_parameters.table_prefix == "layered"):
             WiredTigerTestCase.verbose(None, 1, f'    Replacing, old uri = "{uri}"')
             uri = replace_uri(uri)
             WiredTigerTestCase.verbose(None, 1, f'    Replacing, new uri = "{uri}"')
@@ -400,7 +400,7 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
         self.disagg_config = ''
         self.disagg_page_log = 'palm'
         self.disagg_role = 'leader'
-        self.table_type = 'layered'
+        self.table_prefix = 'layered'
 
         for param_key, param_value in params:
             if param_key == 'config':
@@ -409,8 +409,8 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
                 self.disagg_page_log = param_value
             elif param_key == 'role':
                 self.disagg_role = param_value
-            elif param_key == 'table_type':
-                self.table_type = param_value
+            elif param_key == 'table_prefix':
+                self.table_prefix = param_value
             else:
                 raise Exception('hook_disagg: unknown parameter {}'.format(param_key))
 
@@ -449,7 +449,7 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
         result.config = self.disagg_config
         result.role = self.disagg_role
         result.page_log = self.disagg_page_log
-        result.table_type = self.table_type
+        result.table_prefix = self.table_prefix
         return result
 
 # Every hook file must have a top level initialize function,


### PR DESCRIPTION
This pull request adds another method test the creation layered tables through `config block_manager=disagg,type=layered` and added it to the hook_disagg.py