### PR TITLE
WT-15225 Fix newly created table and drop() EBUSY issue

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -510,6 +510,9 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
     if (btree->root.page == NULL)
         goto err;
 
+    /* Ignore tables that are empty or is currently in a bulk-load phase. */
+    if (btree->original)
+        goto err;
     /*
      * FLCS pages cannot be discarded and must be rewritten as implicitly filling in missing chunks
      * of FLCS namespace is problematic.

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -42,6 +42,7 @@ test_cursor21.py
 test_debug_mode08.py
 test_drop.py
 test_drop03.py
+test_drop04.py
 test_drop_create.py
 test_dump.py
 test_dump01.py # RTS message

--- a/test/suite/test_drop04.py
+++ b/test/suite/test_drop04.py
@@ -58,7 +58,7 @@ from test_cc01 import test_cc_base
 import wttest
 
 # test_drop04.py
-# Test dropping a collection on empty logged table.
+# Test dropping a collection on empty logged table. The python test reproduces the WT-15225 bug.
 class test_drop04(test_cc_base):
     conn_config = 'log=(enabled=true)'
     uri = 'table:test_drop04'
@@ -71,10 +71,8 @@ class test_drop04(test_cc_base):
         self.prout("Finished checkpoint.")
 
         for i in range(100):
-            self.prout(f"Iteration {i+1}: drop with force=false should fail.")
-            self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, "force=false")),
-                            "was expecting drop call to fail with EBUSY")
-            self.prout(f"Iteration {i+1}: Exists after unsuccessful drop.")
+            self.session.create(self.uri, 'key_format=i,value_format=S')
+            self.assertEqual(self.session.drop(self.uri, "force=false"), 0)
             self.session.checkpoint()
             self.prout(f"Finished checkpoint {i+1}.")
 

--- a/test/suite/test_drop04.py
+++ b/test/suite/test_drop04.py
@@ -64,28 +64,14 @@ class test_drop04(test_cc_base):
     uri = 'table:test_drop04'
 
     def test_drop_after_bulk_load(self):
-        self.session.create(self.uri, 'key_format=i,value_format=S')
-
-        # Checkpoint the database and wait for the checkpoint cleanup.
-        self.wait_for_cc_to_run()
-        self.prout("Finished checkpoint.")
-
         for i in range(100):
             self.session.create(self.uri, 'key_format=i,value_format=S')
             self.assertEqual(self.session.drop(self.uri, "force=false"), 0)
-            self.session.checkpoint()
-            self.prout(f"Finished checkpoint {i+1}.")
+            # Checkpoint the database and wait for the checkpoint cleanup.
+            self.wait_for_cc_to_run()
+            self.pr("Finished checkpoint {i}")
 
-        # Perform an insert, following by checkpoint to let the drop succeed.
-        cursor = self.session.open_cursor(self.uri, None, None)
-        self.session.begin_transaction()
-        cursor[1] = "value1"
-        self.session.commit_transaction()
-        self.session.checkpoint()
-        cursor.close()
-        self.assertEqual(self.session.drop(self.uri), 0)
-
-        self.prout("Done.")
+        self.pr("Done.")
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_drop04.py
+++ b/test/suite/test_drop04.py
@@ -65,7 +65,7 @@ class test_drop04(test_cc_base):
 
     def test_drop_after_bulk_load(self):
         for i in range(100):
-            self.session.create(self.uri, 'key_format=i,value_format=S')
+            self.assertEqual(self.session.create(self.uri, 'key_format=i,value_format=S'), 0)
             # Checkpoint the database and wait for the checkpoint cleanup.
             self.wait_for_cc_to_run()
             self.pr("Finished checkpoint {i}, performing drop...")

--- a/test/suite/test_drop04.py
+++ b/test/suite/test_drop04.py
@@ -66,10 +66,10 @@ class test_drop04(test_cc_base):
     def test_drop_after_bulk_load(self):
         for i in range(100):
             self.session.create(self.uri, 'key_format=i,value_format=S')
-            self.assertEqual(self.session.drop(self.uri, "force=false"), 0)
             # Checkpoint the database and wait for the checkpoint cleanup.
             self.wait_for_cc_to_run()
-            self.pr("Finished checkpoint {i}")
+            self.pr("Finished checkpoint {i}, performing drop...")
+            self.assertEqual(self.session.drop(self.uri, "force=false"), 0)
 
         self.pr("Done.")
 

--- a/test/suite/test_drop04.py
+++ b/test/suite/test_drop04.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from test_cc01 import test_cc_base
+import wttest
+
+# test_drop04.py
+# Test dropping a collection on empty logged table.
+class test_drop04(test_cc_base):
+    conn_config = 'log=(enabled=true)'
+    uri = 'table:test_drop04'
+
+    def test_drop_after_bulk_load(self):
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+
+        # Checkpoint the database and wait for the checkpoint cleanup.
+        self.wait_for_cc_to_run()
+        self.prout("Finished checkpoint.")
+
+        for i in range(100):
+            self.prout(f"Iteration {i+1}: drop with force=false should fail.")
+            self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, "force=false")),
+                            "was expecting drop call to fail with EBUSY")
+            self.prout(f"Iteration {i+1}: Exists after unsuccessful drop.")
+            self.session.checkpoint()
+            self.prout(f"Finished checkpoint {i+1}.")
+
+        # Perform an insert, following by checkpoint to let the drop succeed.
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.session.begin_transaction()
+        cursor[1] = "value1"
+        self.session.commit_transaction()
+        self.session.checkpoint()
+        cursor.close()
+        self.assertEqual(self.session.drop(self.uri), 0)
+
+        self.prout("Done.")
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
The issue starts from the interaction of bulk loading a newly created logged btree, checkpoint cleanup and drop() call. After we finish bulk loading a tree, we do not unset the btree->original flag until we perform an update/insert operation. Now the background thread checkpoint thread will dirty the btree. A drop() call on the newly bulk-loaded logged btree will return EBUSY.
