### PR TITLE
WT-14553 DisAgg verify testing - use right FIXME tiket

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -1753,7 +1753,7 @@ err:
         WT_STAT_CONN_INCR(session, session_table_verify_success);
 
     /*
-     * FIXME-WT-14553: Implement verify for disagg. For now we are skipping the expected ENOTSUP
+     * FIXME-WT-14908: Implement verify for disagg. For now we are skipping the expected ENOTSUP
      * error.
      */
     if (__wt_conn_is_disagg(session) && ret == ENOTSUP) {

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -18,7 +18,7 @@ ops.compaction=0
 ops.salvage=0
 ops.throttle=0
 ops.truncate=0
-# FIXME-WT-14553 should fix WT_SESSION->verify for layered tables.
+# FIXME-WT-14908 should fix WT_SESSION->verify for layered tables.
 ops.verify=0
 quiet=0
 runs.in_memory=0


### PR DESCRIPTION
The original WT-14553 DisAgg verification ticket was split into several fine-grained ones, and the common ticket was subsequently closed. This PR updates the FIXME comments to reference the correct new fine-grained ticket, which is WT-14908 in this case.

