### PR TITLE
WT-15096 reuse a version list in compatibility test script and python test suite

### DIFF
--- a/test/compatibility/common/compatibility_common.py
+++ b/test/compatibility/common/compatibility_common.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os, re, sys
-from compatibility_config import *
+from compatibility_config import BRANCHES, BRANCHES_DIR
 
 # Remember the top-level test directory and the top-level project directory.
 TEST_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
@@ -44,35 +44,6 @@ test_util.setup_3rdparty_paths()
 
 # The default build directory
 DEFAULT_BUILD_DIR = 'build.compatibility'
-
-def is_branch_supported(branch):
-    '''
-    Check whether the branch is supported by the compatibility test.
-    '''
-    return branch == 'this' or branch == 'develop' or branch.startswith('mongodb-')
-
-def is_branch_order_asc(a, b):
-    '''
-    Compare two branches for whether the two branches are in ascending order with respect their
-    version numbers; i.e., whether branch "b" is newer than branch "a".
-    '''
-    if not is_branch_supported(a):
-        raise Exception('Unsupported branch "%s"' % a)
-    if not is_branch_supported(b):
-        raise Exception('Unsupported branch "%s"' % b)
-    if a == b:
-        return False
-
-    # Assume that 'this' branch is newer than 'develop'.
-    if a == 'this':
-        return False
-    if b == 'this':
-        return True
-    if a == 'develop':
-        return False
-    if b == 'develop':
-        return True
-    return b > a
 
 def branch_path(branch):
     '''

--- a/test/compatibility/common/compatibility_config.py
+++ b/test/compatibility/common/compatibility_config.py
@@ -30,7 +30,6 @@
 
 import os
 import re
-from typing import Dict, List
 
 from compatibility_version import WTVersion
 
@@ -41,7 +40,7 @@ from compatibility_version import WTVersion
 # To make this branches compatitable with existing "compatibility_test_for_releases.sh", the
 # version is imported from the bash file of "meta/versions.sh"
 
-class WTBranchs:
+class WTBranches:
 
     def __init__(self, bash_script:str):
         self.SUITE_RELEASE_BRANCHES = []
@@ -49,16 +48,16 @@ class WTBranchs:
 
     def extract_versions(self, bash_script:str):
         with open(bash_script, "r") as f:
-            lines = f.read().split('\n')
-        for line in lines:
-            match = re.match(r'export\s+([A-Z_]+)\s*=\s*"([^"]*)"', line)
+            content = f.read()
+        for name in ['SUITE_RELEASE_BRANCHES']:
+            match = re.search(r'export\s+'+name+r'\s*=\s*"([^"]*)"', content)
             if match:
-                name = match.group(1)
-                if name in ['SUITE_RELEASE_BRANCHES']:
-                    versions = match.group(2).split()
-                    versions = [WTVersion(version) for version in versions]
-                    versions = [version for version in versions if version]
-                    setattr(self, name, versions)
+                versions = match.group(1)
+                # This is designed to compatitate with multi-line variable define
+                versions = versions.replace('\n', '').replace('\\', '').split()
+                versions = [WTVersion(version) for version in versions]
+                versions = [version for version in versions if version]
+                setattr(self, name, versions)
         if not self:
             raise Exception("Failed to extract versions from " + bash_script)
 
@@ -66,10 +65,10 @@ class WTBranchs:
         return bool(self.SUITE_RELEASE_BRANCHES)
 
 META_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'meta')
-BRANCHES : WTBranchs = WTBranchs(os.path.join(META_DIR, "versions.sh"))
+BRANCHES : WTBranches = WTBranches(os.path.join(META_DIR, "versions.sh"))
 
 # Example use of the 'this' branch (useful for debugging):
-# BRANCHES = {'SUITE_RELEASE_BRANCHES' : ['this', 'mongodb-7.0']}
+# BRANCHES.SUITE_RELEASE_BRANCHES == ['this', 'mongodb-7.0']
 
 # The default directory to which the test will check out other branches, relative to the project's
 # top-level directory.

--- a/test/compatibility/common/compatibility_config.py
+++ b/test/compatibility/common/compatibility_config.py
@@ -41,7 +41,7 @@ from compatibility_version import WTVersion
 # To make this branches compatitable with existing "compatibility_test_for_releases.sh", the
 # version is imported from the bash file of "meta/versions.sh"
 
-def version_extract(bash_script):
+def extract_versions(bash_script):
     version_ret = {}
     with open(bash_script, "r") as f:
         lines = f.read().split('\n')
@@ -52,15 +52,15 @@ def version_extract(bash_script):
             versions = match.group(2).split()
             versions = [WTVersion(version) for version in versions]
             version_ret[name] = [version for version in versions if version]
+    if not version_ret:
+        raise Exception("Failed to extract versions from " + bash_script)
     return version_ret
 
-META_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../meta')
-BRANCHES : Dict[str, List[WTVersion]]  = version_extract(os.path.join(META_DIR, "versions.sh"))
-
-# BRANCHES = ['develop', 'mongodb-7.1', 'mongodb-7.0', 'mongodb-6.3']
+META_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'meta')
+BRANCHES : Dict[str, List[WTVersion]] = extract_versions(os.path.join(META_DIR, "versions.sh"))
 
 # Example use of the 'this' branch (useful for debugging):
-# BRANCHES = ['this', 'mongodb-7.0']
+# BRANCHES = {'SUITE_RELEASE_BRANCHES' : ['this', 'mongodb-7.0']}
 
 # The default directory to which the test will check out other branches, relative to the project's
 # top-level directory.

--- a/test/compatibility/common/compatibility_config.py
+++ b/test/compatibility/common/compatibility_config.py
@@ -32,6 +32,7 @@ import os
 import re
 
 from compatibility_version import WTVersion
+from typing import List
 
 # The branches we use for the testing. We support special branch name 'this' that refers to the
 # current branch. This is useful when debugging a compatibility issue on the current branch, but it
@@ -42,9 +43,9 @@ from compatibility_version import WTVersion
 
 class WTBranches:
 
-    def __init__(self, bash_script:str):
-        self.SUITE_RELEASE_BRANCHES = []
-        self.extract_versions(bash_script)
+    def __init__(self, branches:List[str] = []):
+        # The branches here aims to support non-script mode
+        self.SUITE_RELEASE_BRANCHES = [WTVersion(branch) for branch in branches]
 
     def extract_versions(self, bash_script:str):
         with open(bash_script, "r") as f:
@@ -60,15 +61,16 @@ class WTBranches:
                 setattr(self, name, versions)
         if not self:
             raise Exception("Failed to extract versions from " + bash_script)
+        return self
 
     def __bool__(self):
         return bool(self.SUITE_RELEASE_BRANCHES)
 
 META_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'meta')
-BRANCHES : WTBranches = WTBranches(os.path.join(META_DIR, "versions.sh"))
+BRANCHES : WTBranches = WTBranches().extract_versions(os.path.join(META_DIR, "versions.sh"))
 
 # Example use of the 'this' branch (useful for debugging):
-# BRANCHES.SUITE_RELEASE_BRANCHES == ['this', 'mongodb-7.0']
+# BRANCHES : WTBranches = WTBranches(['this', 'mongodb-7.0'])
 
 # The default directory to which the test will check out other branches, relative to the project's
 # top-level directory.

--- a/test/compatibility/common/compatibility_config.py
+++ b/test/compatibility/common/compatibility_config.py
@@ -51,6 +51,8 @@ class WTBranches:
         with open(bash_script, "r") as f:
             content = f.read()
         for name in ['SUITE_RELEASE_BRANCHES']:
+            # The regex is searching for multi lines of environment variables define
+            # Example: export SUITE_RELEASE_BRANCHES = "this mongodb-7.1 mongodb-7.2"
             match = re.search(r'export\s+'+name+r'\s*=\s*"([^"]*)"', content)
             if match:
                 versions = match.group(1)

--- a/test/compatibility/common/compatibility_config.py
+++ b/test/compatibility/common/compatibility_config.py
@@ -57,10 +57,14 @@ class WTBranches:
             if match:
                 versions = match.group(1)
                 # This is designed to compatitate with multi-line variable define
-                versions = versions.replace('\n', '').replace('\\', '').split()
-                versions = [WTVersion(version) for version in versions]
+                versions:List[str] = versions.replace('\n', '').replace('\\', '').split()
+                # Versions are constructured from str to WTVersions
+                versions:List[WTVersion] = [WTVersion(version) for version in versions]
+                # Following 'if' is used to filter out invalid branches
                 versions = [version for version in versions if version]
                 setattr(self, name, versions)
+        # the following "not self" is equivelent to self.__bool__()
+        # the purpose here is to make sure all expected variables are found
         if not self:
             raise Exception("Failed to extract versions from " + bash_script)
         return self

--- a/test/compatibility/common/compatibility_config.py
+++ b/test/compatibility/common/compatibility_config.py
@@ -28,10 +28,36 @@
 
 # Common configuration for compatibility tests.
 
+import os
+import re
+from typing import Dict, List
+
+from compatibility_version import WTVersion
+
 # The branches we use for the testing. We support special branch name 'this' that refers to the
 # current branch. This is useful when debugging a compatibility issue on the current branch, but it
 # should not be enabled when testing on Evergreen.
-BRANCHES = ['develop', 'mongodb-7.1', 'mongodb-7.0', 'mongodb-6.3']
+
+# To make this branches compatitable with existing "compatibility_test_for_releases.sh", the
+# version is imported from the bash file of "meta/versions.sh"
+
+def version_extract(bash_script):
+    version_ret = {}
+    with open(bash_script, "r") as f:
+        lines = f.read().split('\n')
+    for line in lines:
+        match = re.match(r'export\s+([A-Z_]+)\s*=\s*"([^"]*)"', line)
+        if match:
+            name = match.group(1)
+            versions = match.group(2).split()
+            versions = [WTVersion(version) for version in versions]
+            version_ret[name] = [version for version in versions if version]
+    return version_ret
+
+META_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../meta')
+BRANCHES : Dict[str, List[WTVersion]]  = version_extract(os.path.join(META_DIR, "versions.sh"))
+
+# BRANCHES = ['develop', 'mongodb-7.1', 'mongodb-7.0', 'mongodb-6.3']
 
 # Example use of the 'this' branch (useful for debugging):
 # BRANCHES = ['this', 'mongodb-7.0']

--- a/test/compatibility/common/compatibility_config.py
+++ b/test/compatibility/common/compatibility_config.py
@@ -41,23 +41,32 @@ from compatibility_version import WTVersion
 # To make this branches compatitable with existing "compatibility_test_for_releases.sh", the
 # version is imported from the bash file of "meta/versions.sh"
 
-def extract_versions(bash_script):
-    version_ret = {}
-    with open(bash_script, "r") as f:
-        lines = f.read().split('\n')
-    for line in lines:
-        match = re.match(r'export\s+([A-Z_]+)\s*=\s*"([^"]*)"', line)
-        if match:
-            name = match.group(1)
-            versions = match.group(2).split()
-            versions = [WTVersion(version) for version in versions]
-            version_ret[name] = [version for version in versions if version]
-    if not version_ret:
-        raise Exception("Failed to extract versions from " + bash_script)
-    return version_ret
+class WTBranchs:
+
+    def __init__(self, bash_script:str):
+        self.SUITE_RELEASE_BRANCHES = []
+        self.extract_versions(bash_script)
+
+    def extract_versions(self, bash_script:str):
+        with open(bash_script, "r") as f:
+            lines = f.read().split('\n')
+        for line in lines:
+            match = re.match(r'export\s+([A-Z_]+)\s*=\s*"([^"]*)"', line)
+            if match:
+                name = match.group(1)
+                if name in ['SUITE_RELEASE_BRANCHES']:
+                    versions = match.group(2).split()
+                    versions = [WTVersion(version) for version in versions]
+                    versions = [version for version in versions if version]
+                    setattr(self, name, versions)
+        if not self:
+            raise Exception("Failed to extract versions from " + bash_script)
+
+    def __bool__(self):
+        return bool(self.SUITE_RELEASE_BRANCHES)
 
 META_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'meta')
-BRANCHES : Dict[str, List[WTVersion]] = extract_versions(os.path.join(META_DIR, "versions.sh"))
+BRANCHES : WTBranchs = WTBranchs(os.path.join(META_DIR, "versions.sh"))
 
 # Example use of the 'this' branch (useful for debugging):
 # BRANCHES = {'SUITE_RELEASE_BRANCHES' : ['this', 'mongodb-7.0']}

--- a/test/compatibility/common/compatibility_version.py
+++ b/test/compatibility/common/compatibility_version.py
@@ -43,8 +43,8 @@ class WTVersion:
         # group is used to unify this and develop
         # this : 2, develop : 1, mongod-a.b : 0
         self.group = 0
-        self.main = 0
-        self.sub = 0
+        self.major = 0
+        self.minor = 0
         if name == "this":
             self.group = 2
         if name == "develop":
@@ -53,8 +53,8 @@ class WTVersion:
             # Match patterns like mongodb-8.0, without prefix and suffix
             match = re.match(r'^mongodb-(\d+)\.(\d+)$', name)
             if match:
-                self.main = int(match.group(1))
-                self.sub = int(match.group(2))
+                self.major = int(match.group(1))
+                self.minor = int(match.group(2))
             else:
                 self.is_valid = False
 
@@ -68,8 +68,8 @@ class WTVersion:
         else:
             return (
                 self.group == other.group
-                and self.main == other.main
-                and self.sub == other.sub
+                and self.major == other.major
+                and self.minor == other.minor
             )
 
     def __lt__(self, other: "WTVersion"):
@@ -77,12 +77,12 @@ class WTVersion:
             return True
         elif self.group > other.group:
             return False
-        elif self.main < other.main:
+        elif self.major < other.major:
             return True
-        elif self.main > other.main:
+        elif self.major > other.major:
             return False
         else:
-            return self.sub < other.sub
+            return self.minor < other.minor
 
     def __gt__(self, other: "WTVersion"):
         if self < other or self == other:

--- a/test/compatibility/common/compatibility_version.py
+++ b/test/compatibility/common/compatibility_version.py
@@ -55,21 +55,21 @@ class WTVersion:
                 self.sub = int(match.group(2))
             else:
                 self.is_valid = False
-    
+
     def __bool__(self):
         return self.is_valid
-    
+
     # string format others will directly compare the name
     def __eq__(self, other : Union["WTVersion", str]):
         if isinstance(other, str):
             return self.name == other
         else:
             return (
-                self.group == other.group 
-                and self.main == other.main 
+                self.group == other.group
+                and self.main == other.main
                 and self.sub == other.sub
             )
-    
+
     def __lt__(self, other: "WTVersion"):
         if self.group < other.group:
             return True
@@ -81,7 +81,7 @@ class WTVersion:
             return False
         else:
             return self.sub < other.sub
-    
+
     def __gt__(self, other: "WTVersion"):
         if self < other or self == other:
             return False
@@ -90,7 +90,7 @@ class WTVersion:
 
     # Hash is used to support set collection, make it able to remove redundant
     def __hash__(self):
-        return hash(self.name)    
-    
+        return hash(self.name)
+
     def __str__(self):
         return self.name

--- a/test/compatibility/common/compatibility_version.py
+++ b/test/compatibility/common/compatibility_version.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re
+from typing import Union
+
+# This is a version class aimed to provide a operatable version object
+# For compare, this > develop > mongodb-{major}:{minor}
+# For invalid version string, this will return false by bool operator
+
+class WTVersion:
+
+    def __init__(self, name:str):
+        self.name = name
+        self.is_valid = True
+        # group is used to unify this and develop
+        # this : 2, develop : 1, mongod-a.b : 0
+        self.group = 0
+        self.main = 0
+        self.sub = 0
+        if name == "this":
+            self.group = 2
+        if name == "develop":
+            self.group = 1
+        else:
+            # Match patterns like mongodb-8.0, without prefix and suffix
+            match = re.match(r'^mongodb-(\d+)\.(\d+)$', name)
+            if match:
+                self.main = int(match.group(1))
+                self.sub = int(match.group(2))
+            else:
+                self.is_valid = False
+    
+    def __bool__(self):
+        return self.is_valid
+    
+    # string format others will directly compare the name
+    def __eq__(self, other : Union["WTVersion", str]):
+        if isinstance(other, str):
+            return self.name == other
+        else:
+            return (
+                self.group == other.group 
+                and self.main == other.main 
+                and self.sub == other.sub
+            )
+    
+    def __lt__(self, other: "WTVersion"):
+        if self.group < other.group:
+            return True
+        elif self.group > other.group:
+            return False
+        elif self.main < other.main:
+            return True
+        elif self.main > other.main:
+            return False
+        else:
+            return self.sub < other.sub
+    
+    def __gt__(self, other: "WTVersion"):
+        if self < other or self == other:
+            return False
+        else:
+            return True
+
+    # Hash is used to support set collection, make it able to remove redundant
+    def __hash__(self):
+        return hash(self.name)    
+    
+    def __str__(self):
+        return self.name

--- a/test/compatibility/common/compatibility_version.py
+++ b/test/compatibility/common/compatibility_version.py
@@ -31,6 +31,8 @@ from typing import Union
 
 # This is a version class aimed to provide a operatable version object
 # For compare, this > develop > mongodb-{major}:{minor}
+#    the branch of 'this' here means the code in current folder,
+#    and if 'this' is used, 'git checkout ...' will not be executed.
 # For invalid version string, this will return false by bool operator
 
 class WTVersion:

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -739,36 +739,24 @@ gittags['mongodb-4.2']="mongodb-4.2"
 #gittags['mongodb-5.0']="ce1d1e58ba35166710552e3aaa1c426ddba513fd"
 #gittags['mongodb-4.4']="ec742d6807b943cd6f2baf1a55853d296eb5b5c6"
 
-# This array is used to configure the release branches we'd like to use for testing the importing
-# of files created in previous versions of WiredTiger. Go all the way back to mongodb-4.2 since
-# that's the first release where we don't support live import.
-import_release_branches=(develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4 mongodb-4.2)
+# The version list is defined in the "meta/versions.sh" folder
+# The variable name is the uppercased variable name
 
-# Branches in below 2 arrays should be put in newer-to-older order.
-#
-# An overlap (last element of the 1st array & first element of the 2nd array)
-# is expected to avoid missing the edge testing coverage.
-#
-# The 2 arrays should be adjusted over time when newer branches are created,
-# or older branches are EOL.
-newer_release_branches=(develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4)
-older_release_branches=(mongodb-4.4 mongodb-4.2)
+# Use relative folder to locate the meta file
 
-# This array is used to generate compatible configuration files between releases, because
-# upgrade/downgrade test runs each build's format test program on the second build's
-# configuration file.
-compatible_upgrade_downgrade_release_branches=(mongodb-4.4 mongodb-4.2)
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+VERSIONS_FILE="$SCRIPT_DIR/meta/versions.sh"
+source "$VERSIONS_FILE"
 
-# This array is used to configure the release branches we'd like to run patch version
-# upgrade/downgrade test.
-patch_version_upgrade_downgrade_release_branches=(mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4)
+# The meaning of the names of each version list can be found in the version list file.
 
-# This array is used to configure the release branches we'd like to run test checkpoint
-# upgrade/downgrade test.
-test_checkpoint_release_branches=(develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4)
-
-# This array is used to configure the release branches we'd like to run upgrade to latest test.
-upgrade_to_latest_upgrade_downgrade_release_branches=(mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4)
+import_release_branches=($IMPORT_RELEASE_BRANCHES)
+newer_release_branches=($NEWER_RELEASE_BRANCHES)
+older_release_branches=($OLDER_RELEASE_BRANCHES)
+compatible_upgrade_downgrade_release_branches=($COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
+patch_version_upgrade_downgrade_release_branches=($PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
+test_checkpoint_release_branches=($TEST_CHECKPOINT_RELEASE_BRANCHES)
+upgrade_to_latest_upgrade_downgrade_release_branches=($UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
 
 declare -A scopes
 scopes[import]="import files from previous versions"

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -739,7 +739,7 @@ gittags['mongodb-4.2']="mongodb-4.2"
 #gittags['mongodb-5.0']="ce1d1e58ba35166710552e3aaa1c426ddba513fd"
 #gittags['mongodb-4.4']="ec742d6807b943cd6f2baf1a55853d296eb5b5c6"
 
-# The version list is defined in the "meta/versions.sh" folder
+# The version list is defined in the "meta/versions.sh" shell script
 # The variable name is the uppercased variable name
 
 # Use relative folder to locate the meta file

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+##############################################################################################
+# This is the version list extracted from compatibility_test_for_releases
+# The reason to extract this list out is to reuse it for python framework test
+##############################################################################################
+
+# Currently this is a temporary setup for python testsuite
+# This will be merged with the following variables in the future
+export PYTHON_RELEASE_BRANCHS="develop mongodb-7.1 mongodb-7.0 mongodb-6.3"
+
+# This array is used to configure the release branches we'd like to use for testing the importing
+# of files created in previous versions of WiredTiger. Go all the way back to mongodb-4.2 since
+# that's the first release where we don't support live import.
+export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4 mongodb-4.2"
+
+# Branches in below 2 arrays should be put in newer-to-older order.
+#
+# An overlap (last element of the 1st array & first element of the 2nd array)
+# is expected to avoid missing the edge testing coverage.
+#
+# The 2 arrays should be adjusted over time when newer branches are created,
+# or older branches are EOL.
+export NEWER_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export OLDER_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
+
+# This array is used to generate compatible configuration files between releases, because
+# upgrade/downgrade test runs each build's format test program on the second build's
+# configuration file.
+export COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
+
+# This array is used to configure the release branches we'd like to run patch version
+# upgrade/downgrade test.
+export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
+
+# This array is used to configure the release branches we'd like to run test checkpoint
+# upgrade/downgrade test.
+export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
+
+# This array is used to configure the release branches we'd like to run upgrade to latest test.
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -6,7 +6,7 @@
 
 # Currently this is a temporary setup for python testsuite
 # This will be merged with the following variables in the future
-export PYTHON_RELEASE_BRANCHS="develop mongodb-7.1 mongodb-7.0 mongodb-6.3"
+export SUITE_RELEASE_BRANCHES="develop mongodb-7.1 mongodb-7.0 mongodb-6.3"
 
 # This array is used to configure the release branches we'd like to use for testing the importing
 # of files created in previous versions of WiredTiger. Go all the way back to mongodb-4.2 since

--- a/test/compatibility/suite/compatibility_test.py
+++ b/test/compatibility/suite/compatibility_test.py
@@ -231,7 +231,7 @@ def add_branch_pair_scenarios(suite):
                 # need to build the version object from the string list
                 return [WTVersion(version) for version in versions]
             else:
-                return compatibility_common.BRANCHES['SUITE_RELEASE_BRANCHES']
+                return compatibility_common.BRANCHES.SUITE_RELEASE_BRANCHES
         older = extract_versions(test, 'older')
         newer = extract_versions(test, 'newer')
 
@@ -240,7 +240,7 @@ def add_branch_pair_scenarios(suite):
         unsupported_branches = list([
             branch
             for branch in set([*older, *newer])
-            if branch not in compatibility_common.BRANCHES['SUITE_RELEASE_BRANCHES']
+            if branch not in compatibility_common.BRANCHES.SUITE_RELEASE_BRANCHES
         ])
 
         if len(unsupported_branches) > 0:
@@ -290,7 +290,7 @@ def prepare_tests(suites):
                 all_build_configs.append(config)
 
     # Check out and build all relevant branches.
-    for branch in compatibility_common.BRANCHES['SUITE_RELEASE_BRANCHES']:
+    for branch in compatibility_common.BRANCHES.SUITE_RELEASE_BRANCHES:
         for config in all_build_configs:
             compatibility_common.prepare_branch(branch.name, config)
 

--- a/test/compatibility/suite/compatibility_test.py
+++ b/test/compatibility/suite/compatibility_test.py
@@ -31,6 +31,8 @@ import argparse, inspect, os, pickle, shutil, subprocess, sys, tempfile, unittes
 # Import the common compatibility test functionality
 sys.path.insert(1, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'common'))
 import compatibility_common
+from compatibility_version import WTVersion
+from typing import List
 
 # Now we can import our test/py_utility and third-party dependencies
 import abstract_test_case, testtools, test_result, test_util, wtscenario
@@ -54,12 +56,12 @@ class CompatibilityTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         build_config = self.build_config if hasattr(self, 'build_config') else None
         return compatibility_common.branch_build_path(branch, build_config)
 
-    def run_method_on_branch(self, branch, method):
+    def run_method_on_branch(self, branch:WTVersion, method):
         '''
         Run a method on a branch.
         '''
         cwd = os.getcwd()
-        branch_path = self.branch_build_path(branch)
+        branch_path = self.branch_build_path(branch.name)
         build_python_path = os.path.join(branch_path, 'lang', 'python')
         this_script_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -200,20 +202,19 @@ def run_tests(suites):
         print("[pid:{}]: ERROR: running test: {}".format(os.getpid(), e))
         raise e
 
-def make_branch_scenarios(older, newer):
+def make_branch_scenarios(older:List[WTVersion], newer:List[WTVersion]):
     '''
     Create scenarios with the specified older and newer branches.
     '''
     older_branches = []
     for branch in older:
-        older_branches.append(('older=%s' % branch, { 'older_branch': branch }))
+        older_branches.append(('older=%s' % branch.name, { 'older_branch': branch }))
     newer_branches = []
     for branch in newer:
-        newer_branches.append(('newer=%s' % branch, { 'newer_branch': branch }))
+        newer_branches.append(('newer=%s' % branch.name, { 'newer_branch': branch }))
 
     return list(filter(
-        lambda scenario: compatibility_common.is_branch_order_asc(scenario[1]['older_branch'],
-                                                                  scenario[1]['newer_branch']),
+        lambda scenario: scenario[1]['older_branch'] < scenario[1]['newer_branch'],
         wtscenario.make_scenarios(older_branches, newer_branches)))
 
 def add_branch_pair_scenarios(suite):
@@ -222,20 +223,30 @@ def add_branch_pair_scenarios(suite):
     '''
     for test in testtools.iterate_tests(suite):
         # Get the older and newer branches, allowing tests to specify their own.
-        older = getattr(test, 'older', compatibility_common.BRANCHES)
-        newer = getattr(test, 'newer', compatibility_common.BRANCHES)
-        if type(older) is not list:
-            older = [older]
-        if type(newer) is not list:
-            newer = [newer]
+        def extract_versions(t, key:str):
+            versions = getattr(t, key, None)
+            if versions:
+                if type(versions) is not list:
+                    versions = [versions]
+                # need to build the version object from the string list
+                return [WTVersion(version) for version in versions]
+            else:
+                return compatibility_common.BRANCHES['PYTHON_RELEASE_BRANCHS']
+        older = extract_versions(test, 'older')
+        newer = extract_versions(test, 'newer')
 
         # Validate that the test is using only supported branches. Otherwise they may not be ready.
-        unsupported_branches = list(filter(lambda b: b not in compatibility_common.BRANCHES,
-                                           older + list(set(newer) - set(older))))
+        # support means branch name appeared in the branch list
+        unsupported_branches = list([
+            branch
+            for branch in set([*older, *newer])
+            if branch not in compatibility_common.BRANCHES['PYTHON_RELEASE_BRANCHS']
+        ])
+
         if len(unsupported_branches) > 0:
             unsupported_branches.sort()
             raise Exception('Test \'%s\' specifies unsupported branches: %s'
-                            % (test, ', '.join(unsupported_branches)))
+                            % (test, ', '.join([branch.name for branch in unsupported_branches])))
 
         # Make the scenarios from the older and newer branches.
         branch_scenarios = make_branch_scenarios(older, newer)
@@ -279,9 +290,9 @@ def prepare_tests(suites):
                 all_build_configs.append(config)
 
     # Check out and build all relevant branches.
-    for branch in compatibility_common.BRANCHES:
+    for branch in compatibility_common.BRANCHES['PYTHON_RELEASE_BRANCHS']:
         for config in all_build_configs:
-            compatibility_common.prepare_branch(branch, config)
+            compatibility_common.prepare_branch(branch.name, config)
 
     # Add branch arguments to the tests' scenarios.
     add_branch_pair_scenarios(suites)

--- a/test/compatibility/suite/compatibility_test.py
+++ b/test/compatibility/suite/compatibility_test.py
@@ -231,7 +231,7 @@ def add_branch_pair_scenarios(suite):
                 # need to build the version object from the string list
                 return [WTVersion(version) for version in versions]
             else:
-                return compatibility_common.BRANCHES['PYTHON_RELEASE_BRANCHS']
+                return compatibility_common.BRANCHES['SUITE_RELEASE_BRANCHES']
         older = extract_versions(test, 'older')
         newer = extract_versions(test, 'newer')
 
@@ -240,7 +240,7 @@ def add_branch_pair_scenarios(suite):
         unsupported_branches = list([
             branch
             for branch in set([*older, *newer])
-            if branch not in compatibility_common.BRANCHES['PYTHON_RELEASE_BRANCHS']
+            if branch not in compatibility_common.BRANCHES['SUITE_RELEASE_BRANCHES']
         ])
 
         if len(unsupported_branches) > 0:
@@ -290,7 +290,7 @@ def prepare_tests(suites):
                 all_build_configs.append(config)
 
     # Check out and build all relevant branches.
-    for branch in compatibility_common.BRANCHES['PYTHON_RELEASE_BRANCHS']:
+    for branch in compatibility_common.BRANCHES['SUITE_RELEASE_BRANCHES']:
         for config in all_build_configs:
             compatibility_common.prepare_branch(branch.name, config)
 


### PR DESCRIPTION
Several major actions is introduced:
- Separate the version list into a standalone file, provided in meta folder, make it able to be reused by python compatibility test suite.
- Introduce a new class named `WTVersion` to handle the compare and validate operations for branch name.
- Modify the `compatibility_config.py` file to make it able to reference the version list appeared in the meta folder. 