### PR TITLE
WT-15389 Disable truncate ops in test/model for disagg

### DIFF
--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -562,6 +562,9 @@ kv_workload_generator::run()
         /* FIXME-WT-15041 Handling abandoned checkpoints is not yet supported. */
         _spec.crash = 0;
         _spec.checkpoint_crash = 0;
+
+        /* FIXME-WT-14998 Truncate is not yet supported. */
+        _spec.truncate = 0;
     }
 
     /* Create tables. */


### PR DESCRIPTION
Truncate is not supported in disagg yet, disabling it in test/model.