### PR TITLE
WT-14657 Track stats for oldest id rollback due to cache stuck (v8.0 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -755,6 +755,7 @@ conn_stats = [
     TxnStat('txn_prepared_updates_rolledback', 'Number of prepared updates rolled back'),
     TxnStat('txn_query_ts', 'query timestamp calls'),
     TxnStat('txn_rollback', 'transactions rolled back'),
+    TxnStat('txn_rollback_oldest_id', 'oldest transaction ID rolled back for eviction'),
     TxnStat('txn_rollback_oldest_pinned', 'oldest pinned transaction ID rolled back for eviction'),
     TxnStat('txn_rollback_to_stable_running', 'transaction rollback to stable currently running', 'no_clear,no_scale'),
     TxnStat('txn_rts', 'rollback to stable calls'),

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2521,7 +2521,8 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly)
         if (!F_ISSET(conn, WT_CONN_RECOVERING) && __wt_cache_stuck(session)) {
             ret = __wt_txn_is_blocking(session);
             if (ret == WT_ROLLBACK) {
-                __wt_atomic_decrement_if_positive(&evict->evict_aggressive_score);
+                __wt_atomic_decrement_if_positive(&cache->evict_aggressive_score);
+
                 if (F_ISSET(session, WT_SESSION_SAVE_ERRORS))
                     __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
                       session->err_info.err_msg);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2523,9 +2523,8 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly)
             if (ret == WT_ROLLBACK) {
                 __wt_atomic_decrement_if_positive(&cache->evict_aggressive_score);
 
-                if (F_ISSET(session, WT_SESSION_SAVE_ERRORS))
-                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
-                      session->err_info.err_msg);
+                __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
+                  session->txn->rollback_reason);
             }
             WT_ERR(ret);
         }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2521,11 +2521,10 @@ __wt_cache_eviction_worker(WT_SESSION_IMPL *session, bool busy, bool readonly)
         if (!F_ISSET(conn, WT_CONN_RECOVERING) && __wt_cache_stuck(session)) {
             ret = __wt_txn_is_blocking(session);
             if (ret == WT_ROLLBACK) {
-                __wt_atomic_decrement_if_positive(&cache->evict_aggressive_score);
-
-                WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
-                __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
-                  session->txn->rollback_reason);
+                __wt_atomic_decrement_if_positive(&evict->evict_aggressive_score);
+                if (F_ISSET(session, WT_SESSION_SAVE_ERRORS))
+                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "rollback reason: %s",
+                      session->err_info.err_msg);
             }
             WT_ERR(ret);
         }

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1017,6 +1017,7 @@ struct __wt_connection_stats {
     int64_t txn_read_race_prepare_commit;
     int64_t txn_read_overflow_remove;
     int64_t txn_rollback_oldest_pinned;
+    int64_t txn_rollback_oldest_id;
     int64_t txn_prepare;
     int64_t txn_prepare_commit;
     int64_t txn_prepare_active;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7098,144 +7098,146 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1650
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
 #define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1651
+/*! transaction: oldest transaction ID rolled back for eviction */
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1652
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1652
+#define	WT_STAT_CONN_TXN_PREPARE			1653
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1653
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1654
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1654
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1655
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1655
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1656
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1656
+#define	WT_STAT_CONN_TXN_QUERY_TS			1657
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1657
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1658
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1658
+#define	WT_STAT_CONN_TXN_RTS				1659
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1659
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1660
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1660
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1661
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1661
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1662
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1662
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1663
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1663
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1664
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1664
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1665
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1665
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1666
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1666
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1667
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1667
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1668
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1668
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1669
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1669
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1670
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1670
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1671
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1671
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1672
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1672
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1673
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1673
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1674
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1674
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1675
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1675
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1676
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1676
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1677
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1677
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1678
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1678
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1679
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1679
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1680
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1680
+#define	WT_STAT_CONN_TXN_SET_TS				1681
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1681
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1682
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1682
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1683
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1683
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1684
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1684
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1685
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1685
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1686
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1686
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1687
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1687
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1688
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1688
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1689
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1689
+#define	WT_STAT_CONN_TXN_BEGIN				1690
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1690
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1691
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1691
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1692
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1692
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1693
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1693
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1694
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1694
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1695
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1695
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1696
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1696
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1697
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1697
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1698
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1698
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1699
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1699
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1700
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1700
+#define	WT_STAT_CONN_TXN_COMMIT				1701
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1701
+#define	WT_STAT_CONN_TXN_ROLLBACK			1702
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1702
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1703
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2070,6 +2070,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: a reader raced with a prepared transaction commit and skipped an update or updates",
   "transaction: number of times overflow removed value is read",
   "transaction: oldest pinned transaction ID rolled back for eviction",
+  "transaction: oldest transaction ID rolled back for eviction",
   "transaction: prepared transactions",
   "transaction: prepared transactions committed",
   "transaction: prepared transactions currently active",
@@ -2819,6 +2820,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->txn_read_race_prepare_commit = 0;
     stats->txn_read_overflow_remove = 0;
     stats->txn_rollback_oldest_pinned = 0;
+    stats->txn_rollback_oldest_id = 0;
     stats->txn_prepare = 0;
     stats->txn_prepare_commit = 0;
     stats->txn_prepare_active = 0;
@@ -3606,35 +3608,41 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->thread_write_active += WT_STAT_READ(from, thread_write_active);
     to->application_cache_ops += WT_STAT_READ(from, application_cache_ops);
     to->application_evict_snapshot_refreshed +=
-      WT_STAT_READ(from, application_evict_snapshot_refreshed);
-    to->application_cache_time += WT_STAT_READ(from, application_cache_time);
-    to->txn_release_blocked += WT_STAT_READ(from, txn_release_blocked);
-    to->conn_close_blocked_lsm += WT_STAT_READ(from, conn_close_blocked_lsm);
-    to->dhandle_lock_blocked += WT_STAT_READ(from, dhandle_lock_blocked);
-    to->page_index_slot_ref_blocked += WT_STAT_READ(from, page_index_slot_ref_blocked);
-    to->prepared_transition_blocked_page += WT_STAT_READ(from, prepared_transition_blocked_page);
-    to->page_busy_blocked += WT_STAT_READ(from, page_busy_blocked);
-    to->page_forcible_evict_blocked += WT_STAT_READ(from, page_forcible_evict_blocked);
-    to->page_locked_blocked += WT_STAT_READ(from, page_locked_blocked);
-    to->page_read_blocked += WT_STAT_READ(from, page_read_blocked);
-    to->page_sleep += WT_STAT_READ(from, page_sleep);
-    to->page_del_rollback_blocked += WT_STAT_READ(from, page_del_rollback_blocked);
-    to->child_modify_blocked_page += WT_STAT_READ(from, child_modify_blocked_page);
-    to->txn_prepared_updates += WT_STAT_READ(from, txn_prepared_updates);
-    to->txn_prepared_updates_committed += WT_STAT_READ(from, txn_prepared_updates_committed);
-    to->txn_prepared_updates_key_repeated += WT_STAT_READ(from, txn_prepared_updates_key_repeated);
-    to->txn_prepared_updates_rolledback += WT_STAT_READ(from, txn_prepared_updates_rolledback);
-    to->txn_read_race_prepare_commit += WT_STAT_READ(from, txn_read_race_prepare_commit);
-    to->txn_read_overflow_remove += WT_STAT_READ(from, txn_read_overflow_remove);
-    to->txn_rollback_oldest_pinned += WT_STAT_READ(from, txn_rollback_oldest_pinned);
-    to->txn_prepare += WT_STAT_READ(from, txn_prepare);
-    to->txn_prepare_commit += WT_STAT_READ(from, txn_prepare_commit);
-    to->txn_prepare_active += WT_STAT_READ(from, txn_prepare_active);
-    to->txn_prepare_rollback += WT_STAT_READ(from, txn_prepare_rollback);
-    to->txn_query_ts += WT_STAT_READ(from, txn_query_ts);
-    to->txn_read_race_prepare_update += WT_STAT_READ(from, txn_read_race_prepare_update);
-    to->txn_rts += WT_STAT_READ(from, txn_rts);
-    to->txn_rts_sweep_hs_keys_dryrun += WT_STAT_READ(from, txn_rts_sweep_hs_keys_dryrun);
+      WT_STAT_CONN_READ(from, application_evict_snapshot_refreshed);
+    to->application_cache_time += WT_STAT_CONN_READ(from, application_cache_time);
+    to->application_cache_interruptible_time +=
+      WT_STAT_CONN_READ(from, application_cache_interruptible_time);
+    to->application_cache_uninterruptible_time +=
+      WT_STAT_CONN_READ(from, application_cache_uninterruptible_time);
+    to->txn_release_blocked += WT_STAT_CONN_READ(from, txn_release_blocked);
+    to->dhandle_lock_blocked += WT_STAT_CONN_READ(from, dhandle_lock_blocked);
+    to->page_index_slot_ref_blocked += WT_STAT_CONN_READ(from, page_index_slot_ref_blocked);
+    to->prepared_transition_blocked_page +=
+      WT_STAT_CONN_READ(from, prepared_transition_blocked_page);
+    to->page_busy_blocked += WT_STAT_CONN_READ(from, page_busy_blocked);
+    to->page_forcible_evict_blocked += WT_STAT_CONN_READ(from, page_forcible_evict_blocked);
+    to->page_locked_blocked += WT_STAT_CONN_READ(from, page_locked_blocked);
+    to->page_read_blocked += WT_STAT_CONN_READ(from, page_read_blocked);
+    to->page_sleep += WT_STAT_CONN_READ(from, page_sleep);
+    to->page_del_rollback_blocked += WT_STAT_CONN_READ(from, page_del_rollback_blocked);
+    to->child_modify_blocked_page += WT_STAT_CONN_READ(from, child_modify_blocked_page);
+    to->txn_prepared_updates += WT_STAT_CONN_READ(from, txn_prepared_updates);
+    to->txn_prepared_updates_committed += WT_STAT_CONN_READ(from, txn_prepared_updates_committed);
+    to->txn_prepared_updates_key_repeated +=
+      WT_STAT_CONN_READ(from, txn_prepared_updates_key_repeated);
+    to->txn_prepared_updates_rolledback += WT_STAT_CONN_READ(from, txn_prepared_updates_rolledback);
+    to->txn_read_race_prepare_commit += WT_STAT_CONN_READ(from, txn_read_race_prepare_commit);
+    to->txn_read_overflow_remove += WT_STAT_CONN_READ(from, txn_read_overflow_remove);
+    to->txn_rollback_oldest_pinned += WT_STAT_CONN_READ(from, txn_rollback_oldest_pinned);
+    to->txn_rollback_oldest_id += WT_STAT_CONN_READ(from, txn_rollback_oldest_id);
+    to->txn_prepare += WT_STAT_CONN_READ(from, txn_prepare);
+    to->txn_prepare_commit += WT_STAT_CONN_READ(from, txn_prepare_commit);
+    to->txn_prepare_active += WT_STAT_CONN_READ(from, txn_prepare_active);
+    to->txn_prepare_rollback += WT_STAT_CONN_READ(from, txn_prepare_rollback);
+    to->txn_query_ts += WT_STAT_CONN_READ(from, txn_query_ts);
+    to->txn_read_race_prepare_update += WT_STAT_CONN_READ(from, txn_read_race_prepare_update);
+    to->txn_rts += WT_STAT_CONN_READ(from, txn_rts);
+    to->txn_rts_sweep_hs_keys_dryrun += WT_STAT_CONN_READ(from, txn_rts_sweep_hs_keys_dryrun);
     to->txn_rts_hs_stop_older_than_newer_start +=
       WT_STAT_READ(from, txn_rts_hs_stop_older_than_newer_start);
     to->txn_rts_inconsistent_ckpt += WT_STAT_READ(from, txn_rts_inconsistent_ckpt);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -3608,41 +3608,36 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->thread_write_active += WT_STAT_READ(from, thread_write_active);
     to->application_cache_ops += WT_STAT_READ(from, application_cache_ops);
     to->application_evict_snapshot_refreshed +=
-      WT_STAT_CONN_READ(from, application_evict_snapshot_refreshed);
-    to->application_cache_time += WT_STAT_CONN_READ(from, application_cache_time);
-    to->application_cache_interruptible_time +=
-      WT_STAT_CONN_READ(from, application_cache_interruptible_time);
-    to->application_cache_uninterruptible_time +=
-      WT_STAT_CONN_READ(from, application_cache_uninterruptible_time);
-    to->txn_release_blocked += WT_STAT_CONN_READ(from, txn_release_blocked);
-    to->dhandle_lock_blocked += WT_STAT_CONN_READ(from, dhandle_lock_blocked);
-    to->page_index_slot_ref_blocked += WT_STAT_CONN_READ(from, page_index_slot_ref_blocked);
-    to->prepared_transition_blocked_page +=
-      WT_STAT_CONN_READ(from, prepared_transition_blocked_page);
-    to->page_busy_blocked += WT_STAT_CONN_READ(from, page_busy_blocked);
-    to->page_forcible_evict_blocked += WT_STAT_CONN_READ(from, page_forcible_evict_blocked);
-    to->page_locked_blocked += WT_STAT_CONN_READ(from, page_locked_blocked);
-    to->page_read_blocked += WT_STAT_CONN_READ(from, page_read_blocked);
-    to->page_sleep += WT_STAT_CONN_READ(from, page_sleep);
-    to->page_del_rollback_blocked += WT_STAT_CONN_READ(from, page_del_rollback_blocked);
-    to->child_modify_blocked_page += WT_STAT_CONN_READ(from, child_modify_blocked_page);
-    to->txn_prepared_updates += WT_STAT_CONN_READ(from, txn_prepared_updates);
-    to->txn_prepared_updates_committed += WT_STAT_CONN_READ(from, txn_prepared_updates_committed);
-    to->txn_prepared_updates_key_repeated +=
-      WT_STAT_CONN_READ(from, txn_prepared_updates_key_repeated);
-    to->txn_prepared_updates_rolledback += WT_STAT_CONN_READ(from, txn_prepared_updates_rolledback);
-    to->txn_read_race_prepare_commit += WT_STAT_CONN_READ(from, txn_read_race_prepare_commit);
-    to->txn_read_overflow_remove += WT_STAT_CONN_READ(from, txn_read_overflow_remove);
-    to->txn_rollback_oldest_pinned += WT_STAT_CONN_READ(from, txn_rollback_oldest_pinned);
-    to->txn_rollback_oldest_id += WT_STAT_CONN_READ(from, txn_rollback_oldest_id);
-    to->txn_prepare += WT_STAT_CONN_READ(from, txn_prepare);
-    to->txn_prepare_commit += WT_STAT_CONN_READ(from, txn_prepare_commit);
-    to->txn_prepare_active += WT_STAT_CONN_READ(from, txn_prepare_active);
-    to->txn_prepare_rollback += WT_STAT_CONN_READ(from, txn_prepare_rollback);
-    to->txn_query_ts += WT_STAT_CONN_READ(from, txn_query_ts);
-    to->txn_read_race_prepare_update += WT_STAT_CONN_READ(from, txn_read_race_prepare_update);
-    to->txn_rts += WT_STAT_CONN_READ(from, txn_rts);
-    to->txn_rts_sweep_hs_keys_dryrun += WT_STAT_CONN_READ(from, txn_rts_sweep_hs_keys_dryrun);
+      WT_STAT_READ(from, application_evict_snapshot_refreshed);
+    to->application_cache_time += WT_STAT_READ(from, application_cache_time);
+    to->txn_release_blocked += WT_STAT_READ(from, txn_release_blocked);
+    to->conn_close_blocked_lsm += WT_STAT_READ(from, conn_close_blocked_lsm);
+    to->dhandle_lock_blocked += WT_STAT_READ(from, dhandle_lock_blocked);
+    to->page_index_slot_ref_blocked += WT_STAT_READ(from, page_index_slot_ref_blocked);
+    to->prepared_transition_blocked_page += WT_STAT_READ(from, prepared_transition_blocked_page);
+    to->page_busy_blocked += WT_STAT_READ(from, page_busy_blocked);
+    to->page_forcible_evict_blocked += WT_STAT_READ(from, page_forcible_evict_blocked);
+    to->page_locked_blocked += WT_STAT_READ(from, page_locked_blocked);
+    to->page_read_blocked += WT_STAT_READ(from, page_read_blocked);
+    to->page_sleep += WT_STAT_READ(from, page_sleep);
+    to->page_del_rollback_blocked += WT_STAT_READ(from, page_del_rollback_blocked);
+    to->child_modify_blocked_page += WT_STAT_READ(from, child_modify_blocked_page);
+    to->txn_prepared_updates += WT_STAT_READ(from, txn_prepared_updates);
+    to->txn_prepared_updates_committed += WT_STAT_READ(from, txn_prepared_updates_committed);
+    to->txn_prepared_updates_key_repeated += WT_STAT_READ(from, txn_prepared_updates_key_repeated);
+    to->txn_prepared_updates_rolledback += WT_STAT_READ(from, txn_prepared_updates_rolledback);
+    to->txn_read_race_prepare_commit += WT_STAT_READ(from, txn_read_race_prepare_commit);
+    to->txn_read_overflow_remove += WT_STAT_READ(from, txn_read_overflow_remove);
+    to->txn_rollback_oldest_pinned += WT_STAT_READ(from, txn_rollback_oldest_pinned);
+    to->txn_rollback_oldest_id += WT_STAT_READ(from, txn_rollback_oldest_id);
+    to->txn_prepare += WT_STAT_READ(from, txn_prepare);
+    to->txn_prepare_commit += WT_STAT_READ(from, txn_prepare_commit);
+    to->txn_prepare_active += WT_STAT_READ(from, txn_prepare_active);
+    to->txn_prepare_rollback += WT_STAT_READ(from, txn_prepare_rollback);
+    to->txn_query_ts += WT_STAT_READ(from, txn_query_ts);
+    to->txn_read_race_prepare_update += WT_STAT_READ(from, txn_read_race_prepare_update);
+    to->txn_rts += WT_STAT_READ(from, txn_rts);
+    to->txn_rts_sweep_hs_keys_dryrun += WT_STAT_READ(from, txn_rts_sweep_hs_keys_dryrun);
     to->txn_rts_hs_stop_older_than_newer_start +=
       WT_STAT_READ(from, txn_rts_hs_stop_older_than_newer_start);
     to->txn_rts_inconsistent_ckpt += WT_STAT_READ(from, txn_rts_inconsistent_ckpt);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2781,10 +2781,17 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     /*
      * Check if either the transaction's ID or its pinned ID is equal to the oldest transaction ID.
      */
-    return (__wt_atomic_loadv64(&txn_shared->id) == global_oldest ||
-          __wt_atomic_loadv64(&txn_shared->pinned_id) == global_oldest ?
-        __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION) :
-        0);
+    bool is_txn_id_global_oldest;
+    if (((is_txn_id_global_oldest = __wt_atomic_loadv64(&txn_shared->id) == global_oldest)) ||
+      __wt_atomic_loadv64(&txn_shared->pinned_id) == global_oldest) {
+        if (is_txn_id_global_oldest)
+            WT_STAT_CONN_INCR(session, txn_rollback_oldest_id);
+        else
+            WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
+        WT_RET_SUB(
+          session, WT_ROLLBACK, WT_OLDEST_FOR_EVICTION, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
+    }
+    return (0);
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2748,6 +2748,7 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     uint64_t global_oldest;
+    bool is_txn_id_global_oldest;
 
     txn = session->txn;
     txn_shared = WT_SESSION_TXN_SHARED(session);
@@ -2781,14 +2782,13 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     /*
      * Check if either the transaction's ID or its pinned ID is equal to the oldest transaction ID.
      */
-    bool is_txn_id_global_oldest;
     if (((is_txn_id_global_oldest = __wt_atomic_loadv64(&txn_shared->id) == global_oldest)) ||
       __wt_atomic_loadv64(&txn_shared->pinned_id) == global_oldest) {
         if (is_txn_id_global_oldest)
             WT_STAT_CONN_INCR(session, txn_rollback_oldest_id);
         else
             WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
-        return __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
+        return (__wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION));
     }
     return (0);
 }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2788,8 +2788,7 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
             WT_STAT_CONN_INCR(session, txn_rollback_oldest_id);
         else
             WT_STAT_CONN_INCR(session, txn_rollback_oldest_pinned);
-        WT_RET_SUB(
-          session, WT_ROLLBACK, WT_OLDEST_FOR_EVICTION, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
+        return __wt_txn_rollback_required(session, WT_TXN_ROLLBACK_REASON_OLDEST_FOR_EVICTION);
     }
     return (0);
 }


### PR DESCRIPTION
This is [BACKPORT-25242](https://jira.mongodb.org/browse/BACKPORT-25242) that adds [WT-14657](https://jira.mongodb.org/browse/WT-14657) to mongodb 8.0