### PR TITLE
WT-15260 Update block manager read statistics in __wt_block_compact_page_rewrite()

### DIFF
--- a/src/block/block_compact.c
+++ b/src/block/block_compact.c
@@ -674,7 +674,9 @@ __wt_block_compact_page_rewrite(
     *addr_sizep = WT_PTRDIFF(endp, addr);
     block->compact_bytes_rewritten += size;
 
+    WT_STAT_CONN_INCR(session, block_read);
     WT_STAT_CONN_INCR(session, block_write);
+    WT_STAT_CONN_INCRV(session, block_byte_read, size);
     WT_STAT_CONN_INCRV(session, block_byte_write, size);
     WT_STAT_CONN_INCRV(session, block_byte_write_compact, size);
 

--- a/test/suite/test_layered15.py
+++ b/test/suite/test_layered15.py
@@ -215,6 +215,7 @@ class test_layered15(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.session.checkpoint()
         time.sleep(1)
         checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+        self.tty('checkpoint metadata = ' + checkpoint_meta)
 
         # Ensure that the shared metadata table has all the expected URIs after the checkpoint
         self.check_shared_metadata(self.all_uris)

--- a/test/suite/test_layered15.py
+++ b/test/suite/test_layered15.py
@@ -215,7 +215,6 @@ class test_layered15(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.session.checkpoint()
         time.sleep(1)
         checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
-        self.tty('checkpoint metadata = ' + checkpoint_meta)
 
         # Ensure that the shared metadata table has all the expected URIs after the checkpoint
         self.check_shared_metadata(self.all_uris)


### PR DESCRIPTION
When compaction moves a page that was not in the WT cache, it should increase both read and write statistics for the block manager, since it is both reading and writing the page. This change adds the missing updates the the block manager read stats.
