### PR TITLE
WT-15290 Provide a faster API for setting the materialization frontier

### DIFF
--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1054,9 +1054,9 @@ connection_ops(WT_CONNECTION *conn)
       conn->configure_method(conn, "WT_SESSION.open_cursor", "my_data:", "devices", "list", NULL));
     /*! [Configure method configuration] */
 
-    /*! [Set the last materialized LSN] */
-    error_check(conn->set_global_lsn_uint(conn, WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED, 100));
-    /*! [Set the last materialized LSN] */
+    /*! [Set the last materialized LSN by the page log service] */
+    error_check(conn->set_context_uint(conn, WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN, 100));
+    /*! [Set the last materialized LSN by the page log service] */
 
     /*! [Close a connection] */
     error_check(conn->close(conn, NULL));

--- a/examples/c/ex_all.c
+++ b/examples/c/ex_all.c
@@ -1054,6 +1054,10 @@ connection_ops(WT_CONNECTION *conn)
       conn->configure_method(conn, "WT_SESSION.open_cursor", "my_data:", "devices", "list", NULL));
     /*! [Configure method configuration] */
 
+    /*! [Set the last materialized LSN] */
+    error_check(conn->set_global_lsn_uint(conn, WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED, 100));
+    /*! [Set the last materialized LSN] */
+
     /*! [Close a connection] */
     error_check(conn->close(conn, NULL));
     /*! [Close a connection] */

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2921,6 +2921,31 @@ __conn_version_verify(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __conn_set_global_lsn_uint --
+ *     Set the global LSN.
+ */
+static int
+__conn_set_global_lsn_uint(WT_CONNECTION *wt_conn, WT_GLOBAL_LSN_TYPE which, uint64_t lsn)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+
+    conn = (WT_CONNECTION_IMPL *)wt_conn;
+
+    CONNECTION_API_CALL_NOCONF(conn, session, set_global_lsn_uint);
+
+    switch (which) {
+    case WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED:
+        WT_ERR(__wti_disagg_set_last_materialized_lsn(session, lsn));
+        break;
+    }
+
+err:
+    API_END_RET(session, ret);
+}
+
+/*
  * wiredtiger_open --
  *     Main library entry point: open a new connection to a WiredTiger database.
  */
@@ -2933,7 +2958,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
       __conn_open_session, __conn_query_timestamp, __conn_set_timestamp, __conn_rollback_to_stable,
       __conn_load_extension, __conn_add_data_source, __conn_add_collator, __conn_add_compressor,
       __conn_add_encryptor, __conn_set_file_system, __conn_add_page_log, __conn_add_storage_source,
-      __conn_get_page_log, __conn_get_storage_source, __conn_get_extension_api};
+      __conn_get_page_log, __conn_get_storage_source, __conn_set_global_lsn_uint,
+      __conn_get_extension_api};
     static const WT_NAME_FLAG file_types[] = {
       {"data", WT_FILE_TYPE_DATA}, {"log", WT_FILE_TYPE_LOG}, {NULL, 0}};
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2921,11 +2921,11 @@ __conn_version_verify(WT_SESSION_IMPL *session)
 }
 
 /*
- * __conn_set_global_lsn_uint --
- *     Set the global LSN.
+ * __conn_set_context_uint --
+ *     Set a global context parameter.
  */
 static int
-__conn_set_global_lsn_uint(WT_CONNECTION *wt_conn, WT_GLOBAL_LSN_TYPE which, uint64_t lsn)
+__conn_set_context_uint(WT_CONNECTION *wt_conn, WT_CONTEXT_TYPE which, uint64_t value)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
@@ -2933,11 +2933,11 @@ __conn_set_global_lsn_uint(WT_CONNECTION *wt_conn, WT_GLOBAL_LSN_TYPE which, uin
 
     conn = (WT_CONNECTION_IMPL *)wt_conn;
 
-    CONNECTION_API_CALL_NOCONF(conn, session, set_global_lsn_uint);
+    CONNECTION_API_CALL_NOCONF(conn, session, set_context_uint);
 
     switch (which) {
-    case WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED:
-        WT_ERR(__wti_disagg_set_last_materialized_lsn(session, lsn));
+    case WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN:
+        WT_ERR(__wti_disagg_set_last_materialized_lsn(session, value));
         break;
     }
 
@@ -2958,7 +2958,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
       __conn_open_session, __conn_query_timestamp, __conn_set_timestamp, __conn_rollback_to_stable,
       __conn_load_extension, __conn_add_data_source, __conn_add_collator, __conn_add_compressor,
       __conn_add_encryptor, __conn_set_file_system, __conn_add_page_log, __conn_add_storage_source,
-      __conn_get_page_log, __conn_get_storage_source, __conn_set_global_lsn_uint,
+      __conn_get_page_log, __conn_get_storage_source, __conn_set_context_uint,
       __conn_get_extension_api};
     static const WT_NAME_FLAG file_types[] = {
       {"data", WT_FILE_TYPE_DATA}, {"log", WT_FILE_TYPE_LOG}, {NULL, 0}};

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -860,11 +860,11 @@ err:
 }
 
 /*
- * __disagg_set_last_materialized_lsn --
+ * __wti_disagg_set_last_materialized_lsn --
  *     Set the latest materialized LSN.
  */
-static int
-__disagg_set_last_materialized_lsn(WT_SESSION_IMPL *session, uint64_t lsn)
+int
+__wti_disagg_set_last_materialized_lsn(WT_SESSION_IMPL *session, uint64_t lsn)
 {
     WT_DISAGGREGATED_STORAGE *disagg;
     uint64_t cur_lsn;
@@ -951,7 +951,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     /* Get the last materialized LSN. */
     WT_ERR(__wt_config_gets(session, cfg, "disaggregated.last_materialized_lsn", &cval));
     if (cval.len > 0 && cval.val >= 0)
-        WT_ERR(__disagg_set_last_materialized_lsn(session, (uint64_t)cval.val));
+        WT_ERR(__wti_disagg_set_last_materialized_lsn(session, (uint64_t)cval.val));
 
     /* Set the role. */
     WT_ERR(__wt_config_gets(session, cfg, "disaggregated.role", &cval));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1486,6 +1486,8 @@ extern int __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_disagg_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_disagg_set_last_materialized_lsn(WT_SESSION_IMPL *session, uint64_t lsn)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_ensure_clean_startup_dir(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_execute_handle_operation(WT_SESSION_IMPL *session, const char *uri,

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2041,6 +2041,11 @@ struct __wt_session {
 #endif
 };
 
+/*! WT_CONNECTION::set_global_lsn_uint LSN types */
+typedef enum {
+    WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED, /*!< The LSN of the last materialized log entry. */
+} WT_GLOBAL_LSN_TYPE;
+
 /*!
  * A connection to a WiredTiger database.  The connection may be opened within
  * the same address space as the caller or accessed over a socket connection.
@@ -2909,6 +2914,19 @@ struct __wt_connection {
      */
     int __F(get_storage_source)(WT_CONNECTION *connection, const char *name,
         WT_STORAGE_SOURCE **storage_sourcep);
+
+    /*!
+     * Set a global log sequence number (LSN).
+     *
+     * @snippet ex_all.c Set the last materialized LSN
+     *
+     * @param connection the connection handle
+     * @param which the LSN being set (see ::WT_GLOBAL_LSN_TYPE for available options).
+     * @param lsn the LSN.
+     * @errors
+     */
+    int __F(set_global_lsn_uint)(WT_CONNECTION *connection, WT_GLOBAL_LSN_TYPE which,
+        uint64_t lsn);
 #endif
 
     /*!

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2041,10 +2041,10 @@ struct __wt_session {
 #endif
 };
 
-/*! WT_CONNECTION::set_global_lsn_uint LSN types */
+/*! WT_CONNECTION::set_context_uint types */
 typedef enum {
-    WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED, /*!< The LSN of the last materialized log entry. */
-} WT_GLOBAL_LSN_TYPE;
+    WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN, /*!< The LSN of the last materialized page log entry. */
+} WT_CONTEXT_TYPE;
 
 /*!
  * A connection to a WiredTiger database.  The connection may be opened within
@@ -2916,17 +2916,18 @@ struct __wt_connection {
         WT_STORAGE_SOURCE **storage_sourcep);
 
     /*!
-     * Set a global log sequence number (LSN).
+     * Set a global context parameter, which tells WiredTiger about relevant changes
+     * in the running system, such as the state of the page log service.
      *
-     * @snippet ex_all.c Set the last materialized LSN
+     * @snippet ex_all.c Set the last materialized page log LSN by the page log service
      *
      * @param connection the connection handle
-     * @param which the LSN being set (see ::WT_GLOBAL_LSN_TYPE for available options).
-     * @param lsn the LSN.
+     * @param which the context parameter being set (see ::WT_CONTEXT_TYPE for available options).
+     * @param value the value
      * @errors
      */
-    int __F(set_global_lsn_uint)(WT_CONNECTION *connection, WT_GLOBAL_LSN_TYPE which,
-        uint64_t lsn);
+    int __F(set_context_uint)(WT_CONNECTION *connection, WT_CONTEXT_TYPE which,
+        uint64_t value);
 #endif
 
     /*!

--- a/test/suite/test_layered39.py
+++ b/test/suite/test_layered39.py
@@ -86,8 +86,8 @@ class test_layered39(wttest.WiredTigerTestCase, DisaggConfigMixin):
                 if i % 20_000 == 0:
                     self.conn.reconfigure(f'disaggregated=(last_materialized_lsn={last_lsn})')
                 else:
-                    self.conn.set_global_lsn_uint(wiredtiger.WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED,
-                                                  last_lsn)
+                    self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN,
+                                               last_lsn)
         cursor.close()
 
         self.pr(f'cache_scrub_restore = {self.get_stat(wiredtiger.stat.conn.cache_scrub_restore)}')

--- a/test/suite/test_layered39.py
+++ b/test/suite/test_layered39.py
@@ -76,13 +76,18 @@ class test_layered39(wttest.WiredTigerTestCase, DisaggConfigMixin):
             cursor["Hello " + str(i)] = "World"
             cursor["Hi " + str(i)] = "There"
             cursor["OK " + str(i)] = "Go"
-            if i % 10000 == 0:
+            if i % 10_000 == 0:
                 self.session.checkpoint()
                 (ret, last_lsn) = page_log.pl_get_last_lsn(self.session)
                 self.pr(f"{i=} {last_lsn=}")
                 self.assertEqual(ret, 0)
                 page_log.pl_set_last_materialized_lsn(self.session, last_lsn)
-                self.conn.reconfigure(f'disaggregated=(last_materialized_lsn={last_lsn})')
+                # Test both ways of setting the last materialized LSN.
+                if i % 20_000 == 0:
+                    self.conn.reconfigure(f'disaggregated=(last_materialized_lsn={last_lsn})')
+                else:
+                    self.conn.set_global_lsn_uint(wiredtiger.WT_GLOBAL_LSN_TYPE_LAST_MATERIALIZED,
+                                                  last_lsn)
         cursor.close()
 
         self.pr(f'cache_scrub_restore = {self.get_stat(wiredtiger.stat.conn.cache_scrub_restore)}')


### PR DESCRIPTION
Provide a faster path to setting the last materialization frontier.

There are two ways to do this:
* Improving the current method by providing an even faster path through `WT_CONNECTION::reconfigure`.
* Adding a new method to `WT_CONNECTION` for setting the LSN, modeled after `WT_SESSION::timestamp_transaction_uint`

The PR prototypes both options to provide a stake in the ground for discussion. We can include one or both of these options.