### PR TITLE
WT-15135 Use unused field for ref_changes instead of extending the ref structure

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -213,7 +213,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     *skipp = true;
     WT_STAT_CONN_DSRC_INCR(session, rec_page_delete_fast);
 
-    if (WT_DELTA_INT_ENABLED(session))
+    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /* Set the page to its new state. */
@@ -329,7 +329,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
 
-    if (WT_DELTA_INT_ENABLED(session))
+    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_SET_STATE(ref, current_state);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -213,7 +213,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     *skipp = true;
     WT_STAT_CONN_DSRC_INCR(session, rec_page_delete_fast);
 
-    __wt_atomic_addv16(&ref->ref_changes, 1);
+    __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /* Set the page to its new state. */
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
@@ -328,7 +328,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
 
-    __wt_atomic_addv16(&ref->ref_changes, 1);
+    __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_SET_STATE(ref, current_state);
     return (0);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -233,13 +233,14 @@ err:
  *     Transaction rollback for a fast-truncate operation.
  */
 int
-__wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
+__wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 {
     WT_REF_STATE current_state;
     WT_TXN *txn;
     WT_UPDATE **updp;
     uint64_t sleep_usecs, yield_count;
     bool locked;
+    WT_REF *ref = op->u.ref;
 
     txn = session->txn;
 

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -108,6 +108,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_ADDR_COPY addr;
     WT_DECL_RET;
     WT_REF_STATE previous_state;
+    WT_BTREE *btree = S2BT(session);
 
     *skipp = false;
 
@@ -121,9 +122,9 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
         }
 
         WT_RET(__wt_curhs_cache(session));
-        (void)__wt_atomic_addv32(&S2BT(session)->evict_busy, 1);
+        (void)__wt_atomic_addv32(&btree->evict_busy, 1);
         ret = __wt_evict(session, ref, previous_state, 0);
-        (void)__wt_atomic_subv32(&S2BT(session)->evict_busy, 1);
+        (void)__wt_atomic_subv32(&btree->evict_busy, 1);
         WT_RET_BUSY_OK(ret);
         ret = 0;
     }
@@ -213,7 +214,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     *skipp = true;
     WT_STAT_CONN_DSRC_INCR(session, rec_page_delete_fast);
 
-    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+    if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /* Set the page to its new state. */
@@ -330,7 +331,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
         }
     }
 
-    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+    if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_SET_STATE(ref, current_state);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -213,7 +213,8 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     *skipp = true;
     WT_STAT_CONN_DSRC_INCR(session, rec_page_delete_fast);
 
-    __wt_atomic_addv8(&ref->ref_changes, 1);
+    if (WT_DELTA_INT_ENABLED(session))
+        __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /* Set the page to its new state. */
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
@@ -328,7 +329,8 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
         }
     }
 
-    __wt_atomic_addv8(&ref->ref_changes, 1);
+    if (WT_DELTA_INT_ENABLED(session))
+        __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_SET_STATE(ref, current_state);
     return (0);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -660,7 +660,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     size_t parent_decr, size;
     uint64_t split_gen;
     uint32_t deleted_entries, *deleted_refs, hint, i, j, parent_entries, result_entries;
-    uint16_t ref_changes;
+    uint8_t ref_changes;
     bool empty_parent;
 
 #ifdef HAVE_DIAGNOSTIC
@@ -1796,7 +1796,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
         break;
     }
 
-    __wt_atomic_addv16(&ref->ref_changes, 1);
+    __wt_atomic_addv8(&ref->ref_changes, 1);
 
     switch (page->type) {
     case WT_PAGE_COL_INT:
@@ -2417,7 +2417,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi, bool 
     __wt_ref_out(session, ref);
 
     /* Swap the new page into place. */
-    __wt_atomic_addv16(&ref->ref_changes, 1);
+    __wt_atomic_addv8(&ref->ref_changes, 1);
     ref->page = new->page;
 
     if (change_ref_state)

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1796,7 +1796,8 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
         break;
     }
 
-    __wt_atomic_addv8(&ref->ref_changes, 1);
+    if (WT_DELTA_INT_ENABLED(session))
+        __wt_atomic_addv8(&ref->ref_changes, 1);
 
     switch (page->type) {
     case WT_PAGE_COL_INT:
@@ -2417,7 +2418,8 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi, bool 
     __wt_ref_out(session, ref);
 
     /* Swap the new page into place. */
-    __wt_atomic_addv8(&ref->ref_changes, 1);
+    if (WT_DELTA_INT_ENABLED(session))
+        __wt_atomic_addv8(&ref->ref_changes, 1);
     ref->page = new->page;
 
     if (change_ref_state)

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -710,7 +710,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
              * which seems like asking for trouble.) Don't discard any ref has the prefetch flag,
              * the prefetch thread would crash if it sees a freed ref.
              */
-            if (WT_DELTA_INT_ENABLED(session))
+            if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
                 WT_ACQUIRE_READ(ref_changes, next_ref->ref_changes);
             else
                 ref_changes = 0;
@@ -1796,7 +1796,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
         break;
     }
 
-    if (WT_DELTA_INT_ENABLED(session))
+    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     switch (page->type) {
@@ -2418,7 +2418,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi, bool 
     __wt_ref_out(session, ref);
 
     /* Swap the new page into place. */
-    if (WT_DELTA_INT_ENABLED(session))
+    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
     ref->page = new->page;
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -710,7 +710,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
              * which seems like asking for trouble.) Don't discard any ref has the prefetch flag,
              * the prefetch thread would crash if it sees a freed ref.
              */
-            if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+            if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
                 WT_ACQUIRE_READ(ref_changes, next_ref->ref_changes);
             else
                 ref_changes = 0;

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -330,7 +330,7 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
          * For deleted and on-disk pages, increment ref_changes if there has been a change in the
          * ref's state. There's nothing to do for in-memory pages as we don't change those.
          */
-        if (WT_DELTA_INT_ENABLED(session) && previous_state != new_state)
+        if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)) && previous_state != new_state)
             __wt_atomic_addv8(&ref->ref_changes, 1);
         WT_REF_UNLOCK(ref, new_state);
         WT_RET(ret);

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -330,7 +330,7 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
          * For deleted and on-disk pages, increment ref_changes if there has been a change in the
          * ref's state. There's nothing to do for in-memory pages as we don't change those.
          */
-        if (previous_state != new_state)
+        if (WT_DELTA_INT_ENABLED(session) && previous_state != new_state)
             __wt_atomic_addv8(&ref->ref_changes, 1);
         WT_REF_UNLOCK(ref, new_state);
         WT_RET(ret);

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -331,7 +331,7 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
          * ref's state. There's nothing to do for in-memory pages as we don't change those.
          */
         if (previous_state != new_state)
-            __wt_atomic_addv16(&ref->ref_changes, 1);
+            __wt_atomic_addv8(&ref->ref_changes, 1);
         WT_REF_UNLOCK(ref, new_state);
         WT_RET(ret);
     } else

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1185,7 +1185,17 @@ struct __wt_ref {
     wt_shared WT_PAGE *volatile home;        /* Reference page */
     wt_shared volatile uint32_t pindex_hint; /* Reference page index hint */
 
-    uint8_t unused; /* Padding: before the flags field so flags can be easily expanded. */
+    /*
+     * A counter used to track how many times a ref has changed during internal page reconciliation.
+     * The value is compared and swapped to 0 for each internal page reconciliation. If the counter
+     * has a value greater than zero, this implies that the ref has been changed concurrently and
+     * that the ref remains dirty after internal page reconciliation. It is possible for other
+     * operations such as page splits and fast-truncate to concurrently write new values to the ref,
+     * but depending on timing or race conditions, it cannot be guaranteed that these new values are
+     * included as part of the reconciliation. The page would need to be reconciled again to ensure
+     * that these modifications are included.
+     */
+    wt_shared volatile uint8_t ref_changes;
 
 /*
  * Define both internal- and leaf-page flags for now: we only need one, but it provides an easy way
@@ -1358,19 +1368,6 @@ struct __wt_ref {
     WT_REF_HIST hist[WT_REF_SAVE_STATE_MAX];
     uint64_t histoff;
 #endif
-
-    /*
-     * A counter used to track how many times a ref has changed during internal page reconciliation.
-     * The value is compared and swapped to 0 for each internal page reconciliation. If the counter
-     * has a value greater than zero, this implies that the ref has been changed concurrently and
-     * that the ref remains dirty after internal page reconciliation. It is possible for other
-     * operations such as page splits and fast-truncate to concurrently write new values to the ref,
-     * but depending on timing or race conditions, it cannot be guaranteed that these new values are
-     * included as part of the reconciliation. The page would need to be reconciled again to ensure
-     * that these modifications are included.
-     */
-    wt_shared volatile uint16_t ref_changes;
-    char pad[6]; /* Padding */
 };
 
 #ifdef HAVE_REF_TRACK
@@ -1383,9 +1380,9 @@ struct __wt_ref {
  * WT_REF_SIZE is the expected structure size -- we verify the build to ensure the compiler hasn't
  * inserted padding which would break the world.
  */
-#define WT_REF_SIZE (56 + WT_REF_SAVE_STATE_MAX * sizeof(WT_REF_HIST) + 8)
+#define WT_REF_SIZE (48 + WT_REF_SAVE_STATE_MAX * sizeof(WT_REF_HIST) + 8)
 #else
-#define WT_REF_SIZE 56
+#define WT_REF_SIZE 48
 #define WT_REF_CLEAR_SIZE (sizeof(WT_REF))
 #endif
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -334,9 +334,9 @@ struct __wt_salvage_cookie {
     (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && \
       F_ISSET(&S2C(session)->page_delta, WT_LEAF_PAGE_DELTA))
 
-#define WT_DELTA_INT_ENABLED(session)                  \
-    (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && \
-      F_ISSET(&S2C(session)->page_delta, WT_INTERNAL_PAGE_DELTA))
+#define WT_DELTA_INT_ENABLED(btree, conn) \
+    (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && F_ISSET(&conn->page_delta, WT_INTERNAL_PAGE_DELTA))
 
-#define WT_DELTA_ENABLED_FOR_PAGE(session, type) \
-    ((type) == WT_PAGE_ROW_LEAF ? WT_DELTA_LEAF_ENABLED(session) : WT_DELTA_INT_ENABLED(session))
+#define WT_DELTA_ENABLED_FOR_PAGE(session, type)                   \
+    ((type) == WT_PAGE_ROW_LEAF ? WT_DELTA_LEAF_ENABLED(session) : \
+                                  WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -561,7 +561,7 @@ extern int __wt_debug_tree_shape(WT_SESSION_IMPL *session, WT_REF *ref, const ch
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_decrypt(WT_SESSION_IMPL *session, WT_ENCRYPTOR *encryptor, size_t skip, WT_ITEM *in,
   WT_ITEM *out) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_REF *ref)
+extern int __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_delete_redo_window_cleanup(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2373,7 +2373,7 @@ static WT_INLINE void __wt_tree_modify_set(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_txn_cursor_op(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_txn_err_set(WT_SESSION_IMPL *session, int ret);
 static WT_INLINE void __wt_txn_op_delete_apply_prepare_state(
-  WT_SESSION_IMPL *session, WT_REF *ref, bool commit);
+  WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit);
 static WT_INLINE void __wt_txn_op_set_recno(WT_SESSION_IMPL *session, uint64_t recno);
 static WT_INLINE void __wt_txn_pinned_stable_timestamp(
   WT_SESSION_IMPL *session, wt_timestamp_t *pinned_stable_tsp);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -352,11 +352,12 @@ __wt_txn_unmodify(WT_SESSION_IMPL *session)
  *     del update list.
  */
 static WT_INLINE void
-__wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_REF *ref, bool commit)
+__wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit)
 {
     WT_PAGE_DELETED *page_del;
     WT_REF_STATE previous_state;
     WT_UPDATE **updp;
+    WT_REF *ref = op->u.ref;
 
     /* Lock the ref to ensure we don't race with page instantiation. */
     WT_REF_LOCK(session, ref, &previous_state);
@@ -389,7 +390,7 @@ __wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_REF *ref, bo
     if ((page_del = ref->page_del) != NULL)
         __txn_apply_prepare_state_page_del(session, page_del, commit);
 
-    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+    if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_UNLOCK(ref, previous_state);
@@ -651,7 +652,7 @@ __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool validate
          * transaction commit call.
          */
         if (op->type == WT_TXN_OP_REF_DELETE)
-            __wt_txn_op_delete_apply_prepare_state(session, op->u.ref, true);
+            __wt_txn_op_delete_apply_prepare_state(session, op, true);
         else {
             upd = op->u.op_upd;
 

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -389,7 +389,7 @@ __wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_REF *ref, bo
     if ((page_del = ref->page_del) != NULL)
         __txn_apply_prepare_state_page_del(session, page_del, commit);
 
-    if (WT_DELTA_INT_ENABLED(session))
+    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_UNLOCK(ref, previous_state);
@@ -514,7 +514,7 @@ __wt_txn_op_delete_commit(
     if (assign_timestamp)
         __txn_op_delete_commit_apply_page_del_timestamp(session, op);
 
-    if (WT_DELTA_INT_ENABLED(session))
+    if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
 err:

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -389,7 +389,8 @@ __wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_REF *ref, bo
     if ((page_del = ref->page_del) != NULL)
         __txn_apply_prepare_state_page_del(session, page_del, commit);
 
-    __wt_atomic_addv8(&ref->ref_changes, 1);
+    if (WT_DELTA_INT_ENABLED(session))
+        __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_UNLOCK(ref, previous_state);
 }
@@ -513,7 +514,8 @@ __wt_txn_op_delete_commit(
     if (assign_timestamp)
         __txn_op_delete_commit_apply_page_del_timestamp(session, op);
 
-    __wt_atomic_addv8(&ref->ref_changes, 1);
+    if (WT_DELTA_INT_ENABLED(session))
+        __wt_atomic_addv8(&ref->ref_changes, 1);
 
 err:
     WT_REF_UNLOCK(ref, previous_state);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -389,7 +389,7 @@ __wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_REF *ref, bo
     if ((page_del = ref->page_del) != NULL)
         __txn_apply_prepare_state_page_del(session, page_del, commit);
 
-    __wt_atomic_addv16(&ref->ref_changes, 1);
+    __wt_atomic_addv8(&ref->ref_changes, 1);
 
     WT_REF_UNLOCK(ref, previous_state);
 }
@@ -513,7 +513,7 @@ __wt_txn_op_delete_commit(
     if (assign_timestamp)
         __txn_op_delete_commit_apply_page_del_timestamp(session, op);
 
-    __wt_atomic_addv16(&ref->ref_changes, 1);
+    __wt_atomic_addv8(&ref->ref_changes, 1);
 
 err:
     WT_REF_UNLOCK(ref, previous_state);

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -332,7 +332,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
+        if (WT_DELTA_INT_ENABLED(session))
+            __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -332,7 +332,7 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+        if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
             __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -332,7 +332,7 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        if (WT_DELTA_INT_ENABLED(session))
+        if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
             __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -219,7 +219,7 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
     WTI_REC_KV *val;
     WT_REF *ref;
     WT_TIME_AGGREGATE ft_ta, ta;
-    uint16_t prev_ref_changes;
+    uint8_t prev_ref_changes;
 
     btree = S2BT(session);
     page = pageref->page;
@@ -332,7 +332,7 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        __wt_atomic_casv16(&ref->ref_changes, prev_ref_changes, 0);
+        __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -238,7 +238,7 @@ __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
  */
 static int
 __rec_row_merge(
-  WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *ref, uint16_t ref_changes, bool *build_delta)
+  WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *ref, uint8_t ref_changes, bool *build_delta)
 {
     WT_ADDR *addr;
     WT_MULTI *multi;
@@ -343,7 +343,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     WT_REF *ref;
     WT_TIME_AGGREGATE ft_ta, *source_ta, ta;
     size_t size;
-    uint16_t prev_ref_changes;
+    uint8_t prev_ref_changes;
     bool build_delta, retain_onpage;
     const void *p;
 
@@ -441,7 +441,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              * Set the ref_changes state to zero if there were no concurrent changes while
              * reconciling the internal page.
              */
-            __wt_atomic_casv16(&ref->ref_changes, prev_ref_changes, 0);
+            __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
             /*
              * Ignored child.
              */
@@ -470,7 +470,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                __wt_atomic_casv16(&ref->ref_changes, prev_ref_changes, 0);
+                __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
                 continue;
@@ -481,7 +481,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                __wt_atomic_casv16(&ref->ref_changes, prev_ref_changes, 0);
+                __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
                 continue;
@@ -593,7 +593,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        __wt_atomic_casv16(&ref->ref_changes, prev_ref_changes, 0);
+        __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -441,7 +441,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              * Set the ref_changes state to zero if there were no concurrent changes while
              * reconciling the internal page.
              */
-            __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
+            if (WT_DELTA_INT_ENABLED(session))
+                __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
             /*
              * Ignored child.
              */
@@ -470,7 +471,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
+                if (WT_DELTA_INT_ENABLED(session))
+                    __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
                 continue;
@@ -481,7 +483,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
+                if (WT_DELTA_INT_ENABLED(session))
+                    __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
                 continue;
@@ -593,7 +596,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
+        if (WT_DELTA_INT_ENABLED(session))
+            __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -441,7 +441,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              * Set the ref_changes state to zero if there were no concurrent changes while
              * reconciling the internal page.
              */
-            if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+            if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
                 __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
             /*
              * Ignored child.
@@ -471,7 +471,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+                if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
                     __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
@@ -483,7 +483,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+                if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
                     __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
@@ -596,7 +596,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+        if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
             __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -441,7 +441,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              * Set the ref_changes state to zero if there were no concurrent changes while
              * reconciling the internal page.
              */
-            if (WT_DELTA_INT_ENABLED(session))
+            if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
                 __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
             /*
              * Ignored child.
@@ -471,7 +471,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                if (WT_DELTA_INT_ENABLED(session))
+                if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
                     __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
@@ -483,7 +483,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  * Set the ref_changes state to zero if there were no concurrent changes while
                  * reconciling the internal page.
                  */
-                if (WT_DELTA_INT_ENABLED(session))
+                if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
                     __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
@@ -596,7 +596,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * Set the ref_changes state to zero if there were no concurrent changes while reconciling
          * the internal page.
          */
-        if (WT_DELTA_INT_ENABLED(session))
+        if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
             __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
     }
     WT_INTL_FOREACH_END;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3382,7 +3382,7 @@ split:
         break;
     }
 
-    if (WT_DELTA_INT_ENABLED(session))
+    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3382,7 +3382,7 @@ split:
         break;
     }
 
-    __wt_atomic_addv16(&ref->ref_changes, 1);
+    __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /*
      * If the page has post-instantiation delete information, we don't need it any more. Note: this

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3382,7 +3382,7 @@ split:
         break;
     }
 
-    if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
+    if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
         __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3382,7 +3382,8 @@ split:
         break;
     }
 
-    __wt_atomic_addv8(&ref->ref_changes, 1);
+    if (WT_DELTA_INT_ENABLED(session))
+        __wt_atomic_addv8(&ref->ref_changes, 1);
 
     /*
      * If the page has post-instantiation delete information, we don't need it any more. Note: this

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -458,11 +458,10 @@ typedef struct {
  * Called when building the internal page image to indicate should we start to build a delta for the
  * page. We are still building so multi_next should still be 0 instead of 1.
  */
-#define WT_BUILD_DELTA_INT(session, r)                                                   \
-    WT_DELTA_INT_ENABLED((S2BT(session), S2C(session))) && !__wt_ref_is_root(r->ref) &&  \
-      (r)->multi_next == 0 &&                                                            \
-      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INTL_PINDEX_UPDATE) && \
-      WT_REC_RESULT_SINGLE_PAGE((session), (r))
+#define WT_BUILD_DELTA_INT(session, r)                                                    \
+    WT_DELTA_INT_ENABLED((S2BT(session)), (S2C(session))) && !__wt_ref_is_root(r->ref) && \
+      (r)->multi_next == 0 &&                                                             \
+      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INTL_PINDEX_UPDATE) &&
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -458,9 +458,10 @@ typedef struct {
  * Called when building the internal page image to indicate should we start to build a delta for the
  * page. We are still building so multi_next should still be 0 instead of 1.
  */
-#define WT_BUILD_DELTA_INT(session, r)                                                      \
-    WT_DELTA_INT_ENABLED((session)) && !__wt_ref_is_root(r->ref) && (r)->multi_next == 0 && \
-      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INTL_PINDEX_UPDATE) &&    \
+#define WT_BUILD_DELTA_INT(session, r)                                                   \
+    WT_DELTA_INT_ENABLED((S2BT(session), S2C(session))) && !__wt_ref_is_root(r->ref) &&  \
+      (r)->multi_next == 0 &&                                                            \
+      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INTL_PINDEX_UPDATE) && \
       WT_REC_RESULT_SINGLE_PAGE((session), (r))
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -461,7 +461,8 @@ typedef struct {
 #define WT_BUILD_DELTA_INT(session, r)                                                    \
     WT_DELTA_INT_ENABLED((S2BT(session)), (S2C(session))) && !__wt_ref_is_root(r->ref) && \
       (r)->multi_next == 0 &&                                                             \
-      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INTL_PINDEX_UPDATE) &&
+      !F_ISSET_ATOMIC_16(r->ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INTL_PINDEX_UPDATE) &&  \
+      WT_REC_RESULT_SINGLE_PAGE((session), (r))
 
 /* DO NOT EDIT: automatically built by prototypes.py: BEGIN */
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2151,7 +2151,7 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
             }
             break;
         case WT_TXN_OP_REF_DELETE:
-            __wt_txn_op_delete_apply_prepare_state(session, op->u.ref, false);
+            __wt_txn_op_delete_apply_prepare_state(session, op, false);
             break;
         case WT_TXN_OP_TRUNCATE_COL:
         case WT_TXN_OP_TRUNCATE_ROW:

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2270,7 +2270,7 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[], bool api_call)
             }
             break;
         case WT_TXN_OP_REF_DELETE:
-            WT_TRET(__wt_delete_page_rollback(session, op->u.ref));
+            WT_TRET(__wt_delete_page_rollback(session, op));
             break;
         case WT_TXN_OP_TRUNCATE_COL:
         case WT_TXN_OP_TRUNCATE_ROW:


### PR DESCRIPTION
WT_REF added a ref_changes field which increase the memory usage per WT_REF and caused a performance regression, this ticket is to use the unused field in WT_REF as an alternation for ref_changes so we can save the memory usage.