### PR TITLE
WT-14899 Align the code for preserve prepared and non-preserve prepared config

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1416,7 +1416,7 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
          * ingest table. */
         if (tombstone != NULL) {
             tombstone->txnid = tw.stop_txn;
-            tombstone->upd_start_ts = tw.stop_ts != WT_TS_MAX ? tw.stop_ts : tw.stop_prepare_ts;
+            tombstone->upd_start_ts = tw.stop_ts;
             tombstone->upd_durable_ts = tw.durable_stop_ts;
             tombstone->prepare_ts = tw.stop_prepare_ts;
             tombstone->prepared_id = tw.stop_prepared_id;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1542,7 +1542,10 @@ struct __wt_update {
 #undef upd_saved_txnid
 #define upd_saved_txnid u.prepare_rollback.saved_txnid
 
-    /* Prepared transaction fields */
+    /*
+     * Prepared transaction fields. Note that when prepare_ts is set, start_ts should always also be
+     * set with prepare_ts.
+     */
     uint64_t prepared_id;
     wt_timestamp_t prepare_ts;
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1543,8 +1543,8 @@ struct __wt_update {
 #define upd_saved_txnid u.prepare_rollback.saved_txnid
 
     /*
-     * Prepared transaction fields. Note that when prepare_ts is set, start_ts should always also be
-     * set with prepare_ts.
+     * When transaction is prepared, both prepare_ts and start_ts should be assigned to prepare
+     * timestamp. After commit, start_ts will store the commit_ts.
      */
     uint64_t prepared_id;
     wt_timestamp_t prepare_ts;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2107,16 +2107,18 @@ __txn_modify_block(
                 rollback = !__wt_txn_tw_stop_visible(session, &tw);
                 if (rollback)
                     __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
-                      "Conflict with update %" PRIu64 " at stop timestamp: %s, prepare timestamp: %s", tw.stop_txn,
-                      __wt_timestamp_to_string(tw.stop_ts, ts_string[0]),
-                    __wt_timestamp_to_string(tw.stop_prepare_ts, ts_string[1]));
+                      "Conflict with update %" PRIu64
+                      " at stop timestamp: %s, prepare timestamp: %s",
+                      tw.stop_txn, __wt_timestamp_to_string(tw.stop_ts, ts_string[0]),
+                      __wt_timestamp_to_string(tw.stop_prepare_ts, ts_string[1]));
             } else {
                 rollback = !__wt_txn_tw_start_visible(session, &tw);
                 if (rollback)
                     __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
-                      "Conflict with update %" PRIu64 " at start timestamp: %s, prepare timestamp: %s", tw.start_txn,
-                      __wt_timestamp_to_string(tw.start_ts, ts_string[0]),
-                    __wt_timestamp_to_string(tw.start_prepare_ts, ts_string[1]));
+                      "Conflict with update %" PRIu64
+                      " at start timestamp: %s, prepare timestamp: %s",
+                      tw.start_txn, __wt_timestamp_to_string(tw.start_ts, ts_string[0]),
+                      __wt_timestamp_to_string(tw.start_prepare_ts, ts_string[1]));
             }
         }
     }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2107,14 +2107,16 @@ __txn_modify_block(
                 rollback = !__wt_txn_tw_stop_visible(session, &tw);
                 if (rollback)
                     __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
-                      "Conflict with update %" PRIu64 " at stop timestamp: %s", tw.stop_txn,
-                      __wt_timestamp_to_string(tw.stop_ts, ts_string[0]));
+                      "Conflict with update %" PRIu64 " at stop timestamp: %s, prepare timestamp: %s", tw.stop_txn,
+                      __wt_timestamp_to_string(tw.stop_ts, ts_string[0]),
+                    __wt_timestamp_to_string(tw.stop_prepare_ts, ts_string[1]));
             } else {
                 rollback = !__wt_txn_tw_start_visible(session, &tw);
                 if (rollback)
                     __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
-                      "Conflict with update %" PRIu64 " at start timestamp: %s", tw.start_txn,
-                      __wt_timestamp_to_string(tw.start_ts, ts_string[1]));
+                      "Conflict with update %" PRIu64 " at start timestamp: %s, prepare timestamp: %s", tw.start_txn,
+                      __wt_timestamp_to_string(tw.start_ts, ts_string[0]),
+                    __wt_timestamp_to_string(tw.start_prepare_ts, ts_string[1]));
             }
         }
     }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2082,7 +2082,7 @@ __txn_modify_block(
               "Conflict with update with txn id %" PRIu64
               " at start timestamp: %s, prepare timestamp: %s",
               upd->txnid, __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
-              __wt_timestamp_to_string(upd->upd_start_ts, ts_string[1]));
+              __wt_timestamp_to_string(upd->prepare_ts, ts_string[1]));
             rollback = true;
             break;
         }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1289,12 +1289,7 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
               upd->type == WT_UPDATE_STANDARD))
             return (WT_VISIBLE_TRUE);
 
-        upd_visible = __wt_txn_visible(session, upd->txnid,
-          F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-              prepare_state == WT_PREPARE_INPROGRESS ?
-            upd->prepare_ts :
-            upd->upd_start_ts,
-          upd->upd_durable_ts);
+        upd_visible = __wt_txn_visible(session, upd->txnid, upd->upd_start_ts, upd->upd_durable_ts);
 
         /*
          * The visibility check is only valid if the update does not change state. If the state does
@@ -2069,7 +2064,7 @@ __txn_modify_block(
     WT_TIME_WINDOW tw;
     WT_TXN *txn;
     uint32_t snap_count;
-    char ts_string[WT_TS_INT_STRING_SIZE];
+    char ts_string[2][WT_TS_INT_STRING_SIZE];
     bool ignore_prepare_set, rollback, tw_found;
 
     rollback = tw_found = false;
@@ -2084,8 +2079,10 @@ __txn_modify_block(
     for (; upd != NULL && !__wt_txn_upd_visible(session, upd); upd = upd->next) {
         if (upd->txnid != WT_TXN_ABORTED) {
             __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
-              "Conflict with update with txn id %" PRIu64 " at timestamp: %s", upd->txnid,
-              __wt_timestamp_to_string(upd->upd_start_ts, ts_string));
+              "Conflict with update with txn id %" PRIu64
+              " at start timestamp: %s, prepare timestamp: %s",
+              upd->txnid, __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
+              __wt_timestamp_to_string(upd->upd_start_ts, ts_string[1]));
             rollback = true;
             break;
         }
@@ -2111,13 +2108,13 @@ __txn_modify_block(
                 if (rollback)
                     __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
                       "Conflict with update %" PRIu64 " at stop timestamp: %s", tw.stop_txn,
-                      __wt_timestamp_to_string(tw.stop_ts, ts_string));
+                      __wt_timestamp_to_string(tw.stop_ts, ts_string[0]));
             } else {
                 rollback = !__wt_txn_tw_start_visible(session, &tw);
                 if (rollback)
                     __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
                       "Conflict with update %" PRIu64 " at start timestamp: %s", tw.start_txn,
-                      __wt_timestamp_to_string(tw.start_ts, ts_string));
+                      __wt_timestamp_to_string(tw.start_ts, ts_string[1]));
             }
         }
     }

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -123,8 +123,7 @@ __prepared_discover_process_prepared_update(WT_SESSION_IMPL *session, WT_ITEM *k
     WT_ASSERT(
       session, upd->prepare_state != WT_PREPARE_INIT && upd->prepare_state != WT_PREPARE_RESOLVED);
 
-    /* TODO: at the moment the prepare time is overloaded, eventually this will be different */
-    prepare_timestamp = upd->upd_start_ts;
+    prepare_timestamp = upd->prepare_ts;
     WT_RET(__wti_prepared_discover_add_artifact_upd(session, prepare_timestamp, key, upd));
     return (0);
 }

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -349,7 +349,7 @@ __rec_hs_cursor_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btr
      * If we find a key with a timestamp larger than or equal to the specified timestamp then the
      * specified timestamp must be mixed mode.
      */
-    char ts_string[4][WT_TS_INT_STRING_SIZE];
+    char ts_string[6][WT_TS_INT_STRING_SIZE];
     WT_ASSERT_ALWAYS(session, ts == 1 || ts == WT_TS_NONE,
       "out-of-order timestamp update detected, found an existing update with "
       "hs_start_ts=%s, start_ts=%s, start_prepare_ts=%s, stop_ts=%s, start_prepare_ts=%s, that "

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -81,7 +81,7 @@ __rec_hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor
 #ifdef HAVE_DIAGNOSTIC
     int cmp;
 #endif
-    char ts_string[5][WT_TS_INT_STRING_SIZE];
+    char ts_string[7][WT_TS_INT_STRING_SIZE];
 
     hs_insert_cursor = NULL;
     hs_cbt = __wt_curhs_get_cbt(hs_cursor);
@@ -180,14 +180,16 @@ __rec_hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor
                 ++cache_hs_order_lose_durable_timestamp;
 
             __wt_verbose(session, WT_VERB_TIMESTAMP,
-              "fixing existing updates by moving them; start_ts=%s, "
+              "fixing existing updates by moving them; start_ts=%s, start_prepare_ts=%s, "
               "durable_start_ts=%s, "
-              "stop_ts=%s, durable_stop_ts=%s, new_ts=%s",
+              "stop_ts=%s, stop_prepare_ts=%s, durable_stop_ts=%s, new_ts=%s",
               __wt_timestamp_to_string(hs_cbt->upd_value->tw.start_ts, ts_string[0]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.durable_start_ts, ts_string[1]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.stop_ts, ts_string[2]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.durable_stop_ts, ts_string[3]),
-              __wt_timestamp_to_string(ts, ts_string[4]));
+              __wt_timestamp_to_string(hs_cbt->upd_value->tw.start_prepare_ts, ts_string[1]),
+              __wt_timestamp_to_string(hs_cbt->upd_value->tw.durable_start_ts, ts_string[2]),
+              __wt_timestamp_to_string(hs_cbt->upd_value->tw.stop_ts, ts_string[3]),
+              __wt_timestamp_to_string(hs_cbt->upd_value->tw.stop_prepare_ts, ts_string[4]),
+              __wt_timestamp_to_string(hs_cbt->upd_value->tw.durable_stop_ts, ts_string[5]),
+              __wt_timestamp_to_string(ts, ts_string[6]));
 
             /*
              * Use the original start time window's timestamps if its timestamp is less than the new
@@ -350,11 +352,14 @@ __rec_hs_cursor_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btr
     char ts_string[4][WT_TS_INT_STRING_SIZE];
     WT_ASSERT_ALWAYS(session, ts == 1 || ts == WT_TS_NONE,
       "out-of-order timestamp update detected, found an existing update with "
-      "hs_start_ts=%s, start_ts=%s, stop_ts=%s, that exists later than specified ts=%s",
+      "hs_start_ts=%s, start_ts=%s, start_prepare_ts=%s, stop_ts=%s, start_prepare_ts=%s, that "
+      "exists later than specified ts=%s",
       __wt_timestamp_to_string(hs_start_ts, ts_string[0]),
       __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->start_ts, ts_string[1]),
-      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->stop_ts, ts_string[2]),
-      __wt_timestamp_to_string(ts, ts_string[3]));
+      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->start_prepare_ts, ts_string[2]),
+      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->stop_ts, ts_string[3]),
+      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->stop_prepare_ts, ts_string[4]),
+      __wt_timestamp_to_string(ts, ts_string[5]));
     return (ret);
 }
 

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -81,8 +81,8 @@ __rec_hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor
 #ifdef HAVE_DIAGNOSTIC
     int cmp;
 #endif
-    char ts_string[7][WT_TS_INT_STRING_SIZE];
-
+    char ts_string[WT_TS_INT_STRING_SIZE];
+    char tw_string[WT_TIME_STRING_SIZE];
     hs_insert_cursor = NULL;
     hs_cbt = __wt_curhs_get_cbt(hs_cursor);
     WT_CLEAR(hs_key);
@@ -180,16 +180,9 @@ __rec_hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor
                 ++cache_hs_order_lose_durable_timestamp;
 
             __wt_verbose(session, WT_VERB_TIMESTAMP,
-              "fixing existing updates by moving them; start_ts=%s, start_prepare_ts=%s, "
-              "durable_start_ts=%s, "
-              "stop_ts=%s, stop_prepare_ts=%s, durable_stop_ts=%s, new_ts=%s",
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.start_ts, ts_string[0]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.start_prepare_ts, ts_string[1]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.durable_start_ts, ts_string[2]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.stop_ts, ts_string[3]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.stop_prepare_ts, ts_string[4]),
-              __wt_timestamp_to_string(hs_cbt->upd_value->tw.durable_stop_ts, ts_string[5]),
-              __wt_timestamp_to_string(ts, ts_string[6]));
+              "fixing existing updates by moving them; tw=%s, new_ts=%s",
+              __wt_time_window_to_string(&(hs_cbt->upd_value->tw), tw_string),
+              __wt_timestamp_to_string(ts, ts_string));
 
             /*
              * Use the original start time window's timestamps if its timestamp is less than the new
@@ -349,18 +342,15 @@ __rec_hs_cursor_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor, uint32_t btr
      * If we find a key with a timestamp larger than or equal to the specified timestamp then the
      * specified timestamp must be mixed mode.
      */
-    char ts_string[6][WT_TS_INT_STRING_SIZE];
+    char ts_string[2][WT_TS_INT_STRING_SIZE];
+    char tw_string[WT_TIME_STRING_SIZE];
     WT_ASSERT_ALWAYS(session, ts == 1 || ts == WT_TS_NONE,
       "out-of-order timestamp update detected, found an existing update with "
-      "hs_start_ts=%s, start_ts=%s, start_prepare_ts=%s, stop_ts=%s, start_prepare_ts=%s, that "
+      "hs_start_ts=%s, time_window=%s, that "
       "exists later than specified ts=%s",
       __wt_timestamp_to_string(hs_start_ts, ts_string[0]),
-      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->start_ts, ts_string[1]),
-      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->start_prepare_ts, ts_string[2]),
-      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->stop_ts, ts_string[3]),
-      __wt_timestamp_to_string(twp == NULL ? WT_TS_NONE : twp->stop_prepare_ts, ts_string[4]),
-      __wt_timestamp_to_string(ts, ts_string[5]));
-    return (ret);
+      __wt_time_window_to_string(twp, tw_string), __wt_timestamp_to_string(ts, ts_string[1]));
+    return (0);
 }
 
 /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -514,12 +514,13 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
             prev_upd->upd_start_ts == prev_upd->upd_durable_ts ||
             prev_upd->upd_durable_ts >= upd->upd_durable_ts,
           "Durable timestamps cannot be out of order for prepared updates: "
-          "prev_upd->upd_start_ts=%s, "
+          "prev_upd->upd_start_ts=%s, prev_upd->prepare_ts_ts=%s, "
           "prev_upd->upd_durable_ts=%s, prev_upd->flags=%" PRIu16
           ", upd->upd_durable_ts=%s, upd->flags=%" PRIu16,
           __wt_timestamp_to_string(prev_upd->upd_start_ts, ts_string[0]),
-          __wt_timestamp_to_string(prev_upd->upd_durable_ts, ts_string[1]), prev_upd->flags,
-          __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[2]), upd->flags);
+          __wt_timestamp_to_string(prev_upd->prepare_ts, ts_string[1]),
+          __wt_timestamp_to_string(prev_upd->upd_durable_ts, ts_string[2]), prev_upd->flags,
+          __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[3]), upd->flags);
 
         /* Validate that the updates older than us have older timestamps. */
         if (prev_upd->upd_start_ts < upd->upd_start_ts) {
@@ -563,22 +564,24 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
                 prev_upd->upd_start_ts == prev_upd->upd_durable_ts ||
                 prev_upd->upd_durable_ts >= vpack->tw.durable_stop_ts,
               "Stop: Durable timestamps cannot be out of order for prepared updates: "
-              "prev_upd->upd_start_ts=%s, prev_upd->upd_durable_ts=%s, prev_upd->flags=%" PRIu16
-              ", vpack->tw.durable_stop_ts=%s",
+              "prev_upd->upd_start_ts=%s, prev_upd->prepare_ts=%s, prev_upd->upd_durable_ts=%s, "
+              "prev_upd->flags=%" PRIu16 ", vpack->tw.durable_stop_ts=%s",
               __wt_timestamp_to_string(prev_upd->upd_start_ts, ts_string[0]),
-              __wt_timestamp_to_string(prev_upd->upd_durable_ts, ts_string[1]), prev_upd->flags,
-              __wt_timestamp_to_string(vpack->tw.durable_stop_ts, ts_string[2]));
+              __wt_timestamp_to_string(prev_upd->prepare_ts, ts_string[1]),
+              __wt_timestamp_to_string(prev_upd->upd_durable_ts, ts_string[2]), prev_upd->flags,
+              __wt_timestamp_to_string(vpack->tw.durable_stop_ts, ts_string[3]));
         else
             WT_ASSERT_ALWAYS(session,
               prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
                 prev_upd->upd_start_ts == prev_upd->upd_durable_ts ||
                 prev_upd->upd_durable_ts >= vpack->tw.durable_start_ts,
               "Start: Durable timestamps cannot be out of order for prepared updates: "
-              "prev_upd->upd_start_ts=%s, prev_upd->upd_durable_ts=%s, prev_upd->flags=%" PRIu16
-              ", vpack->tw.durable_start_ts=%s",
+              "prev_upd->upd_start_ts=%s, prev_upd->prepare_ts=%s, prev_upd->upd_durable_ts=%s, "
+              "prev_upd->flags=%" PRIu16 ", vpack->tw.durable_start_ts=%s",
               __wt_timestamp_to_string(prev_upd->upd_start_ts, ts_string[0]),
-              __wt_timestamp_to_string(prev_upd->upd_durable_ts, ts_string[1]), prev_upd->flags,
-              __wt_timestamp_to_string(vpack->tw.durable_start_ts, ts_string[2]));
+              __wt_timestamp_to_string(prev_upd->prepare_ts, ts_string[1]),
+              __wt_timestamp_to_string(prev_upd->upd_durable_ts, ts_string[2]), prev_upd->flags,
+              __wt_timestamp_to_string(vpack->tw.durable_start_ts, ts_string[3]));
 
         if (prev_upd->upd_start_ts == WT_TS_NONE) {
             if (vpack->tw.start_ts != WT_TS_NONE ||

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -508,7 +508,7 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
         if (upd->txnid == WT_TXN_ABORTED)
             continue;
 
-        char ts_string[3][WT_TS_INT_STRING_SIZE];
+        char ts_string[4][WT_TS_INT_STRING_SIZE];
         WT_ASSERT_ALWAYS(session,
           prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||
             prev_upd->upd_start_ts == prev_upd->upd_durable_ts ||

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -557,7 +557,7 @@ __rec_validate_upd_chain(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *
      * reconciliations ondisk value that we will be comparing against.
      */
     if (vpack != NULL && !WT_TIME_WINDOW_HAS_PREPARE(&(vpack->tw))) {
-        char ts_string[3][WT_TS_INT_STRING_SIZE];
+        char ts_string[4][WT_TS_INT_STRING_SIZE];
         if (WT_TIME_WINDOW_HAS_STOP(&vpack->tw))
             WT_ASSERT_ALWAYS(session,
               prev_upd->prepare_state == WT_PREPARE_INPROGRESS ||

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -552,9 +552,10 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
         upd->prepared_id = hs_tw->start_prepared_id;
         __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
           WT_RTS_VERB_TAG_HS_UPDATE_RESTORED "history store update restored txnid=%" PRIu64
-                                             ", start_ts=%s and durable_ts=%s",
+                                             ", start_ts=%s, prepare_ts=%s and durable_ts=%s",
           upd->txnid, __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
-          __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[1]));
+          __wt_timestamp_to_string(upd->prepare_ts, ts_string[1]),
+          __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[2]));
 
         /*
          * Set the flag to indicate that this update has been restored from history store for the
@@ -594,9 +595,11 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
             tombstone->prepared_id = hs_tw->stop_prepared_id;
             __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
               WT_RTS_VERB_TAG_HS_RESTORE_TOMBSTONE
-              "history store tombstone restored, txnid=%" PRIu64 ", start_ts=%s and durable_ts=%s",
+              "history store tombstone restored, txnid=%" PRIu64
+              ", start_ts=%s, prepare_ts=%s and durable_ts=%s",
               tombstone->txnid, __wt_timestamp_to_string(tombstone->upd_start_ts, ts_string[0]),
-              __wt_timestamp_to_string(tombstone->upd_durable_ts, ts_string[1]));
+              __wt_timestamp_to_string(tombstone->prepare_ts, ts_string[1]),
+              __wt_timestamp_to_string(tombstone->upd_durable_ts, ts_string[2]));
 
             /*
              * Set the flag to indicate that this update has been restored from history store for

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -836,7 +836,7 @@ __txn_prepare_rollback_restore_hs_update(
     wt_timestamp_t durable_ts, hs_stop_durable_ts;
     size_t size, total_size;
     uint64_t type_full;
-    char ts_string[2][WT_TS_INT_STRING_SIZE];
+    char ts_string[3][WT_TS_INT_STRING_SIZE];
 
     WT_ASSERT(session, upd_chain != NULL);
 
@@ -867,9 +867,11 @@ __txn_prepare_rollback_restore_hs_update(
     total_size += size;
 
     __wt_verbose_debug2(session, WT_VERB_TRANSACTION,
-      "update restored from history store (txnid: %" PRIu64 ", start_ts: %s, durable_ts: %s",
+      "update restored from history store (txnid: %" PRIu64
+      ", start_ts: %s, prepare_ts: %s, durable_ts: %s",
       upd->txnid, __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
-      __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[1]));
+      __wt_timestamp_to_string(upd->prepare_ts, ts_string[1]),
+      __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[2]));
 
     /* If the history store record has a valid stop time point, append it. */
     if (hs_stop_durable_ts != WT_TS_MAX) {
@@ -887,9 +889,11 @@ __txn_prepare_rollback_restore_hs_update(
         total_size += size;
 
         __wt_verbose_debug2(session, WT_VERB_TRANSACTION,
-          "tombstone restored from history store (txnid: %" PRIu64 ", start_ts: %s, durable_ts: %s",
+          "tombstone restored from history store (txnid: %" PRIu64
+          ", start_ts: %s, prepare_ts:%s, durable_ts: %s",
           tombstone->txnid, __wt_timestamp_to_string(tombstone->upd_start_ts, ts_string[0]),
-          __wt_timestamp_to_string(tombstone->upd_durable_ts, ts_string[1]));
+          __wt_timestamp_to_string(tombstone->prepare_ts, ts_string[1]),
+          __wt_timestamp_to_string(tombstone->upd_durable_ts, ts_string[2]));
 
         upd = tombstone;
     }


### PR DESCRIPTION
This PR aligns the code for preserve prepared and non-preserve prepared config/
- Ensure both prepare_ts and start_ts are set to the prepare timestamp for prepared transactions
- Update verbose/debug logging to include both start_ts and prepare_ts for better traceability.