### PR TITLE
WT-15011 Return more specific error message about what caused WT_WRITE_CONFLICT

### DIFF
--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -53,6 +53,7 @@
 
 /* Basic constants. */
 #define WT_MILLION_LITERAL 1000000
+#define WT_HUNDRED (100)
 #define WT_THOUSAND (1000)
 #define WT_MILLION (WT_MILLION_LITERAL)
 #define WT_BILLION (1000000000)

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -415,6 +415,8 @@ struct __wt_txn {
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     wt_shared uint32_t flags;
 
+    uint8_t modify_block_count;
+
     /*
      * Zero or more bytes of value (the payload) immediately follows the WT_TXN structure. We use a
      * C99 flexible array member which has the semantics we want.

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -415,7 +415,7 @@ struct __wt_txn {
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     wt_shared uint32_t flags;
 
-    uint8_t modify_block_count;
+    uint16_t modify_block_count;
 
     /*
      * Zero or more bytes of value (the payload) immediately follows the WT_TXN structure. We use a

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2075,7 +2075,7 @@ __txn_modify_block(
         if (upd->txnid != WT_TXN_ABORTED) {
             ++txn->modify_block_count;
             __wt_verbose_level(session, WT_VERB_TRANSACTION,
-              txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
+              txn->modify_block_count >= WT_HUNDRED ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
               "Conflict with update with txn id %" PRIu64
               " at start timestamp: %s, prepare timestamp: %s",
               upd->txnid, __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
@@ -2105,7 +2105,7 @@ __txn_modify_block(
                 if (rollback) {
                     ++txn->modify_block_count;
                     __wt_verbose_level(session, WT_VERB_TRANSACTION,
-                      txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
+                      txn->modify_block_count >= WT_HUNDRED ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
                       "Conflict with update %" PRIu64
                       " at stop timestamp: %s, prepare timestamp: %s",
                       tw.stop_txn, __wt_timestamp_to_string(tw.stop_ts, ts_string[0]),
@@ -2116,7 +2116,7 @@ __txn_modify_block(
                 if (rollback) {
                     ++txn->modify_block_count;
                     __wt_verbose_level(session, WT_VERB_TRANSACTION,
-                      txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
+                      txn->modify_block_count >= WT_HUNDRED ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
                       "Conflict with update %" PRIu64
                       " at start timestamp: %s, prepare timestamp: %s",
                       tw.start_txn, __wt_timestamp_to_string(tw.start_ts, ts_string[0]),
@@ -2129,7 +2129,7 @@ __txn_modify_block(
     if (rollback) {
         /* Dump information about the txn snapshot. */
         WT_VERBOSE_LEVEL level =
-          txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1;
+          txn->modify_block_count >= WT_HUNDRED ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1;
 
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_TRANSACTION, level)) {
             WT_ERR(__wt_scr_alloc(session, 1024, &buf));

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2072,10 +2072,13 @@ __txn_modify_block(
     F_CLR(txn, WT_TXN_IGNORE_PREPARE);
     for (; upd != NULL && !__wt_txn_upd_visible(session, upd); upd = upd->next) {
         if (upd->txnid != WT_TXN_ABORTED) {
-            __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
-              "Conflict with update with txn id %" PRIu64
+            ++txn->modify_block_count;
+            __wt_verbose_level(session, WT_VERB_TRANSACTION,
+              txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
+              "Conflict with %s update with txn id %" PRIu64
               " at start timestamp: %s, prepare timestamp: %s",
-              upd->txnid, __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
+              F_ISSET(txn, WT_TXN_PREPARE) ? "prepared" : "", upd->txnid,
+              __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
               __wt_timestamp_to_string(upd->prepare_ts, ts_string[1]));
             rollback = true;
             break;
@@ -2099,27 +2102,36 @@ __txn_modify_block(
         if (tw_found) {
             if (WT_TIME_WINDOW_HAS_STOP(&tw)) {
                 rollback = !__wt_txn_tw_stop_visible(session, &tw);
-                if (rollback)
-                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
+                if (rollback) {
+                    ++txn->modify_block_count;
+                    __wt_verbose_level(session, WT_VERB_TRANSACTION,
+                      txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
                       "Conflict with update %" PRIu64
                       " at stop timestamp: %s, prepare timestamp: %s",
                       tw.stop_txn, __wt_timestamp_to_string(tw.stop_ts, ts_string[0]),
                       __wt_timestamp_to_string(tw.stop_prepare_ts, ts_string[1]));
+                }
             } else {
                 rollback = !__wt_txn_tw_start_visible(session, &tw);
-                if (rollback)
-                    __wt_verbose_debug1(session, WT_VERB_TRANSACTION,
+                if (rollback) {
+                    ++txn->modify_block_count;
+                    __wt_verbose_level(session, WT_VERB_TRANSACTION,
+                      txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
                       "Conflict with update %" PRIu64
                       " at start timestamp: %s, prepare timestamp: %s",
                       tw.start_txn, __wt_timestamp_to_string(tw.start_ts, ts_string[0]),
                       __wt_timestamp_to_string(tw.start_prepare_ts, ts_string[1]));
+                }
             }
         }
     }
 
     if (rollback) {
         /* Dump information about the txn snapshot. */
-        if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_TRANSACTION, WT_VERBOSE_DEBUG_1)) {
+        WT_VERBOSE_LEVEL level =
+          txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1;
+
+        if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_TRANSACTION, level)) {
             WT_ERR(__wt_scr_alloc(session, 1024, &buf));
             WT_ERR(__wt_buf_fmt(session, buf,
               "snapshot_min=%" PRIu64 ", snapshot_max=%" PRIu64 ", snapshot_count=%" PRIu32,
@@ -2134,8 +2146,12 @@ __txn_modify_block(
                 WT_ERR(__wt_buf_catfmt(
                   session, buf, "%" PRIu64 "]", txn->snapshot_data.snapshot[snap_count]));
             }
-            __wt_verbose_debug1(session, WT_VERB_TRANSACTION, "%s", (const char *)buf->data);
+            __wt_verbose_level(session, WT_VERB_TRANSACTION, level, "%s", (const char *)buf->data);
         }
+
+        /* Reset modify_block_count to prevent int overflow.*/
+        if (txn->modify_block_count >= 100)
+            txn->modify_block_count = 100;
 
         WT_STAT_CONN_DSRC_INCR(session, txn_update_conflict);
         ret = WT_ROLLBACK;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2078,7 +2078,7 @@ __txn_modify_block(
               txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
               "Conflict with update with txn id %" PRIu64
               " at start timestamp: %s, prepare timestamp: %s",
-              __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
+              upd->txnid, __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
               __wt_timestamp_to_string(upd->prepare_ts, ts_string[1]));
             rollback = true;
             break;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1822,6 +1822,7 @@ __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
     txn->commit_timestamp = WT_TS_NONE;
     txn->durable_timestamp = WT_TS_NONE;
     txn->first_commit_timestamp = WT_TS_NONE;
+    txn->modify_block_count = 0;
 
     WT_ASSERT(session, !F_ISSET(txn, WT_TXN_RUNNING));
 
@@ -2075,9 +2076,8 @@ __txn_modify_block(
             ++txn->modify_block_count;
             __wt_verbose_level(session, WT_VERB_TRANSACTION,
               txn->modify_block_count >= 100 ? WT_VERBOSE_INFO : WT_VERBOSE_DEBUG_1,
-              "Conflict with %s update with txn id %" PRIu64
+              "Conflict with update with txn id %" PRIu64
               " at start timestamp: %s, prepare timestamp: %s",
-              F_ISSET(txn, WT_TXN_PREPARE) ? "prepared" : "", upd->txnid,
               __wt_timestamp_to_string(upd->upd_start_ts, ts_string[0]),
               __wt_timestamp_to_string(upd->prepare_ts, ts_string[1]));
             rollback = true;
@@ -2148,10 +2148,6 @@ __txn_modify_block(
             }
             __wt_verbose_level(session, WT_VERB_TRANSACTION, level, "%s", (const char *)buf->data);
         }
-
-        /* Reset modify_block_count to prevent int overflow.*/
-        if (txn->modify_block_count >= 100)
-            txn->modify_block_count = 100;
 
         WT_STAT_CONN_DSRC_INCR(session, txn_update_conflict);
         ret = WT_ROLLBACK;


### PR DESCRIPTION
The current txn modify conflict message lacks the information about the conflict txn is prepared txn or not, and it only writes on debug1 level.
This PR:
1. Adds extra information on whether the txn conflicts with a txn or a prepared txn.
2. Add a `modify_block_counter` in `WT_TXN` to show how many times a txn has conflicted in __txn_modify_block, if the counter reaches 100 we output the log on `WT_VERBOSE_INFO` level.
