### PR TITLE
WT-15050 Remove prepare flag from time window structure

### DIFF
--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -379,9 +379,7 @@ restart_read:
          * we can't cache it; but in that case the on-disk value cannot be globally visible.)
          */
         cbt->cip_saved = cip;
-        if (rle > 1 &&
-          __wt_txn_visible_all(session, unpack.tw.start_txn,
-            WT_MAX(unpack.tw.durable_start_ts, unpack.tw.start_prepare_ts))) {
+        if (rle > 1 && __wt_txn_tw_start_visible_all(session, &unpack.tw)) {
             /*
              * Copy the value into cbt->tmp to cache it. This is perhaps unfortunate, because
              * copying isn't free, but it's currently necessary. The memory we're copying might be

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -380,7 +380,8 @@ restart_read:
          */
         cbt->cip_saved = cip;
         if (rle > 1 &&
-          __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.durable_start_ts)) {
+          __wt_txn_visible_all(session, unpack.tw.start_txn,
+            WT_MAX(unpack.tw.durable_start_ts, unpack.tw.start_prepare_ts))) {
             /*
              * Copy the value into cbt->tmp to cache it. This is perhaps unfortunate, because
              * copying isn't free, but it's currently necessary. The memory we're copying might be

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -538,9 +538,7 @@ restart_read:
          * we can't cache it; but in that case the on-disk value cannot be globally visible.)
          */
         cbt->cip_saved = cip;
-        if (rle > 1 &&
-          __wt_txn_visible_all(session, unpack.tw.start_txn,
-            WT_MAX(unpack.tw.durable_start_ts, unpack.tw.start_prepare_ts))) {
+        if (rle > 1 && __wt_txn_tw_start_visible_all(session, &unpack.tw)) {
             /*
              * Copy the value into cbt->tmp to cache it. This is perhaps unfortunate, because
              * copying isn't free, but it's currently necessary. The memory we're copying might be

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -539,7 +539,8 @@ restart_read:
          */
         cbt->cip_saved = cip;
         if (rle > 1 &&
-          __wt_txn_visible_all(session, unpack.tw.start_txn, unpack.tw.durable_start_ts)) {
+          __wt_txn_visible_all(session, unpack.tw.start_txn,
+            WT_MAX(unpack.tw.durable_start_ts, unpack.tw.start_prepare_ts))) {
             /*
              * Copy the value into cbt->tmp to cache it. This is perhaps unfortunate, because
              * copying isn't free, but it's currently necessary. The memory we're copying might be

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -479,6 +479,7 @@ __tombstone_update_alloc(
         upd->upd_durable_ts = page_del->pg_del_durable_ts;
         upd->upd_start_ts = page_del->pg_del_start_ts;
         upd->prepare_state = page_del->prepare_state;
+        upd->prepare_ts = page_del->prepare_ts;
     }
     *updp = upd;
     return (0);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -480,6 +480,7 @@ __tombstone_update_alloc(
         upd->upd_start_ts = page_del->pg_del_start_ts;
         upd->prepare_state = page_del->prepare_state;
         upd->prepare_ts = page_del->prepare_ts;
+        upd->prepared_id = page_del->prepared_id;
     }
     *updp = upd;
     return (0);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -797,6 +797,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         upd->prepared_id = unpack->tw.start_prepared_id;
         upd->prepare_ts = unpack->tw.start_prepare_ts;
         upd->upd_durable_ts = WT_TS_NONE;
+        upd->upd_start_ts = unpack->tw.start_prepare_ts;
         upd->prepare_state = WT_PREPARE_INPROGRESS;
         F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
         if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
@@ -814,7 +815,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         tombstone->upd_durable_ts = WT_TS_NONE;
         tombstone->txnid = unpack->tw.stop_txn;
         tombstone->prepare_state = WT_PREPARE_INPROGRESS;
-        tombstone->upd_start_ts = unpack->tw.stop_ts;
+        tombstone->upd_start_ts = unpack->tw.stop_prepare_ts;
         tombstone->prepare_ts = unpack->tw.stop_prepare_ts;
         tombstone->prepared_id = unpack->tw.stop_prepared_id;
         tombstone->prepare_state = WT_PREPARE_INPROGRESS;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -420,11 +420,6 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
             standard_value->upd_start_ts = unpack.tw.start_ts;
             standard_value->upd_durable_ts = unpack.tw.durable_start_ts;
             if (WT_TIME_WINDOW_HAS_START_PREPARE(&unpack.tw)) {
-                /*
-                 * FIXME-WT-14899: Remove prepare flag when we align the code between
-                 * preserve_prepared and non-preserve_prepared connections
-                 */
-                WT_ASSERT(session, unpack.tw.prepare);
                 standard_value->prepared_id = unpack.tw.start_prepared_id;
                 standard_value->prepare_ts = unpack.tw.start_prepare_ts;
                 standard_value->prepare_state = WT_PREPARE_INPROGRESS;
@@ -441,7 +436,6 @@ __page_reconstruct_leaf_delta(WT_SESSION_IMPL *session, WT_REF *ref, WT_ITEM *de
                 tombstone->upd_durable_ts = unpack.tw.durable_stop_ts;
 
                 if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&unpack.tw)) {
-                    WT_ASSERT(session, unpack.tw.prepare);
                     tombstone->prepared_id = unpack.tw.stop_prepared_id;
                     tombstone->prepare_ts = unpack.tw.stop_prepare_ts;
                     tombstone->prepare_state = WT_PREPARE_INPROGRESS;
@@ -792,16 +786,29 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
 
     WT_RET(__wt_upd_alloc(session, value, WT_UPDATE_STANDARD, &upd, &size));
     total_size += size;
-    upd->upd_durable_ts = unpack->tw.durable_start_ts;
-    upd->upd_start_ts = unpack->tw.start_ts;
-    upd->txnid = unpack->tw.start_txn;
 
     /*
      * Instantiate both update and tombstone if the prepared update is a tombstone. This is required
      * to ensure that written prepared delete operation must be removed from the data store, when
      * the prepared transaction gets rollback.
      */
-    if (WT_TIME_WINDOW_HAS_STOP(&unpack->tw)) {
+    upd->txnid = unpack->tw.start_txn;
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw))) {
+        upd->prepared_id = unpack->tw.start_prepared_id;
+        upd->prepare_ts = unpack->tw.start_prepare_ts;
+        upd->upd_durable_ts = WT_TS_NONE;
+        upd->prepare_state = WT_PREPARE_INPROGRESS;
+        F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
+        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+            F_SET(upd, WT_UPDATE_PREPARE_DURABLE);
+    } else {
+        upd->upd_durable_ts = unpack->tw.durable_start_ts;
+        upd->upd_start_ts = unpack->tw.start_ts;
+        F_SET(upd, WT_UPDATE_RESTORED_FROM_DS);
+        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+            F_SET(upd, WT_UPDATE_DURABLE);
+    }
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
         WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
         total_size += size;
         tombstone->upd_durable_ts = WT_TS_NONE;
@@ -810,45 +817,14 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
         tombstone->upd_start_ts = unpack->tw.stop_ts;
         tombstone->prepare_ts = unpack->tw.stop_prepare_ts;
         tombstone->prepared_id = unpack->tw.stop_prepared_id;
+        tombstone->prepare_state = WT_PREPARE_INPROGRESS;
         F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
         if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
             F_SET(tombstone, WT_UPDATE_PREPARE_DURABLE);
-
-        /*
-         * Mark the update also as in-progress if the update and tombstone are from same transaction
-         * by comparing both the transaction and timestamps as the transaction information gets lost
-         * after restart. FIXME-WT-14899: Simplify this check when we align the code between
-         * reserve_prepare vs non-reserve_prepare connection.
-         */
-        if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)) ||
-          (unpack->tw.start_ts == unpack->tw.stop_ts &&
-            unpack->tw.durable_start_ts == unpack->tw.durable_stop_ts &&
-            unpack->tw.start_txn == unpack->tw.stop_txn)) {
-            upd->prepared_id = unpack->tw.start_prepared_id;
-            upd->prepare_ts = unpack->tw.start_prepare_ts;
-            upd->upd_durable_ts = WT_TS_NONE;
-            upd->prepare_state = WT_PREPARE_INPROGRESS;
-            F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
-            if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                F_SET(tombstone, WT_UPDATE_PREPARE_DURABLE);
-        } else {
-            F_SET(upd, WT_UPDATE_RESTORED_FROM_DS);
-            if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                F_SET(upd, WT_UPDATE_DURABLE);
-        }
-
         tombstone->next = upd;
         *updp = tombstone;
-    } else {
-        upd->prepared_id = unpack->tw.start_prepared_id;
-        upd->prepare_ts = unpack->tw.start_prepare_ts;
-        upd->upd_durable_ts = WT_TS_NONE;
-        upd->prepare_state = WT_PREPARE_INPROGRESS;
-        F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
-        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-            F_SET(upd, WT_UPDATE_PREPARE_DURABLE);
+    } else
         *updp = upd;
-    }
 
     *sizep = total_size;
     return (0);
@@ -868,7 +844,7 @@ static int
 __page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
   WT_UPDATE **updp, size_t *sizep)
 {
-    if (unpack->tw.prepare)
+    if (WT_TIME_WINDOW_HAS_PREPARE(&(unpack->tw)))
         return (__page_inmem_prepare_update(session, value, unpack, updp, sizep));
 
     return (__page_inmem_tombstone(session, unpack, updp, sizep));
@@ -933,7 +909,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
             cell = WT_COL_PTR(page, cip);
             __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
             rle = __wt_cell_rle(&unpack);
-            if (!unpack.tw.prepare) {
+            if (!WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw))) {
                 recno += rle;
                 continue;
             }
@@ -959,7 +935,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
         for (tw = 0; tw < numtws; tw++) {
             cell = WT_COL_FIX_TW_CELL(page, &page->pg_fix_tws[tw]);
             __wt_cell_unpack_kv(session, page->dsk, cell, &unpack);
-            if (!unpack.tw.prepare)
+            if (!WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw)))
                 continue;
             recno = ref->ref_recno + page->pg_fix_tws[tw].recno_offset;
 
@@ -979,7 +955,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
         WT_ROW_FOREACH (page, rip, i) {
             /* Search for prepare records. */
             __wt_row_leaf_value_cell(session, page, rip, &unpack);
-            if (!unpack.tw.prepare)
+            if (!WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw)))
                 continue;
 
             /* Get the key/value pair and create an update to resolve the prepare. */
@@ -1280,7 +1256,7 @@ __inmem_col_fix(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp,
                 }
                 page->pg_fix_tws[entry_num].recno_offset = recno_offset;
                 page->pg_fix_tws[entry_num].cell_offset = WT_PAGE_DISK_OFFSET(page, unpack.cell);
-                if (unpack.tw.prepare)
+                if (WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw)))
                     instantiate_upd = true;
                 entry_num++;
             } else
@@ -1489,7 +1465,7 @@ __inmem_col_var(
         }
 
         /* If we find a prepare, we'll have to instantiate it in the update chain later. */
-        if (unpack.tw.prepare)
+        if (WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw)))
             instantiate_upd = true;
 
         indx++;
@@ -1785,7 +1761,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp
          * instantiate the tombstone for disaggregated storage. We need the tombstone to trace
          * whether we have included the delete in the delta or not.
          */
-        if (unpack.tw.prepare ||
+        if (WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw)) ||
           (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && WT_TIME_WINDOW_HAS_STOP(&unpack.tw)))
             instantiate_upd = true;
     }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1407,6 +1407,8 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
             upd->txnid = tw.start_txn;
             upd->upd_start_ts = tw.start_ts;
             upd->upd_durable_ts = tw.durable_start_ts;
+            upd->prepare_ts = tw.start_prepare_ts;
+            upd->prepared_id = tw.start_prepared_id;
         } else
             WT_ASSERT(session, tombstone != NULL);
 
@@ -1414,8 +1416,10 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
          * ingest table. */
         if (tombstone != NULL) {
             tombstone->txnid = tw.stop_txn;
-            tombstone->upd_start_ts = tw.start_ts;
-            tombstone->upd_durable_ts = tw.durable_start_ts;
+            tombstone->upd_start_ts = tw.stop_ts;
+            tombstone->upd_durable_ts = tw.durable_stop_ts;
+            tombstone->prepare_ts = tw.start_prepare_ts;
+            tombstone->prepared_id = tw.start_prepared_id;
             tombstone->next = upd;
 
             WT_ASSERT(session, tombstone->upd_durable_ts > last_checkpoint_timestamp);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1416,10 +1416,10 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
          * ingest table. */
         if (tombstone != NULL) {
             tombstone->txnid = tw.stop_txn;
-            tombstone->upd_start_ts = tw.stop_ts;
+            tombstone->upd_start_ts = tw.stop_ts != WT_TS_MAX ? tw.stop_ts : tw.stop_prepare_ts;
             tombstone->upd_durable_ts = tw.durable_stop_ts;
-            tombstone->prepare_ts = tw.start_prepare_ts;
-            tombstone->prepared_id = tw.start_prepared_id;
+            tombstone->prepare_ts = tw.stop_prepare_ts;
+            tombstone->prepared_id = tw.stop_prepared_id;
             tombstone->next = upd;
 
             WT_ASSERT(session, tombstone->upd_durable_ts > last_checkpoint_timestamp);

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1030,11 +1030,13 @@ __curhs_insert(WT_CURSOR *cursor)
      * The actual record to be inserted into the history store. Set the current update start time
      * point as the commit time point to the history store record.
      */
+    /* assert that tw is not prepared? */
     WT_ERR(__wt_upd_alloc(session, &file_cursor->value, WT_UPDATE_STANDARD, &hs_upd, NULL));
     hs_upd->upd_start_ts = hs_cursor->time_window.start_ts;
     hs_upd->upd_durable_ts = hs_cursor->time_window.durable_start_ts;
     hs_upd->txnid = hs_cursor->time_window.start_txn;
-
+    hs_upd->prepare_ts = hs_cursor->time_window.start_prepare_ts;
+    hs_upd->prepared_id = hs_cursor->time_window.start_prepared_id;
     /*
      * Allocate a tombstone only when there is a valid stop time point, and insert the standard
      * update as the update after the tombstone.
@@ -1050,7 +1052,8 @@ __curhs_insert(WT_CURSOR *cursor)
         hs_tombstone->upd_start_ts = hs_cursor->time_window.stop_ts;
         hs_tombstone->upd_durable_ts = hs_cursor->time_window.durable_stop_ts;
         hs_tombstone->txnid = hs_cursor->time_window.stop_txn;
-
+        hs_tombstone->prepare_ts = hs_cursor->time_window.stop_prepare_ts;
+        hs_tombstone->prepared_id = hs_cursor->time_window.stop_prepared_id;
         WT_ASSERT(session,
           hs_tombstone->upd_start_ts >= hs_upd->upd_start_ts &&
             hs_tombstone->upd_durable_ts >= hs_upd->upd_durable_ts);
@@ -1117,7 +1120,9 @@ __curhs_remove_int(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, u_int modify_type
     /* Add a tombstone with WT_TXN_NONE transaction id and WT_TS_NONE timestamps. */
     WT_ERR(__wt_upd_alloc_tombstone(session, &hs_tombstone, NULL));
     hs_tombstone->txnid = WT_TXN_NONE;
-    hs_tombstone->upd_start_ts = hs_tombstone->upd_durable_ts = WT_TS_NONE;
+    hs_tombstone->upd_start_ts = hs_tombstone->upd_durable_ts = hs_tombstone->prepare_ts =
+      WT_TS_NONE;
+    hs_tombstone->prepare_ts = WT_PREPARED_ID_NONE;
     while ((ret = __wt_hs_modify(cbt, hs_tombstone)) == WT_RESTART) {
         WT_WITH_PAGE_INDEX(session, ret = __curhs_search(cbt, false));
         WT_ERR(ret);
@@ -1209,12 +1214,15 @@ __curhs_update(WT_CURSOR *cursor)
     hs_tombstone->upd_start_ts = hs_cursor->time_window.stop_ts;
     hs_tombstone->upd_durable_ts = hs_cursor->time_window.durable_stop_ts;
     hs_tombstone->txnid = hs_cursor->time_window.stop_txn;
+    hs_tombstone->prepare_ts = hs_cursor->time_window.stop_prepare_ts;
+    hs_tombstone->prepared_id = hs_cursor->time_window.stop_prepared_id;
 
     WT_ERR(__wt_upd_alloc(session, &file_cursor->value, WT_UPDATE_STANDARD, &hs_upd, NULL));
     hs_upd->upd_start_ts = hs_cursor->time_window.start_ts;
     hs_upd->upd_durable_ts = hs_cursor->time_window.durable_start_ts;
     hs_upd->txnid = hs_cursor->time_window.start_txn;
-
+    hs_upd->prepare_ts = hs_cursor->time_window.start_prepare_ts;
+    hs_upd->prepared_id = hs_cursor->time_window.start_prepared_id;
     WT_ASSERT(session,
       hs_tombstone->upd_start_ts >= hs_upd->upd_start_ts &&
         hs_tombstone->upd_durable_ts >= hs_upd->upd_durable_ts);

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1121,7 +1121,7 @@ __curhs_remove_int(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, u_int modify_type
     hs_tombstone->txnid = WT_TXN_NONE;
     hs_tombstone->upd_start_ts = hs_tombstone->upd_durable_ts = hs_tombstone->prepare_ts =
       WT_TS_NONE;
-    hs_tombstone->prepare_ts = WT_PREPARED_ID_NONE;
+    hs_tombstone->prepared_id = WT_PREPARED_ID_NONE;
     while ((ret = __wt_hs_modify(cbt, hs_tombstone)) == WT_RESTART) {
         WT_WITH_PAGE_INDEX(session, ret = __curhs_search(cbt, false));
         WT_ERR(ret);

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1030,7 +1030,6 @@ __curhs_insert(WT_CURSOR *cursor)
      * The actual record to be inserted into the history store. Set the current update start time
      * point as the commit time point to the history store record.
      */
-    /* assert that tw is not prepared? */
     WT_ERR(__wt_upd_alloc(session, &file_cursor->value, WT_UPDATE_STANDARD, &hs_upd, NULL));
     hs_upd->upd_start_ts = hs_cursor->time_window.start_ts;
     hs_upd->upd_durable_ts = hs_cursor->time_window.durable_start_ts;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -422,7 +422,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 }
 
                 if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) &&
-                  cbt->upd_value->tw.prepare) {
+                  WT_TIME_WINDOW_HAS_PREPARE(&(cbt->upd_value->tw))) {
                     if (!WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw))
                         goto skip_on_page;
 
@@ -434,7 +434,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                     durable_stop_ts = WT_TS_MAX;
                     version_prepare_state = 0;
                 } else
-                    version_prepare_state = cbt->upd_value->tw.prepare;
+                    version_prepare_state = WT_TIME_WINDOW_HAS_PREPARE(&(cbt->upd_value->tw));
             }
 
             WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -205,9 +205,10 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                  * also need traverse to the next update to get the full value. If the tombstone was
                  * the last update in the update list, retrieve the ondisk value.
                  */
+                /* change here as well */
                 version_cursor->upd_stop_txnid = upd->txnid;
                 version_cursor->upd_durable_stop_ts = upd->upd_durable_ts;
-                version_cursor->upd_stop_ts = upd->upd_start_ts;
+                version_cursor->upd_stop_ts = WT_MAX(upd->upd_start_ts, upd->prepare_ts);
 
                 /* No need to check the next update if the tombstone is globally visible. */
                 if (__wt_txn_upd_visible_all(session, upd))
@@ -391,7 +392,9 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                         goto skip_on_page;
                 }
                 durable_stop_ts = cbt->upd_value->tw.durable_stop_ts;
-                stop_ts = cbt->upd_value->tw.stop_ts;
+                stop_ts = cbt->upd_value->tw.stop_prepare_ts != WT_TS_NONE ?
+                  cbt->upd_value->tw.stop_prepare_ts :
+                  cbt->upd_value->tw.stop_ts;
                 stop_txn = cbt->upd_value->tw.stop_txn;
             }
 
@@ -438,13 +441,16 @@ __curversion_next_single_key(WT_CURSOR *cursor)
             }
 
             WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-              cbt->upd_value->tw.start_txn, cbt->upd_value->tw.start_ts,
-              cbt->upd_value->tw.durable_start_ts, stop_txn, stop_ts, durable_stop_ts,
-              WT_UPDATE_STANDARD, version_prepare_state, 0, WT_CURVERSION_DISK_IMAGE));
+              cbt->upd_value->tw.start_txn,
+              WT_MAX(cbt->upd_value->tw.start_ts, cbt->upd_value->tw.start_prepare_ts),
+              WT_MAX(cbt->upd_value->tw.durable_start_ts, cbt->upd_value->tw.start_prepare_ts),
+              stop_txn, stop_ts, durable_stop_ts, WT_UPDATE_STANDARD, version_prepare_state, 0,
+              WT_CURVERSION_DISK_IMAGE));
 
             version_cursor->upd_stop_txnid = cbt->upd_value->tw.start_txn;
             version_cursor->upd_durable_stop_ts = cbt->upd_value->tw.durable_start_ts;
-            version_cursor->upd_stop_ts = cbt->upd_value->tw.start_ts;
+            version_cursor->upd_stop_ts =
+              WT_MAX(cbt->upd_value->tw.start_ts, cbt->upd_value->tw.start_prepare_ts);
 
             upd_found = true;
         } else
@@ -545,12 +551,13 @@ skip_on_page:
         }
 
         WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-          twp->start_txn, twp->start_ts, twp->durable_start_ts, twp->stop_txn, twp->stop_ts,
+          twp->start_txn, WT_MAX(twp->start_ts, twp->start_prepare_ts),
+          WT_MAX(twp->durable_start_ts, twp->start_prepare_ts), twp->stop_txn, twp->stop_ts,
           twp->durable_stop_ts, hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
 
         version_cursor->upd_stop_txnid = twp->start_txn;
         version_cursor->upd_durable_stop_ts = twp->durable_start_ts;
-        version_cursor->upd_stop_ts = twp->start_ts;
+        version_cursor->upd_stop_ts = WT_MAX(twp->start_ts, twp->start_prepare_ts);
 
         upd_found = true;
     }

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -208,7 +208,8 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 /* change here as well */
                 version_cursor->upd_stop_txnid = upd->txnid;
                 version_cursor->upd_durable_stop_ts = upd->upd_durable_ts;
-                version_cursor->upd_stop_ts = WT_MAX(upd->upd_start_ts, upd->prepare_ts);
+                version_cursor->upd_stop_ts =
+                  upd->prepare_ts != WT_TS_NONE ? upd->prepare_ts : upd->upd_start_ts;
 
                 /* No need to check the next update if the tombstone is globally visible. */
                 if (__wt_txn_upd_visible_all(session, upd))
@@ -442,15 +443,23 @@ __curversion_next_single_key(WT_CURSOR *cursor)
 
             WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
               cbt->upd_value->tw.start_txn,
-              WT_MAX(cbt->upd_value->tw.start_ts, cbt->upd_value->tw.start_prepare_ts),
-              WT_MAX(cbt->upd_value->tw.durable_start_ts, cbt->upd_value->tw.start_prepare_ts),
+              cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+                cbt->upd_value->tw.start_prepare_ts :
+                cbt->upd_value->tw.start_ts,
+              cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+                cbt->upd_value->tw.start_prepare_ts :
+                cbt->upd_value->tw.durable_start_ts,
               stop_txn, stop_ts, durable_stop_ts, WT_UPDATE_STANDARD, version_prepare_state, 0,
               WT_CURVERSION_DISK_IMAGE));
 
             version_cursor->upd_stop_txnid = cbt->upd_value->tw.start_txn;
-            version_cursor->upd_durable_stop_ts = cbt->upd_value->tw.durable_start_ts;
-            version_cursor->upd_stop_ts =
-              WT_MAX(cbt->upd_value->tw.start_ts, cbt->upd_value->tw.start_prepare_ts);
+            version_cursor->upd_durable_stop_ts =
+              cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+              cbt->upd_value->tw.start_prepare_ts :
+              cbt->upd_value->tw.durable_start_ts;
+            version_cursor->upd_stop_ts = cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+              cbt->upd_value->tw.start_prepare_ts :
+              cbt->upd_value->tw.start_ts;
 
             upd_found = true;
         } else
@@ -550,14 +559,19 @@ skip_on_page:
                 goto done;
         }
 
-        WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-          twp->start_txn, WT_MAX(twp->start_ts, twp->start_prepare_ts),
-          WT_MAX(twp->durable_start_ts, twp->start_prepare_ts), twp->stop_txn, twp->stop_ts,
-          twp->durable_stop_ts, hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
+        WT_ERR(
+          __curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
+            twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->start_ts,
+            twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->durable_start_ts,
+            twp->stop_txn, twp->stop_prepare_ts != WT_TS_NONE ? twp->stop_prepare_ts : twp->stop_ts,
+            twp->stop_prepare_ts != WT_TS_NONE ? twp->stop_prepare_ts : twp->durable_stop_ts,
+            hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
 
         version_cursor->upd_stop_txnid = twp->start_txn;
-        version_cursor->upd_durable_stop_ts = twp->durable_start_ts;
-        version_cursor->upd_stop_ts = WT_MAX(twp->start_ts, twp->start_prepare_ts);
+        version_cursor->upd_durable_stop_ts =
+          twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->durable_start_ts;
+        version_cursor->upd_stop_ts =
+          twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->start_ts;
 
         upd_found = true;
     }

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -205,7 +205,6 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                  * also need traverse to the next update to get the full value. If the tombstone was
                  * the last update in the update list, retrieve the ondisk value.
                  */
-                /* change here as well */
                 version_cursor->upd_stop_txnid = upd->txnid;
                 version_cursor->upd_durable_stop_ts = upd->upd_durable_ts;
                 version_cursor->upd_stop_ts =
@@ -393,7 +392,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                         goto skip_on_page;
                 }
                 durable_stop_ts = cbt->upd_value->tw.durable_stop_ts;
-                stop_ts = cbt->upd_value->tw.stop_prepare_ts != WT_TS_NONE ?
+                stop_ts = WT_TIME_WINDOW_HAS_STOP_PREPARE(&(cbt->upd_value->tw)) ?
                   cbt->upd_value->tw.stop_prepare_ts :
                   cbt->upd_value->tw.stop_ts;
                 stop_txn = cbt->upd_value->tw.stop_txn;
@@ -443,10 +442,10 @@ __curversion_next_single_key(WT_CURSOR *cursor)
 
             WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
               cbt->upd_value->tw.start_txn,
-              cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
                 cbt->upd_value->tw.start_prepare_ts :
                 cbt->upd_value->tw.start_ts,
-              cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
                 cbt->upd_value->tw.start_prepare_ts :
                 cbt->upd_value->tw.durable_start_ts,
               stop_txn, stop_ts, durable_stop_ts, WT_UPDATE_STANDARD, version_prepare_state, 0,
@@ -454,10 +453,10 @@ __curversion_next_single_key(WT_CURSOR *cursor)
 
             version_cursor->upd_stop_txnid = cbt->upd_value->tw.start_txn;
             version_cursor->upd_durable_stop_ts =
-              cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
               cbt->upd_value->tw.start_prepare_ts :
               cbt->upd_value->tw.durable_start_ts;
-            version_cursor->upd_stop_ts = cbt->upd_value->tw.start_prepare_ts != WT_TS_NONE ?
+            version_cursor->upd_stop_ts = WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
               cbt->upd_value->tw.start_prepare_ts :
               cbt->upd_value->tw.start_ts;
 
@@ -559,19 +558,19 @@ skip_on_page:
                 goto done;
         }
 
-        WT_ERR(
-          __curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
-            twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->start_ts,
-            twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->durable_start_ts,
-            twp->stop_txn, twp->stop_prepare_ts != WT_TS_NONE ? twp->stop_prepare_ts : twp->stop_ts,
-            twp->stop_prepare_ts != WT_TS_NONE ? twp->stop_prepare_ts : twp->durable_stop_ts,
-            hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
+        WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
+          twp->start_txn,
+          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts,
+          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts,
+          twp->stop_txn, WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
+          WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
+          hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
 
         version_cursor->upd_stop_txnid = twp->start_txn;
         version_cursor->upd_durable_stop_ts =
-          twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->durable_start_ts;
+          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts;
         version_cursor->upd_stop_ts =
-          twp->start_prepare_ts != WT_TS_NONE ? twp->start_prepare_ts : twp->start_ts;
+          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts;
 
         upd_found = true;
     }

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -947,8 +947,8 @@ copy_cell_restart:
                  */
                 WT_ASSERT(session, temp_stop_ts == WT_TS_NONE);
                 if (preserve_prepared) {
-                    WT_ASSERT(
-                      session, temp_durable_start_ts != WT_TS_NONE && temp_durable_stop_ts == WT_TS_NONE);
+                    WT_ASSERT(session,
+                      temp_durable_start_ts != WT_TS_NONE && temp_durable_stop_ts == WT_TS_NONE);
                     tw->start_prepare_ts = temp_start_ts;
                     tw->start_prepared_id = temp_durable_start_ts;
                     tw->stop_prepare_ts = temp_start_ts;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -53,29 +53,17 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
 
     flags = 0;
     /* We pack prepared txn info to stop_ts and durable_stop_ts when:
-     *  - disagg is on
      *  - txn is prepared
      *  - transaction is in delete prepared (meaning it has stop_txn defined)
      */
-    bool pack_prepare_info_to_stop =
-      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+    bool pack_prepare_info_to_stop = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
 
     /* We pack prepared txn info to start_ts and durable start_ts when:
-     *  - disagg is on
      *  - txn is prepared
      *  - transaction is in start prepared (no stop), or both start and delete are prepared, which
      * means both start and stop transactions are the same
      */
-    bool pack_prepare_info_to_start =
-      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && WT_TIME_WINDOW_HAS_START_PREPARE(tw);
-
-    /*
-     * Assert that a prepare timestamp is set if and only if we're packing prepare info (either to
-     * start or stop) FIXME-WT-14899: Can remove this check when prepare flag is removed from the
-     * time window structure.
-     */
-    if (tw->prepare && F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED))
-        WT_ASSERT(session, pack_prepare_info_to_start || pack_prepare_info_to_stop);
+    bool pack_prepare_info_to_start = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
 
     if (pack_prepare_info_to_start && pack_prepare_info_to_stop)
         WT_ASSERT(session, tw->start_prepared_id == tw->stop_prepared_id);
@@ -96,11 +84,20 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
         LF_SET(WT_CELL_TXN_START);
     }
 
-    /* If we write prepare_ts to start_ts, we write prepared_id to durable_start_ts as well */
     if (pack_prepare_info_to_start) {
-        WT_ASSERT(session, tw->start_prepared_id != WT_PREPARED_ID_NONE);
-        WT_RET(__wt_vpack_uint(pp, 0, tw->start_prepared_id));
-        LF_SET(WT_CELL_TS_DURABLE_START);
+        /*
+         * If the preserve prepared config is enabled, we write prepared_id to durable_start_ts as
+         * well
+         */
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
+            WT_ASSERT(session, tw->start_prepared_id != WT_PREPARED_ID_NONE);
+            WT_RET(__wt_vpack_uint(pp, 0, tw->start_prepared_id));
+            LF_SET(WT_CELL_TS_DURABLE_START);
+        } else if (tw->start_prepare_ts - reference_ts > 0) {
+            /* Write the start_prepare_ts for backward compatibility. */
+            WT_RET(__wt_vpack_uint(pp, 0, tw->start_prepare_ts - reference_ts));
+            LF_SET(WT_CELL_TS_DURABLE_START);
+        }
     } else if (tw->durable_start_ts != WT_TS_NONE) {
         WT_ASSERT(session, reference_ts <= tw->durable_start_ts);
         /* Store differences if any, not absolutes. */
@@ -128,9 +125,17 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
      * should not pack the difference.
      */
     if (pack_prepare_info_to_stop) {
-        WT_ASSERT(session, tw->stop_prepared_id != WT_PREPARED_ID_NONE);
-        WT_RET(__wt_vpack_uint(pp, 0, pack_prepare_info_to_start ? 0 : tw->stop_prepared_id));
-        LF_SET(WT_CELL_TS_DURABLE_STOP);
+        /*
+         * If the preserve prepared config is enabled, we write prepared_id to durable_start_ts as
+         * well
+         */
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
+            if (!pack_prepare_info_to_start) {
+                WT_ASSERT(session, tw->stop_prepared_id != WT_PREPARED_ID_NONE);
+                WT_RET(__wt_vpack_uint(pp, 0, tw->stop_prepared_id));
+                LF_SET(WT_CELL_TS_DURABLE_STOP);
+            }
+        }
     } else if (tw->durable_stop_ts != WT_TS_NONE) {
         WT_ASSERT(session, tw->stop_ts <= tw->durable_stop_ts);
         /* Store differences if any, not absolutes. */
@@ -139,7 +144,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
             LF_SET(WT_CELL_TS_DURABLE_STOP);
         }
     }
-    if (tw->prepare)
+    if (pack_prepare_info_to_stop || pack_prepare_info_to_start)
         LF_SET(WT_CELL_PREPARE);
     *flagsp = flags;
 
@@ -906,8 +911,6 @@ copy_cell_restart:
         temp_start_ts = temp_durable_start_ts = temp_durable_stop_ts = WT_TS_NONE;
         temp_stop_ts = WT_TS_MAX;
 
-        if (LF_ISSET(WT_CELL_PREPARE))
-            tw->prepare = 1;
         if (LF_ISSET(WT_CELL_TS_START)) {
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_start_ts));
         }
@@ -929,7 +932,8 @@ copy_cell_restart:
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_durable_stop_ts));
 
         /* Load temporary values to the right fields */
-        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && tw->prepare) {
+        if (LF_ISSET(WT_CELL_PREPARE)) {
+            bool preserve_prepared = F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
             /*
              * We can compare the txn_id only here, but cannot do it everywhere else because when
              * recovering, all transaction ids are reset to WT_TXN_NONE, so we cannot compare the
@@ -939,40 +943,56 @@ copy_cell_restart:
                 /*
                  * This is a special case where both transaction start and stop are in prepared
                  * state (same prepared id), so the same prepared id is packed to
-                 * WT_CELL_TS_DURABLE_START and 0 is packed into WT_CELL_TS_DURABLE_STOP since we
-                 * only store the difference.
+                 * WT_CELL_TS_DURABLE_START
                  */
-                WT_ASSERT(session, temp_stop_ts == 0 && temp_durable_stop_ts == 0);
-                WT_ASSERT(session,
-                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
-                    LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
-                tw->start_prepare_ts = temp_start_ts;
-                tw->start_prepared_id = temp_durable_start_ts;
-                tw->stop_prepare_ts = temp_start_ts;
-                tw->stop_prepared_id = temp_durable_start_ts;
+                WT_ASSERT(session, temp_stop_ts == 0);
+                if (preserve_prepared) {
+                    WT_ASSERT(
+                      session, temp_durable_start_ts != 0 && temp_durable_stop_ts == WT_TS_NONE);
+                    tw->start_prepare_ts = temp_start_ts;
+                    tw->start_prepared_id = temp_durable_start_ts;
+                    tw->stop_prepare_ts = temp_start_ts;
+                    tw->stop_prepared_id = temp_durable_start_ts;
+                } else {
+                    WT_ASSERT(session,
+                      temp_durable_start_ts == temp_durable_stop_ts &&
+                        temp_durable_stop_ts == WT_TS_NONE);
+                    tw->start_prepare_ts = tw->stop_prepare_ts = temp_start_ts;
+                }
             } else if (tw->stop_txn != WT_TXN_MAX) {
                 /*
-                 * This case happens where the transaction is done, but the transaction stop is
-                 * prepared. In this case, we store the start timestamp and durable start timestamp
-                 * in WT_CELL_TS_START and WT_CELL_TS_DURABLE_START, prepare ts in WT_CELL_TS_STOP
-                 * prepared id in WT_CELL_TS_DURABLE_STOP.
+                 * This case happens where the transaction start is committed, but the transaction
+                 * stop is prepared. In this case, we store the start timestamp and durable start
+                 * timestamp in WT_CELL_TS_START and WT_CELL_TS_DURABLE_START, prepare ts in
+                 * WT_CELL_TS_STOP prepared id in WT_CELL_TS_DURABLE_STOP.
                  */
-                WT_ASSERT(session, LF_ISSET(WT_CELL_TS_STOP) && LF_ISSET(WT_CELL_TS_DURABLE_STOP));
+                /* unpack start ts and durable start ts like normal */
                 tw->start_ts = temp_start_ts;
-                tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
+                if (temp_durable_start_ts != WT_TS_NONE)
+                    tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
+                else {
+                    tw->durable_start_ts = tw->start_ts;
+                }
+                WT_ASSERT(session, temp_stop_ts != WT_TS_MAX);
                 tw->stop_prepare_ts = tw->start_ts + temp_stop_ts;
-                tw->stop_prepared_id = temp_durable_stop_ts;
+
+                if (preserve_prepared) {
+                    WT_ASSERT(session, temp_durable_stop_ts != WT_TS_NONE);
+                    tw->stop_prepared_id = temp_durable_stop_ts;
+                } else
+                    WT_ASSERT(session, temp_durable_stop_ts == WT_TS_NONE);
             } else {
+                WT_ASSERT(session, tw->start_ts == WT_TXN_NONE);
                 /*
                  * This case happens when only transaction start is prepared, and there is no
                  * transaction stop. In this case, we store the prepare ts in WT_CELL_TS_START and
                  * prepared id in WT_CELL_TS_DURABLE_START.
                  */
-                WT_ASSERT(session,
-                  LF_ISSET(WT_CELL_TS_START) && LF_ISSET(WT_CELL_TS_DURABLE_START) &&
-                    !LF_ISSET(WT_CELL_TS_STOP) && !LF_ISSET(WT_CELL_TS_DURABLE_STOP));
                 tw->start_prepare_ts = temp_start_ts;
-                tw->start_prepared_id = temp_durable_start_ts;
+                if (preserve_prepared) {
+                    tw->start_prepared_id = temp_durable_start_ts;
+                } else
+                    WT_ASSERT(session, temp_durable_start_ts == WT_TS_NONE);
             }
         } else {
             if (LF_ISSET(WT_CELL_TS_START))

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -93,11 +93,9 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
             WT_ASSERT(session, tw->start_prepared_id != WT_PREPARED_ID_NONE);
             WT_RET(__wt_vpack_uint(pp, 0, tw->start_prepared_id));
             LF_SET(WT_CELL_TS_DURABLE_START);
-        } else if (tw->start_prepare_ts - reference_ts > 0) {
-            /* Write the start_prepare_ts for backward compatibility. */
-            WT_RET(__wt_vpack_uint(pp, 0, tw->start_prepare_ts - reference_ts));
-            LF_SET(WT_CELL_TS_DURABLE_START);
-        }
+        } else
+            /* For non preserve_prepared case, there's no durable ts to write here */
+            WT_ASSERT(session, tw->start_prepare_ts == reference_ts);
     } else if (tw->durable_start_ts != WT_TS_NONE) {
         WT_ASSERT(session, reference_ts <= tw->durable_start_ts);
         /* Store differences if any, not absolutes. */

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -945,10 +945,10 @@ copy_cell_restart:
                  * state (same prepared id), so the same prepared id is packed to
                  * WT_CELL_TS_DURABLE_START
                  */
-                WT_ASSERT(session, temp_stop_ts == 0);
+                WT_ASSERT(session, temp_stop_ts == WT_TS_NONE);
                 if (preserve_prepared) {
                     WT_ASSERT(
-                      session, temp_durable_start_ts != 0 && temp_durable_stop_ts == WT_TS_NONE);
+                      session, temp_durable_start_ts != WT_TS_NONE && temp_durable_stop_ts == WT_TS_NONE);
                     tw->start_prepare_ts = temp_start_ts;
                     tw->start_prepared_id = temp_durable_start_ts;
                     tw->stop_prepare_ts = temp_start_ts;
@@ -966,13 +966,12 @@ copy_cell_restart:
                  * timestamp in WT_CELL_TS_START and WT_CELL_TS_DURABLE_START, prepare ts in
                  * WT_CELL_TS_STOP prepared id in WT_CELL_TS_DURABLE_STOP.
                  */
-                /* unpack start ts and durable start ts like normal */
                 tw->start_ts = temp_start_ts;
                 if (temp_durable_start_ts != WT_TS_NONE)
                     tw->durable_start_ts = temp_durable_start_ts + tw->start_ts;
-                else {
+                else
                     tw->durable_start_ts = tw->start_ts;
-                }
+
                 WT_ASSERT(session, temp_stop_ts != WT_TS_MAX);
                 tw->stop_prepare_ts = tw->start_ts + temp_stop_ts;
 
@@ -989,9 +988,9 @@ copy_cell_restart:
                  * prepared id in WT_CELL_TS_DURABLE_START.
                  */
                 tw->start_prepare_ts = temp_start_ts;
-                if (preserve_prepared) {
+                if (preserve_prepared)
                     tw->start_prepared_id = temp_durable_start_ts;
-                } else
+                else
                     WT_ASSERT(session, temp_durable_start_ts == WT_TS_NONE);
             }
         } else {

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -38,11 +38,6 @@ struct __wt_time_window {
     wt_timestamp_t stop_prepare_ts; /* default value: WT_TS_NONE */
     uint64_t stop_txn;              /* default value: WT_TXN_MAX */
     uint64_t stop_prepared_id;      /* default value: WT_PREPARED_ID_NONE */
-    /*
-     * Prepare information isn't really part of a time window, but we need to aggregate it to the
-     * internal page information in reconciliation, and this is the simplest place to put it.
-     */
-    uint8_t prepare;
 };
 
 /*

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -21,20 +21,18 @@
         (tw)->stop_txn = WT_TXN_MAX;                   \
         (tw)->stop_prepare_ts = WT_TS_NONE;            \
         (tw)->stop_prepared_id = WT_PREPARED_ID_NONE;  \
-        (tw)->prepare = 0;                             \
     } while (0)
 
 /* Copy the values from one time window structure to another. */
 #define WT_TIME_WINDOW_COPY(dest, source) (*(dest) = *(source))
 
 /* Return true if the time window is equivalent to the default time window. */
-#define WT_TIME_WINDOW_IS_EMPTY(tw)                                                           \
-    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&                  \
-      (tw)->start_txn == WT_TXN_NONE && (tw)->start_prepare_ts == WT_TS_NONE &&               \
-      (tw)->start_prepared_id == WT_PREPARED_ID_NONE && (tw)->stop_ts == WT_TS_MAX &&         \
-      (tw)->stop_txn == WT_TXN_MAX && (tw)->durable_stop_ts == WT_TS_NONE &&                  \
-      (tw)->stop_prepare_ts == WT_TS_NONE && (tw)->stop_prepared_id == WT_PREPARED_ID_NONE && \
-      (tw)->prepare == 0)
+#define WT_TIME_WINDOW_IS_EMPTY(tw)                                                   \
+    ((tw)->durable_start_ts == WT_TS_NONE && (tw)->start_ts == WT_TS_NONE &&          \
+      (tw)->start_txn == WT_TXN_NONE && (tw)->start_prepare_ts == WT_TS_NONE &&       \
+      (tw)->start_prepared_id == WT_PREPARED_ID_NONE && (tw)->stop_ts == WT_TS_MAX && \
+      (tw)->stop_txn == WT_TXN_MAX && (tw)->durable_stop_ts == WT_TS_NONE &&          \
+      (tw)->stop_prepare_ts == WT_TS_NONE && (tw)->stop_prepared_id == WT_PREPARED_ID_NONE)
 
 /* Check if the start time window is set. */
 #define WT_TIME_WINDOW_HAS_START(tw) \
@@ -51,6 +49,15 @@
 #define WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) \
     ((tw)->stop_prepared_id != WT_PREPARED_ID_NONE || (tw)->stop_prepare_ts != WT_TS_NONE)
 
+#define WT_TIME_WINDOW_HAS_PREPARE(tw) \
+    (WT_TIME_WINDOW_HAS_START_PREPARE(tw) || WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
+
+#define WT_TIME_WINDOW_USE_STOP_PREPARE_TS_OR(tw, ts) \
+    ((tw)->stop_prepare_ts != WT_TS_NONE ? (tw)->stop_prepare_ts : ts)
+
+#define WT_TIME_WINDOW_USE_START_PREPARE_TS_OR(tw, ts) \
+    ((tw)->start_prepare_ts != WT_TS_NONE ? (tw)->start_prepare_ts : ts)
+
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                          \
     ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts && \
@@ -59,51 +66,42 @@
       (tw1)->start_prepared_id == (tw2)->start_prepared_id &&                                    \
       (tw1)->durable_stop_ts == (tw2)->durable_stop_ts && (tw1)->stop_ts == (tw2)->stop_ts &&    \
       (tw1)->stop_txn == (tw2)->stop_txn && (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts &&  \
-      (tw1)->stop_prepared_id == (tw2)->stop_prepared_id && (tw1)->prepare == (tw2)->prepare)
+      (tw1)->stop_prepared_id == (tw2)->stop_prepared_id)
 
 /* Return true if the stop time windows are the same. */
-#define WT_TIME_WINDOWS_STOP_EQUAL(tw1, tw2)                                                 \
-    ((tw1)->durable_stop_ts == (tw2)->durable_stop_ts && (tw1)->stop_ts == (tw2)->stop_ts && \
-      (tw1)->stop_txn == (tw2)->stop_txn && (tw1)->prepare == (tw2)->prepare &&              \
-      (tw1)->stop_prepared_id == (tw2)->stop_prepared_id &&                                  \
+#define WT_TIME_WINDOWS_STOP_EQUAL(tw1, tw2)                                                      \
+    ((tw1)->durable_stop_ts == (tw2)->durable_stop_ts && (tw1)->stop_ts == (tw2)->stop_ts &&      \
+      (tw1)->stop_txn == (tw2)->stop_txn && (tw1)->stop_prepared_id == (tw2)->stop_prepared_id && \
       (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts)
 
 /*
- * Set the start values of a time window from those in an update structure. Durable timestamp can be
- * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
- * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between
- * preserve_prepared and non-preserve_prepared connections.
+ * Set the start values of a time window from those in an update structure.
  */
-#define WT_TIME_WINDOW_SET_START(session, tw, upd)                     \
-    do {                                                               \
-        (tw)->durable_start_ts = (tw)->start_ts = (upd)->upd_start_ts; \
-        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {        \
-            (tw)->start_prepare_ts = (upd)->prepare_ts;                \
-            (tw)->start_prepared_id = (upd)->prepared_id;              \
-        }                                                              \
-                                                                       \
-        if ((upd)->upd_durable_ts != WT_TS_NONE)                       \
-            (tw)->durable_start_ts = (upd)->upd_durable_ts;            \
-        (tw)->start_txn = (upd)->txnid;                                \
+#define WT_TIME_WINDOW_SET_START(tw, upd, prepare_state)                                    \
+    do {                                                                                    \
+        (tw)->start_txn = (upd)->txnid;                                                     \
+        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) { \
+            (tw)->start_prepare_ts = (upd)->prepare_ts;                                     \
+            (tw)->start_prepared_id = (upd)->prepared_id;                                   \
+        } else {                                                                            \
+            (tw)->start_ts = (upd)->upd_start_ts;                                           \
+            (tw)->durable_start_ts = (upd)->upd_durable_ts;                                 \
+        }                                                                                   \
     } while (0)
 
 /*
- * Set the start values of a time window from those in an update structure. Durable timestamp can be
- * 0 for prepared updates, in those cases use the prepared timestamp as durable timestamp.
- * FIXME-WT-14899: Can remove preserve_prepared check when we align the code between
- * preserve_prepared and non-preserve_prepared connections.
+ * Set the stop values of a time window from those in an update structure.
  */
-#define WT_TIME_WINDOW_SET_STOP(session, tw, upd)                    \
-    do {                                                             \
-        (tw)->durable_stop_ts = (tw)->stop_ts = (upd)->upd_start_ts; \
-        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {      \
-            (tw)->stop_prepare_ts = (upd)->prepare_ts;               \
-            (tw)->stop_prepared_id = (upd)->prepared_id;             \
-        }                                                            \
-                                                                     \
-        if ((upd)->upd_durable_ts != WT_TS_NONE)                     \
-            (tw)->durable_stop_ts = (upd)->upd_durable_ts;           \
-        (tw)->stop_txn = (upd)->txnid;                               \
+#define WT_TIME_WINDOW_SET_STOP(tw, upd, prepare_state)                                     \
+    do {                                                                                    \
+        (tw)->stop_txn = (upd)->txnid;                                                      \
+        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) { \
+            (tw)->stop_prepare_ts = (upd)->prepare_ts;                                      \
+            (tw)->stop_prepared_id = (upd)->prepared_id;                                    \
+        } else {                                                                            \
+            (tw)->stop_ts = (upd)->upd_start_ts;                                            \
+            (tw)->durable_stop_ts = (upd)->upd_durable_ts;                                  \
+        }                                                                                   \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */
@@ -112,7 +110,6 @@
         (dest)->durable_start_ts = (source)->durable_start_ts;   \
         (dest)->start_ts = (source)->start_ts;                   \
         (dest)->start_txn = (source)->start_txn;                 \
-        (dest)->prepare = (source)->prepare;                     \
         (dest)->start_prepare_ts = (source)->start_prepare_ts;   \
         (dest)->start_prepared_id = (source)->start_prepared_id; \
     } while (0)
@@ -123,7 +120,6 @@
         (dest)->durable_stop_ts = (source)->durable_stop_ts;   \
         (dest)->stop_ts = (source)->stop_ts;                   \
         (dest)->stop_txn = (source)->stop_txn;                 \
-        (dest)->prepare = (source)->prepare;                   \
         (dest)->stop_prepare_ts = (source)->stop_prepare_ts;   \
         (dest)->stop_prepared_id = (source)->stop_prepared_id; \
     } while (0)
@@ -211,7 +207,7 @@
               WT_MAX((tw)->stop_prepare_ts, (ta)->newest_stop_durable_ts);                 \
         }                                                                                  \
         (ta)->newest_stop_txn = WT_MAX((tw)->stop_txn, (ta)->newest_stop_txn);             \
-        if ((tw)->prepare != 0)                                                            \
+        if (WT_TIME_WINDOW_HAS_PREPARE(tw))                                                \
             (ta)->prepare = 1;                                                             \
     } while (0)
 

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -68,9 +68,7 @@
       (tw1)->stop_txn == (tw2)->stop_txn && (tw1)->stop_prepared_id == (tw2)->stop_prepared_id && \
       (tw1)->stop_prepare_ts == (tw2)->stop_prepare_ts)
 
-/*
- * Set the start values of a time window from those in an update structure.
- */
+/* Set the start values of a time window from those in an update structure. */
 #define WT_TIME_WINDOW_SET_START(tw, upd, prepare_state)                                    \
     do {                                                                                    \
         (tw)->start_txn = (upd)->txnid;                                                     \
@@ -83,9 +81,7 @@
         }                                                                                   \
     } while (0)
 
-/*
- * Set the stop values of a time window from those in an update structure.
- */
+/* Set the stop values of a time window from those in an update structure. */
 #define WT_TIME_WINDOW_SET_STOP(tw, upd, prepare_state)                                     \
     do {                                                                                    \
         (tw)->stop_txn = (upd)->txnid;                                                      \

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -52,12 +52,6 @@
 #define WT_TIME_WINDOW_HAS_PREPARE(tw) \
     (WT_TIME_WINDOW_HAS_START_PREPARE(tw) || WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
 
-#define WT_TIME_WINDOW_USE_STOP_PREPARE_TS_OR(tw, ts) \
-    ((tw)->stop_prepare_ts != WT_TS_NONE ? (tw)->stop_prepare_ts : ts)
-
-#define WT_TIME_WINDOW_USE_START_PREPARE_TS_OR(tw, ts) \
-    ((tw)->start_prepare_ts != WT_TS_NONE ? (tw)->start_prepare_ts : ts)
-
 /* Return true if the time windows are the same. */
 #define WT_TIME_WINDOWS_EQUAL(tw1, tw2)                                                          \
     ((tw1)->durable_start_ts == (tw2)->durable_start_ts && (tw1)->start_ts == (tw2)->start_ts && \

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1086,7 +1086,6 @@ __wt_txn_tw_stop_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 static WT_INLINE bool
 __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    /* If time window is start prepare, return false. */
     if (WT_TIME_WINDOW_HAS_START_PREPARE(tw))
         return (false);
     return (__wt_txn_visible(session, tw->start_txn, tw->start_ts, tw->durable_start_ts));
@@ -1099,7 +1098,6 @@ __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 static WT_INLINE bool
 __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    /* If time window is start prepare, return false. */
     if (WT_TIME_WINDOW_HAS_START_PREPARE(tw))
         return (false);
     return (__wt_txn_visible_all(session, tw->start_txn, tw->durable_start_ts));

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2330,7 +2330,7 @@ __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
         WT_TIME_WINDOW_SET_STOP(&(upd_value->tw), upd, prepare_state);
     else
         WT_TIME_WINDOW_SET_START(&(upd_value->tw), upd, prepare_state);
-        
+
     upd_value->type = upd->type;
 }
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1062,7 +1062,7 @@ __wt_txn_upd_visible_all(WT_SESSION_IMPL *session, WT_UPDATE *upd)
 static WT_INLINE bool
 __wt_txn_upd_value_visible_all(WT_SESSION_IMPL *session, WT_UPDATE_VALUE *upd_value)
 {
-    WT_ASSERT(session, upd_value->tw.prepare == 0);
+    WT_ASSERT(session, !WT_TIME_WINDOW_HAS_PREPARE(&(upd_value->tw)));
     return (upd_value->type == WT_UPDATE_TOMBSTONE ?
         __wt_txn_visible_all(session, upd_value->tw.stop_txn, upd_value->tw.durable_stop_ts) :
         __wt_txn_visible_all(session, upd_value->tw.start_txn, upd_value->tw.durable_start_ts));
@@ -1075,7 +1075,7 @@ __wt_txn_upd_value_visible_all(WT_SESSION_IMPL *session, WT_UPDATE_VALUE *upd_va
 static WT_INLINE bool
 __wt_txn_tw_stop_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    return (WT_TIME_WINDOW_HAS_STOP(tw) && !tw->prepare &&
+    return (WT_TIME_WINDOW_HAS_STOP(tw) && !WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) &&
       __wt_txn_visible(session, tw->stop_txn, tw->stop_ts, tw->durable_stop_ts));
 }
 
@@ -1086,15 +1086,10 @@ __wt_txn_tw_stop_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 static WT_INLINE bool
 __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    /*
-     * Check the prepared flag if there is no stop time point or the start and stop time points are
-     * from the same transaction.
-     */
-    return (((WT_TIME_WINDOW_HAS_STOP(tw) &&
-               (tw->start_txn != tw->stop_txn || tw->start_ts != tw->stop_ts ||
-                 tw->durable_start_ts != tw->durable_stop_ts)) ||
-              !tw->prepare) &&
-      __wt_txn_visible(session, tw->start_txn, tw->start_ts, tw->durable_start_ts));
+    /* If time window is start prepare, return false. */
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw))
+        return (false);
+    return (__wt_txn_visible(session, tw->start_txn, tw->start_ts, tw->durable_start_ts));
 }
 
 /*
@@ -1104,15 +1099,10 @@ __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 static WT_INLINE bool
 __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    /*
-     * Check the prepared flag if there is no stop time point or the start and stop time points are
-     * from the same transaction.
-     */
-    return (((WT_TIME_WINDOW_HAS_STOP(tw) &&
-               (tw->start_txn != tw->stop_txn || tw->start_ts != tw->stop_ts ||
-                 tw->durable_start_ts != tw->durable_stop_ts)) ||
-              !tw->prepare) &&
-      __wt_txn_visible_all(session, tw->start_txn, tw->durable_start_ts));
+    /* If time window is start prepare, return false. */
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw))
+        return (false);
+    return (__wt_txn_visible_all(session, tw->start_txn, tw->durable_start_ts));
 }
 
 /*
@@ -1122,7 +1112,7 @@ __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 static WT_INLINE bool
 __wt_txn_tw_stop_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    return (WT_TIME_WINDOW_HAS_STOP(tw) && !tw->prepare &&
+    return (WT_TIME_WINDOW_HAS_STOP(tw) && !WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) &&
       __wt_txn_visible_all(session, tw->stop_txn, tw->durable_stop_ts));
 }
 
@@ -1468,11 +1458,7 @@ __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, 
          */
         if (upd->type == WT_UPDATE_TOMBSTONE && F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE) &&
           !WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw)) {
-            cbt->upd_value->tw.durable_stop_ts = upd->upd_durable_ts;
-            cbt->upd_value->tw.stop_ts = upd->upd_start_ts;
-            cbt->upd_value->tw.stop_txn = upd->txnid;
-            cbt->upd_value->tw.prepare =
-              prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
+            WT_TIME_WINDOW_SET_STOP(&cbt->upd_value->tw, upd, prepare_state);
             continue;
         }
 
@@ -2341,16 +2327,10 @@ __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
         upd_value->buf.size = upd->size;
     }
     if (upd->type == WT_UPDATE_TOMBSTONE) {
-        upd_value->tw.durable_stop_ts = upd->upd_durable_ts;
-        upd_value->tw.stop_ts = upd->upd_start_ts;
-        upd_value->tw.stop_txn = upd->txnid;
+        WT_TIME_WINDOW_SET_STOP(&(upd_value->tw), upd, prepare_state);
     } else {
-        upd_value->tw.durable_start_ts = upd->upd_durable_ts;
-        upd_value->tw.start_ts = upd->upd_start_ts;
-        upd_value->tw.start_txn = upd->txnid;
+        WT_TIME_WINDOW_SET_START(&(upd_value->tw), upd, prepare_state);
     }
-    upd_value->tw.prepare =
-      prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
     upd_value->type = upd->type;
 }
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2326,11 +2326,11 @@ __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd)
         upd_value->buf.data = upd->data;
         upd_value->buf.size = upd->size;
     }
-    if (upd->type == WT_UPDATE_TOMBSTONE) {
+    if (upd->type == WT_UPDATE_TOMBSTONE)
         WT_TIME_WINDOW_SET_STOP(&(upd_value->tw), upd, prepare_state);
-    } else {
+    else
         WT_TIME_WINDOW_SET_START(&(upd_value->tw), upd, prepare_state);
-    }
+        
     upd_value->type = upd->type;
 }
 

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -103,7 +103,7 @@ __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_RO
     __wt_cell_get_tw(vpack, &tw);
 
     /* Done if the record wasn't prepared. */
-    if (!tw->prepare)
+    if (!WT_TIME_WINDOW_HAS_PREPARE(tw))
         return (0);
 
     WT_RET(__prepared_discover_process_ondisk_kv(session, ref, rip, recno, row_key, vpack));

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -86,7 +86,8 @@ __rec_append_orig_value(
     conn = S2C(session);
 
     WT_ASSERT_ALWAYS(session,
-      upd != NULL && unpack != NULL && unpack->type != WT_CELL_DEL && !unpack->tw.prepare,
+      upd != NULL && unpack != NULL && unpack->type != WT_CELL_DEL &&
+        !WT_TIME_WINDOW_HAS_PREPARE(&(unpack->tw)),
       "__rec_append_orig_value requires an onpage, non-prepared update");
 
     append = oldest_upd = tombstone = NULL;
@@ -306,7 +307,7 @@ __rec_need_save_upd(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_UPDATE_SELEC
     if (F_ISSET(r, WT_REC_REWRITE_DELTA))
         return (false);
 
-    if (upd_select->tw.prepare)
+    if (WT_TIME_WINDOW_HAS_PREPARE(&(upd_select->tw)))
         return (true);
 
     if (F_ISSET(r, WT_REC_EVICT) && has_newer_updates)
@@ -430,6 +431,7 @@ __timestamp_no_ts_fix(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
 
         select_tw->durable_start_ts = select_tw->durable_stop_ts;
         select_tw->start_ts = select_tw->stop_ts;
+        select_tw->start_prepare_ts = select_tw->stop_prepare_ts;
         return (true);
     }
     return (false);
@@ -552,7 +554,7 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
      * the update chain but checkpoint won't replace the page image as such it will be the previous
      * reconciliations ondisk value that we will be comparing against.
      */
-    if (vpack != NULL && !vpack->tw.prepare) {
+    if (vpack != NULL && !WT_TIME_WINDOW_HAS_PREPARE(&(vpack->tw))) {
         char ts_string[3][WT_TS_INT_STRING_SIZE];
         if (WT_TIME_WINDOW_HAS_STOP(&vpack->tw))
             WT_ASSERT_ALWAYS(session,
@@ -861,13 +863,6 @@ __rec_fill_tw_from_upd_select(
      */
 
     /*
-     * Mark the prepare flag if the selected update is an uncommitted prepare. As tombstone updates
-     * are never returned to write, set this flag before we move into the previous update to write.
-     */
-    if (upd->prepare_state == WT_PREPARE_INPROGRESS)
-        select_tw->prepare = 1;
-
-    /*
      * If the newest is a tombstone then select the update before it and set the end of the
      * visibility window to its time point as appropriate to indicate that we should return "not
      * found" for reads after this point.
@@ -876,7 +871,7 @@ __rec_fill_tw_from_upd_select(
      * that the value is visible to any timestamp/transaction id ahead of it.
      */
     if (upd->type == WT_UPDATE_TOMBSTONE) {
-        WT_TIME_WINDOW_SET_STOP(session, select_tw, upd);
+        WT_TIME_WINDOW_SET_STOP(select_tw, upd, upd->prepare_state);
         tombstone = upd_select->tombstone = upd;
 
         /* Find the update this tombstone applies to. */
@@ -894,7 +889,7 @@ __rec_fill_tw_from_upd_select(
 
     if (upd != NULL)
         /* The beginning of the validity window is the selected update's time point. */
-        WT_TIME_WINDOW_SET_START(session, select_tw, upd);
+        WT_TIME_WINDOW_SET_START(select_tw, upd, upd->prepare_state);
     else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
         WT_ASSERT_ALWAYS(
           session, tombstone != NULL, "The only contents of the update list is a single tombstone");
@@ -910,7 +905,8 @@ __rec_fill_tw_from_upd_select(
 
         WT_ASSERT_ALWAYS(
           session, vpack != NULL && vpack->type != WT_CELL_DEL, "No on-disk value is found");
-        WT_ASSERT_ALWAYS(session, !vpack->tw.prepare, "On-disk value is a prepared update");
+        WT_ASSERT_ALWAYS(
+          session, !WT_TIME_WINDOW_HAS_PREPARE(&(vpack->tw)), "On-disk value is a prepared update");
 
         /* Move the pointer to the last update on the update chain. */
         for (last_upd = tombstone; last_upd->next != NULL; last_upd = last_upd->next)
@@ -954,7 +950,7 @@ __rec_fill_tw_from_upd_select(
               "Tombstone is globally visible, but the tombstoned update is on the update "
               "chain");
             upd_select->upd = last_upd->next;
-            WT_TIME_WINDOW_SET_START(session, select_tw, last_upd->next);
+            WT_TIME_WINDOW_SET_START(select_tw, last_upd->next, last_upd->next->prepare_state);
         } else {
             /*
              * It's possible that onpage value is not appended if the tombstone becomes globally
@@ -972,7 +968,6 @@ __rec_fill_tw_from_upd_select(
             upd_select->upd = tombstone;
         }
     }
-
     return (0);
 }
 
@@ -1177,7 +1172,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
      * appended to the update chain when the page is read into memory.
      */
     if (upd_select->upd != NULL && vpack != NULL && vpack->type != WT_CELL_DEL &&
-      !vpack->tw.prepare && (upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
+      !WT_TIME_WINDOW_HAS_PREPARE(&(vpack->tw)) &&
+      (upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
         WT_RET(__rec_append_orig_value(session, page, upd_select->upd, vpack));
 
     __wti_rec_time_window_clear_obsolete(session, upd_select, NULL, r);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -431,7 +431,7 @@ __timestamp_no_ts_fix(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
 
         select_tw->durable_start_ts = select_tw->durable_stop_ts;
         select_tw->start_ts = select_tw->stop_ts;
-        select_tw->start_prepare_ts = select_tw->stop_prepare_ts;
+        /* select_tw->start_prepare_ts = select_tw->stop_prepare_ts; */
         return (true);
     }
     return (false);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -422,7 +422,9 @@ __timestamp_no_ts_fix(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
      * start_txn, this is no longer true so assert that we don't encounter it.
      */
     WT_ASSERT(session, select_tw->stop_txn >= select_tw->start_txn);
-
+    WT_ASSERT(session,
+      !WT_TIME_WINDOW_HAS_STOP_PREPARE(select_tw) ||
+        select_tw->stop_prepare_ts >= select_tw->start_ts);
     if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(select_tw) && select_tw->stop_ts < select_tw->start_ts) {
         WT_ASSERT(session, select_tw->stop_ts == WT_TS_NONE);
         __wt_verbose(session, WT_VERB_TIMESTAMP,

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -423,7 +423,7 @@ __timestamp_no_ts_fix(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
      */
     WT_ASSERT(session, select_tw->stop_txn >= select_tw->start_txn);
 
-    if (select_tw->stop_ts < select_tw->start_ts) {
+    if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(select_tw) && select_tw->stop_ts < select_tw->start_ts) {
         WT_ASSERT(session, select_tw->stop_ts == WT_TS_NONE);
         __wt_verbose(session, WT_VERB_TIMESTAMP,
           "Warning: fixing remove without a timestamp earlier than value; time window %s",
@@ -431,7 +431,6 @@ __timestamp_no_ts_fix(WT_SESSION_IMPL *session, WT_TIME_WINDOW *select_tw)
 
         select_tw->durable_start_ts = select_tw->durable_stop_ts;
         select_tw->start_ts = select_tw->stop_ts;
-        /* select_tw->start_prepare_ts = select_tw->stop_prepare_ts; */
         return (true);
     }
     return (false);

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -50,7 +50,7 @@ __rec_cell_tw_stats(WTI_RECONCILE *r, WT_TIME_WINDOW *tw)
         ++r->count_stop_ts;
     if (tw->stop_txn != WT_TXN_MAX)
         ++r->count_stop_txn;
-    if (tw->prepare)
+    if (WT_TIME_WINDOW_HAS_PREPARE(tw))
         ++r->count_prepare;
 }
 
@@ -491,7 +491,7 @@ __wti_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WTI_UPDATE_SELECT
      * create an extra update on the end of the chain later in reconciliation as we'll re-append the
      * disk image value to the update chain.
      */
-    if (!tw->prepare && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
+    if (!WT_TIME_WINDOW_HAS_PREPARE(tw) && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
       !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
         /*
          * Check if the start of the time window is globally visible, and if so remove unnecessary

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -433,7 +433,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
          * the written proper timestamp, so comparing against it with history store shouldn't have
          * any problem.
          */
-        if (hs_tw->start_ts <= tw->start_ts || tw->prepare) {
+        if (hs_tw->start_ts <= tw->start_ts || WT_TIME_WINDOW_HAS_PREPARE(tw)) {
             if (type == WT_UPDATE_MODIFY) {
                 __wt_modify_max_memsize_format(
                   hs_value->data, S2BT(session)->value_format, full_value->size, &max_memsize);
@@ -501,7 +501,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
               "history store update valid with time_window=%s, type=%s and stable_timestamp=%s",
               __wt_time_window_to_string(hs_tw, tw_string), __wt_update_type_str(type),
               __wt_timestamp_to_string(rollback_timestamp, ts_string[0]));
-            WT_ASSERT(session, tw->prepare || hs_tw->start_ts <= tw->start_ts);
+            WT_ASSERT(session, WT_TIME_WINDOW_HAS_PREPARE(tw) || hs_tw->start_ts <= tw->start_ts);
             valid_update_found = true;
             break;
         }
@@ -548,6 +548,8 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
             upd->txnid = hs_tw->start_txn;
         upd->upd_durable_ts = hs_tw->durable_start_ts;
         upd->upd_start_ts = hs_tw->start_ts;
+        upd->prepare_ts = hs_tw->start_prepare_ts;
+        upd->prepared_id = hs_tw->start_prepared_id;
         __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
           WT_RTS_VERB_TAG_HS_UPDATE_RESTORED "history store update restored txnid=%" PRIu64
                                              ", start_ts=%s and durable_ts=%s",
@@ -573,7 +575,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
              */
             WT_ASSERT(session,
               hs_stop_durable_ts == WT_TS_NONE || hs_stop_durable_ts < newer_hs_durable_ts ||
-                tw->prepare);
+                WT_TIME_WINDOW_HAS_PREPARE(tw));
 
             WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
             /*
@@ -588,6 +590,8 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
                 tombstone->txnid = hs_tw->stop_txn;
             tombstone->upd_durable_ts = hs_tw->durable_stop_ts;
             tombstone->upd_start_ts = hs_tw->stop_ts;
+            tombstone->prepare_ts = hs_tw->stop_prepare_ts;
+            tombstone->prepared_id = hs_tw->stop_prepared_id;
             __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
               WT_RTS_VERB_TAG_HS_RESTORE_TOMBSTONE
               "history store tombstone restored, txnid=%" PRIu64 ", start_ts=%s and durable_ts=%s",
@@ -680,7 +684,7 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
     /* Retrieve the time window from the unpacked value cell. */
     __wt_cell_get_tw(vpack, &tw);
 
-    prepared = tw->prepare;
+    prepared = WT_TIME_WINDOW_HAS_PREPARE(tw);
     if (WT_IS_HS(session->dhandle)) {
         /*
          * Abort the history store update with stop durable timestamp greater than the stable
@@ -735,8 +739,8 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
          * windows can be the same. To abort these updates, check for any stable update from history
          * store or remove the key.
          */
-        if (tw->start_ts == tw->stop_ts && tw->durable_start_ts == tw->durable_stop_ts &&
-          tw->start_txn == tw->stop_txn) {
+        if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) && tw->start_prepared_id == tw->stop_prepared_id &&
+          tw->start_prepare_ts == tw->stop_prepare_ts && tw->start_txn == tw->stop_txn) {
             WT_ASSERT(session, prepared == true);
             if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
               !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
@@ -773,6 +777,8 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
                 upd->txnid = tw->start_txn;
             upd->upd_durable_ts = tw->durable_start_ts;
             upd->upd_start_ts = tw->start_ts;
+            upd->prepare_ts = tw->start_prepare_ts;
+            upd->prepared_id = tw->start_prepared_id;
             F_SET(upd, WT_UPDATE_RESTORED_FROM_DS);
             if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED))
                 F_SET(upd, WT_UPDATE_DURABLE);

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -739,9 +739,9 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
          * windows can be the same. To abort these updates, check for any stable update from history
          * store or remove the key.
          */
-        if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) && tw->start_prepared_id == tw->stop_prepared_id &&
+        if (WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_prepared_id == tw->stop_prepared_id &&
           tw->start_prepare_ts == tw->stop_prepare_ts && tw->start_txn == tw->stop_txn) {
-            WT_ASSERT(session, prepared == true);
+            WT_ASSERT(session, prepared);
             if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
               !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
                 return (__rts_btree_ondisk_fixup_key(

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -51,7 +51,7 @@ __wt_time_window_to_string(WT_TIME_WINDOW *tw, char *tw_string)
       __wt_timestamp_to_string(tw->start_ts, ts_string[1]), tw->start_txn,
       __wt_timestamp_to_string(tw->durable_stop_ts, ts_string[2]),
       __wt_timestamp_to_string(tw->stop_ts, ts_string[3]), tw->stop_txn,
-      tw->prepare ? ", prepared" : ""));
+      WT_TIME_WINDOW_HAS_PREPARE(tw) ? ", prepared" : ""));
     return (tw_string);
 }
 
@@ -406,9 +406,16 @@ __time_value_validate_parent(
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
 
-    if (tw->start_ts < parent->oldest_start_ts)
+    if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_ts < parent->oldest_start_ts)
         WT_TIME_VALIDATE_RET(session,
           "value time window has a start time before its parent's oldest start time; time window "
+          "%s, parent %s",
+          __wt_time_window_to_string(tw, time_string[0]),
+          __wt_time_aggregate_to_string(parent, time_string[1]));
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_prepare_ts < parent->oldest_start_ts)
+        WT_TIME_VALIDATE_RET(session,
+          "value time window has a start prepare time before its parent's oldest start time; time "
+          "window "
           "%s, parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
@@ -428,9 +435,17 @@ __time_value_validate_parent(
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
 
-    if (tw->stop_ts > parent->newest_stop_ts)
+    if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) && tw->stop_ts > parent->newest_stop_ts)
         WT_TIME_VALIDATE_RET(session,
           "value time window has a stop time after its parent's newest stop time; time window %s, "
+          "parent %s",
+          __wt_time_window_to_string(tw, time_string[0]),
+          __wt_time_aggregate_to_string(parent, time_string[1]));
+
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) && tw->stop_prepare_ts > parent->newest_stop_ts)
+        WT_TIME_VALIDATE_RET(session,
+          "value time window has a stop prepare time after its parent's newest stop time; time "
+          "window %s, "
           "parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
@@ -442,7 +457,7 @@ __time_value_validate_parent(
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
 
-    if (tw->prepare && !parent->prepare)
+    if (WT_TIME_WINDOW_HAS_PREPARE(tw) && !parent->prepare)
         WT_TIME_VALIDATE_RET(session,
           "value time window is prepared but its parent is not; time window %s, parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
@@ -495,82 +510,77 @@ __wt_time_value_validate(
         WT_TIME_VALIDATE_RET(session,
           "value time window has a durable start time after its durable stop time; time window %s",
           __wt_time_window_to_string(tw, time_string[0]));
-
-    if (tw->prepare && F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
-        if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) && !WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+    /* Validate that if start prepare_ts is set, start_prepared_id must be set */
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
+        if (tw->start_prepare_ts == WT_TS_NONE) {
             WT_TIME_VALIDATE_RET(session,
-              "Prepared value time window has neither start or stop prepared information; time "
-              "window %s",
-              __wt_time_window_to_string(tw, time_string[0]));
-        } else {
-            /* Validate that if start prepare_ts is set, start_prepared_id must be set */
-            if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
-                if (tw->start_prepare_ts == WT_TS_NONE) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Start prepared value time window has no start prepare time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-                if (tw->start_prepared_id == WT_PREPARED_ID_NONE) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Start prepared value time window has no start prepared id; time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-                if (tw->start_ts != WT_TS_NONE) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Start prepared value time window has a start time set; time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-                if (tw->durable_start_ts != WT_TS_NONE) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Start prepared value time window has a durable start time set; time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-            }
-            if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
-                if (tw->stop_prepare_ts == WT_TS_NONE) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Stop prepared value time window has no stop prepare time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-                if (tw->stop_prepared_id == WT_PREPARED_ID_NONE) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Stop prepared value time window has no stop prepared id; time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-                if (tw->stop_ts != WT_TS_MAX) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Stop prepared value time window has a stop time set; time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-                if (tw->durable_stop_ts != WT_TS_NONE) {
-                    WT_TIME_VALIDATE_RET(session,
-                      "Stop prepared value time window has a durable stop time set; time "
-                      "window %s",
-                      __wt_time_window_to_string(tw, time_string[0]));
-                }
-            }
-        }
-    } else {
-        /* Validate that prepare_ts and prepared_id must be none */
-        if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
-            WT_TIME_VALIDATE_RET(session,
-              "Non-prepared value time window contains start prepared ts and prepared id; time "
+              "Start prepared value time window has no start prepare time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
         }
-        if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
+            if (tw->start_prepared_id == WT_PREPARED_ID_NONE)
+                WT_TIME_VALIDATE_RET(session,
+                  "Start prepared value time window has no start prepared id; time "
+                  "window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+        } else if (tw->start_prepared_id != WT_PREPARED_ID_NONE) {
             WT_TIME_VALIDATE_RET(session,
-              "Non-prepared value time window contains stop prepared ts and prepared id; time "
+              "Preserve_prepared config is off but start prepared value time window has start "
+              "prepared id; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
         }
+        if (tw->start_ts != WT_TS_NONE) {
+            WT_TIME_VALIDATE_RET(session,
+              "Start prepared value time window has a start time set; time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
+        if (tw->durable_start_ts != WT_TS_NONE) {
+            WT_TIME_VALIDATE_RET(session,
+              "Start prepared value time window has a durable start time set; time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
+    }
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+        if (tw->stop_prepare_ts == WT_TS_NONE) {
+            WT_TIME_VALIDATE_RET(session,
+              "Stop prepared value time window has no stop prepare time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
+        if F_ISSET (S2C(session), WT_CONN_PRESERVE_PREPARED) {
+            if (tw->stop_prepared_id == WT_PREPARED_ID_NONE)
+                WT_TIME_VALIDATE_RET(session,
+                  "Stop prepared value time window has no stop prepared id; time "
+                  "window %s",
+                  __wt_time_window_to_string(tw, time_string[0]));
+        } else if (tw->stop_prepared_id != WT_PREPARED_ID_NONE) {
+            WT_TIME_VALIDATE_RET(session,
+              "Preserve_prepared config is off but stop prepared value time window has stop "
+              "prepared id; time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
+        if (tw->stop_ts != WT_TS_MAX) {
+            WT_TIME_VALIDATE_RET(session,
+              "Stop prepared value time window has a stop time set; time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
+        if (tw->durable_stop_ts != WT_TS_NONE) {
+            WT_TIME_VALIDATE_RET(session,
+              "Stop prepared value time window has a durable stop time set; time "
+              "window %s",
+              __wt_time_window_to_string(tw, time_string[0]));
+        }
+    } else if (tw->stop_txn != WT_TXN_MAX && tw->stop_ts == WT_TS_MAX) {
+        WT_TIME_VALIDATE_RET(session,
+          "Time window has a stop transaction id but no prepare or stop time set; time "
+          "window %s",
+          __wt_time_window_to_string(tw, time_string[0]));
     }
 
     /*

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -406,15 +406,15 @@ __time_value_validate_parent(
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
     if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
-          if (tw->start_prepare_ts < parent->oldest_start_ts)
-        WT_TIME_VALIDATE_RET(session,
-          "value time window has a start prepare time before its parent's oldest start time; time "
-          "window "
-          "%s, parent %s",
-          __wt_time_window_to_string(tw, time_string[0]),
-          __wt_time_aggregate_to_string(parent, time_string[1]));
-        }
-    else if (tw->start_ts < parent->oldest_start_ts)
+        if (tw->start_prepare_ts < parent->oldest_start_ts)
+            WT_TIME_VALIDATE_RET(session,
+              "value time window has a start prepare time before its parent's oldest start time; "
+              "time "
+              "window "
+              "%s, parent %s",
+              __wt_time_window_to_string(tw, time_string[0]),
+              __wt_time_aggregate_to_string(parent, time_string[1]));
+    } else if (tw->start_ts < parent->oldest_start_ts)
         WT_TIME_VALIDATE_RET(session,
           "value time window has a start time before its parent's oldest start time; time window "
           "%s, parent %s",
@@ -435,16 +435,16 @@ __time_value_validate_parent(
           "time window %s, parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
-    
+
     if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
-      if (tw->stop_prepare_ts > parent->newest_stop_ts)
-        WT_TIME_VALIDATE_RET(session,
-          "value time window has a stop prepare time after its parent's newest stop time; time "
-          "window %s, "
-          "parent %s",
-          __wt_time_window_to_string(tw, time_string[0]),
-          __wt_time_aggregate_to_string(parent, time_string[1]));
-        } else if (tw->stop_ts > parent->newest_stop_ts)
+        if (tw->stop_prepare_ts > parent->newest_stop_ts)
+            WT_TIME_VALIDATE_RET(session,
+              "value time window has a stop prepare time after its parent's newest stop time; time "
+              "window %s, "
+              "parent %s",
+              __wt_time_window_to_string(tw, time_string[0]),
+              __wt_time_aggregate_to_string(parent, time_string[1]));
+    } else if (tw->stop_ts > parent->newest_stop_ts)
         WT_TIME_VALIDATE_RET(session,
           "value time window has a stop time after its parent's newest stop time; time window %s, "
           "parent %s",

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -547,7 +547,7 @@ __wt_time_value_validate(
               "Stop prepared value time window has no stop prepare time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        if F_ISSET (S2C(session), WT_CONN_PRESERVE_PREPARED) {
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
             if (tw->stop_prepared_id == WT_PREPARED_ID_NONE)
                 WT_TIME_VALIDATE_RET(session,
                   "Stop prepared value time window has no stop prepared id; time "

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -405,17 +405,18 @@ __time_value_validate_parent(
           "time; time window %s, parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
-
-    if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_ts < parent->oldest_start_ts)
-        WT_TIME_VALIDATE_RET(session,
-          "value time window has a start time before its parent's oldest start time; time window "
-          "%s, parent %s",
-          __wt_time_window_to_string(tw, time_string[0]),
-          __wt_time_aggregate_to_string(parent, time_string[1]));
-    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_prepare_ts < parent->oldest_start_ts)
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
+          if (tw->start_prepare_ts < parent->oldest_start_ts)
         WT_TIME_VALIDATE_RET(session,
           "value time window has a start prepare time before its parent's oldest start time; time "
           "window "
+          "%s, parent %s",
+          __wt_time_window_to_string(tw, time_string[0]),
+          __wt_time_aggregate_to_string(parent, time_string[1]));
+        }
+    else if (tw->start_ts < parent->oldest_start_ts)
+        WT_TIME_VALIDATE_RET(session,
+          "value time window has a start time before its parent's oldest start time; time window "
           "%s, parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
@@ -434,18 +435,18 @@ __time_value_validate_parent(
           "time window %s, parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
-
-    if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) && tw->stop_ts > parent->newest_stop_ts)
-        WT_TIME_VALIDATE_RET(session,
-          "value time window has a stop time after its parent's newest stop time; time window %s, "
-          "parent %s",
-          __wt_time_window_to_string(tw, time_string[0]),
-          __wt_time_aggregate_to_string(parent, time_string[1]));
-
-    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) && tw->stop_prepare_ts > parent->newest_stop_ts)
+    
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+      if (tw->stop_prepare_ts > parent->newest_stop_ts)
         WT_TIME_VALIDATE_RET(session,
           "value time window has a stop prepare time after its parent's newest stop time; time "
           "window %s, "
+          "parent %s",
+          __wt_time_window_to_string(tw, time_string[0]),
+          __wt_time_aggregate_to_string(parent, time_string[1]));
+        } else if (tw->stop_ts > parent->newest_stop_ts)
+        WT_TIME_VALIDATE_RET(session,
+          "value time window has a stop time after its parent's newest stop time; time window %s, "
           "parent %s",
           __wt_time_window_to_string(tw, time_string[0]),
           __wt_time_aggregate_to_string(parent, time_string[1]));
@@ -512,76 +513,67 @@ __wt_time_value_validate(
           __wt_time_window_to_string(tw, time_string[0]));
     /* Validate that if start prepare_ts is set, start_prepared_id must be set */
     if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
-        if (tw->start_prepare_ts == WT_TS_NONE) {
+        if (tw->start_prepare_ts == WT_TS_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Start prepared value time window has no start prepare time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
         if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
             if (tw->start_prepared_id == WT_PREPARED_ID_NONE)
                 WT_TIME_VALIDATE_RET(session,
                   "Start prepared value time window has no start prepared id; time "
                   "window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
-        } else if (tw->start_prepared_id != WT_PREPARED_ID_NONE) {
+        } else if (tw->start_prepared_id != WT_PREPARED_ID_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Preserve_prepared config is off but start prepared value time window has start "
               "prepared id; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
-        if (tw->start_ts != WT_TS_NONE) {
+        if (tw->start_ts != WT_TS_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Start prepared value time window has a start time set; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
-        if (tw->durable_start_ts != WT_TS_NONE) {
+        if (tw->durable_start_ts != WT_TS_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Start prepared value time window has a durable start time set; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
     }
     if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
-        if (tw->stop_prepare_ts == WT_TS_NONE) {
+        if (tw->stop_prepare_ts == WT_TS_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Stop prepared value time window has no stop prepare time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
         if F_ISSET (S2C(session), WT_CONN_PRESERVE_PREPARED) {
             if (tw->stop_prepared_id == WT_PREPARED_ID_NONE)
                 WT_TIME_VALIDATE_RET(session,
                   "Stop prepared value time window has no stop prepared id; time "
                   "window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
-        } else if (tw->stop_prepared_id != WT_PREPARED_ID_NONE) {
+        } else if (tw->stop_prepared_id != WT_PREPARED_ID_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Preserve_prepared config is off but stop prepared value time window has stop "
               "prepared id; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
-        if (tw->stop_ts != WT_TS_MAX) {
+        if (tw->stop_ts != WT_TS_MAX)
             WT_TIME_VALIDATE_RET(session,
               "Stop prepared value time window has a stop time set; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
-        if (tw->durable_stop_ts != WT_TS_NONE) {
+        if (tw->durable_stop_ts != WT_TS_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Stop prepared value time window has a durable stop time set; time "
               "window %s",
               __wt_time_window_to_string(tw, time_string[0]));
-        }
-    } else if (tw->stop_txn != WT_TXN_MAX && tw->stop_ts == WT_TS_MAX) {
+    } else if (tw->stop_txn != WT_TXN_MAX && tw->stop_ts == WT_TS_MAX)
         WT_TIME_VALIDATE_RET(session,
           "Time window has a stop transaction id but no prepare or stop time set; time "
           "window %s",
           __wt_time_window_to_string(tw, time_string[0]));
-    }
 
     /*
      * Optionally validate the time window against a parent's time window.

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1435,7 +1435,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
          */
         if (!commit && first_committed_upd == NULL) {
             tw_found = __wt_read_cell_time_window(cbt, &tw);
-            if (tw_found && tw.prepare == WT_PREPARE_INPROGRESS)
+            if (tw_found && WT_TIME_WINDOW_HAS_PREPARE(&tw))
                 WT_ERR(__txn_append_tombstone(session, op, cbt));
         }
         break;

--- a/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
+++ b/test/catch2/misc_tests/test_cell_prepared_time_window.cpp
@@ -29,9 +29,6 @@ create_test_time_window(wt_timestamp_t start_ts, uint64_t start_txn, wt_timestam
     tw.stop_ts = stop_ts;
     tw.stop_txn = stop_txn;
 
-    if (has_start_prepare || has_stop_prepare) {
-        tw.prepare = 1;
-    }
     if (tw.start_ts != WT_TS_NONE)
         tw.durable_start_ts = tw.start_ts;
 
@@ -139,7 +136,6 @@ compare_time_windows(const WT_TIME_WINDOW &expected, const WT_TIME_WINDOW &actua
     CHECK(expected.start_txn == actual.start_txn);
     CHECK(expected.stop_ts == actual.stop_ts);
     CHECK(expected.stop_txn == actual.stop_txn);
-    CHECK(expected.prepare == actual.prepare);
     CHECK(expected.start_prepare_ts == actual.start_prepare_ts);
     CHECK(expected.start_prepared_id == actual.start_prepared_id);
     CHECK(expected.stop_prepare_ts == actual.stop_prepare_ts);


### PR DESCRIPTION
This PR removes prepare flag from time window structure:
- Replace boolean prepare flag with explicit prepare timestamp/ID checks
- Simplify time window visibility logic using WT_TIME_WINDOW_HAS_PREPARE macros  
- Update cell packing to maintain backward compatibility for preserve_prepared config
- Ensure prepare_ts and prepared_id are properly propagated in all update & time window paths