### PR TITLE
WT-15198 Data Validation for Leader/Follower Mode in Disagg (test/format)

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -331,7 +331,7 @@ real_checkpointer(THREAD_DATA *td)
             goto done;
 
         /* Verify the checkpoint we just wrote. */
-        /* FIXME-WT-15378 Disagg: Implement checkpoint cursors */
+        /* FIXME-WT-15357 Disagg: Implement checkpoint cursors */
         if (!g.opts.disagg_storage) {
             if ((ret = verify_consistency(session, WT_TS_NONE, true)) != 0)
                 return (log_print_err("verify_consistency (checkpoint)", ret, 1));

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1467,6 +1467,16 @@ variables:
           format_args: disagg.mode=follower
           times: 5
 
+  - &format-stress-data-validation-test-disagg-follower
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=follower ops.verify=1 runs.mirror=1
+          times: 5
+
   - &format-stress-test
     exec_timeout_secs: 25200
     commands:
@@ -4339,6 +4349,21 @@ tasks:
     tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-5
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-data-validation-test-disagg-follower
+    name: format-stress-data-validation-test-disagg-follower-1
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-data-validation-test-disagg-follower
+    name: format-stress-data-validation-test-disagg-follower-2
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-data-validation-test-disagg-follower
+    name: format-stress-data-validation-test-disagg-follower-3
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-data-validation-test-disagg-follower
+    name: format-stress-data-validation-test-disagg-follower-4
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-data-validation-test-disagg-follower
+    name: format-stress-data-validation-test-disagg-follower-5
     tags: ["stress-test-disagg"]
   # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures has been resolved.
   - <<: *format-stress-test-disagg-switch

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1476,8 +1476,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          # Validate data with a non-layered table.
-          format_args: disagg.mode=follower ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0
+          format_args: disagg.mode=follower ops.verify=1 runs.mirror=1
           times: 5
 
   - &format-stress-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1444,7 +1444,12 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=leader runs.tables=2 runs.rows=100000 runs.ops=300000 ops.verify=1 runs.mirror=1
+          format_args: |
+            disagg.mode=leader
+            # Validate data with a non-layered table.
+            ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0
+            # FIXME-WT-14566 Limit the runs for now.
+            runs.tables=2 runs.rows=100000 runs.ops=300000
           times: 5
 
   - &format-stress-test-disagg-switch
@@ -1474,7 +1479,10 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=follower ops.verify=1 runs.mirror=1
+          format_args: |
+           disagg.mode=follower
+           # Validate data with a non-layered table.
+           ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0
           times: 5
 
   - &format-stress-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1444,12 +1444,9 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: |
-            disagg.mode=leader
-            # Validate data with a non-layered table.
-            ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0
-            # FIXME-WT-14566 Limit the runs for now.
-            runs.tables=2 runs.rows=100000 runs.ops=300000
+          # Validate data with a non-layered table.
+          # FIXME-WT-14566 Limit the runs for now.
+          format_args: disagg.mode=leader ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.tables=2 runs.rows=100000 runs.ops=300000
           times: 5
 
   - &format-stress-test-disagg-switch
@@ -1479,10 +1476,8 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: |
-           disagg.mode=follower
-           # Validate data with a non-layered table.
-           ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0
+          # Validate data with a non-layered table.
+          format_args: disagg.mode=follower ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0
           times: 5
 
   - &format-stress-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1437,6 +1437,16 @@ variables:
           format_args: disagg.mode=leader runs.tables=1 runs.timer=3
           times: 5
 
+  - &format-stress-data-validation-test-disagg-leader
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=leader runs.tables=2 runs.rows=100000 runs.ops=300000 ops.verify=1 runs.mirror=1
+          times: 5
+
   - &format-stress-test-disagg-switch
     depends_on:
       - name: compile
@@ -4299,6 +4309,21 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-5
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-data-validation-test-disagg-leader
+    name: format-stress-data-validation-test-disagg-leader-1
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-data-validation-test-disagg-leader
+    name: format-stress-data-validation-test-disagg-leader-2
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-data-validation-test-disagg-leader
+    name: format-stress-data-validation-test-disagg-leader-3
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-data-validation-test-disagg-leader
+    name: format-stress-data-validation-test-disagg-leader-4
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-data-validation-test-disagg-leader
+    name: format-stress-data-validation-test-disagg-leader-5
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-1

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -3,6 +3,7 @@
 ############################################
 # A configuration for disaggregated storage.
 backup=0
+checkpoint=on
 precise_checkpoint=1
 disagg.page_log=palm
 disagg.enabled=1

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -6,11 +6,16 @@ backup=0
 checkpoint=on
 precise_checkpoint=1
 disagg.page_log=palm
+disagg.mode=leader
+runs.tables=2
+runs.rows=1000
+runs.ops=1000
+ops.verify=1
+runs.mirror=1
 disagg.enabled=1
 disagg.layered=1
 runs.source=layered
 runs.type=row-store
-runs.tables=3
 import=0
 ops.alter=0
 # FIXME-WT-14467 should fix cursor->modify for layered tables.

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -6,16 +6,11 @@ backup=0
 checkpoint=on
 precise_checkpoint=1
 disagg.page_log=palm
-disagg.mode=leader
-runs.tables=2
-runs.rows=1000
-runs.ops=1000
-ops.verify=1
-runs.mirror=1
 disagg.enabled=1
 disagg.layered=1
 runs.source=layered
 runs.type=row-store
+runs.tables=3
 import=0
 ops.alter=0
 # FIXME-WT-14467 should fix cursor->modify for layered tables.

--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -160,8 +160,10 @@ checkpoint(void *arg)
         if (backup_locked)
             lock_writeunlock(session, &g.backup_lock);
 
-        /* Verify the checkpoints. */
-        wts_verify_mirrors(conn, ckpt_vrfy_name, NULL);
+        /* FIXME-WT-15357 Checkpoint cursors are not compatible with disagg for now. */
+        if (!g.disagg_storage_config)
+            /* Verify the checkpoints. */
+            wts_verify_mirrors(conn, ckpt_vrfy_name, NULL);
 
         max_secs = g.disagg_storage_config ? 10 : 40;
         secs = mmrand(&g.extra_rnd, 5, max_secs);

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1528,11 +1528,11 @@ config_disagg_storage(void)
         config_single(NULL, "transaction.timestamps=on", true);
 
         /* It makes sense to do checkpoints. */
-        config_single(NULL, "checkpoint=on", false);
+        if (!config_explicit(NULL, "checkpoint"))
+            config_single(NULL, "checkpoint=on", false);
 
         /* TODO: Some operations are not yet supported for disaggregated storage. */
         config_off(NULL, "ops.salvage");
-        config_off(NULL, "ops.verify");
         config_off(NULL, "backup");
         config_off(NULL, "backup.incremental");
         config_off(NULL, "ops.compaction");

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -47,12 +47,9 @@ table_verify(TABLE *table, void *arg)
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);
     ret = session->verify(session, table->uri, "strict");
-    testutil_assert(
-        ret == 0 ||
-        ret == EBUSY ||
-        /* FIXME-WT-15413: Verify on follower may return ENOENT if stable uri is missing. */
-        (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT)
-    );
+    testutil_assert(ret == 0 || ret == EBUSY ||
+      /* FIXME-WT-15413: Verify on follower may return ENOENT if stable uri is missing. */
+      (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
 
     if (ret == EBUSY)
         WARN("table.%u skipped verify because of EBUSY", table->id);

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -198,7 +198,7 @@ table_verify_mirror(
     uint64_t range_begin, range_end;
     char buf[256], tagbuf[128];
 
-    base_keyno = table_keyno = 0;             /* -Wconditional-uninitialized */
+    base_id = base_keyno = table_id = table_keyno = 0;             /* -Wconditional-uninitialized */
     base_bitv = table_bitv = FIX_VALUE_WRONG; /* -Wconditional-uninitialized */
     base_ret = table_ret = 0;
     last_match = 0;
@@ -218,10 +218,12 @@ table_verify_mirror(
      */
     for (;;) {
         wt_wrap_open_cursor(session, base->uri, checkpoint == NULL ? NULL : buf, &base_cursor);
-        base_id = base_cursor->checkpoint_id(base_cursor);
         wt_wrap_open_cursor(session, table->uri, checkpoint == NULL ? NULL : buf, &table_cursor);
-        table_id = table_cursor->checkpoint_id(table_cursor);
 
+        if (checkpoint != NULL) {
+            base_id = base_cursor->checkpoint_id(base_cursor);
+            table_id = table_cursor->checkpoint_id(table_cursor);
+        }
         testutil_assert((checkpoint == NULL && base_id == 0 && table_id == 0) ||
           (checkpoint != NULL && base_id != 0 && table_id != 0));
 

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -47,8 +47,13 @@ table_verify(TABLE *table, void *arg)
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);
     ret = session->verify(session, table->uri, "strict");
-    if (!g.disagg_storage_config)
-        testutil_assert(ret == 0 || ret == EBUSY);
+    testutil_assert(
+        ret == 0 ||
+        ret == EBUSY ||
+        /* FIXME-WT-15413: Verify on follower may return ENOENT if stable uri is missing. */
+        (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT)
+    );
+
     if (ret == EBUSY)
         WARN("table.%u skipped verify because of EBUSY", table->id);
     wt_wrap_close_session(session);

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -47,7 +47,8 @@ table_verify(TABLE *table, void *arg)
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);
     ret = session->verify(session, table->uri, "strict");
-    testutil_assert(ret == 0 || ret == EBUSY);
+    if (!g.disagg_storage_config)
+        testutil_assert(ret == 0 || ret == EBUSY);
     if (ret == EBUSY)
         WARN("table.%u skipped verify because of EBUSY", table->id);
     wt_wrap_close_session(session);

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -199,8 +199,8 @@ table_verify_mirror(
     uint64_t range_begin, range_end;
     char buf[256], tagbuf[128];
 
-    base_id = base_keyno = table_id = table_keyno = 0;             /* -Wconditional-uninitialized */
-    base_bitv = table_bitv = FIX_VALUE_WRONG; /* -Wconditional-uninitialized */
+    base_id = base_keyno = table_id = table_keyno = 0; /* -Wconditional-uninitialized */
+    base_bitv = table_bitv = FIX_VALUE_WRONG;          /* -Wconditional-uninitialized */
     base_ret = table_ret = 0;
     last_match = 0;
     failures = 0;


### PR DESCRIPTION
This PR enables mirrored tables in test/format (for disagg leader/follower mode). We now create two tables and, after writing data to both, verify that their contents match. This provides strong correctness testing.

The key improvement is that we mirror against a non-layered table, allowing us to validate all disagg functionality by writing the same data to both disagg and non-disagg tables, then comparing them.

I’ve seen many successful runs locally, though there are some consistent failures that still need to be addressed.