### PR TITLE
WT-15085 Add compatibility error for live restore with disaggregated storage

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2769,6 +2769,10 @@ __conn_config_file_system(WT_SESSION_IMPL *session, const char *cfg[])
         if (F_ISSET(conn, WT_CONN_IN_MEMORY))
             WT_RET_MSG(
               session, EINVAL, "Live restore is not compatible with an in-memory connections");
+        WT_RET(__wt_config_gets(session, cfg, "disaggregated.page_log", &cval));
+        if (cval.len != 0)
+            WT_RET_MSG(
+              session, EINVAL, "Live restore is not compatible with disaggregated storage mode");
 #ifdef _MSC_VER
         /* FIXME-WT-14051 Add support for Windows */
         WT_RET_MSG(session, EINVAL, "Live restore is not supported on Windows");

--- a/test/suite/test_live_restore01.py
+++ b/test/suite/test_live_restore01.py
@@ -104,6 +104,8 @@ class test_live_restore01(backup_base):
         # Specify statistics are disabled.
         self.expect_failure("statistics=(none),live_restore=(enabled=true,path=SOURCE)", "/Statistics must be enabled when live restore is active./")
 
+        self.expect_failure("live_restore=(enabled=true,path=SOURCE),disaggregated=(page_log=palm)", "/Live restore is not compatible with disaggregated storage mode/")
+
         # Expect a failure if statistics are disabled via a reconfigure call.
         self.open_conn("DEST", config="live_restore=(enabled=true,path=SOURCE)")
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,


### PR DESCRIPTION
This adds two checks:
1. Return EINVAL if disaggregated storage and live restore are both configured in the configuration string.
2. Avoid dereferencing the file handle in `__meta_live_restore_to_meta` if the backing storage is remote.