### PR TITLE
WT-14140 Unnecessary schema lock taken for active file: dhandles that are not swept (v8.1 backport)  (#12124) v8.0 backport

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1316,6 +1316,7 @@ tid
 tinfo
 tlb
 tmp
+tod
 tokenizer
 toklen
 tokname

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -13,6 +13,42 @@
       (dhandle)->references == 0)
 
 /*
+ * __sweep_file_dhandle_check_and_reset_tod --
+ *     Check if the file dhandle exists for the table dhandle and resets its time-of-death if it
+ *     does.
+ */
+static int
+__sweep_file_dhandle_check_and_reset_tod(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle)
+{
+    WT_DECL_RET;
+    WT_TABLE *table;
+
+    ret = WT_NOTFOUND;
+    /*
+     * The sweep server's algorithm is altered to prevent unnecessary table dhandle closures. This
+     * is done by checking for associated file dhandles before marking table dhandles for sweeping.
+     * It resolves schema lock contention caused by repetitive table dhandle operations during
+     * MongoDB cursor activity on simple tables, and ensures table dhandles are retained for active
+     * file dhandles, which is required for file dhandle access.
+     */
+    table = (WT_TABLE *)dhandle;
+    if (table->is_simple && table->cg_complete) {
+        ret = __wt_conn_dhandle_find(session, table->cgroups[0]->source, NULL);
+
+        /*
+         * Reset the time of death if the file dhandle exists for the associated table dhandle.
+         */
+        if (ret == 0) {
+            dhandle->timeofdeath = 0;
+            session->dhandle = NULL;
+            return (ret);
+        }
+    }
+
+    return (ret);
+}
+
+/*
  * __sweep_mark --
  *     Mark idle handles with a time of death, and note if we see dead handles.
  */
@@ -21,6 +57,7 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE *dhandle;
+    WT_DECL_RET;
 
     conn = S2C(session);
 
@@ -43,6 +80,20 @@ __sweep_mark(WT_SESSION_IMPL *session, uint64_t now)
         if (F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE) ||
           __wt_atomic_loadi32(&dhandle->session_inuse) > 0 || dhandle->timeofdeath != 0)
             continue;
+
+        /* For table dhandles, skip expiration if associated file dhandles exist. */
+        if (dhandle->type == WT_DHANDLE_TYPE_TABLE) {
+            WT_WITH_TABLE_READ_LOCK(session,
+              WT_WITH_HANDLE_LIST_READ_LOCK(
+                session, (ret = __sweep_file_dhandle_check_and_reset_tod(session, dhandle))));
+
+            /* Continue if the file dhandle exists for the associated table dhandle. */
+            if (ret == 0)
+                continue;
+
+            WT_ASSERT_ALWAYS(
+              session, ret == WT_NOTFOUND, "Connection dhandle find has returned an error.");
+        }
 
         /*
          * Never close out the history store handle via sweep. It can cause a deadlock if eviction

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_sweep06.py
+# This test confirms that table dhandles are correctly retained and not
+# marked for sweep server expiry when file data dhandles are present.
+
+from suite_subprocess import suite_subprocess
+import wttest, threading
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
+    dhandles = 200
+    format='key_format=i,value_format=S'
+    tablebase = 'test_sweep06'
+    uri = 'table:' + tablebase
+    conn_config = 'file_manager=(close_handle_minimum=0,' + \
+                  'close_idle_time=60,close_scan_interval=30),session_max=530'
+
+    cursor_caching = [
+        ('cursor_caching_disabled', dict(cursor_caching=False)),
+        ('cursor_caching_enabled', dict(cursor_caching=True)),
+    ]
+
+    scenarios = make_scenarios(cursor_caching)
+
+    def insert(self, i, start, rows):
+        session = self.conn.open_session()
+        uri = self.uri + str(i)
+        cursor = session.open_cursor(uri)
+
+        session.begin_transaction()
+        for i in range(start, rows):
+            cursor.set_key(i)
+            cursor.set_value(str(i))
+            cursor.insert()
+        session.commit_transaction()
+        cursor.close()
+        session.close()
+
+    def test_dhandles(self):
+        if self.cursor_caching:
+            self.session.reconfigure('cache_cursors=true')
+        for i in range(1,self.dhandles):
+            uri = self.uri + str(i)
+            self.session.create(uri, self.format)
+
+        for i in range(1,100):
+            threads = []
+            for i in range(1,self.dhandles):
+                thread = threading.Thread(target=self.insert, args=(i, 0, 100))
+                thread.start()
+                threads.append(thread)
+
+            for thread in threads:
+                thread.join()
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        close1 = stat_cursor[stat.conn.dh_sweep_dead_close][2]
+        close2 = stat_cursor[stat.conn.dh_sweep_expired_close][2]
+        stat_cursor.close()
+
+        # The expectation is that no dhandles have been closed.
+        self.assertEqual(close1, 0)
+        self.assertEqual(close2, 0)

--- a/test/suite/test_sweep06.py
+++ b/test/suite/test_sweep06.py
@@ -82,10 +82,8 @@ class test_sweep06(wttest.WiredTigerTestCase, suite_subprocess):
                 thread.join()
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
-        close1 = stat_cursor[stat.conn.dh_sweep_dead_close][2]
-        close2 = stat_cursor[stat.conn.dh_sweep_expired_close][2]
+        close1 = stat_cursor[stat.conn.dh_sweep_close][2]
         stat_cursor.close()
 
         # The expectation is that no dhandles have been closed.
         self.assertEqual(close1, 0)
-        self.assertEqual(close2, 0)


### PR DESCRIPTION


(cherry picked from commit 0a90b5cad12aa0f4253ef8582d79ea461df4331b)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
