### PR TITLE
WT-15330 Prevent prepare discover cursor from claiming the same prepare txn twice

### DIFF
--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -109,7 +109,8 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
         memset((void *)pending_prepare_items, 0, sizeof(WT_PENDING_PREPARED_MAP));
     }
     if (unclaimed_count > 0)
-        WT_ERR_MSG(session, WT_ERROR, "Found %" PRIu64 " unclaimed prepared transactions", unclaimed_count);
+        WT_ERR_MSG(
+          session, WT_ERROR, "Found %" PRIu64 " unclaimed prepared transactions", unclaimed_count);
 err:
 
     __wt_free(session, cursor_prepare->list);

--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -81,29 +81,35 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_OP *op;
     uint64_t i, j;
+    uint64_t unclaimed_count;
     cursor_prepare = (WT_CURSOR_PREPARE_DISCOVERED *)cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, NULL);
 
     txn_global = &S2C(session)->txn_global;
     pending_prepare_items = &txn_global->pending_prepare_items;
+    unclaimed_count = 0;
     if (pending_prepare_items->hash != NULL) {
         for (i = 0; i < pending_prepare_items->hash_size; i++) {
             while ((item = TAILQ_FIRST(&pending_prepare_items->hash[i])) != NULL) {
+                /*
+                 * Claimed prepare transactions should have been removed from the hash map already.
+                 * Increase the counter if we find unclaimed item left in map.
+                 */
+                unclaimed_count++;
                 TAILQ_REMOVE(&pending_prepare_items->hash[i], item, hashq);
                 /* Clean up memory of unclaimed mod array */
                 for (j = 0, op = item->mod; j < item->mod_count; j++, op++) {
                     __wt_txn_op_free(session, op);
                 }
                 __wt_free(session, item->mod);
-                item->mod_alloc = 0;
-                item->mod_count = 0;
                 __wt_free(session, item);
             }
         }
         __wt_free(session, pending_prepare_items->hash);
         memset((void *)pending_prepare_items, 0, sizeof(WT_PENDING_PREPARED_MAP));
     }
-
+    if (unclaimed_count > 0)
+        WT_ERR_MSG(session, WT_ERROR, "Found %lu unclaimed prepared transactions", unclaimed_count);
 err:
 
     __wt_free(session, cursor_prepare->list);

--- a/src/cursor/cur_prepared_discover.c
+++ b/src/cursor/cur_prepared_discover.c
@@ -109,7 +109,7 @@ __cursor_prepared_discover_close(WT_CURSOR *cursor)
         memset((void *)pending_prepare_items, 0, sizeof(WT_PENDING_PREPARED_MAP));
     }
     if (unclaimed_count > 0)
-        WT_ERR_MSG(session, WT_ERROR, "Found %lu unclaimed prepared transactions", unclaimed_count);
+        WT_ERR_MSG(session, WT_ERROR, "Found %" PRIu64 " unclaimed prepared transactions", unclaimed_count);
 err:
 
     __wt_free(session, cursor_prepare->list);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -880,8 +880,9 @@ extern int __wt_prefetch_page_in(WT_SESSION_IMPL *session, WT_PREFETCH_QUEUE_ENT
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_prepared_discover_find_item(WT_SESSION_IMPL *session,
-  uint64_t prepare_transaction_id, WT_PENDING_PREPARED_ITEM **prepared_item)
+extern int __wt_prepared_discover_find_item(WT_SESSION_IMPL *session, uint64_t prepared_id,
+  WT_PENDING_PREPARED_ITEM **prepared_item) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1520,11 +1521,10 @@ extern int __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
 extern int __wti_prefetch_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prepared_discover_add_artifact_ondisk_row(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_prepared_discover_add_artifact_upd(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_ITEM *key, WT_UPDATE *upd)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, uint64_t prepared_id,
+  WT_ITEM *key, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey(WT_SESSION_IMPL *session, uint32_t cell_offset, const void *key,
   size_t size, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey_incr(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t cell_offset,
@@ -2155,8 +2155,8 @@ static WT_INLINE int __wt_txn_autocommit_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_begin(WT_SESSION_IMPL *session, WT_CONF *conf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE int __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session,
-  wt_timestamp_t prepared_transaction_id) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_txn_claim_prepared_txn(WT_SESSION_IMPL *session, uint64_t prepared_id)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_check(WT_SESSION_IMPL *session, bool requires_txn)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_context_prepare_check(WT_SESSION_IMPL *session)

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -147,6 +147,7 @@ struct __wt_txn_shared {
 struct __wt_pending_prepared_item {
     TAILQ_ENTRY(__wt_pending_prepared_item) hashq;
     uint64_t prepared_id;
+    wt_timestamp_t prepare_timestamp;
     WT_TXN_OP *mod;
     size_t mod_alloc;
     uint32_t mod_count;

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -8,15 +8,15 @@
 
 #include "wt_internal.h"
 
-#define WT_DEFAULT_PENDING_PREPARED_DISCOVER_HASHSIZE 64
+#define WT_DEFAULT_PENDING_PREPARED_DISCOVER_HASHSIZE 256
 
 /*
  * __wt_prepared_discover_find_item --
  *     Find a pending prepared item by its ID in the pending prepared items hash map.
  */
 int
-__wt_prepared_discover_find_item(WT_SESSION_IMPL *session, uint64_t prepare_transaction_id,
-  WT_PENDING_PREPARED_ITEM **prepared_item)
+__wt_prepared_discover_find_item(
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_PENDING_PREPARED_ITEM **prepared_item)
 {
     WT_CONNECTION_IMPL *conn;
     WT_PENDING_PREPARED_ITEM *item;
@@ -27,9 +27,9 @@ __wt_prepared_discover_find_item(WT_SESSION_IMPL *session, uint64_t prepare_tran
     txn_global = &conn->txn_global;
     pending_prepare_items = &txn_global->pending_prepare_items;
     if (pending_prepare_items->hash != NULL) {
-        bucket = prepare_transaction_id & (pending_prepare_items->hash_size - 1);
+        bucket = prepared_id & (pending_prepare_items->hash_size - 1);
         TAILQ_FOREACH (item, &pending_prepare_items->hash[bucket], hashq) {
-            if (item->prepared_id == prepare_transaction_id) {
+            if (item->prepared_id == prepared_id) {
                 *prepared_item = item;
                 return (0);
             }
@@ -65,8 +65,8 @@ __pending_prepare_items_init(
  *     item.
  */
 static int
-__prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepare_transaction_id,
-  WT_PENDING_PREPARED_ITEM **prepared_item)
+__prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepared_id,
+  wt_timestamp_t prepare_timestamp, WT_PENDING_PREPARED_ITEM **prepared_item)
 {
     WT_CONNECTION_IMPL *conn;
     WT_PENDING_PREPARED_ITEM *item;
@@ -74,7 +74,7 @@ __prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepa
     WT_TXN_GLOBAL *txn_global;
     uint64_t bucket;
 
-    if (__wt_prepared_discover_find_item(session, prepare_transaction_id, prepared_item) == 0)
+    if (__wt_prepared_discover_find_item(session, prepared_id, prepared_item) == 0)
         return (0);
 
     conn = S2C(session);
@@ -86,12 +86,45 @@ __prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepa
     }
 
     WT_RET(__wt_calloc_one(session, &item));
-    item->prepared_id = prepare_transaction_id;
-
-    bucket = prepare_transaction_id & (pending_prepare_items->hash_size - 1);
+    item->prepared_id = prepared_id;
+    item->prepare_timestamp = prepare_timestamp;
+    bucket = prepared_id & (pending_prepare_items->hash_size - 1);
     TAILQ_INSERT_HEAD(&pending_prepare_items->hash[bucket], item, hashq);
     *prepared_item = item;
     return (0);
+}
+
+/*
+ * __wt_prepared_discover_remove_item --
+ *     Find and remove a pending prepared item by its ID in the pending prepared items hash map.
+ */
+int
+__wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_id)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_PENDING_PREPARED_ITEM *item;
+    WT_PENDING_PREPARED_MAP *pending_prepare_items;
+    WT_TXN_GLOBAL *txn_global;
+    uint64_t bucket;
+    conn = S2C(session);
+    txn_global = &conn->txn_global;
+    pending_prepare_items = &txn_global->pending_prepare_items;
+
+    if (pending_prepare_items->hash != NULL) {
+        bucket = prepared_id & (pending_prepare_items->hash_size - 1);
+        TAILQ_FOREACH (item, &pending_prepare_items->hash[bucket], hashq) {
+            if (item->prepared_id == prepared_id) {
+                TAILQ_REMOVE(&pending_prepare_items->hash[bucket], item, hashq);
+                /* Clean up memory of unclaimed mod array */
+                WT_ASSERT_ALWAYS(
+                  session, item->mod_count == 0, "Removing an unclaimed prepared item.");
+                __wt_free(session, item->mod);
+                __wt_free(session, item);
+                return (0);
+            }
+        }
+    }
+    return (WT_NOTFOUND);
 }
 
 /*
@@ -100,13 +133,13 @@ __prepared_discover_find_or_create_item(WT_SESSION_IMPL *session, uint64_t prepa
  */
 int
 __wti_prepared_discover_add_artifact_upd(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_ITEM *key, WT_UPDATE *upd)
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_ITEM *key, WT_UPDATE *upd)
 {
     WT_PENDING_PREPARED_ITEM *prepared_item;
     WT_TXN_OP *op;
 
-    WT_RET(
-      __prepared_discover_find_or_create_item(session, prepare_transaction_id, &prepared_item));
+    WT_RET(__prepared_discover_find_or_create_item(
+      session, prepared_id, upd->prepare_ts, &prepared_item));
 
     WT_RET(__wt_pending_prepared_next_op(session, &op, prepared_item, key));
     WT_RET(__wt_op_modify(session, upd, op));
@@ -125,22 +158,23 @@ __wti_prepared_discover_add_artifact_upd(
  */
 int
 __wti_prepared_discover_add_artifact_ondisk_row(
-  WT_SESSION_IMPL *session, wt_timestamp_t prepare_transaction_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
+  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
 {
     WT_DECL_RET;
     WT_UPDATE *upd;
 
     /*
      * Create an update structure with the time information and state populated - that allows this
-     * code to reuse existing machinery for installing transaction operations.
+     * code to reuse existing machinery for installing transaction operations. FIXME-WT-15346 Handle
+     * claiming prepared delete.
      */
     WT_RET(__wt_upd_alloc(session, NULL, WT_UPDATE_STANDARD, &upd, NULL));
     upd->txnid = session->txn->id;
     upd->upd_durable_ts = tw->durable_start_ts;
-    upd->upd_start_ts = tw->start_ts;
     upd->prepare_state = WT_PREPARE_INPROGRESS;
-
-    WT_ERR(__wti_prepared_discover_add_artifact_upd(session, prepare_transaction_id, key, upd));
+    upd->prepared_id = prepared_id;
+    upd->upd_start_ts = upd->prepare_ts = tw->start_prepare_ts;
+    WT_ERR(__wti_prepared_discover_add_artifact_upd(session, prepared_id, key, upd));
 err:
     /*
      * It's OK to free the update now, the transaction structure will lookup using the key since

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -71,7 +71,8 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
 
     /* Add an entry for this key to the transaction structure */
     if (rip != NULL)
-        WT_ERR(__wti_prepared_discover_add_artifact_ondisk_row(session, tw->start_ts, tw, key));
+        WT_ERR(
+          __wti_prepared_discover_add_artifact_ondisk_row(session, tw->start_prepared_id, tw, key));
     else
         WT_ASSERT_ALWAYS(
           session, false, "Column store prepared transaction discovery not supported");
@@ -118,13 +119,13 @@ __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_RO
 static int
 __prepared_discover_process_prepared_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *upd)
 {
-    wt_timestamp_t prepare_timestamp;
+    uint64_t prepared_id;
 
     WT_ASSERT(
       session, upd->prepare_state != WT_PREPARE_INIT && upd->prepare_state != WT_PREPARE_RESOLVED);
 
-    prepare_timestamp = upd->prepare_ts;
-    WT_RET(__wti_prepared_discover_add_artifact_upd(session, prepare_timestamp, key, upd));
+    prepared_id = upd->prepared_id;
+    WT_RET(__wti_prepared_discover_add_artifact_upd(session, prepared_id, key, upd));
     return (0);
 }
 

--- a/test/suite/test_prepare_discover02.py
+++ b/test/suite/test_prepare_discover02.py
@@ -94,7 +94,7 @@ class test_prepare_discover02(wttest.WiredTigerTestCase, suite_subprocess):
         while prepared_discover_cursor.next() == 0:
             count += 1
             prepared_id = prepared_discover_cursor.get_key()
-            self.assertEqual(prepared_id, 100)
+            self.assertEqual(prepared_id, 123)
             c2s2.begin_transaction("claim_prepared=" + self.timestamp_str(prepared_id))
             c2s2.commit_transaction("commit_timestamp=" + self.timestamp_str(200)+",durable_timestamp=" + self.timestamp_str(210))
         self.assertEqual(count, 1)


### PR DESCRIPTION
Key Changes:
- Add a new `claimed` field to prevent the same prepared transaction from being claimed multiple times
- Rename all `prepare_transaction_id` to `prepared_id` across prepared discovery functions
- Increase hash table size from 64 to 256 buckets to reduce collisions
- Bug fix: use correct prepared IDs in discovery logic and fix test expectations