### PR TITLE
WT-15205 Fix checkpoint cleanup 09 Python test for disagg

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -18,7 +18,6 @@ test_cc05.py
 test_cc06.py # uses statistics we don't support in disagg
 test_cc07.py
 test_cc08.py
-test_cc09.py
 test_compat05.py
 test_config02.py
 test_config09.py

--- a/test/suite/test_cc09.py
+++ b/test/suite/test_cc09.py
@@ -61,6 +61,8 @@ class test_cc09(test_cc_base):
         create_params = 'key_format=i,value_format=S'
         nrows = 100000
         uri = 'table:cc09'
+        stable_uri = 'file:cc09.wt_stable'
+
         value = 'k' * 1024
 
         self.session.create(uri, create_params)
@@ -80,7 +82,10 @@ class test_cc09(test_cc_base):
 
         # Open the table as we need the dhandle to be open for checkpoint cleanup to process the
         # table.
-        cursor = self.session.open_cursor(uri, None, None)
+        if hasattr(self, 'disagg_leader'):
+            cursor = self.session.open_cursor(stable_uri, None, None)
+        else:
+            cursor = self.session.open_cursor(uri, None, None)
 
         if self.has_delete:
             self.session.begin_transaction()

--- a/test/suite/test_cc09.py
+++ b/test/suite/test_cc09.py
@@ -61,8 +61,6 @@ class test_cc09(test_cc_base):
         create_params = 'key_format=i,value_format=S'
         nrows = 100000
         uri = 'table:cc09'
-        stable_uri = 'file:cc09.wt_stable'
-
         value = 'k' * 1024
 
         self.session.create(uri, create_params)
@@ -80,12 +78,11 @@ class test_cc09(test_cc_base):
         # Restart to have everything on disk.
         self.reopen_conn()
 
-        # Open the table as we need the dhandle to be open for checkpoint cleanup to process the
-        # table.
-        if hasattr(self, 'disagg_leader'):
-            cursor = self.session.open_cursor(stable_uri, None, None)
-        else:
-            cursor = self.session.open_cursor(uri, None, None)
+        # Open the table and perform a read as we need the dhandle to be open for checkpoint cleanup
+        # to process the table.
+        cursor = self.session.open_cursor(uri, None, None)
+        self.assertEqual(cursor.next(), 0)
+        self.assertEqual(cursor.reset(), 0)
 
         if self.has_delete:
             self.session.begin_transaction()


### PR DESCRIPTION
Fixing the error where stable table was not eligible for checkpoint cleanup under disagg mode, fixed by checking if we're running on disagg mode, and opening the cursor using a stable table uri.
