### PR TITLE
WT-14653 Add reconciliation stats for history store wrapup (8.1 backport) (#12025)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -801,7 +801,9 @@ conn_stats = [
     YieldStat('page_index_slot_ref_blocked', 'get reference for page index and slot time sleeping (usecs)'),
     YieldStat('page_locked_blocked', 'page acquire locked blocked'),
     YieldStat('page_read_blocked', 'page acquire read blocked'),
+    YieldStat('page_read_skip_deleted', 'pages skipped during read due to deleted state'),
     YieldStat('page_sleep', 'page acquire time sleeping (usecs)'),
+    YieldStat('page_split_restart', 'page split and restart read'),
     YieldStat('prepared_transition_blocked_page', 'page access yielded due to prepare state change'),
     YieldStat('txn_release_blocked', 'connection close blocked waiting for transaction state stabilization'),
 ]
@@ -1130,6 +1132,7 @@ conn_dsrc_stats = [
     ##########################################
     # Reconciliation statistics
     ##########################################
+    RecStat('rec_hs_wrapup_next_prev_calls', 'cursor next/prev calls during HS wrapup search_near'),
     RecStat('rec_overflow_key_leaf', 'leaf-page overflow keys'),
     RecStat('rec_overflow_value', 'overflow values written'),
     RecStat('rec_page_delete', 'pages deleted'),

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -776,6 +776,10 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 
     WT_STAT_CONN_DSRC_INCR(session, cursor_next);
 
+    /* Track next calls during HS wrapup */
+    if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
+        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+
     flags = WT_READ_NO_SPLIT | WT_READ_SKIP_INTL; /* tree walk flags */
     if (truncating)
         LF_SET(WT_READ_TRUNCATE);
@@ -881,6 +885,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
                 continue;
             }
         }
+
         /*
          * If we saw a lot of deleted records on this page, or we went all the way through a page
          * and only saw deleted records, try to evict the page when we release it. Otherwise

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -749,6 +749,10 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 
     WT_STAT_CONN_DSRC_INCR(session, cursor_prev);
 
+    /* Track prev calls during HS wrapup */
+    if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
+        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+
     /* tree walk flags */
     flags = WT_READ_NO_SPLIT | WT_READ_PREV | WT_READ_SKIP_INTL;
     if (truncating)

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -352,8 +352,10 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
             if (LF_ISSET(WT_READ_CACHE | WT_READ_NO_WAIT))
                 return (WT_NOTFOUND);
             if (LF_ISSET(WT_READ_SKIP_DELETED) &&
-              __wti_delete_page_skip(session, ref, !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT)))
+              __wti_delete_page_skip(session, ref, !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))) {
+                WT_STAT_CONN_INCR(session, page_read_skip_deleted);
                 return (WT_NOTFOUND);
+            }
             goto read;
         case WT_REF_DISK:
             /* Optionally limit reads to cache-only. */
@@ -401,6 +403,7 @@ read:
             stalled = true;
             break;
         case WT_REF_SPLIT:
+            WT_STAT_CONN_INCR(session, page_split_restart);
             return (WT_RESTART);
         case WT_REF_MEM:
             /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -206,6 +206,11 @@ struct __wt_session_impl {
         uint64_t total_reentry_hs_eviction_time;
     } reconcile_timeline;
 
+    /* Record statistics in an reconciliation. */
+    struct __wt_reconcile_stats {
+        uint64_t hs_wrapup_next_prev_calls;
+    } reconcile_stats;
+
     /*
      * Record the important timestamps of each stage in an eviction. If an eviction takes a long
      * time and times out, we can trace the time usage of each stage from this information.
@@ -301,21 +306,22 @@ struct __wt_session_impl {
 #define WT_SESSION_DEBUG_DO_NOT_CLEAR_TXN_ID 0x000020u
 #define WT_SESSION_DEBUG_RELEASE_EVICT 0x000040u
 #define WT_SESSION_EVICTION 0x000080u
-#define WT_SESSION_IGNORE_CACHE_SIZE 0x000100u
-#define WT_SESSION_IMPORT 0x000200u
-#define WT_SESSION_IMPORT_REPAIR 0x000400u
-#define WT_SESSION_INTERNAL 0x000800u
-#define WT_SESSION_LOGGING_INMEM 0x001000u
-#define WT_SESSION_NO_DATA_HANDLES 0x002000u
-#define WT_SESSION_NO_RECONCILE 0x004000u
-#define WT_SESSION_PREFETCH_ENABLED 0x008000u
-#define WT_SESSION_PREFETCH_THREAD 0x010000u
-#define WT_SESSION_QUIET_CORRUPT_FILE 0x020000u
-#define WT_SESSION_READ_WONT_NEED 0x040000u
-#define WT_SESSION_RESOLVING_TXN 0x080000u
-#define WT_SESSION_ROLLBACK_TO_STABLE 0x100000u
-#define WT_SESSION_SAVE_ERRORS 0x200000u
-#define WT_SESSION_SCHEMA_TXN 0x400000u
+#define WT_SESSION_HS_WRAPUP 0x000100u
+#define WT_SESSION_IGNORE_CACHE_SIZE 0x000200u
+#define WT_SESSION_IMPORT 0x000400u
+#define WT_SESSION_IMPORT_REPAIR 0x000800u
+#define WT_SESSION_INTERNAL 0x001000u
+#define WT_SESSION_LOGGING_INMEM 0x002000u
+#define WT_SESSION_NO_DATA_HANDLES 0x004000u
+#define WT_SESSION_NO_RECONCILE 0x008000u
+#define WT_SESSION_PREFETCH_ENABLED 0x010000u
+#define WT_SESSION_PREFETCH_THREAD 0x020000u
+#define WT_SESSION_QUIET_CORRUPT_FILE 0x040000u
+#define WT_SESSION_READ_WONT_NEED 0x080000u
+#define WT_SESSION_RESOLVING_TXN 0x100000u
+#define WT_SESSION_ROLLBACK_TO_STABLE 0x200000u
+#define WT_SESSION_SAVE_ERRORS 0x400000u
+#define WT_SESSION_SCHEMA_TXN 0x800000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t flags;
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -988,6 +988,7 @@ struct __wt_connection_stats {
     int64_t rec_vlcs_emptied_pages;
     int64_t rec_time_window_bytes_ts;
     int64_t rec_time_window_bytes_txn;
+    int64_t rec_hs_wrapup_next_prev_calls;
     int64_t rec_page_delete_fast;
     int64_t rec_overflow_key_leaf;
     int64_t rec_maximum_milliseconds;
@@ -1083,6 +1084,8 @@ struct __wt_connection_stats {
     int64_t page_sleep;
     int64_t page_del_rollback_blocked;
     int64_t child_modify_blocked_page;
+    int64_t page_split_restart;
+    int64_t page_read_skip_deleted;
     int64_t txn_prepared_updates;
     int64_t txn_prepared_updates_committed;
     int64_t txn_prepared_updates_key_repeated;
@@ -1395,6 +1398,7 @@ struct __wt_dsrc_stats {
     int64_t rec_vlcs_emptied_pages;
     int64_t rec_time_window_bytes_ts;
     int64_t rec_time_window_bytes_txn;
+    int64_t rec_hs_wrapup_next_prev_calls;
     int64_t rec_dictionary;
     int64_t rec_page_delete_fast;
     int64_t rec_suffix_compression;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6793,419 +6793,425 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * written
  */
 #define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1575
+/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1576
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1576
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1577
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1577
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1578
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1578
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1579
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1579
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1580
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1580
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1581
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1581
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1582
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1582
+#define	WT_STAT_CONN_REC_PAGES				1583
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1583
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1584
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1584
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1585
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1585
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1586
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1586
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1587
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1587
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1588
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1588
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1589
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1589
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1590
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1590
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1591
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1591
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1592
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1592
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1593
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1593
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1594
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1594
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1595
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1595
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1596
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1596
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1597
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1597
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1598
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1598
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1599
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1599
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1600
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1600
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1601
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1601
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1602
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1602
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1603
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1603
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1604
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1604
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1605
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1605
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1606
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1606
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1607
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1607
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1608
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1608
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1609
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1609
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1610
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1610
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1611
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1611
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1612
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1612
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1613
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1613
+#define	WT_STAT_CONN_FLUSH_TIER				1614
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1614
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1615
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1615
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1616
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1616
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1617
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1617
+#define	WT_STAT_CONN_SESSION_OPEN			1618
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1618
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1619
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1619
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1620
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1620
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1621
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1621
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1622
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1622
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1623
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1623
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1624
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1624
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1625
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1625
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1626
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1626
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1627
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1627
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1628
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1628
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1629
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1629
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1630
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1630
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1631
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1631
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1632
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1632
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1633
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1633
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1634
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1634
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1635
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1635
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1636
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1636
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1637
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1637
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1638
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1638
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1639
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1639
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1640
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1640
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1641
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1641
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1642
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1642
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1643
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1643
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1644
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1644
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1645
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1645
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1646
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1646
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1647
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1647
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1648
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1648
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1649
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1649
+#define	WT_STAT_CONN_TIERED_RETENTION			1650
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1650
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1651
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1651
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1652
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1652
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1653
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1653
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1654
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1654
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1655
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1655
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1656
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1656
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1657
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1657
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1658
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1658
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1659
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1659
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1660
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1660
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1661
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1661
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1662
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1662
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1663
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1663
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1664
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1664
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1665
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1665
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1666
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1666
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1667
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1667
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1668
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1668
+#define	WT_STAT_CONN_PAGE_SLEEP				1669
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1669
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1670
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1670
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1671
+/*! thread-yield: page split and restart read */
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1672
+/*! thread-yield: pages skipped during read due to deleted state */
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1673
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1671
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1674
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1672
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1675
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1673
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1676
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1674
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1677
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1675
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1678
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1676
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1679
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1677
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1680
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1678
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1681
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1679
+#define	WT_STAT_CONN_TXN_PREPARE			1682
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1680
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1683
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1681
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1684
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1682
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1685
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1683
+#define	WT_STAT_CONN_TXN_QUERY_TS			1686
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1684
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1687
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1685
+#define	WT_STAT_CONN_TXN_RTS				1688
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1686
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1689
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1687
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1690
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1688
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1691
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1689
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1692
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1690
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1693
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1691
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1694
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1692
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1695
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1693
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1696
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1694
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1697
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1695
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1698
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1696
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1699
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1697
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1700
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1698
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1701
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1699
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1702
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1700
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1703
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1701
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1704
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1702
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1705
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1703
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1706
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1704
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1707
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1705
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1708
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1706
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1709
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1707
+#define	WT_STAT_CONN_TXN_SET_TS				1710
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1708
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1711
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1709
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1712
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1710
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1713
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1711
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1714
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1712
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1715
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1713
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1716
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1714
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1717
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1715
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1718
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1716
+#define	WT_STAT_CONN_TXN_BEGIN				1719
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1717
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1720
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1718
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1721
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1719
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1722
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1720
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1723
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1721
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1724
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1722
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1725
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1723
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1726
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1724
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1727
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1725
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1728
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1726
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1729
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1727
+#define	WT_STAT_CONN_TXN_COMMIT				1730
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1728
+#define	WT_STAT_CONN_TXN_ROLLBACK			1731
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1729
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1732
 
 /*!
  * @}
@@ -7968,171 +7974,173 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * written
  */
 #define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2245
+/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2246
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2246
+#define	WT_STAT_DSRC_REC_DICTIONARY			2247
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2247
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2248
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2248
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2249
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2249
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2250
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2250
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2251
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2251
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2252
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2252
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2253
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2253
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2254
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2254
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2255
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2255
+#define	WT_STAT_DSRC_REC_PAGES				2256
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2256
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2257
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2257
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2258
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2258
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2259
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2259
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2260
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2260
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2261
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2261
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2262
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2262
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2263
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2263
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2264
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2264
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2265
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2265
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2266
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2266
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2267
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2267
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2268
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2268
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2269
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2269
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2270
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2270
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2271
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2271
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2272
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2272
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2273
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2273
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2274
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2274
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2275
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2275
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2276
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2276
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2277
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2277
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2278
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2278
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2279
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2279
+#define	WT_STAT_DSRC_SESSION_COMPACT			2280
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2280
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2281
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2281
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2282
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2282
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2283
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2283
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2284
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2284
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2285
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2285
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2286
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2286
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2287
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2287
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2288
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2288
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2289
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2289
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2290
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2290
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2291
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2291
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2292
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2292
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2293
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2293
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2294
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2294
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2295
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2295
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2296
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2296
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2297
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2297
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2298
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2298
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2299
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2299
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2300
 
 /*!
  * @}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -307,6 +307,8 @@ struct __wt_prefetch_queue_entry;
 typedef struct __wt_prefetch_queue_entry WT_PREFETCH_QUEUE_ENTRY;
 struct __wt_process;
 typedef struct __wt_process WT_PROCESS;
+struct __wt_reconcile_stats;
+typedef struct __wt_reconcile_stats WT_RECONCILE_STATS;
 struct __wt_reconcile_timeline;
 typedef struct __wt_reconcile_timeline WT_RECONCILE_TIMELINE;
 struct __wt_recovery_timeline;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2679,6 +2679,10 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
 
     btree = S2BT(session);
 
+    /* Set a flag in the session to track that we're in HS wrapup */
+    F_SET(session, WT_SESSION_HS_WRAPUP);
+    session->reconcile_stats.hs_wrapup_next_prev_calls = 0;
+
     /*
      * Sanity check: Can't insert updates into history store from the history store itself or from
      * the metadata file.
@@ -2701,7 +2705,10 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
             }
         }
 
+    WT_STAT_CONN_INCRV(
+      session, rec_hs_wrapup_next_prev_calls, session->reconcile_stats.hs_wrapup_next_prev_calls);
 err:
+    F_CLR(session, WT_SESSION_HS_WRAPUP);
     return (ret);
 }
 

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -264,6 +264,7 @@ static const char *const __stats_dsrc_desc[] = {
   "reconciliation: VLCS pages explicitly reconciled as empty",
   "reconciliation: approximate byte size of timestamps in pages written",
   "reconciliation: approximate byte size of transaction IDs in pages written",
+  "reconciliation: cursor next/prev calls during HS wrapup search_near",
   "reconciliation: dictionary matches",
   "reconciliation: fast-path pages deleted",
   "reconciliation: internal page key bytes discarded using suffix compression",
@@ -609,6 +610,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->rec_vlcs_emptied_pages = 0;
     stats->rec_time_window_bytes_ts = 0;
     stats->rec_time_window_bytes_txn = 0;
+    stats->rec_hs_wrapup_next_prev_calls = 0;
     stats->rec_dictionary = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_suffix_compression = 0;
@@ -949,6 +951,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->rec_vlcs_emptied_pages += from->rec_vlcs_emptied_pages;
     to->rec_time_window_bytes_ts += from->rec_time_window_bytes_ts;
     to->rec_time_window_bytes_txn += from->rec_time_window_bytes_txn;
+    to->rec_hs_wrapup_next_prev_calls += from->rec_hs_wrapup_next_prev_calls;
     to->rec_dictionary += from->rec_dictionary;
     to->rec_page_delete_fast += from->rec_page_delete_fast;
     to->rec_suffix_compression += from->rec_suffix_compression;
@@ -1316,6 +1319,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->rec_vlcs_emptied_pages += WT_STAT_DSRC_READ(from, rec_vlcs_emptied_pages);
     to->rec_time_window_bytes_ts += WT_STAT_DSRC_READ(from, rec_time_window_bytes_ts);
     to->rec_time_window_bytes_txn += WT_STAT_DSRC_READ(from, rec_time_window_bytes_txn);
+    to->rec_hs_wrapup_next_prev_calls += WT_STAT_DSRC_READ(from, rec_hs_wrapup_next_prev_calls);
     to->rec_dictionary += WT_STAT_DSRC_READ(from, rec_dictionary);
     to->rec_page_delete_fast += WT_STAT_DSRC_READ(from, rec_page_delete_fast);
     to->rec_suffix_compression += WT_STAT_DSRC_READ(from, rec_suffix_compression);
@@ -1979,6 +1983,7 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: VLCS pages explicitly reconciled as empty",
   "reconciliation: approximate byte size of timestamps in pages written",
   "reconciliation: approximate byte size of transaction IDs in pages written",
+  "reconciliation: cursor next/prev calls during HS wrapup search_near",
   "reconciliation: fast-path pages deleted",
   "reconciliation: leaf-page overflow keys",
   "reconciliation: maximum milliseconds spent in a reconciliation call",
@@ -2076,6 +2081,8 @@ static const char *const __stats_connection_desc[] = {
   "thread-yield: page acquire time sleeping (usecs)",
   "thread-yield: page delete rollback time sleeping for state change (usecs)",
   "thread-yield: page reconciliation yielded due to child modification",
+  "thread-yield: page split and restart read",
+  "thread-yield: pages skipped during read due to deleted state",
   "transaction: Number of prepared updates",
   "transaction: Number of prepared updates committed",
   "transaction: Number of prepared updates repeated on the same key",
@@ -2757,6 +2764,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->rec_vlcs_emptied_pages = 0;
     stats->rec_time_window_bytes_ts = 0;
     stats->rec_time_window_bytes_txn = 0;
+    stats->rec_hs_wrapup_next_prev_calls = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_overflow_key_leaf = 0;
     /* not clearing rec_maximum_milliseconds */
@@ -2852,6 +2860,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->page_sleep = 0;
     stats->page_del_rollback_blocked = 0;
     stats->child_modify_blocked_page = 0;
+    stats->page_split_restart = 0;
+    stats->page_read_skip_deleted = 0;
     stats->txn_prepared_updates = 0;
     stats->txn_prepared_updates_committed = 0;
     stats->txn_prepared_updates_key_repeated = 0;
@@ -3605,6 +3615,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_vlcs_emptied_pages += WT_STAT_CONN_READ(from, rec_vlcs_emptied_pages);
     to->rec_time_window_bytes_ts += WT_STAT_CONN_READ(from, rec_time_window_bytes_ts);
     to->rec_time_window_bytes_txn += WT_STAT_CONN_READ(from, rec_time_window_bytes_txn);
+    to->rec_hs_wrapup_next_prev_calls += WT_STAT_CONN_READ(from, rec_hs_wrapup_next_prev_calls);
     to->rec_page_delete_fast += WT_STAT_CONN_READ(from, rec_page_delete_fast);
     to->rec_overflow_key_leaf += WT_STAT_CONN_READ(from, rec_overflow_key_leaf);
     to->rec_maximum_milliseconds += WT_STAT_CONN_READ(from, rec_maximum_milliseconds);
@@ -3720,6 +3731,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->page_sleep += WT_STAT_CONN_READ(from, page_sleep);
     to->page_del_rollback_blocked += WT_STAT_CONN_READ(from, page_del_rollback_blocked);
     to->child_modify_blocked_page += WT_STAT_CONN_READ(from, child_modify_blocked_page);
+    to->page_split_restart += WT_STAT_CONN_READ(from, page_split_restart);
+    to->page_read_skip_deleted += WT_STAT_CONN_READ(from, page_read_skip_deleted);
     to->txn_prepared_updates += WT_STAT_CONN_READ(from, txn_prepared_updates);
     to->txn_prepared_updates_committed += WT_STAT_CONN_READ(from, txn_prepared_updates_committed);
     to->txn_prepared_updates_key_repeated +=


### PR DESCRIPTION
These are the stats we are adding as part of trying to identify an issue with workloads getting stuck during history store wrap up. They include:

- A stat to track pages skipped during read due to deleted state
- A stat to track how often pages were split and read restarted
- A stat to track how often next/prev were called during HS wrap up

(cherry picked from commit 6d4a8f816992bc9f9c5b3bdd8f6dddad918f157c)