### PR TITLE
WT-15033 Optimize cursor->reset calls during search() and search_near() in DSC

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1250,20 +1250,7 @@ __clayered_search_near(WT_CURSOR *cursor, int *exactp)
     CURSOR_API_CALL(cursor, session, ret, search_near, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
-
-    /*
-     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to
-     * release the snapshot when the count of active cursors is zero. Reset the constituent cursors
-     * to adhere to that behavior. Ideally we should not be changing the active cursors counter
-     * outside of the file cursor code.
-     */
-    if (__wt_txn_read_last_check(session)) {
-        WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
-        WT_ERR(__clayered_reset_cursors(clayered, false));
-    }
-
     WT_ERR(__clayered_enter(clayered, true, false, false));
-
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
     /*

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -127,7 +127,7 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, bool reset, bool update, bool iter
      * to adhere to that behavior. Ideally we should not be changing the active cursors counter
      * outside of the file cursor code.
      */
-    if (reset && __wt_txn_read_last_check(session)) {
+    if (reset && __wt_txn_read_committed_should_release_snapshot(session)) {
         WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
         WT_RET(__clayered_reset_cursors(clayered, false));
     }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1201,13 +1201,14 @@ __clayered_search(WT_CURSOR *cursor)
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
     /*
-     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to release the 
-     * snapshot when the count of active cursors is zero. Reset the constituent cursors to adhere to that
-     * behaviour. Ideally we should not be changing the active cursors counter outside of the file cursor code.
+     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to
+     * release the snapshot when the count of active cursors is zero. Reset the constituent cursors
+     * to adhere to that behavior. Ideally we should not be changing the active cursors counter
+     * outside of the file cursor code.
      */
     if (__wt_txn_read_last_check(session)) {
         WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
-        WT_RET(__clayered_reset_cursors(clayered, false));
+        WT_ERR(__clayered_reset_cursors(clayered, false));
     }
     WT_ERR(__clayered_enter(clayered, false, false));
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
@@ -1251,13 +1252,14 @@ __clayered_search_near(WT_CURSOR *cursor, int *exactp)
     __cursor_novalue(cursor);
 
     /*
-     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to release the 
-     * snapshot when the count of active cursors is zero. Reset the constituent cursors to adhere to that
-     * behaviour. Ideally we should not be changing the active cursors counter outside of the file cursor code.
+     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to
+     * release the snapshot when the count of active cursors is zero. Reset the constituent cursors
+     * to adhere to that behavior. Ideally we should not be changing the active cursors counter
+     * outside of the file cursor code.
      */
     if (__wt_txn_read_last_check(session)) {
         WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
-        WT_RET(__clayered_reset_cursors(clayered, false));
+        WT_ERR(__clayered_reset_cursors(clayered, false));
     }
 
     WT_ERR(__clayered_enter(clayered, false, false));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -114,18 +114,13 @@ __clayered_cursor_compare(WT_CURSOR_LAYERED *clayered, WT_CURSOR *c1, WT_CURSOR 
  *     Start an operation on a layered cursor.
  */
 static WT_INLINE int
-__clayered_enter(WT_CURSOR_LAYERED *clayered, bool reset, bool update, bool iteration)
+__clayered_enter(WT_CURSOR_LAYERED *clayered, bool update, bool iteration)
 {
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     bool external_state_change;
 
     session = CUR2S(clayered);
-
-    if (reset) {
-        WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
-        WT_RET(__clayered_reset_cursors(clayered, false));
-    }
 
     WT_RET(__clayered_adjust_state(clayered, update, iteration, &external_state_change));
 
@@ -787,7 +782,7 @@ __clayered_next(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, next, clayered->dhandle);
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, false, true));
+    WT_ERR(__clayered_enter(clayered, false, true));
 
     /* If we aren't positioned for a forward scan, get started. */
     if (clayered->current_cursor == NULL || !F_ISSET(clayered, WT_CLAYERED_ITERATE_NEXT)) {
@@ -854,7 +849,7 @@ __layered_prev_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, false, true));
+    WT_ERR(__clayered_enter(clayered, false, true));
 
     /* If we aren't positioned for a reverse scan, get started. */
     if (clayered->current_cursor == NULL || !F_ISSET(clayered, WT_CLAYERED_ITERATE_PREV)) {
@@ -1205,7 +1200,16 @@ __clayered_search(WT_CURSOR *cursor)
     CURSOR_API_CALL(cursor, session, ret, search, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, true, false, false));
+    /*
+     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to release the 
+     * snapshot when the count of active cursors is zero. Reset the constituent cursors to adhere to that
+     * behaviour. Ideally we should not be changing the active cursors counter outside of the file cursor code.
+     */
+    if (__wt_txn_read_last_check(session)) {
+        WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
+        WT_RET(__clayered_reset_cursors(clayered, false));
+    }
+    WT_ERR(__clayered_enter(clayered, false, false));
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
     ret = __clayered_lookup(session, clayered, &cursor->value);
@@ -1245,7 +1249,19 @@ __clayered_search_near(WT_CURSOR *cursor, int *exactp)
     CURSOR_API_CALL(cursor, session, ret, search_near, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, true, false, false));
+
+    /*
+     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to release the 
+     * snapshot when the count of active cursors is zero. Reset the constituent cursors to adhere to that
+     * behaviour. Ideally we should not be changing the active cursors counter outside of the file cursor code.
+     */
+    if (__wt_txn_read_last_check(session)) {
+        WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
+        WT_RET(__clayered_reset_cursors(clayered, false));
+    }
+
+    WT_ERR(__clayered_enter(clayered, false, false));
+
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
     /*
@@ -1530,7 +1546,7 @@ __clayered_insert(WT_CURSOR *cursor)
     CURSOR_UPDATE_API_CALL(cursor, session, ret, insert, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
-    WT_ERR(__clayered_enter(clayered, false, true, false));
+    WT_ERR(__clayered_enter(clayered, true, false));
 
     /*
      * It isn't necessary to copy the key out after the lookup in this case because any non-failed
@@ -1582,7 +1598,7 @@ __clayered_update(WT_CURSOR *cursor)
     CURSOR_UPDATE_API_CALL(cursor, session, ret, update, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
-    WT_ERR(__clayered_enter(clayered, false, true, false));
+    WT_ERR(__clayered_enter(clayered, true, false));
 
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
         WT_ERR(__clayered_lookup(session, clayered, &value));
@@ -1643,12 +1659,12 @@ __clayered_remove(WT_CURSOR *cursor)
      * top-level.
      */
     if (!positioned) {
-        WT_ERR(__clayered_enter(clayered, false, false, false));
+        WT_ERR(__clayered_enter(clayered, false, false));
         WT_ERR(__clayered_lookup(session, clayered, &value));
         __clayered_leave(clayered);
     }
 
-    WT_ERR(__clayered_enter(clayered, false, true, false));
+    WT_ERR(__clayered_enter(clayered, true, false));
     /*
      * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may have
      * landed on.
@@ -1697,7 +1713,7 @@ __clayered_reserve(WT_CURSOR *cursor)
 
     /* WT_CURSOR.reserve is update-without-overwrite and a special value. */
     F_CLR(cursor, WT_CURSTD_OVERWRITE);
-    WT_ERR(__clayered_enter(clayered, false, true, false));
+    WT_ERR(__clayered_enter(clayered, true, false));
     WT_ERR(__clayered_lookup(session, clayered, &value));
     /*
      * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may have
@@ -1743,7 +1759,7 @@ __clayered_largest_key(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, largest_key, clayered->dhandle);
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, false, false));
+    WT_ERR(__clayered_enter(clayered, false, false));
 
     ingest_cursor = clayered->ingest_cursor;
     stable_cursor = clayered->stable_cursor;
@@ -1872,7 +1888,7 @@ __clayered_next_random(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, next, clayered->dhandle);
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, false, true));
+    WT_ERR(__clayered_enter(clayered, false, true));
 
     for (;;) {
         /* FIXME-WT-14736: consider the size of ingest table in the future. */
@@ -1927,7 +1943,7 @@ __clayered_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
 
     CURSOR_UPDATE_API_CALL(cursor, session, ret, modify, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
-    WT_ERR(__clayered_enter(clayered, false, true, false));
+    WT_ERR(__clayered_enter(clayered, true, false));
 
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
         WT_ERR(__clayered_lookup(session, clayered, &value));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -114,13 +114,23 @@ __clayered_cursor_compare(WT_CURSOR_LAYERED *clayered, WT_CURSOR *c1, WT_CURSOR 
  *     Start an operation on a layered cursor.
  */
 static WT_INLINE int
-__clayered_enter(WT_CURSOR_LAYERED *clayered, bool update, bool iteration)
+__clayered_enter(WT_CURSOR_LAYERED *clayered, bool reset, bool update, bool iteration)
 {
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     bool external_state_change;
 
     session = CUR2S(clayered);
+    /*
+     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to
+     * release the snapshot when the count of active cursors is zero. Reset the constituent cursors
+     * to adhere to that behavior. Ideally we should not be changing the active cursors counter
+     * outside of the file cursor code.
+     */
+    if (reset && __wt_txn_read_last_check(session)) {
+        WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
+        WT_RET(__clayered_reset_cursors(clayered, false));
+    }
 
     WT_RET(__clayered_adjust_state(clayered, update, iteration, &external_state_change));
 
@@ -782,7 +792,7 @@ __clayered_next(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, next, clayered->dhandle);
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, true));
+    WT_ERR(__clayered_enter(clayered, false, false, true));
 
     /* If we aren't positioned for a forward scan, get started. */
     if (clayered->current_cursor == NULL || !F_ISSET(clayered, WT_CLAYERED_ITERATE_NEXT)) {
@@ -849,7 +859,7 @@ __layered_prev_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, true));
+    WT_ERR(__clayered_enter(clayered, false, false, true));
 
     /* If we aren't positioned for a reverse scan, get started. */
     if (clayered->current_cursor == NULL || !F_ISSET(clayered, WT_CLAYERED_ITERATE_PREV)) {
@@ -1200,17 +1210,7 @@ __clayered_search(WT_CURSOR *cursor)
     CURSOR_API_CALL(cursor, session, ret, search, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
-    /*
-     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to
-     * release the snapshot when the count of active cursors is zero. Reset the constituent cursors
-     * to adhere to that behavior. Ideally we should not be changing the active cursors counter
-     * outside of the file cursor code.
-     */
-    if (__wt_txn_read_last_check(session)) {
-        WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
-        WT_ERR(__clayered_reset_cursors(clayered, false));
-    }
-    WT_ERR(__clayered_enter(clayered, false, false));
+    WT_ERR(__clayered_enter(clayered, true, false, false));
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
     ret = __clayered_lookup(session, clayered, &cursor->value);
@@ -1262,7 +1262,7 @@ __clayered_search_near(WT_CURSOR *cursor, int *exactp)
         WT_ERR(__clayered_reset_cursors(clayered, false));
     }
 
-    WT_ERR(__clayered_enter(clayered, false, false));
+    WT_ERR(__clayered_enter(clayered, true, false, false));
 
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
@@ -1548,7 +1548,7 @@ __clayered_insert(WT_CURSOR *cursor)
     CURSOR_UPDATE_API_CALL(cursor, session, ret, insert, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
-    WT_ERR(__clayered_enter(clayered, true, false));
+    WT_ERR(__clayered_enter(clayered, false, true, false));
 
     /*
      * It isn't necessary to copy the key out after the lookup in this case because any non-failed
@@ -1600,7 +1600,7 @@ __clayered_update(WT_CURSOR *cursor)
     CURSOR_UPDATE_API_CALL(cursor, session, ret, update, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
-    WT_ERR(__clayered_enter(clayered, true, false));
+    WT_ERR(__clayered_enter(clayered, false, true, false));
 
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
         WT_ERR(__clayered_lookup(session, clayered, &value));
@@ -1661,12 +1661,12 @@ __clayered_remove(WT_CURSOR *cursor)
      * top-level.
      */
     if (!positioned) {
-        WT_ERR(__clayered_enter(clayered, false, false));
+        WT_ERR(__clayered_enter(clayered, false, false, false));
         WT_ERR(__clayered_lookup(session, clayered, &value));
         __clayered_leave(clayered);
     }
 
-    WT_ERR(__clayered_enter(clayered, true, false));
+    WT_ERR(__clayered_enter(clayered, false, true, false));
     /*
      * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may have
      * landed on.
@@ -1715,7 +1715,7 @@ __clayered_reserve(WT_CURSOR *cursor)
 
     /* WT_CURSOR.reserve is update-without-overwrite and a special value. */
     F_CLR(cursor, WT_CURSTD_OVERWRITE);
-    WT_ERR(__clayered_enter(clayered, true, false));
+    WT_ERR(__clayered_enter(clayered, false, true, false));
     WT_ERR(__clayered_lookup(session, clayered, &value));
     /*
      * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may have
@@ -1761,7 +1761,7 @@ __clayered_largest_key(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, largest_key, clayered->dhandle);
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, false));
+    WT_ERR(__clayered_enter(clayered, false, false, false));
 
     ingest_cursor = clayered->ingest_cursor;
     stable_cursor = clayered->stable_cursor;
@@ -1890,7 +1890,7 @@ __clayered_next_random(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, next, clayered->dhandle);
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, false, true));
+    WT_ERR(__clayered_enter(clayered, false, false, true));
 
     for (;;) {
         /* FIXME-WT-14736: consider the size of ingest table in the future. */
@@ -1945,7 +1945,7 @@ __clayered_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
 
     CURSOR_UPDATE_API_CALL(cursor, session, ret, modify, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
-    WT_ERR(__clayered_enter(clayered, true, false));
+    WT_ERR(__clayered_enter(clayered, false, true, false));
 
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
         WT_ERR(__clayered_lookup(session, clayered, &value));

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -275,7 +275,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
      * When the count of active cursors in the session goes to zero, there are no active cursors,
      * and we can release any snapshot we're holding for read committed isolation.
      */
-    if (session->ncursors == 0 || !WT_READING_CHECKPOINT(session))
+    if (session->ncursors == 0 && !WT_READING_CHECKPOINT(session))
         __wt_txn_read_last(session);
 
     /* If we're not holding a cursor reference, we're done. */

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -275,7 +275,7 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
      * When the count of active cursors in the session goes to zero, there are no active cursors,
      * and we can release any snapshot we're holding for read committed isolation.
      */
-    if (session->ncursors == 0 && !WT_READING_CHECKPOINT(session))
+    if (session->ncursors == 0 || !WT_READING_CHECKPOINT(session))
         __wt_txn_read_last(session);
 
     /* If we're not holding a cursor reference, we're done. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1916,6 +1916,8 @@ static WT_INLINE bool __wt_txn_has_newest_and_visible_all(WT_SESSION_IMPL *sessi
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_log_op_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_txn_read_last_check(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1916,7 +1916,7 @@ static WT_INLINE bool __wt_txn_has_newest_and_visible_all(WT_SESSION_IMPL *sessi
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_log_op_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_txn_read_last_check(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wt_txn_read_committed_should_release_snapshot(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2251,11 +2251,11 @@ __wt_txn_read_last(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_txn_read_last_check --
+ * __wt_txn_read_committed_should_release_snapshot --
  *     Called to check whether we want to release our snapshot through calling WT_CURSOR::reset().
  */
 static WT_INLINE bool
-__wt_txn_read_last_check(WT_SESSION_IMPL *session)
+__wt_txn_read_committed_should_release_snapshot(WT_SESSION_IMPL *session)
 {
     WT_TXN *txn;
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2251,6 +2251,21 @@ __wt_txn_read_last(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wt_txn_read_last_check --
+ *     Called when the last page for a session is released.
+ */
+static WT_INLINE bool
+__wt_txn_read_last_check(WT_SESSION_IMPL *session)
+{
+    WT_TXN *txn;
+
+    txn = session->txn;
+
+    /* Check if we can release the snap_min ID we put in the global table. */
+    return ((!F_ISSET(txn, WT_TXN_RUNNING) || txn->isolation != WT_ISO_SNAPSHOT) && txn->forced_iso == 0);
+}
+
+/*
  * __wt_txn_cursor_op --
  *     Called for each cursor operation.
  */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2252,7 +2252,7 @@ __wt_txn_read_last(WT_SESSION_IMPL *session)
 
 /*
  * __wt_txn_read_last_check --
- *     Called when the last page for a session is released.
+ *     Called to check whether we want to release our snapshot through calling WT_CURSOR::reset().
  */
 static WT_INLINE bool
 __wt_txn_read_last_check(WT_SESSION_IMPL *session)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2262,7 +2262,8 @@ __wt_txn_read_last_check(WT_SESSION_IMPL *session)
     txn = session->txn;
 
     /* Check if we can release the snap_min ID we put in the global table. */
-    return ((!F_ISSET(txn, WT_TXN_RUNNING) || txn->isolation != WT_ISO_SNAPSHOT) && txn->forced_iso == 0);
+    return (
+      (!F_ISSET(txn, WT_TXN_RUNNING) || txn->isolation != WT_ISO_SNAPSHOT) && txn->forced_iso == 0);
 }
 
 /*


### PR DESCRIPTION
There is no explicit reason why we need to call __clayered_reset_cursors and we should align the behaviour of ASC and DSC to match performance as close as possible. Inside DSC we should rely on the constituent cursors to call reset() rather than have DSC ensuring it. 

I have created a patch build with removed the cursor->reset() and shows one test failure which has been fixed via the `__wt_txn_read_last_check` if statement. The layered cursor increases the session->ncursors before calling search(). The file cursor code expects to release the snapshot inside a read committed transaction when session->ncursors is 0. This means the txn_read_last function would never be called. For the short term, call reset() beforehand to ensure txn_read_last gets called during constituent cursor->reset().