### PR TITLE
WT-14614 Improve error message when parsing unexpected escaped character

### DIFF
--- a/src/config/config.c
+++ b/src/config/config.c
@@ -303,7 +303,15 @@ __config_next(WT_CONFIG *conf, WT_CONFIG_ITEM *key, WT_CONFIG_ITEM *value)
             break;
 
         case A_BAD:
-            return (__config_err(conf, "Unexpected character", EINVAL));
+            switch (*conf->cur) {
+            case '\b':
+            case '\n':
+            case '\r':
+            case '\t':
+                return (__config_err(conf, "Unexpected escaped character", EINVAL));
+            default:
+                return (__config_err(conf, "Unexpected character", EINVAL));
+            }
 
         case A_DOWN:
             if (conf->top == -1)

--- a/test/suite/test_encrypt05.py
+++ b/test/suite/test_encrypt05.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_encrypt03.py
+#   Test some error conditions with quoted escaped characters.
+#
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+# Test error conditions with quoted escaped characters.
+class test_encrypt05(wttest.WiredTigerTestCase):
+
+    types = [
+        ('table', dict(uri='table:test_encrypt05')),
+    ]
+    encrypt = [
+        ('rotn', dict( sys_encrypt='rotn', sys_encrypt_args=',keyid=11',
+            file_encrypt='rotn', file_encrypt_args=',keyid=13')),
+    ]
+    scenarios = make_scenarios(types, encrypt)
+
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        extlist.extension('encryptors', self.sys_encrypt)
+        extlist.extension('encryptors', self.file_encrypt)
+
+    def conn_config(self):
+        return 'encryption=(name={0}{1}),'.format(
+            self.sys_encrypt, self.sys_encrypt_args)
+
+    # Open connection with a config that has a malformed keyid.
+    # The keyid is malformed because it contains a quoted escaped character.
+    def test_encrypt(self):
+        escaped_chars = ['\n', '\r', '\t', '\b']
+        for escaped_char in escaped_chars:
+            sys_encrypt = 'rotn'
+            sys_encrypt_args = f',keyid=\"11{escaped_char}\"' # Intentionally malformed keyid
+            config = 'encryption=(name={0}{1}),'.format(
+                sys_encrypt, sys_encrypt_args)
+
+            try:
+                self.reopen_conn(config=config)
+            except wiredtiger.WiredTigerError as e:
+                # If we get an error, it should be about the malformed keyid.
+                self.assertTrue('Invalid argument' in str(e), f"Unexpected error: {e}")
+
+            continue
+
+        # Reopen the connection with a valid config to avoid teardown errors using the
+        # problematic config that had the malformed keyid.
+        config = ""
+        self.reopen_conn(config=config)
+
+        self.ignoreStderrPatternIfExists("Unexpected escaped character: Invalid argument")

--- a/test/suite/test_encrypt05.py
+++ b/test/suite/test_encrypt05.py
@@ -68,8 +68,6 @@ class test_encrypt05(wttest.WiredTigerTestCase):
                 # If we get an error, it should be about the malformed keyid.
                 self.assertTrue('Invalid argument' in str(e), f"Unexpected error: {e}")
 
-            continue
-
         # Reopen the connection with a valid config to avoid teardown errors using the
         # problematic config that had the malformed keyid.
         config = ""

--- a/test/suite/test_encrypt05.py
+++ b/test/suite/test_encrypt05.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# test_encrypt03.py
+# test_encrypt05.py
 #   Test some error conditions with quoted escaped characters.
 #
 
@@ -40,15 +40,13 @@ class test_encrypt05(wttest.WiredTigerTestCase):
         ('table', dict(uri='table:test_encrypt05')),
     ]
     encrypt = [
-        ('rotn', dict( sys_encrypt='rotn', sys_encrypt_args=',keyid=11',
-            file_encrypt='rotn', file_encrypt_args=',keyid=13')),
+        ('rotn', dict( sys_encrypt='rotn', sys_encrypt_args=',keyid=11')),
     ]
     scenarios = make_scenarios(types, encrypt)
 
     def conn_extensions(self, extlist):
         extlist.skip_if_missing = True
         extlist.extension('encryptors', self.sys_encrypt)
-        extlist.extension('encryptors', self.file_encrypt)
 
     def conn_config(self):
         return 'encryption=(name={0}{1}),'.format(

--- a/test/suite/test_encrypt05.py
+++ b/test/suite/test_encrypt05.py
@@ -35,14 +35,15 @@ from wtscenario import make_scenarios
 
 # Test error conditions with quoted escaped characters.
 class test_encrypt05(wttest.WiredTigerTestCase):
-
-    types = [
-        ('table', dict(uri='table:test_encrypt05')),
+    sys_encrypt = 'rotn'
+    sys_encrypt_args = ',keyid=11'
+    escaped_characters = [
+        ('check newline', dict(escaped_char='\n')),
+        ('check carriage return', dict(escaped_char='\r')),
+        ('check tab', dict(escaped_char='\t')),
+        ('check backspace', dict(escaped_char='\b')),
     ]
-    encrypt = [
-        ('rotn', dict( sys_encrypt='rotn', sys_encrypt_args=',keyid=11')),
-    ]
-    scenarios = make_scenarios(types, encrypt)
+    scenarios = make_scenarios(escaped_characters)
 
     def conn_extensions(self, extlist):
         extlist.skip_if_missing = True
@@ -55,18 +56,15 @@ class test_encrypt05(wttest.WiredTigerTestCase):
     # Open connection with a config that has a malformed keyid.
     # The keyid is malformed because it contains a quoted escaped character.
     def test_encrypt(self):
-        escaped_chars = ['\n', '\r', '\t', '\b']
-        for escaped_char in escaped_chars:
-            sys_encrypt = 'rotn'
-            sys_encrypt_args = f',keyid=\"11{escaped_char}\"' # Intentionally malformed keyid
-            config = 'encryption=(name={0}{1}),'.format(
-                sys_encrypt, sys_encrypt_args)
+        sys_encrypt_args = f',keyid=\"11{self.escaped_char}\"' # Intentionally malformed keyid
+        config = 'encryption=(name={0}{1}),'.format(
+            self.sys_encrypt, sys_encrypt_args)
 
-            try:
-                self.reopen_conn(config=config)
-            except wiredtiger.WiredTigerError as e:
-                # If we get an error, it should be about the malformed keyid.
-                self.assertTrue('Invalid argument' in str(e), f"Unexpected error: {e}")
+        try:
+            self.reopen_conn(config=config)
+        except wiredtiger.WiredTigerError as e:
+            # If we get an error, it should be about the malformed keyid.
+            self.assertTrue('Invalid argument' in str(e), f"Unexpected error: {e}")
 
         # Reopen the connection with a valid config to avoid teardown errors using the
         # problematic config that had the malformed keyid.


### PR DESCRIPTION
The newline character enclosed in quotes is currently treated as an unexpected character by the config string parsing function in wiredtiger. The error message will be broken down into 2 lines when printed out (thanks to the newline character).

The change in this PR tries to improve the error message by mentioning it's an escape character for newline '\n', carriage return '\r', tab '\t', backspace '\b', all of which are treated as unexpected characters within quotes.