### PR TITLE
WT-14836 Add unclean shutdown to compatibility tests

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -556,7 +556,7 @@ test_dirty_upgrade()
 
     # Ignore the error resulting from the segfault.
     set +e
-    ./t "$flags" -c "$config_file" -h "$dir" format.abort=1
+    ./t ${flags} -c "$config_file" -h "$dir" format.abort=1
     set -e
     popd
 
@@ -564,7 +564,7 @@ test_dirty_upgrade()
     # against those.
     pushd "${dst_branch}/build/test/format"
     local dir="../../../../${src_branch}/build/test/format/RUNDIR.${src_branch}"
-    ./t "$flags" -c "$config_file" -h "$dir"
+    ./t ${flags} -c "$config_file" -h "$dir"
 
     # Remove the database so future runs don't try to use it.
     rm -rf "$dir"

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -547,7 +547,8 @@ test_dirty_restart()
 
     # Don't worry about changing flags for the dst branch, we're going to restart it from the source
     # branch's working directory anwyay.
-    local flags="-1q $(bflag $src_branch)"
+    # local flags="-1q $(bflag $src_branch)"
+    local flags="-1q "
     local config_file="../../../../CONFIG_${src_branch}"
 
     # Run format on the source branch until it aborts.
@@ -556,15 +557,20 @@ test_dirty_restart()
 
     # Ignore the error resulting from the segfault.
     set +e
-    ./t ${flags} -c "$config_file" -h "$dir" format.abort=1
+    ./t ${flags} -c "$config_file" -h "$dir" format.abort=1 btree.reverse=0
     set -e
     popd
 
     # We now have a directory with WT files that resulted from a crash. Run the newer version
     # against those.
     pushd "${dst_branch}/build/test/format"
+    pwd
     local dir="../../../../${src_branch}/build/test/format/RUNDIR.${src_branch}"
-    ./t ${flags} -c "$config_file" -h "$dir"
+    # TODO giant hack, replace the old-school path with the new one
+    pwd
+    ls
+    sed --in-place -e 's/\/\.libs//g' "$dir"/WiredTiger.basecfg
+    ./t ${flags} -R -h "$dir" format.abort=0
 
     # Remove the database so future runs don't try to use it.
     rm -rf "$dir"
@@ -970,7 +976,7 @@ if [ "$dirty_restart" = true ]; then
     # treat that as a combination worth testing.
     for b1 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
         for b2 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
-            if [[ "$b1" != "$b2" ]]; then
+            if [[ "$b1" < "$b2" ]]; then
                 test_dirty_restart "$b1" "$b2"
             fi
         done

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -961,8 +961,6 @@ if [ "$upgrade_to_latest" = true ]; then
 fi
 
 if [ "$dirty_upgrade" = true ]; then
-    test_root="$(pwd)"
-
     for b in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
         create_configs "$b"
         pushd .
@@ -970,7 +968,8 @@ if [ "$dirty_upgrade" = true ]; then
         popd
     done
 
-    # Go over the release branches, from pair to pair. If a pair is a
+    # Go over the release branches, from pair to pair. If a pair has the LHS older than the RHS,
+    # treat that as a combination worth testing.
     for b1 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
         for b2 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
             if [[ "$b1" < "$b2" ]]; then

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -17,7 +17,7 @@ bcopy()
     test "$1" = "mongodb-7.0" && echo "1"
     test "$1" = "mongodb-6.0" && echo "1"
     test "$1" = "mongodb-5.0" && echo "1"
-    # test "$1" = "mongodb-4.4" && echo "1"
+    test "$1" = "mongodb-4.4" && echo "1"
     # Anything newer than mongodb-8.0 returns false.
     return 0
 }
@@ -34,7 +34,7 @@ bflag()
     test "$1" = "mongodb-7.0" && echo "-B "
     test "$1" = "mongodb-6.0" && echo "-B "
     test "$1" = "mongodb-5.0" && echo "-B "
-    # test "$1" = "mongodb-4.4" && echo "-B "
+    test "$1" = "mongodb-4.4" && echo "-B "
     return 0
 }
 
@@ -554,7 +554,7 @@ test_dirty_upgrade()
     pushd "${src_branch}/build/test/format"
     local dir="RUNDIR.${src_branch}"
 
-    # Ignore the error resulting from the segfault
+    # Ignore the error resulting from the segfault.
     set +e
     ./t "$flags" -c "$config_file" -h "$dir" format.abort=1
     set -e
@@ -563,7 +563,7 @@ test_dirty_upgrade()
     # We now have a directory with WT files that resulted from a crash. Run the newer version
     # against those.
     pushd "${dst_branch}/build/test/format"
-    local dir="../../../../$src_branch/build/test/format/RUNDIR.${src_branch}"
+    local dir="../../../../${src_branch}/build/test/format/RUNDIR.${src_branch}"
     ./t "$flags" -c "$config_file" -h "$dir"
 
     # Remove the database so future runs don't try to use it.
@@ -762,8 +762,8 @@ gittags['mongodb-8.0']="mongodb-8.0"
 gittags['mongodb-7.0']="mongodb-7.0"
 gittags['mongodb-6.0']="mongodb-6.0"
 gittags['mongodb-5.0']="mongodb-5.0"
-# gittags['mongodb-4.4']="mongodb-4.4"
-# gittags['mongodb-4.2']="mongodb-4.2"
+gittags['mongodb-4.4']="mongodb-4.4"
+gittags['mongodb-4.2']="mongodb-4.2"
 # Then, optionally, replace one or more tags with a particular branch or commit hash where required for testing
 # For example, this set of commit hashes will reproduce the bug in WT-9795
 #gittags['develop']="d031f0af518c9b5f15dc586de4ae55d6867f423b"
@@ -785,8 +785,6 @@ source "$VERSIONS_FILE"
 import_release_branches=($IMPORT_RELEASE_BRANCHES)
 newer_release_branches=($NEWER_RELEASE_BRANCHES)
 older_release_branches=($OLDER_RELEASE_BRANCHES)
-echo "asdfasdfasdfasdf"
-echo $older_release_branches=
 compatible_upgrade_downgrade_release_branches=($COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
 patch_version_upgrade_downgrade_release_branches=($PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
 test_checkpoint_release_branches=($TEST_CHECKPOINT_RELEASE_BRANCHES)

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -540,36 +540,61 @@ upgrade_downgrade()
     done
 }
 
+# test/format manually specifies paths to loadable extensions. It also relies on WiredTiger.basecfg
+# existing, so the result is a bunch of paths to .so files in WiredTiger.basecfg. This is fine, but
+# the change from autoconf to cmake resulted in these files living in different directories. It's a
+# bit awful, but this method fixes up the paths in WiredTiger.basecfg when upgrading between
+# versions built with different build systems. This whole thing can go away once we stop caring
+# about 5.0.
+fixup_format_extension_paths()
+{
+    local src_branch="$1"
+    local dst_branch="$2"
+    local working_dir="$3"
+
+    local src_build_system=$(get_build_system "$src_branch")
+    local dst_build_system=$(get_build_system "$dst_branch")
+
+    if [ "$src_build_system" != "$dst_build_system" ]; then
+        if [ "$src_build_system" = "autoconf" ]; then
+            sed --in-place -e 's/\/\.libs//g' "$working_dir"/WiredTiger.basecfg
+        fi
+
+        # We don't need to make the inverse translation when going from cmake to autoconf, since
+        # autoconf puts the libraries in both the .libs/ directory, and the root of the extension's
+        # build directory. Thus, when a newer version saves a path without .libs/ it'll still find
+        # the right shared library.
+    fi
+}
+
+# Run test/format from $src_branch, and crash. Recover using test/format from $dst_branch.
 test_dirty_restart()
 {
     local src_branch="$1"
     local dst_branch="$2"
 
-    # Don't worry about changing flags for the dst branch, we're going to restart it from the source
-    # branch's working directory anwyay.
-    # local flags="-1q $(bflag $src_branch)"
-    local flags="-1q "
+    # We can reuse these flags for the dst branch. We're going to restart it from the source
+    # branch's working directory, and test/format will automatically pick up that config.
+    local flags="-1q $(bflag $src_branch)"
     local config_file="../../../../CONFIG_${src_branch}"
 
     # Run format on the source branch until it aborts.
     pushd "${src_branch}/build/test/format"
     local dir="RUNDIR.${src_branch}"
 
-    # Ignore the error resulting from the segfault.
+    # Ignore the error resulting from the segfault. We set a few options: backup=0 since it's
+    # incompatible with verify, and the compatibility version in case $src_branch is newer than
+    # $dst_branch.
     set +e
-    ./t ${flags} -c "$config_file" -h "$dir" format.abort=1 btree.reverse=0
+    ./t ${flags} -c "$config_file" -C "compatibility=(release=10.0.0)" -h "$dir" format.abort=1 backup=0
     set -e
     popd
 
     # We now have a directory with WT files that resulted from a crash. Run the newer version
     # against those.
     pushd "${dst_branch}/build/test/format"
-    pwd
     local dir="../../../../${src_branch}/build/test/format/RUNDIR.${src_branch}"
-    # TODO giant hack, replace the old-school path with the new one
-    pwd
-    ls
-    sed --in-place -e 's/\/\.libs//g' "$dir"/WiredTiger.basecfg
+    fixup_format_extension_paths "$src_branch" "$dst_branch" "$dir"
     ./t ${flags} -R -h "$dir" format.abort=0
 
     # Remove the database so future runs don't try to use it.
@@ -976,7 +1001,7 @@ if [ "$dirty_restart" = true ]; then
     # treat that as a combination worth testing.
     for b1 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
         for b2 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
-            if [[ "$b1" < "$b2" ]]; then
+            if [[ "$b1" != "$b2" ]]; then
                 test_dirty_restart "$b1" "$b2"
             fi
         done

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -540,7 +540,7 @@ upgrade_downgrade()
     done
 }
 
-test_dirty_upgrade()
+test_dirty_restart()
 {
     local src_branch="$1"
     local dst_branch="$2"
@@ -744,7 +744,7 @@ import_compatibility_test()
 }
 
 # Only one of below flags will be set by the 1st argument of the script.
-dirty_upgrade=false
+dirty_restart=false
 import=false
 older=false
 newer=false
@@ -791,7 +791,7 @@ test_checkpoint_release_branches=($TEST_CHECKPOINT_RELEASE_BRANCHES)
 upgrade_to_latest_upgrade_downgrade_release_branches=($UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
 
 declare -A scopes
-scopes[dirty_upgrade]="upgrade from an unclean shutdown of a previous version"
+scopes[dirty_restart]="start from an unclean shutdown of a different version"
 scopes[import]="import files from previous versions"
 scopes[newer]="newer stable release branches"
 scopes[older]="older stable release branches"
@@ -844,7 +844,7 @@ get_build_system()
 usage()
 {
     echo -e "Usage: \tcompatibility_test_for_releases [-d|-i|-n|-o|-p|-u|-w|-v]"
-    echo -e "\t-d\trun compatibility tests for ${scopes[dirty_upgrade]}"
+    echo -e "\t-d\trun compatibility tests for ${scopes[dirty_restart]}"
     echo -e "\t-i\trun compatibility tests for ${scopes[import]}"
     echo -e "\t-n\trun compatibility tests for ${scopes[newer]}"
     echo -e "\t-o\trun compatibility tests for ${scopes[older]}"
@@ -862,9 +862,9 @@ fi
 # Script argument processing
 case $1 in
 "-d")
-    dirty_upgrade=true
+    dirty_restart=true
     echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-    echo "Performing compatibility tests for ${scopes[dirty_upgrade]}"
+    echo "Performing compatibility tests for ${scopes[dirty_restart]}"
     echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 ;;
 "-i")
@@ -958,7 +958,7 @@ if [ "$upgrade_to_latest" = true ]; then
     done
 fi
 
-if [ "$dirty_upgrade" = true ]; then
+if [ "$dirty_restart" = true ]; then
     for b in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
         create_configs "$b"
         pushd .
@@ -966,12 +966,12 @@ if [ "$dirty_upgrade" = true ]; then
         popd
     done
 
-    # Go over the release branches, from pair to pair. If a pair has the LHS older than the RHS,
+    # Go over the release branches, from pair to pair. If a pair has the LHS different to the RHS,
     # treat that as a combination worth testing.
     for b1 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
         for b2 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
-            if [[ "$b1" < "$b2" ]]; then
-                test_dirty_upgrade "$b1" "$b2"
+            if [[ "$b1" != "$b2" ]]; then
+                test_dirty_restart "$b1" "$b2"
             fi
         done
     done

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -17,7 +17,7 @@ bcopy()
     test "$1" = "mongodb-7.0" && echo "1"
     test "$1" = "mongodb-6.0" && echo "1"
     test "$1" = "mongodb-5.0" && echo "1"
-    test "$1" = "mongodb-4.4" && echo "1"
+    # test "$1" = "mongodb-4.4" && echo "1"
     # Anything newer than mongodb-8.0 returns false.
     return 0
 }
@@ -34,7 +34,7 @@ bflag()
     test "$1" = "mongodb-7.0" && echo "-B "
     test "$1" = "mongodb-6.0" && echo "-B "
     test "$1" = "mongodb-5.0" && echo "-B "
-    test "$1" = "mongodb-4.4" && echo "-B "
+    # test "$1" = "mongodb-4.4" && echo "-B "
     return 0
 }
 
@@ -104,9 +104,9 @@ build_branch()
     git checkout --quiet "${git_tag}"
 
     build_system=$(get_build_system $1)
+    config=""
     if [ "$build_system" == "cmake" ]; then
         . ./test/evergreen/find_cmake.sh
-        config=""
         config+="-DENABLE_SNAPPY=1 "
         # Need to disable configs since WT-9455 enabled additional items by default.
         # Old releases didn't have these enabled, need to make it consistent.
@@ -540,6 +540,37 @@ upgrade_downgrade()
     done
 }
 
+test_dirty_upgrade()
+{
+    local src_branch="$1"
+    local dst_branch="$2"
+
+    # Don't worry about changing flags for the dst branch, we're going to restart it from the source
+    # branch's working directory anwyay.
+    local flags="-1q $(bflag $src_branch)"
+    local config_file="../../../../CONFIG_${src_branch}"
+
+    # Run format on the source branch until it aborts.
+    pushd "${src_branch}/build/test/format"
+    local dir="RUNDIR.${src_branch}"
+
+    # Ignore the error resulting from the segfault
+    set +e
+    ./t "$flags" -c "$config_file" -h "$dir" format.abort=1
+    set -e
+    popd
+
+    # We now have a directory with WT files that resulted from a crash. Run the newer version
+    # against those.
+    pushd "${dst_branch}/build/test/format"
+    local dir="../../../../$src_branch/build/test/format/RUNDIR.${src_branch}"
+    ./t "$flags" -c "$config_file" -h "$dir"
+
+    # Remove the database so future runs don't try to use it.
+    rm -rf "$dir"
+    popd
+}
+
 #############################################################
 # test_upgrade_to_branch:
 #       arg1: release branch name
@@ -713,6 +744,7 @@ import_compatibility_test()
 }
 
 # Only one of below flags will be set by the 1st argument of the script.
+dirty_upgrade=false
 import=false
 older=false
 newer=false
@@ -730,8 +762,8 @@ gittags['mongodb-8.0']="mongodb-8.0"
 gittags['mongodb-7.0']="mongodb-7.0"
 gittags['mongodb-6.0']="mongodb-6.0"
 gittags['mongodb-5.0']="mongodb-5.0"
-gittags['mongodb-4.4']="mongodb-4.4"
-gittags['mongodb-4.2']="mongodb-4.2"
+# gittags['mongodb-4.4']="mongodb-4.4"
+# gittags['mongodb-4.2']="mongodb-4.2"
 # Then, optionally, replace one or more tags with a particular branch or commit hash where required for testing
 # For example, this set of commit hashes will reproduce the bug in WT-9795
 #gittags['develop']="d031f0af518c9b5f15dc586de4ae55d6867f423b"
@@ -753,12 +785,15 @@ source "$VERSIONS_FILE"
 import_release_branches=($IMPORT_RELEASE_BRANCHES)
 newer_release_branches=($NEWER_RELEASE_BRANCHES)
 older_release_branches=($OLDER_RELEASE_BRANCHES)
+echo "asdfasdfasdfasdf"
+echo $older_release_branches=
 compatible_upgrade_downgrade_release_branches=($COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
 patch_version_upgrade_downgrade_release_branches=($PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
 test_checkpoint_release_branches=($TEST_CHECKPOINT_RELEASE_BRANCHES)
 upgrade_to_latest_upgrade_downgrade_release_branches=($UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES)
 
 declare -A scopes
+scopes[dirty_upgrade]="upgrade from an unclean shutdown of a previous version"
 scopes[import]="import files from previous versions"
 scopes[newer]="newer stable release branches"
 scopes[older]="older stable release branches"
@@ -810,7 +845,8 @@ get_build_system()
 #############################################################
 usage()
 {
-    echo -e "Usage: \tcompatibility_test_for_releases [-i|-n|-o|-p|-u|-w|-v]"
+    echo -e "Usage: \tcompatibility_test_for_releases [-d|-i|-n|-o|-p|-u|-w|-v]"
+    echo -e "\t-d\trun compatibility tests for ${scopes[dirty_upgrade]}"
     echo -e "\t-i\trun compatibility tests for ${scopes[import]}"
     echo -e "\t-n\trun compatibility tests for ${scopes[newer]}"
     echo -e "\t-o\trun compatibility tests for ${scopes[older]}"
@@ -827,6 +863,12 @@ fi
 
 # Script argument processing
 case $1 in
+"-d")
+    dirty_upgrade=true
+    echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+    echo "Performing compatibility tests for ${scopes[dirty_upgrade]}"
+    echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+;;
 "-i")
     import=true
     echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
@@ -915,6 +957,26 @@ if [ "$upgrade_to_latest" = true ]; then
         # cleanup.
         cd $test_root
         rm -rf $test_data_root
+    done
+fi
+
+if [ "$dirty_upgrade" = true ]; then
+    test_root="$(pwd)"
+
+    for b in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
+        create_configs "$b"
+        pushd .
+        build_branch "$b"
+        popd
+    done
+
+    # Go over the release branches, from pair to pair. If a pair is a
+    for b1 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
+        for b2 in "${upgrade_to_latest_upgrade_downgrade_release_branches[@]}"; do
+            if [[ "$b1" < "$b2" ]]; then
+                test_dirty_upgrade "$b1" "$b2"
+            fi
+        done
     done
 fi
 

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -11,7 +11,7 @@ export SUITE_RELEASE_BRANCHES="develop mongodb-7.1 mongodb-7.0 mongodb-6.3"
 # This array is used to configure the release branches we'd like to use for testing the importing
 # of files created in previous versions of WiredTiger. Go all the way back to mongodb-4.2 since
 # that's the first release where we don't support live import.
-export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0"
+export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4 mongodb-4.2"
 
 # Branches in below 2 arrays should be put in newer-to-older order.
 #
@@ -20,21 +20,21 @@ export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mong
 #
 # The 2 arrays should be adjusted over time when newer branches are created,
 # or older branches are EOL.
-export NEWER_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0"
-export OLDER_RELEASE_BRANCHES=""
+export NEWER_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export OLDER_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
 
 # This array is used to generate compatible configuration files between releases, because
 # upgrade/downgrade test runs each build's format test program on the second build's
 # configuration file.
-export COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES=""
+export COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
 
 # This array is used to configure the release branches we'd like to run patch version
 # upgrade/downgrade test.
-export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run test checkpoint
 # upgrade/downgrade test.
-export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run upgrade to latest test.
-export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0"
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -11,7 +11,7 @@ export SUITE_RELEASE_BRANCHES="develop mongodb-7.1 mongodb-7.0 mongodb-6.3"
 # This array is used to configure the release branches we'd like to use for testing the importing
 # of files created in previous versions of WiredTiger. Go all the way back to mongodb-4.2 since
 # that's the first release where we don't support live import.
-export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4 mongodb-4.2"
+export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0"
 
 # Branches in below 2 arrays should be put in newer-to-older order.
 #
@@ -20,21 +20,21 @@ export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mong
 #
 # The 2 arrays should be adjusted over time when newer branches are created,
 # or older branches are EOL.
-export NEWER_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
-export OLDER_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
+export NEWER_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0"
+export OLDER_RELEASE_BRANCHES=""
 
 # This array is used to generate compatible configuration files between releases, because
 # upgrade/downgrade test runs each build's format test program on the second build's
 # configuration file.
-export COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
+export COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES=""
 
 # This array is used to configure the release branches we'd like to run patch version
 # upgrade/downgrade test.
-export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
+export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to run test checkpoint
 # upgrade/downgrade test.
-export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
+export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to run upgrade to latest test.
-export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0"

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -37,4 +37,4 @@ export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0
 export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run upgrade to latest test.
-export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-5.0"

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -37,4 +37,4 @@ export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0
 export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run upgrade to latest test.
-export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-5.0"
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2765,7 +2765,7 @@ tasks:
             # By default the test_push_pull uses dir_store as a storage source.
             ./test_push_pull -PT
 
-  - name: compatibility-test-for-newer-releases
+  - name: dirty-upgrade-compatibility-test
     commands:
       - func: "get project"
       - func: "compatibility test"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2765,7 +2765,7 @@ tasks:
             # By default the test_push_pull uses dir_store as a storage source.
             ./test_push_pull -PT
 
-  - name: dirty-upgrade-compatibility-test
+  - name: compatibility-test-dirty-upgrade
     commands:
       - func: "get project"
       - func: "compatibility test"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2770,6 +2770,13 @@ tasks:
       - func: "get project"
       - func: "compatibility test"
         vars:
+          compat_test_args: -d
+
+  - name: compatibility-test-for-newer-releases
+    commands:
+      - func: "get project"
+      - func: "compatibility test"
+        vars:
           compat_test_args: -n
 
   - name: compatibility-test-for-older-releases

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2765,7 +2765,7 @@ tasks:
             # By default the test_push_pull uses dir_store as a storage source.
             ./test_push_pull -PT
 
-  - name: compatibility-test-dirty-upgrade
+  - name: compatibility-test-dirty-restart
     commands:
       - func: "get project"
       - func: "compatibility test"

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -132,7 +132,7 @@ buildvariants:
     - name: compatibility-test-for-newer-releases
     - name: compatibility-test-for-patch-releases
     - name: import-compatibility-test
-    - name: compatibility-test-dirty-upgrade
+    - name: compatibility-test-dirty-restart
 
 - name: infrequent-checks
   display_name: "~ Infrequent checks"

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -132,6 +132,7 @@ buildvariants:
     - name: compatibility-test-for-newer-releases
     - name: compatibility-test-for-patch-releases
     - name: import-compatibility-test
+    - name: dirty-upgrade-compatibility-test
 
 - name: infrequent-checks
   display_name: "~ Infrequent checks"

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -132,7 +132,7 @@ buildvariants:
     - name: compatibility-test-for-newer-releases
     - name: compatibility-test-for-patch-releases
     - name: import-compatibility-test
-    - name: dirty-upgrade-compatibility-test
+    - name: compatibility-test-dirty-upgrade
 
 - name: infrequent-checks
   display_name: "~ Infrequent checks"


### PR DESCRIPTION
This adds a new `-d` (for "dirty") flag to the compatibility test script.

It does this by first running `test/format` with the `format.abort` flag. Once this is done (i.e. has crashed) we run a newer`test/format` on the files the first run generated.

Thanks Sid for validating the original idea and making sure the first run does what we thought it should!