### PR TITLE
WT-15275 Deprecate delta_count from PALI GET arguments

### DIFF
--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -959,7 +959,6 @@ palm_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t page_id,
               "base dek is not zeroed, delta encryption is zero and should not be");
             goto err;
         }
-        get_args->delta_count = count;
     }
     /* Did the caller give us enough output entries to hold all the results? */
     if (count == *results_count && palm_kv_next_page_match(&matches))

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -757,7 +757,6 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %ignore __wt_page_log_discard_args::backlink_checkpoint_id;
 %ignore __wt_page_log_discard_args::base_checkpoint_id;
 %ignore __wt_page_log_discard_args::lsn_frontier;
-%ignore __wt_page_log_discard_args::delta_count;
 %ignore __wt_page_log_encryption::dek;
 %ignore __wt_page_log_put_args::backlink_lsn;
 %ignore __wt_page_log_put_args::base_lsn;
@@ -773,7 +772,6 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %ignore __wt_page_log_get_args::base_checkpoint_id;
 %ignore __wt_page_log_get_args::encryption;
 %ignore __wt_page_log_get_args::lsn_frontier;
-%ignore __wt_page_log_get_args::delta_count;
 
 OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, compare, (self, other))
 OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, equals, (self, other))

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -186,12 +186,11 @@ reread:
                 if (result == last) {
                     WT_ASSERT(session, get_args.lsn > 0);
                     WT_ASSERT(session,
-                      (get_args.delta_count > 0) ==
-                        FLD_ISSET(flags, WT_BLOCK_DISAGG_ADDR_FLAG_DELTA));
+                      (*results_count > 1) == FLD_ISSET(flags, WT_BLOCK_DISAGG_ADDR_FLAG_DELTA));
 
                     /* The server is allowed to set base LSN to 0 for full page images. */
                     WT_ASSERT(session,
-                      (get_args.base_lsn == 0 && get_args.delta_count == 0) ||
+                      (get_args.base_lsn == 0 && *results_count == 1) ||
                         get_args.base_lsn == base_lsn);
 
                     /* Set the other metadata returned by the Page Service. */
@@ -199,9 +198,7 @@ reread:
                     block_meta->backlink_lsn = get_args.backlink_lsn;
                     block_meta->base_lsn = get_args.base_lsn;
                     block_meta->disagg_lsn = get_args.lsn;
-                    block_meta->delta_count = get_args.delta_count == 0 ?
-                      (uint8_t)(*results_count - 1) :
-                      (uint8_t)get_args.delta_count;
+                    block_meta->delta_count = (uint8_t)(*results_count - 1);
                     block_meta->checksum = checksum;
                     block_meta->encryption = get_args.encryption;
                     if (block_meta->delta_count > 0)

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -5656,7 +5656,6 @@ struct __wt_page_log_get_args {
        uint64_t base_lsn;
        uint64_t backlink_checkpoint_id;
        uint64_t base_checkpoint_id;
-       uint32_t delta_count;
 
        WT_PAGE_LOG_ENCRYPTION encryption;
 };


### PR DESCRIPTION
Deprecate `delta_count`, as (1) it is redundant with `*result_count - 1`, and (2) it is not currently used by the server. As a result, the use of `delta_count` was causing problems in the server's testing.