### PR TITLE
WT-15150 Allow opening database written with preserve prepared config without the config

### DIFF
--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -526,12 +526,7 @@ __wt_time_value_validate(
                   "Start prepared value time window has no start prepared id; time "
                   "window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
-        } else if (tw->start_prepared_id != WT_PREPARED_ID_NONE)
-            WT_TIME_VALIDATE_RET(session,
-              "Preserve_prepared config is off but start prepared value time window has start "
-              "prepared id; time "
-              "window %s",
-              __wt_time_window_to_string(tw, time_string[0]));
+        }
         if (tw->start_ts != WT_TS_NONE)
             WT_TIME_VALIDATE_RET(session,
               "Start prepared value time window has a start time set; time "
@@ -555,12 +550,7 @@ __wt_time_value_validate(
                   "Stop prepared value time window has no stop prepared id; time "
                   "window %s",
                   __wt_time_window_to_string(tw, time_string[0]));
-        } else if (tw->stop_prepared_id != WT_PREPARED_ID_NONE)
-            WT_TIME_VALIDATE_RET(session,
-              "Preserve_prepared config is off but stop prepared value time window has stop "
-              "prepared id; time "
-              "window %s",
-              __wt_time_window_to_string(tw, time_string[0]));
+        }
         if (tw->stop_ts != WT_TS_MAX)
             WT_TIME_VALIDATE_RET(session,
               "Stop prepared value time window has a stop time set; time "

--- a/test/suite/test_prepare31.py
+++ b/test/suite/test_prepare31.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger
+import wiredtiger, wttest
 from prepare_util import test_prepare_preserve_prepare_base
 
 # Tests checkpoint behavior with aborted prepared transactions based on stable timestamp:
@@ -91,10 +91,10 @@ class test_prepare31(test_prepare_preserve_prepare_base):
         self.assertEqual(rec_time_window_prepared, expected_value)
         stat_cursor.close()
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_skip_aborted_prepare_update_if_stable_rollback_timestamp(self):
         self.setup_initial_data(self.uri)
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         # Create and rollback a prepared transaction
         self.create_prepared_transaction(self.uri, prepare_ts=70, rollback_ts=80)
 
@@ -107,10 +107,10 @@ class test_prepare31(test_prepare_preserve_prepare_base):
             wiredtiger.stat.dsrc.rec_time_window_prepared: False,
         }, self.uri)
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_skip_aborted_prepare_update_if_prepare_timestamp_not_stable(self):
         self.setup_initial_data(self.uri)
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         # Create and rollback a prepared transaction
         self.create_prepared_transaction(self.uri, prepare_ts=70, rollback_ts=80)
 
@@ -120,10 +120,10 @@ class test_prepare31(test_prepare_preserve_prepare_base):
             wiredtiger.stat.dsrc.rec_time_window_prepared: False,
         }, self.uri)
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_write_prepare_update_if_rollback_timestamp_not_stable(self):
         self.setup_initial_data(self.uri)
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         # Create and rollback a prepared transaction
         self.create_prepared_transaction(self.uri, prepare_ts=70, rollback_ts=80)
 

--- a/test/suite/test_prepare32.py
+++ b/test/suite/test_prepare32.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger
+import wiredtiger, wttest
 from prepare_util import test_prepare_preserve_prepare_base
 
 # test_prepare32.py
@@ -38,12 +38,12 @@ from prepare_util import test_prepare_preserve_prepare_base
 class test_prepare32(test_prepare_preserve_prepare_base):
     uri = 'table:test_prepare32'
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_committed_prepare(self):
         # Set initial timestamps - start with lower values
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 

--- a/test/suite/test_prepare33.py
+++ b/test/suite/test_prepare33.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger
+import wiredtiger, wttest
 from prepare_util import test_prepare_preserve_prepare_base
 
 # Tests checkpoint behavior for rolled back prepared transactions with tombstones:
@@ -36,12 +36,12 @@ from prepare_util import test_prepare_preserve_prepare_base
 class test_prepare33(test_prepare_preserve_prepare_base):
     uri = 'table:test_prepare32'
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_rollbacked_prepare(self):
         # Set initial timestamps - start with lower values
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 

--- a/test/suite/test_prepare34.py
+++ b/test/suite/test_prepare34.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger
+import wiredtiger, wttest
 from prepare_util import test_prepare_preserve_prepare_base
 
 # Tests checkpoint behavior for prepared modify operations:
@@ -37,6 +37,7 @@ from prepare_util import test_prepare_preserve_prepare_base
 class test_prepare34(test_prepare_preserve_prepare_base):
     uri = 'table:test_prepare34'
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_rollback_prepare_modify(self):
         """
         Test that prepared transactions containing modify operations that are rolled back
@@ -46,9 +47,6 @@ class test_prepare34(test_prepare_preserve_prepare_base):
         # Set initial timestamps
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
 
         uri = 'table:test_prepare34'
         create_params = 'key_format=i,value_format=S'
@@ -123,7 +121,7 @@ class test_prepare34(test_prepare_preserve_prepare_base):
             self.assertEqual(value, cursor[i])
         self.session.rollback_transaction()
 
-
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_commit_prepare_modify(self):
         """
         Test that prepared transactions containing modify operations that are rolled back
@@ -133,8 +131,6 @@ class test_prepare34(test_prepare_preserve_prepare_base):
         # Set initial timestamps
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
 
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)

--- a/test/suite/test_prepare35.py
+++ b/test/suite/test_prepare35.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger
+import wiredtiger, wttest
 from prepare_util import test_prepare_preserve_prepare_base
 
 # Tests checkpoint behavior with prepared transactions, specifically:
@@ -37,12 +37,12 @@ from prepare_util import test_prepare_preserve_prepare_base
 class test_prepare35(test_prepare_preserve_prepare_base):
     uri = 'table:test_prepare35'
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_committed_prepare(self):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 

--- a/test/suite/test_prepare37.py
+++ b/test/suite/test_prepare37.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger
+import wiredtiger, wttest
 from prepare_util import test_prepare_preserve_prepare_base
 
 # Test eviction free updates with prepared transactions
@@ -34,12 +34,12 @@ from prepare_util import test_prepare_preserve_prepare_base
 class test_prepare37(test_prepare_preserve_prepare_base):
     uri = 'table:test_prepare37'
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_commit_prepare(self):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 
@@ -146,12 +146,11 @@ class test_prepare37(test_prepare_preserve_prepare_base):
         self.assertEqual(read_cursor[20], "committed_value_20_1")
         self.session.rollback_transaction()
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_rollback_prepare(self):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 
@@ -253,12 +252,12 @@ class test_prepare37(test_prepare_preserve_prepare_base):
         self.assertEqual(read_cursor[20], "committed_value_20_1")
         self.session.rollback_transaction()
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_commit_prepare_delete(self):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 
@@ -362,12 +361,12 @@ class test_prepare37(test_prepare_preserve_prepare_base):
         self.assertEqual(read_cursor[20], "committed_value_20_1")
         self.session.rollback_transaction()
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_rollback_prepare_delete(self):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 

--- a/test/suite/test_prepare38.py
+++ b/test/suite/test_prepare38.py
@@ -25,6 +25,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
+import wttest
 from helper import copy_wiredtiger_home
 from prepare_util import test_prepare_preserve_prepare_base
 
@@ -34,9 +35,8 @@ from prepare_util import test_prepare_preserve_prepare_base
 class test_prepare38(test_prepare_preserve_prepare_base):
     uri = 'table:test_prepare38'
 
+    @wttest.skip_for_hook("disagg", "Skip test until cell packing/unpacking is supported for page delta")
     def test_open(self):
-        if 'disagg' in self.hook_names:
-            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)
 

--- a/test/suite/test_prepare38.py
+++ b/test/suite/test_prepare38.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+from helper import copy_wiredtiger_home
+from prepare_util import test_prepare_preserve_prepare_base
+
+# Test database without the preserve prepared config can read data written by
+# the database with the preserve prepared config.
+
+class test_prepare38(test_prepare_preserve_prepare_base):
+    uri = 'table:test_prepare38'
+
+    def test_open(self):
+        if 'disagg' in self.hook_names:
+            self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(self.uri, create_params)
+
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri)
+        cursor[1] = "value1"
+        self.session.commit_transaction()
+
+        self.session.begin_transaction()
+        # Do a prepared remove
+        cursor.set_key(1)
+        cursor.remove()
+        # Do a prepared update
+        cursor[2] = "value2"
+        # Do a prepared update remove
+        cursor[3] = "value3"
+        cursor.set_key(3)
+        cursor.remove()
+        self.session.prepare_transaction(f"prepare_timestamp={self.timestamp_str(10)},prepared_id={self.prepared_id_str(1)}")
+
+        # Make the prepared timestamp stable
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+
+        session2 = self.conn.open_session()
+        # Write the prepared updates to disk
+        session2.checkpoint()
+
+        copy_wiredtiger_home(self, ".", "RESTART")
+        # Reopen without the preserve prepared config
+        conn = self.wiredtiger_open("RESTART", "preserve_prepared=false")
+        conn.close()
+
+        self.session.rollback_transaction(f"rollback_timestamp={self.timestamp_str(30)}")
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))


### PR DESCRIPTION
We should allow to open the database written with the preserve prepared config without the config. Rollback to stable should remove all the prepared updates.