### PR TITLE
WT-15230 Disable RTS when precise checkpoint is on

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -728,11 +728,6 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
                     break;
                 continue;
             }
-
-            /*
-             * If we have seen a tombstone that rolled back the prepared update, this must be the
-             * prepared update. No need to walk further.
-             */
             txnid = upd->upd_saved_txnid;
         }
 
@@ -811,10 +806,6 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
         if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
           !F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DELTA)) {
             if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
-                WT_ASSERT_ALWAYS(session,
-                  upd_select->upd == NULL || F_ISSET(r, WT_REC_CHECKPOINT) ||
-                    upd_select->upd->txnid == upd->txnid,
-                  "Cannot have two different prepared transactions active on the same key");
 
                 if (upd->prepare_ts > r->rec_start_pinned_stable_ts) {
                     WT_ASSERT(session, !is_hs_page);
@@ -932,6 +923,10 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
               *write_prepare && upd->prepare_state == WT_PREPARE_INPROGRESS &&
                 prepare_rollback_tombstone->next == upd);
             upd_select->upd = upd;
+            /*
+             * If we have seen a tombstone that rolled back the prepared update, this must be the
+             * prepared update. No need to walk further.
+             */
             prepare_rollback_tombstone = NULL;
         }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -733,7 +733,6 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
              * If we have seen a tombstone that rolled back the prepared update, this must be the
              * prepared update. No need to walk further.
              */
-            prepare_rollback_tombstone = NULL;
             txnid = upd->upd_saved_txnid;
         }
 
@@ -933,6 +932,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_UPDATE *first_up
               *write_prepare && upd->prepare_state == WT_PREPARE_INPROGRESS &&
                 prepare_rollback_tombstone->next == upd);
             upd_select->upd = upd;
+            prepare_rollback_tombstone = NULL;
         }
 
         /* Track the selected update transaction id and timestamp. */

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1189,9 +1189,10 @@ done:
      * 1. The connection is not read-only. A read-only connection expects that there shouldn't be
      *    any changes that need to be done on the database other than reading.
      * 2. The history store file was found in the metadata.
-     * 3. We are not using disaggregated storage.
+     * 3. We are not using disaggregated storage or precise checkpoint
      */
-    if (hs_exists_local && !F_ISSET(conn, WT_CONN_READONLY) && !disagg) {
+    if (hs_exists_local && !F_ISSET(conn, WT_CONN_READONLY) && !disagg &&
+      !F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT)) {
         const char *rts_cfg[] = {
           WT_CONFIG_BASE(session, WT_CONNECTION_rollback_to_stable), NULL, NULL};
         __wt_timer_start(session, &rts_timer);

--- a/test/suite/prepare_util.py
+++ b/test/suite/prepare_util.py
@@ -30,22 +30,25 @@ import wttest
 class test_prepare_preserve_prepare_base(wttest.WiredTigerTestCase):
     conn_config = 'precise_checkpoint=true,preserve_prepared=true,statistics=(all)'
 
-    def get_stats(self, stats, uri):
+    def get_stats(self, stats, uri, session):
         """Get the current values of multiple statistics."""
-        stat_cursor = self.session.open_cursor('statistics:' + uri)
+        stat_cursor = session.open_cursor('statistics:' + uri)
         results = {}
         for stat in stats:
             results[stat] = stat_cursor[stat][2]
         stat_cursor.close()
         return results
 
-    def checkpoint_and_verify_stats(self, expected_changes, uri):
+    def checkpoint_and_verify_stats(self, expected_changes, uri, session = None):
+        if session is None:
+            session = self.session
+
         stats_to_check = list(expected_changes.keys())
-        old_stats = self.get_stats(stats_to_check, uri)
+        old_stats = self.get_stats(stats_to_check, uri, session)
 
-        self.session.checkpoint()
+        session.checkpoint()
 
-        new_stats = self.get_stats(stats_to_check, uri)
+        new_stats = self.get_stats(stats_to_check, uri, session)
 
         for stat, expect_increase in expected_changes.items():
             diff = new_stats[stat] - old_stats[stat]

--- a/test/suite/test_prepare40.py
+++ b/test/suite/test_prepare40.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_prepare40.py
+# Test that checkpoint after opening a backup with prepared updates (preserve prepared on) doesn't crash by:
+# - checkpoint writes prepared update to disk
+# - Claim the prepared updateand rollback, do not advance the stable timestamp
+# - Checkpoint again. it should not crash and should write the rolled back update as prepared to disk
+
+import random, sys
+from suite_subprocess import suite_subprocess
+import wttest
+from wtscenario import make_scenarios
+
+class test_prepare40(wttest.WiredTigerTestCase, suite_subprocess):
+    tablename = 'test_prepare40'
+    uri = 'table:' + tablename
+    conn_config = 'precise_checkpoint=true,preserve_prepared=true'
+
+    types = [
+        ('row', dict(s_config='key_format=i,value_format=S')),
+    ]
+
+    # Transaction end types
+    txn_end = [
+        ('txn_commit', dict(txn_commit=True)),
+    ]
+
+    scenarios = make_scenarios(types, txn_end)
+
+    def test_prepare_discover01(self):
+        # Currently this test will crash because we try recover before setting preserve_prepared flag.
+        # Support this by moving recovery to after setting precise_checkpoint and preserve_prepared flags.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
+        self.session.create(self.uri, self.s_config)
+        c = self.session.open_cursor(self.uri)
+
+        self.session.begin_transaction()
+        c[1] = "commit ts=60"
+        c[2] = "commit ts=60"
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(60))
+
+        # Insert a few keys then prepare the transaction
+        self.session.begin_transaction()
+        c[3] = "prepare ts=100"
+        c[4] = "prepare ts=100"
+        c[5] = "prepare ts=100"
+        # Prepare with a timestamp greater than current stable
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +',prepared_id=' + self.prepared_id_str(123))
+        # Move the stable timestamp to include the prepared transaction
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
+        # Create a checkpoint
+        session2 = self.conn.open_session()
+        session2.checkpoint()
+
+        # Creating backup that will preserve artifacts
+        backup_dir = 'bkp'
+        self.backup(backup_dir, session2)
+
+        # Opening backup database
+        conn2 = self.wiredtiger_open(backup_dir, self.conn_config)
+
+        c2s1 = conn2.open_session()
+
+        # Opening prepared discover cursor
+        prepared_discover_cursor = c2s1.open_cursor("prepared_discover:")
+
+        # Walking through prepared discover cursor
+        c2s2 = conn2.open_session()
+        count = 0
+        while prepared_discover_cursor.next() == 0:
+            count += 1
+            prepared_id = prepared_discover_cursor.get_key()
+            self.assertEqual(prepared_id, 100)
+            c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
+            c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
+        self.assertEqual(count, 1)
+
+        prepared_discover_cursor.close()
+
+        session3 = self.conn.open_session()
+        session3.checkpoint()

--- a/test/suite/test_prepare40.py
+++ b/test/suite/test_prepare40.py
@@ -29,7 +29,7 @@
 # test_prepare40.py
 # Test that checkpoint after opening a backup with prepared updates (preserve prepared on) doesn't crash by:
 # - Checkpoint writes prepared update to disk
-# - Collback the transaction with rollback timestamp > stable timestamp
+# - Rollback the transaction with rollback timestamp > stable timestamp
 # - Checkpoint again. it should not crash and should write the rolled back update as prepared to disk
 
 import wiredtiger
@@ -68,7 +68,7 @@ class test_prepare40(test_prepare_preserve_prepare_base):
         session2 = self.conn.open_session()
         session2.checkpoint()
 
-        # Step 6: Force eviction to trigger reconciliation
+        # Force eviction to trigger reconciliation
         # This ensures the committed update gets written to disk storage
         session_evict = self.conn.open_session("debug=(release_evict_page=true)")
         session_evict.begin_transaction("ignore_prepare=true")

--- a/test/suite/test_prepare40.py
+++ b/test/suite/test_prepare40.py
@@ -28,8 +28,8 @@
 #
 # test_prepare40.py
 # Test that checkpoint after opening a backup with prepared updates (preserve prepared on) doesn't crash by:
-# - checkpoint writes prepared update to disk
-# - Claim the prepared updateand rollback, do not advance the stable timestamp
+# - Checkpoint writes prepared update to disk
+# - Collback the transaction with rollback timestamp > stable timestamp
 # - Checkpoint again. it should not crash and should write the rolled back update as prepared to disk
 
 import wiredtiger
@@ -68,33 +68,23 @@ class test_prepare40(test_prepare_preserve_prepare_base):
         session2 = self.conn.open_session()
         session2.checkpoint()
 
-        # Creating backup that will preserve artifacts
-        backup_dir = 'bkp'
-        self.backup(backup_dir, session2)
+        # Step 6: Force eviction to trigger reconciliation
+        # This ensures the committed update gets written to disk storage
+        session_evict = self.conn.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 3):  # Evict to trigger reconciliation
+            evict_cursor.set_key(i)
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
 
-        # Opening backup database
-        conn2 = self.wiredtiger_open(backup_dir, self.conn_config)
+        self.session.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
 
-        c2s1 = conn2.open_session()
-
-        # Opening prepared discover cursor
-        prepared_discover_cursor = c2s1.open_cursor("prepared_discover:")
-
-        # Walking through prepared discover cursor
-        c2s2 = conn2.open_session()
-        count = 0
-        while prepared_discover_cursor.next() == 0:
-            count += 1
-            prepared_id = prepared_discover_cursor.get_key()
-            self.assertEqual(prepared_id, 100)
-            c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
-            c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
-        self.assertEqual(count, 1)
-
-        prepared_discover_cursor.close()
         session3 = self.conn.open_session()
-
-        # check that we're writing updates as prepared again
+        # Check that we're writing updates as prepared again
         self.checkpoint_and_verify_stats({
             wiredtiger.stat.dsrc.rec_time_window_prepared: True,
         }, self.uri, session3)

--- a/test/suite/test_prepare40.py
+++ b/test/suite/test_prepare40.py
@@ -32,33 +32,22 @@
 # - Claim the prepared updateand rollback, do not advance the stable timestamp
 # - Checkpoint again. it should not crash and should write the rolled back update as prepared to disk
 
-import random, sys
-from suite_subprocess import suite_subprocess
-import wttest
+import wiredtiger
+from prepare_util import test_prepare_preserve_prepare_base
 from wtscenario import make_scenarios
 
-class test_prepare40(wttest.WiredTigerTestCase, suite_subprocess):
+class test_prepare40(test_prepare_preserve_prepare_base):
     tablename = 'test_prepare40'
     uri = 'table:' + tablename
     conn_config = 'precise_checkpoint=true,preserve_prepared=true'
 
-    types = [
-        ('row', dict(s_config='key_format=i,value_format=S')),
-    ]
 
-    # Transaction end types
-    txn_end = [
-        ('txn_commit', dict(txn_commit=True)),
-    ]
+    def test_prepare40(self):
 
-    scenarios = make_scenarios(types, txn_end)
-
-    def test_prepare_discover01(self):
-        # Currently this test will crash because we try recover before setting preserve_prepared flag.
-        # Support this by moving recovery to after setting precise_checkpoint and preserve_prepared flags.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
-        self.session.create(self.uri, self.s_config)
+        create_params = 'key_format=i,value_format=S'
+        self.session.create(self.uri, create_params)
         c = self.session.open_cursor(self.uri)
 
         self.session.begin_transaction()
@@ -103,6 +92,9 @@ class test_prepare40(wttest.WiredTigerTestCase, suite_subprocess):
         self.assertEqual(count, 1)
 
         prepared_discover_cursor.close()
-
         session3 = self.conn.open_session()
-        session3.checkpoint()
+
+        # check that we're writing updates as prepared again
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+        }, self.uri, session3)

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -52,8 +52,6 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
     scenarios = make_scenarios(types, txn_end)
 
     def test_prepare_discover01(self):
-        # Currently this test will crash because we try recover before setting preserve_prepared flag.
-        # Support this by moving recovery to after setting precise_checkpoint and preserve_prepared flags.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
         self.session.create(self.uri, self.s_config)

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -80,6 +80,7 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         # Creating backup that will preserve artifacts
         backup_dir = 'bkp'
         self.backup(backup_dir, session2)
+
         # Opening backup database
         conn2 = self.wiredtiger_open(backup_dir, self.conn_config)
 

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -56,7 +56,6 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         # Support this by moving recovery to after setting precise_checkpoint and preserve_prepared flags.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
-        self.skipTest('FIXME-WT-15113 Enable when we support recovery from backup with preserve_prepare config')
         self.session.create(self.uri, self.s_config)
         c = self.session.open_cursor(self.uri)
 
@@ -81,7 +80,6 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         # Creating backup that will preserve artifacts
         backup_dir = 'bkp'
         self.backup(backup_dir, session2)
-
         # Opening backup database
         conn2 = self.wiredtiger_open(backup_dir, self.conn_config)
 


### PR DESCRIPTION
Before `test_prepare_discover01` would fail because RTS will rollback all prepared transactions. This PR disables RTS when precise checkpoint is on, and fixes prepare_rollback_tombstone reset logic so that prepare discover cursor can work properly with this setting. 