### PR TITLE
WT-15167 Refactor to make __wt_page_block_meta a pointer on the page and introduce __wt_page_disagg_info

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -78,8 +78,7 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
 
     WT_CLEAR(get_args);
     get_args.lsn = lsn;
-    if (block_meta != NULL)
-        WT_CLEAR(*block_meta);
+    WT_ASSERT(session, block_meta != NULL);
 
     __wt_verbose(session, WT_VERB_READ,
       "page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64 ", base_lsn %" PRIu64 ", size %" PRIu32
@@ -184,7 +183,7 @@ reread:
                     goto corrupt;
                 }
 
-                if (result == last && block_meta != NULL) {
+                if (result == last) {
                     WT_ASSERT(session, get_args.lsn > 0);
                     WT_ASSERT(session,
                       (get_args.delta_count > 0) ==

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -202,7 +202,7 @@ reread:
                     block_meta->disagg_lsn = get_args.lsn;
                     block_meta->delta_count = get_args.delta_count == 0 ?
                       (uint8_t)(*results_count - 1) :
-                      (unit8_t)get_args.delta_count;
+                      (uint8_t)get_args.delta_count;
                     block_meta->checksum = checksum;
                     block_meta->encryption = get_args.encryption;
                     if (block_meta->delta_count > 0)

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -200,8 +200,9 @@ reread:
                     block_meta->backlink_lsn = get_args.backlink_lsn;
                     block_meta->base_lsn = get_args.base_lsn;
                     block_meta->disagg_lsn = get_args.lsn;
-                    block_meta->delta_count =
-                      get_args.delta_count == 0 ? *results_count - 1 : get_args.delta_count;
+                    block_meta->delta_count = get_args.delta_count == 0 ?
+                      (uint8_t)(*results_count - 1) :
+                      (unit8_t)get_args.delta_count;
                     block_meta->checksum = checksum;
                     block_meta->encryption = get_args.encryption;
                     if (block_meta->delta_count > 0)

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -150,9 +150,6 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
         break;
     }
 
-    if (page->disagg_info != NULL)
-        __wt_free(session, page->disagg_info);
-
     /* Discard any allocated disk image. */
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))
         __wt_overwrite_and_free_len(session, dsk, dsk->mem_size);

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -76,8 +76,8 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
      * issue a read for the page we're evicting. That means we're free to write the page even if
      * it's ahead of the materialization frontier.
      */
-    if (!(F_ISSET(session->dhandle, WT_DHANDLE_DEAD) || F_ISSET(S2C(session), WT_CONN_CLOSING)) &&
-      page->disagg_info != NULL)
+    if (page->disagg_info != NULL &&
+      !(F_ISSET(session->dhandle, WT_DHANDLE_DEAD) || F_ISSET(S2C(session), WT_CONN_CLOSING)))
         if (!__wt_page_materialization_check(session, page->disagg_info->old_rec_lsn_max))
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_ahead_of_last_materialized_lsn);
 

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -149,6 +149,9 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
         break;
     }
 
+    if (page->block_meta != NULL)
+        __wt_free(session, page->block_meta);
+
     /* Discard any allocated disk image. */
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))
         __wt_overwrite_and_free_len(session, dsk, dsk->mem_size);

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -76,8 +76,9 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
      * issue a read for the page we're evicting. That means we're free to write the page even if
      * it's ahead of the materialization frontier.
      */
-    if (!(F_ISSET(session->dhandle, WT_DHANDLE_DEAD) || F_ISSET(S2C(session), WT_CONN_CLOSING)))
-        if (!__wt_page_materialization_check(session, page->old_rec_lsn_max))
+    if (!(F_ISSET(session->dhandle, WT_DHANDLE_DEAD) || F_ISSET(S2C(session), WT_CONN_CLOSING)) &&
+      page->disagg_info != NULL)
+        if (!__wt_page_materialization_check(session, page->disagg_info->old_rec_lsn_max))
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_ahead_of_last_materialized_lsn);
 
     /*
@@ -149,8 +150,8 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
         break;
     }
 
-    if (page->block_meta != NULL)
-        __wt_free(session, page->block_meta);
+    if (page->disagg_info != NULL)
+        __wt_free(session, page->disagg_info);
 
     /* Discard any allocated disk image. */
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -774,8 +774,8 @@ __wti_btree_tree_open(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
     WT_ERR(__wti_page_inmem(session, NULL, dsk.data,
       WT_DATA_IN_ITEM(&dsk) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, &page, NULL));
     dsk.mem = NULL;
-    if (page->block_meta != NULL)
-        *page->block_meta = block_meta;
+    if (page->disagg_info != NULL)
+        page->disagg_info->block_meta = block_meta;
 
     /* Finish initializing the root, root reference links. */
     __wt_root_ref_init(session, &btree->root, page, btree->type != BTREE_ROW);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -774,7 +774,8 @@ __wti_btree_tree_open(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
     WT_ERR(__wti_page_inmem(session, NULL, dsk.data,
       WT_DATA_IN_ITEM(&dsk) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, &page, NULL));
     dsk.mem = NULL;
-    page->block_meta = block_meta;
+    if (page->block_meta != NULL)
+        *page->block_meta = block_meta;
 
     /* Finish initializing the root, root reference links. */
     __wt_root_ref_init(session, &btree->root, page, btree->type != BTREE_ROW);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -658,7 +658,7 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
         size += sizeof(WT_PAGE_DISAGG_INFO);
         WT_RET(__wt_calloc(session, 1, size, &page));
         page->disagg_info =
-          (WT_PAGE_DISAGG_INFO *)((void *)page + size - sizeof(WT_PAGE_DISAGG_INFO));
+          (WT_PAGE_DISAGG_INFO *)((uin8_t *)page + size - sizeof(WT_PAGE_DISAGG_INFO));
     } else
         WT_RET(__wt_calloc(session, 1, size, &page));
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -532,7 +532,8 @@ __wti_page_reconstruct_deltas(
                 /* The split code works with WT_MULTI structures, build one for the disk image. */
                 memset(&multi, 0, sizeof(multi));
                 multi.disk_image = mod->mod_disk_image;
-                multi.block_meta = *ref->page->block_meta;
+                WT_RET(__wt_calloc_one(session, &multi.block_meta));
+                *multi.block_meta = *ref->page->block_meta;
 
                 /*
                  * Store the disk image to a temporary pointer in case we fail to rewrite the page
@@ -541,6 +542,7 @@ __wti_page_reconstruct_deltas(
                 tmp = mod->mod_disk_image;
                 mod->mod_disk_image = NULL;
                 ret = __wt_split_rewrite(session, ref, &multi, false);
+                __wt_free(session, multi.block_meta);
                 if (ret != 0) {
                     mod->mod_disk_image = tmp;
                     WT_STAT_CONN_DSRC_INCR(session, cache_read_flatten_leaf_delta_fail);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -533,7 +533,7 @@ __wti_page_reconstruct_deltas(
                 memset(&multi, 0, sizeof(multi));
                 multi.disk_image = mod->mod_disk_image;
                 WT_RET(__wt_calloc_one(session, &multi.block_meta));
-                *multi.block_meta = *ref->page->block_meta;
+                *multi.block_meta = ref->page->disagg_info->block_meta;
 
                 /*
                  * Store the disk image to a temporary pointer in case we fail to rewrite the page
@@ -590,9 +590,6 @@ __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
     btree = S2BT(session);
 
     WT_CLEAR(*meta);
-    if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-        return;
-
     /*
      * Allocate an interim page ID. If the page is actually being loaded from disk, it's ok to waste
      * some IDs for now.
@@ -661,9 +658,9 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
     page->type = type;
     __wt_evict_page_init(page);
 
-    /* Allocate an empty block meta. */
+    /* Allocate the structure that holds the disaggregated information for the page. */
     if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
-        WT_ERR(__wt_calloc_one(session, &page->block_meta));
+        WT_ERR(__wt_calloc_one(session, &page->disagg_info));
         size += sizeof(WT_PAGE_BLOCK_META);
     }
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -661,7 +661,7 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
     /* Allocate the structure that holds the disaggregated information for the page. */
     if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
         WT_ERR(__wt_calloc_one(session, &page->disagg_info));
-        size += sizeof(WT_PAGE_BLOCK_META);
+        size += sizeof(WT_PAGE_DISAGG_INFO);
     }
 
     switch (type) {

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -655,20 +655,15 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
 
     /* Allocate the structure that holds the disaggregated information for the page. */
     if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
-        WT_RET(__wt_calloc(session, 1, sizeof(WT_PAGE) + sizeof(WT_PAGE_DISAGG_INFO), &page));
-        page->disagg_info = (WT_PAGE_DISAGG_INFO *)(page + 1);
         size += sizeof(WT_PAGE_DISAGG_INFO);
+        WT_RET(__wt_calloc(session, 1, size, &page));
+        page->disagg_info =
+          (WT_PAGE_DISAGG_INFO *)((void *)page + size - sizeof(WT_PAGE_DISAGG_INFO));
     } else
-        WT_RET(__wt_calloc(session, 1, sizeof(WT_PAGE), &page));
+        WT_RET(__wt_calloc(session, 1, size, &page));
 
     page->type = type;
     __wt_evict_page_init(page);
-
-    /* Allocate the structure that holds the disaggregated information for the page. */
-    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
-        WT_ERR(__wt_calloc_one(session, &page->disagg_info));
-        size += sizeof(WT_PAGE_DISAGG_INFO);
-    }
 
     switch (type) {
     case WT_PAGE_COL_FIX:

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -653,7 +653,13 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
         return (__wt_illegal_value(session, type));
     }
 
-    WT_RET(__wt_calloc(session, 1, size, &page));
+    /* Allocate the structure that holds the disaggregated information for the page. */
+    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
+        WT_RET(__wt_calloc(session, 1, sizeof(WT_PAGE) + sizeof(WT_PAGE_DISAGG_INFO), &page));
+        page->disagg_info = (WT_PAGE_DISAGG_INFO *)(page + 1);
+        size += sizeof(WT_PAGE_DISAGG_INFO);
+    } else
+        WT_RET(__wt_calloc(session, 1, sizeof(WT_PAGE), &page));
 
     page->type = type;
     __wt_evict_page_init(page);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -660,7 +660,7 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
     __wt_evict_page_init(page);
 
     /* Allocate an empty block meta. */
-    if (F_ISSET(S2C(session), WT_BTREE_DISAGGREGATED)) {
+    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
         WT_ERR(__wt_calloc_one(session, &page->block_meta));
         size += sizeof(WT_PAGE_BLOCK_META);
     }

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -658,7 +658,7 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
         size += sizeof(WT_PAGE_DISAGG_INFO);
         WT_RET(__wt_calloc(session, 1, size, &page));
         page->disagg_info =
-          (WT_PAGE_DISAGG_INFO *)((uin8_t *)page + size - sizeof(WT_PAGE_DISAGG_INFO));
+          (WT_PAGE_DISAGG_INFO *)((uint8_t *)page + size - sizeof(WT_PAGE_DISAGG_INFO));
     } else
         WT_RET(__wt_calloc(session, 1, size, &page));
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -532,7 +532,7 @@ __wti_page_reconstruct_deltas(
                 /* The split code works with WT_MULTI structures, build one for the disk image. */
                 memset(&multi, 0, sizeof(multi));
                 multi.disk_image = mod->mod_disk_image;
-                multi.block_meta = ref->page->block_meta;
+                multi.block_meta = *ref->page->block_meta;
 
                 /*
                  * Store the disk image to a temporary pointer in case we fail to rewrite the page
@@ -659,6 +659,12 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
     page->type = type;
     __wt_evict_page_init(page);
 
+    /* Allocate an empty block meta. */
+    if (F_ISSET(S2C(session), WT_BTREE_DISAGGREGATED)) {
+        WT_ERR(__wt_calloc_one(session, &page->block_meta));
+        size += sizeof(WT_PAGE_BLOCK_META);
+    }
+
     switch (type) {
     case WT_PAGE_COL_FIX:
         page->entries = alloc_entries;
@@ -685,12 +691,7 @@ __wt_page_alloc(WT_SESSION_IMPL *session, uint8_t type, uint32_t alloc_entries, 
                 }
             if (0) {
 err:
-                WT_INTL_INDEX_GET_SAFE(page, pindex);
-                if (pindex != NULL) {
-                    for (i = 0; i < pindex->entries; ++i)
-                        __wt_free(session, pindex->index[i]);
-                    __wt_free(session, pindex);
-                }
+                __wt_page_out(session, &page);
                 return (ret);
             }
         }
@@ -706,9 +707,6 @@ err:
     default:
         return (__wt_illegal_value(session, type));
     }
-
-    /* A new page doesn't have a page id. */
-    page->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
     /* Increment the cache statistics. */
     __wt_cache_page_inmem_incr(session, page, size, false);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -598,9 +598,9 @@ __wt_page_block_meta_assign(WT_SESSION_IMPL *session, WT_PAGE_BLOCK_META *meta)
     WT_ASSERT(session, page_id >= WT_BLOCK_MIN_PAGE_ID);
 
     meta->page_id = page_id;
-    meta->disagg_lsn = 0;
-    meta->backlink_lsn = 0;
-    meta->base_lsn = 0;
+    meta->disagg_lsn = WT_DISAGG_LSN_NONE;
+    meta->backlink_lsn = WT_DISAGG_LSN_NONE;
+    meta->base_lsn = WT_DISAGG_LSN_NONE;
 
     /*
      * 0 means there is no delta written for this page yet. We always write a full page for a new

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -258,10 +258,10 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         FLD_SET(page_flags, WT_PAGE_WITH_DELTAS);
     WT_ERR(__wti_page_inmem(session, ref, tmp[0].data, page_flags, &notused, &instantiate_upd));
     tmp[0].mem = NULL;
-    if (ref->page->block_meta != NULL) {
-        *ref->page->block_meta = block_meta;
-        ref->page->old_rec_lsn_max = block_meta.disagg_lsn;
-        ref->page->rec_lsn_max = block_meta.disagg_lsn;
+    if (ref->page->disagg_info != NULL) {
+        ref->page->disagg_info->block_meta = block_meta;
+        ref->page->disagg_info->old_rec_lsn_max = block_meta.disagg_lsn;
+        ref->page->disagg_info->rec_lsn_max = block_meta.disagg_lsn;
     }
 
     /* Reconstruct deltas*/

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -258,9 +258,11 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         FLD_SET(page_flags, WT_PAGE_WITH_DELTAS);
     WT_ERR(__wti_page_inmem(session, ref, tmp[0].data, page_flags, &notused, &instantiate_upd));
     tmp[0].mem = NULL;
-    ref->page->block_meta = block_meta;
-    ref->page->old_rec_lsn_max = block_meta.disagg_lsn;
-    ref->page->rec_lsn_max = block_meta.disagg_lsn;
+    if (ref->page->block_meta != NULL) {
+        *ref->page->block_meta = block_meta;
+        ref->page->old_rec_lsn_max = block_meta.disagg_lsn;
+        ref->page->rec_lsn_max = block_meta.disagg_lsn;
+    }
 
     /* Reconstruct deltas*/
     if (count > 1) {

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1453,9 +1453,9 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
 
     /* Preserve the relevant metadata. */
     if (page->block_meta != NULL) {
-        *page->block_meta = multi->block_meta;
-        ref->page->old_rec_lsn_max = multi->block_meta.disagg_lsn;
-        page->rec_lsn_max = multi->block_meta.disagg_lsn;
+        *page->block_meta = *multi->block_meta;
+        ref->page->old_rec_lsn_max = multi->block_meta->disagg_lsn;
+        page->rec_lsn_max = multi->block_meta->disagg_lsn;
     }
     WT_STAT_CONN_DSRC_INCR(session, cache_scrub_restore);
 

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1452,9 +1452,11 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
     multi->disk_image = NULL;
 
     /* Preserve the relevant metadata. */
-    page->block_meta = multi->block_meta;
-    ref->page->old_rec_lsn_max = multi->block_meta.disagg_lsn;
-    page->rec_lsn_max = multi->block_meta.disagg_lsn;
+    if (page->block_meta != NULL) {
+        *page->block_meta = multi->block_meta;
+        ref->page->old_rec_lsn_max = multi->block_meta.disagg_lsn;
+        page->rec_lsn_max = multi->block_meta.disagg_lsn;
+    }
     WT_STAT_CONN_DSRC_INCR(session, cache_scrub_restore);
 
     /*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1452,10 +1452,10 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
     multi->disk_image = NULL;
 
     /* Preserve the relevant metadata. */
-    if (page->block_meta != NULL) {
-        *page->block_meta = *multi->block_meta;
-        ref->page->old_rec_lsn_max = multi->block_meta->disagg_lsn;
-        page->rec_lsn_max = multi->block_meta->disagg_lsn;
+    if (page->disagg_info != NULL) {
+        page->disagg_info->block_meta = *multi->block_meta;
+        ref->page->disagg_info->old_rec_lsn_max = multi->block_meta->disagg_lsn;
+        page->disagg_info->rec_lsn_max = multi->block_meta->disagg_lsn;
     }
     WT_STAT_CONN_DSRC_INCR(session, cache_scrub_restore);
 

--- a/src/conn/conn_page_history.c
+++ b/src/conn/conn_page_history.c
@@ -341,12 +341,12 @@ __wt_conn_page_history_track_evict(WT_SESSION_IMPL *session, WT_PAGE *page)
     (void)__wt_atomic_add64(&page_history->global_evict_count, 1);
 
     /* So far this works only for disaggregated storage, as we don't have page IDs without it. */
-    if (!F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
+    if (page->disagg_info == NULL) {
         (void)__wt_atomic_add64(&page_history->global_evict_count_local, 1);
         return (0);
     }
 
-    page_id = page->block_meta->page_id;
+    page_id = page->disagg_info->block_meta.page_id;
     if (page_id == WT_BLOCK_INVALID_PAGE_ID) {
         (void)__wt_atomic_add64(&page_history->global_evict_count_no_page_id, 1);
         return (0);
@@ -393,12 +393,12 @@ __wt_conn_page_history_track_read(WT_SESSION_IMPL *session, WT_PAGE *page)
     current_global_read_count = __wt_atomic_add64(&page_history->global_read_count, 1);
 
     /* So far this works only for disaggregated storage, as we don't have page IDs without it. */
-    if (!F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
+    if (page->disagg_info == NULL) {
         (void)__wt_atomic_add64(&page_history->global_read_count_local, 1);
         return (0);
     }
 
-    page_id = page->block_meta->page_id;
+    page_id = page->disagg_info->block_meta.page_id;
     if (page_id == WT_BLOCK_INVALID_PAGE_ID) /* This should not happen. */
         return (0);
 

--- a/src/conn/conn_page_history.c
+++ b/src/conn/conn_page_history.c
@@ -346,8 +346,8 @@ __wt_conn_page_history_track_evict(WT_SESSION_IMPL *session, WT_PAGE *page)
         return (0);
     }
 
-    page_id = page->block_meta.page_id;
-    if (page_id == 0) {
+    page_id = page->block_meta->page_id;
+    if (page_id == WT_BLOCK_INVALID_PAGE_ID) {
         (void)__wt_atomic_add64(&page_history->global_evict_count_no_page_id, 1);
         return (0);
     }
@@ -398,8 +398,8 @@ __wt_conn_page_history_track_read(WT_SESSION_IMPL *session, WT_PAGE *page)
         return (0);
     }
 
-    page_id = page->block_meta.page_id;
-    if (page_id == 0) /* This should not happen. */
+    page_id = page->block_meta->page_id;
+    if (page_id == WT_BLOCK_INVALID_PAGE_ID) /* This should not happen. */
         return (0);
 
     item = NULL;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -491,8 +491,10 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
             /* The split code works with WT_MULTI structures, build one for the disk image. */
             memset(&multi, 0, sizeof(multi));
             multi.disk_image = mod->mod_disk_image;
-            if (ref->page->block_meta != NULL)
-                multi.block_meta = *ref->page->block_meta;
+            if (ref->page->block_meta != NULL) {
+                WT_RET(__wt_calloc_one(session, &multi.block_meta));
+                *multi.block_meta = *ref->page->block_meta;
+            }
             WT_ASSERT(session, mod->mod_replace.block_cookie == NULL);
             /*
              * Store the disk image to a temporary pointer in case we fail to rewrite the page and
@@ -501,6 +503,7 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
             tmp = mod->mod_disk_image;
             mod->mod_disk_image = NULL;
             ret = __wt_split_rewrite(session, ref, &multi, true);
+            __wt_free(session, multi.block_meta);
             if (ret != 0) {
                 mod->mod_disk_image = tmp;
                 return (ret);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -491,7 +491,8 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
             /* The split code works with WT_MULTI structures, build one for the disk image. */
             memset(&multi, 0, sizeof(multi));
             multi.disk_image = mod->mod_disk_image;
-            multi.block_meta = ref->page->block_meta;
+            if (ref->page->block_meta != NULL)
+                multi.block_meta = *ref->page->block_meta;
             WT_ASSERT(session, mod->mod_replace.block_cookie == NULL);
             /*
              * Store the disk image to a temporary pointer in case we fail to rewrite the page and

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -491,9 +491,9 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
             /* The split code works with WT_MULTI structures, build one for the disk image. */
             memset(&multi, 0, sizeof(multi));
             multi.disk_image = mod->mod_disk_image;
-            if (ref->page->block_meta != NULL) {
+            if (ref->page->disagg_info != NULL) {
                 WT_RET(__wt_calloc_one(session, &multi.block_meta));
-                *multi.block_meta = *ref->page->block_meta;
+                *multi.block_meta = ref->page->disagg_info->block_meta;
             }
             WT_ASSERT(session, mod->mod_replace.block_cookie == NULL);
             /*
@@ -967,7 +967,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
      * We must do scrub dirty eviction for disaggregated storage btrees as we cannot read back the
      * evicted page until they are materialized.
      */
-    if (!closing && F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
+    if (!closing && ref->page->disagg_info != NULL) {
         /*
          * We should not evict dirty internal pages for disaggregated storage as they cannot be
          * recreated in-memory and it doesn't effectively reduce cache usage.

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -805,6 +805,8 @@ struct __wt_page {
 
     /* 1 byte hole expected. */
 
+    wt_shared size_t memory_footprint; /* Memory attached to the page */
+
     /* Page's on-disk representation: NULL for pages created in memory. */
     const WT_PAGE_HEADER *dsk;
 
@@ -815,8 +817,6 @@ struct __wt_page {
      * !!!
      * This is the 64 byte boundary, try to keep hot fields above here.
      */
-    
-    wt_shared size_t memory_footprint; /* Memory attached to the page */
 
 /*
  * The page's read generation acts as an LRU value for each page in the

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -271,6 +271,18 @@ struct __wt_page_block_meta {
 };
 
 /*
+ * WT_PAGE_DISAGG_INFO --
+ *  Page information associated with disaggregated storage.
+ */
+struct __wt_page_disagg_info {
+    WT_PAGE_BLOCK_META block_meta;
+
+    uint64_t old_rec_lsn_max; /* The LSN associated with the page's before the most recent
+                                 reconciliation */
+    uint64_t rec_lsn_max;     /* The LSN associated with the page's most recent reconciliation */
+};
+
+/*
  * WT_MULTI --
  *	Replacement block information used during reconciliation.
  */
@@ -836,10 +848,7 @@ struct __wt_page {
     uint64_t cache_create_gen; /* Page create timestamp */
     uint64_t evict_pass_gen;   /* Eviction pass generation */
 
-    uint64_t old_rec_lsn_max; /* The LSN associated with the page's before the most recent
-                                 reconciliation */
-    uint64_t rec_lsn_max;     /* The LSN associated with the page's most recent reconciliation */
-    WT_PAGE_BLOCK_META *block_meta;
+    WT_PAGE_DISAGG_INFO *disagg_info;
 
 #ifdef HAVE_DIAGNOSTIC
 #define WT_SPLIT_SAVE_STATE_MAX 3

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -275,11 +275,11 @@ struct __wt_page_block_meta {
  *  Page information associated with disaggregated storage.
  */
 struct __wt_page_disagg_info {
-    WT_PAGE_BLOCK_META block_meta;
-
     uint64_t old_rec_lsn_max; /* The LSN associated with the page's before the most recent
                                  reconciliation */
     uint64_t rec_lsn_max;     /* The LSN associated with the page's most recent reconciliation */
+
+    WT_PAGE_BLOCK_META block_meta;
 };
 
 /*
@@ -805,8 +805,6 @@ struct __wt_page {
 
     /* 1 byte hole expected. */
 
-    wt_shared size_t memory_footprint; /* Memory attached to the page */
-
     /* Page's on-disk representation: NULL for pages created in memory. */
     const WT_PAGE_HEADER *dsk;
 
@@ -817,6 +815,8 @@ struct __wt_page {
      * !!!
      * This is the 64 byte boundary, try to keep hot fields above here.
      */
+    
+    wt_shared size_t memory_footprint; /* Memory attached to the page */
 
 /*
  * The page's read generation acts as an LRU value for each page in the

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -262,11 +262,12 @@ struct __wt_page_block_meta {
 
     uint64_t backlink_lsn;
     uint64_t base_lsn;
-    uint32_t delta_count;
 
     uint32_t checksum;
 
     WT_PAGE_LOG_ENCRYPTION encryption;
+
+    uint8_t delta_count;
 };
 
 /*
@@ -838,7 +839,7 @@ struct __wt_page {
     uint64_t old_rec_lsn_max; /* The LSN associated with the page's before the most recent
                                  reconciliation */
     uint64_t rec_lsn_max;     /* The LSN associated with the page's most recent reconciliation */
-    WT_PAGE_BLOCK_META block_meta;
+    WT_PAGE_BLOCK_META *block_meta;
 
 #ifdef HAVE_DIAGNOSTIC
 #define WT_SPLIT_SAVE_STATE_MAX 3

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -288,7 +288,7 @@ struct __wt_multi {
      * memory.
      */
     void *disk_image;
-    WT_PAGE_BLOCK_META block_meta; /* the metadata for the disk image */
+    WT_PAGE_BLOCK_META *block_meta; /* the metadata for the disk image */
 
     /*
      * List of unresolved updates. Updates are either a row-store insert or update list, or

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1645,8 +1645,8 @@ __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref, bool page_replacement
 
     WT_ERR(__wt_btree_block_free(session, addr.addr, addr.size, page_replacement));
 
-    if (!page_replacement && ref->page != NULL && ref->page->block_meta != NULL)
-        ref->page->block_meta->page_id = WT_BLOCK_INVALID_PAGE_ID;
+    if (!page_replacement && ref->page != NULL && ref->page->disagg_info != NULL)
+        ref->page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
     /* Clear the address (so we don't free it twice). */
     __wt_ref_addr_free(session, ref);
@@ -1924,9 +1924,6 @@ __wt_page_materialization_check(WT_SESSION_IMPL *session, uint64_t rec_lsn_max)
     WT_DISAGGREGATED_STORAGE *disagg;
     uint64_t last_materialized_lsn;
 
-    if (!F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED))
-        return (true);
-
     /*
      * Pages that haven't been written back can be evicted. This will lead to them being reconciled
      * and retained, not actually evicted.
@@ -1978,8 +1975,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * to happen, as long as their equivalent content remains in cache until the materialization
      * frontier is satisfied.
      */
-    if (mod == NULL) {
-        if (__wt_page_materialization_check(session, page->rec_lsn_max))
+    if (mod == NULL && page->disagg_info != NULL) {
+        if (__wt_page_materialization_check(session, page->disagg_info->rec_lsn_max))
             return (true);
         else {
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_materialization);
@@ -2036,7 +2033,8 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * Clean pages that are in front of the materialization check should not proceed to eviction.
      * They would not go through reconciliation, but just be discarded which isn't OK.
      */
-    if (!modified && !__wt_page_materialization_check(session, page->rec_lsn_max)) {
+    if (!modified && page->disagg_info != NULL &&
+      !__wt_page_materialization_check(session, page->disagg_info->rec_lsn_max)) {
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_materialization);
         return (false);
     }
@@ -2055,7 +2053,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * Don't evict dirty internal pages for disaggregated storage. They cannot be recreated
      * in-memory and it will not reduce cache usage.
      */
-    if (modified && F_ISSET(btree, WT_BTREE_DISAGGREGATED) && F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
+    if (modified && btree->disagg_info != NULL && F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_disagg_dirty_internal_page);
         return (false);
     }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1975,8 +1975,9 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * to happen, as long as their equivalent content remains in cache until the materialization
      * frontier is satisfied.
      */
-    if (mod == NULL && page->disagg_info != NULL) {
-        if (__wt_page_materialization_check(session, page->disagg_info->rec_lsn_max))
+    if (mod == NULL) {
+        if (page->disagg_info != NULL &&
+          __wt_page_materialization_check(session, page->disagg_info->rec_lsn_max))
             return (true);
         else {
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_materialization);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2053,7 +2053,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * Don't evict dirty internal pages for disaggregated storage. They cannot be recreated
      * in-memory and it will not reduce cache usage.
      */
-    if (modified && btree->disagg_info != NULL && F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
+    if (modified && page->disagg_info != NULL && F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_disagg_dirty_internal_page);
         return (false);
     }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1976,8 +1976,9 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
      * frontier is satisfied.
      */
     if (mod == NULL) {
-        if (page->disagg_info != NULL &&
-          __wt_page_materialization_check(session, page->disagg_info->rec_lsn_max))
+        if (page->disagg_info == NULL)
+            return (true);
+        else if (__wt_page_materialization_check(session, page->disagg_info->rec_lsn_max))
             return (true);
         else {
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_materialization);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1645,8 +1645,8 @@ __wt_ref_block_free(WT_SESSION_IMPL *session, WT_REF *ref, bool page_replacement
 
     WT_ERR(__wt_btree_block_free(session, addr.addr, addr.size, page_replacement));
 
-    if (!page_replacement && ref->page != NULL)
-        ref->page->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
+    if (!page_replacement && ref->page != NULL && ref->page->block_meta != NULL)
+        ref->page->block_meta->page_id = WT_BLOCK_INVALID_PAGE_ID;
 
     /* Clear the address (so we don't free it twice). */
     __wt_ref_addr_free(session, ref);

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -337,6 +337,8 @@ struct __wt_page_deleted;
 typedef struct __wt_page_deleted WT_PAGE_DELETED;
 struct __wt_page_delta_config;
 typedef struct __wt_page_delta_config WT_PAGE_DELTA_CONFIG;
+struct __wt_page_disagg_info;
+typedef struct __wt_page_disagg_info WT_PAGE_DISAGG_INFO;
 struct __wt_page_header;
 typedef struct __wt_page_header WT_PAGE_HEADER;
 struct __wt_page_history;

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -602,9 +602,12 @@ __rec_hs_pack_key(WT_SESSION_IMPL *session, WT_BTREE *btree, WTI_RECONCILE *r, W
   WT_ROW *rip, WT_ITEM *key)
 {
     WT_DECL_RET;
+    WT_PAGE *page;
     uint8_t *p;
 
-    switch (r->page->type) {
+    page = r->page;
+
+    switch (page->type) {
     case WT_PAGE_COL_FIX:
     case WT_PAGE_COL_VAR:
         p = key->mem;
@@ -613,8 +616,7 @@ __rec_hs_pack_key(WT_SESSION_IMPL *session, WT_BTREE *btree, WTI_RECONCILE *r, W
         break;
     case WT_PAGE_ROW_LEAF:
         if (ins == NULL) {
-            WT_WITH_BTREE(
-              session, btree, ret = __wt_row_leaf_key(session, r->page, rip, key, false));
+            WT_WITH_BTREE(session, btree, ret = __wt_row_leaf_key(session, page, rip, key, false));
             WT_RET(ret);
         } else {
             key->data = WT_INSERT_KEY(ins);
@@ -622,7 +624,7 @@ __rec_hs_pack_key(WT_SESSION_IMPL *session, WT_BTREE *btree, WTI_RECONCILE *r, W
         }
         break;
     default:
-        WT_RET(__wt_illegal_value(session, r->page->type));
+        WT_RET(__wt_illegal_value(session, page->type));
     }
 
     return (ret);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3172,9 +3172,9 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
 
     btree = S2BT(session);
     bm = btree->bm;
-    mod = page->modify;
     ref = r->ref;
     page = r->page;
+    mod = page->modify;
     WT_TIME_AGGREGATE_INIT(&ta);
     previous_ref_state = 0;
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -444,13 +444,14 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
     mod->rec_max_timestamp = r->max_ts;
     mod->rec_pinned_stable_timestamp = r->rec_start_pinned_stable_ts;
 
-    page->old_rec_lsn_max = page->rec_lsn_max;
     /* Track the page's most recent LSN. */
-    if (page->block_meta != NULL) {
+    if (page->disagg_info != NULL) {
+        page->disagg_info->old_rec_lsn_max = page->disagg_info->rec_lsn_max;
         if (mod->rec_result == WT_PM_REC_MULTIBLOCK)
-            page->rec_lsn_max = mod->mod_multi[mod->mod_multi_entries - 1].block_meta->disagg_lsn;
+            page->disagg_info->rec_lsn_max =
+              mod->mod_multi[mod->mod_multi_entries - 1].block_meta->disagg_lsn;
         else
-            page->rec_lsn_max = page->block_meta->disagg_lsn;
+            page->disagg_info->rec_lsn_max = page->disagg_info->block_meta.disagg_lsn;
     }
 
     /*
@@ -2527,7 +2528,7 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
 
     conn = S2C(session);
     multi = &r->multi[r->multi_next - 1];
-    block_meta = r->ref->page->block_meta;
+    block_meta = &r->ref->page->disagg_info->block_meta;
 
     WT_ASSERT(session, block_meta != NULL);
 
@@ -2625,7 +2626,7 @@ __rec_write_image(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
 
     page = r->page;
     multi = &r->multi[r->multi_next - 1];
-    block_meta = page->block_meta;
+    block_meta = &page->disagg_info->block_meta;
 
     /* If we split the page, create a new page id. Otherwise, reuse the existing page id. */
     if (block_meta != NULL) {
@@ -2680,8 +2681,8 @@ __rec_copy_prev_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         WT_ASSERT_ALWAYS(session, false, "write delta for a new page.");
         break;
     case WT_PM_REC_REPLACE: /* 1-for-1 page swap */
-        if (page->block_meta != NULL)
-            *multi->block_meta = *page->block_meta;
+        if (page->disagg_info != NULL)
+            *multi->block_meta = page->disagg_info->block_meta;
         if (mod->mod_replace.block_cookie != NULL) {
             WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_replace.ta);
             WT_RET(__wt_memdup(session, mod->mod_replace.block_cookie,
@@ -2739,7 +2740,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     btree = S2BT(session);
     page = r->page;
     build_delta = false;
-    block_meta = page->block_meta;
+    block_meta = &page->disagg_info->block_meta;
 #ifdef HAVE_DIAGNOSTIC
     verify_image = true;
 #endif
@@ -2777,7 +2778,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
         return (__wt_illegal_value(session, page->type));
     }
     multi->supd_restore = false;
-    if (page->block_meta != NULL)
+    if (page->disagg_info != NULL)
         WT_RET(__wt_calloc_one(session, &multi->block_meta));
 
     /* Set the key. */
@@ -3071,7 +3072,8 @@ __rec_split_discard(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     /* Also reset the page's latest LSN, so that it can be safely discarded. */
     /* FIXME-WT-14882: this is unnecessary, we overwrite it later. */
-    page->rec_lsn_max = WT_DISAGG_LSN_NONE;
+    if (page->disagg_info != NULL)
+        page->disagg_info->rec_lsn_max = WT_DISAGG_LSN_NONE;
 
     /*
      * This routine would be trivial, and only walk a single page freeing any blocks written to
@@ -3300,8 +3302,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 __wt_page_block_meta_assign(session, &r->wrapup_checkpoint_block_meta);
             WT_RET(bm->checkpoint(
               bm, session, NULL, &r->wrapup_checkpoint_block_meta, btree->ckpt, false));
-            if (r->ref->page->block_meta != NULL)
-                *r->ref->page->block_meta = r->wrapup_checkpoint_block_meta;
+            if (r->ref->page->disagg_info != NULL)
+                r->ref->page->disagg_info->block_meta = r->wrapup_checkpoint_block_meta;
         }
 
         /*
@@ -3325,8 +3327,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          */
         if (F_ISSET(r, WT_REC_IN_MEMORY) || r->multi->supd_restore) {
             WT_ASSERT(session, !F_ISSET(r, WT_REC_REWRITE_DELTA));
-            if (r->ref->page->block_meta != NULL)
-                *r->ref->page->block_meta = *r->multi->block_meta;
+            if (r->ref->page->disagg_info != NULL)
+                r->ref->page->disagg_info->block_meta = *r->multi->block_meta;
             WT_ASSERT_ALWAYS(session,
               F_ISSET(r, WT_REC_IN_MEMORY) ||
                 (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && r->multi->supd_entries != 0),
@@ -3345,8 +3347,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 r->multi->addr.block_cookie = NULL;
                 mod->mod_disk_image = r->multi->disk_image;
                 r->multi->disk_image = NULL;
-                if (r->ref->page->block_meta != NULL)
-                    *r->ref->page->block_meta = *r->multi->block_meta;
+                if (r->ref->page->disagg_info != NULL)
+                    r->ref->page->disagg_info->block_meta = *r->multi->block_meta;
                 WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
             } else
                 WT_ASSERT(
@@ -3356,8 +3358,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             WT_RET(
               __rec_write(session, r->wrapup_checkpoint, &r->wrapup_checkpoint_block_meta, NULL,
                 NULL, NULL, true, F_ISSET(r, WT_REC_CHECKPOINT), r->wrapup_checkpoint_compressed));
-            if (r->ref->page->block_meta != NULL)
-                *r->ref->page->block_meta = r->wrapup_checkpoint_block_meta;
+            if (r->ref->page->disagg_info != NULL)
+                r->ref->page->disagg_info->block_meta = r->wrapup_checkpoint_block_meta;
             WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &r->multi->addr.ta);
         }
 
@@ -3378,8 +3380,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * instead of reusing the existing page id. Building deltas on the split page is a future
          * thing.
          */
-        if (r->ref->page->block_meta != NULL)
-            r->ref->page->block_meta->page_id = WT_BLOCK_INVALID_PAGE_ID;
+        if (r->ref->page->disagg_info != NULL)
+            r->ref->page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
 split:
         mod->mod_multi = r->multi;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -446,10 +446,12 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
 
     page->old_rec_lsn_max = page->rec_lsn_max;
     /* Track the page's most recent LSN. */
-    if (mod->rec_result == WT_PM_REC_MULTIBLOCK)
-        page->rec_lsn_max = mod->mod_multi[mod->mod_multi_entries - 1].block_meta.disagg_lsn;
-    else
-        page->rec_lsn_max = r->page->block_meta->disagg_lsn;
+    if (page->block_meta != NULL) {
+        if (mod->rec_result == WT_PM_REC_MULTIBLOCK)
+            page->rec_lsn_max = mod->mod_multi[mod->mod_multi_entries - 1].block_meta.disagg_lsn;
+        else
+            page->rec_lsn_max = page->block_meta->disagg_lsn;
+    }
 
     /*
      * Track the tree's maximum transaction ID (used to decide if it's safe to discard the tree) and

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -448,7 +448,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
     /* Track the page's most recent LSN. */
     if (page->block_meta != NULL) {
         if (mod->rec_result == WT_PM_REC_MULTIBLOCK)
-            page->rec_lsn_max = mod->mod_multi[mod->mod_multi_entries - 1].block_meta.disagg_lsn;
+            page->rec_lsn_max = mod->mod_multi[mod->mod_multi_entries - 1].block_meta->disagg_lsn;
         else
             page->rec_lsn_max = page->block_meta->disagg_lsn;
     }
@@ -865,6 +865,7 @@ __rec_cleanup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         __wt_free(session, multi->disk_image);
         __wt_free(session, multi->supd);
         __wt_free(session, multi->addr.block_cookie);
+        __wt_free(session, multi->block_meta);
     }
     __wt_free(session, r->multi);
 
@@ -2530,17 +2531,17 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
 
     WT_ASSERT(session, block_meta != NULL);
 
-    multi->block_meta = *block_meta;
+    *multi->block_meta = *block_meta;
 
     /* The first delta needs to explicitly initialize the base LSN. */
-    if (multi->block_meta.delta_count == 0)
-        multi->block_meta.base_lsn = multi->block_meta.disagg_lsn;
-    WT_ASSERT(session, multi->block_meta.base_lsn > 0);
-    multi->block_meta.backlink_lsn = block_meta->disagg_lsn;
-    ++multi->block_meta.delta_count;
+    if (multi->block_meta->delta_count == 0)
+        multi->block_meta->base_lsn = multi->block_meta->disagg_lsn;
+    WT_ASSERT(session, multi->block_meta->base_lsn > 0);
+    multi->block_meta->backlink_lsn = block_meta->disagg_lsn;
+    ++multi->block_meta->delta_count;
 
     /* Get the checkpoint ID. */
-    WT_RET(__wt_blkcache_write(session, &r->delta, &multi->block_meta, addr, addr_sizep,
+    WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, addr, addr_sizep,
       compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
     /* Turn off compression adjustment for delta. */
     *compressed_sizep = 0;
@@ -2572,13 +2573,13 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
             WT_STAT_CONN_INCR(session, block_byte_write_intl_delta_gt100);
 
         /* Increase this count only when we write the first delta. */
-        if (multi->block_meta.delta_count == 1)
+        if (multi->block_meta->delta_count == 1)
             WT_STAT_CONN_DSRC_INCR(session, rec_pages_with_internal_deltas);
 
-        if (multi->block_meta.delta_count >
+        if (multi->block_meta->delta_count >
           __wt_atomic_load64(&conn->page_delta.max_internal_delta_count))
             __wt_atomic_store64(
-              &conn->page_delta.max_internal_delta_count, multi->block_meta.delta_count);
+              &conn->page_delta.max_internal_delta_count, multi->block_meta->delta_count);
     } else if (F_ISSET(r->ref, WT_REF_FLAG_LEAF)) {
         WT_STAT_CONN_DSRC_INCR(session, rec_page_delta_leaf);
         WT_STAT_CONN_INCRV(
@@ -2598,13 +2599,13 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
             WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_gt100);
 
         /* Increase this count only when we write the first delta. */
-        if (multi->block_meta.delta_count == 1)
+        if (multi->block_meta->delta_count == 1)
             WT_STAT_CONN_DSRC_INCR(session, rec_pages_with_leaf_deltas);
 
-        if (multi->block_meta.delta_count >
+        if (multi->block_meta->delta_count >
           __wt_atomic_load64(&conn->page_delta.max_leaf_delta_count))
             __wt_atomic_store64(
-              &conn->page_delta.max_leaf_delta_count, multi->block_meta.delta_count);
+              &conn->page_delta.max_leaf_delta_count, multi->block_meta->delta_count);
     }
 
     return (0);
@@ -2630,22 +2631,22 @@ __rec_write_image(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     if (block_meta != NULL) {
         if (last_block && block_meta != NULL && r->multi_next == 1 &&
           block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
-            multi->block_meta = *block_meta;
+            *multi->block_meta = *block_meta;
             /*
              * Full page's backlink is the previous full page. If the previous page is a delta, use
              * the base as the new backlink. Otherwise, use the previous page as the backlink.
              */
-            if (multi->block_meta.delta_count > 0) {
-                WT_ASSERT(session, multi->block_meta.base_lsn > 0);
-                multi->block_meta.backlink_lsn = multi->block_meta.base_lsn;
+            if (multi->block_meta->delta_count > 0) {
+                WT_ASSERT(session, multi->block_meta->base_lsn > WT_DISAGG_LSN_NONE);
+                multi->block_meta->backlink_lsn = multi->block_meta->base_lsn;
             } else
-                multi->block_meta.backlink_lsn = multi->block_meta.disagg_lsn;
-            multi->block_meta.delta_count = 0;
-            multi->block_meta.base_lsn = 0;
+                multi->block_meta->backlink_lsn = multi->block_meta->disagg_lsn;
+            multi->block_meta->delta_count = 0;
+            multi->block_meta->base_lsn = WT_DISAGG_LSN_NONE;
         } else
-            __wt_page_block_meta_assign(session, &multi->block_meta);
+            __wt_page_block_meta_assign(session, multi->block_meta);
     }
-    WT_RET(__rec_write(session, &chunk->image, &multi->block_meta, addr, addr_sizep,
+    WT_RET(__rec_write(session, &chunk->image, multi->block_meta, addr, addr_sizep,
       compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
 
     if (F_ISSET(r->ref, WT_REF_FLAG_INTERNAL))
@@ -2680,7 +2681,7 @@ __rec_copy_prev_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         break;
     case WT_PM_REC_REPLACE: /* 1-for-1 page swap */
         if (page->block_meta != NULL)
-            multi->block_meta = *page->block_meta;
+            *multi->block_meta = *page->block_meta;
         if (mod->mod_replace.block_cookie != NULL) {
             WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_replace.ta);
             WT_RET(__wt_memdup(session, mod->mod_replace.block_cookie,
@@ -2694,7 +2695,7 @@ __rec_copy_prev_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         break;
     case WT_PM_REC_MULTIBLOCK: /* Multiple blocks */
         WT_ASSERT(session, mod->mod_multi_entries == 1);
-        multi->block_meta = mod->mod_multi->block_meta;
+        *multi->block_meta = *mod->mod_multi->block_meta;
         if (mod->mod_multi->addr.block_cookie != NULL) {
             WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_multi->addr.ta);
             WT_RET(__wt_memdup(session, mod->mod_multi->addr.block_cookie,
@@ -2776,7 +2777,8 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
         return (__wt_illegal_value(session, page->type));
     }
     multi->supd_restore = false;
-    WT_CLEAR(multi->block_meta);
+    if (page->block_meta != NULL)
+        WT_RET(__wt_calloc_one(session, &multi->block_meta));
 
     /* Set the key. */
     if (btree->type == BTREE_ROW)
@@ -3324,7 +3326,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         if (F_ISSET(r, WT_REC_IN_MEMORY) || r->multi->supd_restore) {
             WT_ASSERT(session, !F_ISSET(r, WT_REC_REWRITE_DELTA));
             if (r->ref->page->block_meta != NULL)
-                *r->ref->page->block_meta = r->multi->block_meta;
+                *r->ref->page->block_meta = *r->multi->block_meta;
             WT_ASSERT_ALWAYS(session,
               F_ISSET(r, WT_REC_IN_MEMORY) ||
                 (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && r->multi->supd_entries != 0),
@@ -3344,7 +3346,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 mod->mod_disk_image = r->multi->disk_image;
                 r->multi->disk_image = NULL;
                 if (r->ref->page->block_meta != NULL)
-                    *r->ref->page->block_meta = r->multi->block_meta;
+                    *r->ref->page->block_meta = *r->multi->block_meta;
                 WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
             } else
                 WT_ASSERT(

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -21,7 +21,7 @@ static int __rec_split_row_promote(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_ITEM *
 static int __rec_split_write(WT_SESSION_IMPL *, WTI_RECONCILE *, WTI_REC_CHUNK *, bool);
 static void __rec_write_page_status(WT_SESSION_IMPL *, WTI_RECONCILE *);
 static int __rec_write_err(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_PAGE *);
-static int __rec_write_wrapup(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_PAGE *);
+static int __rec_write_wrapup(WT_SESSION_IMPL *, WTI_RECONCILE *);
 static int __reconcile(WT_SESSION_IMPL *, WT_REF *, WT_SALVAGE_COOKIE *, uint32_t, bool *);
 
 /*
@@ -325,7 +325,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
      * checkpoint.
      */
     if (ret == 0 && !(btree->evict_disabled > 0 || !F_ISSET(btree->dhandle, WT_DHANDLE_OPEN)) &&
-      F_ISSET(r, WT_REC_EVICT) && !WT_PAGE_IS_INTERNAL(r->page) && r->multi_next == 1 &&
+      F_ISSET(r, WT_REC_EVICT) && !WT_PAGE_IS_INTERNAL(r->ref->page) && r->multi_next == 1 &&
       F_ISSET(r, WT_REC_CALL_URGENT) && !r->update_used && r->cache_write_restore_invisible &&
       !r->cache_upd_chain_all_aborted) {
         /*
@@ -360,7 +360,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     }
 
     /* Wrap up the page reconciliation. Panic on failure. */
-    WT_ERR(__rec_write_wrapup(session, r, page));
+    WT_ERR(__rec_write_wrapup(session, r));
     __rec_write_page_status(session, r);
     WT_ERR(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
 
@@ -2828,7 +2828,8 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
          * We need to assign a new page id for the root every time. We don't support delta for root
          * page yet.
          */
-        __wt_page_block_meta_assign(session, &r->wrapup_checkpoint_block_meta);
+        if (page->disagg_info != NULL)
+            __wt_page_block_meta_assign(session, &r->wrapup_checkpoint_block_meta);
 
         return (0);
     }
@@ -3011,7 +3012,7 @@ __wt_bulk_wrapup(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     }
 
     WT_ERR(__wti_rec_split_finish(session, r));
-    WT_ERR(__rec_write_wrapup(session, r, r->page));
+    WT_ERR(__rec_write_wrapup(session, r));
     __rec_write_page_status(session, r);
 
     /* Mark the page's parent and the tree dirty. */
@@ -3156,12 +3157,13 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
  *     Finish the reconciliation.
  */
 static int
-__rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
+__rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
 {
     WT_BM *bm;
     WT_BTREE *btree;
     WT_DECL_RET;
     WT_MULTI *multi;
+    WT_PAGE *page;
     WT_PAGE_MODIFY *mod;
     WT_REF *ref;
     WT_REF_STATE previous_ref_state;
@@ -3172,6 +3174,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     bm = btree->bm;
     mod = page->modify;
     ref = r->ref;
+    page = r->page;
     WT_TIME_AGGREGATE_INIT(&ta);
     previous_ref_state = 0;
 
@@ -3295,15 +3298,15 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * FIXME-WT-14884: we need to check with the page service team if we need to write an empty
          * root page.
          */
-        ref = r->ref;
         if (__wt_ref_is_root(ref)) {
             __wt_checkpoint_tree_reconcile_update(session, &ta);
-            if (r->wrapup_checkpoint_block_meta.page_id == WT_BLOCK_INVALID_PAGE_ID)
+            if (page->disagg_info != NULL &&
+              r->wrapup_checkpoint_block_meta.page_id == WT_BLOCK_INVALID_PAGE_ID)
                 __wt_page_block_meta_assign(session, &r->wrapup_checkpoint_block_meta);
             WT_RET(bm->checkpoint(
               bm, session, NULL, &r->wrapup_checkpoint_block_meta, btree->ckpt, false));
-            if (r->ref->page->disagg_info != NULL)
-                r->ref->page->disagg_info->block_meta = r->wrapup_checkpoint_block_meta;
+            if (page->disagg_info != NULL)
+                page->disagg_info->block_meta = r->wrapup_checkpoint_block_meta;
         }
 
         /*
@@ -3327,8 +3330,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          */
         if (F_ISSET(r, WT_REC_IN_MEMORY) || r->multi->supd_restore) {
             WT_ASSERT(session, !F_ISSET(r, WT_REC_REWRITE_DELTA));
-            if (r->ref->page->disagg_info != NULL)
-                r->ref->page->disagg_info->block_meta = *r->multi->block_meta;
+            if (page->disagg_info != NULL)
+                page->disagg_info->block_meta = *r->multi->block_meta;
             WT_ASSERT_ALWAYS(session,
               F_ISSET(r, WT_REC_IN_MEMORY) ||
                 (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && r->multi->supd_entries != 0),
@@ -3347,8 +3350,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 r->multi->addr.block_cookie = NULL;
                 mod->mod_disk_image = r->multi->disk_image;
                 r->multi->disk_image = NULL;
-                if (r->ref->page->disagg_info != NULL)
-                    r->ref->page->disagg_info->block_meta = *r->multi->block_meta;
+                if (page->disagg_info != NULL)
+                    page->disagg_info->block_meta = *r->multi->block_meta;
                 WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
             } else
                 WT_ASSERT(
@@ -3358,8 +3361,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             WT_RET(
               __rec_write(session, r->wrapup_checkpoint, &r->wrapup_checkpoint_block_meta, NULL,
                 NULL, NULL, true, F_ISSET(r, WT_REC_CHECKPOINT), r->wrapup_checkpoint_compressed));
-            if (r->ref->page->disagg_info != NULL)
-                r->ref->page->disagg_info->block_meta = r->wrapup_checkpoint_block_meta;
+            if (page->disagg_info != NULL)
+                page->disagg_info->block_meta = r->wrapup_checkpoint_block_meta;
             WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &r->multi->addr.ta);
         }
 
@@ -3380,8 +3383,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * instead of reusing the existing page id. Building deltas on the split page is a future
          * thing.
          */
-        if (r->ref->page->disagg_info != NULL)
-            r->ref->page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
+        if (page->disagg_info != NULL)
+            page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
 
 split:
         mod->mod_multi = r->multi;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -449,7 +449,7 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
     if (mod->rec_result == WT_PM_REC_MULTIBLOCK)
         page->rec_lsn_max = mod->mod_multi[mod->mod_multi_entries - 1].block_meta.disagg_lsn;
     else
-        page->rec_lsn_max = r->page->block_meta.disagg_lsn;
+        page->rec_lsn_max = r->page->block_meta->disagg_lsn;
 
     /*
      * Track the tree's maximum transaction ID (used to decide if it's safe to discard the tree) and
@@ -2524,7 +2524,9 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
 
     conn = S2C(session);
     multi = &r->multi[r->multi_next - 1];
-    block_meta = &r->ref->page->block_meta;
+    block_meta = r->ref->page->block_meta;
+
+    WT_ASSERT(session, block_meta != NULL);
 
     multi->block_meta = *block_meta;
 
@@ -2620,24 +2622,27 @@ __rec_write_image(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
 
     page = r->page;
     multi = &r->multi[r->multi_next - 1];
-    block_meta = &page->block_meta;
+    block_meta = page->block_meta;
 
     /* If we split the page, create a new page id. Otherwise, reuse the existing page id. */
-    if (last_block && r->multi_next == 1 && block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
-        multi->block_meta = *block_meta;
-        /*
-         * Full page's backlink is the previous full page. If the previous page is a delta, use the
-         * base as the new backlink. Otherwise, use the previous page as the backlink.
-         */
-        if (multi->block_meta.delta_count > 0) {
-            WT_ASSERT(session, multi->block_meta.base_lsn > 0);
-            multi->block_meta.backlink_lsn = multi->block_meta.base_lsn;
+    if (block_meta != NULL) {
+        if (last_block && block_meta != NULL && r->multi_next == 1 &&
+          block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
+            multi->block_meta = *block_meta;
+            /*
+             * Full page's backlink is the previous full page. If the previous page is a delta, use
+             * the base as the new backlink. Otherwise, use the previous page as the backlink.
+             */
+            if (multi->block_meta.delta_count > 0) {
+                WT_ASSERT(session, multi->block_meta.base_lsn > 0);
+                multi->block_meta.backlink_lsn = multi->block_meta.base_lsn;
+            } else
+                multi->block_meta.backlink_lsn = multi->block_meta.disagg_lsn;
+            multi->block_meta.delta_count = 0;
+            multi->block_meta.base_lsn = 0;
         } else
-            multi->block_meta.backlink_lsn = multi->block_meta.disagg_lsn;
-        multi->block_meta.delta_count = 0;
-        multi->block_meta.base_lsn = 0;
-    } else
-        __wt_page_block_meta_assign(session, &multi->block_meta);
+            __wt_page_block_meta_assign(session, &multi->block_meta);
+    }
     WT_RET(__rec_write(session, &chunk->image, &multi->block_meta, addr, addr_sizep,
       compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
 
@@ -2672,7 +2677,8 @@ __rec_copy_prev_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         WT_ASSERT_ALWAYS(session, false, "write delta for a new page.");
         break;
     case WT_PM_REC_REPLACE: /* 1-for-1 page swap */
-        multi->block_meta = page->block_meta;
+        if (page->block_meta != NULL)
+            multi->block_meta = *page->block_meta;
         if (mod->mod_replace.block_cookie != NULL) {
             WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_replace.ta);
             WT_RET(__wt_memdup(session, mod->mod_replace.block_cookie,
@@ -2730,7 +2736,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     btree = S2BT(session);
     page = r->page;
     build_delta = false;
-    block_meta = &page->block_meta;
+    block_meta = page->block_meta;
 #ifdef HAVE_DIAGNOSTIC
     verify_image = true;
 #endif
@@ -3290,7 +3296,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 __wt_page_block_meta_assign(session, &r->wrapup_checkpoint_block_meta);
             WT_RET(bm->checkpoint(
               bm, session, NULL, &r->wrapup_checkpoint_block_meta, btree->ckpt, false));
-            r->ref->page->block_meta = r->wrapup_checkpoint_block_meta;
+            if (r->ref->page->block_meta != NULL)
+                *r->ref->page->block_meta = r->wrapup_checkpoint_block_meta;
         }
 
         /*
@@ -3314,7 +3321,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          */
         if (F_ISSET(r, WT_REC_IN_MEMORY) || r->multi->supd_restore) {
             WT_ASSERT(session, !F_ISSET(r, WT_REC_REWRITE_DELTA));
-            r->ref->page->block_meta = r->multi->block_meta;
+            if (r->ref->page->block_meta != NULL)
+                *r->ref->page->block_meta = r->multi->block_meta;
             WT_ASSERT_ALWAYS(session,
               F_ISSET(r, WT_REC_IN_MEMORY) ||
                 (F_ISSET(r, WT_REC_EVICT) && r->leave_dirty && r->multi->supd_entries != 0),
@@ -3333,7 +3341,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 r->multi->addr.block_cookie = NULL;
                 mod->mod_disk_image = r->multi->disk_image;
                 r->multi->disk_image = NULL;
-                r->ref->page->block_meta = r->multi->block_meta;
+                if (r->ref->page->block_meta != NULL)
+                    *r->ref->page->block_meta = r->multi->block_meta;
                 WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
             } else
                 WT_ASSERT(
@@ -3343,7 +3352,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             WT_RET(
               __rec_write(session, r->wrapup_checkpoint, &r->wrapup_checkpoint_block_meta, NULL,
                 NULL, NULL, true, F_ISSET(r, WT_REC_CHECKPOINT), r->wrapup_checkpoint_compressed));
-            r->ref->page->block_meta = r->wrapup_checkpoint_block_meta;
+            if (r->ref->page->block_meta != NULL)
+                *r->ref->page->block_meta = r->wrapup_checkpoint_block_meta;
             WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &r->multi->addr.ta);
         }
 
@@ -3364,7 +3374,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * instead of reusing the existing page id. Building deltas on the split page is a future
          * thing.
          */
-        r->ref->page->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
+        if (r->ref->page->block_meta != NULL)
+            r->ref->page->block_meta->page_id = WT_BLOCK_INVALID_PAGE_ID;
 
 split:
         mod->mod_multi = r->multi;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2626,10 +2626,10 @@ __rec_write_image(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
 
     page = r->page;
     multi = &r->multi[r->multi_next - 1];
-    block_meta = &page->disagg_info->block_meta;
 
     /* If we split the page, create a new page id. Otherwise, reuse the existing page id. */
-    if (block_meta != NULL) {
+    if (page->disagg_info != NULL) {
+        block_meta = &page->disagg_info->block_meta;
         if (last_block && block_meta != NULL && r->multi_next == 1 &&
           block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID) {
             *multi->block_meta = *block_meta;
@@ -2673,6 +2673,9 @@ __rec_copy_prev_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
     mod = page->modify;
     multi = &r->multi[r->multi_next - 1];
 
+    /* We must be in disagg code. */
+    WT_ASSERT(session, multi->block_meta != NULL && page->disagg_info != NULL);
+
     switch (mod->rec_result) {
     case 0:
         WT_ASSERT(session, r->ref->addr != NULL);
@@ -2681,8 +2684,7 @@ __rec_copy_prev_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         WT_ASSERT_ALWAYS(session, false, "write delta for a new page.");
         break;
     case WT_PM_REC_REPLACE: /* 1-for-1 page swap */
-        if (page->disagg_info != NULL)
-            *multi->block_meta = page->disagg_info->block_meta;
+        *multi->block_meta = page->disagg_info->block_meta;
         if (mod->mod_replace.block_cookie != NULL) {
             WT_TIME_AGGREGATE_COPY(&multi->addr.ta, &mod->mod_replace.ta);
             WT_RET(__wt_memdup(session, mod->mod_replace.block_cookie,
@@ -2740,7 +2742,6 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     btree = S2BT(session);
     page = r->page;
     build_delta = false;
-    block_meta = &page->disagg_info->block_meta;
 #ifdef HAVE_DIAGNOSTIC
     verify_image = true;
 #endif
@@ -2869,16 +2870,20 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
         WT_ASSERT_ALWAYS(session, chunk->entries > 0, "Trying to write an empty chunk");
     }
 
-    if (WT_DELTA_ENABLED_FOR_PAGE(session, r->page->type) && last_block && r->multi_next == 1 &&
-      block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID &&
-      block_meta->delta_count < conn->page_delta.max_consecutive_delta) {
-        WT_RET(__rec_build_delta(session, r, chunk->image.mem, &build_delta));
-        /*
-         * Discard the delta if it is larger than the configured percentage of the size of the full
-         * image.
-         */
-        if (build_delta && ((r->delta.size * 100) / chunk->image.size) > conn->page_delta.delta_pct)
-            build_delta = false;
+    if (page->disagg_info != NULL) {
+        block_meta = &page->disagg_info->block_meta;
+        if (WT_DELTA_ENABLED_FOR_PAGE(session, r->page->type) && last_block && r->multi_next == 1 &&
+          block_meta->page_id != WT_BLOCK_INVALID_PAGE_ID &&
+          block_meta->delta_count < conn->page_delta.max_consecutive_delta) {
+            WT_RET(__rec_build_delta(session, r, chunk->image.mem, &build_delta));
+            /*
+             * Discard the delta if it is larger than the configured percentage of the size of the
+             * full image.
+             */
+            if (build_delta &&
+              ((r->delta.size * 100) / chunk->image.size) > conn->page_delta.delta_pct)
+                build_delta = false;
+        }
     }
 
     /* Write the disk image and get an address. */


### PR DESCRIPTION
The aim of this pr is to wrap everything needed for disagg on a page to the same structure. So we can save memory for the non-disagg case as they are not needed.