### PR TITLE
WT-15118 Free update chain with on-page prepared update

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1709,7 +1709,6 @@ static void
 __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi)
 {
     WT_SAVE_UPD *supd;
-    WT_UPDATE **tmp;
     uint32_t i, slot;
 
     /*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1778,7 +1778,7 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
                 upd = supd->ins->upd;
 
             WT_ASSERT(session, upd != NULL);
-            for (; upd->next != NULL && upd->next != NULL; upd = upd->next)
+            for (; upd->next != NULL; upd = upd->next)
                 ;
             upd->next = supd->free_upds;
         }

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1430,9 +1430,9 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
     WT_SAVE_UPD *supd;
     WT_UPDATE *last_upd, *prev_onpage, *tmp, *upd;
     size_t free_size;
-    uint64_t recno;
+    uint64_t recno, txnid;
     uint32_t i, slot;
-    bool instantiate_upd;
+    bool free_updates, instantiate_upd;
 
     /*
      * This code re-creates an in-memory page from a disk image, and adds references to any
@@ -1486,6 +1486,12 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
         return (0);
 
     free_size = 0;
+    /*
+     * We can't truncate the updates for an in-memory database or an in-memory btree as we cannot
+     * insert the older updates to the history store.
+     */
+    free_updates =
+      !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY);
 
     if (orig->type == WT_PAGE_ROW_LEAF)
         WT_RET(__wt_scr_alloc(session, 0, &key));
@@ -1510,32 +1516,65 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
         WT_ASSERT(session, upd != NULL);
 
         /*
-         * Truncate the onpage value and the older versions moved to the history store. We can't
-         * truncate the updates for an in memory database as it doesn't support the history store.
-         * We can't free the truncated updates here as we may still fail. If we fail, we will append
-         * them back to their original update chains. Truncate before we restore them to ensure the
-         * size of the page is correct.
+         * Truncate the updates that we can safely free. We can't free the truncated updates here as
+         * we may still fail. If we fail, we will append them back to their original update chains.
+         * Truncate before we restore them to ensure the size of the page is correct.
          */
-        if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-          !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
+        if (free_updates && supd->onpage_upd != NULL) {
             /*
-             * If there is an on-page tombstone we need to remove it as well while performing update
-             * restore eviction.
+             * If we have written a prepared update, we need to retain the next update that is not a
+             * tombstone. Otherwise, we don't have anything to write in the next reconciliation if
+             * the prepared update is reverted.
              */
-            tmp = supd->onpage_tombstone != NULL ? supd->onpage_tombstone : supd->onpage_upd;
+            if (WT_TIME_WINDOW_HAS_START_PREPARE(&supd->tw)) {
+                for (tmp = supd->onpage_upd->next; tmp != NULL; tmp = tmp->next) {
+                    /*
+                     * We can get away not using an ordered read here as we can simply skip aborted
+                     * updates.
+                     */
+                    WT_READ_ONCE(txnid, tmp->txnid);
+                    if (txnid == WT_TXN_ABORTED)
+                        continue;
 
-            /*
-             * We have decided to restore this update chain so it must have newer updates than the
-             * onpage value on it or we write a prepared update to disk.
-             */
-            WT_ASSERT(session, upd != tmp || WT_TIME_WINDOW_HAS_PREPARE(&supd->tw));
-            WT_ASSERT(session, F_ISSET(tmp, WT_UPDATE_DS));
+                    /* Skip the update from the same prepared transaction */
+                    if (txnid == supd->tw.start_txn)
+                        continue;
 
-            /* FIXME-WT-15118: Don't free the update chain with prepared updates for now. */
-            if (!WT_TIME_WINDOW_HAS_PREPARE(&supd->tw)) {
+                    /* We are looking for a full update. */
+                    if (tmp->type == WT_UPDATE_TOMBSTONE)
+                        continue;
+
+                    break;
+                }
+
+                if (tmp != NULL) {
+                    supd->free_upds = tmp->next;
+                    tmp->next = NULL;
+                }
+            } else if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&supd->tw)) {
                 /*
-                 * Move the pointer to the position before the onpage value and truncate all the
-                 * updates starting from the onpage value.
+                 * If we write a prepared tombstone, we still need to retain the update it deletes
+                 * on the update chain. Otherwise, if the prepared update is aborted, we will have
+                 * nothing to write in the next reconciliation.
+                 */
+                supd->free_upds = supd->onpage_upd->next;
+                supd->onpage_upd->next = NULL;
+            } else {
+                /*
+                 * For non-prepared case, free the on-page value and the on-page tombstone if there
+                 * is one.
+                 */
+                tmp = supd->onpage_tombstone != NULL ? supd->onpage_tombstone : supd->onpage_upd;
+
+                /*
+                 * We have decided to restore this update chain so it must have newer updates than
+                 * the onpage value on it or we write a prepared update to disk.
+                 */
+                WT_ASSERT(session, upd != tmp);
+                WT_ASSERT(session, F_ISSET(tmp, WT_UPDATE_DS));
+                /*
+                 * Move the pointer to the position before the update we can safely free and
+                 * truncate all the updates starting from the onpage value.
                  */
                 for (prev_onpage = upd; prev_onpage->next != NULL && prev_onpage->next != tmp;
                      prev_onpage = prev_onpage->next)
@@ -1555,7 +1594,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
                     WT_ASSERT(
                       session, tmp == supd->onpage_tombstone || tmp->txnid == WT_TXN_ABORTED);
 #endif
-                /* Discard updates/tombstone after prev_onpage. */
+                supd->free_upds = prev_onpage->next;
                 prev_onpage->next = NULL;
             }
         }
@@ -1701,19 +1740,9 @@ __split_multi_inmem_final(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mul
         } else
             supd->ins->upd = NULL;
 
-        /*
-         * Free the updates written to the data store and the history store when there exists an
-         * onpage value except when we write a prepared update to disk (FIXME-WT-15118). It is
-         * possible that there can be an onpage tombstone without an onpage value when the tombstone
-         * is globally visible. Do not free them here as it is possible that the globally visible
-         * tombstone is already freed as part of update obsolete check.
-         */
-        if (supd->onpage_upd != NULL && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-          !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) && !WT_TIME_WINDOW_HAS_PREPARE(&supd->tw)) {
-            tmp = supd->onpage_tombstone != NULL ? &supd->onpage_tombstone : &supd->onpage_upd;
-            __wt_free_update_list(session, tmp);
-            supd->onpage_tombstone = supd->onpage_upd = NULL;
-        }
+        /* Free the updates are no longer needed. */
+        if (supd->free_upds != NULL)
+            __wt_free_update_list(session, &supd->free_upds);
     }
 }
 
@@ -1726,7 +1755,7 @@ static void
 __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT_REF *ref)
 {
     WT_SAVE_UPD *supd;
-    WT_UPDATE *tmp, *upd;
+    WT_UPDATE *upd;
     uint32_t i, slot;
 
     if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
@@ -1739,8 +1768,7 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
             if (!supd->restore || supd->onpage_upd == NULL)
                 continue;
 
-            /* FIXME-WT-15118: Update chain with prepared update is not freed. */
-            if (WT_TIME_WINDOW_HAS_PREPARE(&supd->tw))
+            if (supd->free_upds == NULL)
                 continue;
 
             if (supd->ins == NULL) {
@@ -1751,11 +1779,9 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
                 upd = supd->ins->upd;
 
             WT_ASSERT(session, upd != NULL);
-            tmp = supd->onpage_tombstone != NULL ? supd->onpage_tombstone : supd->onpage_upd;
-            for (; upd->next != NULL && upd->next != tmp; upd = upd->next)
+            for (; upd->next != NULL && upd->next != NULL; upd = upd->next)
                 ;
-            if (upd->next == NULL)
-                upd->next = tmp;
+            upd->next = supd->free_upds;
         }
 
     /*

--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -177,14 +177,17 @@ __wt_row_modify(WT_CURSOR_BTREE *cbt, const WT_ITEM *key, const WT_ITEM *value,
             /*
              * If we restore an update chain in update restore eviction, there should be no update
              * or a restored tombstone on the existing update chain except for btrees with leaf
-             * delta enabled. FIXME-WT-14885: No need to consider the delta case if we have
-             * implemented delta consolidation.
+             * delta enabled or a prepared update if the preserve prepared config is enabled.
+             * FIXME-WT-14885: No need to consider the delta case if we have implemented delta
+             * consolidation.
              */
             WT_ASSERT_ALWAYS(session,
               !restore ||
                 (*upd_entry == NULL ||
                   (WT_DELTA_LEAF_ENABLED(session) && (*upd_entry)->type == WT_UPDATE_TOMBSTONE &&
-                    F_ISSET(*upd_entry, WT_UPDATE_RESTORED_FROM_DS))),
+                    F_ISSET(*upd_entry, WT_UPDATE_RESTORED_FROM_DS)) ||
+                  (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+                    (*upd_entry)->prepare_state == WT_PREPARE_INPROGRESS)),
               "Illegal update on chain during update restore eviction");
 
             /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -247,6 +247,7 @@ struct __wt_save_upd {
     WT_ROW *rip;    /* Original on-page reference */
     WT_UPDATE *onpage_upd;
     WT_UPDATE *onpage_tombstone;
+    WT_UPDATE *free_upds; /* Updates to be freed */
     WT_TIME_WINDOW tw;
     bool restore; /* Whether to restore this saved update chain */
 };

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -505,9 +505,8 @@ __rec_hs_insert_record(WT_SESSION_IMPL *session, WT_CURSOR *cursor, WT_BTREE *bt
      * visible to checkpoint and the modifications it makes to the history store will be the same as
      * what checkpoint would've done.
      */
-    if (error_on_ts_ordering && __wt_txn_tw_start_visible_all(session, tw)) {
+    if (error_on_ts_ordering && __wt_txn_tw_start_visible_all(session, tw))
         error_on_ts_ordering = false;
-    }
 
     if (ret == 0) {
         WT_ASSERT(session, tw->start_ts + 1 > WT_TS_NONE);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1275,22 +1275,7 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     if (!WT_IS_HS(session->dhandle) && upd_select->tombstone != NULL &&
       !F_ISSET(upd_select->tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS) &&
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw)) {
-        upd = upd_select->upd;
-
-        /*
-         * The selected update can be the tombstone itself when the tombstone is globally visible.
-         * Compare the tombstone's timestamp with either the next update in the update list or the
-         * on-disk cell timestamp to determine if the tombstone is discarding a timestamp.
-         */
-        if (upd_select->tombstone == upd) {
-            upd = upd->next;
-
-            /* Loop until a valid update is found. */
-            while (upd != NULL && upd->txnid == WT_TXN_ABORTED)
-                upd = upd->next;
-        }
-
-        if ((upd != NULL && upd_select->tw.start_ts > upd_select->tw.stop_ts) ||
+        if (upd_select->tw.start_ts > upd_select->tw.stop_ts ||
           (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts)) {
             WT_ASSERT(session, upd_select->tw.stop_ts == WT_TS_NONE);
             upd_select->no_ts_tombstone = true;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1250,21 +1250,6 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     if (upd != NULL)
         WT_RET(__rec_fill_tw_from_upd_select(session, page, vpack, upd_select, write_prepare, r));
 
-    /*
-     * Fixup any missing timestamps, assert that checkpoint wasn't running when this round of
-     * reconciliation started.
-     *
-     * Returning EBUSY here is okay as the previous call to validate the update chain wouldn't have
-     * caught the situation where only a tombstone is selected.
-     */
-    if (__timestamp_no_ts_fix(session, &upd_select->tw) && F_ISSET(r, WT_REC_HS) &&
-      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)) {
-        /* Catch this case in diagnostic builds. */
-        WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_3);
-        WT_ASSERT(session, false);
-        return (EBUSY);
-    }
-
     /* Mark the page dirty after reconciliation. */
     if (has_newer_updates)
         r->leave_dirty = true;
@@ -1288,7 +1273,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
      * functions perform the history store truncation for this key.
      */
     if (!WT_IS_HS(session->dhandle) && upd_select->tombstone != NULL &&
-      !F_ISSET(upd_select->tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS)) {
+      !F_ISSET(upd_select->tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS) &&
+      !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw)) {
         upd = upd_select->upd;
 
         /*
@@ -1304,8 +1290,26 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
                 upd = upd->next;
         }
 
-        if (upd != NULL && upd_select->tw.stop_ts == WT_TS_NONE)
+        if ((upd != NULL && upd_select->tw.start_ts > upd_select->tw.stop_ts) ||
+          (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts)) {
+            WT_ASSERT(session, upd_select->tw.stop_ts == WT_TS_NONE);
             upd_select->no_ts_tombstone = true;
+        }
+    }
+
+    /*
+     * Fixup any missing timestamps, assert that checkpoint wasn't running when this round of
+     * reconciliation started.
+     *
+     * Returning EBUSY here is okay as the previous call to validate the update chain wouldn't have
+     * caught the situation where only a tombstone is selected.
+     */
+    if (__timestamp_no_ts_fix(session, &upd_select->tw) && F_ISSET(r, WT_REC_HS) &&
+      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)) {
+        /* Catch this case in diagnostic builds. */
+        WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_3);
+        WT_ASSERT(session, false);
+        return (EBUSY);
     }
 
     /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1250,6 +1250,21 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     if (upd != NULL)
         WT_RET(__rec_fill_tw_from_upd_select(session, page, vpack, upd_select, write_prepare, r));
 
+    /*
+     * Fixup any missing timestamps, assert that checkpoint wasn't running when this round of
+     * reconciliation started.
+     *
+     * Returning EBUSY here is okay as the previous call to validate the update chain wouldn't have
+     * caught the situation where only a tombstone is selected.
+     */
+    if (__timestamp_no_ts_fix(session, &upd_select->tw) && F_ISSET(r, WT_REC_HS) &&
+      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)) {
+        /* Catch this case in diagnostic builds. */
+        WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_3);
+        WT_ASSERT(session, false);
+        return (EBUSY);
+    }
+
     /* Mark the page dirty after reconciliation. */
     if (has_newer_updates)
         r->leave_dirty = true;
@@ -1272,7 +1287,7 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
      * Set the flag if the selected tombstone has no timestamp. Based on this flag, the caller
      * functions perform the history store truncation for this key.
      */
-    if (!F_ISSET(session->dhandle, WT_DHANDLE_HS) && upd_select->tombstone != NULL &&
+    if (!WT_IS_HS(session->dhandle) && upd_select->tombstone != NULL &&
       !F_ISSET(upd_select->tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS)) {
         upd = upd_select->upd;
 
@@ -1289,24 +1304,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
                 upd = upd->next;
         }
 
-        if ((upd != NULL && upd->upd_start_ts > upd_select->tombstone->upd_start_ts) ||
-          (vpack != NULL && vpack->tw.start_ts > upd_select->tombstone->upd_start_ts))
+        if (upd != NULL && upd_select->tw.stop_ts == WT_TS_NONE)
             upd_select->no_ts_tombstone = true;
-    }
-
-    /*
-     * Fixup any missing timestamps, assert that checkpoint wasn't running when this round of
-     * reconciliation started.
-     *
-     * Returning EBUSY here is okay as the previous call to validate the update chain wouldn't have
-     * caught the situation where only a tombstone is selected.
-     */
-    if (__timestamp_no_ts_fix(session, &upd_select->tw) && F_ISSET(r, WT_REC_HS) &&
-      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)) {
-        /* Catch this case in diagnostic builds. */
-        WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_3);
-        WT_ASSERT(session, false);
-        return (EBUSY);
     }
 
     /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1275,8 +1275,9 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     if (!WT_IS_HS(session->dhandle) && upd_select->tombstone != NULL &&
       !F_ISSET(upd_select->tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS) &&
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw)) {
-        if (upd_select->tw.start_ts > upd_select->tw.stop_ts ||
-          (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts)) {
+        if (upd_select->tombstone != upd_select->upd &&
+          (upd_select->tw.start_ts > upd_select->tw.stop_ts ||
+            (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts))) {
             WT_ASSERT(session, upd_select->tw.stop_ts == WT_TS_NONE);
             upd_select->no_ts_tombstone = true;
         }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1275,9 +1275,9 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     if (!WT_IS_HS(session->dhandle) && upd_select->tombstone != NULL &&
       !F_ISSET(upd_select->tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS) &&
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw)) {
-        if (upd_select->tombstone != upd_select->upd &&
-          (upd_select->tw.start_ts > upd_select->tw.stop_ts ||
-            (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts))) {
+        if ((upd_select->tombstone != upd_select->upd &&
+              upd_select->tw.start_ts > upd_select->tw.stop_ts) ||
+          (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts)) {
             WT_ASSERT(session, upd_select->tw.stop_ts == WT_TS_NONE);
             upd_select->no_ts_tombstone = true;
         }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -36,6 +36,7 @@ __rec_update_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins, WT
     supd->rip = rip;
     supd->onpage_upd = onpage_upd;
     supd->onpage_tombstone = tombstone;
+    supd->free_upds = NULL;
     supd->tw = *tw;
     supd->restore = supd_restore;
     ++r->supd_next;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1277,7 +1277,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw)) {
         if ((upd_select->tombstone != upd_select->upd &&
               upd_select->tw.start_ts > upd_select->tw.stop_ts) ||
-          (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts)) {
+          (vpack != NULL && vpack->tw.start_ts > upd_select->tw.stop_ts &&
+            upd_select->tw.stop_ts == WT_TS_NONE)) {
             WT_ASSERT(session, upd_select->tw.stop_ts == WT_TS_NONE);
             upd_select->no_ts_tombstone = true;
         }

--- a/test/suite/prepare_util.py
+++ b/test/suite/prepare_util.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+import wttest
+
+class test_prepare_preserve_prepare_base(wttest.WiredTigerTestCase):
+    conn_config = 'checkpoint=(precise=true),preserve_prepared=true,statistics=(all)'
+
+    def get_stats(self, stats, uri):
+        """Get the current values of multiple statistics."""
+        stat_cursor = self.session.open_cursor('statistics:' + uri)
+        results = {}
+        for stat in stats:
+            results[stat] = stat_cursor[stat][2]
+        stat_cursor.close()
+        return results
+
+    def checkpoint_and_verify_stats(self, expected_changes, uri):
+        stats_to_check = list(expected_changes.keys())
+        old_stats = self.get_stats(stats_to_check, uri)
+
+        self.session.checkpoint()
+
+        new_stats = self.get_stats(stats_to_check, uri)
+
+        for stat, expect_increase in expected_changes.items():
+            diff = new_stats[stat] - old_stats[stat]
+            if expect_increase:
+                self.assertGreater(diff, 0,
+                    f"Stat {stat}: expected increase, got diff {diff}")
+            else:
+                self.assertEqual(diff, 0,
+                    f"Stat {stat}: expected no change, got diff {diff}")
+
+        return new_stats

--- a/test/suite/test_prepare37.py
+++ b/test/suite/test_prepare37.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger
+from prepare_util import test_prepare_preserve_prepare_base
+
+# Test eviction free updates with prepared transactions
+
+class test_prepare37(test_prepare_preserve_prepare_base):
+    uri = 'table:test_prepare37'
+
+    def test_committed_prepare(self):
+        # Setup: Initialize timestamps with stable < prepare timestamp
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        if 'disagg' in self.hook_names:
+            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(self.uri, create_params)
+
+        # Step 1: Insert a base value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_1")
+            cursor_committed.insert()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor_committed.close()
+
+        # Step 2: Update the value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_2")
+            cursor_committed.update()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor_committed.close()
+
+        # Step 3: Update key 20 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(20)
+        cursor_prepare.set_value("prepared_value_20_3")
+        cursor_prepare.insert()
+        session_prepare.prepare_transaction('prepare_timestamp=' + self.timestamp_str(35)+',prepared_id=' + self.prepared_id_str(1))
+        cursor_prepare.close()
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Verify checkpoint writes prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+        }, self.uri)
+
+        # Step 4: Commit prepared transaction
+        session_prepare.commit_transaction("commit_timestamp=" + self.timestamp_str(40) + ',durable_timestamp=' + self.timestamp_str(45))
+        session_prepare.close()
+
+        # Step 5: Force eviction to trigger reconciliation with the prepared data
+        # This ensures the prepared update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "prepared_value_20_3")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+        # Make durable timestamp of the prepared transaction stable
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(45))
+
+        # Step 6: Force eviction to trigger reconciliation
+        # This ensures the committed update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "prepared_value_20_3")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+    def test_committed_prepare(self):
+        # Setup: Initialize timestamps with stable < prepare timestamp
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        if 'disagg' in self.hook_names:
+            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(self.uri, create_params)
+
+        # Step 1: Insert a base value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_1")
+            cursor_committed.insert()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor_committed.close()
+
+        # Step 2: Update the value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_2")
+            cursor_committed.update()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor_committed.close()
+
+        # Step 3: Update key 20 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(20)
+        cursor_prepare.set_value("prepared_value_20_3")
+        cursor_prepare.insert()
+        session_prepare.prepare_transaction('prepare_timestamp=' + self.timestamp_str(35)+',prepared_id=' + self.prepared_id_str(1))
+        cursor_prepare.close()
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Verify checkpoint writes prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+        }, self.uri)
+
+        # Step 4: Commit prepared transaction
+        session_prepare.commit_transaction("commit_timestamp=" + self.timestamp_str(40) + ',durable_timestamp=' + self.timestamp_str(45))
+        session_prepare.close()
+
+        # Step 5: Force eviction to trigger reconciliation with the prepared data
+        # This ensures the prepared update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "prepared_value_20_3")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+        # Make durable timestamp of the prepared transaction stable
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(45))
+
+        # Step 6: Force eviction to trigger reconciliation
+        # This ensures the committed update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "prepared_value_20_3")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+    def test_rollback_prepare(self):
+        # Setup: Initialize timestamps with stable < prepare timestamp
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        if 'disagg' in self.hook_names:
+            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(self.uri, create_params)
+
+        # Step 1: Insert a base value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_1")
+            cursor_committed.insert()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor_committed.close()
+
+        # Step 2: Update the value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_2")
+            cursor_committed.update()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor_committed.close()
+
+        # Step 3: Update key 20 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(20)
+        cursor_prepare.set_value("prepared_value_20_3")
+        cursor_prepare.insert()
+        session_prepare.prepare_transaction('prepare_timestamp=' + self.timestamp_str(35)+',prepared_id=' + self.prepared_id_str(1))
+        cursor_prepare.close()
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Verify checkpoint writes prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+        }, self.uri)
+
+        # Step 4: Rollback prepared transaction
+        session_prepare.rollback_transaction("rollback_timestamp=" + self.timestamp_str(40))
+        session_prepare.close()
+
+        # Step 5: Force eviction to trigger reconciliation with the prepared data
+        # This ensures the prepared update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(40))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+        # Make rollback timestamp of the prepared transaction stable
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
+
+        # Step 6: Force eviction to trigger reconciliation
+        # This ensures the committed update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(40))
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+    def test_prepare_delete(self):
+        # Setup: Initialize timestamps with stable < prepare timestamp
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        if 'disagg' in self.hook_names:
+            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(self.uri, create_params)
+
+        # Step 1: Insert a base value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_1")
+            cursor_committed.insert()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor_committed.close()
+
+        # Step 2: Update the value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_2")
+            cursor_committed.update()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor_committed.close()
+
+        # Step 3: Delete key 20 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(20)
+        cursor_prepare.remove()
+        session_prepare.prepare_transaction('prepare_timestamp=' + self.timestamp_str(35)+',prepared_id=' + self.prepared_id_str(1))
+        cursor_prepare.close()
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Verify checkpoint writes prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+        }, self.uri)
+
+        # Step 4: Commit prepared transaction
+        session_prepare.commit_transaction("commit_timestamp=" + self.timestamp_str(40) + ',durable_timestamp=' + self.timestamp_str(45))
+        session_prepare.close()
+
+        # Step 5: Force eviction to trigger reconciliation with the prepared data
+        # This ensures the prepared update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 20):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        read_cursor.set_key(20)
+        self.assertEqual(read_cursor.search(), wiredtiger.WT_NOTFOUND)
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+        # Make durable timestamp of the prepared transaction stable
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(45))
+
+        # Step 6: Force eviction to trigger reconciliation
+        # This ensures the committed update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 20):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
+        read_cursor.set_key(20)
+        self.assertEqual(read_cursor.search(), wiredtiger.WT_NOTFOUND)
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()

--- a/test/suite/test_prepare37.py
+++ b/test/suite/test_prepare37.py
@@ -34,119 +34,7 @@ from prepare_util import test_prepare_preserve_prepare_base
 class test_prepare37(test_prepare_preserve_prepare_base):
     uri = 'table:test_prepare37'
 
-    def test_committed_prepare(self):
-        # Setup: Initialize timestamps with stable < prepare timestamp
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
-        create_params = 'key_format=i,value_format=S'
-        self.session.create(self.uri, create_params)
-
-        # Step 1: Insert a base value
-        cursor_committed = self.session.open_cursor(self.uri)
-        self.session.begin_transaction()
-        for i in range(1, 21):
-            cursor_committed.set_key(i)
-            cursor_committed.set_value("committed_value_" + str(i) + "_1")
-            cursor_committed.insert()
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
-        cursor_committed.close()
-
-        # Step 2: Update the value
-        cursor_committed = self.session.open_cursor(self.uri)
-        self.session.begin_transaction()
-        for i in range(1, 21):
-            cursor_committed.set_key(i)
-            cursor_committed.set_value("committed_value_" + str(i) + "_2")
-            cursor_committed.update()
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
-        cursor_committed.close()
-
-        # Step 3: Update key 20 with a prepared update prepared_id=1
-        session_prepare = self.conn.open_session()
-        cursor_prepare = session_prepare.open_cursor(self.uri)
-        session_prepare.begin_transaction()
-        cursor_prepare.set_key(20)
-        cursor_prepare.set_value("prepared_value_20_3")
-        cursor_prepare.insert()
-        session_prepare.prepare_transaction('prepare_timestamp=' + self.timestamp_str(35)+',prepared_id=' + self.prepared_id_str(1))
-        cursor_prepare.close()
-
-        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
-
-        # Verify checkpoint writes prepared time window to disk
-        self.checkpoint_and_verify_stats({
-            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
-        }, self.uri)
-
-        # Step 4: Commit prepared transaction
-        session_prepare.commit_transaction("commit_timestamp=" + self.timestamp_str(40) + ',durable_timestamp=' + self.timestamp_str(45))
-        session_prepare.close()
-
-        # Step 5: Force eviction to trigger reconciliation with the prepared data
-        # This ensures the prepared update gets written to disk storage
-        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
-        session_evict.begin_transaction("ignore_prepare=true")
-        evict_cursor = session_evict.open_cursor(self.uri, None, None)
-        for i in range(1, 21):  # Evict committed data pages
-            evict_cursor.set_key(i)
-            self.assertEqual(evict_cursor.search(), 0)
-            evict_cursor.reset()
-        evict_cursor.close()
-        session_evict.rollback_transaction()
-        session_evict.close()
-
-        # Verify key 20 is visible
-        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
-        read_cursor = self.session.open_cursor(self.uri, None, None)
-        self.assertEqual(read_cursor[20], "prepared_value_20_3")
-        self.session.rollback_transaction()
-
-        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
-        read_cursor = self.session.open_cursor(self.uri, None, None)
-        self.assertEqual(read_cursor[20], "committed_value_20_2")
-        self.session.rollback_transaction()
-
-        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
-        read_cursor = self.session.open_cursor(self.uri, None, None)
-        self.assertEqual(read_cursor[20], "committed_value_20_1")
-        self.session.rollback_transaction()
-
-        # Make durable timestamp of the prepared transaction stable
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(45))
-
-        # Step 6: Force eviction to trigger reconciliation
-        # This ensures the committed update gets written to disk storage
-        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
-        session_evict.begin_transaction("ignore_prepare=true")
-        evict_cursor = session_evict.open_cursor(self.uri, None, None)
-        for i in range(1, 21):  # Evict committed data pages
-            evict_cursor.set_key(i)
-            self.assertEqual(evict_cursor.search(), 0)
-            evict_cursor.reset()
-        evict_cursor.close()
-        session_evict.rollback_transaction()
-        session_evict.close()
-
-        # Verify key 20 is visible
-        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
-        read_cursor = self.session.open_cursor(self.uri, None, None)
-        self.assertEqual(read_cursor[20], "prepared_value_20_3")
-        self.session.rollback_transaction()
-
-        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
-        read_cursor = self.session.open_cursor(self.uri, None, None)
-        self.assertEqual(read_cursor[20], "committed_value_20_2")
-        self.session.rollback_transaction()
-
-        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
-        read_cursor = self.session.open_cursor(self.uri, None, None)
-        self.assertEqual(read_cursor[20], "committed_value_20_1")
-        self.session.rollback_transaction()
-
-    def test_committed_prepare(self):
+    def test_commit_prepare(self):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
@@ -365,7 +253,7 @@ class test_prepare37(test_prepare_preserve_prepare_base):
         self.assertEqual(read_cursor[20], "committed_value_20_1")
         self.session.rollback_transaction()
 
-    def test_prepare_delete(self):
+    def test_commit_prepare_delete(self):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
@@ -464,6 +352,112 @@ class test_prepare37(test_prepare_preserve_prepare_base):
         self.session.begin_transaction('read_timestamp='+ self.timestamp_str(45))
         read_cursor.set_key(20)
         self.assertEqual(read_cursor.search(), wiredtiger.WT_NOTFOUND)
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+    def test_rollback_prepare_delete(self):
+        # Setup: Initialize timestamps with stable < prepare timestamp
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        if 'disagg' in self.hook_names:
+            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(self.uri, create_params)
+
+        # Step 1: Insert a base value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_1")
+            cursor_committed.insert()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(25))
+        cursor_committed.close()
+
+        # Step 2: Update the value
+        cursor_committed = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 21):
+            cursor_committed.set_key(i)
+            cursor_committed.set_value("committed_value_" + str(i) + "_2")
+            cursor_committed.update()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor_committed.close()
+
+        # Step 3: Delete key 20 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(20)
+        cursor_prepare.remove()
+        session_prepare.prepare_transaction('prepare_timestamp=' + self.timestamp_str(35)+',prepared_id=' + self.prepared_id_str(1))
+        cursor_prepare.close()
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Verify checkpoint writes prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+        }, self.uri)
+
+        # Step 4: Rollback prepared transaction
+        session_prepare.rollback_transaction("rollback_timestamp=" + self.timestamp_str(40))
+        session_prepare.close()
+
+        # Step 5: Force eviction to trigger reconciliation with the prepared data
+        # This ensures the prepared update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(40))
+        read_cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
+        self.session.rollback_transaction()
+
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(25))
+        self.assertEqual(read_cursor[20], "committed_value_20_1")
+        self.session.rollback_transaction()
+
+        # Make rollback timestamp of the prepared transaction stable
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
+
+        # Step 6: Force eviction to trigger reconciliation
+        # This ensures the committed update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 21):  # Evict committed data pages
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Verify key 20 is visible
+        self.session.begin_transaction('read_timestamp='+ self.timestamp_str(40))
+        self.assertEqual(read_cursor[20], "committed_value_20_2")
         self.session.rollback_transaction()
 
         self.session.begin_transaction('read_timestamp='+ self.timestamp_str(30))


### PR DESCRIPTION
Free the updates with prepared update in update restore eviction.

Fixed a bug in __wti_rec_upd_select that compares the timestamps on the update, which is actually a prepared id if the prepared update is rolled back. Instead, compare the timestamps on the time window.