### PR TITLE
WT-15214 Bring block cache encryption to consistency.

### DIFF
--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -42,6 +42,39 @@ __blkcache_read_corrupt(WT_SESSION_IMPL *session, int error, const uint8_t *addr
 }
 
 /*
+ * __blkcache_read_decrypt --
+ *     Decrypt the content of one item into another.
+ *
+ * This uses the decryptor on the btree, and requires that the output item is already backed by a
+ *     scratch buffer that can be grown as needed.
+ */
+static int
+__blkcache_read_decrypt(
+  WT_SESSION_IMPL *session, WT_ITEM *in, WT_ITEM *out, const uint8_t *addr, size_t addr_size)
+{
+    WT_BM *bm;
+    WT_BTREE *btree;
+    WT_DECL_RET;
+    WT_ENCRYPTOR *encryptor;
+
+    btree = S2BT(session);
+    bm = btree->bm;
+    encryptor = btree->kencryptor == NULL ? NULL : btree->kencryptor->encryptor;
+
+    if (encryptor == NULL || encryptor->decrypt == NULL)
+        WT_RET(__blkcache_read_corrupt(
+          session, WT_ERROR, addr, addr_size, "encrypted block for which no decryptor configured"));
+
+    if ((ret = __wt_decrypt(session, encryptor, bm->encrypt_skip(bm, session), in, out)) != 0)
+        WT_RET(__blkcache_read_corrupt(session, ret, addr, addr_size, "block decryption failed"));
+
+    /* Clear the ENCRYPTED flag. */
+    F_CLR(((WT_PAGE_HEADER *)out->data), WT_PAGE_ENCRYPTED);
+
+    return (0);
+}
+
+/*
  * __blkcache_cache_wants_encrypted_data --
  *     Return if the configured block cache wants to store encrypted blocks.
  */
@@ -82,7 +115,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     size_t compression_ratio, result_len;
     uint64_t time_diff, time_start, time_stop;
     u_int count, i, results_count;
-    bool actually_encrypted, blkcache_found, expect_conversion, found, skip_cache_put, timer;
+    bool blkcache_found, expect_conversion, found, skip_cache_put, timer;
 
     blkcache = &S2C(session)->blkcache;
     blkcache_item = NULL;
@@ -90,7 +123,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     bm = btree->bm;
     compressor = btree->compressor;
     encryptor = btree->kencryptor == NULL ? NULL : btree->kencryptor->encryptor;
-    actually_encrypted = blkcache_found = found = false;
+    blkcache_found = found = false;
     skip_cache_put = (blkcache->type == WT_BLKCACHE_UNCONFIGURED);
     results_count = 0;
 
@@ -110,7 +143,6 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     WT_RET(__wti_blkcache_map_read(session, ip, addr, addr_size, &found));
     if (found) {
         skip_cache_put = true;
-        actually_encrypted = F_ISSET((WT_PAGE_HEADER*)ip->data, WT_PAGE_ENCRYPTED);
         if (!expect_conversion)
             goto verify;
     }
@@ -120,7 +152,6 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
         __wti_blkcache_get(session, addr, addr_size, &blkcache_item, &found, &skip_cache_put);
         if (found) {
             blkcache_found = true;
-            actually_encrypted = __blkcache_cache_wants_encrypted_data(session);
             ip->data = blkcache_item->data;
             ip->size = blkcache_item->data_size;
             if (block_meta != NULL) {
@@ -170,7 +201,6 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
             *block_meta = block_meta_tmp;
 
         dsk = ip->data;
-        actually_encrypted = F_ISSET(dsk, WT_PAGE_ENCRYPTED);
 
         /*
          * Disallow reading an unencrypted block from original source when encryption is configured.
@@ -204,24 +234,9 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
      */
     dsk = ip->data;
     ip_orig = ip;
-    if (actually_encrypted) {
-        /*
-         * We need this machinery with "actually_encrypted" because decryption doesn't clear the
-         * WT_PAGE_ENCRYPTED flag, and we need to know if the block was actually encrypted or not.
-         */
-        if (encryptor == NULL || encryptor->decrypt == NULL)
-            WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
-              "encrypted block for which no decryptor configured"));
-
-        /*
-         * If checksums were turned off because we're depending on decryption to fail on any
-         * corrupted data, we'll end up here on corrupted data.
-         */
+    if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
         WT_ERR(__wt_scr_alloc(session, 0, &etmp));
-        if ((ret = __wt_decrypt(session, encryptor, bm->encrypt_skip(bm, session), ip, etmp)) != 0)
-            WT_ERR(
-              __blkcache_read_corrupt(session, ret, addr, addr_size, "block decryption failed"));
-
+        WT_ERR(__blkcache_read_decrypt(session, ip, etmp, addr, addr_size));
         ip = etmp;
     }
 
@@ -324,36 +339,6 @@ err:
 }
 
 /*
- * __read_decrypt --
- *     Decrypt the content of one item into another.
- *
- * This uses the decryptor on the btree, and requires that the output item is already backed by a
- *     scratch buffer that can be grown as needed.
- */
-static int
-__read_decrypt(
-  WT_SESSION_IMPL *session, WT_ITEM *in, WT_ITEM *out, const uint8_t *addr, size_t addr_size)
-{
-    WT_BM *bm;
-    WT_BTREE *btree;
-    WT_DECL_RET;
-    WT_ENCRYPTOR *encryptor;
-
-    btree = S2BT(session);
-    bm = btree->bm;
-    encryptor = btree->kencryptor == NULL ? NULL : btree->kencryptor->encryptor;
-
-    if (encryptor == NULL || encryptor->decrypt == NULL)
-        WT_RET(__blkcache_read_corrupt(
-          session, WT_ERROR, addr, addr_size, "encrypted block for which no decryptor configured"));
-
-    if ((ret = __wt_decrypt(session, encryptor, bm->encrypt_skip(bm, session), in, out)) != 0)
-        WT_RET(__blkcache_read_corrupt(session, ret, addr, addr_size, "block decryption failed"));
-
-    return (0);
-}
-
-/*
  * __read_decompress --
  *     Decompress data into a WT_ITEM.
  *
@@ -426,13 +411,13 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     const WT_PAGE_HEADER *dsk;
     uint32_t count, i;
     uint8_t type;
-    bool actually_encrypted, blkcache_found, found, skip_cache_put;
+    bool blkcache_found, found, skip_cache_put;
 
     WT_CLEAR(block_meta_tmp);
     WT_CLEAR(results);
 
     blkcache = &S2C(session)->blkcache;
-    actually_encrypted = blkcache_found = false;
+    blkcache_found = false;
     blkcache_item = NULL;
     btree = S2BT(session);
     bm = btree->bm;
@@ -464,7 +449,6 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED) {
         __wti_blkcache_get(session, addr, addr_size, &blkcache_item, &found, &skip_cache_put);
         if (found) {
-            actually_encrypted = __blkcache_cache_wants_encrypted_data(session);
             blkcache_found = true;
             WT_ASSERT_ALWAYS(session, blkcache_item->num_deltas <= WT_DELTA_LIMIT,
               "block cache item has too many deltas");
@@ -506,7 +490,6 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
         ip = &results[0];
         dsk = ip->data;
         type = dsk->type;
-        actually_encrypted = F_ISSET(dsk, WT_PAGE_ENCRYPTED);
 
         /*
          * Disallow reading an unencrypted block from original source when encryption is configured.
@@ -537,13 +520,9 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
 
     /* Decrypt. */
     ip_orig = ip;
-    if (actually_encrypted) {
-        /*
-         * We need this machinery with "actually_encrypted" because decryption doesn't clear the
-         * WT_PAGE_ENCRYPTED flag, and we need to know if the block was actually encrypted or not.
-         */
+    if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
         WT_ERR(__wt_scr_alloc(session, 0, &etmp));
-        WT_ERR(__read_decrypt(session, ip, etmp, addr, addr_size));
+        WT_ERR(__blkcache_read_decrypt(session, ip, etmp, addr, addr_size));
         ip = etmp;
     }
 
@@ -613,7 +592,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
              * based on the flag.
              */
             WT_ERR(__wt_scr_alloc(session, 0, &etmp));
-            WT_ERR(__read_decrypt(session, ip, etmp, addr, addr_size));
+            WT_ERR(__blkcache_read_decrypt(session, ip, etmp, addr, addr_size));
             ip = etmp;
         }
         if (F_ISSET(blk, WT_BLOCK_DISAGG_COMPRESSED)) {

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -42,6 +42,23 @@ __blkcache_read_corrupt(WT_SESSION_IMPL *session, int error, const uint8_t *addr
 }
 
 /*
+ * __cache_wants_encrypted_data --
+ *     Return if the configured block cache wants to store encrypted blocks.
+ */
+static bool
+__cache_wants_encrypted_data(WT_SESSION_IMPL *session)
+{
+    /*!!!
+     * Guidance for adding new block cache types here:
+     *  - If cache only stores pages in RAM, we save CPU by storing unencrypted pages.
+     *  - If cache can store pages on external media, we store encrypted pages if encryption is
+     * configured.
+     */
+    u_int type = S2C(session)->blkcache.type;
+    return (type == WT_BLKCACHE_NVRAM);
+}
+
+/*
  * __wt_blkcache_read --
  *     Read an address-cookie referenced block into a buffer.
  */
@@ -58,14 +75,14 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     WT_ENCRYPTOR *encryptor;
-    WT_ITEM *ip;
+    WT_ITEM *ip, *ip_orig;
     WT_ITEM results[WT_DELTA_LIMIT + 1];
     WT_PAGE_BLOCK_META block_meta_tmp;
     const WT_PAGE_HEADER *dsk;
     size_t compression_ratio, result_len;
     uint64_t time_diff, time_start, time_stop;
     u_int count, i, results_count;
-    bool blkcache_found, expect_conversion, found, skip_cache_put, timer;
+    bool blkcache_found, expect_conversion, found, skip_cache_put, timer, actually_encrypted;
 
     blkcache = &S2C(session)->blkcache;
     blkcache_item = NULL;
@@ -73,7 +90,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     bm = btree->bm;
     compressor = btree->compressor;
     encryptor = btree->kencryptor == NULL ? NULL : btree->kencryptor->encryptor;
-    blkcache_found = found = false;
+    actually_encrypted = blkcache_found = found = false;
     skip_cache_put = (blkcache->type == WT_BLKCACHE_UNCONFIGURED);
     results_count = 0;
 
@@ -93,6 +110,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     WT_RET(__wti_blkcache_map_read(session, ip, addr, addr_size, &found));
     if (found) {
         skip_cache_put = true;
+        actually_encrypted = __cache_wants_encrypted_data(session);
         if (!expect_conversion)
             goto verify;
     }
@@ -102,6 +120,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
         __wti_blkcache_get(session, addr, addr_size, &blkcache_item, &found, &skip_cache_put);
         if (found) {
             blkcache_found = true;
+            actually_encrypted = __cache_wants_encrypted_data(session);
             ip->data = blkcache_item->data;
             ip->size = blkcache_item->data_size;
             if (block_meta != NULL) {
@@ -151,6 +170,13 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
             *block_meta = block_meta_tmp;
 
         dsk = ip->data;
+        actually_encrypted = F_ISSET(dsk, WT_PAGE_ENCRYPTED);
+
+        /* Disallow reading an unencrypted block from original source when encryption is configured.
+         */
+        if (!F_ISSET(dsk, WT_PAGE_ENCRYPTED) && btree->kencryptor != NULL)
+            WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
+              "read unencrypted block for which encryption configured"));
 
         /*
          * Increment statistics before we do anymore processing such as decompression or decryption
@@ -176,26 +202,26 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
      * block-cache blocks are never encrypted.
      */
     dsk = ip->data;
-    if (!blkcache_found || blkcache->type != WT_BLKCACHE_DRAM) {
-        if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
-            if (encryptor == NULL || encryptor->decrypt == NULL)
-                WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
-                  "encrypted block for which no decryptor configured"));
-
-            /*
-             * If checksums were turned off because we're depending on decryption to fail on any
-             * corrupted data, we'll end up here on corrupted data.
-             */
-            WT_ERR(__wt_scr_alloc(session, 0, &etmp));
-            if ((ret = __wt_decrypt(session, encryptor, bm->encrypt_skip(bm, session), ip, etmp)) !=
-              0)
-                WT_ERR(__blkcache_read_corrupt(
-                  session, ret, addr, addr_size, "block decryption failed"));
-
-            ip = etmp;
-        } else if (btree->kencryptor != NULL)
+    ip_orig = ip;
+    if (actually_encrypted) {
+        /*
+         * We need this machinery with "actually_encrypted" because decryption doesn't clear the
+         * WT_PAGE_ENCRYPTED flag, and we need to know if the block was actually encrypted or not.
+         */
+        if (encryptor == NULL || encryptor->decrypt == NULL)
             WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
-              "unencrypted block for which encryption configured"));
+              "encrypted block for which no decryptor configured"));
+
+        /*
+         * If checksums were turned off because we're depending on decryption to fail on any
+         * corrupted data, we'll end up here on corrupted data.
+         */
+        WT_ERR(__wt_scr_alloc(session, 0, &etmp));
+        if ((ret = __wt_decrypt(session, encryptor, bm->encrypt_skip(bm, session), ip, etmp)) != 0)
+            WT_ERR(
+              __blkcache_read_corrupt(session, ret, addr, addr_size, "block decryption failed"));
+
+        ip = etmp;
     }
 
     /*
@@ -205,10 +231,13 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     if (results_count > 1)
         skip_cache_put = true;
 
-    /* Store the decrypted, possibly compressed, block in the block_cache. */
-    if (!skip_cache_put)
+    if (!skip_cache_put) {
+        /* Choose either the encrypted or decrypted data for the cache. */
+        WT_ITEM *cache_item = __cache_wants_encrypted_data(session) ? ip_orig : ip;
         /* Use a local variable for block metadata, because the passed-in pointer could be NULL. */
-        WT_ERR(__wti_blkcache_put(session, ip, NULL, 0, &block_meta_tmp, addr, addr_size, false));
+        WT_ERR(__wti_blkcache_put(
+          session, cache_item, NULL, 0, &block_meta_tmp, addr, addr_size, false));
+    }
 
     dsk = ip->data;
     if (F_ISSET(dsk, WT_PAGE_COMPRESSED)) {
@@ -391,18 +420,18 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     WT_DECL_ITEM(etmp);
     WT_DECL_RET;
     WT_ITEM results[WT_DELTA_LIMIT + 1];
-    WT_ITEM *tmp, *ip;
+    WT_ITEM *tmp, *ip, *ip_orig;
     WT_PAGE_BLOCK_META block_meta_tmp;
     const WT_PAGE_HEADER *dsk;
     uint32_t count, i;
     uint8_t type;
-    bool blkcache_found, found, skip_cache_put;
+    bool blkcache_found, found, skip_cache_put, actually_encrypted;
 
     WT_CLEAR(block_meta_tmp);
     WT_CLEAR(results);
 
     blkcache = &S2C(session)->blkcache;
-    blkcache_found = false;
+    actually_encrypted = blkcache_found = false;
     blkcache_item = NULL;
     btree = S2BT(session);
     bm = btree->bm;
@@ -434,6 +463,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED) {
         __wti_blkcache_get(session, addr, addr_size, &blkcache_item, &found, &skip_cache_put);
         if (found) {
+            actually_encrypted = __cache_wants_encrypted_data(session);
             blkcache_found = true;
             WT_ASSERT_ALWAYS(session, blkcache_item->num_deltas <= WT_DELTA_LIMIT,
               "block cache item has too many deltas");
@@ -475,6 +505,13 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
         ip = &results[0];
         dsk = ip->data;
         type = dsk->type;
+        actually_encrypted = F_ISSET(dsk, WT_PAGE_ENCRYPTED);
+
+        /* Disallow reading an unencrypted block from original source when encryption is configured.
+         */
+        if (!F_ISSET(dsk, WT_PAGE_ENCRYPTED) && btree->kencryptor != NULL)
+            WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
+              "multi_read unencrypted block for which encryption configured"));
 
         /*
          * Increment statistics before we do any more processing such as decompression or decryption
@@ -496,20 +533,24 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
         (void)__wt_atomic_add64(&S2C(session)->cache->bytes_read, dsk->mem_size);
     }
 
-    /* Store the compressed block in the block_cache. */
-    /* FIXME-WT-14718: decrypt the block first? */
-    if (!skip_cache_put)
-        WT_ERR(__wti_blkcache_put(
-          session, ip, &results[1], count - 1, &block_meta_tmp, addr, addr_size, false));
-
     /* Decrypt. */
-    if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
+    ip_orig = ip;
+    if (actually_encrypted) {
+        /*
+         * We need this machinery with "actually_encrypted" because decryption doesn't clear the
+         * WT_PAGE_ENCRYPTED flag, and we need to know if the block was actually encrypted or not.
+         */
         WT_ERR(__wt_scr_alloc(session, 0, &etmp));
         WT_ERR(__read_decrypt(session, ip, etmp, addr, addr_size));
         ip = etmp;
-    } else if (btree->kencryptor != NULL)
-        WT_ERR(__blkcache_read_corrupt(
-          session, WT_ERROR, addr, addr_size, "unencrypted block for which encryption configured"));
+    }
+
+    /* Store the compressed block in the block_cache. */
+    if (!skip_cache_put) {
+        WT_ITEM *cache_item = __cache_wants_encrypted_data(session) ? ip_orig : ip;
+        WT_ERR(__wti_blkcache_put(
+          session, cache_item, &results[1], count - 1, &block_meta_tmp, addr, addr_size, false));
+    }
 
     /*
      * It might be possible to get a cleaner handover between the decryption and decompression
@@ -565,6 +606,10 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
             WT_STAT_CONN_INCRV(session, block_byte_read_leaf_disk, ip->size);
 
         if (F_ISSET(blk, WT_BLOCK_DISAGG_ENCRYPTED)) {
+            /*
+             * Deltas are currently not supported by the block cache, so they are always decrypted
+             * based on the flag.
+             */
             WT_ERR(__wt_scr_alloc(session, 0, &etmp));
             WT_ERR(__read_decrypt(session, ip, etmp, addr, addr_size));
             ip = etmp;
@@ -820,10 +865,12 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
         WT_STAT_CONN_INCR(session, block_cache_bypass_chkpt);
     else if (!blkcache->cache_on_writes)
         WT_STAT_CONN_INCR(session, block_cache_bypass_writealloc);
-    else if (!checkpoint)
+    else if (!checkpoint) {
         /* If we are here, it means that we don't have deltas, so let's just ignore them. */
-        WT_ERR(__wti_blkcache_put(
-          session, compressed ? ctmp : buf, NULL, 0, block_meta, addr, *addr_sizep, true));
+        WT_ITEM *cache_item = __cache_wants_encrypted_data(session) ? ip : compressed ? ctmp : buf;
+        WT_ERR(
+          __wti_blkcache_put(session, cache_item, NULL, 0, block_meta, addr, *addr_sizep, true));
+    }
 
 err:
     __wt_scr_free(session, &ctmp);

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -587,10 +587,6 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
             WT_STAT_CONN_INCRV(session, block_byte_read_leaf_disk, ip->size);
 
         if (F_ISSET(blk, WT_BLOCK_DISAGG_ENCRYPTED)) {
-            /*
-             * Deltas are currently not supported by the block cache, so they are always decrypted
-             * based on the flag.
-             */
             WT_ERR(__wt_scr_alloc(session, 0, &etmp));
             WT_ERR(__blkcache_read_decrypt(session, ip, etmp, addr, addr_size));
             ip = etmp;

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -844,7 +844,9 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
         WT_STAT_CONN_INCR(session, block_cache_bypass_writealloc);
     else if (!checkpoint) {
         /* If we are here, it means that we don't have deltas, so let's just ignore them. */
-        WT_ITEM *cache_item = __blkcache_cache_wants_encrypted_data(session) ? ip : compressed ? ctmp : buf;
+        WT_ITEM *cache_item = __blkcache_cache_wants_encrypted_data(session) ? ip :
+          compressed                                                         ? ctmp :
+                                                                               buf;
         WT_ERR(
           __wti_blkcache_put(session, cache_item, NULL, 0, block_meta, addr, *addr_sizep, true));
     }

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -172,7 +172,8 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
         dsk = ip->data;
         actually_encrypted = F_ISSET(dsk, WT_PAGE_ENCRYPTED);
 
-        /* Disallow reading an unencrypted block from original source when encryption is configured.
+        /*
+         * Disallow reading an unencrypted block from original source when encryption is configured.
          */
         if (!F_ISSET(dsk, WT_PAGE_ENCRYPTED) && btree->kencryptor != NULL)
             WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,
@@ -507,7 +508,8 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
         type = dsk->type;
         actually_encrypted = F_ISSET(dsk, WT_PAGE_ENCRYPTED);
 
-        /* Disallow reading an unencrypted block from original source when encryption is configured.
+        /*
+         * Disallow reading an unencrypted block from original source when encryption is configured.
          */
         if (!F_ISSET(dsk, WT_PAGE_ENCRYPTED) && btree->kencryptor != NULL)
             WT_ERR(__blkcache_read_corrupt(session, WT_ERROR, addr, addr_size,

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -42,11 +42,11 @@ __blkcache_read_corrupt(WT_SESSION_IMPL *session, int error, const uint8_t *addr
 }
 
 /*
- * __cache_wants_encrypted_data --
+ * __blkcache_cache_wants_encrypted_data --
  *     Return if the configured block cache wants to store encrypted blocks.
  */
 static bool
-__cache_wants_encrypted_data(WT_SESSION_IMPL *session)
+__blkcache_cache_wants_encrypted_data(WT_SESSION_IMPL *session)
 {
     /*!!!
      * Guidance for adding new block cache types here:
@@ -82,7 +82,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     size_t compression_ratio, result_len;
     uint64_t time_diff, time_start, time_stop;
     u_int count, i, results_count;
-    bool blkcache_found, expect_conversion, found, skip_cache_put, timer, actually_encrypted;
+    bool actually_encrypted, blkcache_found, expect_conversion, found, skip_cache_put, timer;
 
     blkcache = &S2C(session)->blkcache;
     blkcache_item = NULL;
@@ -110,7 +110,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     WT_RET(__wti_blkcache_map_read(session, ip, addr, addr_size, &found));
     if (found) {
         skip_cache_put = true;
-        actually_encrypted = __cache_wants_encrypted_data(session);
+        actually_encrypted = F_ISSET((WT_PAGE_HEADER*)ip->data, WT_PAGE_ENCRYPTED);
         if (!expect_conversion)
             goto verify;
     }
@@ -120,7 +120,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
         __wti_blkcache_get(session, addr, addr_size, &blkcache_item, &found, &skip_cache_put);
         if (found) {
             blkcache_found = true;
-            actually_encrypted = __cache_wants_encrypted_data(session);
+            actually_encrypted = __blkcache_cache_wants_encrypted_data(session);
             ip->data = blkcache_item->data;
             ip->size = blkcache_item->data_size;
             if (block_meta != NULL) {
@@ -234,7 +234,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
 
     if (!skip_cache_put) {
         /* Choose either the encrypted or decrypted data for the cache. */
-        WT_ITEM *cache_item = __cache_wants_encrypted_data(session) ? ip_orig : ip;
+        WT_ITEM *cache_item = __blkcache_cache_wants_encrypted_data(session) ? ip_orig : ip;
         /* Use a local variable for block metadata, because the passed-in pointer could be NULL. */
         WT_ERR(__wti_blkcache_put(
           session, cache_item, NULL, 0, &block_meta_tmp, addr, addr_size, false));
@@ -426,7 +426,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     const WT_PAGE_HEADER *dsk;
     uint32_t count, i;
     uint8_t type;
-    bool blkcache_found, found, skip_cache_put, actually_encrypted;
+    bool actually_encrypted, blkcache_found, found, skip_cache_put;
 
     WT_CLEAR(block_meta_tmp);
     WT_CLEAR(results);
@@ -464,7 +464,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED) {
         __wti_blkcache_get(session, addr, addr_size, &blkcache_item, &found, &skip_cache_put);
         if (found) {
-            actually_encrypted = __cache_wants_encrypted_data(session);
+            actually_encrypted = __blkcache_cache_wants_encrypted_data(session);
             blkcache_found = true;
             WT_ASSERT_ALWAYS(session, blkcache_item->num_deltas <= WT_DELTA_LIMIT,
               "block cache item has too many deltas");
@@ -549,7 +549,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
 
     /* Store the compressed block in the block_cache. */
     if (!skip_cache_put) {
-        WT_ITEM *cache_item = __cache_wants_encrypted_data(session) ? ip_orig : ip;
+        WT_ITEM *cache_item = __blkcache_cache_wants_encrypted_data(session) ? ip_orig : ip;
         WT_ERR(__wti_blkcache_put(
           session, cache_item, &results[1], count - 1, &block_meta_tmp, addr, addr_size, false));
     }
@@ -869,7 +869,7 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
         WT_STAT_CONN_INCR(session, block_cache_bypass_writealloc);
     else if (!checkpoint) {
         /* If we are here, it means that we don't have deltas, so let's just ignore them. */
-        WT_ITEM *cache_item = __cache_wants_encrypted_data(session) ? ip : compressed ? ctmp : buf;
+        WT_ITEM *cache_item = __blkcache_cache_wants_encrypted_data(session) ? ip : compressed ? ctmp : buf;
         WT_ERR(
           __wti_blkcache_put(session, cache_item, NULL, 0, block_meta, addr, *addr_sizep, true));
     }


### PR DESCRIPTION
Encryption in the block cache is inconsistent across both read and write paths - some expect pages to be encrypted, others don't.