### PR TITLE
WT-15342 Re-enable RTS for precise checkpoint to unblock test format

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1189,10 +1189,11 @@ done:
      * 1. The connection is not read-only. A read-only connection expects that there shouldn't be
      *    any changes that need to be done on the database other than reading.
      * 2. The history store file was found in the metadata.
-     * 3. We are not using disaggregated storage or precise checkpoint
+     * 3. We are not using disaggregated storage or precise checkpoint\
+     * FIXME-WT-15343 Disable RTS for precise checkpoint when claim prepared is implemented in test
+     * format
      */
-    if (hs_exists_local && !F_ISSET(conn, WT_CONN_READONLY | WT_CONN_PRECISE_CHECKPOINT) &&
-      !disagg) {
+    if (hs_exists_local && !F_ISSET(conn, WT_CONN_READONLY) && !disagg) {
         const char *rts_cfg[] = {
           WT_CONFIG_BASE(session, WT_CONNECTION_rollback_to_stable), NULL, NULL};
         __wt_timer_start(session, &rts_timer);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1189,7 +1189,7 @@ done:
      * 1. The connection is not read-only. A read-only connection expects that there shouldn't be
      *    any changes that need to be done on the database other than reading.
      * 2. The history store file was found in the metadata.
-     * 3. We are not using disaggregated storage or precise checkpoint\
+     * 3. We are not using disaggregated storage or precise checkpoint.
      * FIXME-WT-15343 Disable RTS for precise checkpoint when claim prepared is implemented in test
      * format
      */

--- a/test/suite/test_prepare_discover01.py
+++ b/test/suite/test_prepare_discover01.py
@@ -51,6 +51,7 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(types, txn_end)
 
+    @wttest.only_for_hook("disagg", "FIXME-WT-15343 disable RTS when precise checkpoint is on")
     def test_prepare_discover01(self):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))

--- a/test/suite/test_prepare_discover02.py
+++ b/test/suite/test_prepare_discover02.py
@@ -51,6 +51,7 @@ class test_prepare_discover02(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(types, txn_end)
 
+    @wttest.only_for_hook("disagg", "FIXME-WT-15343 disable RTS when precise checkpoint is on")
     def test_prepare_discover02(self):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -923,6 +923,18 @@ def skip_for_hook(hookname, description):
     else:
         return runit_decorator
 
+def only_for_hook(hookname, description):
+    """
+    Used as a function decorator, e.g., @wttest.only_for_hook("tiered", "only runs with tiered hook").
+    The test will be skipped unless the specified hook is active.
+    """
+    def runit_decorator(func):
+        return func
+    if hookname not in WiredTigerTestCase.hook_names:
+        return unittest.skip(f"only runs with hook '{hookname}': {description}")
+    else:
+        return runit_decorator
+
 # Override a test's setUp function to instead skip and report the reason for skipping
 def register_skipped_test(test, hook, skip_reason):
 


### PR DESCRIPTION
Re-enable RTS for precise checkpoint to unblock test format. Disable this setting when claim prepared is implemented in test format