### PR TITLE
WT-15070 Migrate develop branch off of perf.send

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -782,38 +782,26 @@ functions:
     # Since we later remove the WiredTiger folder, we need to check for core dumps now.
     - *dump_stacktraces
     - *upload_stacktraces
-    - command: shell.exec
+    - command: subprocess.exec
       params:
-        script: |
-          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
-          if [ "${requester}" == "commit" ]; then
-            is_mainline=true
-          else
-            is_mainline=false
-          fi
-
-          # Parse the username out of the order_id. Patches append the username. The Signal Processing Service (SPS) endpoint does not need the other information.
-          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
-
-          # Submit the performance data to the SPS endpoint
-          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
-            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
-            -H 'accept: application/json' \
-            -H 'Content-Type: application/json' \
-            -d @./wiredtiger/cmake_build/test/cppsuite/${test_name}.json)
-
-          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
-          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
-
-          # We want to throw an error if the data was not successfully submitted
-          if [ "$http_status" -ne 200 ]; then
-            echo "Error: Received HTTP status $http_status"
-            echo "Response Body: $response_body"
-            exit 1
-          fi
-
-          echo "Response Body: $response_body"
-          echo "HTTP Status: $http_status"
+        binary: bash
+        args:
+          - .evergreen/perf_submission.sh
+        working_dir: src
+        env:
+          perf_file_path: ./wiredtiger/cmake_build/test/cppsuite/${test_name}.json
+        include_expansions_in_env:
+          - requester
+          - revision_order_id
+          - project_id
+          - version_id
+          - build_variant
+          - parsed_order_id
+          - task_name
+          - task_id
+          - execution
+          - is_mainline
+      type: test
     # Cleanup tasks.
     - *cppsuite_remove_files
     - *cppsuite_archive
@@ -1217,38 +1205,26 @@ functions:
           ${python_binary|python3} ../../../bench/perf_run_py/perf_run.py --${test_type|wtperf} -e ${exec_path|./wtperf} -t ${perf-test-path|../../../bench/wtperf/runners}/${perf-test-name} -ho WT_TEST -m ${maxruns} -v -re -o test_stats/atlas_out_${perf-test-name}.json ${wtarg}
 
   "upload test stats":
-    - command: shell.exec
+    - command: subprocess.exec
       params:
-        script: |
-          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
-          if [ "${requester}" == "commit" ]; then
-            is_mainline=true
-          else
-            is_mainline=false
-          fi
-
-          # Parse the username out of the order_id. Patches append the username. The Signal Processing Service (SPS) endpoint does not need the other information.
-          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
-
-          # Submit the performance data to the SPS endpoint
-          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
-            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
-            -H 'accept: application/json' \
-            -H 'Content-Type: application/json' \
-            -d @./wiredtiger/cmake_build/${test_path}.json)
-
-          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
-          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
-
-          # We want to throw an error if the data was not successfully submitted
-          if [ "$http_status" -ne 200 ]; then
-            echo "Error: Received HTTP status $http_status"
-            echo "Response Body: $response_body"
-            exit 1
-          fi
-
-          echo "Response Body: $response_body"
-          echo "HTTP Status: $http_status"
+        binary: bash
+        args:
+          - .evergreen/perf_submission.sh
+        working_dir: src
+        env:
+          perf_file_path: ./wiredtiger/cmake_build/${test_path}.json
+        include_expansions_in_env:
+          - requester
+          - revision_order_id
+          - project_id
+          - version_id
+          - build_variant
+          - parsed_order_id
+          - task_name
+          - task_id
+          - execution
+          - is_mainline
+      type: test
 
   "convert-to-atlas-evergreen-format":
     - command: shell.exec
@@ -1277,38 +1253,26 @@ functions:
           ${python_binary|python3} automation-scripts/evergreen/upload_stats_atlas.py -u ${atlas_perf_test_username} -p ${atlas_perf_test_password} -c ${collection|} -d ${database|} -f ${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/atlas_out_${test-name}.json -t ${created_at} -i "$EVERGREEN_TASK_INFO" -g "./wiredtiger"
 
   "upload stats to evergreen":
-    - command: shell.exec
+    - command: subprocess.exec
       params:
-        script: |
-          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
-          if [ "${requester}" == "commit" ]; then
-            is_mainline=true
-          else
-            is_mainline=false
-          fi
-
-          # Parse the username out of the order_id. Patches append the username. The Signal Processing Service (SPS) endpoint does not need the other information.
-          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
-
-          # Submit the performance data to the SPS endpoint
-          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
-            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
-            -H 'accept: application/json' \
-            -H 'Content-Type: application/json' \
-            -d @${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/evergreen_out_${test-name}.json)
-
-          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
-          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
-
-          # We want to throw an error if the data was not successfully submitted
-          if [ "$http_status" -ne 200 ]; then
-            echo "Error: Received HTTP status $http_status"
-            echo "Response Body: $response_body"
-            exit 1
-          fi
-
-          echo "Response Body: $response_body"
-          echo "HTTP Status: $http_status"
+        binary: bash
+        args:
+          - .evergreen/perf_submission.sh
+        working_dir: src
+        env:
+          perf_file_path: ${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/evergreen_out_${test-name}.json
+        include_expansions_in_env:
+          - requester
+          - revision_order_id
+          - project_id
+          - version_id
+          - build_variant
+          - parsed_order_id
+          - task_name
+          - task_id
+          - execution
+          - is_mainline
+      type: test
     # Push the json results to the 'Files' tab of the task in Evergreen
     # Parameterised using the 'test-name' variable
     - command: s3.put

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -782,10 +782,38 @@ functions:
     # Since we later remove the WiredTiger folder, we need to check for core dumps now.
     - *dump_stacktraces
     - *upload_stacktraces
-    - command: perf.send
-      type: setup
+    - command: shell.exec
       params:
-        file: ./wiredtiger/cmake_build/test/cppsuite/${test_name}.json
+        script: |
+          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+          if [ "${requester}" == "commit" ]; then
+            is_mainline=true
+          else
+            is_mainline=false
+          fi
+
+          # Parse the username out of the order_id. Patches append the username. The Signal Processing Service (SPS) endpoint does not need the other information.
+          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
+
+          # Submit the performance data to the SPS endpoint
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -d @./wiredtiger/cmake_build/test/cppsuite/${test_name}.json)
+
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+          # We want to throw an error if the data was not successfully submitted
+          if [ "$http_status" -ne 200 ]; then
+            echo "Error: Received HTTP status $http_status"
+            echo "Response Body: $response_body"
+            exit 1
+          fi
+
+          echo "Response Body: $response_body"
+          echo "HTTP Status: $http_status"
     # Cleanup tasks.
     - *cppsuite_remove_files
     - *cppsuite_archive
@@ -1189,10 +1217,38 @@ functions:
           ${python_binary|python3} ../../../bench/perf_run_py/perf_run.py --${test_type|wtperf} -e ${exec_path|./wtperf} -t ${perf-test-path|../../../bench/wtperf/runners}/${perf-test-name} -ho WT_TEST -m ${maxruns} -v -re -o test_stats/atlas_out_${perf-test-name}.json ${wtarg}
 
   "upload test stats":
-    - command: perf.send
-      type: setup
+    - command: shell.exec
       params:
-        file: ./wiredtiger/cmake_build/${test_path}.json
+        script: |
+          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+          if [ "${requester}" == "commit" ]; then
+            is_mainline=true
+          else
+            is_mainline=false
+          fi
+
+          # Parse the username out of the order_id. Patches append the username. The Signal Processing Service (SPS) endpoint does not need the other information.
+          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
+
+          # Submit the performance data to the SPS endpoint
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -d @./wiredtiger/cmake_build/${test_path}.json)
+
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+          # We want to throw an error if the data was not successfully submitted
+          if [ "$http_status" -ne 200 ]; then
+            echo "Error: Received HTTP status $http_status"
+            echo "Response Body: $response_body"
+            exit 1
+          fi
+
+          echo "Response Body: $response_body"
+          echo "HTTP Status: $http_status"
 
   "convert-to-atlas-evergreen-format":
     - command: shell.exec
@@ -1221,10 +1277,38 @@ functions:
           ${python_binary|python3} automation-scripts/evergreen/upload_stats_atlas.py -u ${atlas_perf_test_username} -p ${atlas_perf_test_password} -c ${collection|} -d ${database|} -f ${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/atlas_out_${test-name}.json -t ${created_at} -i "$EVERGREEN_TASK_INFO" -g "./wiredtiger"
 
   "upload stats to evergreen":
-    - command: perf.send
-      type: setup
+    - command: shell.exec
       params:
-        file: ${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/evergreen_out_${test-name}.json
+        script: |
+          # We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+          if [ "${requester}" == "commit" ]; then
+            is_mainline=true
+          else
+            is_mainline=false
+          fi
+
+          # Parse the username out of the order_id. Patches append the username. The Signal Processing Service (SPS) endpoint does not need the other information.
+          parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
+
+          # Submit the performance data to the SPS endpoint
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+            "https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
+            -H 'accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -d @${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/evergreen_out_${test-name}.json)
+
+          http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+          response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+          # We want to throw an error if the data was not successfully submitted
+          if [ "$http_status" -ne 200 ]; then
+            echo "Error: Received HTTP status $http_status"
+            echo "Response Body: $response_body"
+            exit 1
+          fi
+
+          echo "Response Body: $response_body"
+          echo "HTTP Status: $http_status"
     # Push the json results to the 'Files' tab of the task in Evergreen
     # Parameterised using the 'test-name' variable
     - command: s3.put

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -795,12 +795,9 @@ functions:
           - project_id
           - version_id
           - build_variant
-          - parsed_order_id
           - task_name
           - task_id
           - execution
-          - is_mainline
-      type: test
     # Cleanup tasks.
     - *cppsuite_remove_files
     - *cppsuite_archive
@@ -1217,12 +1214,9 @@ functions:
           - project_id
           - version_id
           - build_variant
-          - parsed_order_id
           - task_name
           - task_id
           - execution
-          - is_mainline
-      type: test
 
   "convert-to-atlas-evergreen-format":
     - command: shell.exec
@@ -1264,12 +1258,9 @@ functions:
           - project_id
           - version_id
           - build_variant
-          - parsed_order_id
           - task_name
           - task_id
           - execution
-          - is_mainline
-      type: test
     # Push the json results to the 'Files' tab of the task in Evergreen
     # Parameterised using the 'test-name' variable
     - command: s3.put

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -786,8 +786,7 @@ functions:
       params:
         binary: bash
         args:
-          - .evergreen/perf_submission.sh
-        working_dir: src
+          - ./wiredtiger/test/evergreen/perf_submission.sh
         env:
           perf_file_path: ./wiredtiger/cmake_build/test/cppsuite/${test_name}.json
         include_expansions_in_env:
@@ -1209,8 +1208,7 @@ functions:
       params:
         binary: bash
         args:
-          - .evergreen/perf_submission.sh
-        working_dir: src
+          - ./wiredtiger/test/evergreen/perf_submission.sh
         env:
           perf_file_path: ./wiredtiger/cmake_build/${test_path}.json
         include_expansions_in_env:
@@ -1257,8 +1255,7 @@ functions:
       params:
         binary: bash
         args:
-          - .evergreen/perf_submission.sh
-        working_dir: src
+          - ./wiredtiger/test/evergreen/perf_submission.sh
         env:
           perf_file_path: ${stats_dir|./wiredtiger/cmake_build/bench/wtperf/test_stats}/evergreen_out_${test-name}.json
         include_expansions_in_env:

--- a/test/evergreen/perf_submission.sh
+++ b/test/evergreen/perf_submission.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# We use the requester expansion to determine whether the data is from a mainline evergreen run or not
+if [ "${requester}" == "commit" ]; then
+is_mainline=true
+else
+is_mainline=false
+fi
+
+# Parse the username out of the order_id. Patches append the username. The Signal Processing Service (SPS) endpoint does not need the other information.
+parsed_order_id=$(echo "${revision_order_id}" | awk -F'_' '{print $NF}')
+
+# Submit the performance data to the SPS endpoint
+response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -X 'POST' \
+"https://performance-monitoring-api.corp.mongodb.com/raw_perf_results/cedar_report?project=${project_id}&version=${version_id}&variant=${build_variant}&order=$parsed_order_id&task_name=${task_name}&task_id=${task_id}&execution=${execution}&mainline=$is_mainline" \
+-H 'accept: application/json' \
+-H 'Content-Type: application/json' \
+-d @${perf_file_path})
+
+http_status=$(echo "$response" | grep "HTTP_STATUS" | awk -F':' '{print $2}')
+response_body=$(echo "$response" | sed '/HTTP_STATUS/d')
+
+# We want to throw an error if the data was not successfully submitted
+if [ "$http_status" -ne 200 ]; then
+echo "Error: Received HTTP status $http_status"
+echo "Response Body: $response_body"
+exit 1
+fi
+
+echo "Response Body: $response_body"
+echo "HTTP Status: $http_status"


### PR DESCRIPTION
The perf.send command is no longer being maintained and will be decommissioned soon. Users can now submit performance data using the "raw_perf_results" end point provided by the performance-monitoring-api. This PR migrates the develop branch over to that API.