### PR TITLE
WT-15259 Use uncommitted snapshot isolation for metadata reads

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -129,11 +129,15 @@ __wti_block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool 
     len = strlen("file:") + strlen(block_disagg->name) + 4;
     WT_ERR(__wt_calloc_def(session, len, &md_key));
 
-    /* Get a metadata cursor pointing to this table */
+    /*
+     * FIXME-WT-15416: Fix metadata cursors.
+     *
+     *  Get a metadata cursor pointing to this table
+     */
     WT_ERR(__wt_metadata_cursor(session, &md_cursor));
     WT_ERR(__wt_snprintf(md_key, len, "file:%s", block_disagg->name));
     md_cursor->set_key(md_cursor, md_key);
-    WT_ERR(md_cursor->search(md_cursor));
+    WT_ERR(__wt_metadata_cursor_search(session, md_cursor));
     WT_ERR(md_cursor->get_value(md_cursor, &md_value));
 
     /*

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -667,19 +667,23 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
     exact = 0;
     key = value = NULL;
 
-    /* Use a metadata cursor to have access to the existing URIs. */
+    /*
+     * FIXME-WT-15416: Fix metadata cursors
+     *
+     * Use a metadata cursor to have access to the existing URIs.
+     */
     WT_ERR(__wt_metadata_cursor(session, &cursor));
 
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
-    WT_ERR(cursor->search_near(cursor, &exact));
+    WT_ERR(__wt_metadata_cursor_search_near(session, cursor, &exact));
 
     /*
      * The given URI may not exist in the metadata file. Since we always want to return a URI that
      * is lexicographically larger the given one, make sure not to go backwards.
      */
     if (exact <= 0)
-        WT_ERR(cursor->next(cursor));
+        WT_ERR(__wt_metadata_cursor_next(session, cursor));
 
     /* Loop through the eligible candidates. */
     do {
@@ -695,7 +699,7 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
         /* Check the given uri needs checkpoint cleanup. */
         if (__checkpoint_cleanup_eligibility(session, key, value))
             break;
-    } while ((ret = cursor->next(cursor)) == 0);
+    } while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0);
     WT_ERR(ret);
 
     /* Save the selected uri. */

--- a/src/conn/conn_chunkcache.c
+++ b/src/conn/conn_chunkcache.c
@@ -38,9 +38,10 @@ __chunkcache_get_metadata_config(WT_SESSION_IMPL *session, char **config)
 
     *config = NULL;
 
+    /* FIXME-WT-15416: Fix metadata cursors */
     WT_RET(__wt_metadata_cursor(session, &cursor));
     cursor->set_key(cursor, WT_CC_METAFILE_URI);
-    WT_ERR(cursor->search(cursor));
+    WT_ERR(__wt_metadata_cursor_search(session, cursor));
 
     WT_ERR(cursor->get_value(cursor, &tmp));
     WT_ERR(__wt_strdup(session, tmp, config));

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -465,19 +465,23 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
     key = NULL;
     value = NULL;
 
-    /* Use a metadata cursor to have access to the existing URIs. */
+    /*
+     * FIXME-WT-15416: Fix metadata cursors
+     *
+     * Use a metadata cursor to have access to the existing URIs.
+     */
     WT_ERR(__wt_metadata_cursor(session, &cursor));
 
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
-    WT_ERR(cursor->search_near(cursor, &exact));
+    WT_ERR(__wt_metadata_cursor_search_near(session, cursor, &exact));
 
     /*
      * The given URI may not exist in the metadata file. Since we always want to return a URI that
      * is lexicographically larger the given one, make sure not to go backwards.
      */
     if (exact <= 0)
-        WT_ERR(cursor->next(cursor));
+        WT_ERR(__wt_metadata_cursor_next(session, cursor));
 
     /* Loop through the eligible candidates. */
     do {
@@ -501,7 +505,7 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
             if (!skip)
                 break;
         }
-    } while ((ret = cursor->next(cursor)) == 0);
+    } while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0);
     WT_ERR(ret);
 
     /* Save the selected uri. */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -131,12 +131,13 @@ __layered_create_missing_stable_tables(WT_SESSION_IMPL *session)
     stable_uri = NULL;
 
     WT_ERR(__wt_open_internal_session(conn, "disagg-step-up", false, 0, 0, &internal_session));
+    /* FIXME-WT-15416: Fix metadata cursors */
     WT_ERR(__wt_metadata_cursor(internal_session, &cursor_check));
     WT_ERR(__wt_metadata_cursor(internal_session, &cursor_scan));
 
     cursor_scan->set_key(cursor_scan, "layered:");
     WT_ERR(cursor_scan->bound(cursor_scan, "bound=lower"));
-    while ((ret = cursor_scan->next(cursor_scan)) == 0) {
+    while ((ret = __wt_metadata_cursor_next(session, cursor_scan)) == 0) {
         WT_ERR(cursor_scan->get_key(cursor_scan, &layered_uri));
         WT_ERR(cursor_scan->get_value(cursor_scan, &layered_cfg));
         if (!WT_PREFIX_MATCH(layered_uri, "layered:"))
@@ -148,7 +149,7 @@ __layered_create_missing_stable_tables(WT_SESSION_IMPL *session)
 
         /* Check if the URI exists. */
         cursor_check->set_key(cursor_check, stable_uri);
-        WT_ERR_NOTFOUND_OK(cursor_check->search(cursor_check), true);
+        WT_ERR_NOTFOUND_OK(__wt_metadata_cursor_search(session, cursor_check), true);
 
         /* Create the stable table if it does not exist. */
         if (ret == WT_NOTFOUND) {
@@ -369,10 +370,14 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     /* We need an internal session when modifying metadata. */
     WT_ERR(__wt_open_internal_session(conn, "checkpoint-pick-up", false, 0, 0, &internal_session));
 
-    /* Open up a metadata cursor pointing at our table */
+    /*
+     * FIXME-WT-15416: Fix metadata cursors
+     *
+     * Open up a metadata cursor pointing at our table
+     */
     WT_ERR(__wt_metadata_cursor(internal_session, &md_cursor));
     md_cursor->set_key(md_cursor, metadata_key);
-    WT_ERR(md_cursor->search(md_cursor));
+    WT_ERR(__wt_metadata_cursor_search(session, md_cursor));
 
     /* Pull the value out. */
     WT_ERR(md_cursor->get_value(md_cursor, &current_value));
@@ -414,7 +419,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
         WT_ERR(cursor->get_value(cursor, &metadata_value));
 
         md_cursor->set_key(md_cursor, metadata_key);
-        WT_ERR_NOTFOUND_OK(md_cursor->search(md_cursor), true);
+        WT_ERR_NOTFOUND_OK(__wt_metadata_cursor_search(session, md_cursor), true);
 
         if (ret == 0 && WT_PREFIX_MATCH(metadata_key, "file:")) {
             /* Existing table: Just apply the new metadata. */
@@ -459,7 +464,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
                     memcpy(layered_ingest_uri, cval.str, cval.len);
                     layered_ingest_uri[cval.len] = '\0';
                     md_cursor->set_key(md_cursor, layered_ingest_uri);
-                    WT_ERR_NOTFOUND_OK(md_cursor->search(md_cursor), true);
+                    WT_ERR_NOTFOUND_OK(__wt_metadata_cursor_search(session, md_cursor), true);
                     if (ret == WT_NOTFOUND)
                         WT_ERR(__layered_create_missing_ingest_table(
                           internal_session, layered_ingest_uri, metadata_value));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -795,10 +795,16 @@ extern int __wt_metadata_cursor(WT_SESSION_IMPL *session, WT_CURSOR **cursorp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_cursor_close(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_metadata_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_cursor_open(WT_SESSION_IMPL *session, const char *config,
   WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_cursor_release(WT_SESSION_IMPL *session, WT_CURSOR **cursorp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_metadata_cursor_search(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_metadata_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor,
+  int *exactp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_metadata_get_ckptlist(WT_SESSION *session, const char *name, WT_CKPT **ckptbasep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -332,7 +332,7 @@ __live_restore_init_work_queue(WT_SESSION_IMPL *session)
     WT_CURSOR *cursor;
     WT_RET(__wt_metadata_cursor(session, &cursor));
     uint64_t work_count = 0;
-    while ((ret = cursor->next(cursor)) == 0) {
+    while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0) {
         char *uri = NULL;
         WT_ERR(cursor->get_key(cursor, &uri));
         if (WT_PREFIX_MATCH(uri, "file:"))

--- a/src/live_restore/live_restore_server.c
+++ b/src/live_restore/live_restore_server.c
@@ -329,6 +329,7 @@ __live_restore_init_work_queue(WT_SESSION_IMPL *session)
     __wt_verbose_debug1(
       session, WT_VERB_LIVE_RESTORE, "%s", "Live restore server: Initializing the work queue");
 
+    /* FIXME-WT-15416: Fix metadata cursors */
     WT_CURSOR *cursor;
     WT_RET(__wt_metadata_cursor(session, &cursor));
     uint64_t work_count = 0;

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1115,6 +1115,7 @@ __wt_meta_correct_base_write_gen(WT_SESSION_IMPL *session)
     char *config, *uri;
 
     uri = NULL;
+    /* FIXME-WT-15416: Fix metadata cursors */
     WT_RET(__wt_metadata_cursor(session, &cursor));
     while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &uri));

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1116,7 +1116,7 @@ __wt_meta_correct_base_write_gen(WT_SESSION_IMPL *session)
 
     uri = NULL;
     WT_RET(__wt_metadata_cursor(session, &cursor));
-    while ((ret = cursor->next(cursor)) == 0) {
+    while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &uri));
 
         if (!WT_BTREE_PREFIX(uri))

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -352,6 +352,85 @@ err:
 }
 
 /*
+ * __wt_metadata_cursor_search --
+ *     Call cursor search on the metadata using read uncommitted isolation.
+ *
+ * FIXME-WT-15416: Fix metadata cursors This can be removed once the metadata cursor methods work
+ *     correctly.
+ */
+int
+__wt_metadata_cursor_search(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+{
+    WT_DECL_RET;
+
+    WT_ASSERT(session, cursor != NULL);
+
+    /*
+     * All metadata reads are at read-uncommitted isolation. That's because once a schema-level
+     * operation completes, subsequent operations must see the current version of checkpoint
+     * metadata, or they may try to read blocks that may have been freed from a file. Metadata
+     * updates use non-transactional techniques (such as the schema and metadata locks) to protect
+     * access to in-flight updates.
+     */
+    WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search(cursor));
+
+    return (ret);
+}
+
+/*
+ * __wt_metadata_cursor_search_near --
+ *     Call cursor search on the metadata using read uncommitted isolation.
+ *
+ * FIXME-WT-15416: Fix metadata cursors This can be removed once the metadata cursor methods work
+ *     correctly.
+ */
+int
+__wt_metadata_cursor_search_near(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exactp)
+{
+    WT_DECL_RET;
+
+    WT_ASSERT(session, cursor != NULL);
+
+    /*
+     * All metadata reads are at read-uncommitted isolation. That's because once a schema-level
+     * operation completes, subsequent operations must see the current version of checkpoint
+     * metadata, or they may try to read blocks that may have been freed from a file. Metadata
+     * updates use non-transactional techniques (such as the schema and metadata locks) to protect
+     * access to in-flight updates.
+     */
+    WT_WITH_TXN_ISOLATION(
+      session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, exactp));
+
+    return (ret);
+}
+
+/*
+ * __wt_metadata_cursor_next --
+ *     Call cursor next on the metadata using read uncommitted isolation.
+ *
+ * FIXME-WT-15416: Fix metadata cursors This can be removed once the metadata cursor methods work
+ *     correctly.
+ */
+int
+__wt_metadata_cursor_next(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
+{
+    WT_DECL_RET;
+
+    WT_ASSERT(session, cursor != NULL);
+
+    /*
+     * All metadata reads are at read-uncommitted isolation. That's because once a schema-level
+     * operation completes, subsequent operations must see the current version of checkpoint
+     * metadata, or they may try to read blocks that may have been freed from a file. Metadata
+     * updates use non-transactional techniques (such as the schema and metadata locks) to protect
+     * access to in-flight updates.
+     */
+    WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+
+    return (ret);
+}
+
+/*
  * __wt_metadata_btree_id_to_uri --
  *     Given a btree id, find the matching entry in the metadata and return a copy of the uri. The
  *     caller has to free the returned uri.

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -284,6 +284,8 @@ __metadata_load_bulk(WT_SESSION_IMPL *session)
     bool exist;
 
     /*
+     * FIXME-WT-15416: Fix metadata cursors
+     *
      * If a file was being bulk-loaded during the hot backup, it will appear in the metadata file,
      * but the file won't exist. Create on demand.
      */

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -288,7 +288,7 @@ __metadata_load_bulk(WT_SESSION_IMPL *session)
      * but the file won't exist. Create on demand.
      */
     WT_RET(__wt_metadata_cursor(session, &cursor));
-    while ((ret = cursor->next(cursor)) == 0) {
+    while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &key));
         if (!WT_PREFIX_SKIP(key, "file:"))
             continue;

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -402,6 +402,8 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
     bool has_prepare;
 
     /*
+     * FIXME-WT-15416: Fix metadata cursors
+     *
      * TODO: how careful does this need to be about concurrent schema operations? If this step needs
      * to be exclusive in some way it should probably accumulate a set of relevant handles before
      * releasing that access and doing the processing after generating the list.

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -408,7 +408,7 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
      */
     WT_RET(__wt_metadata_cursor(session, &cursor));
 
-    while ((ret = cursor->next(cursor)) == 0) {
+    while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &uri));
         /* Only interested in btree handles that aren't the metadata */
         if (!WT_BTREE_PREFIX(uri) || strcmp(uri, WT_METAFILE_URI) == 0)

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -184,6 +184,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     rts_threads_started = false;
 
     /*
+     * FIXME-WT-15416: Fix metadata cursors
+     *
      * Walk the metadata first to count how many files we have overall. That allows us to give
      * signal about progress.
      */

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -189,7 +189,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      */
     WT_RET(__wt_metadata_cursor(session, &cursor));
     have_cursor = true;
-    while ((ret = cursor->next(cursor)) == 0) {
+    while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &uri));
         if (WT_BTREE_PREFIX(uri))
             ++max_count;
@@ -203,7 +203,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
 
     WT_ERR(__wt_metadata_cursor(session, &cursor));
     have_cursor = true;
-    while ((ret = cursor->next(cursor)) == 0) {
+    while ((ret = __wt_metadata_cursor_next(session, cursor)) == 0) {
         /* Log a progress message. */
         WT_ERR(cursor->get_key(cursor, &uri));
         WT_ERR(cursor->get_value(cursor, &config));

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -258,9 +258,9 @@ __schema_open_index(
     /* Find matching indices. */
     WT_ERR(__wt_metadata_cursor(session, &cursor));
     cursor->set_key(cursor, tmp->data);
-    if ((ret = cursor->search_near(cursor, &cmp)) == 0 && cmp < 0)
-        ret = cursor->next(cursor);
-    for (i = 0; ret == 0; i++, ret = cursor->next(cursor)) {
+    if ((ret = __wt_metadata_cursor_search_near(session, cursor, &cmp)) == 0 && cmp < 0)
+        ret = __wt_metadata_cursor_next(session, cursor);
+    for (i = 0; ret == 0; i++, ret = __wt_metadata_cursor_next(session, cursor)) {
         WT_ERR(cursor->get_key(cursor, &uri));
         name = uri;
 

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -255,7 +255,11 @@ __schema_open_index(
     WT_ERR(__wt_scr_alloc(session, 512, &tmp));
     WT_ERR(__wt_buf_fmt(session, tmp, "index:%s:", tablename));
 
-    /* Find matching indices. */
+    /*
+     * FIXME-WT-15416: Fix metadata cursors
+     *
+     * Find matching indices.
+     */
     WT_ERR(__wt_metadata_cursor(session, &cursor));
     cursor->set_key(cursor, tmp->data);
     if ((ret = __wt_metadata_cursor_search_near(session, cursor, &cmp)) == 0 && cmp < 0)


### PR DESCRIPTION
This adds wrapper functions to use uncommitted snapshot isolation for metadata cursor read operations. These are intended to be temporary and should be fixed when metadata cursors are fixed in WT-15416.