### PR TITLE
WT-15336 Fix checking the wrong update's prepare state

### DIFF
--- a/src/btree/row_modify.c
+++ b/src/btree/row_modify.c
@@ -414,7 +414,7 @@ __wt_update_obsolete_check(
         if (upd->txnid == WT_TXN_NONE && upd->upd_start_ts == WT_TS_NONE &&
           upd->type == WT_UPDATE_TOMBSTONE && upd->next != NULL &&
           upd->next->txnid == WT_TXN_ABORTED) {
-            WT_ACQUIRE_READ(prepare_state, upd->prepare_state);
+            WT_ACQUIRE_READ(prepare_state, upd->next->prepare_state);
             /* We may see a locked prepare state if we race with prepare rollback. */
             if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED)
                 continue;


### PR DESCRIPTION
It is a fallout from WT-15238. I mistakenly checked the prepared update for the wrong update and we have race between obsolete check and txn read.