### PR TITLE
WT-15315 Add 8.2 into compatibility tests

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -888,16 +888,8 @@ if [ "$import" = true ]; then
     done
 
     for i in ${!import_release_branches[@]}; do
-        newer=${import_release_branches[$i]}
-
-        # MongoDB v4.2 doesn't support live import so it should only ever be used as the "older" branch
-        # that we're importing from.
-        if [ $newer = mongodb-4.2 ]; then
-            continue
-        fi
-
-        older=${import_release_branches[$i+1]}
-        import_compatibility_test $older $newer
+        [[ $((i+1)) < ${#import_release_branches[@]} ]] && \
+        (import_compatibility_test ${import_release_branches[$i+1]} ${import_release_branches[$i]})
     done
 fi
 

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -888,8 +888,9 @@ if [ "$import" = true ]; then
     done
 
     for i in ${!import_release_branches[@]}; do
-        [[ $((i+1)) < ${#import_release_branches[@]} ]] && \
-        (import_compatibility_test ${import_release_branches[$i+1]} ${import_release_branches[$i]})
+        if [ $((i+1)) < ${#import_release_branches[@]} ]; then
+            (import_compatibility_test ${import_release_branches[$i+1]} ${import_release_branches[$i]})
+        fi
     done
 fi
 

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -6,12 +6,12 @@
 
 # Currently this is a temporary setup for python testsuite
 # This will be merged with the following variables in the future
-export SUITE_RELEASE_BRANCHES="develop mongodb-7.1 mongodb-7.0 mongodb-6.3"
+export SUITE_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to use for testing the importing
 # of files created in previous versions of WiredTiger. Go all the way back to mongodb-4.2 since
 # that's the first release where we don't support live import.
-export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4 mongodb-4.2"
+export IMPORT_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # Branches in below 2 arrays should be put in newer-to-older order.
 #
@@ -20,7 +20,7 @@ export IMPORT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mong
 #
 # The 2 arrays should be adjusted over time when newer branches are created,
 # or older branches are EOL.
-export NEWER_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export NEWER_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
 export OLDER_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
 
 # This array is used to generate compatible configuration files between releases, because
@@ -30,11 +30,11 @@ export COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
 
 # This array is used to configure the release branches we'd like to run patch version
 # upgrade/downgrade test.
-export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
+export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run test checkpoint
 # upgrade/downgrade test.
-export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-4.4"
+export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run upgrade to latest test.
-export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"


### PR DESCRIPTION
This PR add 8.2 into the compatibility tests as it's going to be a LTS (rather than a rapid) release. Also take the chance adjusting outdated branch setting for python and import compatibility tests.