### PR TITLE
WT-15251 Skip test_sweep04 on 8.0

### DIFF
--- a/test/suite/test_sweep04.py
+++ b/test/suite/test_sweep04.py
@@ -109,6 +109,8 @@ class test_sweep04(wttest.WiredTigerTestCase):
             c.close()
 
     def test_big_run(self):
+        # FIXME-WT-13706
+        self.skipTest("FIXME-WT-13706")
         # populate
         r = suite_random()
 


### PR DESCRIPTION
This test was previously skipped on the develop branch due to a bug. It has now started failing on the 8.0 branch, so this commit ensures it is skipped here as well to prevent failures