### PR TITLE
WT-14984 Fix copy_wiredtiger_home for disagg tests

### DIFF
--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -114,8 +114,10 @@ def copy_wiredtiger_home(testcase, olddir, newdir, aligned=True):
         raise AssertionError(
             'copy_wiredtiger_home: unaligned copy impossible on Windows')
     shutil.rmtree(newdir, ignore_errors=True)
+    # Get the list of files first to avoid recursion.
+    files = list(os.listdir(olddir))
     os.mkdir(newdir)
-    for fname in os.listdir(olddir):
+    for fname in files:
         fullname = os.path.join(olddir, fname)
         # Skip lock file, on Windows it is locked.
         # Skip temporary log files.
@@ -144,6 +146,8 @@ def copy_wiredtiger_home(testcase, olddir, newdir, aligned=True):
                 cmd_list = ['dd', inpf, outf, 'bs=300']
                 a = subprocess.Popen(cmd_list)
                 a.wait()
+        elif os.path.isdir(fullname):
+            shutil.copytree(fullname, os.path.join(newdir, fname))
 
 # Simulate a crash from olddir and restart in newdir.
 def simulate_crash_restart(testcase, olddir, newdir):

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -227,9 +227,9 @@ def session_create_replace(orig_session_create, session_self, uri, config):
             uri = replace_uri(uri)
             WiredTigerTestCase.verbose(None, 1, f'    Replacing, new uri = "{uri}"')
         else:
-            WiredTigerTestCase.verbose(None, 1, f'    Replacing, old config = "\{config}"')
+            WiredTigerTestCase.verbose(None, 1, f'    Replacing, old config = "{config}"')
             config += ',block_manager=disagg,type=layered'
-            WiredTigerTestCase.verbose(None, 1, f'    Replacing, new config = "\{config}"')
+            WiredTigerTestCase.verbose(None, 1, f'    Replacing, new config = "{config}"')
 
     # If this is an index create and the main table was already tagged to be layered,
     # there's nothing we can do to "fix" it.  Currently "index:foo" is hardwired to

--- a/test/suite/test_checkpoint_snapshot01.py
+++ b/test/suite/test_checkpoint_snapshot01.py
@@ -90,10 +90,6 @@ class test_checkpoint_snapshot01(wttest.WiredTigerTestCase):
         #Simulate a crash by copying to a new directory(RESTART).
         copy_wiredtiger_home(self, ".", "RESTART")
 
-        # FIXME-WT-14984  Works up to this point, then fails.
-        if self.runningHook('disagg'):
-            self.skipTest('After simulated crash restart, a page cannot be found from DS')
-
         # Open the new directory.
         self.conn = self.setUpConnectionOpen("RESTART")
         self.session = self.setUpSessionOpen(self.conn)

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -130,9 +130,6 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
     def perform_backup_or_crash_restart(self, fromdir, todir):
         if self.restart == True:
             #Simulate a crash by copying to a new directory(RESTART).
-            # FIXME-WT-14944  Works up to this point, then fails.
-            if self.runningHook('disagg'):
-                self.skipTest('After simulated crash restart, the URI is not found')
             simulate_crash_restart(self, fromdir, todir)
         else:
             #Take a backup and restore it.
@@ -180,10 +177,6 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             ckpt.join()
 
         self.perform_backup_or_crash_restart(".", self.backup_dir)
-
-        # FIXME-WT-14944  Works up to this point, then fails.
-        if self.runningHook('disagg'):
-            self.skipTest('After simulated crash restart, the URI is not found')
 
         # Check the table contains the last checkpointed value.
         self.check(self.valuea, self.uri, self.nrows, 0, True)

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -136,7 +136,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         if not self.runningHook('disagg'):
             self.assertEqual(count, targetCount)
         else:
-            # If Disag, it's ok to get the double coount since transaction could make it through.
+            # If Disag, it's ok to get the double count since transaction could make it through.
             # TODO: Make sure it's ok as part of FIXME-WT-15429.
             self.assertTrue(count == targetCount or count == targetCount * 2)
 

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -59,7 +59,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(format_values, restart_values)
 
     def conn_config(self):
-        config = 'cache_size=10MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=true),timing_stress_for_test=[checkpoint_slow]'
+        config = 'cache_size=10MB,statistics=(all),statistics_log=(json,on_close,wait=1),log=(enabled=false),timing_stress_for_test=[checkpoint_slow]'
         return config
 
     def moresetup(self):
@@ -118,14 +118,27 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         cursor = session.open_cursor(uri)
         count = 0
+        last_key = 0
         for k, v in cursor:
+            if k - last_key > 1:
+                print(f"Gap in keys: {last_key} to {k}")
+            elif k < last_key:
+                print(f"Keys out of order: {last_key} to {k}")
+            last_key = k
             if flcs_tolerance and count >= nrows:
                 self.assertEqual(v, 0)
             else:
                 self.assertEqual(v, check_value)
             count += 1
         session.commit_transaction()
-        self.assertEqual(count, nrows * 2 if flcs_tolerance else nrows)
+        targetCount = nrows * 2 if flcs_tolerance else nrows
+        if count != targetCount and count != 2*targetCount: print(f"Counted {count} out of {nrows} rows. Last key: {k}.")
+        if not self.runningHook('disagg'):
+            self.assertEqual(count, targetCount)
+        else:
+            # If Disag, it's ok to get the double coount since transaction could make it through.
+            # TODO: Make sure it's ok as part of FIXME-WT-15429.
+            self.assertTrue(count == targetCount or count == targetCount * 2)
 
     def perform_backup_or_crash_restart(self, fromdir, todir):
         if self.restart == True:
@@ -136,6 +149,29 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             self.take_full_backup(fromdir, todir)
             self.reopen_conn(todir)
 
+    def ckpt_snapshot(self, sessionX):
+        # Create a checkpoint thread
+        done = threading.Event()
+        ckpt = checkpoint_thread(self.conn, done)
+        try:
+            ckpt.start()
+
+            # Wait for checkpoint to start and acquire its snapshot before committing.
+            ckpt_snapshot = 0
+            while not ckpt_snapshot:
+                stat_cursor = self.session.open_cursor('statistics:', None, None)
+                ckpt_snapshot = stat_cursor[stat.conn.checkpoint_snapshot_acquired][2]
+                stat_cursor.close()
+                time.sleep(1)
+
+            sessionX.commit_transaction()
+
+        finally:
+            done.set()
+            ckpt.join()
+
+
+    @wttest.skip_for_hook("disagg", "Fails in Disagg with error: Gap in keys. FIXME-WT-15429.")
     def test_checkpoint_snapshot(self):
         self.moresetup()
 
@@ -156,25 +192,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             cursor1.set_value(self.valuea)
             self.assertEqual(cursor1.insert(), 0)
 
-        # Create a checkpoint thread
-        done = threading.Event()
-        ckpt = checkpoint_thread(self.conn, done)
-        try:
-            ckpt.start()
-
-            # Wait for checkpoint to start and acquire its snapshot before committing.
-            ckpt_snapshot = 0
-            while not ckpt_snapshot:
-                time.sleep(1)
-                stat_cursor = self.session.open_cursor('statistics:', None, None)
-                ckpt_snapshot = stat_cursor[stat.conn.checkpoint_snapshot_acquired][2]
-                stat_cursor.close()
-
-            session1.commit_transaction()
-
-        finally:
-            done.set()
-            ckpt.join()
+        self.ckpt_snapshot(session1)
 
         self.perform_backup_or_crash_restart(".", self.backup_dir)
 
@@ -186,9 +204,11 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
         stat_cursor.close()
 
-        self.assertGreater(inconsistent_ckpt, 0)
         self.assertGreaterEqual(keys_removed, 0)
+        if not self.runningHook('disagg'):
+            self.assertGreater(inconsistent_ckpt, 0)
 
+    @wttest.skip_for_hook("disagg", "Fails in Disagg with error: Gap in keys. FIXME-WT-15429.")
     def test_checkpoint_snapshot_with_timestamp(self):
         self.moresetup()
 
@@ -217,25 +237,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         # Set stable timestamp to 25
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
 
-        # Create a checkpoint thread
-        done = threading.Event()
-        ckpt = checkpoint_thread(self.conn, done)
-        try:
-            ckpt.start()
-
-            # Wait for checkpoint to start and acquire its snapshot before committing.
-            ckpt_snapshot = 0
-            while not ckpt_snapshot:
-                time.sleep(1)
-                stat_cursor = self.session.open_cursor('statistics:', None, None)
-                ckpt_snapshot = stat_cursor[stat.conn.checkpoint_snapshot_acquired][2]
-                stat_cursor.close()
-
-            session1.commit_transaction()
-
-        finally:
-            done.set()
-            ckpt.join()
+        self.ckpt_snapshot(session1)
 
         self.perform_backup_or_crash_restart(".", self.backup_dir)
 
@@ -251,6 +253,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         self.assertGreaterEqual(keys_removed, 0)
 
     @wttest.skip_for_hook("tiered", "Fails with tiered storage")
+    @wttest.skip_for_hook("disagg", "Fails in Disagg with error: Gap in keys. FIXME-WT-15429.")
     def test_checkpoint_snapshot_with_txnid_and_timestamp(self):
         self.moresetup()
 
@@ -282,25 +285,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         # Set stable timestamp to 40
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40))
 
-        # Create a checkpoint thread
-        done = threading.Event()
-        ckpt = checkpoint_thread(self.conn, done)
-        try:
-            ckpt.start()
-
-            # Wait for checkpoint to start and acquire its snapshot before committing.
-            ckpt_snapshot = 0
-            while not ckpt_snapshot:
-                time.sleep(1)
-                stat_cursor = self.session.open_cursor('statistics:', None, None)
-                ckpt_snapshot = stat_cursor[stat.conn.checkpoint_snapshot_acquired][2]
-                stat_cursor.close()
-
-            session2.commit_transaction()
-
-        finally:
-            done.set()
-            ckpt.join()
+        self.ckpt_snapshot(session2)
 
         session1.rollback_transaction()
 
@@ -314,7 +299,8 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
         stat_cursor.close()
 
-        self.assertGreater(inconsistent_ckpt, 0)
+        if not self.runningHook('disagg'):
+            self.assertGreater(inconsistent_ckpt, 0)
         self.assertGreaterEqual(keys_removed, 0)
 
         self.perform_backup_or_crash_restart(self.backup_dir, self.backup_dir2)
@@ -327,5 +313,6 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
         stat_cursor.close()
 
-        self.assertGreaterEqual(inconsistent_ckpt, 0)
+        if not self.runningHook('disagg'):
+            self.assertGreaterEqual(inconsistent_ckpt, 0)
         self.assertEqual(keys_removed, 0)

--- a/test/suite/test_checkpoint_snapshot02.py
+++ b/test/suite/test_checkpoint_snapshot02.py
@@ -159,10 +159,10 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
             # Wait for checkpoint to start and acquire its snapshot before committing.
             ckpt_snapshot = 0
             while not ckpt_snapshot:
+                time.sleep(1)
                 stat_cursor = self.session.open_cursor('statistics:', None, None)
                 ckpt_snapshot = stat_cursor[stat.conn.checkpoint_snapshot_acquired][2]
                 stat_cursor.close()
-                time.sleep(1)
 
             sessionX.commit_transaction()
 
@@ -205,7 +205,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         stat_cursor.close()
 
         self.assertGreaterEqual(keys_removed, 0)
-        if not self.runningHook('disagg'):
+        if not self.runningHook('disagg'): # Disagg doesn't have inconsistent checkpoints or RTS.
             self.assertGreater(inconsistent_ckpt, 0)
 
     @wttest.skip_for_hook("disagg", "Fails in Disagg with error: Gap in keys. FIXME-WT-15429.")
@@ -299,7 +299,7 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
         stat_cursor.close()
 
-        if not self.runningHook('disagg'):
+        if not self.runningHook('disagg'): # Disagg doesn't have inconsistent checkpoints or RTS.
             self.assertGreater(inconsistent_ckpt, 0)
         self.assertGreaterEqual(keys_removed, 0)
 
@@ -313,6 +313,6 @@ class test_checkpoint_snapshot02(wttest.WiredTigerTestCase):
         keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
         stat_cursor.close()
 
-        if not self.runningHook('disagg'):
+        if not self.runningHook('disagg'): # Disagg doesn't have inconsistent checkpoints or RTS.
             self.assertGreaterEqual(inconsistent_ckpt, 0)
         self.assertEqual(keys_removed, 0)

--- a/test/suite/test_checkpoint_snapshot03.py
+++ b/test/suite/test_checkpoint_snapshot03.py
@@ -87,10 +87,6 @@ class test_checkpoint_snapshot03(wttest.WiredTigerTestCase):
         self.assertEqual(count, nrows + 1 if flcs_tolerance else nrows)
 
     def test_checkpoint_snapshot(self):
-        # FIXME-WT-14986
-        if self.runningHook('disagg') and self.key_format == 'S':
-            self.skipTest('crashes with checkpoint_id assertion')
-
         ds = SimpleDataSet(self, self.uri, 0, \
                 key_format=self.key_format, value_format=self.value_format, \
                 config='leaf_page_max=4k')
@@ -144,9 +140,6 @@ class test_checkpoint_snapshot03(wttest.WiredTigerTestCase):
         session1.rollback_transaction()
 
         # Simulate a server crash and restart.
-        # FIXME-WT-14944  Works up to this point, then fails.
-        if self.runningHook('disagg'):
-            self.skipTest('After simulated crash restart, the URI is not found')
         simulate_crash_restart(self, ".", "RESTART")
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)

--- a/test/suite/test_checkpoint_snapshot03.py
+++ b/test/suite/test_checkpoint_snapshot03.py
@@ -150,8 +150,9 @@ class test_checkpoint_snapshot03(wttest.WiredTigerTestCase):
         upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]
         stat_cursor.close()
 
-        self.assertGreater(inconsistent_ckpt, 0)
         self.assertEqual(upd_aborted, 0)
         self.assertGreaterEqual(keys_removed, 0)
         self.assertEqual(keys_restored, 0)
-        self.assertGreater(pages_skipped, 0)
+        if not self.runningHook('disagg'):
+            self.assertGreater(inconsistent_ckpt, 0)
+            self.assertGreater(pages_skipped, 0)

--- a/test/suite/test_checkpoint_snapshot03.py
+++ b/test/suite/test_checkpoint_snapshot03.py
@@ -153,6 +153,6 @@ class test_checkpoint_snapshot03(wttest.WiredTigerTestCase):
         self.assertEqual(upd_aborted, 0)
         self.assertGreaterEqual(keys_removed, 0)
         self.assertEqual(keys_restored, 0)
-        if not self.runningHook('disagg'):
+        if not self.runningHook('disagg'): # Disagg doesn't have inconsistent checkpoints or RTS.
             self.assertGreater(inconsistent_ckpt, 0)
             self.assertGreater(pages_skipped, 0)


### PR DESCRIPTION
1. Fix issue:
    * Update `copy_wiredtiger_home` to also copy subdirectories.
2. Related changes:
    * Re-enable test fragments that were failing.
    * Fix other errors in tests that are no longer disabled.
    * Modify `test_checkpoint_snapshot02` not to use WAL.
    * Disable `test_checkpoint_snapshot02` for Disagg since it exposes an unrelated bug in Disagg checkpoints. Follow-up bug: WT-15429.