### PR TITLE
WT-15203 Disable test_error_info02 for disagg hook

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -47,7 +47,6 @@ test_empty.py
 test_encrypt06.py
 test_env01.py
 test_error_info01.py
-test_error_info02.py
 test_error_info03.py
 test_eviction02.py
 test_eviction03.py

--- a/test/suite/test_error_info02.py
+++ b/test/suite/test_error_info02.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import time, wiredtiger
+import time, wiredtiger, wttest
 from error_info_util import error_info_util
 
 # test_error_info02.py

--- a/test/suite/test_error_info02.py
+++ b/test/suite/test_error_info02.py
@@ -32,6 +32,9 @@ from error_info_util import error_info_util
 # test_error_info02.py
 #   Test that the get_last_error() session API returns the last error for rollback error to
 #   occur in the session.
+
+# FIXME-14684
+@wttest.skip_for_hook("disagg", "Fails with PALM mapsize limit reached")
 class test_error_info02(error_info_util):
     uri = "table:test_error_info.wt"
 

--- a/test/suite/test_error_info02.py
+++ b/test/suite/test_error_info02.py
@@ -33,7 +33,7 @@ from error_info_util import error_info_util
 #   Test that the get_last_error() session API returns the last error for rollback error to
 #   occur in the session.
 
-# FIXME-14684
+# FIXME-WT-14684
 @wttest.skip_for_hook("disagg", "Fails with PALM mapsize limit reached")
 class test_error_info02(error_info_util):
     uri = "table:test_error_info.wt"


### PR DESCRIPTION
`test_error_info02` is currently failing due to PALM's `Environment mapsize limit reached` error, we're unable allocate a new node in PALM so reconciliation (triggered by eviction) fails, so we fail to evict a page.

This PR skips the test for disagg hook for now until we implement a better alternative for PALM