### PR TITLE
WT-15158 Avoid setting ingest_btree->prune_timestamp during initialization

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -680,6 +680,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     if (F_ISSET(session, WT_SESSION_IMPORT))
         btree->modified = true;
 
+    /* FIXME-WT-15192: Consider setting `prune_timestamp` to `last_checkpoint_timestamp` */
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
         btree->prune_timestamp = WT_TS_NONE;
 

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -681,8 +681,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
         btree->modified = true;
 
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-        WT_ACQUIRE_READ(
-          btree->prune_timestamp, conn->disaggregated_storage.last_checkpoint_timestamp);
+        btree->prune_timestamp = WT_TS_NONE;
 
     return (0);
 }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1630,8 +1630,8 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
             /*
              * For each checkpoint, see of the handle is in use. If not, it is safe to gc.
              * FIXME-WT-15192: `ckpt_inuse` and `last_ckpt` could be obtained from different tables
-             * and that's not correct to compare checkpoint orders from different tables since
-             * they are unrelated.
+             * and that's not correct to compare checkpoint orders from different tables since they
+             * are unrelated.
              */
             while (ckpt_inuse < last_ckpt) {
                 WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1629,6 +1629,9 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
 
             /*
              * For each checkpoint, see of the handle is in use. If not, it is safe to gc.
+             * FIXME-WT-15192: `ckpt_inuse` and `last_ckpt` could be obtained from different tables
+             * and that's not correct to compare checkpoint orders from different tables since
+             * they are unrelated.
              */
             while (ckpt_inuse < last_ckpt) {
                 WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -639,6 +639,7 @@ __schema_open_layered_ingest(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered
     /* Flag the ingest btree as participating in automatic garbage collection */
     F_SET(ingest_btree, WT_BTREE_GARBAGE_COLLECT);
 
+    /* FIXME-WT-15192: Consider setting `prune_timestamp` to `last_checkpoint_timestamp` */
     ingest_btree->prune_timestamp = WT_TS_NONE;
 
     WT_RET(__wt_session_release_dhandle(session));

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -639,8 +639,7 @@ __schema_open_layered_ingest(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered
     /* Flag the ingest btree as participating in automatic garbage collection */
     F_SET(ingest_btree, WT_BTREE_GARBAGE_COLLECT);
 
-    WT_ACQUIRE_READ(
-      ingest_btree->prune_timestamp, S2C(session)->disaggregated_storage.last_checkpoint_timestamp);
+    ingest_btree->prune_timestamp = WT_TS_NONE;
 
     WT_RET(__wt_session_release_dhandle(session));
     return (0);


### PR DESCRIPTION
Currently during the ingest table initialization we set `prune_timestamp` to the last known checkpoint timestamp. According to the current logic it could cause the following assertion failure:
```c
__layered_update_gc_ingest_tables_prune_timestamps(...) {
     WT_ASSERT(session, prune_timestamp >= btree->prune_timestamp);
``` 

It happens because we always update timestamp to the last checkpoint's timestamp for this table which is in use and it could be newer than the last known checkpoint timestamp. 

This logic does require a redesign which is the main scope for WT-15192
Since this issue blocks other activities it was decided to merge it without a regression test, the regression test would be provided as a separate PR as well (WT-15191)