### PR TITLE
WT-15352 Use atomic ops for shared doubles

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -505,7 +505,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
 static WT_INLINE void
 __checkpoint_set_scrub_target(WT_SESSION_IMPL *session, double target)
 {
-    __wt_set_shared_double(&S2C(session)->evict->eviction_scrub_target, target);
+    __wt_atomic_store_double(&S2C(session)->evict->eviction_scrub_target, target);
     WT_STAT_CONN_SET(session, checkpoint_scrub_target, (int64_t)target);
 }
 

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -537,8 +537,7 @@ __wt_evict_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double *pc
     if (pct_fullp != NULL)
         *pct_fullp = WT_MAX(0.0,
           100.0 -
-            WT_MIN(
-              WT_MIN(evict->eviction_trigger - pct_full, dirty_trigger - pct_dirty),
+            WT_MIN(WT_MIN(evict->eviction_trigger - pct_full, dirty_trigger - pct_dirty),
               evict->eviction_updates_trigger - pct_updates));
 
     /*

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -413,8 +413,8 @@ __wti_evict_dirty_target(WT_EVICT *evict)
 {
     double dirty_target, scrub_target;
 
-    dirty_target = __wt_read_shared_double(&evict->eviction_dirty_target);
-    scrub_target = __wt_read_shared_double(&evict->eviction_scrub_target);
+    dirty_target = __wt_atomic_load_double(&evict->eviction_dirty_target);
+    scrub_target = __wt_atomic_load_double(&evict->eviction_scrub_target);
 
     return (scrub_target > 0 && scrub_target < dirty_target ? scrub_target : dirty_target);
 }
@@ -438,6 +438,7 @@ static WT_INLINE bool
 __wt_evict_dirty_needed(WT_SESSION_IMPL *session, double *pct_fullp)
 {
     uint64_t bytes_dirty, bytes_max;
+    double dirty_trigger = __wt_atomic_load_double(&S2C(session)->evict->eviction_dirty_trigger);
 
     /*
      * Avoid division by zero if the cache size has not yet been set in a shared cache.
@@ -448,8 +449,7 @@ __wt_evict_dirty_needed(WT_SESSION_IMPL *session, double *pct_fullp)
     if (pct_fullp != NULL)
         *pct_fullp = (100.0 * bytes_dirty) / bytes_max;
 
-    return (
-      bytes_dirty > (uint64_t)(S2C(session)->evict->eviction_dirty_trigger * bytes_max) / 100);
+    return (bytes_dirty > (uint64_t)(dirty_trigger * bytes_max) / 100);
 }
 
 /* !!!
@@ -508,7 +508,7 @@ static WT_INLINE bool
 __wt_evict_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double *pct_fullp)
 {
     WT_EVICT *evict;
-    double pct_dirty, pct_full, pct_updates;
+    double pct_dirty, pct_full, pct_updates, dirty_trigger;
     bool clean_needed, dirty_needed, updates_needed;
 
     evict = S2C(session)->evict;
@@ -533,11 +533,12 @@ __wt_evict_needed(WT_SESSION_IMPL *session, bool busy, bool readonly, double *pc
      * Calculate the cache full percentage; anything over the trigger means we involve the
      * application thread.
      */
+    dirty_trigger = __wt_atomic_load_double(&evict->eviction_dirty_trigger);
     if (pct_fullp != NULL)
         *pct_fullp = WT_MAX(0.0,
           100.0 -
             WT_MIN(
-              WT_MIN(evict->eviction_trigger - pct_full, evict->eviction_dirty_trigger - pct_dirty),
+              WT_MIN(evict->eviction_trigger - pct_full, dirty_trigger - pct_dirty),
               evict->eviction_updates_trigger - pct_updates));
 
     /*
@@ -570,8 +571,8 @@ __wt_evict_favor_clearing_dirty_cache(WT_SESSION_IMPL *session)
      * Ramp the eviction dirty target down to encourage eviction threads to clear dirty content out
      * of cache.
      */
-    __wt_set_shared_double(&evict->eviction_dirty_trigger, 1.0);
-    __wt_set_shared_double(&evict->eviction_dirty_target, 0.1);
+    __wt_atomic_store_double(&evict->eviction_dirty_trigger, 1.0);
+    __wt_atomic_store_double(&evict->eviction_dirty_target, 0.1);
 }
 
 /*

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -678,7 +678,7 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
     evict = conn->evict;
 
     dirty_target = __wti_evict_dirty_target(evict);
-    dirty_trigger = evict->eviction_dirty_trigger;
+    dirty_trigger = __wt_atomic_load_double(&evict->eviction_dirty_trigger);
     target = evict->eviction_target;
     trigger = evict->eviction_trigger;
     updates_target = evict->eviction_updates_target;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1968,8 +1968,6 @@ static WT_INLINE const char *__wt_prepare_state_str(uint8_t val)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE const char *__wt_update_type_str(uint8_t val)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE double __wt_read_shared_double(double *to_read)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_4b_pack_posint1(uint8_t **pp, uint8_t *end, uint64_t x1)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_4b_pack_posint2(uint8_t **pp, uint8_t *end, uint64_t x1, uint64_t x2)
@@ -2396,7 +2394,6 @@ static WT_INLINE void __wt_row_leaf_value_set(WT_ROW *rip, WT_CELL_UNPACK_KV *un
 static WT_INLINE void __wt_scr_free(WT_SESSION_IMPL *session, WT_ITEM **bufp);
 static WT_INLINE void __wt_seconds(WT_SESSION_IMPL *session, uint64_t *secondsp);
 static WT_INLINE void __wt_seconds32(WT_SESSION_IMPL *session, uint32_t *secondsp);
-static WT_INLINE void __wt_set_shared_double(double *to_set, double value);
 static WT_INLINE void __wt_spin_backoff(uint64_t *yield_count, uint64_t *sleep_usecs);
 static WT_INLINE void __wt_spin_destroy(WT_SESSION_IMPL *session, WT_SPINLOCK *t);
 static WT_INLINE void __wt_spin_lock(WT_SESSION_IMPL *session, WT_SPINLOCK *t);

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -164,9 +164,8 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
 }
 
 /*
- * We can't use the WT_ATOMIC_FUNC or __wt_atomic_load/store_generic macros for doubles,
- * since these interfaces support only integers and pointers on some compilers.
- * Define them individually.
+ * We can't use the WT_ATOMIC_FUNC or __wt_atomic_load/store_generic macros for doubles, since these
+ * interfaces support only integers and pointers on some compilers. Define them individually.
  */
 
 /*
@@ -178,7 +177,7 @@ __wt_atomic_load_double(double *vp)
 {
     double value;
     __atomic_load(vp, &value, __ATOMIC_RELAXED);
-    return value;
+    return (value);
 }
 
 /*
@@ -190,7 +189,6 @@ __wt_atomic_store_double(double *vp, double v)
 {
     __atomic_store(vp, &v, __ATOMIC_RELAXED);
 }
-
 
 /*
  * Generic atomic functions that accept any type. The typed macros above should be preferred since

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -164,6 +164,35 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
 }
 
 /*
+ * We can't use the WT_ATOMIC_FUNC or __wt_atomic_load/store_generic macros for doubles,
+ * since these interfaces support only integers and pointers on some compilers.
+ * Define them individually.
+ */
+
+/*
+ * __wt_atomic_load_double --
+ *     Atomically read a double variable.
+ */
+static inline double
+__wt_atomic_load_double(double *vp)
+{
+    double value;
+    __atomic_load(vp, &value, __ATOMIC_RELAXED);
+    return value;
+}
+
+/*
+ * __wt_atomic_store_double --
+ *     Atomically set a double variable.
+ */
+static inline void
+__wt_atomic_store_double(double *vp, double v)
+{
+    __atomic_store(vp, &v, __ATOMIC_RELAXED);
+}
+
+
+/*
  * Generic atomic functions that accept any type. The typed macros above should be preferred since
  * they provide better type checking.
  */

--- a/src/include/misc_inline.h
+++ b/src/include/misc_inline.h
@@ -294,26 +294,6 @@ __wt_failpoint(WT_SESSION_IMPL *session, uint64_t conn_flag, u_int probability)
 }
 
 /*
- * __wt_set_shared_double --
- *     This function enables suppressing TSan warnings about setting doubles in a shared context.
- */
-static WT_INLINE void
-__wt_set_shared_double(double *to_set, double value)
-{
-    *to_set = value;
-}
-
-/*
- * __wt_read_shared_double --
- *     This function enables suppressing TSan warnings about reading doubles in a shared context.
- */
-static WT_INLINE double
-__wt_read_shared_double(double *to_read)
-{
-    return (*to_read);
-}
-
-/*
  * The hardware-accelerated checksum code that originally shipped on Windows did not correctly
  * handle memory that wasn't 8B aligned and a multiple of 8B. It's likely that calculations were
  * always 8B aligned, but there's some risk.

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -107,7 +107,6 @@ __wt_atomic_store_double(double *vp, double v)
     *vp = v;
 }
 
-
 /*
  * We can't use the WT_ATOMIC_FUNC macro for booleans as MSVC doesn't have Interlocked intrinsics
  * that support booleans. These atomic loads and stores were non-atomic memory accesses originally,

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -143,7 +143,7 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
 static inline double
 __wt_atomic_load_double(double *vp)
 {
-    return *vp;
+    return (*vp);
 }
 
 /*

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -136,6 +136,28 @@ __wt_atomic_storevbool(volatile bool *vp, bool v)
 }
 
 /*
+ * __wt_atomic_load_double --
+ *     Read a double variable. These reads are non-atomic due to MSVC lacking Interlocked intrinsics
+ *     for doubles per the comment above.
+ */
+static inline double
+__wt_atomic_load_double(double *vp)
+{
+    return *vp;
+}
+
+/*
+ * __wt_atomic_store_double --
+ *     Set a double variable. These reads are non-atomic due to MSVC lacking Interlocked intrinsics
+ *     for doubles per the comment above.
+ */
+static inline void
+__wt_atomic_store_double(double *vp, double v)
+{
+    *vp = v;
+}
+
+/*
  * Generic atomic functions that accept any type. The typed macros above should be preferred since
  * they provide better type checking.
  */

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -86,6 +86,29 @@ WT_ATOMIC_FUNC(iv64, int64_t, volatile int64_t, 64, __int64)
 WT_ATOMIC_FUNC(size, size_t, size_t, 64, __int64)
 
 /*
+ * __wt_atomic_load_double --
+ *     Read a double variable. These reads are non-atomic due to MSVC lacking Interlocked intrinsics
+ *     for relaxed memory per the comment above.
+ */
+static inline double
+__wt_atomic_load_double(double *vp)
+{
+    return (*vp);
+}
+
+/*
+ * __wt_atomic_store_double --
+ *     Set a double variable. These reads are non-atomic due to MSVC lacking Interlocked intrinsics
+ *     for relaxed memory per the comment above.
+ */
+static inline void
+__wt_atomic_store_double(double *vp, double v)
+{
+    *vp = v;
+}
+
+
+/*
  * We can't use the WT_ATOMIC_FUNC macro for booleans as MSVC doesn't have Interlocked intrinsics
  * that support booleans. These atomic loads and stores were non-atomic memory accesses originally,
  * so we'll maintain that behavior on Windows.
@@ -133,28 +156,6 @@ static inline void
 __wt_atomic_storevbool(volatile bool *vp, bool v)
 {
     *(vp) = (v);
-}
-
-/*
- * __wt_atomic_load_double --
- *     Read a double variable. These reads are non-atomic due to MSVC lacking Interlocked intrinsics
- *     for doubles per the comment above.
- */
-static inline double
-__wt_atomic_load_double(double *vp)
-{
-    return (*vp);
-}
-
-/*
- * __wt_atomic_store_double --
- *     Set a double variable. These reads are non-atomic due to MSVC lacking Interlocked intrinsics
- *     for doubles per the comment above.
- */
-static inline void
-__wt_atomic_store_double(double *vp, double v)
-{
-    *vp = v;
 }
 
 /*

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -4,8 +4,8 @@
 # an error that is missing information and the message "failed to restore the stack"
 
 # These functions enable threads to access double values in a shared context, and catch all TSan warnings.
-race:__wt_read_shared_double
-race:__wt_set_shared_double
+# race:__wt_read_shared_double
+# race:__wt_set_shared_double
 
 # Stats are allowed to be fuzzy. Ignore races in TSan
 race:src/include/stat.h
@@ -26,7 +26,7 @@ race:__tiered_queue_peek_empty
 # The ref track code is diagnostic only and allows for races
 race:__ref_track_state
 
-# __wt_configure_method intentionally allows for races between threads to avoid the overhead of taking a lock on each API call.  
+# __wt_configure_method intentionally allows for races between threads to avoid the overhead of taking a lock on each API call.
 race:__wt_configure_method
 
 # FIXME-WT-14930 Dhandle timeofdeath synchronization

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -3,10 +3,6 @@
 # before running tests with TSan. history_size isn't required but it reduces the chance that TSan reports
 # an error that is missing information and the message "failed to restore the stack"
 
-# These functions enable threads to access double values in a shared context, and catch all TSan warnings.
-# race:__wt_read_shared_double
-# race:__wt_set_shared_double
-
 # Stats are allowed to be fuzzy. Ignore races in TSan
 race:src/include/stat.h
 race:src/support/stat.c


### PR DESCRIPTION
Currently shared doubles that could cause data races still use plain load/stores since it wasn't clear what API can we use for these cases. This PR is an attempt to start using atomic operations in that cases.