### PR TITLE
WT-15330 Prevent prepare discover cursor from claiming the same prepare txn twice

### DIFF
--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -91,7 +91,7 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
     if (pending_prepare_items->hash != NULL) {
         for (i = 0; i < pending_prepare_items->hash_size; i++) {
             while ((item = TAILQ_FIRST(&pending_prepare_items->hash[i])) != NULL) {
-                /* 
+                /*
                  * Claimed prepare transactions should have been removed from the hash map already.
                  * Increase the counter if we find unclaimed item left in map.
                  */

--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -91,10 +91,10 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
     if (pending_prepare_items->hash != NULL) {
         for (i = 0; i < pending_prepare_items->hash_size; i++) {
             while ((item = TAILQ_FIRST(&pending_prepare_items->hash[i])) != NULL) {
-                if (!item->claimed) {
-                    /* Found an unclaimed prepare but still need to clean up this cursor */
-                    unclaimed_count++;
-                }
+                /* Claimed prepare transactions should have been removed from the hash map already.
+                 * Increase the counter if we find unclaimed item left in map.
+                 */
+                unclaimed_count++;
                 TAILQ_REMOVE(&pending_prepare_items->hash[i], item, hashq);
                 /* Clean up memory of unclaimed mod array */
                 for (j = 0, op = item->mod; j < item->mod_count; j++, op++) {

--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -89,6 +89,10 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
     if (pending_prepare_items->hash != NULL) {
         for (i = 0; i < pending_prepare_items->hash_size; i++) {
             while ((item = TAILQ_FIRST(&pending_prepare_items->hash[i])) != NULL) {
+                if (!item->claimed) {
+                    /* Found an unclaimed prepare but still need to clean up this cursor */
+                    ret = WT_ERROR;
+                }
                 TAILQ_REMOVE(&pending_prepare_items->hash[i], item, hashq);
                 /* Clean up memory of unclaimed mod array */
                 for (j = 0, op = item->mod; j < item->mod_count; j++, op++) {

--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -91,7 +91,8 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
     if (pending_prepare_items->hash != NULL) {
         for (i = 0; i < pending_prepare_items->hash_size; i++) {
             while ((item = TAILQ_FIRST(&pending_prepare_items->hash[i])) != NULL) {
-                /* Claimed prepare transactions should have been removed from the hash map already.
+                /* 
+                 * Claimed prepare transactions should have been removed from the hash map already.
                  * Increase the counter if we find unclaimed item left in map.
                  */
                 unclaimed_count++;

--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -81,17 +81,19 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_OP *op;
     uint64_t i, j;
+    uint64_t unclaimed_count;
     cursor_prepare = (WT_CURSOR_PREPARE_DISCOVERED *)cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, NULL);
 
     txn_global = &S2C(session)->txn_global;
     pending_prepare_items = &txn_global->pending_prepare_items;
+    unclaimed_count = 0;
     if (pending_prepare_items->hash != NULL) {
         for (i = 0; i < pending_prepare_items->hash_size; i++) {
             while ((item = TAILQ_FIRST(&pending_prepare_items->hash[i])) != NULL) {
                 if (!item->claimed) {
                     /* Found an unclaimed prepare but still need to clean up this cursor */
-                    ret = WT_ERROR;
+                    unclaimed_count++;
                 }
                 TAILQ_REMOVE(&pending_prepare_items->hash[i], item, hashq);
                 /* Clean up memory of unclaimed mod array */
@@ -107,7 +109,8 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
         __wt_free(session, pending_prepare_items->hash);
         memset((void *)pending_prepare_items, 0, sizeof(WT_PENDING_PREPARED_MAP));
     }
-
+    if (unclaimed_count > 0)
+        WT_ERR_MSG(session, WT_ERROR, "Found %lu unclaimed prepared transactions", unclaimed_count);
 err:
 
     __wt_free(session, cursor_prepare->list);

--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -102,8 +102,6 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
                     __wt_txn_op_free(session, op);
                 }
                 __wt_free(session, item->mod);
-                item->mod_alloc = 0;
-                item->mod_count = 0;
                 __wt_free(session, item);
             }
         }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1519,11 +1519,10 @@ extern int __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
 extern int __wti_prefetch_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prepared_discover_add_artifact_ondisk_row(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_prepared_discover_add_artifact_upd(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_ITEM *key, WT_UPDATE *upd)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, uint64_t prepared_id,
+  WT_ITEM *key, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey(WT_SESSION_IMPL *session, uint32_t cell_offset, const void *key,
   size_t size, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey_incr(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t cell_offset,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2154,8 +2154,8 @@ static WT_INLINE int __wt_txn_autocommit_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session,
-  uint64_t prepared_id) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, uint64_t prepared_id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_prepare_check(WT_SESSION_IMPL *session)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -881,6 +881,8 @@ extern int __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_prepared_discover_find_item(WT_SESSION_IMPL *session, uint64_t prepared_id,
   WT_PENDING_PREPARED_ITEM **prepared_item) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_random_descent(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -879,9 +879,8 @@ extern int __wt_prefetch_page_in(WT_SESSION_IMPL *session, WT_PREFETCH_QUEUE_ENT
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_prepared_discover_find_item(WT_SESSION_IMPL *session,
-  uint64_t prepare_transaction_id, WT_PENDING_PREPARED_ITEM **prepared_item)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_prepared_discover_find_item(WT_SESSION_IMPL *session, uint64_t prepared_id,
+  WT_PENDING_PREPARED_ITEM **prepared_item) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_random_descent(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags,
@@ -2154,7 +2153,7 @@ static WT_INLINE int __wt_txn_autocommit_check(WT_SESSION_IMPL *session)
 static WT_INLINE int __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session,
-  wt_timestamp_t prepared_transaction_id) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  wt_timestamp_t prepared_id) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_prepare_check(WT_SESSION_IMPL *session)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2155,7 +2155,7 @@ static WT_INLINE int __wt_txn_autocommit_check(WT_SESSION_IMPL *session)
 static WT_INLINE int __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session,
-  wt_timestamp_t prepared_id) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  uint64_t prepared_id) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_prepare_check(WT_SESSION_IMPL *session)

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -147,10 +147,10 @@ struct __wt_txn_shared {
 struct __wt_pending_prepared_item {
     TAILQ_ENTRY(__wt_pending_prepared_item) hashq;
     uint64_t prepared_id;
+    wt_timestamp_t prepare_timestamp;
     WT_TXN_OP *mod;
     size_t mod_alloc;
     uint32_t mod_count;
-    bool claimed;
 #ifdef HAVE_DIAGNOSTIC
     uint32_t prepare_count;
 #endif

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -150,6 +150,7 @@ struct __wt_pending_prepared_item {
     WT_TXN_OP *mod;
     size_t mod_alloc;
     uint32_t mod_count;
+    bool claimed;
 #ifdef HAVE_DIAGNOSTIC
     uint32_t prepare_count;
 #endif

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1823,7 +1823,7 @@ __txn_remove_from_global_table(WT_SESSION_IMPL *session)
  *     Claim a prepared transaction.
  */
 static WT_INLINE int
-__wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, uin64_t prepared_id)
+__wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, uint64_t prepared_id)
 {
     WT_DECL_RET;
     WT_PENDING_PREPARED_ITEM *prepared_item;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1831,9 +1831,9 @@ __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_id
     WT_TXN_OP *tmp_mod;
     txn = session->txn;
     WT_RET(__wt_prepared_discover_find_item(session, prepared_id, &prepared_item));
-    F_SET(txn, WT_TXN_PREPARE | WT_TXN_HAS_PREPARED_ID | WT_TXN_HAS_TS_PREPARE | WT_TXN_RUNNING);
     txn->prepared_id = prepared_id;
     txn->prepare_timestamp = prepared_item->prepare_timestamp;
+    F_SET(txn, WT_TXN_PREPARE | WT_TXN_HAS_PREPARED_ID | WT_TXN_HAS_TS_PREPARE | WT_TXN_RUNNING);
     /*
      * Swap mod array with prepared_item to avoid double-free on cursor close and when
      * commit/rollback.

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1823,7 +1823,7 @@ __txn_remove_from_global_table(WT_SESSION_IMPL *session)
  *     Claim a prepared transaction.
  */
 static WT_INLINE int
-__wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_id)
+__wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, uin64_t prepared_id)
 {
     WT_DECL_RET;
     WT_PENDING_PREPARED_ITEM *prepared_item;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1823,20 +1823,20 @@ __txn_remove_from_global_table(WT_SESSION_IMPL *session)
  *     Claim a prepared transaction.
  */
 static WT_INLINE int
-__wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_transaction_id)
+__wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_id)
 {
     WT_DECL_RET;
     WT_PENDING_PREPARED_ITEM *prepared_item;
     WT_TXN *txn;
     WT_TXN_OP *tmp_mod;
     txn = session->txn;
-    WT_RET(__wt_prepared_discover_find_item(session, prepared_transaction_id, &prepared_item));
+    WT_RET(__wt_prepared_discover_find_item(session, prepared_id, &prepared_item));
     if (prepared_item->claimed)
         WT_RET_MSG(
-          session, WT_ERROR, "Prepared id %lu has already been claimed", prepared_transaction_id);
+          session, WT_ERROR, "Prepared id %" PRIu64 " has already been claimed", prepared_id);
     F_SET(txn, WT_TXN_PREPARE | WT_TXN_HAS_PREPARED_ID | WT_TXN_RUNNING);
-    txn->prepared_id = prepared_transaction_id;
-    txn->prepare_timestamp = prepared_transaction_id;
+    txn->prepared_id = prepared_id;
+    txn->prepare_timestamp = prepared_id;
 
     /*
      * Swap mod array with prepared_item to avoid double-free on cursor close and when
@@ -1871,7 +1871,7 @@ __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
 {
     WT_CONFIG_ITEM cval;
     WT_TXN *txn;
-    wt_timestamp_t prepared_transaction_id;
+    wt_timestamp_t prepared_id;
 
     txn = session->txn;
     txn->isolation = session->isolation;
@@ -1888,8 +1888,8 @@ __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
     if (conf != NULL) {
         WT_RET(__wt_conf_gets_def(session, conf, claim_prepared_id, 0, &cval));
         if (cval.len != 0) {
-            WT_RET(__wt_txn_parse_prepared_id(session, &prepared_transaction_id, &cval));
-            WT_RET(__wt_txn_claim_prepared_txn(session, prepared_transaction_id));
+            WT_RET(__wt_txn_parse_prepared_id(session, &prepared_id, &cval));
+            WT_RET(__wt_txn_claim_prepared_txn(session, prepared_id));
             return (0);
         }
     }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1831,6 +1831,9 @@ __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_tr
     WT_TXN_OP *tmp_mod;
     txn = session->txn;
     WT_RET(__wt_prepared_discover_find_item(session, prepared_transaction_id, &prepared_item));
+    if (prepared_item->claimed)
+        WT_RET_MSG(
+          session, WT_ERROR, "Prepared id %lu has already been claimed", prepared_transaction_id);
     F_SET(txn, WT_TXN_PREPARE | WT_TXN_HAS_PREPARED_ID | WT_TXN_RUNNING);
     txn->prepared_id = prepared_transaction_id;
     txn->prepare_timestamp = prepared_transaction_id;
@@ -1848,6 +1851,7 @@ __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_tr
     prepared_item->mod = tmp_mod;
     prepared_item->mod_alloc = 0;
     prepared_item->mod_count = 0;
+    prepared_item->claimed = true;
 #ifdef HAVE_DIAGNOSTIC
     txn->prepare_count = prepared_item->prepare_count;
     prepared_item->prepare_count = 0;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1831,13 +1831,9 @@ __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_id
     WT_TXN_OP *tmp_mod;
     txn = session->txn;
     WT_RET(__wt_prepared_discover_find_item(session, prepared_id, &prepared_item));
-    if (prepared_item->claimed)
-        WT_RET_MSG(
-          session, WT_ERROR, "Prepared id %" PRIu64 " has already been claimed", prepared_id);
-    F_SET(txn, WT_TXN_PREPARE | WT_TXN_HAS_PREPARED_ID | WT_TXN_RUNNING);
+    F_SET(txn, WT_TXN_PREPARE | WT_TXN_HAS_PREPARED_ID | WT_TXN_HAS_TS_PREPARE | WT_TXN_RUNNING);
     txn->prepared_id = prepared_id;
-    txn->prepare_timestamp = prepared_id;
-
+    txn->prepare_timestamp = prepared_item->prepare_timestamp;
     /*
      * Swap mod array with prepared_item to avoid double-free on cursor close and when
      * commit/rollback.
@@ -1851,7 +1847,7 @@ __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, wt_timestamp_t prepared_id
     prepared_item->mod = tmp_mod;
     prepared_item->mod_alloc = 0;
     prepared_item->mod_count = 0;
-    prepared_item->claimed = true;
+    WT_RET(__wt_prepared_discover_remove_item(session, prepared_id));
 #ifdef HAVE_DIAGNOSTIC
     txn->prepare_count = prepared_item->prepare_count;
     prepared_item->prepare_count = 0;

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -65,8 +65,8 @@ __pending_prepare_items_init(
  *     item.
  */
 static int
-__prepared_discover_find_or_create_item(
-  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_PENDING_PREPARED_ITEM **prepared_item)
+__prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepared_id,
+  wt_timestamp_t prepare_timestamp, WT_PENDING_PREPARED_ITEM **prepared_item)
 {
     WT_CONNECTION_IMPL *conn;
     WT_PENDING_PREPARED_ITEM *item;
@@ -87,11 +87,48 @@ __prepared_discover_find_or_create_item(
 
     WT_RET(__wt_calloc_one(session, &item));
     item->prepared_id = prepared_id;
-    item->claimed = false;
+    item->prepare_timestamp = prepare_timestamp;
     bucket = prepared_id & (pending_prepare_items->hash_size - 1);
     TAILQ_INSERT_HEAD(&pending_prepare_items->hash[bucket], item, hashq);
     *prepared_item = item;
     return (0);
+}
+
+/*
+ * __wt_prepared_discover_remove_item --
+ *     Find and remove a pending prepared item by its ID in the pending prepared items hash map.
+ */
+int
+__wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_id)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_PENDING_PREPARED_ITEM *item;
+    WT_PENDING_PREPARED_MAP *pending_prepare_items;
+    WT_TXN_GLOBAL *txn_global;
+    WT_TXN_OP *op;
+    uint64_t bucket, i;
+    conn = S2C(session);
+    txn_global = &conn->txn_global;
+    pending_prepare_items = &txn_global->pending_prepare_items;
+
+    if (pending_prepare_items->hash != NULL) {
+        bucket = prepared_id & (pending_prepare_items->hash_size - 1);
+        TAILQ_FOREACH (item, &pending_prepare_items->hash[bucket], hashq) {
+            if (item->prepared_id == prepared_id) {
+                TAILQ_REMOVE(&pending_prepare_items->hash[bucket], item, hashq);
+                /* Clean up memory of unclaimed mod array */
+                for (i = 0, op = item->mod; i < item->mod_count; i++, op++) {
+                    __wt_txn_op_free(session, op);
+                }
+                __wt_free(session, item->mod);
+                item->mod_alloc = 0;
+                item->mod_count = 0;
+                __wt_free(session, item);
+                return (0);
+            }
+        }
+    }
+    return (WT_NOTFOUND);
 }
 
 /*
@@ -105,7 +142,8 @@ __wti_prepared_discover_add_artifact_upd(
     WT_PENDING_PREPARED_ITEM *prepared_item;
     WT_TXN_OP *op;
 
-    WT_RET(__prepared_discover_find_or_create_item(session, prepared_id, &prepared_item));
+    WT_RET(__prepared_discover_find_or_create_item(
+      session, prepared_id, upd->prepare_ts, &prepared_item));
 
     WT_RET(__wt_pending_prepared_next_op(session, &op, prepared_item, key));
     WT_RET(__wt_op_modify(session, upd, op));

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -15,8 +15,8 @@
  *     Find a pending prepared item by its ID in the pending prepared items hash map.
  */
 int
-__wt_prepared_discover_find_item(WT_SESSION_IMPL *session, uint64_t prepare_transaction_id,
-  WT_PENDING_PREPARED_ITEM **prepared_item)
+__wt_prepared_discover_find_item(
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_PENDING_PREPARED_ITEM **prepared_item)
 {
     WT_CONNECTION_IMPL *conn;
     WT_PENDING_PREPARED_ITEM *item;
@@ -27,9 +27,9 @@ __wt_prepared_discover_find_item(WT_SESSION_IMPL *session, uint64_t prepare_tran
     txn_global = &conn->txn_global;
     pending_prepare_items = &txn_global->pending_prepare_items;
     if (pending_prepare_items->hash != NULL) {
-        bucket = prepare_transaction_id & (pending_prepare_items->hash_size - 1);
+        bucket = prepared_id & (pending_prepare_items->hash_size - 1);
         TAILQ_FOREACH (item, &pending_prepare_items->hash[bucket], hashq) {
-            if (item->prepared_id == prepare_transaction_id) {
+            if (item->prepared_id == prepared_id) {
                 *prepared_item = item;
                 return (0);
             }
@@ -131,7 +131,8 @@ __wti_prepared_discover_add_artifact_ondisk_row(
 
     /*
      * Create an update structure with the time information and state populated - that allows this
-     * code to reuse existing machinery for installing transaction operations.
+     * code to reuse existing machinery for installing transaction operations. FIXME-WT-15346 Handle
+     * claiming prepared delete.
      */
     WT_RET(__wt_upd_alloc(session, NULL, WT_UPDATE_STANDARD, &upd, NULL));
     upd->txnid = session->txn->id;

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -118,8 +118,6 @@ __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_i
                 /* Clean up memory of unclaimed mod array */
                 WT_ASSERT_ALWAYS(session, item->mod_count == 0, "Removing an unclaimed prepared item.");
                 __wt_free(session, item->mod);
-                item->mod_alloc = 0;
-                item->mod_count = 0;
                 __wt_free(session, item);
                 return (0);
             }

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -105,8 +105,7 @@ __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_i
     WT_PENDING_PREPARED_ITEM *item;
     WT_PENDING_PREPARED_MAP *pending_prepare_items;
     WT_TXN_GLOBAL *txn_global;
-    WT_TXN_OP *op;
-    uint64_t bucket, i;
+    uint64_t bucket;
     conn = S2C(session);
     txn_global = &conn->txn_global;
     pending_prepare_items = &txn_global->pending_prepare_items;
@@ -117,9 +116,7 @@ __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_i
             if (item->prepared_id == prepared_id) {
                 TAILQ_REMOVE(&pending_prepare_items->hash[bucket], item, hashq);
                 /* Clean up memory of unclaimed mod array */
-                for (i = 0, op = item->mod; i < item->mod_count; i++, op++) {
-                    __wt_txn_op_free(session, op);
-                }
+                WT_ASSERT_ALWAYS(session, item->mod_count == 0, "Removing an unclaimed prepared item.");
                 __wt_free(session, item->mod);
                 item->mod_alloc = 0;
                 item->mod_count = 0;

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -116,7 +116,8 @@ __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_i
             if (item->prepared_id == prepared_id) {
                 TAILQ_REMOVE(&pending_prepare_items->hash[bucket], item, hashq);
                 /* Clean up memory of unclaimed mod array */
-                WT_ASSERT_ALWAYS(session, item->mod_count == 0, "Removing an unclaimed prepared item.");
+                WT_ASSERT_ALWAYS(
+                  session, item->mod_count == 0, "Removing an unclaimed prepared item.");
                 __wt_free(session, item->mod);
                 __wt_free(session, item);
                 return (0);

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -8,7 +8,7 @@
 
 #include "wt_internal.h"
 
-#define WT_DEFAULT_PENDING_PREPARED_DISCOVER_HASHSIZE 64
+#define WT_DEFAULT_PENDING_PREPARED_DISCOVER_HASHSIZE 256
 
 /*
  * __wt_prepared_discover_find_item --
@@ -65,8 +65,8 @@ __pending_prepare_items_init(
  *     item.
  */
 static int
-__prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepare_transaction_id,
-  WT_PENDING_PREPARED_ITEM **prepared_item)
+__prepared_discover_find_or_create_item(
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_PENDING_PREPARED_ITEM **prepared_item)
 {
     WT_CONNECTION_IMPL *conn;
     WT_PENDING_PREPARED_ITEM *item;
@@ -74,7 +74,7 @@ __prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepa
     WT_TXN_GLOBAL *txn_global;
     uint64_t bucket;
 
-    if (__wt_prepared_discover_find_item(session, prepare_transaction_id, prepared_item) == 0)
+    if (__wt_prepared_discover_find_item(session, prepared_id, prepared_item) == 0)
         return (0);
 
     conn = S2C(session);
@@ -86,9 +86,9 @@ __prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepa
     }
 
     WT_RET(__wt_calloc_one(session, &item));
-    item->prepared_id = prepare_transaction_id;
-
-    bucket = prepare_transaction_id & (pending_prepare_items->hash_size - 1);
+    item->prepared_id = prepared_id;
+    item->claimed = false;
+    bucket = prepared_id & (pending_prepare_items->hash_size - 1);
     TAILQ_INSERT_HEAD(&pending_prepare_items->hash[bucket], item, hashq);
     *prepared_item = item;
     return (0);
@@ -100,13 +100,12 @@ __prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepa
  */
 int
 __wti_prepared_discover_add_artifact_upd(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_ITEM *key, WT_UPDATE *upd)
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_ITEM *key, WT_UPDATE *upd)
 {
     WT_PENDING_PREPARED_ITEM *prepared_item;
     WT_TXN_OP *op;
 
-    WT_RET(
-      __prepared_discover_find_or_create_item(session, prepare_transaction_id, &prepared_item));
+    WT_RET(__prepared_discover_find_or_create_item(session, prepared_id, &prepared_item));
 
     WT_RET(__wt_pending_prepared_next_op(session, &op, prepared_item, key));
     WT_RET(__wt_op_modify(session, upd, op));
@@ -125,7 +124,7 @@ __wti_prepared_discover_add_artifact_upd(
  */
 int
 __wti_prepared_discover_add_artifact_ondisk_row(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
 {
     WT_DECL_RET;
     WT_UPDATE *upd;
@@ -137,10 +136,10 @@ __wti_prepared_discover_add_artifact_ondisk_row(
     WT_RET(__wt_upd_alloc(session, NULL, WT_UPDATE_STANDARD, &upd, NULL));
     upd->txnid = session->txn->id;
     upd->upd_durable_ts = tw->durable_start_ts;
-    upd->upd_start_ts = tw->start_ts;
     upd->prepare_state = WT_PREPARE_INPROGRESS;
-
-    WT_ERR(__wti_prepared_discover_add_artifact_upd(session, prepare_transaction_id, key, upd));
+    upd->prepared_id = prepared_id;
+    upd->upd_start_ts = upd->prepare_ts = tw->start_prepare_ts;
+    WT_ERR(__wti_prepared_discover_add_artifact_upd(session, prepared_id, key, upd));
 err:
     /*
      * It's OK to free the update now, the transaction structure will lookup using the key since

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -70,8 +70,10 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
     __wt_cell_get_tw(vpack, &tw);
 
     /* Add an entry for this key to the transaction structure */
+    /* TODO: Handle stop ts case */
     if (rip != NULL)
-        WT_ERR(__wti_prepared_discover_add_artifact_ondisk_row(session, tw->start_ts, tw, key));
+        WT_ERR(
+          __wti_prepared_discover_add_artifact_ondisk_row(session, tw->start_prepared_id, tw, key));
     else
         WT_ASSERT_ALWAYS(
           session, false, "Column store prepared transaction discovery not supported");
@@ -118,13 +120,13 @@ __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_RO
 static int
 __prepared_discover_process_prepared_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *upd)
 {
-    wt_timestamp_t prepare_timestamp;
+    uint64_t prepared_id;
 
     WT_ASSERT(
       session, upd->prepare_state != WT_PREPARE_INIT && upd->prepare_state != WT_PREPARE_RESOLVED);
 
-    prepare_timestamp = upd->prepare_ts;
-    WT_RET(__wti_prepared_discover_add_artifact_upd(session, prepare_timestamp, key, upd));
+    prepared_id = upd->prepared_id;
+    WT_RET(__wti_prepared_discover_add_artifact_upd(session, prepared_id, key, upd));
     return (0);
 }
 

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -70,7 +70,6 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
     __wt_cell_get_tw(vpack, &tw);
 
     /* Add an entry for this key to the transaction structure */
-    /* TODO: Handle stop ts case */
     if (rip != NULL)
         WT_ERR(
           __wti_prepared_discover_add_artifact_ondisk_row(session, tw->start_prepared_id, tw, key));

--- a/test/suite/test_prepare_discover02.py
+++ b/test/suite/test_prepare_discover02.py
@@ -94,7 +94,7 @@ class test_prepare_discover02(wttest.WiredTigerTestCase, suite_subprocess):
         while prepared_discover_cursor.next() == 0:
             count += 1
             prepared_id = prepared_discover_cursor.get_key()
-            self.assertEqual(prepared_id, 100)
+            self.assertEqual(prepared_id, 123)
             c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
             c2s2.commit_transaction("commit_timestamp=" + self.timestamp_str(200)+",durable_timestamp=" + self.timestamp_str(210))
         self.assertEqual(count, 1)

--- a/test/suite/test_prepare_discover03.py
+++ b/test/suite/test_prepare_discover03.py
@@ -106,6 +106,6 @@ class test_prepare_discover03(wttest.WiredTigerTestCase, suite_subprocess):
                 break
         self.assertEqual(count, 1)
         # Try to claim an already claimed prepared transaction, should return an error
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(123)), "/Prepared id 123 has already been claimed/")
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(123)), "")
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: prepared_discover_cursor.close(), "/Found 1 unclaimed prepared transactions/")

--- a/test/suite/test_prepare_discover03.py
+++ b/test/suite/test_prepare_discover03.py
@@ -50,6 +50,7 @@ class test_prepare_discover03(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(types, txn_end)
 
+    @wttest.only_for_hook("disagg", "FIXME-WT-15343 disable RTS when precise checkpoint is on")
     def test_prepare_discover03(self):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
@@ -102,7 +103,9 @@ class test_prepare_discover03(wttest.WiredTigerTestCase, suite_subprocess):
             c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
             c2s2.commit_transaction("commit_timestamp=" + self.timestamp_str(200)+",durable_timestamp=" + self.timestamp_str(210))
             if count == 1:
-                break;
+                break
         self.assertEqual(count, 1)
+        # Try to claim an already claimed prepared transaction, should return an error
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(123)), "/Prepared id 123 has already been claimed/")
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: prepared_discover_cursor.close(), "")
+            lambda: prepared_discover_cursor.close(), "/Found 1 unclaimed prepared transactions/")

--- a/test/suite/test_prepare_discover03.py
+++ b/test/suite/test_prepare_discover03.py
@@ -38,17 +38,7 @@ class test_prepare_discover03(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_prepare_discover03'
     uri = 'table:' + tablename
     conn_config = 'precise_checkpoint=true,preserve_prepared=true'
-
-    types = [
-        ('row', dict(s_config='key_format=i,value_format=S')),
-    ]
-
-    # Transaction end types
-    txn_end = [
-        ('txn_commit', dict(txn_commit=True)),
-    ]
-
-    scenarios = make_scenarios(types, txn_end)
+    s_config = 'key_format=i,value_format=S'
 
     @wttest.only_for_hook("disagg", "FIXME-WT-15343 disable RTS when precise checkpoint is on")
     def test_prepare_discover03(self):

--- a/test/suite/test_prepare_discover04.py
+++ b/test/suite/test_prepare_discover04.py
@@ -26,17 +26,16 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# test_prepare_discover01.py
-#   Test that pending prepared transaction artifacts can be discovered after recovery
-#   and rolled back
+# test_prepare_discover03.py
+#   Test that prepare discover cursor should return an error when closed with unclaimed prepared transactions
 
-import random, sys
+import wiredtiger
 from suite_subprocess import suite_subprocess
 import wttest
 from wtscenario import make_scenarios
 
-class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
-    tablename = 'test_prepare_discover01'
+class test_prepare_discover03(wttest.WiredTigerTestCase, suite_subprocess):
+    tablename = 'test_prepare_discover03'
     uri = 'table:' + tablename
     conn_config = 'precise_checkpoint=true,preserve_prepared=true'
 
@@ -51,8 +50,7 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(types, txn_end)
 
-    @wttest.only_for_hook("disagg", "FIXME-WT-15343 disable RTS when precise checkpoint is on")
-    def test_prepare_discover01(self):
+    def test_prepare_discover03(self):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
         self.session.create(self.uri, self.s_config)
@@ -70,19 +68,25 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
         c[5] = "prepare ts=100"
         # Prepare with a timestamp greater than current stable
         self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +',prepared_id=' + self.prepared_id_str(123))
+
+        session2 = self.conn.open_session()
+        c2 = session2.open_cursor(self.uri)
+        session2.begin_transaction()
+        c2[1] = "prepare ts=100"
+        c2[2] = "prepare ts=100"
+        session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +',prepared_id=' + self.prepared_id_str(150))
         # Move the stable timestamp to include the prepared transaction
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
         # Create a checkpoint
-        session2 = self.conn.open_session()
-        session2.checkpoint()
+        session3 = self.conn.open_session()
+        session3.checkpoint()
 
         # Creating backup that will preserve artifacts
         backup_dir = 'bkp'
-        self.backup(backup_dir, session2)
+        self.backup(backup_dir, session3)
 
         # Opening backup database
         conn2 = self.wiredtiger_open(backup_dir, self.conn_config)
-
         c2s1 = conn2.open_session()
 
         # Opening prepared discover cursor
@@ -96,7 +100,9 @@ class test_prepare_discover01(wttest.WiredTigerTestCase, suite_subprocess):
             prepared_id = prepared_discover_cursor.get_key()
             self.assertEqual(prepared_id, 123)
             c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
-            c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
+            c2s2.commit_transaction("commit_timestamp=" + self.timestamp_str(200)+",durable_timestamp=" + self.timestamp_str(210))
+            if count == 1:
+                break;
         self.assertEqual(count, 1)
-
-        prepared_discover_cursor.close()
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: prepared_discover_cursor.close(), "")


### PR DESCRIPTION
This PR implements prepared transaction discovery with safeguards against double-claiming and proper error handling.

Key Changes:
- Add a new `claimed` field to prevent the same prepared transaction from being claimed multiple times
- Rename all `prepare_transaction_id` to `prepared_id` across prepared discovery functions
- Increase hash table size from 64 to 256 buckets to reduce collisions
- Bug fix: use correct prepared IDs in discovery logic and fix test expectations