### PR TITLE
WT-15355 disable test_cache_evict_config02 for disagg

### DIFF
--- a/test/suite/test_cache_evict_config02.py
+++ b/test/suite/test_cache_evict_config02.py
@@ -31,6 +31,9 @@ from wiredtiger import stat
 
 # Test that cache eviction controls can be reconfigured dynamically
 # and that WT_CACHE_EVICT_SCRUB_UNDER_TARGET behaves correctly.
+
+# FIXME-WT-14684
+@wttest.skip_for_hook("disagg", "Fails with PALM mapsize limit reached")
 class test_cache_evict_config02(wttest.WiredTigerTestCase):
     conn_config = "cache_size=5MB,statistics=(all),cache_eviction_controls=[scrub_evict_under_target_limit=false]"
     uri = "table:eviction02"


### PR DESCRIPTION
Similar to [WT-15203](https://jira.mongodb.org/browse/WT-15203), this is eviction panic caused by a PALM failure. For now this PR disables the test for disagg until the fix [WT-14684](https://jira.mongodb.org/browse/WT-14684) is done.