### PR TITLE
WT-14983 Eliminate schema lock from layered cursor open

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -149,7 +149,7 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, bool reset, bool update, bool iter
                     break;
             }
         }
-        WT_WITH_SCHEMA_LOCK(session, ret = __clayered_open_cursors(session, clayered, update));
+        ret = __clayered_open_cursors(session, clayered, update);
 
         /*
          * We only check the external state once. There will always be a race where the state

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -519,8 +519,6 @@ __clayered_open_cursors(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, b
     conn = S2C(session);
     layered = (WT_LAYERED_TABLE *)session->dhandle;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
-
     /*
      * Query operations need a full set of cursors. Overwrite cursors do queries in service of
      * updates.


### PR DESCRIPTION
The schema lock restricts all accesses to modifications that would change the number of metadata entries on the table. If an operation requires modification of one specific metadata entry, no lock is needed as it doesn't change the state of the metadata table. A general case of using the schema lock is when a particular feature needs to fetch all the dhandles of the database.
Here are the most/all cases of schema lock usage:
• Creating or dropping tables - Needs to schema lock because we are modifying number of the metadata entries in the table.
• Checkpoint preparation phase, Rollback to stable operations, Backup cursor operations - Fetches all dhandles from the metadata table

In the clayered_enter() function, the schema_lock is not needed because the function does not modify or require the metadata table to be static. The clayered_enter() function opens the stable or ingest cursor if it is NULL. Cursor opens do not require the schema lock.

Note: We don't need to worry about constituent cursors opening at the same time. There should be only on thread of execution per cursor. 