### PR TITLE
WT-15431 Fix the assert in __rec_update_save

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -48,7 +48,7 @@ __rec_update_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins, WT
         ++r->supd_onpage_or_restore;
         r->supd_memsize += upd_memsize;
     } else
-        WT_ASSERT(session, upd_memsize == 0);
+        WT_ASSERT(session, !F_ISSET(r, WT_REC_EVICT) || upd_memsize == 0);
     return (0);
 }
 


### PR DESCRIPTION
If we are not in eviction, it is possible we have a newer updates and we are not restoring the update chain. Therefore, the previous assert was wrong.