### PR TITLE
WT-15314 Introduce WT disagg waterfall testing to auto triage disagg tests

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4097,6 +4097,38 @@ tasks:
             # Keep repeating the model test for 60 minutes
             ./model_test -l 100-200 -g -t 3600
 
+  - name: model-test-disagg-long
+    tags: [".stress-test-disagg-fail"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/model/tools"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            # Keep repeating the model test for 60 minutes
+            ./model_test -D -l 2000-3000 -t 3600
+
+  - name: model-test--disagg-long-random-config
+    tags: [".stress-test-disagg-fail"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/model/tools"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            # Keep repeating the model test for 60 minutes
+            ./model_test -D -l 100-200 -g -t 3600
+
   - name: model-test-long-with-coverage
     tags: ["model_checking"]
     commands:
@@ -4221,50 +4253,50 @@ tasks:
    # FIXME-WT-14566: Enable disagg leader mode on all platforms once failures has been resolved.
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-1
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-2
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-3
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-4
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-5
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-1
-    tags: ["stress-test-disagg-success"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-2
-    tags: ["stress-test-disagg-success"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-3
-    tags: ["stress-test-disagg-success"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-4
-    tags: ["stress-test-disagg-success"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-5
-    tags: ["stress-test-disagg-success"]
+    tags: ["stress-test-disagg"]
   # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures has been resolved.
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-1
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-2
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-3
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-4
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-5
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-fail"]
 
   - name: format-stress-test-no-barrier
     tags: ["stress-test-no-barrier"]
@@ -6200,7 +6232,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: ".stress-test-no-barrier"
       distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
@@ -6221,7 +6253,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: checkpoint-stress-test-tiered
     - name: precise-checkpoint-stress-test-tiered
     - name: format-abort-recovery-stress-test
@@ -6549,7 +6581,7 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
 
@@ -6566,7 +6598,7 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: format-abort-recovery-stress-test
 
 - name: ubuntu2004-nonstandalone
@@ -6601,7 +6633,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: ".stress-test-no-barrier"
       distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
@@ -6627,7 +6659,7 @@ buildvariants:
       distros: ubuntu2004-test
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-test
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: make-check-test
     - name: unit-test
 
@@ -6652,7 +6684,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -6676,7 +6708,7 @@ buildvariants:
       distros: ubuntu2004-arm64-large
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-arm64-large
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: make-check-test
     - name: unit-test
     - name: unit-test-extra-long
@@ -6720,7 +6752,7 @@ buildvariants:
       distros: amazon2023-arm64-latest-large-m8g
     - name: format-abort-recovery-stress-test
       distros: amazon2023-arm64-latest-large-m8g
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: make-check-test
     - name: unit-test
     - name: unit-test-extra-long
@@ -6747,7 +6779,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -6850,7 +6882,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
@@ -6968,7 +7000,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg-success"
+    - name: ".stress-test-disagg"
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -6983,5 +7015,7 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: compile
-    - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-fail"
+      batchtime: 2880 # once every two days
+    - name: ".model_checking"
       batchtime: 2880 # once every two days

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1454,7 +1454,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=leader
+          format_args: disagg.mode=follower
           times: 5
 
   - &format-stress-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1427,6 +1427,36 @@ variables:
 # the number of runs adjusted to provide aproximately six hours of testing.
 #########################################################################################
 
+  - &format-stress-test-disagg-leader
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=leader runs.tables=1 runs.timer=3
+          times: 5
+
+  - &format-stress-test-disagg-switch
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=leader runs.tables=1 runs.timer=3
+          times: 5
+
+  - &format-stress-test-disagg-follower
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=leader runs.tables=1 runs.timer=3
+          times: 5
+
   - &format-stress-test
     exec_timeout_secs: 25200
     commands:
@@ -3565,41 +3595,6 @@ tasks:
 
             RW_LOCK_FILE=$(pwd)/../../cmake_build/test/csuite/rwlock/test_rwlock ./time_shift_test.sh /usr/local/lib/faketime/libfaketimeMT.so.1 0-1 2>&1
 
-  - name: format-disagg-leader-test
-    # FIXME-WT-14566: Enable disagg leader mode once failure has been resolved.
-    # tags: ["stress-disagg-test"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.mode=leader
-          times: 10
-
-  - name: format-disagg-follower-test
-    tags: ["stress-disagg-test"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.mode=follower
-          times: 10
-
-  - name: format-disagg-switch-test
-    # FIXME-WT-14566: Enable disagg switch mode once failure has been resolved.
-    # tags: ["stress-disagg-test"]
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.mode=switch
-          times: 10
-
   - name: format-mirror-test
     commands:
       - func: "get project"
@@ -4223,6 +4218,53 @@ tasks:
   - <<: *recovery-stress-test
     name: recovery-stress-test-3
     tags: ["stress-test-3", "stress-test-zseries-3"]
+   # FIXME-WT-14566: Enable disagg leader mode on all platforms once failures has been resolved.
+  - <<: *format-stress-test-disagg-leader
+    name: format-stress-test-disagg-leader-1
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-leader
+    name: format-stress-test-disagg-leader-2
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-leader
+    name: format-stress-test-disagg-leader-3
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-leader
+    name: format-stress-test-disagg-leader-4
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-leader
+    name: format-stress-test-disagg-leader-5
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-follower
+    name: format-stress-test-disagg-follower-1
+    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+  - <<: *format-stress-test-disagg-follower
+    name: format-stress-test-disagg-follower-2
+    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+  - <<: *format-stress-test-disagg-follower
+    name: format-stress-test-disagg-follower-3
+    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+  - <<: *format-stress-test-disagg-follower
+    name: format-stress-test-disagg-follower-4
+    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+  - <<: *format-stress-test-disagg-follower
+    name: format-stress-test-disagg-follower-5
+    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+  # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures has been resolved.
+  - <<: *format-stress-test-disagg-switch
+    name: format-stress-test-disagg-switch-1
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-switch
+    name: format-stress-test-disagg-switch-2
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-switch
+    name: format-stress-test-disagg-switch-3
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-switch
+    name: format-stress-test-disagg-switch-4
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-switch
+    name: format-stress-test-disagg-switch-5
+    tags: ["stress-test-disagg"]
 
   - name: format-stress-test-no-barrier
     tags: ["stress-test-no-barrier"]
@@ -6931,4 +6973,16 @@ buildvariants:
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
+      batchtime: 720 # 12 hours
+
+- name: amazon2023-disagg-stress
+  display_name: "(ARMV9) Amazon 2023 Disagg Stress tests"
+  run_on:
+  - amazon2023-arm64-latest-large-m8g
+  expansions:
+    ENABLE_TCMALLOC: 1
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+  tasks:
+    - name: compile
+    - name: ".stress-test-disagg"
       batchtime: 720 # 12 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6985,4 +6985,4 @@ buildvariants:
   tasks:
     - name: compile
     - name: ".stress-test-disagg"
-      batchtime: 720 # 12 hours
+      batchtime: 1440 # once a day

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6201,6 +6201,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg-success"
+    - name: ".stress-test-no-barrier"
       distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
@@ -6548,7 +6549,8 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-test-disagg-success"test
+    - name: ".stress-test-disagg-success"
+    - name: format-abort-recovery-stress-test
     - name: format-predictable-test
 
 - name: ubuntu2004-release-stress-tests-arm64
@@ -6564,7 +6566,8 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-test-disagg-success"test
+    - name: ".stress-test-disagg-success"
+    - name: format-abort-recovery-stress-test
 
 - name: ubuntu2004-nonstandalone
   display_name: "Ubuntu 20.04 (Non-standalone)"
@@ -6599,6 +6602,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg-success"
+    - name: ".stress-test-no-barrier"
       distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -6624,6 +6628,7 @@ buildvariants:
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-test
     - name: ".stress-test-disagg-success"
+    - name: make-check-test
     - name: unit-test
 
 - name: ubuntu2004-arm64-nonstandalone
@@ -6648,6 +6653,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg-success"
+    - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -6671,6 +6677,7 @@ buildvariants:
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-arm64-large
     - name: ".stress-test-disagg-success"
+    - name: make-check-test
     - name: unit-test
     - name: unit-test-extra-long
       distros: ubuntu2004-arm64-large
@@ -6714,6 +6721,7 @@ buildvariants:
     - name: format-abort-recovery-stress-test
       distros: amazon2023-arm64-latest-large-m8g
     - name: ".stress-test-disagg-success"
+    - name: make-check-test
     - name: unit-test
     - name: unit-test-extra-long
       distros: amazon2023-arm64-latest-large-m8g
@@ -6740,6 +6748,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg-success"
+    - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -6842,6 +6851,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg-success"
+    - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -7017,5 +7017,3 @@ buildvariants:
     - name: compile
     - name: ".stress-test-disagg-fail"
       batchtime: 2880 # once every two days
-    - name: ".model_checking"
-      batchtime: 2880 # once every two days

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1444,7 +1444,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=leader runs.tables=1 runs.timer=3
+          format_args: disagg.mode=switch runs.tables=1 runs.timer=3
           times: 5
 
   - &format-stress-test-disagg-follower
@@ -1454,7 +1454,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=leader runs.tables=1 runs.timer=3
+          format_args: disagg.mode=leader
           times: 5
 
   - &format-stress-test
@@ -4236,19 +4236,19 @@ tasks:
     tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-1
-    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+    tags: ["stress-test-disagg-success"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-2
-    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+    tags: ["stress-test-disagg-success"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-3
-    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+    tags: ["stress-test-disagg-success"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-4
-    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+    tags: ["stress-test-disagg-success"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-5
-    tags: ["stress-test-disagg", "stress-test-disagg-success"]
+    tags: ["stress-test-disagg-success"]
   # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures has been resolved.
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-1
@@ -6200,8 +6200,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-disagg-test"
-    - name: ".stress-test-no-barrier"
+    - name: ".stress-test-disagg-success"
       distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
@@ -6221,8 +6220,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-disagg-test"
-    - name: ".stress-test-no-barrier"
+    - name: ".stress-test-disagg-success"
     - name: checkpoint-stress-test-tiered
     - name: precise-checkpoint-stress-test-tiered
     - name: format-abort-recovery-stress-test
@@ -6550,8 +6548,7 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-disagg-test"
-    - name: format-abort-recovery-stress-test
+    - name: ".stress-test-disagg-success"test
     - name: format-predictable-test
 
 - name: ubuntu2004-release-stress-tests-arm64
@@ -6567,8 +6564,7 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-disagg-test"
-    - name: format-abort-recovery-stress-test
+    - name: ".stress-test-disagg-success"test
 
 - name: ubuntu2004-nonstandalone
   display_name: "Ubuntu 20.04 (Non-standalone)"
@@ -6602,8 +6598,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-disagg-test"
-    - name: ".stress-test-no-barrier"
+    - name: ".stress-test-disagg-success"
       distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -6628,8 +6623,7 @@ buildvariants:
       distros: ubuntu2004-test
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-test
-    - name: ".stress-disagg-test"
-    - name: make-check-test
+    - name: ".stress-test-disagg-success"
     - name: unit-test
 
 - name: ubuntu2004-arm64-nonstandalone
@@ -6653,8 +6647,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-disagg-test"
-    - name: ".stress-test-no-barrier"
+    - name: ".stress-test-disagg-success"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -6677,8 +6670,7 @@ buildvariants:
       distros: ubuntu2004-arm64-large
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-arm64-large
-    - name: ".stress-disagg-test"
-    - name: make-check-test
+    - name: ".stress-test-disagg-success"
     - name: unit-test
     - name: unit-test-extra-long
       distros: ubuntu2004-arm64-large
@@ -6721,8 +6713,7 @@ buildvariants:
       distros: amazon2023-arm64-latest-large-m8g
     - name: format-abort-recovery-stress-test
       distros: amazon2023-arm64-latest-large-m8g
-    - name: ".stress-disagg-test"
-    - name: make-check-test
+    - name: ".stress-test-disagg-success"
     - name: unit-test
     - name: unit-test-extra-long
       distros: amazon2023-arm64-latest-large-m8g
@@ -6748,8 +6739,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-disagg-test"
-    - name: ".stress-test-no-barrier"
+    - name: ".stress-test-disagg-success"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -6851,8 +6841,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-disagg-test"
-    - name: ".stress-test-no-barrier"
+    - name: ".stress-test-disagg-success"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
@@ -6969,7 +6958,7 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-disagg-test"
+    - name: ".stress-test-disagg-success"
     - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -6985,4 +6974,4 @@ buildvariants:
   tasks:
     - name: compile
     - name: ".stress-test-disagg"
-      batchtime: 1440 # once a day
+      batchtime: 2880 # once every two days

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4098,7 +4098,7 @@ tasks:
             ./model_test -l 100-200 -g -t 3600
 
   - name: model-test-disagg-long
-    tags: [".stress-test-disagg-fail"]
+    tags: ["stress-test-disagg-fail"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
@@ -4114,7 +4114,7 @@ tasks:
             ./model_test -D -l 2000-3000 -t 3600
 
   - name: model-test--disagg-long-random-config
-    tags: [".stress-test-disagg-fail"]
+    tags: ["stress-test-disagg-fail"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4113,7 +4113,7 @@ tasks:
             # Keep repeating the model test for 60 minutes
             ./model_test -D -l 2000-3000 -t 3600
 
-  - name: model-test--disagg-long-random-config
+  - name: model-test-disagg-long-random-config
     tags: ["stress-test-disagg-fail"]
     commands:
       - func: "get project"

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -9,7 +9,8 @@ disagg.enabled=1
 disagg.layered=1
 runs.source=layered
 runs.type=row-store
-runs.tables=3
+runs.tables=1
+runs.timer=3
 import=0
 ops.alter=0
 # FIXME-WT-14467 should fix cursor->modify for layered tables.

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -9,8 +9,7 @@ disagg.enabled=1
 disagg.layered=1
 runs.source=layered
 runs.type=row-store
-runs.tables=1
-runs.timer=3
+runs.tables=3
 import=0
 ops.alter=0
 # FIXME-WT-14467 should fix cursor->modify for layered tables.

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -762,10 +762,13 @@ main(int argc, char *argv[])
         int ch;
 
         __wt_optwt = 1;
-        while ((ch = __wt_getopt(progname, argc, argv, "C:G:h:I:i:l:M:gnpRS:T:t:w:?")) != EOF)
+        while ((ch = __wt_getopt(progname, argc, argv, "C:DG:h:I:i:l:M:gnpRS:T:t:w:?")) != EOF)
             switch (ch) {
             case 'C':
                 conn_config = model::join(conn_config, __wt_optarg);
+                break;
+            case 'D':
+                spec.disaggregated = 1;
                 break;
             case 'G':
                 update_spec(spec, conn_config, table_config, __wt_optarg);


### PR DESCRIPTION
The disagg testing project plans to add a disagg build variant under develop waterfall that periodically runs (twice/once a week). The disagg build variant aims to run all stress tests including test/format (leader/follower/switch) , test/checkpoint(leader/follow) stress testing. Here are the reasons why we want to do this:
- Utilise BB-UI to triage these failures: Removing the need to constantly re-run patch builds to find all the failures within a test configuration.
- Helps us understand priority of the failures and stability concerns: Through generating the number of BFGs from BB-UI, we can detect how often occur a particular test failure appears or identify possible segmentation faults/crashes.
- Reduce project effort to manually triage tests (Internal to Foundations team):  All tickets that triage test/format and test/checkpoint configurations can be done through BB-UI, reducing the need to constantly re-run stress tests 