### PR TITLE
WT-15148 Use conditional variable to sync threads

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -106,11 +106,11 @@ extern int __wt_optind;
 extern char *__wt_optarg;
 
 static struct {
-    bool tmr_ready_to_go;
-    WT_CONDVAR *cond_tmr_thrd;
+    bool timer_ready_to_go;
+    WT_CONDVAR *timer_cond;
     bool ckpt_ready_to_go;
-    WT_CONDVAR *cond_ckpt_thrd;
-} thrd_sync_conds = {false, NULL, false, NULL};
+    WT_CONDVAR *ckpt_cond;
+} thread_sync_conds = {false, NULL, false, NULL};
 
 /*
  * Print that we are doing backup verification.
@@ -350,11 +350,11 @@ thread_ts_run(void *arg)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     /* While is to wait for all written thread reached the commit. */
     /* Using while is to avoid spurious wakeups of conditional variables */
-    while (!thrd_sync_conds.tmr_ready_to_go) {
+    while (!thread_sync_conds.timer_ready_to_go) {
         /* Actually we don't need this value */
         bool cv_signalled;
         /* Wait maximum 1s each round */
-        __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_tmr_thrd, WT_MILLION,
+        __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thread_sync_conds.timer_cond, WT_MILLION,
           NULL, &cv_signalled);
     }
     printf("Timestamp thread started...\n");
@@ -376,8 +376,8 @@ thread_ts_run(void *arg)
             testutil_snprintf(tscfg, sizeof(tscfg),
               "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64, ts, ts);
         testutil_check(conn->set_timestamp(conn, tscfg));
-        thrd_sync_conds.ckpt_ready_to_go = true;
-        __wt_cond_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_ckpt_thrd);
+        thread_sync_conds.ckpt_ready_to_go = true;
+        __wt_cond_signal((WT_SESSION_IMPL *)session, thread_sync_conds.ckpt_cond);
         /*
          * Only perform the reconfigure test after statistics have a chance to run. If we do it too
          * frequently then internal servers like the statistics server get destroyed and restarted
@@ -496,11 +496,11 @@ thread_ckpt_run(void *arg)
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
     /* While is to wait for stable_timestamp is configured. */
     /* Using while is to avoid spurious wakeups of conditional variables. */
-    while (!thrd_sync_conds.ckpt_ready_to_go) {
+    while (!thread_sync_conds.ckpt_ready_to_go) {
         bool cv_signalled;
         /* Wait maximum 1s each round */
-        __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_ckpt_thrd,
-          WT_MILLION, NULL, &cv_signalled);
+        __wt_cond_wait_signal(
+          (WT_SESSION_IMPL *)session, thread_sync_conds.ckpt_cond, WT_MILLION, NULL, &cv_signalled);
     }
     printf("Checkpoint thread started...\n");
     first_ckpt = true;
@@ -849,8 +849,8 @@ rollback:
                 printf("--- syncing %u/%u @ Thread: %" PRIu32 " ---\n", current_progress, nth,
                   td->threadnum);
                 if (current_progress == nth) {
-                    thrd_sync_conds.tmr_ready_to_go = true;
-                    __wt_cond_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_tmr_thrd);
+                    thread_sync_conds.timer_ready_to_go = true;
+                    __wt_cond_signal((WT_SESSION_IMPL *)session, thread_sync_conds.timer_cond);
                 }
             }
             WT_RELEASE_WRITE_WITH_BARRIER(active_timestamps[td->threadnum], active_ts);
@@ -975,10 +975,10 @@ run_workload(uint32_t workload_iteration)
     opts->running = true;
     /* Initialize cond machines */
     opt_session = (WT_SESSION_IMPL *)opts->session;
-    thrd_sync_conds.tmr_ready_to_go = false;
-    testutil_check(__wt_cond_alloc(opt_session, "timer thread cv", &thrd_sync_conds.cond_tmr_thrd));
-    thrd_sync_conds.ckpt_ready_to_go = false;
-    testutil_check(__wt_cond_alloc(opt_session, "ckpt thread cv", &thrd_sync_conds.cond_ckpt_thrd));
+    thread_sync_conds.timer_ready_to_go = false;
+    testutil_check(__wt_cond_alloc(opt_session, "timer thread cv", &thread_sync_conds.timer_cond));
+    thread_sync_conds.ckpt_ready_to_go = false;
+    testutil_check(__wt_cond_alloc(opt_session, "ckpt thread cv", &thread_sync_conds.ckpt_cond));
     /* The backup, checkpoint, timestamp, and worker threads are added at the end. */
     backup_id = nth;
     if (use_backups) {
@@ -1028,8 +1028,8 @@ run_workload(uint32_t workload_iteration)
     for (i = 0; i <= ts_id; ++i)
         testutil_check(__wt_thread_join(NULL, &thr[i]));
 
-    __wt_cond_destroy(opt_session, &thrd_sync_conds.cond_tmr_thrd);
-    __wt_cond_destroy(opt_session, &thrd_sync_conds.cond_ckpt_thrd);
+    __wt_cond_destroy(opt_session, &thread_sync_conds.timer_cond);
+    __wt_cond_destroy(opt_session, &thread_sync_conds.ckpt_cond);
 
     /*
      * NOTREACHED

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -349,8 +349,10 @@ thread_ts_run(void *arg)
     td = (THREAD_DATA *)arg;
     conn = td->conn;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    /* Wait for all working threads to complete as there will be a
-     * stable timestamp available to work with. */
+    /*
+     * Wait for all working threads to complete as there will be a stable timestamp available to
+     * work with.
+     */
     while (!thread_sync_conds.timer_ready_to_go) {
         bool cv_signalled;
         /* Under a high workload, there is no need to check very often, check every second. */
@@ -1045,12 +1047,12 @@ run_workload(uint32_t workload_iteration)
     for (i = 0; i <= ts_id; ++i)
         testutil_check(__wt_thread_join(NULL, &thr[i]));
 
-    __wt_cond_destroy(opt_session, &thread_sync_conds.timer_cond);
-    __wt_cond_destroy(opt_session, &thread_sync_conds.ckpt_cond);
-
     /*
      * NOTREACHED
      */
+    __wt_cond_destroy(opt_session, &thread_sync_conds.timer_cond);
+    __wt_cond_destroy(opt_session, &thread_sync_conds.ckpt_cond);
+
     free(thr);
     free(td);
     _exit(EXIT_SUCCESS);

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -845,10 +845,10 @@ rollback:
         if (use_ts) {
             static uint32_t progress = 0;
             if (WT_TS_NONE == active_timestamps[td->threadnum]) {
-                progress++;
-                printf(
-                  "---syncing %u/%u @ Thread: %" PRIu32 " ---\n", progress, nth, td->threadnum);
-                if (progress == nth) {
+                uint32_t current_progress = __wt_atomic_add32(&progress, 1);
+                printf("--- syncing %u/%u @ Thread: %" PRIu32 " ---\n", current_progress, nth,
+                  td->threadnum);
+                if (current_progress == nth) {
                     thrd_sync_conds.tmr_ready_to_go = true;
                     __wt_cond_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_tmr_thrd);
                 }

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -862,11 +862,11 @@ rollback:
             WT_RELEASE_WRITE_WITH_BARRIER(active_timestamps[td->threadnum], active_ts);
         } else {
             uint32_t current_progress = __wt_atomic_add32(&thread_sync_conds.workload_progress, 1);
-            /* In use_ts == false mode, thread sync is no more required for checkpoint creation.
-               Only first thread notify the checkpoint thread to start */
+            /* When timestamps are not in use, we don't need to sync all threads before starting the
+             * checkpoint thread. Use the first thread to notify the checkpoint thread to start. */
             if (current_progress == 1) {
                 printf(
-                  "Thread %" PRIu32 " reach syncing point, Trigger checkpoint. \n", td->threadnum);
+                  "Thread %" PRIu32 " reach syncing point, trigger checkpoint.\n", td->threadnum);
                 thread_sync_conds.ckpt_ready_to_go = true;
                 __wt_cond_signal((WT_SESSION_IMPL *)session, thread_sync_conds.ckpt_cond);
             }

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -352,7 +352,7 @@ thread_ts_run(void *arg)
      * work with. */
     while (!thread_sync_conds.timer_ready_to_go) {
         bool cv_signalled;
-        /* Wait maximum 1s each round */
+        /* Under a high workload, there is no need to check very often, check every second. */
         __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thread_sync_conds.timer_cond, WT_MILLION,
           NULL, &cv_signalled);
     }
@@ -493,11 +493,14 @@ thread_ckpt_run(void *arg)
      */
     (void)unlink(ckpt_file);
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
-    /* Wait for the stable timestamp is configured as there will make the last_checkpoint timestamp
-     * not 0 */
+    /* 
+     * Wait for the stable timestamp to be configured before starting the checkpoint thread. If
+     * there is no stable timestamp, we won't create the sentinel file and we will have to
+     * checkpoint again which will delay the test.
+     */
     while (!thread_sync_conds.ckpt_ready_to_go) {
         bool cv_signalled;
-        /* Wait maximum 1s each round */
+        /* Under a high workload, there is no need to check very often, check every second. */
         __wt_cond_wait_signal(
           (WT_SESSION_IMPL *)session, thread_sync_conds.ckpt_cond, WT_MILLION, NULL, &cv_signalled);
     }
@@ -848,6 +851,7 @@ rollback:
                 printf("--- syncing %u/%u @ Thread: %" PRIu32 " ---\n", current_progress, nth,
                   td->threadnum);
                 if (current_progress == nth) {
+                    /* All threads are done working and should have updated the active timestamps array with a non-zero timestamp. It's time for the timer thread to get started. */
                     thread_sync_conds.timer_ready_to_go = true;
                     __wt_cond_signal((WT_SESSION_IMPL *)session, thread_sync_conds.timer_cond);
                 }
@@ -972,7 +976,7 @@ run_workload(uint32_t workload_iteration)
     }
 
     opts->running = true;
-    /* Initialize cond machines */
+    /* Initialize cond variables. */
     opt_session = (WT_SESSION_IMPL *)opts->session;
     thread_sync_conds.timer_ready_to_go = false;
     testutil_check(__wt_cond_alloc(opt_session, "timer thread cv", &thread_sync_conds.timer_cond));

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -348,10 +348,8 @@ thread_ts_run(void *arg)
     td = (THREAD_DATA *)arg;
     conn = td->conn;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    /* While is to wait for all written thread reached the commit. */
-    /* Using while is to avoid spurious wakeups of conditional variables */
+    /* Wait for all working threads to complete as there will be a stable timestamp available to work with. */
     while (!thrd_sync_conds.tmr_ready_to_go) {
-        /* Actually we don't need this value */
         bool cv_signalled;
         /* Wait maximum 1s each round */
         __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_tmr_thrd, WT_MILLION,

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -111,7 +111,7 @@ static struct {
     WT_CONDVAR *timer_cond;
     bool ckpt_ready_to_go;
     WT_CONDVAR *ckpt_cond;
-} thread_sync_conds = {false, NULL, false, NULL};
+} thread_sync_conds = {0, false, NULL, false, NULL};
 
 /*
  * Print that we are doing backup verification.
@@ -865,8 +865,8 @@ rollback:
             /* In use_ts == false mode, thread sync is no more required for checkpoint creation.
                Only first thread notify the checkpoint thread to start */
             if (current_progress == 1) {
-                printf("Thread %" PRIu32 " reach syncing point, Trigger checkpoint. \n",
-                  td->threadnum, current_progress, nth);
+                printf(
+                  "Thread %" PRIu32 " reach syncing point, Trigger checkpoint. \n", td->threadnum);
                 thread_sync_conds.ckpt_ready_to_go = true;
                 __wt_cond_signal((WT_SESSION_IMPL *)session, thread_sync_conds.ckpt_cond);
             }

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -105,6 +105,13 @@ static int recover_and_verify(uint32_t backup_index, uint32_t workload_iteration
 extern int __wt_optind;
 extern char *__wt_optarg;
 
+static struct {
+    bool tmr_ready_to_go;
+    WT_CONDVAR *cond_tmr_thrd;
+    bool ckpt_ready_to_go;
+    WT_CONDVAR *cond_ckpt_thrd;
+} thrd_sync_conds = {false, NULL, false, NULL};
+
 /*
  * Print that we are doing backup verification.
  */
@@ -340,9 +347,17 @@ thread_ts_run(void *arg)
 
     td = (THREAD_DATA *)arg;
     conn = td->conn;
-
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-
+    /* While is to wait for all written thread reached the commit. */
+    /* Using while is to avoid spurious wakeups of conditional variables */
+    while (!thrd_sync_conds.tmr_ready_to_go) {
+        /* Actually we don't need this value */
+        bool cv_signalled;
+        /* Wait maximum 1s each round */
+        __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_tmr_thrd, WT_MILLION,
+          NULL, &cv_signalled);
+    }
+    printf("Timestamp thread started...\n");
     __wt_seconds((WT_SESSION_IMPL *)session, &last_reconfig);
     /* Update the oldest/stable timestamps every 1 millisecond. */
     for (last_ts = 0;; __wt_sleep(0, WT_THOUSAND)) {
@@ -361,7 +376,8 @@ thread_ts_run(void *arg)
             testutil_snprintf(tscfg, sizeof(tscfg),
               "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64, ts, ts);
         testutil_check(conn->set_timestamp(conn, tscfg));
-
+        thrd_sync_conds.ckpt_ready_to_go = true;
+        __wt_cond_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_ckpt_thrd);
         /*
          * Only perform the reconfigure test after statistics have a chance to run. If we do it too
          * frequently then internal servers like the statistics server get destroyed and restarted
@@ -478,6 +494,15 @@ thread_ckpt_run(void *arg)
      */
     (void)unlink(ckpt_file);
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
+    /* While is to wait for stable_timestamp is configured. */
+    /* Using while is to avoid spurious wakeups of conditional variables. */
+    while (!thrd_sync_conds.ckpt_ready_to_go) {
+        bool cv_signalled;
+        /* Wait maximum 1s each round */
+        __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_ckpt_thrd,
+          WT_MILLION, NULL, &cv_signalled);
+    }
+    printf("Checkpoint thread started...\n");
     first_ckpt = true;
     for (i = 1;; ++i) {
         sleep_time = __wt_random(&td->extra_rnd) % MAX_CKPT_INVL;
@@ -817,8 +842,19 @@ rollback:
         }
 
         /* We're done with the timestamps, allow oldest and stable to move forward. */
-        if (use_ts)
+        if (use_ts) {
+            static uint32_t progress = 0;
+            if (WT_TS_NONE == active_timestamps[td->threadnum]) {
+                progress++;
+                printf(
+                  "---syncing %u/%u @ Thread: %" PRIu32 " ---\n", progress, nth, td->threadnum);
+                if (progress == nth) {
+                    thrd_sync_conds.tmr_ready_to_go = true;
+                    __wt_cond_signal((WT_SESSION_IMPL *)session, thrd_sync_conds.cond_tmr_thrd);
+                }
+            }
             WT_RELEASE_WRITE_WITH_BARRIER(active_timestamps[td->threadnum], active_ts);
+        }
     }
     /* NOTREACHED */
 }
@@ -851,6 +887,7 @@ run_workload(uint32_t workload_iteration)
 {
     WT_CONNECTION *conn;
     WT_SESSION *session;
+    WT_SESSION_IMPL *opt_session;
     THREAD_DATA *td;
     wt_thread_t *thr;
     uint32_t backup_id, cache_mb, ckpt_id, i, ts_id;
@@ -936,7 +973,12 @@ run_workload(uint32_t workload_iteration)
     }
 
     opts->running = true;
-
+    /* Initialize cond machines */
+    opt_session = (WT_SESSION_IMPL *)opts->session;
+    thrd_sync_conds.tmr_ready_to_go = false;
+    testutil_check(__wt_cond_alloc(opt_session, "timer thread cv", &thrd_sync_conds.cond_tmr_thrd));
+    thrd_sync_conds.ckpt_ready_to_go = false;
+    testutil_check(__wt_cond_alloc(opt_session, "ckpt thread cv", &thrd_sync_conds.cond_ckpt_thrd));
     /* The backup, checkpoint, timestamp, and worker threads are added at the end. */
     backup_id = nth;
     if (use_backups) {
@@ -985,6 +1027,9 @@ run_workload(uint32_t workload_iteration)
     fflush(stdout);
     for (i = 0; i <= ts_id; ++i)
         testutil_check(__wt_thread_join(NULL, &thr[i]));
+
+    __wt_cond_destroy(opt_session, &thrd_sync_conds.cond_tmr_thrd);
+    __wt_cond_destroy(opt_session, &thrd_sync_conds.cond_ckpt_thrd);
 
     /*
      * NOTREACHED

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -348,10 +348,9 @@ thread_ts_run(void *arg)
     td = (THREAD_DATA *)arg;
     conn = td->conn;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    /* While is to wait for all written thread reached the commit. */
-    /* Using while is to avoid spurious wakeups of conditional variables */
+    /* Wait for all working threads to complete as there will be a stable timestamp available to
+     * work with. */
     while (!thread_sync_conds.timer_ready_to_go) {
-        /* Actually we don't need this value */
         bool cv_signalled;
         /* Wait maximum 1s each round */
         __wt_cond_wait_signal((WT_SESSION_IMPL *)session, thread_sync_conds.timer_cond, WT_MILLION,
@@ -494,8 +493,8 @@ thread_ckpt_run(void *arg)
      */
     (void)unlink(ckpt_file);
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
-    /* While is to wait for stable_timestamp is configured. */
-    /* Using while is to avoid spurious wakeups of conditional variables. */
+    /* Wait for the stable timestamp is configured as there will make the last_checkpoint timestamp
+     * not 0 */
     while (!thread_sync_conds.ckpt_ready_to_go) {
         bool cv_signalled;
         /* Wait maximum 1s each round */

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -106,6 +106,7 @@ extern int __wt_optind;
 extern char *__wt_optarg;
 
 static struct {
+    uint32_t workload_progress;
     bool timer_ready_to_go;
     WT_CONDVAR *timer_cond;
     bool ckpt_ready_to_go;
@@ -348,8 +349,8 @@ thread_ts_run(void *arg)
     td = (THREAD_DATA *)arg;
     conn = td->conn;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
-    /* Wait for all working threads to complete as there will be a stable timestamp available to
-     * work with. */
+    /* Wait for all working threads to complete as there will be a
+     * stable timestamp available to work with. */
     while (!thread_sync_conds.timer_ready_to_go) {
         bool cv_signalled;
         /* Under a high workload, there is no need to check very often, check every second. */
@@ -493,7 +494,7 @@ thread_ckpt_run(void *arg)
      */
     (void)unlink(ckpt_file);
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
-    /* 
+    /*
      * Wait for the stable timestamp to be configured before starting the checkpoint thread. If
      * there is no stable timestamp, we won't create the sentinel file and we will have to
      * checkpoint again which will delay the test.
@@ -845,18 +846,30 @@ rollback:
 
         /* We're done with the timestamps, allow oldest and stable to move forward. */
         if (use_ts) {
-            static uint32_t progress = 0;
             if (WT_TS_NONE == active_timestamps[td->threadnum]) {
-                uint32_t current_progress = __wt_atomic_add32(&progress, 1);
-                printf("--- syncing %u/%u @ Thread: %" PRIu32 " ---\n", current_progress, nth,
-                  td->threadnum);
+                uint32_t current_progress =
+                  __wt_atomic_add32(&thread_sync_conds.workload_progress, 1);
+                printf("Thread %" PRIu32 " reach syncing point, overall progress: %u/%u. \n",
+                  td->threadnum, current_progress, nth);
                 if (current_progress == nth) {
-                    /* All threads are done working and should have updated the active timestamps array with a non-zero timestamp. It's time for the timer thread to get started. */
+                    /* All threads are done working and should have updated the active timestamps
+                     * array with a non-zero timestamp. It's time for the timer thread to get
+                     * started. */
                     thread_sync_conds.timer_ready_to_go = true;
                     __wt_cond_signal((WT_SESSION_IMPL *)session, thread_sync_conds.timer_cond);
                 }
             }
             WT_RELEASE_WRITE_WITH_BARRIER(active_timestamps[td->threadnum], active_ts);
+        } else {
+            uint32_t current_progress = __wt_atomic_add32(&thread_sync_conds.workload_progress, 1);
+            /* In use_ts == false mode, thread sync is no more required for checkpoint creation.
+               Only first thread notify the checkpoint thread to start */
+            if (current_progress == 1) {
+                printf("Thread %" PRIu32 " reach syncing point, Trigger checkpoint. \n",
+                  td->threadnum, current_progress, nth);
+                thread_sync_conds.ckpt_ready_to_go = true;
+                __wt_cond_signal((WT_SESSION_IMPL *)session, thread_sync_conds.ckpt_cond);
+            }
         }
     }
     /* NOTREACHED */
@@ -978,6 +991,7 @@ run_workload(uint32_t workload_iteration)
     opts->running = true;
     /* Initialize cond variables. */
     opt_session = (WT_SESSION_IMPL *)opts->session;
+    thread_sync_conds.workload_progress = 0;
     thread_sync_conds.timer_ready_to_go = false;
     testutil_check(__wt_cond_alloc(opt_session, "timer thread cv", &thread_sync_conds.timer_cond));
     thread_sync_conds.ckpt_ready_to_go = false;


### PR DESCRIPTION
The changes introduce new conditional variables to the timestamp_abort test: they are needed to avoid the timeout issue faced. Without them, the checkpoint thread may run without the test being ready for it. Each checkpoint run can be slow due to the pressure on the system and lead to timeout issues. With the condition variables in place, the checkpoint thread only starts when the test is ready which greatly reduces the chances to reach the timeout limit.