### PR TITLE
WT-15438 Do not preserve checkpoint_meta and last_materialized_lsn in the connection config

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -332,7 +332,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     WT_ITEM item;
     WT_SESSION_IMPL *internal_session, *shared_metadata_session;
     size_t len, metadata_value_cfg_len;
-    uint64_t checkpoint_timestamp;
+    uint64_t checkpoint_timestamp, current_meta_lsn;
     char *buf, *cfg_ret, *checkpoint_config, *root, *metadata_value_cfg, *layered_ingest_uri;
     const char *cfg[3], *current_value, *metadata_key, *metadata_value;
 
@@ -352,6 +352,14 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     WT_CLEAR(item);
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+
+    /* We should not pick up a checkpoint with an earlier LSN. */
+    WT_ACQUIRE_READ(current_meta_lsn, conn->disaggregated_storage.last_checkpoint_meta_lsn);
+    if (meta_lsn < current_meta_lsn)
+        WT_RET_MSG(session, EINVAL,
+          "Attempting to pick up an older checkpoint: current metadata LSN = %" PRIu64
+          ", new metadata LSN = %" PRIu64,
+          current_meta_lsn, meta_lsn);
 
     /*
      * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.
@@ -1044,8 +1052,9 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     if (reconfig) {
 
         /* Pick up a new checkpoint (followers only). */
-        WT_ERR(__wt_config_gets(session, cfg, "disaggregated.checkpoint_meta", &cval));
-        if (cval.len > 0) {
+        WT_ERR_NOTFOUND_OK(
+          __wt_config_gets(session, cfg, "disaggregated.checkpoint_meta", &cval), true);
+        if (ret == 0 && cval.len > 0) {
             /*
              * FIXME-WT-14733: currently the leader silently ignores the checkpoint_meta
              * configuration as it may have an obsolete configuration in its base config when it is
@@ -1058,13 +1067,16 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
                   (int)cval.len, cval.str);
             }
         }
+
+        ret = 0;
     }
 
     /* Common settings between initial connection config and reconfig. */
 
     /* Get the last materialized LSN. */
-    WT_ERR(__wt_config_gets(session, cfg, "disaggregated.last_materialized_lsn", &cval));
-    if (cval.len > 0 && cval.val >= 0)
+    WT_ERR_NOTFOUND_OK(
+      __wt_config_gets(session, cfg, "disaggregated.last_materialized_lsn", &cval), true);
+    if (ret == 0 && cval.len > 0 && cval.val >= 0)
         WT_ERR_MSG_CHK(session, __wti_disagg_set_last_materialized_lsn(session, (uint64_t)cval.val),
           "Failed to set the last materialized LSN to %" PRIu64, (uint64_t)cval.val);
 
@@ -1129,14 +1141,17 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
         WT_ERR(__disagg_metadata_table_init(session));
 
         /* Pick up the selected checkpoint. */
-        WT_ERR(__wt_config_gets(session, cfg, "disaggregated.checkpoint_meta", &cval));
-        if (cval.len > 0) {
+        WT_ERR_NOTFOUND_OK(
+          __wt_config_gets(session, cfg, "disaggregated.checkpoint_meta", &cval), true);
+        if (ret == 0 && cval.len > 0) {
             WT_WITH_CHECKPOINT_LOCK(
               session, ret = __disagg_pick_up_checkpoint_meta(session, &cval));
             WT_ERR_MSG_CHK(session, ret, "Failed to pick up a new checkpoint with config: %.*s",
               (int)cval.len, cval.str);
             picked_up = true;
         }
+
+        ret = 0;
 
         /* If we are starting as primary (e.g., for internal testing), begin the checkpoint. */
         if (leader && !picked_up) {

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1072,6 +1072,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     /* Common settings between initial connection config and reconfig. */
 
     /* Get the last materialized LSN. */
+    /* FIXME-WT-15447 Consider deprecating this. */
     WT_ERR_NOTFOUND_OK(
       __wt_config_gets(session, cfg, "disaggregated.last_materialized_lsn", &cval), true);
     if (ret == 0 && cval.len > 0 && cval.val >= 0)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -361,6 +361,8 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
           ", new metadata LSN = %" PRIu64,
           current_meta_lsn, meta_lsn);
 
+    /* FIXME-WT-15448 We might also want to add a check for picking up the same checkpoint again. */
+
     /*
      * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.
      */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1067,8 +1067,6 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
                   (int)cval.len, cval.str);
             }
         }
-
-        ret = 0;
     }
 
     /* Common settings between initial connection config and reconfig. */
@@ -1150,8 +1148,6 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
               (int)cval.len, cval.str);
             picked_up = true;
         }
-
-        ret = 0;
 
         /* If we are starting as primary (e.g., for internal testing), begin the checkpoint. */
         if (leader && !picked_up) {

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -496,8 +496,12 @@ __wti_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
     WT_ERR(__wt_rollback_to_stable_reconfig(session, cfg));
 
 done:
-    /* Third, merge everything together, creating a new connection state. */
-    WT_ERR(__wt_config_merge(session, cfg, NULL, &p));
+    /*
+     * Third, merge everything together, creating a new connection state. Exclude any configuration
+     * parameters that should not be preserved across calls to reconfigure.
+     */
+    WT_ERR(__wt_config_merge(
+      session, cfg, "disaggregated=(checkpoint_meta=,last_materialized_lsn=)", &p));
     __wt_free(session, conn->cfg);
     conn->cfg = p;
 

--- a/test/suite/test_layered39.py
+++ b/test/suite/test_layered39.py
@@ -107,3 +107,8 @@ class test_layered39(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN,
                                                last_lsn + 10)
         self.conn.reconfigure(f'disaggregated=(role=leader)')
+
+        # Ensure that the latest materialized LSN cannot go backwards.
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+            lambda: self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN,
+                                               last_lsn + 5))

--- a/test/suite/test_layered39.py
+++ b/test/suite/test_layered39.py
@@ -100,3 +100,10 @@ class test_layered39(wttest.WiredTigerTestCase, DisaggConfigMixin):
             self.get_stat(wiredtiger.stat.conn.checkpoint_pages_reconciled_bytes), self.nitems * 3 * 10)
         self.assertGreaterEqual(scrub_restore,
             self.get_stat(wiredtiger.stat.conn.cache_eviction_ahead_of_last_materialized_lsn))
+
+        # Now let's also ensure that reconfigure does not preserve the last_materialized_lsn
+        # across calls.
+        self.conn.reconfigure(f'disaggregated=(last_materialized_lsn={last_lsn})')
+        self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN,
+                                               last_lsn + 10)
+        self.conn.reconfigure(f'disaggregated=(role=leader)')


### PR DESCRIPTION
We should not preserve certain disaggregated config parameters in the connection config after `WT_CONNECTION::reconfigure` because:
* Preserving `checkpoint_meta` could cause an unrelated `reconfigure` call to pick up the same checkpoint again, which is at best wasteful. At the same time, we cannot ignore the direction to _not_ pick up a checkpoint if requested, as, for example, `test_layered38` depends on that behavior.
* Preserving `last_materialized_lsn` could cause problems, because there are ways to update it other than `reconfigure`.