### PR TITLE
WT-14653 Add reconciliation stats for history store wrapup (7.0 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -664,7 +664,9 @@ conn_stats = [
     YieldStat('page_index_slot_ref_blocked', 'get reference for page index and slot time sleeping (usecs)'),
     YieldStat('page_locked_blocked', 'page acquire locked blocked'),
     YieldStat('page_read_blocked', 'page acquire read blocked'),
+    YieldStat('page_read_skip_deleted', 'pages skipped during read due to deleted state'),
     YieldStat('page_sleep', 'page acquire time sleeping (usecs)'),
+    YieldStat('page_split_restart', 'page split and restart read'),
     YieldStat('prepared_transition_blocked_page', 'page access yielded due to prepare state change'),
     YieldStat('txn_release_blocked', 'connection close blocked waiting for transaction state stabilization'),
 ]
@@ -989,6 +991,7 @@ conn_dsrc_stats = [
     ##########################################
     # Reconciliation statistics
     ##########################################
+    RecStat('rec_hs_wrapup_next_prev_calls', 'cursor next/prev calls during HS wrapup search_near'),
     RecStat('rec_page_delete', 'pages deleted'),
     RecStat('rec_page_delete_fast', 'fast-path pages deleted'),
     RecStat('rec_pages', 'page reconciliation calls'),

--- a/src/btree/bt_curnext.c
+++ b/src/btree/bt_curnext.c
@@ -788,6 +788,10 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
 
     WT_STAT_CONN_DATA_INCR(session, cursor_next);
 
+    /* Track next calls during HS wrapup */
+    if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
+        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+
     flags = WT_READ_NO_SPLIT | WT_READ_SKIP_INTL; /* tree walk flags */
     if (truncating)
         LF_SET(WT_READ_TRUNCATE);
@@ -891,6 +895,7 @@ __wt_btcur_next(WT_CURSOR_BTREE *cbt, bool truncating)
                 continue;
             }
         }
+
         /*
          * If we saw a lot of deleted records on this page, or we went all the way through a page
          * and only saw deleted records, try to evict the page when we release it. Otherwise

--- a/src/btree/bt_curprev.c
+++ b/src/btree/bt_curprev.c
@@ -752,6 +752,10 @@ __wt_btcur_prev(WT_CURSOR_BTREE *cbt, bool truncating)
 
     WT_STAT_CONN_DATA_INCR(session, cursor_prev);
 
+    /* Track prev calls during HS wrapup */
+    if (F_ISSET(session, WT_SESSION_HS_WRAPUP))
+        session->reconcile_stats.hs_wrapup_next_prev_calls++;
+
     /* tree walk flags */
     flags = WT_READ_NO_SPLIT | WT_READ_PREV | WT_READ_SKIP_INTL;
     if (truncating)

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -290,8 +290,10 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
             if (LF_ISSET(WT_READ_CACHE | WT_READ_NO_WAIT))
                 return (WT_NOTFOUND);
             if (LF_ISSET(WT_READ_SKIP_DELETED) &&
-              __wt_delete_page_skip(session, ref, !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT)))
+              __wt_delete_page_skip(session, ref, !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))) {
+                WT_STAT_CONN_INCR(session, page_read_skip_deleted);
                 return (WT_NOTFOUND);
+            }
             goto read;
         case WT_REF_DISK:
             /* Optionally limit reads to cache-only. */
@@ -337,6 +339,7 @@ read:
             stalled = true;
             break;
         case WT_REF_SPLIT:
+            WT_STAT_CONN_INCR(session, page_split_restart);
             return (WT_RESTART);
         case WT_REF_MEM:
             /*

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -154,6 +154,11 @@ struct __wt_session_impl {
         uint64_t total_reentry_hs_eviction_time;
     } reconcile_timeline;
 
+    /* Record statistics in an reconciliation. */
+    struct __wt_reconcile_stats {
+        uint64_t hs_wrapup_next_prev_calls;
+    } reconcile_stats;
+
     /*
      * Record the important timestamps of each stage in an eviction. If an eviction takes a long
      * time and times out, we can trace the time usage of each stage from this information.
@@ -249,18 +254,19 @@ struct __wt_session_impl {
 #define WT_SESSION_DEBUG_DO_NOT_CLEAR_TXN_ID 0x00010u
 #define WT_SESSION_DEBUG_RELEASE_EVICT 0x00020u
 #define WT_SESSION_EVICTION 0x00040u
-#define WT_SESSION_IGNORE_CACHE_SIZE 0x00080u
-#define WT_SESSION_IMPORT 0x00100u
-#define WT_SESSION_IMPORT_REPAIR 0x00200u
-#define WT_SESSION_INTERNAL 0x00400u
-#define WT_SESSION_LOGGING_INMEM 0x00800u
-#define WT_SESSION_NO_DATA_HANDLES 0x01000u
-#define WT_SESSION_NO_RECONCILE 0x02000u
-#define WT_SESSION_QUIET_CORRUPT_FILE 0x04000u
-#define WT_SESSION_READ_WONT_NEED 0x08000u
-#define WT_SESSION_RESOLVING_TXN 0x10000u
-#define WT_SESSION_ROLLBACK_TO_STABLE 0x20000u
-#define WT_SESSION_SCHEMA_TXN 0x40000u
+#define WT_SESSION_HS_WRAPUP 0x00080u
+#define WT_SESSION_IGNORE_CACHE_SIZE 0x00100u
+#define WT_SESSION_IMPORT 0x00200u
+#define WT_SESSION_IMPORT_REPAIR 0x00400u
+#define WT_SESSION_INTERNAL 0x00800u
+#define WT_SESSION_LOGGING_INMEM 0x01000u
+#define WT_SESSION_NO_DATA_HANDLES 0x02000u
+#define WT_SESSION_NO_RECONCILE 0x04000u
+#define WT_SESSION_QUIET_CORRUPT_FILE 0x08000u
+#define WT_SESSION_READ_WONT_NEED 0x10000u
+#define WT_SESSION_RESOLVING_TXN 0x20000u
+#define WT_SESSION_ROLLBACK_TO_STABLE 0x40000u
+#define WT_SESSION_SCHEMA_TXN 0x80000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t flags;
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -774,6 +774,7 @@ struct __wt_connection_stats {
     int64_t rec_vlcs_emptied_pages;
     int64_t rec_time_window_bytes_ts;
     int64_t rec_time_window_bytes_txn;
+    int64_t rec_hs_wrapup_next_prev_calls;
     int64_t rec_page_delete_fast;
     int64_t rec_overflow_key_leaf;
     int64_t rec_maximum_milliseconds;
@@ -865,6 +866,8 @@ struct __wt_connection_stats {
     int64_t page_sleep;
     int64_t page_del_rollback_blocked;
     int64_t child_modify_blocked_page;
+    int64_t page_split_restart;
+    int64_t page_read_skip_deleted;
     int64_t txn_prepared_updates;
     int64_t txn_prepared_updates_committed;
     int64_t txn_prepared_updates_key_repeated;
@@ -1190,6 +1193,7 @@ struct __wt_dsrc_stats {
     int64_t rec_vlcs_emptied_pages;
     int64_t rec_time_window_bytes_ts;
     int64_t rec_time_window_bytes_txn;
+    int64_t rec_hs_wrapup_next_prev_calls;
     int64_t rec_dictionary;
     int64_t rec_page_delete_fast;
     int64_t rec_suffix_compression;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6407,465 +6407,471 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * written
  */
 #define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1434
+/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1435
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1435
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1436
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1436
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1437
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1437
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1438
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1438
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1439
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1439
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1440
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1440
+#define	WT_STAT_CONN_REC_PAGES				1441
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1441
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1442
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1442
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1443
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1443
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1444
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1444
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1445
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1445
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1446
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1446
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1447
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1447
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1448
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1448
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1449
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1449
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1450
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1450
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1451
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1451
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1452
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1452
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1453
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1453
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1454
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1454
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1455
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1455
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1456
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1456
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1457
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1457
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1458
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1458
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1459
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1459
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1460
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1460
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1461
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1461
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1462
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1462
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1463
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1463
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1464
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1464
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1465
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1465
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1466
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1466
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1467
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1467
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1468
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1468
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1469
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1469
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1470
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1470
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1471
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1471
+#define	WT_STAT_CONN_FLUSH_TIER				1472
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1472
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1473
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1473
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1474
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1474
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1475
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1475
+#define	WT_STAT_CONN_SESSION_OPEN			1476
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1476
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1477
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1477
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1478
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1478
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1479
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1479
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1480
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1480
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1481
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1481
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1482
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1482
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1483
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1483
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1484
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1484
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1485
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1485
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1486
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1486
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1487
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1487
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1488
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1488
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1489
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1489
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1490
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1490
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1491
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1491
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1492
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1492
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1493
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1493
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1494
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1494
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1495
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1495
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1496
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1496
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1497
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1497
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1498
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1498
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1499
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1499
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1500
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1500
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1501
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1501
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1502
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1502
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1503
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1503
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1504
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1504
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1505
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1505
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1506
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1506
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1507
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1507
+#define	WT_STAT_CONN_TIERED_RETENTION			1508
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1508
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1509
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1509
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1510
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1510
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1511
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1511
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1512
 /*! thread-yield: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1512
+#define	WT_STAT_CONN_APPLICATION_EVICT_TIME		1513
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1513
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1514
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1514
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1515
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1515
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1516
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1516
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1517
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1517
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1518
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1518
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1519
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1519
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1520
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1520
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1521
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1521
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1522
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1522
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1523
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1523
+#define	WT_STAT_CONN_PAGE_SLEEP				1524
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1524
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1525
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1525
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1526
+/*! thread-yield: page split and restart read */
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1527
+/*! thread-yield: pages skipped during read due to deleted state */
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1528
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1526
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1529
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1527
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1530
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1528
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1531
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1529
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1532
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1530
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1533
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1531
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	1534
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1532
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1535
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1533
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1536
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1534
+#define	WT_STAT_CONN_TXN_PREPARE			1537
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1535
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1538
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1536
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1539
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1537
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1540
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1538
+#define	WT_STAT_CONN_TXN_QUERY_TS			1541
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1539
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1542
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1540
+#define	WT_STAT_CONN_TXN_RTS				1543
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1541
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1544
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1542
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1545
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1543
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1546
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1544
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1547
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1545
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1548
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1546
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1549
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1547
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1550
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1548
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1551
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1549
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1552
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1550
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1553
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1551
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1554
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1552
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1555
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1553
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1556
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1554
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1557
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1555
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1558
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1556
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1559
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1557
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1560
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1558
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1561
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1559
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1562
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1560
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1563
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1561
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1564
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1562
+#define	WT_STAT_CONN_TXN_SET_TS				1565
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1563
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1566
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1564
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1567
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1565
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1568
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1566
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1569
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1567
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1570
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1568
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1571
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1569
+#define	WT_STAT_CONN_TXN_BEGIN				1572
 /*! transaction: transaction checkpoint currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1570
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING		1573
 /*!
  * transaction: transaction checkpoint currently running for history
  * store file
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1571
+#define	WT_STAT_CONN_TXN_CHECKPOINT_RUNNING_HS		1574
 /*! transaction: transaction checkpoint generation */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1572
+#define	WT_STAT_CONN_TXN_CHECKPOINT_GENERATION		1575
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1573
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1576
 /*! transaction: transaction checkpoint max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1574
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MAX		1577
 /*! transaction: transaction checkpoint min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1575
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_MIN		1578
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * all handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1576
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION	1579
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * applied handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1577
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_APPLY	1580
 /*!
  * transaction: transaction checkpoint most recent duration for gathering
  * skipped handles (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1578
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_DURATION_SKIP	1581
 /*! transaction: transaction checkpoint most recent handles applied */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1579
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_APPLIED	1582
 /*! transaction: transaction checkpoint most recent handles skipped */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1580
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_SKIPPED	1583
 /*! transaction: transaction checkpoint most recent handles walked */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1581
+#define	WT_STAT_CONN_TXN_CHECKPOINT_HANDLE_WALKED	1584
 /*! transaction: transaction checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1582
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_RECENT		1585
 /*! transaction: transaction checkpoint prepare currently running */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1583
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RUNNING	1586
 /*! transaction: transaction checkpoint prepare max time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1584
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MAX		1587
 /*! transaction: transaction checkpoint prepare min time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1585
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_MIN		1588
 /*! transaction: transaction checkpoint prepare most recent time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1586
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_RECENT		1589
 /*! transaction: transaction checkpoint prepare total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1587
+#define	WT_STAT_CONN_TXN_CHECKPOINT_PREP_TOTAL		1590
 /*! transaction: transaction checkpoint scrub dirty target */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1588
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TARGET	1591
 /*! transaction: transaction checkpoint scrub time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1589
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SCRUB_TIME		1592
 /*! transaction: transaction checkpoint stop timing stress active */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1590
+#define	WT_STAT_CONN_TXN_CHECKPOINT_STOP_STRESS_ACTIVE	1593
 /*! transaction: transaction checkpoint total time (msecs) */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1591
+#define	WT_STAT_CONN_TXN_CHECKPOINT_TIME_TOTAL		1594
 /*! transaction: transaction checkpoints */
-#define	WT_STAT_CONN_TXN_CHECKPOINT			1592
+#define	WT_STAT_CONN_TXN_CHECKPOINT			1595
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1593
+#define	WT_STAT_CONN_TXN_CHECKPOINT_OBSOLETE_APPLIED	1596
 /*!
  * transaction: transaction checkpoints skipped because database was
  * clean
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1594
+#define	WT_STAT_CONN_TXN_CHECKPOINT_SKIPPED		1597
 /*!
  * transaction: transaction fsync calls for checkpoint after allocating
  * the transaction ID
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1595
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST		1598
 /*!
  * transaction: transaction fsync duration for checkpoint after
  * allocating the transaction ID (usecs)
  */
-#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1596
+#define	WT_STAT_CONN_TXN_CHECKPOINT_FSYNC_POST_DURATION	1599
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1597
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1600
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1598
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1601
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1599
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1602
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1600
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1603
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1601
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1604
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1602
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1605
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1603
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1606
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1604
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1607
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1605
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1608
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1606
+#define	WT_STAT_CONN_TXN_COMMIT				1609
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1607
+#define	WT_STAT_CONN_TXN_ROLLBACK			1610
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1608
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1611
 
 /*!
  * @}
@@ -7555,175 +7561,177 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * written
  */
 #define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2234
+/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2235
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2235
+#define	WT_STAT_DSRC_REC_DICTIONARY			2236
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2236
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2237
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2237
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2238
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2238
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2239
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2239
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2240
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2240
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2241
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2241
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2242
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2242
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2243
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2243
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2244
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2244
+#define	WT_STAT_DSRC_REC_PAGES				2245
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2245
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2246
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2246
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2247
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2247
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2248
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2248
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2249
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2249
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2250
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2250
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2251
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2251
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2252
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2252
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2253
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2253
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2254
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2254
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2255
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2255
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2256
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2256
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2257
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2257
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2258
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2258
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2259
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2259
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2260
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2260
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2261
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2261
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2262
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2262
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2263
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2263
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2264
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2264
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2265
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2265
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2266
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2266
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2267
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2267
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2268
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2268
+#define	WT_STAT_DSRC_SESSION_COMPACT			2269
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2269
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2270
 /*! transaction: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2270
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_SNAPSHOT_ACQUIRED	2271
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2271
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2272
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2272
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2273
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2273
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2274
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2274
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2275
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2275
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2276
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2276
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2277
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2277
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2278
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2278
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2279
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2279
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2280
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2280
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2281
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2281
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2282
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2282
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2283
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2283
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2284
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2284
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2285
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2285
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2286
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2286
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2287
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2287
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2288
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2288
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2289
 /*! transaction: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2289
+#define	WT_STAT_DSRC_TXN_CHECKPOINT_OBSOLETE_APPLIED	2290
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2290
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2291
 
 /*!
  * @}

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -311,6 +311,8 @@ struct __wt_rec_kv;
 typedef struct __wt_rec_kv WT_REC_KV;
 struct __wt_reconcile;
 typedef struct __wt_reconcile WT_RECONCILE;
+struct __wt_reconcile_stats;
+typedef struct __wt_reconcile_stats WT_RECONCILE_STATS;
 struct __wt_reconcile_timeline;
 typedef struct __wt_reconcile_timeline WT_RECONCILE_TIMELINE;
 struct __wt_recovery_timeline;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2668,6 +2668,10 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     btree = S2BT(session);
 
+    /* Set a flag in the session to track that we're in HS wrapup */
+    F_SET(session, WT_SESSION_HS_WRAPUP);
+    session->reconcile_stats.hs_wrapup_next_prev_calls = 0;
+
     /*
      * Sanity check: Can't insert updates into history store from the history store itself or from
      * the metadata file.
@@ -2697,7 +2701,10 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
             }
         }
 
+    WT_STAT_CONN_INCRV(
+      session, rec_hs_wrapup_next_prev_calls, session->reconcile_stats.hs_wrapup_next_prev_calls);
 err:
+    F_CLR(session, WT_SESSION_HS_WRAPUP);
     return (ret);
 }
 

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -253,6 +253,7 @@ static const char *const __stats_dsrc_desc[] = {
   "reconciliation: VLCS pages explicitly reconciled as empty",
   "reconciliation: approximate byte size of timestamps in pages written",
   "reconciliation: approximate byte size of transaction IDs in pages written",
+  "reconciliation: cursor next/prev calls during HS wrapup search_near",
   "reconciliation: dictionary matches",
   "reconciliation: fast-path pages deleted",
   "reconciliation: internal page key bytes discarded using suffix compression",
@@ -589,6 +590,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->rec_vlcs_emptied_pages = 0;
     stats->rec_time_window_bytes_ts = 0;
     stats->rec_time_window_bytes_txn = 0;
+    stats->rec_hs_wrapup_next_prev_calls = 0;
     stats->rec_dictionary = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_suffix_compression = 0;
@@ -916,6 +918,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->rec_vlcs_emptied_pages += from->rec_vlcs_emptied_pages;
     to->rec_time_window_bytes_ts += from->rec_time_window_bytes_ts;
     to->rec_time_window_bytes_txn += from->rec_time_window_bytes_txn;
+    to->rec_hs_wrapup_next_prev_calls += from->rec_hs_wrapup_next_prev_calls;
     to->rec_dictionary += from->rec_dictionary;
     to->rec_page_delete_fast += from->rec_page_delete_fast;
     to->rec_suffix_compression += from->rec_suffix_compression;
@@ -1253,6 +1256,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->rec_vlcs_emptied_pages += WT_STAT_READ(from, rec_vlcs_emptied_pages);
     to->rec_time_window_bytes_ts += WT_STAT_READ(from, rec_time_window_bytes_ts);
     to->rec_time_window_bytes_txn += WT_STAT_READ(from, rec_time_window_bytes_txn);
+    to->rec_hs_wrapup_next_prev_calls += WT_STAT_READ(from, rec_hs_wrapup_next_prev_calls);
     to->rec_dictionary += WT_STAT_READ(from, rec_dictionary);
     to->rec_page_delete_fast += WT_STAT_READ(from, rec_page_delete_fast);
     to->rec_suffix_compression += WT_STAT_READ(from, rec_suffix_compression);
@@ -1775,6 +1779,7 @@ static const char *const __stats_connection_desc[] = {
   "reconciliation: VLCS pages explicitly reconciled as empty",
   "reconciliation: approximate byte size of timestamps in pages written",
   "reconciliation: approximate byte size of transaction IDs in pages written",
+  "reconciliation: cursor next/prev calls during HS wrapup search_near",
   "reconciliation: fast-path pages deleted",
   "reconciliation: leaf-page overflow keys",
   "reconciliation: maximum milliseconds spent in a reconciliation call",
@@ -1868,6 +1873,8 @@ static const char *const __stats_connection_desc[] = {
   "thread-yield: page acquire time sleeping (usecs)",
   "thread-yield: page delete rollback time sleeping for state change (usecs)",
   "thread-yield: page reconciliation yielded due to child modification",
+  "thread-yield: page split and restart read",
+  "thread-yield: pages skipped during read due to deleted state",
   "transaction: Number of prepared updates",
   "transaction: Number of prepared updates committed",
   "transaction: Number of prepared updates repeated on the same key",
@@ -2432,6 +2439,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->rec_vlcs_emptied_pages = 0;
     stats->rec_time_window_bytes_ts = 0;
     stats->rec_time_window_bytes_txn = 0;
+    stats->rec_hs_wrapup_next_prev_calls = 0;
     stats->rec_page_delete_fast = 0;
     stats->rec_overflow_key_leaf = 0;
     /* not clearing rec_maximum_milliseconds */
@@ -2523,6 +2531,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->page_sleep = 0;
     stats->page_del_rollback_blocked = 0;
     stats->child_modify_blocked_page = 0;
+    stats->page_split_restart = 0;
+    stats->page_read_skip_deleted = 0;
     stats->txn_prepared_updates = 0;
     stats->txn_prepared_updates_committed = 0;
     stats->txn_prepared_updates_key_repeated = 0;
@@ -3118,6 +3128,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->rec_vlcs_emptied_pages += WT_STAT_READ(from, rec_vlcs_emptied_pages);
     to->rec_time_window_bytes_ts += WT_STAT_READ(from, rec_time_window_bytes_ts);
     to->rec_time_window_bytes_txn += WT_STAT_READ(from, rec_time_window_bytes_txn);
+    to->rec_hs_wrapup_next_prev_calls += WT_STAT_READ(from, rec_hs_wrapup_next_prev_calls);
     to->rec_page_delete_fast += WT_STAT_READ(from, rec_page_delete_fast);
     to->rec_overflow_key_leaf += WT_STAT_READ(from, rec_overflow_key_leaf);
     to->rec_maximum_milliseconds += WT_STAT_READ(from, rec_maximum_milliseconds);
@@ -3220,6 +3231,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->page_sleep += WT_STAT_READ(from, page_sleep);
     to->page_del_rollback_blocked += WT_STAT_READ(from, page_del_rollback_blocked);
     to->child_modify_blocked_page += WT_STAT_READ(from, child_modify_blocked_page);
+    to->page_split_restart += WT_STAT_READ(from, page_split_restart);
+    to->page_read_skip_deleted += WT_STAT_READ(from, page_read_skip_deleted);
     to->txn_prepared_updates += WT_STAT_READ(from, txn_prepared_updates);
     to->txn_prepared_updates_committed += WT_STAT_READ(from, txn_prepared_updates_committed);
     to->txn_prepared_updates_key_repeated += WT_STAT_READ(from, txn_prepared_updates_key_repeated);


### PR DESCRIPTION
These are the stats we are adding as part of trying to identify an issue with workloads getting stuck during history store wrap up. They include:

- A stat to track pages skipped during read due to deleted state
- A stat to track how often pages were split and read restarted
- A stat to track how often next/prev were called during HS wrap up

(cherry picked from commit 6d4a8f816992bc9f9c5b3bdd8f6dddad918f157c)

(cherry picked from commit 111bb294a9e86484ef3ba115be85cca1a079f582)

(cherry picked from commit ce4757b9c727aa56f0569866fae6e10e01d5c7fa)
