### PR TITLE
WT-15239 Set durable timestamp during recovery for disagg

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1225,8 +1225,14 @@ done:
           "recovery rollback to stable has successfully finished and ran for %" PRIu64
           " milliseconds",
           conn->recovery_timeline.rts_ms);
-    } else if (disagg)
+    } else if (disagg) {
         __wt_verbose_info(session, WT_VERB_RTS, "%s", "skipped recovery RTS due to disagg");
+
+        /* Disagg doesn’t use rollback to stable, but we still need to set the durable timestamp. */
+        WT_TXN_GLOBAL *txn_global = &conn->txn_global;
+        txn_global->has_durable_timestamp = txn_global->has_stable_timestamp;
+        txn_global->durable_timestamp = txn_global->stable_timestamp;
+    }
 
     /*
      * Sometimes eviction is triggered after doing a checkpoint. However, we don't want eviction to

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1189,7 +1189,9 @@ done:
      * 1. The connection is not read-only. A read-only connection expects that there shouldn't be
      *    any changes that need to be done on the database other than reading.
      * 2. The history store file was found in the metadata.
-     * 3. We are not using disaggregated storage or precise checkpoint
+     * 3. We are not using disaggregated storage or precise checkpoint(In precise checkpoints,
+     * everything is stable except prepared txns. Disagg also uses precise checkpoint, so neither
+     * requires rollback to stable).
      */
     if (hs_exists_local && !F_ISSET(conn, WT_CONN_READONLY | WT_CONN_PRECISE_CHECKPOINT) &&
       !disagg) {
@@ -1225,13 +1227,14 @@ done:
           "recovery rollback to stable has successfully finished and ran for %" PRIu64
           " milliseconds",
           conn->recovery_timeline.rts_ms);
-    } else if (disagg) {
-        __wt_verbose_info(session, WT_VERB_RTS, "%s", "skipped recovery RTS due to disagg");
-
-        /* Disagg doesn’t use rollback to stable, but we still need to set the durable timestamp. */
+    } else {
+        /* Although rollback to stable isn’t needed, we still need to set the durable timestamp. */
         WT_TXN_GLOBAL *txn_global = &conn->txn_global;
         txn_global->has_durable_timestamp = txn_global->has_stable_timestamp;
         txn_global->durable_timestamp = txn_global->stable_timestamp;
+
+        if (disagg)
+            __wt_verbose_info(session, WT_VERB_RTS, "%s", "skipped recovery RTS due to disagg");
     }
 
     /*

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1190,7 +1190,7 @@ done:
      *    any changes that need to be done on the database other than reading.
      * 2. The history store file was found in the metadata.
      * 3. We are not using disaggregated storage or precise checkpoint(In precise checkpoints,
-     * everything is stable except prepared txns. Disagg also uses precise checkpoint, so neither
+     * everything is stable except prepared txn. Disagg also uses precise checkpoint, so neither
      * requires rollback to stable).
      * FIXME-WT-15343 Disable RTS for precise checkpoint when claim prepared is implemented in test
      * format
@@ -1229,7 +1229,7 @@ done:
           " milliseconds",
           conn->recovery_timeline.rts_ms);
     } else {
-        /* Although rollback to stable isn’t needed, we still need to set the durable timestamp. */
+        /* Although rollback to stable is not needed, we still need to set the durable timestamp. */
         WT_TXN_GLOBAL *txn_global = &conn->txn_global;
         txn_global->has_durable_timestamp = txn_global->has_stable_timestamp;
         txn_global->durable_timestamp = txn_global->stable_timestamp;

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -116,7 +116,6 @@ test_timestamp03.py
 test_timestamp05.py
 test_timestamp06.py
 test_timestamp07.py
-test_timestamp08.py
 test_timestamp10.py
 test_timestamp12.py
 test_timestamp20.py


### PR DESCRIPTION
Disagg doesn't need to call `rollback_to_stable` during recovery as we use precise checkpoint, however rts also sets durable timestamp, and we should set this in disagg as well.