### PR TITLE
WT-15396 Coverity analysis defect 175990: Calling risky function

### DIFF
--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -120,7 +120,7 @@ main(int argc, char *argv[])
             g.checkpoint_name = __wt_optarg;
             break;
         case 'C': /* wiredtiger_open config */
-            strcpy(config_open, __wt_optarg);
+            strncpy(config_open, __wt_optarg, sizeof(config_open) - 1);
             break;
         case 'd': /* disaggregated storage options */
             if (enable_disagg(__wt_optarg) != 0) {

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -58,7 +58,7 @@ create_table(WT_SESSION *session, COOKIE *cookie)
           "memory_page_max=64KB,log=(enabled=false)",
           kf, vf);
         if (g.opts.disagg_storage)
-            strcat(config, ",type=layered,block_manager=disagg");
+            testutil_strcat(config, sizeof(config), ",type=layered,block_manager=disagg");
     } else
         testutil_snprintf(config, sizeof(config), "key_format=%s,value_format=%s", kf, vf);
 


### PR DESCRIPTION
- Also: WT-15402 Coverity analysis defect 176670: Calling risky function