### PR TITLE
WT-14911 Extend layered table verification to verify empty ingest table on leader node

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -242,12 +242,19 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
     /*
      * Get a list of the checkpoints for this file. Empty objects have no checkpoints, in which case
      * there's no work to do.
+     *
+     * Note: For ingest uris, __wt_meta_ckptlist_get should always return WT_NOTFOUND since ingest
+     * tables are not checkpointed. Ingest URIs should never make it past this point.
      */
     WT_ERR_NOTFOUND_OK(__wt_meta_ckptlist_get(session, name, false, &ckptbase, NULL), true);
     if (ret == WT_NOTFOUND) {
         ret = 0;
         goto done;
-    }
+    } else if (WT_SUFFIX_MATCH(name, ".wt_ingest"))
+        WT_ERR_MSG(session, EBUSY,
+          "verify (layered): ingest table %s unexpectedly has checkpoints. "
+          "This is a fatal violation as the ingest table does not get checkpointed.",
+          name);
 
     /* Inform the underlying block manager we're verifying. */
     WT_ERR(bm->verify_start(bm, session, ckptbase, cfg));

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -240,11 +240,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
         goto done;
 
     /*
-     * Get a list of the checkpoints for this file. Empty objects have no checkpoints, in which case
-     * there's no work to do.
-     *
-     * Note: For ingest uris, __wt_meta_ckptlist_get should always return WT_NOTFOUND since ingest
-     * tables are not checkpointed. Ingest URIs should never make it past this point.
+     * Get a list of the checkpoints for this file. Empty objects and ingest tables have no
+     * checkpoints, in which case there's no work to do.
      */
     WT_ERR_NOTFOUND_OK(__wt_meta_ckptlist_get(session, name, false, &ckptbase, NULL), true);
     if (ret == WT_NOTFOUND) {

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -249,8 +249,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
         goto done;
     } else if (WT_SUFFIX_MATCH(name, ".wt_ingest"))
         WT_ERR_MSG(session, WT_ERROR,
-          "verify (layered): ingest table %s unexpectedly has checkpoints. "
-          "This is a fatal violation as the ingest table does not get checkpointed.",
+          "verify (layered): ingest table %s unexpectedly has checkpoints. This is a fatal "
+          "violation as the ingest table does not get checkpointed.",
           name);
 
     /* Inform the underlying block manager we're verifying. */

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -248,7 +248,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
         ret = 0;
         goto done;
     } else if (WT_SUFFIX_MATCH(name, ".wt_ingest"))
-        WT_ERR_MSG(session, EBUSY,
+        WT_ERR_MSG(session, WT_ERROR,
           "verify (layered): ingest table %s unexpectedly has checkpoints. "
           "This is a fatal violation as the ingest table does not get checkpointed.",
           name);

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -130,16 +130,13 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
             __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
 
         /*
-         * Map EBUSY to WT_ERROR to prevent server retries, as EBUSY on a leader's ingest table is
-         * an invalid state
+         * FIXME-WT-15433 Add an assertion that verifying the ingest table of the leader never
+         * returns EBUSY.
          */
-        if (ingest_ret == EBUSY)
-            __wt_err(session, WT_ERROR,
-              "Verify (layered): %s ingest table on leader cannot be verified. "
-              "Ingest contains dirty content or open cursors, which is an invalid state.",
-              ingest_uri);
-        else if (ingest_ret != 0)
-            __wt_err(session, ingest_ret, "Verify (layered): %s ingest table verification failed. ",
+        if (ingest_ret != 0)
+            __wt_err(session, ingest_ret,
+              "Verify (layered): %s ingest ingest table verification failed. "
+              "Ingest may contain dirty content or open cursors, which is an invalid state.",
               ingest_uri);
     }
 

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -110,8 +110,8 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
               "Verify (layered): %s ingest table on leader cannot be verified. "
               "Ingest contains dirty content or open cursors, which is an invalid state.",
               ingest_uri);
-    }
     WT_ERR(ret);
+    }
 
     WT_WITHOUT_DHANDLE(session,
       ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -78,19 +78,38 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
   int (*file_func)(WT_SESSION_IMPL *, const char *[]),
   int (*name_func)(WT_SESSION_IMPL *, const char *, bool *), const char *cfg[], uint32_t open_flags)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
+
+    conn = S2C(session);
 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, open_flags));
     WT_LAYERED_TABLE *layered = (WT_LAYERED_TABLE *)session->dhandle;
     const char *stable_uri = layered->stable_uri;
+    const char *ingest_uri = layered->ingest_uri;
 
     WT_ASSERT(session, stable_uri != NULL);
+    WT_ASSERT(session, ingest_uri != NULL);
     WT_ASSERT(session, file_func == __wt_verify);
+
+    if (conn->layered_table_manager.leader) {
+        WT_WITHOUT_DHANDLE(session,
+          ret = __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
+        /* To verify ingest table on leader there must be: no dirty content, no open cursors, no
+         * ckpt */
+        if (ret == EBUSY)
+            /* This is very bad. The ingest table on leader must either be empty or no-op */
+            WT_ERR_MSG(session, ret,
+              "Verify (layered): ingest table %s on leader cannot be verified. Returned EBUSY",
+              ingest_uri);
+    }
 
     WT_WITHOUT_DHANDLE(session,
       ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
 
     WT_TRET(__wt_session_release_dhandle(session));
+
+err:
     return (ret);
 }
 

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -94,7 +94,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     /*
      * Verifying stable tables of layered tables uses the existing verify logic.
      * Ingest tables, however, require special handling:
-     * - On leader: ingest must always be empty/no-op (verification is only valid if empty).
+     * - On leader: ingest must always be empty/no-op.
      * - On followers: ingest contains recent oplog updates layered over the stable table.
      */
 

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -79,14 +79,24 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
+    int ingest_ret, stable_ret;
+    const char *ingest_uri, *stable_uri;
 
     conn = S2C(session);
+    ingest_ret = stable_ret = 0;
 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, open_flags));
     WT_LAYERED_TABLE *layered = (WT_LAYERED_TABLE *)session->dhandle;
-    const char *stable_uri = layered->stable_uri;
-    const char *ingest_uri = layered->ingest_uri;
 
+    ingest_uri = layered->ingest_uri;
+    stable_uri = layered->stable_uri;
+
+    /*
+     * FIXME-WT-15413 - Verify assumes the stable table always exists. However, on followers that
+     * have not yet picked up their first checkpoint, the stable constituent will be missing. We
+     * should handle this transient state by skipping stable verification with a clear message
+     * instead of failing with ENOENT.
+     */
     WT_ASSERT(session, stable_uri != NULL);
     WT_ASSERT(session, ingest_uri != NULL);
     WT_ASSERT(session, file_func == __wt_verify);
@@ -98,27 +108,46 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
      * - On followers: ingest contains recent oplog updates layered over the stable table.
      */
 
+    /* Verify the stable table of the layered table. */
+    WT_WITHOUT_DHANDLE(session,
+      stable_ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
+
+    if (stable_ret != 0)
+        __wt_err(session, stable_ret, "Verify (layered): %s stable table verification failed. ",
+          stable_uri);
+
+    /*
+     * Verify the ingest table of the layered table. FIXME-WT-15047: Implement ingest table
+     * verification on followers.
+     */
     if (conn->layered_table_manager.leader) {
         /*
          * On leader, if verifying ingest returns EBUSY, it means ingest is not empty (dirty
-         * content, open cursors, or checkpoints present), which is an invalid state.
+         * content, or open cursors), which is an invalid state.
          */
         WT_WITHOUT_DHANDLE(session,
-          ret = __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
-        if (ret == EBUSY)
-            WT_ERR_MSG(session, WT_ERROR,
+          ingest_ret =
+            __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
+
+        if (ingest_ret == EBUSY)
+            __wt_err(session, ingest_ret,
               "Verify (layered): %s ingest table on leader cannot be verified. "
               "Ingest contains dirty content or open cursors, which is an invalid state.",
               ingest_uri);
-    WT_ERR(ret);
+
+        /* If ingest verification returned any error other than EBUSY, propagate it. */
+        WT_ERR_ERROR_OK(ingest_ret, EBUSY, true);
     }
 
-    WT_WITHOUT_DHANDLE(session,
-      ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
+err:
+    __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
+      "Verify (layered): stable table %s returned %s, ingest table %s returned %s", stable_uri,
+      __wt_wiredtiger_error(stable_ret), ingest_uri, __wt_wiredtiger_error(ingest_ret));
 
     WT_TRET(__wt_session_release_dhandle(session));
 
-err:
+    ret = (stable_ret != 0) ? stable_ret : ingest_ret;
+
     return (ret);
 }
 

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -111,6 +111,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
               "Ingest contains dirty content or open cursors, which is an invalid state.",
               ingest_uri);
     }
+    WT_ERR(ret);
 
     WT_WITHOUT_DHANDLE(session,
       ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -106,8 +106,10 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
         WT_WITHOUT_DHANDLE(session,
           ret = __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
         if (ret == EBUSY)
-            WT_ERR_MSG(session, ret,
-              "Verify (layered): ingest table %s on leader cannot be verified.", ingest_uri);
+            WT_ERR_MSG(session, WT_ERROR,
+              "Verify (layered): %s ingest table on leader cannot be verified. Returned EBUSY, "
+              "this is an invalid access pattern",
+              ingest_uri);
     }
 
     WT_WITHOUT_DHANDLE(session,

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -101,7 +101,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     if (conn->layered_table_manager.leader) {
         /*
          * On leader, if verifying ingest returns EBUSY, it means ingest is not empty (dirty
-         * content, open cursors, or checkpoints present), which is a fatal violation.
+         * content, open cursors, or checkpoints present), which is an invalid state.
          */
         WT_WITHOUT_DHANDLE(session,
           ret = __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -94,7 +94,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     /*
      * FIXME-WT-15413 - Verify assumes the stable table always exists. However, on followers that
      * have not yet picked up their first checkpoint, the stable constituent will be missing. We
-     * should handle this transient state by skipping stable verification with a clear message
+     * should handle this transient state by skipping stable verification
      * instead of failing with ENOENT.
      */
     WT_ASSERT(session, stable_uri != NULL);

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -107,8 +107,8 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
           ret = __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
         if (ret == EBUSY)
             WT_ERR_MSG(session, WT_ERROR,
-              "Verify (layered): %s ingest table on leader cannot be verified. Returned EBUSY, "
-              "this is an invalid access pattern",
+              "Verify (layered): %s ingest table on leader cannot be verified. "
+              "Ingest contains dirty content or open cursors, which is an invalid state.",
               ingest_uri);
     }
 

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -68,10 +68,9 @@ err:
 
 /*
  * __schema_layered_worker_verify --
- *     Run a schema worker operation (which is verification) on the stable table; ingest is not
- *     supported currently.
+ *     Run a schema worker operation (which is verification) on the layered table.
  *
- * FIXME-WT-15047: Implement ingest table verification (and update the function description)
+ * FIXME-WT-15047: Implement ingest table verification on followers.
  */
 static int
 __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
@@ -92,16 +91,23 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     WT_ASSERT(session, ingest_uri != NULL);
     WT_ASSERT(session, file_func == __wt_verify);
 
+    /*
+     * Verifying stable tables of layered tables uses the existing verify logic.
+     * Ingest tables, however, require special handling:
+     * - On leader: ingest must always be empty/no-op (verification is only valid if empty).
+     * - On followers: ingest contains recent oplog updates layered over the stable table.
+     */
+
     if (conn->layered_table_manager.leader) {
+        /*
+         * On leader, if verifying ingest returns EBUSY, it means ingest is not empty (dirty
+         * content, open cursors, or checkpoints present), which is a fatal violation.
+         */
         WT_WITHOUT_DHANDLE(session,
           ret = __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
-        /* To verify ingest table on leader there must be: no dirty content, no open cursors, no
-         * ckpt */
         if (ret == EBUSY)
-            /* This is very bad. The ingest table on leader must either be empty or no-op */
             WT_ERR_MSG(session, ret,
-              "Verify (layered): ingest table %s on leader cannot be verified. Returned EBUSY",
-              ingest_uri);
+              "Verify (layered): ingest table %s on leader cannot be verified.", ingest_uri);
     }
 
     WT_WITHOUT_DHANDLE(session,

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -105,7 +105,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
      * Verifying stable tables of layered tables uses the existing verify logic.
      * Ingest tables, however, require special handling:
      * - On leader: ingest must always be empty/no-op.
-     * - On followers: ingest contains recent oplog updates layered over the stable table.
+     * - On followers: FIXME-WT-15047 ingest tables are not checkpointed.
      */
 
     /* Verify the stable table of the layered table. */

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -83,7 +83,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     const char *ingest_uri, *stable_uri;
 
     conn = S2C(session);
-    ingest_ret = stable_ret = 0;
+    ingest_ret = 0;
 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, open_flags));
     WT_LAYERED_TABLE *layered = (WT_LAYERED_TABLE *)session->dhandle;
@@ -94,8 +94,8 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     /*
      * FIXME-WT-15413 - Verify assumes the stable table always exists. However, on followers that
      * have not yet picked up their first checkpoint, the stable constituent will be missing. We
-     * should handle this transient state by skipping stable verification
-     * instead of failing with ENOENT.
+     * should handle this transient state by skipping stable verification instead of failing with
+     * ENOENT.
      */
     WT_ASSERT(session, stable_uri != NULL);
     WT_ASSERT(session, ingest_uri != NULL);
@@ -112,7 +112,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     WT_WITHOUT_DHANDLE(session,
       stable_ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
 
-    if (stable_ret != 0)
+    if (stable_ret != 0 && stable_ret != EBUSY)
         __wt_err(session, stable_ret, "Verify (layered): %s stable table verification failed. ",
           stable_uri);
 
@@ -129,17 +129,20 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
           ingest_ret =
             __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
 
+        /*
+         * Map EBUSY to WT_ERROR to prevent server retries, as EBUSY on a leader's ingest table is
+         * an invalid state
+         */
         if (ingest_ret == EBUSY)
-            __wt_err(session, ingest_ret,
+            __wt_err(session, WT_ERROR,
               "Verify (layered): %s ingest table on leader cannot be verified. "
               "Ingest contains dirty content or open cursors, which is an invalid state.",
               ingest_uri);
-
-        /* If ingest verification returned any error other than EBUSY, propagate it. */
-        WT_ERR_ERROR_OK(ingest_ret, EBUSY, true);
+        else if (ingest_ret != 0)
+            __wt_err(session, ingest_ret, "Verify (layered): %s ingest table verification failed. ",
+              ingest_uri);
     }
 
-err:
     __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
       "Verify (layered): stable table %s returned %s, ingest table %s returned %s", stable_uri,
       __wt_wiredtiger_error(stable_ret), ingest_uri, __wt_wiredtiger_error(ingest_ret));

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -113,7 +113,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
       stable_ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
 
     if (stable_ret != 0 && stable_ret != EBUSY)
-        __wt_err(session, stable_ret, "Verify (layered): %s stable table verification failed. ",
+        WT_ERR_MSG(session, stable_ret, "Verify (layered): %s stable table verification failed. ",
           stable_uri);
 
     /*
@@ -134,12 +134,13 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
          * returns EBUSY.
          */
         if (ingest_ret != 0)
-            __wt_err(session, ingest_ret,
-              "Verify (layered): %s ingest ingest table verification failed. "
-              "Ingest may contain dirty content or open cursors, which is an invalid state.",
+            WT_ERR_MSG(session, ingest_ret,
+              "Verify (layered): %s ingest table verification failed. Ingest must always be empty "
+              "on leader.",
               ingest_uri);
     }
 
+err:
     __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
       "Verify (layered): stable table %s returned %s, ingest table %s returned %s", stable_uri,
       __wt_wiredtiger_error(stable_ret), ingest_uri, __wt_wiredtiger_error(ingest_ret));

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -80,7 +80,6 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     int ingest_ret, stable_ret;
-    const char *ingest_uri, *stable_uri;
 
     conn = S2C(session);
     ingest_ret = 0;
@@ -88,8 +87,8 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, open_flags));
     WT_LAYERED_TABLE *layered = (WT_LAYERED_TABLE *)session->dhandle;
 
-    ingest_uri = layered->ingest_uri;
-    stable_uri = layered->stable_uri;
+    const char *ingest_uri = layered->ingest_uri;
+    const char *stable_uri = layered->stable_uri;
 
     /*
      * FIXME-WT-15413 - Verify assumes the stable table always exists. However, on followers that
@@ -147,7 +146,8 @@ err:
 
     WT_TRET(__wt_session_release_dhandle(session));
 
-    ret = (stable_ret != 0) ? stable_ret : ingest_ret;
+    /* Ingest is expected to never return EBUSY so it's enough to check it for 0 only */
+    ret = ingest_ret != 0 ? ingest_ret : stable_ret;
 
     return (ret);
 }

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -117,9 +117,8 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Perform update operations to fill HS
         self.leader_put_data(value_prefix = 'aaa')
         self.leader_put_data(value_prefix = 'bbb')
-        # That's not allowed to perform verification if there is some dirty data
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.verify([self.session]), '/stable table verification failed/')
+        # We're not allowed to perform verification if there is some dirty data
+        self.verify([self.session], errno.EBUSY)
 
         # Checkpoint the data on the leader
         self.session.checkpoint()

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -58,6 +58,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_follow = None
 
     uri = 'layered:test_verify_disagg'
+    # Use internals to test a specific edge case scenario.
     ingest_uri = 'file:test_verify_disagg.wt_ingest'
 
     def leader_put_data(self, value_prefix = '', low = 1, high = nitems):
@@ -146,7 +147,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         # Verify fails as the ingest table on leader has open cursors
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.verify([self.session]), '/ingest table on leader cannot be verified/')
+            lambda: self.verify([self.session]), '/ingest table verification failed/')
 
         ingest_cursor.close()
 

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -99,6 +99,9 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # from the leader (it requires reconfiguration). Followers are only able to create their
         # ingest constituents. They see stable through checkpoint or step-up.
         self.verify([self.session])
+
+        # Follower has not picked up a checkpoint yet, so it has no stable constituent yet
+        # FIXME-WT-15413 - until this is fixed, expect ENOENT
         self.verify([self.session_follow], errno.ENOENT)
 
         # Create an empty checkpoint
@@ -115,7 +118,8 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.leader_put_data(value_prefix = 'aaa')
         self.leader_put_data(value_prefix = 'bbb')
         # That's not allowed to perform verification if there is some dirty data
-        self.verify([self.session], errno.EBUSY)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.verify([self.session]), '/stable table verification failed/')
 
         # Checkpoint the data on the leader
         self.session.checkpoint()

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -58,6 +58,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_follow = None
 
     uri = 'layered:test_verify_disagg'
+    ingest_uri = 'file:test_verify_disagg.wt_ingest'
 
     def leader_put_data(self, value_prefix = '', low = 1, high = nitems):
         cursor = self.session.open_cursor(self.uri, None, None)
@@ -87,14 +88,16 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         if self.fill_hs:
             self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(self.timestamp))
 
-        # Create a table in the leader
+        # Create a layered table on the leader
         self.session.create(self.uri, self.table_cfg)
         # Verify the empty leader's table
         self.verify([self.session])
 
         # Create a follower
         self.create_follower()
-        # The leader's table stays empty, the follower creation doesn't mean loading tables from the leader (it requires reconfiguration)
+        # The leader's table stays empty, the follower creation doesn't mean loading tables
+        # from the leader (it requires reconfiguration). Followers are only able to create their
+        # ingest constituents. They see stable through checkpoint or step-up.
         self.verify([self.session])
         self.verify([self.session_follow], errno.ENOENT)
 
@@ -128,4 +131,20 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.conn_follow.close()
 
         # The leader is still alive, verify it.
+        self.verify([self.session])
+
+    def test_verify_ingest_busy_on_leader(self):
+        # Create a layered table on the leader
+        self.session.create(self.uri, self.table_cfg)
+        self.session.checkpoint()
+
+        # Open a cursor on the ingest component on leader
+        ingest_cursor = self.session.open_cursor(self.ingest_uri, None, None)
+
+        # Verify fails as the ingest table on leader has open cursors
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.verify([self.session]), '/ingest table on leader cannot be verified/')
+
+        ingest_cursor.close()
+
         self.verify([self.session])


### PR DESCRIPTION
We can now verify empty ingest tables on leader nodes.

- In `__schema_layered_worker_verify`, leader ingest verification fails with `EBUSY` if the ingest table is not empty (open cursors, dirty data, checkpoints).
- Added a check in `__wt_verify` to raise an error if ingest uri return checkpoints.
- Added python test to confirm that opening a cursor on the leader’s ingest table causes verify to fail, and that verify succeeds once the cursor is closed.
- Both ingest and stable constituents will be verified, neither will be skipped regardless of `ret`