### PR TITLE
WT-15086 Fix eviction thread panic during connection close with disagg enabled

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -217,6 +217,88 @@ __disagg_get_meta(WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn, WT_I
 }
 
 /*
+ * __disagg_put_meta --
+ *     Write metadata to disaggregated storage.
+ */
+static int
+__disagg_put_meta(WT_SESSION_IMPL *session, uint64_t page_id, const WT_ITEM *item, uint64_t *lsnp)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGGREGATED_STORAGE *disagg;
+    WT_PAGE_LOG_PUT_ARGS put_args;
+
+    conn = S2C(session);
+    disagg = &conn->disaggregated_storage;
+
+    WT_CLEAR(put_args);
+    if (disagg->page_log_meta != NULL) {
+        WT_RET(disagg->page_log_meta->plh_put(
+          disagg->page_log_meta, &session->iface, page_id, 0, &put_args, item));
+        if (lsnp != NULL)
+            *lsnp = put_args.lsn;
+        __wt_atomic_addv64(&disagg->num_meta_put, 1);
+        return (0);
+    }
+    return (ENOTSUP);
+}
+
+/*
+ * __wt_disagg_put_checkpoint_meta --
+ *     Write checkpoint information to the metadata page log and do the relevant bookkeeping.
+ */
+int
+__wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint_root,
+  size_t checkpoint_root_size, uint64_t checkpoint_timestamp)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_ITEM(buf);
+    WT_DECL_RET;
+    WT_DISAGGREGATED_STORAGE *disagg;
+    uint64_t lsn;
+    char *checkpoint_root_copy;
+
+    buf = NULL;
+    checkpoint_root_copy = NULL;
+    conn = S2C(session);
+    disagg = &conn->disaggregated_storage;
+    lsn = 0;
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+
+    if (checkpoint_root == NULL)
+        checkpoint_root = "";
+    if (checkpoint_root_size == 0)
+        checkpoint_root_size = strlen(checkpoint_root);
+
+    WT_ERR(__wt_strndup(session, checkpoint_root, checkpoint_root_size, &checkpoint_root_copy));
+
+    WT_ERR(__wt_scr_alloc(session, 0, &buf));
+    WT_ERR(__wt_buf_fmt(session, buf,
+      "%s\n"
+      "timestamp=%" PRIx64,
+      checkpoint_root_copy, checkpoint_timestamp));
+
+    /*
+     * Write the metadata to disaggregated storage. This should be the last statement in this
+     * function that is allowed to fail.
+     */
+    WT_ERR(__disagg_put_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, buf, &lsn));
+
+    /* Do the bookkeeping. */
+    WT_RELEASE_WRITE(disagg->last_checkpoint_meta_lsn, lsn);
+    WT_RELEASE_WRITE(disagg->last_checkpoint_timestamp, checkpoint_timestamp);
+
+    __wt_free(session, disagg->last_checkpoint_root);
+    disagg->last_checkpoint_root = checkpoint_root_copy;
+    checkpoint_root_copy = NULL;
+
+err:
+    __wt_free(session, checkpoint_root_copy);
+    __wt_scr_free(session, &buf);
+    return (ret);
+}
+
+/*
  * __disagg_pick_up_checkpoint --
  *     Pick up a new checkpoint.
  */
@@ -231,7 +313,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     WT_SESSION_IMPL *internal_session, *shared_metadata_session;
     size_t len, metadata_value_cfg_len;
     uint64_t checkpoint_timestamp;
-    char *buf, *cfg_ret, *checkpoint_config, *metadata_value_cfg, *layered_ingest_uri;
+    char *buf, *cfg_ret, *checkpoint_config, *root, *metadata_value_cfg, *layered_ingest_uri;
     const char *cfg[3], *current_value, *metadata_key, *metadata_value;
 
     conn = S2C(session);
@@ -244,6 +326,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     metadata_value = NULL;
     metadata_value_cfg = NULL;
     layered_ingest_uri = NULL;
+    root = NULL;
     shared_metadata_session = NULL;
     cfg_ret = NULL;
     WT_CLEAR(item);
@@ -279,7 +362,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
 
     /* Save the metadata key-value pair. */
     metadata_key = WT_DISAGG_METADATA_URI;
-    metadata_value = buf;
+    metadata_value = root = buf;
 
     /* We need an internal session when modifying metadata. */
     WT_ERR(__wt_open_internal_session(conn, "checkpoint-pick-up", false, 0, 0, &internal_session));
@@ -407,6 +490,10 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
 
     /* Update the checkpoint timestamp. */
     WT_RELEASE_WRITE(conn->disaggregated_storage.last_checkpoint_timestamp, checkpoint_timestamp);
+
+    /* Remember the root config of the last checkpoint. */
+    __wt_free(session, conn->disaggregated_storage.last_checkpoint_root);
+    WT_ERR(__wt_strdup(session, root, &conn->disaggregated_storage.last_checkpoint_root));
 
     /* Keep a record of past checkpoints, they will be needed for ingest garbage collection. */
     WT_ERR(__layered_track_checkpoint(session, checkpoint_timestamp));
@@ -1285,35 +1372,9 @@ __wti_disagg_destroy(WT_SESSION_IMPL *session)
         disagg->page_log_meta = NULL;
     }
 
+    __wt_free(session, disagg->last_checkpoint_root);
     __wt_free(session, disagg->page_log);
     return (ret);
-}
-
-/*
- * __wt_disagg_put_meta --
- *     Write metadata to disaggregated storage.
- */
-int
-__wt_disagg_put_meta(
-  WT_SESSION_IMPL *session, uint64_t page_id, const WT_ITEM *item, uint64_t *lsnp)
-{
-    WT_CONNECTION_IMPL *conn;
-    WT_DISAGGREGATED_STORAGE *disagg;
-    WT_PAGE_LOG_PUT_ARGS put_args;
-
-    conn = S2C(session);
-    disagg = &conn->disaggregated_storage;
-
-    WT_CLEAR(put_args);
-    if (disagg->page_log_meta != NULL) {
-        WT_RET(disagg->page_log_meta->plh_put(
-          disagg->page_log_meta, &session->iface, page_id, 0, &put_args, item));
-        if (lsnp != NULL)
-            *lsnp = put_args.lsn;
-        __wt_atomic_addv64(&disagg->num_meta_put, 1);
-        return (0);
-    }
-    return (ENOTSUP);
 }
 
 /*
@@ -1823,6 +1884,7 @@ static int
 __layered_track_checkpoint(WT_SESSION_IMPL *session, uint64_t checkpoint_timestamp)
 {
     WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
     WT_DISAGGREGATED_STORAGE *ds;
     int64_t order;
     uint32_t entry, expire;
@@ -1830,8 +1892,12 @@ __layered_track_checkpoint(WT_SESSION_IMPL *session, uint64_t checkpoint_timesta
     conn = S2C(session);
     ds = &conn->disaggregated_storage;
 
-    /* We never expect a not found error, as we just picked up a checkpoint. */
-    WT_RET(__layered_last_checkpoint_order(session, WT_DISAGG_METADATA_URI, &order));
+    WT_RET_NOTFOUND_OK(
+      ret = __layered_last_checkpoint_order(session, WT_DISAGG_METADATA_URI, &order));
+
+    /* If we didn't find a checkpoint, it means that there are no data in the shared storage. */
+    if (ret == WT_NOTFOUND)
+        return (0);
 
     /* Figure out how many entries at the beginning are no longer useful. */
     for (expire = 0; expire < ds->ckpt_track_cnt; ++expire) {

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -265,8 +265,10 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
 
-    if (checkpoint_root == NULL)
+    if (checkpoint_root == NULL) {
+        WT_ASSERT(session, checkpoint_root_size == 0);
         checkpoint_root = "";
+    }
     if (checkpoint_root_size == 0)
         checkpoint_root_size = strlen(checkpoint_root);
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -231,15 +231,15 @@ __disagg_put_meta(WT_SESSION_IMPL *session, uint64_t page_id, const WT_ITEM *ite
     disagg = &conn->disaggregated_storage;
 
     WT_CLEAR(put_args);
-    if (disagg->page_log_meta != NULL) {
-        WT_RET(disagg->page_log_meta->plh_put(
-          disagg->page_log_meta, &session->iface, page_id, 0, &put_args, item));
-        if (lsnp != NULL)
-            *lsnp = put_args.lsn;
-        __wt_atomic_addv64(&disagg->num_meta_put, 1);
-        return (0);
-    }
-    return (ENOTSUP);
+    if (disagg->page_log_meta == NULL)
+        return (ENOTSUP);
+
+    WT_RET(disagg->page_log_meta->plh_put(
+      disagg->page_log_meta, &session->iface, page_id, 0, &put_args, item));
+    if (lsnp != NULL)
+        *lsnp = put_args.lsn;
+    __wt_atomic_addv64(&disagg->num_meta_put, 1);
+    return (0);
 }
 
 /*

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -200,12 +200,13 @@ struct __wt_disaggregated_storage {
     /* Updates are protected by the checkpoint lock. */
     wt_shared uint64_t last_checkpoint_meta_lsn; /* The LSN of the last checkpoint metadata. */
     wt_shared uint64_t last_materialized_lsn;    /* The LSN of the last materialized page. */
+    char *last_checkpoint_root;                  /* The root config of the last checkpoint. */
 
     wt_timestamp_t cur_checkpoint_timestamp; /* The timestamp of the in-progress checkpoint. */
     wt_shared wt_timestamp_t last_checkpoint_timestamp; /* The timestamp of the last checkpoint. */
 
     WT_NAMED_PAGE_LOG *npage_log;
-    WT_PAGE_LOG_HANDLE *page_log_meta;
+    WT_PAGE_LOG_HANDLE *page_log_meta; /* The page log for the metadata. */
 
     wt_shared uint64_t num_meta_put;     /* The number metadata puts since connection open. */
     uint64_t num_meta_put_at_ckpt_begin; /* The number metadata puts at checkpoint begin. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -579,8 +579,9 @@ extern int __wt_disagg_copy_metadata_process(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_copy_shared_metadata_layered(WT_SESSION_IMPL *session, const char *name)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_put_meta(WT_SESSION_IMPL *session, uint64_t page_id, const WT_ITEM *item,
-  uint64_t *lsnp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint_root,
+  size_t checkpoint_root_size, uint64_t checkpoint_timestamp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_update_shared_metadata(WT_SESSION_IMPL *session, const char *key,
   const char *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_encrypt(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t skip,

--- a/test/model/workloads/WT-15086.workload
+++ b/test/model/workloads/WT-15086.workload
@@ -1,0 +1,6 @@
+config("database", "disaggregated=true")
+set_stable_timestamp(683999)
+restart()
+set_stable_timestamp(688849)
+restart()
+set_oldest_timestamp(684401)

--- a/test/suite/test_checkpoint36.py
+++ b/test/suite/test_checkpoint36.py
@@ -37,11 +37,13 @@ class test_checkpoint36(wttest.WiredTigerTestCase):
 
     def test_checkpoint(self):
         # Call checkpoint before setting the stable timestamp
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: self.session.checkpoint(), '')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                                    lambda: self.session.checkpoint(), '/stable timestamp/')
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
 
         # Call checkpoint after setting the stable timestamp
         self.session.checkpoint()
 
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: self.session.checkpoint("use_timestamp=false"), '')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                                     lambda: self.session.checkpoint("use_timestamp=false"), '')


### PR DESCRIPTION
Creating a checkpoint in WiredTiger with attached storage results in creating a checkpoint, even if the only change to the database was advancing the stable timestamp—even though there were no changes to the data. This PR brings the same semantics to WiredTiger for diaggregated storage to result in having consistent behavior.

Also, add an error message if anyone attempts to create a precise checkpoint without a stable timestamp.