### PR TITLE
WT-14653 Add reconciliation stats for history store wrapup (8.0 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -791,7 +791,9 @@ conn_stats = [
     YieldStat('page_index_slot_ref_blocked', 'get reference for page index and slot time sleeping (usecs)'),
     YieldStat('page_locked_blocked', 'page acquire locked blocked'),
     YieldStat('page_read_blocked', 'page acquire read blocked'),
+    YieldStat('page_read_skip_deleted', 'pages skipped during read due to deleted state'),
     YieldStat('page_sleep', 'page acquire time sleeping (usecs)'),
+    YieldStat('page_split_restart', 'page split and restart read'),
     YieldStat('prepared_transition_blocked_page', 'page access yielded due to prepare state change'),
     YieldStat('txn_release_blocked', 'connection close blocked waiting for transaction state stabilization'),
 ]
@@ -1147,6 +1149,7 @@ conn_dsrc_stats = [
     ##########################################
     # Reconciliation statistics
     ##########################################
+    RecStat('rec_hs_wrapup_next_prev_calls', 'cursor next/prev calls during HS wrapup search_near'),
     RecStat('rec_overflow_key_leaf', 'leaf-page overflow keys'),
     RecStat('rec_overflow_value', 'overflow values written'),
     RecStat('rec_page_delete', 'pages deleted'),

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -789,6 +789,10 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 
     WT_STAT_CONN_DATA_INCR(session, cursor_next);
 
+    /* Track next calls during HS wrapup */
+    if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
+        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+
     flags = WT_READ_NO_SPLIT | WT_READ_SKIP_INTL; /* tree walk flags */
     if (truncating)
         LF_SET(WT_READ_TRUNCATE);
@@ -894,6 +898,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
                 continue;
             }
         }
+
         /*
          * If we saw a lot of deleted records on this page, or we went all the way through a page
          * and only saw deleted records, try to evict the page when we release it. Otherwise

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -753,6 +753,10 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 
     WT_STAT_CONN_DATA_INCR(session, cursor_prev);
 
+    /* Track prev calls during HS wrapup */
+    if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
+        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+
     /* tree walk flags */
     flags = WT_READ_NO_SPLIT | WT_READ_PREV | WT_READ_SKIP_INTL;
     if (truncating)

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -302,8 +302,10 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
             if (LF_ISSET(WT_READ_CACHE | WT_READ_NO_WAIT))
                 return (WT_NOTFOUND);
             if (LF_ISSET(WT_READ_SKIP_DELETED) &&
-              __wti_delete_page_skip(session, ref, !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT)))
+              __wti_delete_page_skip(session, ref, !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))) {
+                WT_STAT_CONN_INCR(session, page_read_skip_deleted);
                 return (WT_NOTFOUND);
+            }
             goto read;
         case WT_REF_DISK:
             /* Optionally limit reads to cache-only. */
@@ -350,6 +352,7 @@ read:
             stalled = true;
             break;
         case WT_REF_SPLIT:
+            WT_STAT_CONN_INCR(session, page_split_restart);
             return (WT_RESTART);
         case WT_REF_MEM:
             /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -191,6 +191,11 @@ struct __wt_session_impl {
         uint64_t total_reentry_hs_eviction_time;
     } reconcile_timeline;
 
+    /* Record statistics in an reconciliation. */
+    struct __wt_reconcile_stats {
+        uint64_t hs_wrapup_next_prev_calls;
+    } reconcile_stats;
+
     /*
      * Record the important timestamps of each stage in an eviction. If an eviction takes a long
      * time and times out, we can trace the time usage of each stage from this information.
@@ -294,20 +299,21 @@ struct __wt_session_impl {
 #define WT_SESSION_DEBUG_DO_NOT_CLEAR_TXN_ID 0x000020u
 #define WT_SESSION_DEBUG_RELEASE_EVICT 0x000040u
 #define WT_SESSION_EVICTION 0x000080u
-#define WT_SESSION_IGNORE_CACHE_SIZE 0x000100u
-#define WT_SESSION_IMPORT 0x000200u
-#define WT_SESSION_IMPORT_REPAIR 0x000400u
-#define WT_SESSION_INTERNAL 0x000800u
-#define WT_SESSION_LOGGING_INMEM 0x001000u
-#define WT_SESSION_NO_DATA_HANDLES 0x002000u
-#define WT_SESSION_NO_RECONCILE 0x004000u
-#define WT_SESSION_PREFETCH_ENABLED 0x008000u
-#define WT_SESSION_PREFETCH_THREAD 0x010000u
-#define WT_SESSION_QUIET_CORRUPT_FILE 0x020000u
-#define WT_SESSION_READ_WONT_NEED 0x040000u
-#define WT_SESSION_RESOLVING_TXN 0x080000u
-#define WT_SESSION_ROLLBACK_TO_STABLE 0x100000u
-#define WT_SESSION_SCHEMA_TXN 0x200000u
+#define WT_SESSION_HS_WRAPUP 0x000100u
+#define WT_SESSION_IGNORE_CACHE_SIZE 0x000200u
+#define WT_SESSION_IMPORT 0x000400u
+#define WT_SESSION_IMPORT_REPAIR 0x000800u
+#define WT_SESSION_INTERNAL 0x001000u
+#define WT_SESSION_LOGGING_INMEM 0x002000u
+#define WT_SESSION_NO_DATA_HANDLES 0x004000u
+#define WT_SESSION_NO_RECONCILE 0x008000u
+#define WT_SESSION_PREFETCH_ENABLED 0x010000u
+#define WT_SESSION_PREFETCH_THREAD 0x020000u
+#define WT_SESSION_QUIET_CORRUPT_FILE 0x040000u
+#define WT_SESSION_READ_WONT_NEED 0x080000u
+#define WT_SESSION_RESOLVING_TXN 0x100000u
+#define WT_SESSION_ROLLBACK_TO_STABLE 0x200000u
+#define WT_SESSION_SCHEMA_TXN 0x400000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t flags;
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -923,6 +923,7 @@ struct __wt_connection_stats {
     int64_t rec_vlcs_emptied_pages;
     int64_t rec_time_window_bytes_ts;
     int64_t rec_time_window_bytes_txn;
+    int64_t rec_hs_wrapup_next_prev_calls;
     int64_t rec_page_delete_fast;
     int64_t rec_overflow_key_leaf;
     int64_t rec_maximum_milliseconds;
@@ -1017,6 +1018,8 @@ struct __wt_connection_stats {
     int64_t page_sleep;
     int64_t page_del_rollback_blocked;
     int64_t child_modify_blocked_page;
+    int64_t page_split_restart;
+    int64_t page_read_skip_deleted;
     int64_t txn_prepared_updates;
     int64_t txn_prepared_updates_committed;
     int64_t txn_prepared_updates_key_repeated;
@@ -1344,6 +1347,7 @@ struct __wt_dsrc_stats {
     int64_t rec_vlcs_emptied_pages;
     int64_t rec_time_window_bytes_ts;
     int64_t rec_time_window_bytes_txn;
+    int64_t rec_hs_wrapup_next_prev_calls;
     int64_t rec_dictionary;
     int64_t rec_page_delete_fast;
     int64_t rec_suffix_compression;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6870,405 +6870,411 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * written
  */
 #define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1557
+/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1558
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1558
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1559
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1559
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1560
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1560
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1561
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1561
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1562
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1562
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1563
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1563
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1564
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1564
+#define	WT_STAT_CONN_REC_PAGES				1565
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1565
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1566
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1566
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1567
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1567
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1568
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1568
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1569
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1569
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1570
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1570
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1571
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1571
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1572
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1572
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1573
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1573
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1574
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1574
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1575
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1575
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1576
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1576
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1577
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1577
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1578
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1578
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1579
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1579
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1580
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1580
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1581
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1581
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1582
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1582
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1583
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1583
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1584
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1584
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1585
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1585
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1586
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1586
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1587
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1587
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1588
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1588
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1589
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1589
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1590
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1590
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1591
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1591
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1592
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1592
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1593
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1593
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1594
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1594
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1595
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1595
+#define	WT_STAT_CONN_FLUSH_TIER				1596
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1596
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1597
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1597
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1598
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1598
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1599
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1599
+#define	WT_STAT_CONN_SESSION_OPEN			1600
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1600
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1601
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1601
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1602
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1602
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1603
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1603
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1604
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1604
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1605
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1605
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1606
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1606
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1607
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1607
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1608
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1608
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1609
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1609
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1610
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1610
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1611
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1611
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1612
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1612
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1613
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1613
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1614
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1614
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1615
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1615
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1616
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1616
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1617
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1617
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1618
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1618
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1619
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1619
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1620
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1620
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1621
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1621
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1622
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1622
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1623
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1623
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1624
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1624
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1625
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1625
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1626
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1626
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1627
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1627
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1628
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1628
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1629
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1629
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1630
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1630
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1631
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1631
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1632
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1632
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1633
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1633
+#define	WT_STAT_CONN_TIERED_RETENTION			1634
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1634
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1635
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1635
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1636
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1636
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1637
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1637
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1638
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1638
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1639
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1639
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1640
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1640
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1641
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1641
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1642
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1642
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1643
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1643
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1644
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1644
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1645
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1645
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1646
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1646
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1647
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1647
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1648
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1648
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1649
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1649
+#define	WT_STAT_CONN_PAGE_SLEEP				1650
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1650
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1651
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1651
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1652
+/*! thread-yield: page split and restart read */
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1653
+/*! thread-yield: pages skipped during read due to deleted state */
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1654
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1652
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1655
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1653
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1656
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1654
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1657
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1655
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1658
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1656
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1659
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1657
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1660
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1658
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1661
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1659
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1662
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1660
+#define	WT_STAT_CONN_TXN_PREPARE			1663
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1661
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1664
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1662
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1665
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1663
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1666
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1664
+#define	WT_STAT_CONN_TXN_QUERY_TS			1667
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1665
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1668
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1666
+#define	WT_STAT_CONN_TXN_RTS				1669
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1667
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1670
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1668
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1671
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1669
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1672
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1670
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1673
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1671
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1674
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1672
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1675
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1673
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1676
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1674
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1677
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1675
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1678
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1676
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1679
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1677
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1680
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1678
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1681
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1679
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1682
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1680
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1683
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1681
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1684
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1682
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1685
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1683
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1686
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1684
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1687
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1685
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1688
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1686
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1689
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1687
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1690
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1688
+#define	WT_STAT_CONN_TXN_SET_TS				1691
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1689
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1692
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1690
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1693
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1691
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1694
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1692
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1695
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1693
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1696
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1694
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1697
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1695
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1698
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1696
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1699
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1697
+#define	WT_STAT_CONN_TXN_BEGIN				1700
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1698
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1701
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1699
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1702
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1700
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1703
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1701
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1704
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1702
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1705
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1703
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1706
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1704
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1707
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1705
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1708
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1706
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1709
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1707
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1710
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1708
+#define	WT_STAT_CONN_TXN_COMMIT				1711
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1709
+#define	WT_STAT_CONN_TXN_ROLLBACK			1712
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1710
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1713
 
 /*!
  * @}
@@ -8073,171 +8079,173 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * written
  */
 #define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2260
+/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2261
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2261
+#define	WT_STAT_DSRC_REC_DICTIONARY			2262
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2262
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2263
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2263
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2264
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2264
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2265
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2265
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2266
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2266
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2267
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2267
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2268
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2268
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2269
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2269
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2270
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2270
+#define	WT_STAT_DSRC_REC_PAGES				2271
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2271
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2272
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2272
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2273
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2273
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2274
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2274
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2275
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2275
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2276
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2276
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2277
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2277
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2278
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2278
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2279
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2279
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2280
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2280
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2281
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2281
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2282
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2282
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2283
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2283
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2284
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2284
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2285
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2285
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2286
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2286
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2287
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2287
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2288
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2288
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2289
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2289
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2290
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2290
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2291
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2291
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2292
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2292
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2293
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2293
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2294
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2294
+#define	WT_STAT_DSRC_SESSION_COMPACT			2295
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2295
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2296
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2296
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2297
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2297
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2298
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2298
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2299
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2299
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2300
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2300
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2301
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2301
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2302
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2302
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2303
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2303
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2304
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2304
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2305
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2305
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2306
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2306
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2307
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2307
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2308
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2308
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2309
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2309
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2310
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2310
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2311
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2311
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2312
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2312
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2313
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2313
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2314
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2314
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2315
 
 /*!
  * @}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -355,6 +355,8 @@ struct __wt_rec_kv;
 typedef struct __wt_rec_kv WT_REC_KV;
 struct __wt_reconcile;
 typedef struct __wt_reconcile WT_RECONCILE;
+struct __wt_reconcile_stats;
+typedef struct __wt_reconcile_stats WT_RECONCILE_STATS;
 struct __wt_reconcile_timeline;
 typedef struct __wt_reconcile_timeline WT_RECONCILE_TIMELINE;
 struct __wt_recovery_timeline;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2690,6 +2690,10 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     btree = S2BT(session);
 
+    /* Set a flag in the session to track that we're in HS wrapup */
+    F_SET(session, WT_SESSION_HS_WRAPUP);
+    session->reconcile_stats.hs_wrapup_next_prev_calls = 0;
+
     /*
      * Sanity check: Can't insert updates into history store from the history store itself or from
      * the metadata file.
@@ -2719,7 +2723,10 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
             }
         }
 
+    WT_STAT_CONN_INCRV(
+      session, rec_hs_wrapup_next_prev_calls, session->reconcile_stats.hs_wrapup_next_prev_calls);
 err:
+    F_CLR(session, WT_SESSION_HS_WRAPUP);
     return (ret);
 }
 

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -279,6 +279,7 @@ static const char *const __stats_dsrc_desc[] = {
   "reconciliation: VLCS pages explicitly reconciled as empty",
   "reconciliation: approximate byte size of timestamps in pages written",
   "reconciliation: approximate byte size of transaction IDs in pages written",
+  "reconciliation: cursor next/prev calls during HS wrapup search_near",
   "reconciliation: dictionary matches",
   "reconciliation: fast-path pages deleted",
   "reconciliation: internal page key bytes discarded using suffix compression",
@@ -639,6 +640,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->rec_vlcs_emptied_pages = 0;
     stats->rec_time_window_bytes_ts = 0;
     stats->rec_time_window_bytes_txn = 0;
+    stats->rec_hs_wrapup_next_prev_calls = 0;
     stats->rec_dictionary = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_suffix_compression = 0;
@@ -996,6 +998,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->rec_vlcs_emptied_pages += from->rec_vlcs_emptied_pages;
     to->rec_time_window_bytes_ts += from->rec_time_window_bytes_ts;
     to->rec_time_window_bytes_txn += from->rec_time_window_bytes_txn;
+    to->rec_hs_wrapup_next_prev_calls += from->rec_hs_wrapup_next_prev_calls;
     to->rec_dictionary += from->rec_dictionary;
     to->rec_page_delete_fast += from->rec_page_delete_fast;
     to->rec_suffix_compression += from->rec_suffix_compression;
@@ -1369,6 +1372,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->rec_vlcs_emptied_pages += WT_STAT_READ(from, rec_vlcs_emptied_pages);
     to->rec_time_window_bytes_ts += WT_STAT_READ(from, rec_time_window_bytes_ts);
     to->rec_time_window_bytes_txn += WT_STAT_READ(from, rec_time_window_bytes_txn);
+    to->rec_hs_wrapup_next_prev_calls += WT_STAT_READ(from, rec_hs_wrapup_next_prev_calls);
     to->rec_dictionary += WT_STAT_READ(from, rec_dictionary);
     to->rec_page_delete_fast += WT_STAT_READ(from, rec_page_delete_fast);
     to->rec_suffix_compression += WT_STAT_READ(from, rec_suffix_compression);
@@ -2012,6 +2016,7 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: VLCS pages explicitly reconciled as empty",
   "reconciliation: approximate byte size of timestamps in pages written",
   "reconciliation: approximate byte size of transaction IDs in pages written",
+  "reconciliation: cursor next/prev calls during HS wrapup search_near",
   "reconciliation: fast-path pages deleted",
   "reconciliation: leaf-page overflow keys",
   "reconciliation: maximum milliseconds spent in a reconciliation call",
@@ -2108,6 +2113,8 @@ static const char *const __stats_connection_desc[] = {
   "thread-yield: page acquire time sleeping (usecs)",
   "thread-yield: page delete rollback time sleeping for state change (usecs)",
   "thread-yield: page reconciliation yielded due to child modification",
+  "thread-yield: page split and restart read",
+  "thread-yield: pages skipped during read due to deleted state",
   "transaction: Number of prepared updates",
   "transaction: Number of prepared updates committed",
   "transaction: Number of prepared updates repeated on the same key",
@@ -2771,6 +2778,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->rec_vlcs_emptied_pages = 0;
     stats->rec_time_window_bytes_ts = 0;
     stats->rec_time_window_bytes_txn = 0;
+    stats->rec_hs_wrapup_next_prev_calls = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_overflow_key_leaf = 0;
     /* not clearing rec_maximum_milliseconds */
@@ -2865,6 +2873,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->page_sleep = 0;
     stats->page_del_rollback_blocked = 0;
     stats->child_modify_blocked_page = 0;
+    stats->page_split_restart = 0;
+    stats->page_read_skip_deleted = 0;
     stats->txn_prepared_updates = 0;
     stats->txn_prepared_updates_committed = 0;
     stats->txn_prepared_updates_key_repeated = 0;
@@ -3580,6 +3590,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_vlcs_emptied_pages += WT_STAT_READ(from, rec_vlcs_emptied_pages);
     to->rec_time_window_bytes_ts += WT_STAT_READ(from, rec_time_window_bytes_ts);
     to->rec_time_window_bytes_txn += WT_STAT_READ(from, rec_time_window_bytes_txn);
+    to->rec_hs_wrapup_next_prev_calls += WT_STAT_READ(from, rec_hs_wrapup_next_prev_calls);
     to->rec_page_delete_fast += WT_STAT_READ(from, rec_page_delete_fast);
     to->rec_overflow_key_leaf += WT_STAT_READ(from, rec_overflow_key_leaf);
     to->rec_maximum_milliseconds += WT_STAT_READ(from, rec_maximum_milliseconds);
@@ -3687,6 +3698,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->page_sleep += WT_STAT_READ(from, page_sleep);
     to->page_del_rollback_blocked += WT_STAT_READ(from, page_del_rollback_blocked);
     to->child_modify_blocked_page += WT_STAT_READ(from, child_modify_blocked_page);
+    to->page_split_restart += WT_STAT_READ(from, page_split_restart);
+    to->page_read_skip_deleted += WT_STAT_READ(from, page_read_skip_deleted);
     to->txn_prepared_updates += WT_STAT_READ(from, txn_prepared_updates);
     to->txn_prepared_updates_committed += WT_STAT_READ(from, txn_prepared_updates_committed);
     to->txn_prepared_updates_key_repeated += WT_STAT_READ(from, txn_prepared_updates_key_repeated);


### PR DESCRIPTION
These are the stats we are adding as part of trying to identify an issue with workloads getting stuck during history store wrap up. They include:

- A stat to track pages skipped during read due to deleted state
- A stat to track how often pages were split and read restarted
- A stat to track how often next/prev were called during HS wrap up

(cherry picked from commit 6d4a8f816992bc9f9c5b3bdd8f6dddad918f157c)

(cherry picked from commit 111bb294a9e86484ef3ba115be85cca1a079f582)

