### PR TITLE
WT-14932 Build Framework for Unique WT Verbose IDs (#12144) (v8.0 backport)

### DIFF
--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -132,5 +132,6 @@ __wt_checksum_with_seed
 __wt_conf_gets
 __wt_verbose_error
 __wt_verbose_level
+__wt_verbose_level_id
 __wt_verbose_level_multi
 wt_shared

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1283,7 +1283,7 @@ err:
 
     /* Time since the shutdown has started. */
     __wt_timer_evaluate_ms(session, &timer, &conn->shutdown_timeline.shutdown_ms);
-    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+    __wt_verbose_info_id(session, 1493200, WT_VERB_RECOVERY_PROGRESS,
       "shutdown was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the rollback to stable, and %" PRIu64 "ms for the checkpoint.",
       conn->shutdown_timeline.shutdown_ms, conn->shutdown_timeline.rts_ms,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1998,6 +1998,9 @@ extern void __wt_verbose_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t ts, 
 extern void __wt_verbose_worker(WT_SESSION_IMPL *session, WT_VERBOSE_CATEGORY category,
   WT_VERBOSE_LEVEL level, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 4, 5)))
   WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
+extern void __wt_verbose_worker_id(
+  WT_SESSION_IMPL *session, const WT_VERBOSE_MESSAGE_INFO *verb_info, const char *fmt, ...)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 3, 4))) WT_GCC_FUNC_DECL_ATTRIBUTE((cold));
 extern void __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l);
 extern void __wt_writeunlock(WT_SESSION_IMPL *session, WT_RWLOCK *l);
 extern void __wti_blkcache_get_read_handle(WT_BLOCK *block);

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -441,6 +441,8 @@ struct __wt_update_vector;
 typedef struct __wt_update_vector WT_UPDATE_VECTOR;
 struct __wt_verbose_dump_cookie;
 typedef struct __wt_verbose_dump_cookie WT_VERBOSE_DUMP_COOKIE;
+struct __wt_verbose_message_info;
+typedef struct __wt_verbose_message_info WT_VERBOSE_MESSAGE_INFO;
 struct __wt_verbose_multi_category;
 typedef struct __wt_verbose_multi_category WT_VERBOSE_MULTI_CATEGORY;
 struct __wt_verify_info;

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -229,8 +229,8 @@ __eventv_append_error(const char *err, char *start, char *p, size_t *remainp)
  *     Report a message to an event handler.
  */
 static int
-__eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, int line,
-  WT_VERBOSE_CATEGORY category, WT_VERBOSE_LEVEL level, const char *fmt, va_list ap)
+__eventv(WT_SESSION_IMPL *session, bool is_json, int error, uint32_t log_id, const char *func,
+  int line, WT_VERBOSE_CATEGORY category, WT_VERBOSE_LEVEL level, const char *fmt, va_list ap)
   WT_GCC_FUNC_ATTRIBUTE((cold))
 {
     struct timespec ts;
@@ -316,6 +316,7 @@ __eventv(WT_SESSION_IMPL *session, bool is_json, int error, const char *func, in
     if (is_json) {
         /* Category and verbosity level. */
         WT_ERROR_APPEND(p, remain, "\"category\":\"%s\",", verbose_category_strings[category]);
+        WT_ERROR_APPEND(p, remain, "\"log_id\":%" PRIu32 ",", log_id);
         WT_ERROR_APPEND(p, remain, "\"category_id\":%" PRIu32 ",", category);
         WT_ERROR_APPEND(p, remain, "\"verbose_level\":\"%s\",", verbosity_level_tag);
         WT_ERROR_APPEND(p, remain, "\"verbose_level_id\":%d,", level);
@@ -481,8 +482,8 @@ __wt_err_func(WT_SESSION_IMPL *session, int error, const char *func, int line,
      */
     va_start(ap, fmt);
     WT_IGNORE_RET(__eventv(session,
-      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, error, func,
-      line, category, WT_VERBOSE_ERROR, fmt, ap));
+      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, error,
+      WT_DEFAULT_LOG_ID, func, line, category, WT_VERBOSE_ERROR, fmt, ap));
     va_end(ap);
 }
 
@@ -503,8 +504,8 @@ __wt_errx_func(WT_SESSION_IMPL *session, const char *func, int line, WT_VERBOSE_
      */
     va_start(ap, fmt);
     WT_IGNORE_RET(__eventv(session,
-      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, 0, func, line,
-      category, WT_VERBOSE_ERROR, fmt, ap));
+      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, 0,
+      WT_DEFAULT_LOG_ID, func, line, category, WT_VERBOSE_ERROR, fmt, ap));
     va_end(ap);
 }
 
@@ -535,7 +536,7 @@ __wt_panic_func(WT_SESSION_IMPL *session, int error, const char *func, int line,
     va_start(ap, fmt);
     WT_IGNORE_RET(
       __eventv(session, conn != NULL ? FLD_ISSET(conn->json_output, WT_JSON_OUTPUT_ERROR) : false,
-        error, func, line, category, WT_VERBOSE_ERROR, fmt, ap));
+        error, WT_DEFAULT_LOG_ID, func, line, category, WT_VERBOSE_ERROR, fmt, ap));
     va_end(ap);
 
     /* If the connection has already panicked, just return the error. */
@@ -551,7 +552,8 @@ __wt_panic_func(WT_SESSION_IMPL *session, int error, const char *func, int line,
     va_start(ap, fmt);
     WT_IGNORE_RET(
       __eventv(session, conn != NULL ? FLD_ISSET(conn->json_output, WT_JSON_OUTPUT_ERROR) : false,
-        WT_PANIC, func, line, category, WT_VERBOSE_ERROR, "the process must exit and restart", ap));
+        WT_PANIC, WT_DEFAULT_LOG_ID, func, line, category, WT_VERBOSE_ERROR,
+        "the process must exit and restart", ap));
     va_end(ap);
 
 #ifdef HAVE_DIAGNOSTIC
@@ -617,10 +619,27 @@ __wt_ext_err_printf(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, const char
 
     va_start(ap, fmt);
     ret = __eventv(session,
-      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, 0, NULL, 0,
-      WT_VERB_EXTENSION, WT_VERBOSE_ERROR, fmt, ap);
+      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, 0,
+      WT_DEFAULT_LOG_ID, NULL, 0, WT_VERB_EXTENSION, WT_VERBOSE_ERROR, fmt, ap);
     va_end(ap);
     return (ret);
+}
+
+/*
+ * __wt_verbose_worker_id --
+ *     Verbose message that takes the verbose info structure.
+ */
+void
+__wt_verbose_worker_id(WT_SESSION_IMPL *session, const WT_VERBOSE_MESSAGE_INFO *verb_info,
+  const char *fmt, ...) WT_GCC_FUNC_ATTRIBUTE((format(printf, 3, 4))) WT_GCC_FUNC_ATTRIBUTE((cold))
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    WT_IGNORE_RET(__eventv(session,
+      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_MESSAGE) : false, 0,
+      verb_info->id, NULL, 0, verb_info->category, verb_info->level, fmt, ap));
+    va_end(ap);
 }
 
 /*
@@ -635,8 +654,8 @@ __wt_verbose_worker(WT_SESSION_IMPL *session, WT_VERBOSE_CATEGORY category, WT_V
 
     va_start(ap, fmt);
     WT_IGNORE_RET(__eventv(session,
-      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_MESSAGE) : false, 0, NULL, 0,
-      category, level, fmt, ap));
+      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_MESSAGE) : false, 0,
+      WT_DEFAULT_LOG_ID, NULL, 0, category, level, fmt, ap));
     va_end(ap);
 }
 

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1231,7 +1231,7 @@ done:
 
     /* Time since the recovery has started. */
     __wt_timer_evaluate_ms(session, &timer, &conn->recovery_timeline.recovery_ms);
-    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+    __wt_verbose_level_multi_id(session, 1493201, WT_VERB_RECOVERY_ALL, WT_VERBOSE_INFO,
       "recovery was completed successfully and took %" PRIu64 "ms, including %" PRIu64
       "ms for the log replay, %" PRIu64 "ms for the rollback to stable, and %" PRIu64
       "ms for the checkpoint.",

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -43,6 +43,7 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
     expected_json_schema = {
         'category': {'type': str, 'always_expected': True },
         'category_id': {'type': int, 'always_expected': True },
+        'log_id': {'type': int, 'always_expected': True },
         'error_str': {'type': str, 'always_expected': False },
         'error_code': {'type': int, 'always_expected': False },
         'msg': {'type': str, 'always_expected': True },

--- a/test/suite/test_verbose04.py
+++ b/test/suite/test_verbose04.py
@@ -120,7 +120,7 @@ class test_verbose04(test_verbose_base):
 
         # At this time, no verbose messages should be generated with the following set of operations and the verbosity level
         # WT_VERBOSE_INFO (0), hence we don't expect any output.
-        with self.expect_verbose(['all:0'], self.all_verbose_categories, self.is_json, False) as conn:
+        with self.expect_verbose(['all:0'], self.all_verbose_categories, self.is_json) as conn:
             uri = 'table:test_verbose04_all'
             session = conn.open_session()
             session.create(uri, self.collection_cfg)


### PR DESCRIPTION
This pull request introduces a system for adding unique, structured IDs to WiredTiger verbose log messages, enhancing log readability, searchability, and analysis.

Why this change?
Currently, verbose log messages lack unique identifiers, making it challenging to programmatically track specific log events across different log files, especially during debugging. This change addresses that by:

Improving Traceability: Unique IDs allow for easier identification and correlation of specific log events.
Facilitating Automation: Tools can more reliably parse and filter logs based on these consistent identifiers.
Streamlining Debugging: Quicker pinpointing of relevant messages during issue investigation.
How it works
Adopt Server's Approach of using the Jira ticket number followed by 2-digit number.

Introduced a new struct __wt_verbose_message_info to bundle message ID, category, and level.
Added __wt_verbose_worker_id and __wt_verbose_info_id macros/functions to allow log messages to include a unique ID.
Updated the __eventv function to accept and process the new unique ID, including its inclusion in JSON output.
Updated an existing verbose message in src/conn/conn_api.c and src/txn/txn_recover.c to use the new
__wt_verbose_info_id/__wt_verbose_level_multi_id with a unique ID.

(cherry picked from commit 583f013eca0dfb0dd43e58e6da07b19d7626a327)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
