### PR TITLE
WT-15095 Refine eviction selection of pages with few updates

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2091,22 +2091,21 @@ __evict_skip_dirty_candidate(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (__wt_conn_is_disagg(session) &&
       __wt_atomic_load32(&page->modify->page_state) < WT_EVICT_MODIFY_COUNT_MIN) {
         double pct_dirty = 0.0, pct_updates = 0.0;
-        bool low_pressure = false;
+        bool high_pressure = false;
 
         if (F_ISSET(conn->evict, WT_EVICT_CACHE_DIRTY)) {
             WT_IGNORE_RET(__wt_evict_dirty_needed(session, &pct_dirty));
-            low_pressure = (pct_dirty <
-              (conn->evict->eviction_dirty_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
-        }
+            high_pressure = (pct_dirty >
+                (conn->evict->eviction_dirty_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
+            }
 
-        if (F_ISSET(conn->evict, WT_EVICT_CACHE_UPDATES)) {
+        if (!high_pressure && F_ISSET(conn->evict, WT_EVICT_CACHE_UPDATES)) {
             WT_IGNORE_RET(__wti_evict_updates_needed(session, &pct_updates));
-            low_pressure = low_pressure ||
-              (pct_updates <
+            high_pressure = (pct_updates >
                 (conn->evict->eviction_updates_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
-        }
+            }
 
-        if (low_pressure)
+        if (!high_pressure)
             return (true);
     }
     return (false);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2096,14 +2096,14 @@ __evict_skip_dirty_candidate(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (F_ISSET(conn->evict, WT_EVICT_CACHE_DIRTY)) {
             WT_IGNORE_RET(__wt_evict_dirty_needed(session, &pct_dirty));
             high_pressure = (pct_dirty >
-                (conn->evict->eviction_dirty_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
-            }
+              (conn->evict->eviction_dirty_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
+        }
 
         if (!high_pressure && F_ISSET(conn->evict, WT_EVICT_CACHE_UPDATES)) {
             WT_IGNORE_RET(__wti_evict_updates_needed(session, &pct_updates));
             high_pressure = (pct_updates >
-                (conn->evict->eviction_updates_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
-            }
+              (conn->evict->eviction_updates_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
+        }
 
         if (!high_pressure)
             return (true);


### PR DESCRIPTION
This is an update to a change made in WT-14813 that changed eviction in disaggregated storage to skip queuing pages with fewer updates if there is not much cache pressure. 

The original change considered the cache to be low pressure if either the update or dirty thresholds haven't been reached. This addresses a perf-change and modifies it to consider the cache to be under pressure if either one of update or dirty pages are close to the threshold rather than both, so pages are queued.