### PR TITLE
WT-15038 Track multiblock write stats at connection level

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1056,8 +1056,6 @@ dsrc_stats = [
     # Reconciliation statistics
     ##########################################
     RecStat('rec_dictionary', 'dictionary matches'),
-    RecStat('rec_multiblock_internal', 'internal page multi-block writes'),
-    RecStat('rec_multiblock_leaf', 'leaf page multi-block writes'),
     RecStat('rec_multiblock_max', 'maximum blocks required for a page', 'max_aggregate,no_scale'),
     RecStat('rec_prefix_compression', 'leaf page key bytes discarded using prefix compression', 'size'),
     RecStat('rec_suffix_compression', 'internal page key bytes discarded using suffix compression', 'size'),
@@ -1300,6 +1298,8 @@ conn_dsrc_stats = [
     RecStat('rec_ingest_garbage_collection_keys', 'number of keys that are garbage collected in the ingest table for disaggregated storage'),
     RecStat('rec_max_internal_page_deltas', 'max deltas seen on internal page during reconciliation'),
     RecStat('rec_max_leaf_page_deltas', 'max deltas seen on leaf page during reconciliation'),
+    RecStat('rec_multiblock_internal', 'internal page multi-block writes'),
+    RecStat('rec_multiblock_leaf', 'leaf page multi-block writes'),
     RecStat('rec_overflow_key_leaf', 'leaf-page overflow keys'),
     RecStat('rec_overflow_value', 'overflow values written'),
     RecStat('rec_page_delete', 'pages deleted'),

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1156,7 +1156,9 @@ struct __wt_connection_stats {
     int64_t rec_page_full_image_internal;
     int64_t rec_page_full_image_leaf;
     int64_t rec_page_delta_internal;
+    int64_t rec_multiblock_internal;
     int64_t rec_page_delta_leaf;
+    int64_t rec_multiblock_leaf;
     int64_t rec_overflow_key_leaf;
     int64_t rec_max_internal_page_deltas;
     int64_t rec_max_leaf_page_deltas;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -7772,450 +7772,454 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1737
 /*! reconciliation: internal page deltas written */
 #define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1738
+/*! reconciliation: internal page multi-block writes */
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1739
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1739
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1740
+/*! reconciliation: leaf page multi-block writes */
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1741
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1740
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1742
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1741
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1743
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1742
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1744
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1743
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1745
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1744
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1746
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1745
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1747
 /*!
  * reconciliation: number of keys that are garbage collected in the
  * ingest table for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS	1746
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS	1748
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1747
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1749
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1748
+#define	WT_STAT_CONN_REC_PAGES				1750
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1749
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1751
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1750
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1752
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1751
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1753
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1752
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1754
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1753
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1755
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1754
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1756
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1755
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1757
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1756
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1758
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1757
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1759
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1758
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1760
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1759
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1761
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1760
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1762
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1761
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1763
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1762
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1764
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1763
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1765
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1764
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1766
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1765
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1767
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1766
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1768
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1767
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1769
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1768
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1770
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1769
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1771
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1770
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1772
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1771
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1773
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1772
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1774
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1773
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1775
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1774
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1776
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1775
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1777
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1776
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1778
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1777
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1779
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1778
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1780
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1779
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1781
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1780
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1782
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1781
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1783
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1782
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1784
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1783
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1785
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1784
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1786
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1785
+#define	WT_STAT_CONN_FLUSH_TIER				1787
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1786
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1788
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1787
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1789
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1788
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1790
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1789
+#define	WT_STAT_CONN_SESSION_OPEN			1791
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1790
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1792
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1791
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1793
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1792
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1794
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1793
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1795
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1794
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1796
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1795
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1797
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1796
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1798
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1797
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1799
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1798
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1800
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1799
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1801
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1800
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1802
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1801
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1803
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1802
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1804
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1803
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1805
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1804
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1806
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1805
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1807
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1806
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1808
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1807
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1809
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1808
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1810
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1809
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1811
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1810
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1812
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1811
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1813
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1812
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1814
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1813
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1815
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1814
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1816
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1815
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1817
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1816
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1818
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1817
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1819
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1818
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1820
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1819
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1821
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1820
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1822
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1821
+#define	WT_STAT_CONN_TIERED_RETENTION			1823
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1822
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1824
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1823
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1825
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1824
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1826
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1825
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1827
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1826
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1828
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1827
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1829
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1828
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1830
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1829
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1831
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1830
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1832
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1831
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1833
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1832
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1834
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1833
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1835
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1834
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1836
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1835
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1837
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1836
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1838
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1837
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1839
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1838
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1840
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1839
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1841
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1840
+#define	WT_STAT_CONN_PAGE_SLEEP				1842
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1841
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1843
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1842
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1844
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1843
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1845
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1844
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1846
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1845
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1847
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1846
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1848
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1847
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1849
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1848
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1850
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1849
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1851
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1850
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1852
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1851
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1853
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1852
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1854
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1853
+#define	WT_STAT_CONN_TXN_PREPARE			1855
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1854
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1856
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1855
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1857
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1856
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1858
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1857
+#define	WT_STAT_CONN_TXN_QUERY_TS			1859
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1858
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1860
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1859
+#define	WT_STAT_CONN_TXN_RTS				1861
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1860
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1862
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1861
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1863
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1862
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1864
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1863
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1865
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1864
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1866
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1865
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1867
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1866
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1868
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1867
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1869
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1868
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1870
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1869
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1871
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1870
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1872
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1871
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1873
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1872
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1874
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1873
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1875
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1874
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1876
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1875
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1877
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1876
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1878
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1877
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1879
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1878
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1880
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1879
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1881
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1880
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1882
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1881
+#define	WT_STAT_CONN_TXN_SET_TS				1883
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1882
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1884
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1883
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1885
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1884
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1886
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1885
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1887
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1886
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1888
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1887
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1889
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1888
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1890
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1889
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1891
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1890
+#define	WT_STAT_CONN_TXN_BEGIN				1892
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1891
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1893
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1892
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1894
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1893
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1895
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1894
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1896
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1895
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1897
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1896
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1898
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1897
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1899
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1898
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1900
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1899
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1901
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1900
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1902
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1901
+#define	WT_STAT_CONN_TXN_COMMIT				1903
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1902
+#define	WT_STAT_CONN_TXN_ROLLBACK			1904
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1903
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1905
 
 /*!
  * @}

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3376,9 +3376,9 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         break;
     default: /* Page split */
         if (WT_PAGE_IS_INTERNAL(page))
-            WT_STAT_DSRC_INCR(session, rec_multiblock_internal);
+            WT_STAT_CONN_DSRC_INCR(session, rec_multiblock_internal);
         else
-            WT_STAT_DSRC_INCR(session, rec_multiblock_leaf);
+            WT_STAT_CONN_DSRC_INCR(session, rec_multiblock_leaf);
 
         /* Optionally display the actual split keys in verbose mode. */
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_SPLIT, WT_VERBOSE_DEBUG_2))

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2464,7 +2464,9 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: full internal pages written instead of a page delta",
   "reconciliation: full leaf pages written instead of a page delta",
   "reconciliation: internal page deltas written",
+  "reconciliation: internal page multi-block writes",
   "reconciliation: leaf page deltas written",
+  "reconciliation: leaf page multi-block writes",
   "reconciliation: leaf-page overflow keys",
   "reconciliation: max deltas seen on internal page during reconciliation",
   "reconciliation: max deltas seen on leaf page during reconciliation",
@@ -3417,7 +3419,9 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->rec_page_full_image_internal = 0;
     stats->rec_page_full_image_leaf = 0;
     stats->rec_page_delta_internal = 0;
+    stats->rec_multiblock_internal = 0;
     stats->rec_page_delta_leaf = 0;
+    stats->rec_multiblock_leaf = 0;
     stats->rec_overflow_key_leaf = 0;
     stats->rec_max_internal_page_deltas = 0;
     stats->rec_max_leaf_page_deltas = 0;
@@ -4524,7 +4528,9 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_page_full_image_internal += WT_STAT_CONN_READ(from, rec_page_full_image_internal);
     to->rec_page_full_image_leaf += WT_STAT_CONN_READ(from, rec_page_full_image_leaf);
     to->rec_page_delta_internal += WT_STAT_CONN_READ(from, rec_page_delta_internal);
+    to->rec_multiblock_internal += WT_STAT_CONN_READ(from, rec_multiblock_internal);
     to->rec_page_delta_leaf += WT_STAT_CONN_READ(from, rec_page_delta_leaf);
+    to->rec_multiblock_leaf += WT_STAT_CONN_READ(from, rec_multiblock_leaf);
     to->rec_overflow_key_leaf += WT_STAT_CONN_READ(from, rec_overflow_key_leaf);
     to->rec_max_internal_page_deltas += WT_STAT_CONN_READ(from, rec_max_internal_page_deltas);
     to->rec_max_leaf_page_deltas += WT_STAT_CONN_READ(from, rec_max_leaf_page_deltas);


### PR DESCRIPTION
Statistics for multi-block writes (i.e. pages WT splits when writing/reconciling) are only tracked as data source statistics. This would be useful to know connection wide. So we should make these connection and data source stats.

The statistics in question are:
* `rec_multiblock_internal`: internal page multi-block writes
* `rec_multiblock_leaf`: leaf page multi-block writes
