### PR TITLE
WT-15281 Fix prepare rollback lead to an update missed in delta

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -64,11 +64,12 @@ __rec_delete_hs_upd_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *
     ++r->delete_hs_upd_next;
 
     /* Clear the durable flag to allow them being included in a delta. */
-    if (F_ISSET(upd, WT_UPDATE_DURABLE)) {
+    if (F_ISSET(upd, WT_UPDATE_DURABLE))
         F_CLR(upd, WT_UPDATE_DURABLE);
-        if (tombstone != NULL)
-            F_CLR(tombstone, WT_UPDATE_DURABLE);
-    }
+
+    if (tombstone != NULL && F_ISSET(tombstone, WT_UPDATE_DURABLE))
+        F_CLR(tombstone, WT_UPDATE_DURABLE);
+
     return (0);
 }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -62,6 +62,13 @@ __rec_delete_hs_upd_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *
     delete_hs_upd->upd = upd;
     delete_hs_upd->tombstone = tombstone;
     ++r->delete_hs_upd_next;
+
+    /* Clear the durable flag to allow them being included in a delta. */
+    if (WT_DELTA_LEAF_ENABLED(session)) {
+        F_CLR(upd, WT_UPDATE_DURABLE);
+        if (tombstone != NULL)
+            F_CLR(tombstone, WT_UPDATE_DURABLE);
+    }
     return (0);
 }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -66,10 +66,8 @@ __rec_delete_hs_upd_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *
     /* Clear the durable flag to allow them being included in a delta. */
     if (F_ISSET(upd, WT_UPDATE_DURABLE)) {
         F_CLR(upd, WT_UPDATE_DURABLE);
-        if (tombstone != NULL) {
-            WT_ASSERT(session, F_ISSET(tombstone, WT_UPDATE_DURABLE));
+        if (tombstone != NULL)
             F_CLR(tombstone, WT_UPDATE_DURABLE);
-        }
     }
     return (0);
 }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -64,10 +64,12 @@ __rec_delete_hs_upd_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *
     ++r->delete_hs_upd_next;
 
     /* Clear the durable flag to allow them being included in a delta. */
-    if (WT_DELTA_LEAF_ENABLED(session)) {
+    if (F_ISSET(upd, WT_UPDATE_DURABLE)) {
         F_CLR(upd, WT_UPDATE_DURABLE);
-        if (tombstone != NULL)
+        if (tombstone != NULL) {
+            WT_ASSERT(session, F_ISSET(tombstone, WT_UPDATE_DURABLE));
             F_CLR(tombstone, WT_UPDATE_DURABLE);
+        }
     }
     return (0);
 }


### PR DESCRIPTION
In disagg, when building a delta with prepared updates, the following situation can cause us missing an update in the delta:

* Initially we write update U to the data store and we mark it with the WT_UPDATE_DURABLE flag.
* We do a prepared update Up. Now we have Up -> U on the update chain.
* We rollback the prepared update.
* However, the rollback timestamp is not stable and we still write Up to the data store and U to the history store.
* The rollback timestamp becomes stable and this time we skip Up and skip U as well when building the delta because it already has the WT_UPDATE_DURABLE flag on it.

We know that we need to delete U from the history store in this case as we will write it to the data store. We can clear the WT_UPDATE_DURABLE when saving the update to be deleted from the history store.

