### PR TITLE
WT-15379 Add a log when a read fails despite retrying the maximum number of times

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -135,7 +135,7 @@ reread:
         if (retry < 100)
             goto reread;
         __wt_verbose_error(session, WT_VERB_READ,
-          "%s: read failed for objectid %" PRIx32 ", page_id %" PRIu64 ", flags %" PRIx64
+          "%s: read failed for table ID %" PRIu32 ", page ID %" PRIu64 ", flags %" PRIx64
           ", lsn %" PRIu64 ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
           block_disagg->name, block_disagg->objectid, page_id, flags, lsn, base_lsn, size,
           checksum);

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -135,9 +135,10 @@ reread:
         if (retry < 100)
             goto reread;
         __wt_verbose_error(session, WT_VERB_READ,
-          "read failed for page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64
-          ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
-          page_id, flags, lsn, base_lsn, size, checksum);
+          "%s: read failed for objectid %" PRIx32 ", page_id %" PRIu64 ", flags %" PRIx64
+          ", lsn %" PRIu64 ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
+          block_disagg->name, block_disagg->objectid, page_id, flags, lsn, base_lsn, size,
+          checksum);
         WT_ERR(WT_NOTFOUND);
     }
 

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -134,6 +134,10 @@ reread:
          */
         if (retry < 100)
             goto reread;
+        __wt_verbose_error(session, WT_VERB_READ,
+          "read failed for page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64
+          ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
+          page_id, flags, lsn, base_lsn, size, checksum);
         WT_ERR(WT_NOTFOUND);
     }
 


### PR DESCRIPTION
Added an error log inside `__block_disagg_read_multiple` if we fail reading the requested page.