### PR TITLE
WT-14904 Fix building internal page delta for a previously split child

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1219,6 +1219,7 @@ struct __wt_ref {
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_REF_FLAG_INTERNAL 0x1u /* Page is an internal page */
 #define WT_REF_FLAG_LEAF 0x2u     /* Page is a leaf page */
+#define WT_REF_REC_SPLIT 0x4u     /* Page has been split in reconciliation */
                                   /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1217,10 +1217,10 @@ struct __wt_ref {
  * depending on it to be "!leaf" instead.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_REF_FLAG_INTERNAL 0x1u  /* Page is an internal page */
-#define WT_REF_FLAG_LEAF 0x2u      /* Page is a leaf page */
-#define WT_REF_FLAG_REC_SPLIT 0x4u /* Page has been split in reconciliation */
-                                   /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
+#define WT_REF_FLAG_INTERNAL 0x1u     /* Page is an internal page */
+#define WT_REF_FLAG_LEAF 0x2u         /* Page is a leaf page */
+#define WT_REF_FLAG_REC_MULTIPLE 0x4u /* Page has been split in reconciliation */
+                                      /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1217,10 +1217,10 @@ struct __wt_ref {
  * depending on it to be "!leaf" instead.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_REF_FLAG_INTERNAL 0x1u /* Page is an internal page */
-#define WT_REF_FLAG_LEAF 0x2u     /* Page is a leaf page */
-#define WT_REF_REC_SPLIT 0x4u     /* Page has been split in reconciliation */
-                                  /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
+#define WT_REF_FLAG_INTERNAL 0x1u  /* Page is an internal page */
+#define WT_REF_FLAG_LEAF 0x2u      /* Page is a leaf page */
+#define WT_REF_FLAG_REC_SPLIT 0x4u /* Page has been split in reconciliation */
+                                   /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -257,6 +257,11 @@ __rec_row_merge(
 
     /* FIXME-WT-14880: build delta for split pages. */
     if (mod->mod_multi_entries > 1) {
+        /*
+         * We need to remember what has been written for this ref in this internal page
+         * reconciliation to be able to build the internal page delta in the future. We have to
+         * remember it on the ref otherwise the information is lost if the child page is evicted.
+         */
         F_SET(ref, WT_REF_FLAG_REC_MULTIPLE);
         if (*build_delta && ref_changes > 0) {
             *build_delta = false;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -383,7 +383,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * but the page is not split in the previous reconciliation. In this case, we cannot delete
          * the keys written in the previous reconciliation.
          */
-        if (build_delta && F_ISSET(ref, WT_REF_REC_SPLIT)) {
+        if (build_delta && F_ISSET(ref, WT_REF_FLAG_REC_SPLIT)) {
             build_delta = false;
             r->delta.size = 0;
         }

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -379,11 +379,13 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         /*
          * FIXME-WT-14880: build delta for split pages.
          *
-         * Stop building the delta if the page has ever been split. We may write a split page before
-         * but the page is not split in the previous reconciliation. In this case, we cannot delete
-         * the keys written in the previous reconciliation.
+         * Stop building the delta if the page has ever been split.
+         *
+         * We may split the child before but the it is not split in the most recent reconciliation.
+         * In this case, we cannot delete the keys written in the previous reconciliation if we
+         * build a delta. Stop building a delta.
          */
-        if (build_delta && F_ISSET(ref, WT_REF_FLAG_REC_SPLIT)) {
+        if (build_delta && (r->multi_next > 0 || F_ISSET(ref, WT_REF_FLAG_REC_SPLIT))) {
             build_delta = false;
             r->delta.size = 0;
         }

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -255,6 +255,16 @@ __rec_row_merge(
     key = &r->k;
     val = &r->v;
 
+    /* FIXME-WT-14880: build delta for split pages. */
+    if (mod->mod_multi_entries > 1) {
+        F_SET(ref, WT_REF_FLAG_REC_MULTIPLE);
+        if (*build_delta && ref_changes > 0) {
+            *build_delta = false;
+            r->delta.size = 0;
+        }
+    } else
+        F_CLR(ref, WT_REF_FLAG_REC_MULTIPLE);
+
     /* For each entry in the split array... */
     for (multi = mod->mod_multi, i = 0; i < mod->mod_multi_entries; ++multi, ++i) {
         /*
@@ -381,11 +391,11 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          *
          * Stop building the delta if the page has ever been split.
          *
-         * We may split the child before but the it is not split in the most recent reconciliation.
-         * In this case, we cannot delete the keys written in the previous reconciliation if we
-         * build a delta. Stop building a delta.
+         * We write the child as multiple keys in the previous reconciliation. In this case, we
+         * cannot delete the keys written in the previous reconciliation if we build a delta. Stop
+         * building a delta.
          */
-        if (build_delta && (r->multi_next > 0 || F_ISSET(ref, WT_REF_FLAG_REC_SPLIT))) {
+        if (build_delta && (r->multi_next > 0 || F_ISSET(ref, WT_REF_FLAG_REC_MULTIPLE))) {
             build_delta = false;
             r->delta.size = 0;
         }
@@ -445,6 +455,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              */
             if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
                 __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
+
+            F_CLR(ref, WT_REF_FLAG_REC_MULTIPLE);
             /*
              * Ignored child.
              */
@@ -476,6 +488,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
                     __wt_atomic_casv8(&ref->ref_changes, prev_ref_changes, 0);
 
+                F_CLR(ref, WT_REF_FLAG_REC_MULTIPLE);
                 WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
                 continue;
             case WT_PM_REC_MULTIBLOCK:
@@ -563,6 +576,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         WT_TIME_AGGREGATE_COPY(&ta, source_ta);
         if (page_del != NULL)
             WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, &ft_ta, page_del);
+
+        F_CLR(ref, WT_REF_FLAG_REC_MULTIPLE);
         WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
 
         /* Build key cell. Truncate any 0th key, internal pages don't need 0th keys. */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -255,12 +255,6 @@ __rec_row_merge(
     key = &r->k;
     val = &r->v;
 
-    /* FIXME-WT-14880: build delta for split pages. */
-    if (*build_delta && mod->mod_multi_entries > 1 && ref_changes > 0) {
-        *build_delta = false;
-        r->delta.size = 0;
-    }
-
     /* For each entry in the split array... */
     for (multi = mod->mod_multi, i = 0; i < mod->mod_multi_entries; ++multi, ++i) {
         /*
@@ -382,8 +376,14 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
 
     /* For each entry in the in-memory page... */
     WT_INTL_FOREACH_BEGIN (session, page, ref) {
-        /* FIXME-WT-14880: build delta for split pages. */
-        if (build_delta && r->multi_next > 0) {
+        /*
+         * FIXME-WT-14880: build delta for split pages.
+         *
+         * Stop building the delta if the page has ever been split. We may write a split page before
+         * but the page is not split in the previous reconciliation. In this case, we cannot delete
+         * the keys written in the previous reconciliation.
+         */
+        if (build_delta && F_ISSET(ref, WT_REF_REC_SPLIT)) {
             build_delta = false;
             r->delta.size = 0;
         }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3381,7 +3381,7 @@ split:
         mod->rec_result = WT_PM_REC_MULTIBLOCK;
 
         if (r->multi_next > 1)
-            F_SET(ref, WT_REF_REC_SPLIT);
+            F_SET(ref, WT_REF_FLAG_REC_SPLIT);
 
         r->multi = NULL;
         r->multi_next = 0;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3380,9 +3380,6 @@ split:
         mod->mod_multi_entries = r->multi_next;
         mod->rec_result = WT_PM_REC_MULTIBLOCK;
 
-        if (r->multi_next > 1)
-            F_SET(ref, WT_REF_FLAG_REC_SPLIT);
-
         r->multi = NULL;
         r->multi_next = 0;
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3380,6 +3380,9 @@ split:
         mod->mod_multi_entries = r->multi_next;
         mod->rec_result = WT_PM_REC_MULTIBLOCK;
 
+        if (r->multi_next > 1)
+            F_SET(ref, WT_REF_REC_SPLIT);
+
         r->multi = NULL;
         r->multi_next = 0;
 

--- a/test/suite/test_layered32.py
+++ b/test/suite/test_layered32.py
@@ -38,10 +38,6 @@ import time
 
 @disagg_test_class
 class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
-    compress = [
-        ('none', dict(block_compress='none')),
-        ('snappy', dict(block_compress='snappy')),
-    ]
 
     delta = [
         ('write_leaf_only', dict(delta_config='page_delta=(internal_page_delta=false,leaf_page_delta=true)', delta_type='leaf_only')),
@@ -58,12 +54,12 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
     uri='file:test_layered32'
 
     # Make scenarios for different cloud service providers
-    scenarios = make_scenarios(compress, disagg_storages, delta)
+    scenarios = make_scenarios(disagg_storages, delta)
 
     def session_create_config(self):
         # The delta percentage of 100 is an arbitrary large value, intended to produce
         # deltas a lot of the time.
-        cfg = 'key_format=S,value_format=S,allocation_size=512,leaf_page_max=512,internal_page_max=512,block_manager=disagg,block_compressor={}'.format(self.block_compress)
+        cfg = 'key_format=S,value_format=S,allocation_size=512,leaf_page_max=512,internal_page_max=512,block_manager=disagg'
         return cfg
 
     def conn_config(self):
@@ -71,7 +67,6 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     # Load the storage store extension.
     def conn_extensions(self, extlist):
-        extlist.extension('compressors', self.block_compress)
         DisaggConfigMixin.conn_extensions(self, extlist)
 
     def get_stat(self, stat):

--- a/test/suite/test_layered32.py
+++ b/test/suite/test_layered32.py
@@ -38,24 +38,9 @@ import time
 
 @disagg_test_class
 class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
-    encrypt = [
-        ('none', dict(encryptor='none', encrypt_args='')),
-        ('rotn', dict(encryptor='rotn', encrypt_args='keyid=13')),
-    ]
-
     compress = [
         ('none', dict(block_compress='none')),
         ('snappy', dict(block_compress='snappy')),
-    ]
-
-    uris = [
-        ('layered', dict(uri='layered:test_layered32')),
-        ('btree', dict(uri='file:test_layered32')),
-    ]
-
-    ts = [
-        ('ts', dict(ts=True)),
-        ('non-ts', dict(ts=False)),
     ]
 
     delta = [
@@ -69,25 +54,24 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
                      + 'disaggregated=(page_log=palm),page_delta=(delta_pct=100),'
     disagg_storages = gen_disagg_storages('test_layered32', disagg_only = True)
 
+    nrows = 1000
+    uri='file:test_layered32'
+
     # Make scenarios for different cloud service providers
-    scenarios = make_scenarios(encrypt, compress, disagg_storages, uris, ts, delta)
+    scenarios = make_scenarios(compress, disagg_storages, delta)
 
     def session_create_config(self):
         # The delta percentage of 100 is an arbitrary large value, intended to produce
         # deltas a lot of the time.
-        cfg = 'key_format=S,value_format=S,allocation_size=512,leaf_page_max=512,internal_page_max=512,block_compressor={}'.format(self.block_compress)
-        if self.uri.startswith('file'):
-            cfg += ',block_manager=disagg'
+        cfg = 'key_format=S,value_format=S,allocation_size=512,leaf_page_max=512,internal_page_max=512,block_manager=disagg,block_compressor={}'.format(self.block_compress)
         return cfg
 
     def conn_config(self):
-        enc_conf = 'encryption=(name={0},{1}),'.format(self.encryptor, self.encrypt_args)
-        return self.conn_base_config + f'disaggregated=(role="leader"),{self.delta_config},' + enc_conf
+        return self.conn_base_config + f'disaggregated=(role="leader"),{self.delta_config},'
 
     # Load the storage store extension.
     def conn_extensions(self, extlist):
         extlist.extension('compressors', self.block_compress)
-        extlist.extension('encryptors', self.encryptor)
         DisaggConfigMixin.conn_extensions(self, extlist)
 
     def get_stat(self, stat):
@@ -96,21 +80,18 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
         stat_cursor.close()
         return val
 
-    def insert(self, kv, ts=None):
+    def insert(self, kv, ts):
         cursor = self.session.open_cursor(self.uri, None, None)
         for k, v in kv.items():
             self.session.begin_transaction()
             cursor[k] = v
-            if self.ts:
-                self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(ts))
-            else:
-                self.session.commit_transaction()
+            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(ts))
         cursor.close()
 
     def verify(self, expected_kv, expected_initial_val):
         # Verify the values in the table.
         cursor = self.session.open_cursor(self.uri, None, None)
-        for i in range(1, self.nitems + 1):
+        for i in range(1, self.nrows + 1):
             cursor.set_key(str(i))
             cursor.search()
             if str(i) in expected_kv:
@@ -119,16 +100,13 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
                 self.assertEqual(cursor.get_value(), expected_initial_val)
         cursor.close()
 
-
-    nitems = 10_000
-
     def test_internal_page_delta_simple(self):
         self.session.create(self.uri, self.session_create_config())
 
-        # Populate the table with nitems.
+        # Populate the table with nrows.
         inital_value = "abc" * 10
         inital_ts = 5
-        kv = {str(i): inital_value for i in range(1, self.nitems + 1)}
+        kv = {str(i): inital_value for i in range(1, self.nrows + 1)}
         self.insert(kv, inital_ts)
         self.session.checkpoint()
 
@@ -136,8 +114,8 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.reopen_disagg_conn(self.conn_config())
 
         # Perform two small updates.
-        kv_modfied = {str(10): "10abc", str(220): "220abc"}
-        self.insert(kv_modfied, inital_ts + 1)
+        kv_modified = {str(10): "10abc", str(220): "220abc"}
+        self.insert(kv_modified, inital_ts + 1)
         # Perform a checkpoint to write out a delta.
         self.session.checkpoint()
 
@@ -153,7 +131,7 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.reopen_disagg_conn(self.conn_config())
 
         # Verify the updated values in the table.
-        self.verify(kv_modfied, inital_value)
+        self.verify(kv_modified, inital_value)
 
         # Assert that we have constructed at least one internal page delta.
         if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
@@ -166,7 +144,7 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
         time.sleep(1.0)
 
         # Verify the updated values in the table.
-        self.verify(kv_modfied, inital_value)
+        self.verify(kv_modified, inital_value)
 
         # Assert that we have constructed at least one internal page delta.
         if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
@@ -174,35 +152,35 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
         else:
             self.assertEqual(self.get_stat(stat.conn.cache_read_internal_delta), 0)
 
-    def test_internal_page_delta_random(self):
+    def test_internal_page_delta_split_internal(self):
 
         self.session.create(self.uri, self.session_create_config())
 
-        # Populate the table with nitems.
+        # Initial population of the table with nrows.
         inital_value = "abc" * 100
-        small_value = "b123r" * 5
+        small_value = "b123r" * 20
         inital_ts = 5
 
-        # Initial Population
-        kv = {str(i): small_value for i in range(1, self.nitems + 1)}
+        kv = {str(i): small_value for i in range(1, self.nrows + 1)}
         self.insert(kv, inital_ts)
-    
-        # First Checkpoint & Reopen
+
+        # First Checkpoint & Reopen to ensure all data is read from the disk.
         self.session.checkpoint()
         self.reopen_disagg_conn(self.conn_config())
 
-        # Large Value Insertion
-        keys_to_update = ["4041","4042","4043", "4044", "4045", "4046", "4047", "4048", "4049", "4050"]
+        # Updates a sequence of subset of keys with a large value.
+        keys_to_update = ["241","242","243", "244", "245", "246", "247", "248", "249", "250"]
         kv_modified = {}
         for key in keys_to_update:
             kv = {key: inital_value}
             inital_ts = inital_ts + 1
             self.insert(kv, inital_ts)
 
-        #Second Checkpoint 
+        # Second Checkpoint to force a page split and write the newly split pages to disk.
         self.session.checkpoint()
 
-        # Small Value Update
+        # The same set of keys is then updated with a smaller value, which should cause the
+        # pages to merge back together and write an internal page delta.
         for key in keys_to_update:
             kv = {key: small_value}
             inital_ts = inital_ts + 1
@@ -224,16 +202,6 @@ class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         # Re-open the connection to clear contents out of memory.
         self.reopen_disagg_conn(self.conn_config())
-
-        # Verify the updated values in the table.
-        self.verify(kv_modified, small_value)
-
-        # Re-open the connection to clear contents out of memory.
-        self.reopen_disagg_conn(self.conn_config())
-
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower"),'
-        self.reopen_disagg_conn(follower_config)
-        time.sleep(1.0)
 
         # Verify the updated values in the table.
         self.verify(kv_modified, small_value)

--- a/test/suite/test_layered32.py
+++ b/test/suite/test_layered32.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import random, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+from wiredtiger import stat
+import time
+
+
+# test_layered32.py
+# Test that we write internal page deltas to the page log extension.
+
+@disagg_test_class
+class test_layered32(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    encrypt = [
+        ('none', dict(encryptor='none', encrypt_args='')),
+        ('rotn', dict(encryptor='rotn', encrypt_args='keyid=13')),
+    ]
+
+    compress = [
+        ('none', dict(block_compress='none')),
+        ('snappy', dict(block_compress='snappy')),
+    ]
+
+    uris = [
+        ('layered', dict(uri='layered:test_layered32')),
+        ('btree', dict(uri='file:test_layered32')),
+    ]
+
+    ts = [
+        ('ts', dict(ts=True)),
+        ('non-ts', dict(ts=False)),
+    ]
+
+    delta = [
+        ('write_leaf_only', dict(delta_config='page_delta=(internal_page_delta=false,leaf_page_delta=true)', delta_type='leaf_only')),
+        ('write_internal_only', dict(delta_config='page_delta=(internal_page_delta=true,leaf_page_delta=false)', delta_type='internal_only')),
+        ('write_none', dict(delta_config='page_delta=(internal_page_delta=false,leaf_page_delta=false)', delta_type='none')),
+        ('write_both', dict(delta_config='page_delta=(internal_page_delta=true,leaf_page_delta=true)', delta_type='both')),
+    ]
+
+    conn_base_config = 'cache_size=5G,transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),page_delta=(delta_pct=100),'
+    disagg_storages = gen_disagg_storages('test_layered32', disagg_only = True)
+
+    # Make scenarios for different cloud service providers
+    scenarios = make_scenarios(encrypt, compress, disagg_storages, uris, ts, delta)
+
+    def session_create_config(self):
+        # The delta percentage of 100 is an arbitrary large value, intended to produce
+        # deltas a lot of the time.
+        cfg = 'key_format=S,value_format=S,allocation_size=512,leaf_page_max=512,internal_page_max=512,block_compressor={}'.format(self.block_compress)
+        if self.uri.startswith('file'):
+            cfg += ',block_manager=disagg'
+        return cfg
+
+    def conn_config(self):
+        enc_conf = 'encryption=(name={0},{1}),'.format(self.encryptor, self.encrypt_args)
+        return self.conn_base_config + f'disaggregated=(role="leader"),{self.delta_config},' + enc_conf
+
+    # Load the storage store extension.
+    def conn_extensions(self, extlist):
+        extlist.extension('compressors', self.block_compress)
+        extlist.extension('encryptors', self.encryptor)
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def insert(self, kv, ts=None):
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for k, v in kv.items():
+            self.session.begin_transaction()
+            cursor[k] = v
+            if self.ts:
+                self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(ts))
+            else:
+                self.session.commit_transaction()
+        cursor.close()
+
+    def verify(self, expected_kv, expected_initial_val):
+        # Verify the values in the table.
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(1, self.nitems + 1):
+            cursor.set_key(str(i))
+            cursor.search()
+            if str(i) in expected_kv:
+                self.assertEqual(cursor.get_value(), expected_kv[str(i)])
+            else:
+                self.assertEqual(cursor.get_value(), expected_initial_val)
+        cursor.close()
+
+
+    nitems = 10_000
+
+    def test_internal_page_delta_simple(self):
+        self.session.create(self.uri, self.session_create_config())
+
+        # Populate the table with nitems.
+        inital_value = "abc" * 10
+        inital_ts = 5
+        kv = {str(i): inital_value for i in range(1, self.nitems + 1)}
+        self.insert(kv, inital_ts)
+        self.session.checkpoint()
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        # Perform two small updates.
+        kv_modfied = {str(10): "10abc", str(220): "220abc"}
+        self.insert(kv_modfied, inital_ts + 1)
+        # Perform a checkpoint to write out a delta.
+        self.session.checkpoint()
+
+        if (self.delta_type == 'both' or self.delta_type == 'leaf_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+        if (self.delta_type == 'none'):
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        # Verify the updated values in the table.
+        self.verify(kv_modfied, inital_value)
+
+        # Assert that we have constructed at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+        else:
+            self.assertEqual(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+
+        follower_config = self.conn_base_config + 'disaggregated=(role="follower"),'
+        self.reopen_disagg_conn(follower_config)
+        time.sleep(1.0)
+
+        # Verify the updated values in the table.
+        self.verify(kv_modfied, inital_value)
+
+        # Assert that we have constructed at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+        else:
+            self.assertEqual(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+
+    def test_internal_page_delta_random(self):
+
+        self.session.create(self.uri, self.session_create_config())
+
+        # Populate the table with nitems.
+        inital_value = "abc" * 100
+        small_value = "b123r" * 5
+        inital_ts = 5
+
+        # Initial Population
+        kv = {str(i): small_value for i in range(1, self.nitems + 1)}
+        self.insert(kv, inital_ts)
+    
+        # First Checkpoint & Reopen
+        self.session.checkpoint()
+        self.reopen_disagg_conn(self.conn_config())
+
+        # Large Value Insertion
+        keys_to_update = ["4041","4042","4043", "4044", "4045", "4046", "4047", "4048", "4049", "4050"]
+        kv_modified = {}
+        for key in keys_to_update:
+            kv = {key: inital_value}
+            inital_ts = inital_ts + 1
+            self.insert(kv, inital_ts)
+
+        #Second Checkpoint 
+        self.session.checkpoint()
+
+        # Small Value Update
+        for key in keys_to_update:
+            kv = {key: small_value}
+            inital_ts = inital_ts + 1
+            self.insert(kv, inital_ts)
+            self.session.checkpoint()
+            kv_modified.update(kv)
+
+        # Assert that we have written at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'leaf_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+        if (self.delta_type == 'none'):
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+
+        # Verify the updated values in the table.
+        self.verify(kv_modified, small_value)
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        # Verify the updated values in the table.
+        self.verify(kv_modified, small_value)
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        follower_config = self.conn_base_config + 'disaggregated=(role="follower"),'
+        self.reopen_disagg_conn(follower_config)
+        time.sleep(1.0)
+
+        # Verify the updated values in the table.
+        self.verify(kv_modified, small_value)


### PR DESCRIPTION
We have already disabled building internal page deltas if any child page split in the most recent reconciliation. However, it is not enough. We can have a child that was split in reconciliation 1 but not split in reconciliation 2. If we write the split page in its parent's previous reconciliation, we will unintentionally not deleting those split keys in the second reconciliation if we write a delta. Therefore, we should stop building the internal page delta if we see any child page that is written as multiple keys in the previous internal page reconciliation.

Added a python test test_layered32.py