### PR TITLE
WT-15003 Remove the WT_DELTA_CELL_INT structure and pack internal page deltas with WT_CELL

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -173,7 +173,7 @@ __page_merge_internal_delta_with_base_image(WT_SESSION_IMPL *session, WT_REF *re
             WT_ERR(__page_build_ref(
               session, ref, base_key, base_val, NULL, true, &refs[final_entries++], incr));
         } else if (cmp >= 0) {
-            if (!F_ISSET(delta[j], WT_DELTA_INT_IS_DELETE))
+            if (__wt_cell_type_raw(delta[j]->value.cell) != WT_CELL_ADDR_DEL)
                 WT_ERR(__page_build_ref(
                   session, ref, NULL, NULL, delta[j], false, &refs[final_entries++], incr));
             if (cmp == 0)
@@ -189,7 +189,7 @@ __page_merge_internal_delta_with_base_image(WT_SESSION_IMPL *session, WT_REF *re
           session, ref, base_key, base_val, NULL, true, &refs[final_entries++], incr));
     }
     for (; j < delta_entries; j++)
-        if (!F_ISSET(delta[j], WT_DELTA_INT_IS_DELETE))
+        if (__wt_cell_type_raw(delta[j]->value.cell) != WT_CELL_ADDR_DEL)
             WT_ERR(__page_build_ref(
               session, ref, NULL, NULL, delta[j], false, &refs[final_entries++], incr));
 
@@ -304,8 +304,9 @@ __page_reconstruct_internal_deltas(
     for (i = 0, j = 0; i < (uint32_t)delta_size; ++i, j = 0) {
         header = (WT_PAGE_HEADER *)deltas[i].data;
         WT_ASSERT(session, header->u.entries != 0);
-        delta_size_each[i] = (size_t)header->u.entries;
+        WT_ASSERT(session, header->u.entries % 2 == 0);
 
+        delta_size_each[i] = (size_t)header->u.entries / 2; /* Each entry has a key and a value. */
         WT_ERR(__wt_calloc_def(session, header->u.entries, &unpacked_deltas[i]));
         WT_CELL_FOREACH_DELTA_INT(session, ref->page->dsk, header, unpacked_deltas[i][j])
         {

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -154,18 +154,6 @@ struct __wt_cell {
     uint8_t __chunk[98];
 };
 
-/*
- * WT_DELTA_CELL_INT --
- *  Variable-length, delta internal cell header.
- */
-struct __wt_delta_cell_int {
-    /*
-     * Maximum of 1 byte:
-     *  1: cell descriptor byte
-     */
-    uint8_t __chunk[1];
-};
-
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CELL_UNPACK_OVERFLOW 0x1u            /* cell is an overflow */
 #define WT_CELL_UNPACK_TIME_WINDOW_CLEARED 0x2u /* time window cleared because of restart */
@@ -237,9 +225,6 @@ struct __wt_cell_unpack_delta_int {
     uint32_t __len;
     WT_CELL_UNPACK_KV key;
     WT_CELL_UNPACK_ADDR value;
-
-#define WT_DELTA_INT_IS_DELETE 0x01u
-    uint8_t flags;
 };
 
 #define WT_VALUE_IS_DELETE 0x01u

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1396,37 +1396,6 @@ __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL
 }
 
 /*
- * __wt_cell_unpack_delta_int --
- *     Unpack an internal delta cell into a structure.
- */
-static WT_INLINE void
-__wt_cell_unpack_delta_int(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *page_dsk,
-  const WT_PAGE_HEADER *dsk, WT_DELTA_CELL_INT *cell, WT_CELL_UNPACK_DELTA_INT *unpack_delta)
-{
-    WT_DECL_RET;
-    const uint8_t *p;
-
-    WT_UNUSED(dsk);
-
-    unpack_delta->flags = cell->__chunk[0];
-    p = (uint8_t *)&cell->__chunk[1];
-
-    /* Unpack the key. */
-    __wt_cell_unpack_kv(session, page_dsk, (WT_CELL *)p, &unpack_delta->key);
-    p += unpack_delta->key.__len;
-
-    /* Optionally unpack the value if it exists. */
-    if (!F_ISSET(unpack_delta, WT_DELTA_INT_IS_DELETE)) {
-        __wt_cell_unpack_addr(session, page_dsk, (WT_CELL *)p, &unpack_delta->value);
-        p += unpack_delta->value.__len;
-    }
-
-    unpack_delta->__len = (uint32_t)WT_PTRDIFF(p, &cell->__chunk[0]);
-
-    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
-}
-
-/*
  * __wt_cell_unpack_delta_leaf_value --
  *     Unpack a leaf delta value cell into a structure.
  */
@@ -1547,10 +1516,12 @@ __wt_page_cell_data_ref_kv(
         uint32_t __i;                                                                           \
         uint8_t *__cell;                                                                        \
         for (__cell = WT_PAGE_HEADER_BYTE(S2BT(session), dsk), __i = (dsk)->u.entries; __i > 0; \
-             --__i) {                                                                           \
-            __wt_cell_unpack_delta_int(                                                         \
-              session, page_dsk, dsk, (WT_DELTA_CELL_INT *)__cell, &(unpack));                  \
-            __cell += (unpack).__len;
+             __i -= 2) {                                                                        \
+            WT_CELL_UNPACK_DELTA_INT *t_unpack = &unpack;                                       \
+            __wt_cell_unpack_kv(session, page_dsk, (WT_CELL *)__cell, &t_unpack->key);          \
+            __cell += t_unpack->key.__len;                                                      \
+            __wt_cell_unpack_addr(session, page_dsk, (WT_CELL *)__cell, &t_unpack->value);      \
+            __cell += t_unpack->value.__len;
 
 #define WT_CELL_FOREACH_DELTA_LEAF(session, dsk, unpack)                                        \
     do {                                                                                        \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2339,9 +2339,6 @@ static WT_INLINE void __wt_cell_type_reset(
   WT_SESSION_IMPL *session, WT_CELL *cell, u_int old_type, u_int new_type);
 static WT_INLINE void __wt_cell_unpack_addr(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,
   WT_CELL *cell, WT_CELL_UNPACK_ADDR *unpack_addr);
-static WT_INLINE void __wt_cell_unpack_delta_int(WT_SESSION_IMPL *session,
-  const WT_PAGE_HEADER *page_dsk, const WT_PAGE_HEADER *dsk, WT_DELTA_CELL_INT *cell,
-  WT_CELL_UNPACK_DELTA_INT *unpack_delta);
 static WT_INLINE void __wt_cell_unpack_delta_leaf_value(WT_SESSION_IMPL *session,
   const WT_PAGE_HEADER *dsk, WT_CELL *value_cell, WT_CELL_UNPACK_DELTA_LEAF_KV *unpack);
 static WT_INLINE void __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -225,8 +225,6 @@ struct __wt_data_handle;
 typedef struct __wt_data_handle WT_DATA_HANDLE;
 struct __wt_data_handle_cache;
 typedef struct __wt_data_handle_cache WT_DATA_HANDLE_CACHE;
-struct __wt_delta_cell_int;
-typedef struct __wt_delta_cell_int WT_DELTA_CELL_INT;
 struct __wt_disagg_copy_metadata;
 typedef struct __wt_disagg_copy_metadata WT_DISAGG_COPY_METADATA;
 struct __wt_disaggregated_checkpoint_track;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2194,6 +2194,7 @@ __wti_rec_pack_delta_internal(
     size_t packed_size;
     uint8_t *p;
 
+    WT_CLEAR (t_kv_struct);
     header = (WT_PAGE_HEADER *)r->delta.data;
 
     packed_size = key->len;
@@ -2217,7 +2218,6 @@ __wti_rec_pack_delta_internal(
         t_kv->buf.data = NULL;
         t_kv->buf.size = 0;
 
-        memcpy(p, t_kv->cell.__chunk, sizeof(t_kv->cell.__chunk));
         t_kv->cell_len = __wt_cell_pack_addr(
           session, &t_kv->cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, NULL, NULL, t_kv->buf.size);
         t_kv->len = t_kv->cell_len + t_kv->buf.size;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2194,7 +2194,7 @@ __wti_rec_pack_delta_internal(
     size_t packed_size;
     uint8_t *p;
 
-    WT_CLEAR (t_kv_struct);
+    WT_CLEAR(t_kv_struct);
     header = (WT_PAGE_HEADER *)r->delta.data;
 
     packed_size = key->len;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2219,6 +2219,7 @@ __wti_rec_pack_delta_internal(
 
         t_kv->cell_len = __wt_cell_pack_addr(
           session, &t_kv->cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, NULL, NULL, t_kv->buf.size);
+        t_kv->len = t_kv->cell_len + t_kv->buf.size;
     } else
         __wti_rec_kv_copy(session, p, value);
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2190,35 +2190,42 @@ __wti_rec_pack_delta_internal(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV *key, WTI_REC_KV *value)
 {
     WT_PAGE_HEADER *header;
+    WTI_REC_KV t_kv_struct, *t_kv;
     size_t packed_size;
-    uint8_t flags;
-    uint8_t *p, *head_byte;
-
-    flags = 0;
+    uint8_t *p;
 
     header = (WT_PAGE_HEADER *)r->delta.data;
 
-    packed_size = 1 + key->len;
+    packed_size = key->len;
     if (value != NULL)
         packed_size += value->len;
 
     if (r->delta.size + packed_size > r->delta.memsize)
         WT_RET(__wt_buf_grow(session, &r->delta, r->delta.size + packed_size));
 
-    head_byte = (uint8_t *)r->delta.data + r->delta.size;
-    p = head_byte + 1;
+    p = (uint8_t *)r->delta.data + r->delta.size;
 
     __wti_rec_kv_copy(session, p, key);
     p += key->len;
-    if (value == NULL)
-        LF_SET(WT_DELTA_INT_IS_DELETE);
-    else
+
+    /*
+     * If the value is NULL then write the zeroed out values and set the cell type to
+     * WT_CELL_ADDR_DEL.
+     */
+    if (value == NULL) {
+        t_kv = &t_kv_struct;
+        t_kv->buf.data = NULL;
+        t_kv->buf.size = 0;
+
+        t_kv->cell_len = __wt_cell_pack_addr(
+          session, &t_kv->cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, NULL, NULL, t_kv->buf.size);
+        t_kv->len = t_kv->cell_len + t_kv->buf.size;
+    } else
         __wti_rec_kv_copy(session, p, value);
 
     r->delta.size += packed_size;
-    *head_byte = flags;
 
-    ++header->u.entries;
+    header->u.entries += 2; /* Two entries: key and value. */
     header->mem_size = (uint32_t)r->delta.size;
 
     return (0);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2219,7 +2219,6 @@ __wti_rec_pack_delta_internal(
 
         t_kv->cell_len = __wt_cell_pack_addr(
           session, &t_kv->cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, NULL, NULL, t_kv->buf.size);
-        t_kv->len = t_kv->cell_len + t_kv->buf.size;
     } else
         __wti_rec_kv_copy(session, p, value);
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2217,9 +2217,12 @@ __wti_rec_pack_delta_internal(
         t_kv->buf.data = NULL;
         t_kv->buf.size = 0;
 
+        memcpy(p, t_kv->cell.__chunk, sizeof(t_kv->cell.__chunk));
         t_kv->cell_len = __wt_cell_pack_addr(
           session, &t_kv->cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, NULL, NULL, t_kv->buf.size);
         t_kv->len = t_kv->cell_len + t_kv->buf.size;
+        __wti_rec_kv_copy(session, p, t_kv);
+        packed_size += t_kv->len;
     } else
         __wti_rec_kv_copy(session, p, value);
 

--- a/test/suite/test_layered32.py
+++ b/test/suite/test_layered32.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import random, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+from wiredtiger import stat
+import time
+
+
+# test_layered32.py
+# Test that we write internal page deltas to the page log extension.
+
+@disagg_test_class
+class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    encrypt = [
+        ('none', dict(encryptor='none', encrypt_args='')),
+        ('rotn', dict(encryptor='rotn', encrypt_args='keyid=13')),
+    ]
+
+    compress = [
+        ('none', dict(block_compress='none')),
+        ('snappy', dict(block_compress='snappy')),
+    ]
+
+    uris = [
+        ('layered', dict(uri='layered:test_layered32')),
+        ('btree', dict(uri='file:test_layered32')),
+    ]
+
+    ts = [
+        ('ts', dict(ts=True)),
+        ('non-ts', dict(ts=False)),
+    ]
+
+    delta = [
+        ('write_leaf_only', dict(delta_config='page_delta=(internal_page_delta=false,leaf_page_delta=true)', delta_type='leaf_only')),
+        ('write_internal_only', dict(delta_config='page_delta=(internal_page_delta=true,leaf_page_delta=false)', delta_type='internal_only')),
+        ('write_none', dict(delta_config='page_delta=(internal_page_delta=false,leaf_page_delta=false)', delta_type='none')),
+        ('write_both', dict(delta_config='page_delta=(internal_page_delta=true,leaf_page_delta=true)', delta_type='both')),
+    ]
+
+    conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),page_delta=(delta_pct=100),'
+    disagg_storages = gen_disagg_storages('test_layered32', disagg_only = True)
+
+    # Make scenarios for different cloud service providers
+    scenarios = make_scenarios(encrypt, compress, disagg_storages, uris, ts, delta)
+
+    nitems = 10_000
+
+    def session_create_config(self):
+        # The delta percentage of 100 is an arbitrary large value, intended to produce
+        # deltas a lot of the time.
+        cfg = 'key_format=S,value_format=S,allocation_size=512,leaf_page_max=512,internal_page_max=512,block_compressor={}'.format(self.block_compress)
+        if self.uri.startswith('file'):
+            cfg += ',block_manager=disagg'
+        return cfg
+
+    def conn_config(self):
+        enc_conf = 'encryption=(name={0},{1}),'.format(self.encryptor, self.encrypt_args)
+        return self.conn_base_config + f'disaggregated=(role="leader"),{self.delta_config},' + enc_conf
+
+    # Load the storage store extension.
+    def conn_extensions(self, extlist):
+        extlist.extension('compressors', self.block_compress)
+        extlist.extension('encryptors', self.encryptor)
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def delete_range(self, uri, num_keys):
+        c = self.session.open_cursor(uri, None)
+        for i in range(num_keys):
+            c.set_key(i)
+            c.remove()
+        c.close()
+
+    def insert(self, kv, ts=None):
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for k, v in kv.items():
+            self.session.begin_transaction()
+            cursor[k] = v
+            if self.ts:
+                self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(ts))
+            else:
+                self.session.commit_transaction()
+        cursor.close()
+
+    def verify(self, expected_kv, expected_initial_val):
+        # Verify the values in the table.
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(1, self.nitems + 1):
+            cursor.set_key(str(i))
+            cursor.search()
+            if str(i) in expected_kv:
+                self.assertEqual(cursor.get_value(), expected_kv[str(i)])
+            else:
+                self.assertEqual(cursor.get_value(), expected_initial_val)
+        cursor.close()
+
+    def test_internal_page_delta_simple(self):
+        self.session.create(self.uri, self.session_create_config())
+
+        # Populate the table with nitems.
+        inital_value = "abc" * 10
+        inital_ts = 5
+        kv = {str(i): inital_value for i in range(1, self.nitems + 1)}
+        self.insert(kv, inital_ts)
+        self.session.checkpoint()
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        # Perform two small updates.
+        kv_modfied = {str(10): "10abc", str(220): "220abc"}
+        self.insert(kv_modfied, inital_ts + 1)
+        # Perform a checkpoint to write out a delta.
+        self.session.checkpoint()
+
+        if (self.delta_type == 'both' or self.delta_type == 'leaf_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+        if (self.delta_type == 'none'):
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        # Verify the updated values in the table.
+        self.verify(kv_modfied, inital_value)
+
+        # Assert that we have constructed at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+        else:
+            self.assertEqual(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+
+        follower_config = self.conn_base_config + 'disaggregated=(role="follower"),'
+        self.reopen_disagg_conn(follower_config)
+        time.sleep(1.0)
+
+        # Verify the updated values in the table.
+        self.verify(kv_modfied, inital_value)
+
+        # Assert that we have constructed at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+        else:
+            self.assertEqual(self.get_stat(stat.conn.cache_read_internal_delta), 0)


### PR DESCRIPTION
This pull request has the following changes

Replaced the flag WT_DELTA_INT_IS_DELETE with WT_CELL_ADDR_DEL throughout the codebase.
Replaced WT_DELTA_CELL_INT structure and packing/unpacking the internal delta into WT_CELL structure
Removed the WT_DELTA_CELL_INT struct and its typedef.
Updated packing/unpacking logic and macros to use the new flag.
Updated function signatures and usages to remove references to the deleted struct.
Updated logic in rec_write.c to set the new flag and handle value assignment accordingly.
Added a Python test