### PR TITLE
WT-15106 Make cache walk heuristic reset specific to disaggregated storage

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1820,8 +1820,10 @@ retry:
          * reset the walk effectiveness tracking. Imagine a case where only dirty content has been
          * looked for and this tree doesn't have much dirty content. Then eviction starts looking
          * for clean content - this tree might be a cornucopia of good clean candidate pages.
+         * Specific for disaggregated connections, where we are using WT_EVICT_MODIFY_COUNT_MIN and
+         * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD values to change the priority for this heuristic.
          */
-        if (btree->last_evict_walk_flags != evict->flags) {
+        if (__wt_conn_is_disagg(session) && btree->last_evict_walk_flags != evict->flags) {
             __wt_atomic_store32(&btree->evict_walk_period, 0);
             btree->last_evict_walk_flags = evict->flags;
         }


### PR DESCRIPTION
WT-14813 introduced code that prioritised evicting pages with more dirty content. Most of the changes were restricted to disaggregated storage, but this change that reset the eviction walk flag heuristic was not, and it seems to be responsible for a regression in performance. 

Since this change was originally made for a disaggregated storage specific change to dirty eviction heuristics, we should also make this change specific to disaggregated storage.