### PR TITLE
WT-15173 Fix coverity error, require check for realloc return.

### DIFF
--- a/bench/dhandle/bench_dhandle.c
+++ b/bench/dhandle/bench_dhandle.c
@@ -608,7 +608,7 @@ queuer(void *void_args)
         if (queue_len > 0)
             printf("Work queue length at %d, adding %d items for range %d, %d\n", queue_len,
               items_to_add, shared->low, shared->high);
-        table_numbers = realloc(table_numbers, sizeof(int) * (size_t)table_count);
+        table_numbers = drealloc(table_numbers, sizeof(int) * (size_t)table_count);
         for (i = 0; i < table_count; ++i)
             table_numbers[i] = i;
         shuffle(table_numbers, table_count, &rnd);


### PR DESCRIPTION
The change causes the test to abort with a failure message if realloc returns NULL.