### PR TITLE
WT-15157 Disagg testing: add leader and follower mode to test/checkpoint

### DIFF
--- a/bench/wtperf/CMakeLists.txt
+++ b/bench/wtperf/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 # Smoke-test wtperf as part of running "ctest check".
 define_test_variants(wtperf
     VARIANTS
-        "test_wtperf_small_btree;-O \"${CMAKE_CURRENT_SOURCE_DIR}/runners/small-btree.wtperf\" -o \"run_time=20\""
+        "small_btree|-O \"${CMAKE_CURRENT_SOURCE_DIR}/runners/small-btree.wtperf\" -o \"run_time=20\""
     LABELS
         check
         wtperf

--- a/dist/s_void
+++ b/dist/s_void
@@ -151,6 +151,7 @@ func_ok()
         -e '/int dir_store_file_lock$/d' \
         -e '/int dir_store_file_sync$/d' \
         -e '/int dir_store_fs_terminate$/d' \
+        -e '/int enable_disagg$/d' \
         -e '/int error_handler$/d' \
         -e '/int fail_file_lock$/d' \
         -e '/int fail_file_sync$/d' \

--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -7,52 +7,80 @@ create_test_executable(test_checkpoint
         ${CMAKE_CURRENT_SOURCE_DIR}/recovery-test.sh
 )
 
+# Define test variants for the checkpoint test
 define_test_variants(test_checkpoint
     VARIANTS
         # 1. Mixed tables cases. Use four (or eight) tables because there are four table types.
-        "test_checkpoint_4_mixed;-t m -T 4"
-        "test_checkpoint_8_mixed;-t m -T 8"
-        "test_checkpoint_4_mixed_sweep;-t m -T 4 -W 3 -r 2 -n 100000 -k 100000 -s 1"
-        "test_checkpoint_4_mixed_timestamps;-t m -T 4 -W 3 -r 2 -x -n 100000 -k 100000"
+        "4_mixed|-t m -T 4"
+        "8_mixed|-t m -T 8"
+        "4_mixed_sweep|-t m -T 4 -W 3 -r 2 -n 100000 -k 100000 -s 1"
+        "4_mixed_timestamps|-t m -T 4 -W 3 -r 2 -x -n 100000 -k 100000"
 
         # 1a. Mixed tables with 1/10 the ops and 10x the runs.
-        "test_checkpoint_4_runs_sweep;-t m -T 4 -W 3 -r 20 -n 1000 -s 1"
-        "test_checkpoint_4_runs_timestamps;-t m -T 4 -W 3 -r 20 -x -n 1000"
+        "4_runs_sweep|-t m -T 4 -W 3 -r 20 -n 1000 -s 1"
+        "4_runs_timestamps|-t m -T 4 -W 3 -r 20 -x -n 1000"
 
         # 2. FLCS cases.
-        "test_checkpoint_6_fixed;-t f -T 6"
-        "test_checkpoint_6_fixed_named;-t f -T 6 -c TeSt"
-        "test_checkpoint_6_fixed_prepare;-t f -T 6 -p"
-        "test_checkpoint_6_fixed_named_prepare;-t f -T 6 -c TeSt -p"
-        "test_checkpoint_fixed_stress_sweep_timestamps;-t f -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
-        "test_checkpoint_fixed_sweep_timestamps;-t f -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+        "6_fixed|-t f -T 6"
+        "6_fixed_named|-t f -T 6 -c TeSt"
+        "6_fixed_prepare|-t f -T 6 -p"
+        "6_fixed_named_prepare|-t f -T 6 -c TeSt -p"
+        "fixed_stress_sweep_timestamps|-t f -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
+        "fixed_sweep_timestamps|-t f -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
 
         # 3. VLCS cases.
-        "test_checkpoint_6_column;-t c -T 6"
-        "test_checkpoint_6_column_named;-t c -T 6 -c TeSt"
-        "test_checkpoint_6_column_prepare;-t c -T 6 -p"
-        "test_checkpoint_6_column_named_prepare;-t c -T 6 -c TeSt -p"
-        "test_checkpoint_column_stress_sweep_timestamps;-t c -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
-        "test_checkpoint_column_sweep_timestamps;-t c -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+        "6_column|-t c -T 6"
+        "6_column_named|-t c -T 6 -c TeSt"
+        "6_column_prepare|-t c -T 6 -p"
+        "6_column_named_prepare|-t c -T 6 -c TeSt -p"
+        "column_stress_sweep_timestamps|-t c -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
+        "column_sweep_timestamps|-t c -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
 
         # 4. Row-store cases.
-        "test_checkpoint_6_row;-t r -T 6"
-        "test_checkpoint_6_row_named;-t r -T 6 -c TeSt"
-        "test_checkpoint_6_row_prepare;-t r -T 6 -p"
-        "test_checkpoint_6_row_named_prepare;-t r -T 6 -c TeSt -p"
-        "test_checkpoint_row_stress_sweep_timestamps;-t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
-        "test_checkpoint_row_sweep_timestamps;-t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+        "6_row|-t r -T 6"
+        "6_row_named|-t r -T 6 -c TeSt"
+        "6_row_prepare|-t r -T 6 -p"
+        "6_row_named_prepare|-t r -T 6 -c TeSt -p"
+        "row_stress_sweep_timestamps|-t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
+        "row_sweep_timestamps|-t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
     LABELS
         check
         test_checkpoint
 )
 
+# Define test variants for the disagg test
 define_test_variants(test_checkpoint
     VARIANTS
-        "test_checkpoint_row_server_93028_1;-t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
-        "test_checkpoint_row_server_93028_2;-t r -W 50 -r 2 -s 1 -n 100000 -k 100000 -C cache_size=250MB"
+        # 1. Row-store cases.
+        "disagg_leader_row_stress_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
+        "disagg_leader_row_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+    LABELS
+        # FIXME-WT-15334 re-enable tests once the build is stable
+        # check
+        # test_checkpoint
+        test_checkpoint_disagg
+)
+
+# Define long running test variants for the checkpoint test
+# See SERVER-93028
+define_test_variants(test_checkpoint
+    VARIANTS
+        "row_server_93028_1|-t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
+        "row_server_93028_2|-t r -W 50 -r 2 -s 1 -n 100000 -k 100000 -C cache_size=250MB"
     LABELS
         check
         test_checkpoint
         long_running
+)
+
+# Define long running test variants for the disagg test
+define_test_variants(test_checkpoint
+    VARIANTS
+        "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
+    LABELS
+        # FIXME-WT-15334 re-enable tests once the build is stable
+        # check
+        # test_checkpoint
+        test_checkpoint_disagg
+        # long_running
 )

--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -48,18 +48,18 @@ define_test_variants(test_checkpoint
         test_checkpoint
 )
 
-# Define test variants for the disagg test
-define_test_variants(test_checkpoint
-    VARIANTS
-        # 1. Row-store cases.
-        "disagg_leader_row_stress_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
-        "disagg_leader_row_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
-    LABELS
-        # FIXME-WT-15334 re-enable tests once the build is stable
-        # check
-        # test_checkpoint
-        test_checkpoint_disagg
-)
+# FIXME-WT-15334 re-enable tests once the build is stable
+# # Define test variants for the disagg test
+# define_test_variants(test_checkpoint
+#     VARIANTS
+#         # 1. Row-store cases.
+#         "disagg_leader_row_stress_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
+#         "disagg_leader_row_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+#     LABELS
+#         check
+#         test_checkpoint
+#         test_checkpoint_disagg
+# )
 
 # Define long running test variants for the checkpoint test
 # See SERVER-93028
@@ -73,14 +73,14 @@ define_test_variants(test_checkpoint
         long_running
 )
 
-# Define long running test variants for the disagg test
-define_test_variants(test_checkpoint
-    VARIANTS
-        "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
-    LABELS
-        # FIXME-WT-15334 re-enable tests once the build is stable
-        # check
-        # test_checkpoint
-        test_checkpoint_disagg
-        # long_running
-)
+# FIXME-WT-15334 re-enable tests once the build is stable
+# # Define long running test variants for the disagg test
+# define_test_variants(test_checkpoint
+#     VARIANTS
+#         "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
+#     LABELS
+#         check
+#         test_checkpoint
+#         test_checkpoint_disagg
+#         long_running
+# )

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -331,8 +331,11 @@ real_checkpointer(THREAD_DATA *td)
             goto done;
 
         /* Verify the checkpoint we just wrote. */
-        if ((ret = verify_consistency(session, WT_TS_NONE, true)) != 0)
-            return (log_print_err("verify_consistency (checkpoint)", ret, 1));
+        /* FIXME-WT-15378 Disagg: Implement checkpoint cursors */
+        if (!g.opts.disagg_storage) {
+            if ((ret = verify_consistency(session, WT_TS_NONE, true)) != 0)
+                return (log_print_err("verify_consistency (checkpoint)", ret, 1));
+        }
 
         /* Verify the content of the database at the verify timestamp. */
         if (g.use_timestamps && (ret = verify_consistency(session, verify_ts, false)) != 0)

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -373,6 +373,9 @@ enable_disagg(const char *mode)
         fprintf(stderr, "Invalid disaggregated mode: %s\n", mode);
         return EINVAL;
     }
+
+    g.opts.palm_map_size_mb = 2048; /* Set 2GB map size for palm by default. */
+
     return 0;
 }
 

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -346,7 +346,7 @@ run_complete:
 
 /*
  * enable_disagg --
- *    Enable disaggregated storage with given mode.
+ *     Enable disaggregated storage with given mode.
  */
 static int
 enable_disagg(const char *mode)

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -35,6 +35,7 @@ GLOBAL g;
 static int handle_error(WT_EVENT_HANDLER *, WT_SESSION *, int, const char *);
 static int handle_message(WT_EVENT_HANDLER *, WT_SESSION *, const char *);
 static void onint(int) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
+static int enable_disagg(const char *);
 static void cleanup(bool);
 static int usage(void);
 static void wt_connect(const char *);
@@ -75,20 +76,20 @@ init_thread_data(THREAD_DATA *td, int info)
 
 /*
  * main --
- *     TODO: Add a comment describing this function.
+ *     Main function for the test program. See usage() for command line options.
  */
 int
 main(int argc, char *argv[])
 {
     table_type ttype;
     int base, ch, cnt, i, ret, runs;
-    const char *config_open;
+    char config_open[1024];
     char *end_number, *stop_arg;
     bool verify_only;
 
     (void)testutil_set_progname(argv);
 
-    config_open = NULL;
+    memset(config_open, 0, sizeof(config_open));
     ret = 0;
     ttype = MIX;
     g.checkpoint_name = "WiredTigerCheckpoint";
@@ -113,13 +114,18 @@ main(int argc, char *argv[])
     testutil_parse_begin_opt(argc, argv, SHARED_PARSE_OPTIONS, &g.opts);
 
     while ((ch = __wt_getopt(
-              progname, argc, argv, "C:c:Dk:l:mn:pr:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
+              progname, argc, argv, "C:c:d:Dk:l:mn:pr:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
         switch (ch) {
         case 'c':
             g.checkpoint_name = __wt_optarg;
             break;
         case 'C': /* wiredtiger_open config */
-            config_open = __wt_optarg;
+            strcpy(config_open, __wt_optarg);
+            break;
+        case 'd': /* disaggregated storage options */
+            if (enable_disagg(__wt_optarg) != 0) {
+                return (usage());
+            }
             break;
         case 'D':
             g.debug_mode = true;
@@ -179,7 +185,7 @@ main(int argc, char *argv[])
                 stop_arg += 2;
             } else
                 base = 10;
-            g.stop_ts = (uint64_t)strtoll(stop_arg, &end_number, base);
+            g.stop_ts = strtoull(stop_arg, &end_number, base);
             if (*end_number)
                 return (usage());
             break;
@@ -239,6 +245,12 @@ main(int argc, char *argv[])
     (void)signal(SIGINT, onint);
 
     testutil_work_dir_from_path(g.home, 512, (&g.opts)->home);
+
+    /*
+     * Always preserve home directory. Some tests rely on the home directory being present to
+     * compare results between runs.
+     */
+    g.opts.preserve = true;
 
     /* Start time at 1 since 0 is not a valid timestamp. */
     g.ts_stable = 1;
@@ -327,7 +339,37 @@ run_complete:
     /* Ensure that cleanup is done on error. */
     (void)wt_shutdown();
     free(g.cookies);
+    testutil_cleanup(&g.opts);
+
     return (g.status);
+}
+
+static int
+enable_disagg(const char *mode)
+{
+    if (strcmp(mode, "leader") == 0) {
+        g.opts.disagg_storage = true;
+        g.opts.disagg_switch_mode = false;
+        g.opts.disagg_mode = "leader";
+        g.opts.disagg_page_log = "palm";
+    } else if (strcmp(mode, "follower") == 0) {
+        g.opts.disagg_storage = true;
+        g.opts.disagg_mode = "follower";
+        g.opts.disagg_switch_mode = false;
+        g.opts.disagg_page_log = "palm";
+    } else if (strcmp(mode, "switch") == 0) {
+        g.opts.disagg_storage = true;
+        g.opts.disagg_switch_mode = true;
+        /* For switch mode, randomly pick initial role */
+        bool disagg_leader = (__wt_random(&g.opts.extra_rnd) % 2) == 0;
+        g.opts.disagg_mode = disagg_leader ? "leader" : "follower";
+        g.opts.disagg_page_log = "palm";
+        printf("Switch mode: starting as %s\n", g.opts.disagg_mode);
+    } else {
+        fprintf(stderr, "Invalid disaggregated mode: %s\n", mode);
+        return EINVAL;
+    }
+    return 0;
 }
 
 #define DEBUG_MODE_CFG ",debug_mode=(eviction=true,table_logging=true),verbose=(recovery)"
@@ -642,6 +684,23 @@ flcs_modify(WT_MODIFY *entries, int nentries, uint8_t oldval)
 }
 
 /*
+ * disagg_switch_roles --
+ *     Toggle the current disagg role between "leader" and "follower".
+ */
+int
+disagg_switch_roles(void)
+{
+    testutil_assert(g.opts.disagg_storage);
+    testutil_assert(g.opts.disagg_switch_mode);
+
+    const char *disagg_role = strcmp(g.opts.disagg_mode, "leader") == 0 ? "follower" : "leader";
+    char disagg_cfg[64];
+    testutil_snprintf(disagg_cfg, sizeof(disagg_cfg), "disaggregated=(role=\"%s\")", disagg_role);
+
+    return (g.conn->reconfigure(g.conn, disagg_cfg));
+}
+
+/*
  * type_to_string --
  *     Return the string name of a table type.
  */
@@ -668,13 +727,15 @@ usage(void)
 {
     fprintf(stderr,
       "usage: %s\n"
-      "    [-DmpRvXx] [-C wiredtiger-config] [-c checkpoint] [-h home] [-k keys] [-l log]\n"
+      "    [-DmpRvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k keys] "
+      "[-l log]\n"
       "    [-n ops] [-r runs] [-s 1|2|3|4|5] [-T table-config] [-t f|r|v]\n"
       "    [-W workers]\n",
       progname);
     fprintf(stderr, "%s",
       "\t-C specify wiredtiger_open configuration arguments\n"
       "\t-c checkpoint name to used named checkpoints\n"
+      "\t-d disaggregated storage mode (leader | follower | switch)\n"
       "\t-D debug mode\n"
       "\t-h set a database home directory\n"
       "\t-k set number of keys to load\n"

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -344,6 +344,10 @@ run_complete:
     return (g.status);
 }
 
+/*
+ * enable_disagg --
+ *    Enable disaggregated storage with given mode.
+ */
 static int
 enable_disagg(const char *mode)
 {

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -122,6 +122,7 @@ extern GLOBAL g;
 void end_threads(void);
 uint8_t flcs_encode(const char *);
 uint8_t flcs_modify(WT_MODIFY *, int, uint8_t);
+int disagg_switch_roles(void);
 int log_print_err_worker(const char *, int, const char *, int, int);
 void set_flush_tier_delay(WT_RAND_STATE *);
 void start_threads(void);

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -42,7 +42,7 @@ static int
 create_table(WT_SESSION *session, COOKIE *cookie)
 {
     int ret;
-    char config[256];
+    char config[512];
     const char *kf, *vf;
 
     kf = cookie->type == COL || cookie->type == FIX ? "r" : "q";
@@ -59,6 +59,16 @@ create_table(WT_SESSION *session, COOKIE *cookie)
           kf, vf);
     else
         testutil_snprintf(config, sizeof(config), "key_format=%s,value_format=%s", kf, vf);
+
+    /*
+     * Configure layered. Although disagg support is separated from layered support, we expect them
+     * to be used together, at least for now.
+     */
+    if (g.opts.disagg_storage) {
+        testutil_strcat(config, sizeof(config),
+          ",type=layered"
+          ",block_manager=disagg");
+    }
 
     if ((ret = session->create(session, cookie->uri, config)) != 0)
         if (ret != EEXIST)

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -59,8 +59,7 @@ create_table(WT_SESSION *session, COOKIE *cookie)
           kf, vf);
         if (g.opts.disagg_storage)
             strcat(config, ",type=layered,block_manager=disagg");
-    }
-    else
+    } else
         testutil_snprintf(config, sizeof(config), "key_format=%s,value_format=%s", kf, vf);
 
     if ((ret = session->create(session, cookie->uri, config)) != 0)

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -42,7 +42,7 @@ static int
 create_table(WT_SESSION *session, COOKIE *cookie)
 {
     int ret;
-    char config[512];
+    char config[256];
     const char *kf, *vf;
 
     kf = cookie->type == COL || cookie->type == FIX ? "r" : "q";
@@ -59,16 +59,6 @@ create_table(WT_SESSION *session, COOKIE *cookie)
           kf, vf);
     else
         testutil_snprintf(config, sizeof(config), "key_format=%s,value_format=%s", kf, vf);
-
-    /*
-     * Configure layered. Although disagg support is separated from layered support, we expect them
-     * to be used together, at least for now.
-     */
-    if (g.opts.disagg_storage) {
-        testutil_strcat(config, sizeof(config),
-          ",type=layered"
-          ",block_manager=disagg");
-    }
 
     if ((ret = session->create(session, cookie->uri, config)) != 0)
         if (ret != EEXIST)

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -51,12 +51,15 @@ create_table(WT_SESSION *session, COOKIE *cookie)
     /*
      * If we're using timestamps, turn off logging for the table.
      */
-    if (g.use_timestamps)
+    if (g.use_timestamps) {
         testutil_snprintf(config, sizeof(config),
           "key_format=%s,value_format=%s,allocation_size=512,"
           "leaf_page_max=1KB,internal_page_max=1KB,"
           "memory_page_max=64KB,log=(enabled=false)",
           kf, vf);
+        if (g.opts.disagg_storage)
+            strcat(config, ",type=layered,block_manager=disagg");
+    }
     else
         testutil_snprintf(config, sizeof(config), "key_format=%s,value_format=%s", kf, vf);
 
@@ -282,7 +285,8 @@ worker_op(WT_CURSOR *cursor, table_type type, uint64_t keyno, u_int new_val)
         if (g.sweep_stress)
             testutil_check(cursor->reset(cursor));
     } else {
-        if (new_val % 39 < 30) {
+        /* FIXME-WT-14467 should fix cursor->modify for layered tables. */
+        if (new_val % 39 < 30 && !g.opts.disagg_storage) {
             /* Do modify. */
             ret = cursor->search(cursor);
             if (ret == 0 && (type != FIX || !cursor_fix_at_zero(cursor))) {

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -375,7 +375,7 @@ define_c_test(
 )
 
 define_c_test(
-    TARGET wt13867_interrupt_eviction_handler
+    TARGET test_wt13867_interrupt_eviction_handler
     SOURCES wt13867_interrupt_eviction_handler/main.c
     DIR_NAME wt13867_interrupt_eviction_handler
     ARGUMENTS

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -1,20 +1,59 @@
-# create_test_executable(target SOURCES <source files> [EXECUTABLE_NAME <name>] [BINARY_DIR <dir>] [INCLUDES <includes>]
-#    [ADDITIONAL_FILES <files>] [ADDITIONAL_DIRECTORIES <dirs>] [LIBS <libs>] [FLAGS <flags>])
-# Defines a C/CXX test executable binary. This helper does the necessary initialisation to ensure the correct flags and libraries
-# are used when compiling the test executable.
-#   target - Target name of the test.
-#   SOURCES <source files> - Sources to compile for the given test.
-#   CXX - Indicates that this is a C++ test.
-#   NO_TEST_UTIL - Do not link against the test_util library.
-#   EXECUTABLE_NAME <name> - A name for the output test binary. Defaults to the target name if not given.
-#   BINARY_DIR <dir> - The output directory to install the binaries. Defaults to 'CMAKE_CURRENT_BINARY_DIR' if not given.
-#   INCLUDES <includes> - Additional includes for building the test binary.
-#   ADDITIONAL_FILES <files> - Additional files, scripts, etc we want to copy over to the output test binary. Useful if we need
-#       to setup an additional wrappers needed to run the test.
-#   ADDITIONAL_DIRECTORIES <dirs> - Additional directories we want to copy over to the output test binary. Useful if we need
-#       to setup an additional configs and environments needed to run the test.
-#   LIBS <libs> - Additional libs to link to the test binary.
-#   FLAGS <flags> - Additional flags to compile the test binary with.
+#[=======================================================================[
+create_test_executable(target SOURCES <source files>
+    [CXX] [NO_TEST_UTIL]
+    [EXECUTABLE_NAME <name>]
+    [BINARY_DIR <dir>]
+    [INCLUDES <includes>]
+    [ADDITIONAL_FILES <files>]
+    [ADDITIONAL_DIRECTORIES <dirs>]
+    [LIBS <libs>]
+    [FLAGS <flags>]
+)
+
+Defines a C/CXX test executable binary. This helper does the necessary
+initialisation to ensure the correct flags and libraries are used when
+compiling the test executable.
+
+Parameters:
+
+target
+    Target name of the test.
+
+SOURCES <source files>
+    Sources to compile for the given test.
+
+CXX
+    Indicates that this is a C++ test.
+    
+NO_TEST_UTIL
+    Do not link against the test_util library.
+
+EXECUTABLE_NAME <name>
+    A name for the output test binary. Defaults to the target name if not given.
+
+BINARY_DIR <dir>
+    The output directory to install the binaries.
+    Defaults to 'CMAKE_CURRENT_BINARY_DIR' if not given.
+
+INCLUDES <includes>
+    Additional includes for building the test binary.
+
+ADDITIONAL_FILES <files>
+    Additional files, scripts, etc we want to copy over to the output test
+    binary. Useful if we need to setup an additional wrappers needed to run the
+    test.
+
+ADDITIONAL_DIRECTORIES <dirs>
+    Additional directories we want to copy over to the output test binary.
+    Useful if we need to setup an additional configs and environments needed to
+    run the test.
+
+LIBS <libs>
+    Additional libs to link to the test binary.
+
+FLAGS <flags>
+    Additional flags to compile the test binary with.
+#]=======================================================================]
 function(create_test_executable target)
     cmake_parse_arguments(
         PARSE_ARGV
@@ -24,16 +63,17 @@ function(create_test_executable target)
         "EXECUTABLE_NAME;BINARY_DIR"
         "SOURCES;INCLUDES;ADDITIONAL_FILES;ADDITIONAL_DIRECTORIES;LIBS;FLAGS"
     )
-    if (NOT "${CREATE_TEST_UNPARSED_ARGUMENTS}" STREQUAL "")
-        message(FATAL_ERROR "Unknown arguments to create_test_executable: ${CREATE_TEST_UNPARSED_ARGUMENTS}")
+    if (CREATE_TEST_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unknown arguments to create_test_executable:
+            ${CREATE_TEST_UNPARSED_ARGUMENTS}")
     endif()
-    if ("${CREATE_TEST_SOURCES}" STREQUAL "")
+    if (NOT CREATE_TEST_SOURCES)
         message(FATAL_ERROR "No sources given to create_test_executable")
     endif()
 
     set(test_binary_dir "${CMAKE_CURRENT_BINARY_DIR}")
     # Allow the user to specify a custom binary directory.
-    if(NOT "${CREATE_TEST_BINARY_DIR}" STREQUAL "")
+    if(CREATE_TEST_BINARY_DIR)
         set(test_binary_dir "${CREATE_TEST_BINARY_DIR}")
     endif()
 
@@ -44,10 +84,10 @@ function(create_test_executable target)
     # executable. The name of the binary will either be the name of the target or some other name
     # passed to this function. We need to use the correct one for the dsymutil.
     if (WT_DARWIN)
-        if("${CREATE_TEST_EXECUTABLE_NAME}" STREQUAL "")
-            set(test_name "${target}")
-        else()
+        if(CREATE_TEST_EXECUTABLE_NAME)
             set(test_name "${CREATE_TEST_EXECUTABLE_NAME}")
+        else()
+            set(test_name "${target}")
         endif()
 
         add_custom_command(
@@ -60,7 +100,7 @@ function(create_test_executable target)
     endif()
 
     # If we want the output binary to be a different name than the target.
-    if (NOT "${CREATE_TEST_EXECUTABLE_NAME}" STREQUAL "")
+    if (CREATE_TEST_EXECUTABLE_NAME)
         set_target_properties(${target}
             PROPERTIES
             OUTPUT_NAME "${CREATE_TEST_EXECUTABLE_NAME}"
@@ -77,7 +117,7 @@ function(create_test_executable target)
     else()
         set(test_flags "${COMPILER_DIAGNOSTIC_CXX_FLAGS}")
     endif()
-    if(NOT "${CREATE_TEST_FLAGS}" STREQUAL "")
+    if(CREATE_TEST_FLAGS)
         list(APPEND test_flags ${CREATE_TEST_FLAGS})
     endif()
     target_compile_options(${target} PRIVATE ${test_flags})
@@ -89,7 +129,7 @@ function(create_test_executable target)
             ${CMAKE_SOURCE_DIR}/test/utility
             ${CMAKE_BINARY_DIR}/config
     )
-    if(NOT "${CREATE_TEST_INCLUDES}" STREQUAL "")
+    if(CREATE_TEST_INCLUDES)
         target_include_directories(${target} PRIVATE ${CREATE_TEST_INCLUDES})
     endif()
 
@@ -98,7 +138,7 @@ function(create_test_executable target)
     if(NOT CREATE_TEST_NO_TEST_UTIL)
         target_link_libraries(${target} test_util)
     endif()
-    if(NOT "${CREATE_TEST_LIBS}" STREQUAL "")
+    if(CREATE_TEST_LIBS)
         target_link_libraries(${target} ${CREATE_TEST_LIBS})
     endif()
 
@@ -150,37 +190,87 @@ function(create_test_executable target)
                 ${test_binary_dir}/${file_basename}
             DEPENDS ${file}
         )
-        add_custom_target(copy_file_${target}_${file_basename} DEPENDS ${test_binary_dir}/${file_basename})
-        add_dependencies(${target} copy_file_${target}_${file_basename})
+        set(copy_file_target copy_file_${target}_${file_basename})
+        add_custom_target(${copy_file_target} DEPENDS ${test_binary_dir}/${file_basename})
+        add_dependencies(${target} ${copy_file_target})
     endforeach()
     # Install any additional directories in the output test binary directory.
     # Useful if we need to setup an additional configs and environments needed to run the test executable.
     foreach(dir IN LISTS CREATE_TEST_ADDITIONAL_DIRECTORIES)
         get_filename_component(dir_basename ${dir} NAME)
         # Copy the directory to the given test/targets build directory.
-        add_custom_target(sync_dir_${target}_${dir_basename} ALL
+        set(sync_dir_target sync_dir_${target}_${dir_basename})
+        add_custom_target(${sync_dir_target} ALL
             COMMAND ${CMAKE_COMMAND}
                 -DSYNC_DIR_SRC=${dir}
                 -DSYNC_DIR_DST=${test_binary_dir}/${dir_basename}
                 -P ${CMAKE_SOURCE_DIR}/test/ctest_dir_sync.cmake
         )
-        add_dependencies(${target} sync_dir_${target}_${dir_basename})
+        add_dependencies(${target} ${sync_dir_target})
     endforeach()
 endfunction()
 
+#[=======================================================================[
+define_test_variants(<test_target>
+    VARIANTS <variant1> [<variant2> ...]
+    [DIR_NAME <dir_name>]
+    [LABELS <label1> [<label2> ...] ]
+    [CMD <command>]
+    [DISABLED]
+)
+
+Creates multiple test targets based on the provided variants, each with
+potentially different configurations. Each variant specifies test name and the
+arguments in the format: variant_name|variant args.
+The test_target is used as prefix for all variants: <test_target>_<variant_name>
+
+    Example:
+        define_test_variants(test_checkpoint
+            VARIANTS
+                "4_mixed|-t m -T 4"
+                "8_mixed|-t m -T 8"
+        )
+
+    Generated variants:
+        test_checkpoint_4_mixed
+        test_checkpoint_8_mixed
+
+Parameters:
+
+test_target
+    Test executable target. It is the same name as the target in
+    create_test_executable() call.
+
+VARIANTS <variant1> [<variant2> ...]
+    List of variant names to create. Each variant will generate a separate test
+    target with the test arguments specified.
+    Each variant should be in the format: "variant_name|variant args".
+
+DIR_NAME <dir_name>
+    Optional directory name to create for the test variant. If not specified,
+    the build directory will be used.
+
+LABELS <label1> [<label2> ...]
+    Labels to apply to all test variants. These labels will be applied to
+    every test variant target created.
+
+CMD <command>
+    Custom test command to use with all test variants instead of the
+    given target executable.
+#]=======================================================================]
 function(define_test_variants target)
     cmake_parse_arguments(
         PARSE_ARGV
         1
         "DEFINE_TEST"
         ""
-        "DIR_NAME"
-        "VARIANTS;LABELS;CMDS"
+        "DIR_NAME;CMD"
+        "VARIANTS;LABELS"
     )
-    if (NOT "${DEFINE_TEST_UNPARSED_ARGUMENTS}" STREQUAL "")
+    if (DEFINE_TEST_UNPARSED_ARGUMENTS)
         message(FATAL_ERROR "Unknown arguments to define_test_variants: ${DEFINE_TEST_UNPARSED_ARGUMENTS}")
     endif()
-    if ("${DEFINE_TEST_VARIANTS}" STREQUAL "")
+    if (NOT DEFINE_TEST_VARIANTS)
         message(FATAL_ERROR "Need at least one variant for define_test_variants")
     endif()
 
@@ -192,12 +282,15 @@ function(define_test_variants target)
     endif()
 
     set(defined_tests)
-    foreach(variant ${DEFINE_TEST_VARIANTS})
+    foreach(variant_spec IN LISTS DEFINE_TEST_VARIANTS)
+        # Replace '|' with ';' to convert the string into a proper CMake list
+        string(REPLACE "|" ";" variant "${variant_spec}")
+
         list(LENGTH variant variant_length)
         if (NOT variant_length EQUAL 2)
             message(
                 FATAL_ERROR
-                "Invalid variant format: ${variant} - Expected format 'variant_name;variant args'"
+                "Invalid variant format: ${variant} - Expected format 'variant_name|variant args'"
             )
         endif()
         list(GET variant 0 curr_variant_name)
@@ -208,33 +301,95 @@ function(define_test_variants target)
         else()
             separate_arguments(variant_args UNIX_COMMAND ${curr_variant_args})
         endif()
+        set(variant_name ${target}_${curr_variant_name})
         # Create a variant directory to run the test in.
-        add_custom_command(OUTPUT ${curr_variant_name}_test_dir
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${dir_prefix}/${curr_variant_name}_test_dir
+        add_custom_command(OUTPUT ${variant_name}_test_dir
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${dir_prefix}/${variant_name}_test_dir
         )
-        add_custom_target(create_dir_${curr_variant_name} DEPENDS ${curr_variant_name}_test_dir)
+        set(create_dir_target create_dir_${variant_name})
+        add_custom_target(${create_dir_target} DEPENDS ${variant_name}_test_dir)
         # Ensure the variant target is created prior to building the test.
-        add_dependencies(${target} create_dir_${curr_variant_name})
+        add_dependencies(${target} ${create_dir_target})
         set(test_cmd)
-        if(DEFINE_TEST_CMDS)
-            set(test_cmd ${DEFINE_TEST_CMDS})
+        if(DEFINE_TEST_CMD)
+            set(test_cmd ${DEFINE_TEST_CMD})
         else()
             set(test_cmd $<TARGET_FILE:${target}>)
         endif()
         add_test(
-            NAME ${curr_variant_name}
+            NAME ${variant_name}
             COMMAND ${test_cmd} ${variant_args}
             # Run each variant in its own subdirectory, allowing us to execute variants in
             # parallel.
-            WORKING_DIRECTORY ${dir_prefix}/${curr_variant_name}_test_dir
+            WORKING_DIRECTORY ${dir_prefix}/${variant_name}_test_dir
         )
-        list(APPEND defined_tests ${curr_variant_name})
+        list(APPEND defined_tests ${variant_name})
     endforeach()
     if(DEFINE_TEST_LABELS)
         set_tests_properties(${defined_tests} PROPERTIES LABELS "${DEFINE_TEST_LABELS}")
     endif()
 endfunction()
 
+#[=======================================================================[
+define_c_test(
+    [CXX]
+    TARGET <target_name>
+    SOURCES <source1> [<source2> ...]
+    DIR_NAME <dir_name>
+    [ARGUMENTS <argument1> [<argument2> ...] ]
+    [VARIANTS <variant1> [<variant2> ...] ]
+    [EXEC_SCRIPT <exec_script>]
+    [LABEL <label>]
+    [LIBS lib1 [lib2 ...] ]
+    [FLAGS <flag1> [<flag2> ...] ]
+    [DEPENDS <depend1> [<depend2> ...] ]
+    [ADDITIONAL_FILES <file1> [<file2> ...] ]
+)
+
+Defines the C test with the given parameters. See test/csuite and examples/c
+for examples of usage.
+
+CXX
+    Indicates that this is a C++ test.
+
+TARGET <target_name>
+    The name of the test target to create.
+
+SOURCES <source1> [<source2> ...]
+    The source files to compile for the test.
+
+DIR_NAME <dir_name>
+    The name of the directory to create for the test.
+
+ARGUMENTS <argument1> [<argument2> ...]
+    The arguments to pass to the test executable.
+    Note: This is mutually exclusive with VARIANTS.
+
+VARIANTS <variant1> [<variant2> ...]
+    The test variants to create. See define_test_variants for more information.
+    Note: This is mutually exclusive with ARGUMENTS.
+
+EXEC_SCRIPT <exec_script>
+    Define the C test to be executed with a script, rather than invoking
+    the binary directly.
+
+LABEL <label>
+    The label to assign to the test.
+    Note: Labels 'check' and 'csuite' are always assigned to generated tests.
+
+LIBS <lib1> [<lib2> ...]
+    The libraries to link against for the test executable.
+
+DEPENDS <depend1> [<depend2> ...]
+    Check that the specified csuite dependencies are enabled before compiling
+    and creating the test. If the dependencies are not enabled, the test
+    will not be created.
+
+ADDITIONAL_FILES <files>
+    Additional files, scripts, etc we want to copy over to the output test
+    binary. Useful if we need to setup an additional wrappers needed to run the
+    test.
+#]=======================================================================]
 function(define_c_test)
     cmake_parse_arguments(
         PARSE_ARGV
@@ -244,82 +399,86 @@ function(define_c_test)
         "TARGET;DIR_NAME;EXEC_SCRIPT;LABEL"
         "SOURCES;LIBS;FLAGS;ARGUMENTS;VARIANTS;DEPENDS;ADDITIONAL_FILES"
     )
-    if (NOT "${C_TEST_UNPARSED_ARGUMENTS}" STREQUAL "")
+    if (C_TEST_UNPARSED_ARGUMENTS)
         message(FATAL_ERROR "Unknown arguments to define_c_test: ${C_TEST_UNPARSED_ARGUMENTS}")
     endif()
-    if ("${C_TEST_TARGET}" STREQUAL "")
+    if (NOT C_TEST_TARGET)
         message(FATAL_ERROR "No target name given to define_c_test")
     endif()
-    if ("${C_TEST_SOURCES}" STREQUAL "")
+    if (NOT C_TEST_SOURCES)
         message(FATAL_ERROR "No sources given to define_c_test")
     endif()
-    if ("${C_TEST_DIR_NAME}" STREQUAL "")
+    if (NOT C_TEST_DIR_NAME)
         message(FATAL_ERROR "No directory given to define_c_test")
     endif()
 
-    if("${C_TEST_ARGUMENTS}" AND "${C_TEST_VARIANTS}")
+    if(C_TEST_ARGUMENTS AND C_TEST_VARIANTS)
         message(FATAL_ERROR "Can't pass both ARGUMENTS and VARIANTS, use only one")
     endif()
 
     # Check that the csuite dependencies are enabled before compiling and creating the test.
     eval_dependency("${C_TEST_DEPENDS}" enabled)
-    if(enabled)
-        set(additional_executable_args)
-        set(additional_file_args)
-        if(NOT "${C_TEST_FLAGS}" STREQUAL "")
-            list(APPEND additional_executable_args FLAGS ${C_TEST_FLAGS})
-        endif()
-        if(NOT "${C_TEST_ADDITIONAL_FILES}" STREQUAL "")
-            list(APPEND additional_file_args ${C_TEST_ADDITIONAL_FILES})
-        endif()
-        if(C_TEST_CXX)
-            list(APPEND additional_file_args CXX)
-        endif()
-        set(exec_wrapper)
-        if(WT_WIN)
-            # This is a workaround to run our csuite tests under Windows using CTest. When executing a test,
-            # CTests by-passes the shell and directly executes the test as a child process. In doing so CTest executes the binary with forward-slash paths.
-            # Which while technically valid breaks assumptions in our testing utilities. Wrap the execution in powershell to avoid this.
-            set(exec_wrapper "powershell.exe")
-        endif()
-        set(test_cmd)
-        if (C_TEST_EXEC_SCRIPT)
-            list(APPEND additional_file_args ${C_TEST_EXEC_SCRIPT})
-            # Define the c test to be executed with a script, rather than invoking the binary directly.
-            create_test_executable(${C_TEST_TARGET}
-                SOURCES ${C_TEST_SOURCES}
-                LIBS ${C_TEST_LIBS}
-                ADDITIONAL_FILES ${additional_file_args}
-                BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
-                ${additional_executable_args}
-            )
-            get_filename_component(exec_script_basename ${C_TEST_EXEC_SCRIPT} NAME)
-            set(test_cmd ${exec_wrapper} ${exec_script_basename})
-        else()
-            create_test_executable(${C_TEST_TARGET}
-                SOURCES ${C_TEST_SOURCES}
-                LIBS ${C_TEST_LIBS}
-                ADDITIONAL_FILES ${additional_file_args}
-                BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
-                ${additional_executable_args}
-            )
-            set(test_cmd ${exec_wrapper} $<TARGET_FILE:${C_TEST_TARGET}>)
-        endif()
-        # Define the ctest target.
-        if(C_TEST_VARIANTS)
-            # If we want to define multiple variant executions of the test script/binary.
-            define_test_variants(${C_TEST_TARGET}
-                VARIANTS ${C_TEST_VARIANTS}
-                CMDS ${test_cmd}
-                DIR_NAME ${C_TEST_DIR_NAME}
-                LABELS "check;csuite"
-            )
-        else()
-            add_test(NAME ${C_TEST_TARGET}
-                COMMAND ${test_cmd} ${C_TEST_ARGUMENTS}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
-            )
-            set_tests_properties(${C_TEST_TARGET} PROPERTIES LABELS "check;csuite;${C_TEST_LABEL}")
-        endif()
+    if(NOT enabled)
+        message(WARNING "Skipping test ${C_TEST_TARGET} because dependencies "
+            "${C_TEST_DEPENDS} are not enabled")
+        return()
+    endif()
+
+    set(additional_executable_args)
+    set(additional_file_args)
+    if(C_TEST_FLAGS)
+        list(APPEND additional_executable_args FLAGS ${C_TEST_FLAGS})
+    endif()
+    if(C_TEST_ADDITIONAL_FILES)
+        list(APPEND additional_file_args ${C_TEST_ADDITIONAL_FILES})
+    endif()
+    if(C_TEST_CXX)
+        list(APPEND additional_file_args CXX)
+    endif()
+    set(exec_wrapper)
+    if(WT_WIN)
+        # This is a workaround to run our csuite tests under Windows using CTest. When executing a test,
+        # CTests by-passes the shell and directly executes the test as a child process. In doing so CTest executes the binary with forward-slash paths.
+        # Which while technically valid breaks assumptions in our testing utilities. Wrap the execution in powershell to avoid this.
+        set(exec_wrapper "powershell.exe")
+    endif()
+    set(test_cmd)
+    if (C_TEST_EXEC_SCRIPT)
+        list(APPEND additional_file_args ${C_TEST_EXEC_SCRIPT})
+        # Define the C test to be executed with a script, rather than invoking the binary directly.
+        create_test_executable(${C_TEST_TARGET}
+            SOURCES ${C_TEST_SOURCES}
+            LIBS ${C_TEST_LIBS}
+            ADDITIONAL_FILES ${additional_file_args}
+            BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
+            ${additional_executable_args}
+        )
+        get_filename_component(exec_script_basename ${C_TEST_EXEC_SCRIPT} NAME)
+        set(test_cmd ${exec_wrapper} ${exec_script_basename})
+    else()
+        create_test_executable(${C_TEST_TARGET}
+            SOURCES ${C_TEST_SOURCES}
+            LIBS ${C_TEST_LIBS}
+            ADDITIONAL_FILES ${additional_file_args}
+            BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
+            ${additional_executable_args}
+        )
+        set(test_cmd ${exec_wrapper} $<TARGET_FILE:${C_TEST_TARGET}>)
+    endif()
+    # Define the ctest target.
+    if(C_TEST_VARIANTS)
+        # If we want to define multiple variant executions of the test script/binary.
+        define_test_variants(${C_TEST_TARGET}
+            VARIANTS ${C_TEST_VARIANTS}
+            CMDS ${test_cmd}
+            DIR_NAME ${C_TEST_DIR_NAME}
+            LABELS "check;csuite"
+        )
+    else()
+        add_test(NAME ${C_TEST_TARGET}
+            COMMAND ${test_cmd} ${C_TEST_ARGUMENTS}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${C_TEST_DIR_NAME}
+        )
+        set_tests_properties(${C_TEST_TARGET} PROPERTIES LABELS "check;csuite;${C_TEST_LABEL}")
     endif()
 endfunction(define_c_test)

--- a/test/cursor_order/CMakeLists.txt
+++ b/test/cursor_order/CMakeLists.txt
@@ -7,9 +7,9 @@ create_test_executable(test_cursor_order
 
 define_test_variants(test_cursor_order
     VARIANTS
-        "test_cursor_order_row;-tr"
-        "test_cursor_order_var;-tv"
-        "test_cursor_order_fix;-tf"
+        "row|-tr"
+        "var|-tv"
+        "fix|-tf"
     LABELS
         # Run this during a "ctest check" smoke test.
         check

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -658,7 +658,7 @@ functions:
         . test/evergreen/find_cmake.sh
         cd cmake_build
         echo "Using number of parallel processes '-j ${num_jobs}' for 'make check all'"
-        $CTEST -L check -j ${num_jobs} --output-on-failure ${ctest_extra_args|} 2>&1
+        $CTEST -L "^check$" -j ${num_jobs} --output-on-failure ${ctest_extra_args|} 2>&1
 
   # The following cppsuite tasks define a greater overall task.
   "cppsuite test run": &cppsuite_test_run

--- a/test/huge/CMakeLists.txt
+++ b/test/huge/CMakeLists.txt
@@ -5,7 +5,7 @@ create_test_executable(test_huge
 
 define_test_variants(test_huge
     VARIANTS
-        "test_huge_small;-s"
+        "small|-s"
     LABELS
         check
 )

--- a/test/utility/parse_opts.c
+++ b/test/utility/parse_opts.c
@@ -290,8 +290,10 @@ testutil_parse_end_opt(TEST_OPTS *opts)
     if (opts->tiered_storage) {
         if (opts->tiered_storage_source == NULL)
             opts->tiered_storage_source = dstrdup(DIR_STORE);
+    }
 
-        /* Deduce the build directory. */
+    if (opts->tiered_storage || opts->disagg_storage) {
+        /* Deduce the build directory (for extension loading). */
         testutil_deduce_build_dir(opts);
     }
 

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -105,8 +105,8 @@ typedef struct {
 
     const char *progname;        /* Truncated program name */
     char *build_dir;             /* Build directory path */
-    char *disagg_mode;           /* Disaggregated storage mode */
-    char *disagg_page_log;       /* Page and log service for disaggregated storage */
+    const char *disagg_mode;     /* Disaggregated storage mode */
+    const char *disagg_page_log; /* Page and log service for disaggregated storage */
     char *tiered_storage_source; /* Tiered storage source */
 
     enum {
@@ -134,6 +134,7 @@ typedef struct {
     bool absolute_bucket_dir;  /* Use an absolute bucket path when it is a directory */
     bool compat;               /* Compatibility */
     bool disagg_storage;       /* Uses disaggregated storage */
+    bool disagg_switch_mode;   /* Switching disaggregated storage mode during the test */
     bool do_data_ops;          /* Have schema ops use data */
     bool inmem;                /* In-memory */
     bool make_bucket_dir;      /* Create bucket when it is a directory */


### PR DESCRIPTION
- add `-d` flag to test/checkpoint for disagg modes: leader, follower, mixed
  - the configuration itself prepared by testutil; see `testutil_wiredtiger_open` for details
- define few disagg tests; tests are disabled by default until the build stabilises, but available for on-demand runs
- tidy-up related CMake scripts, add comments