### PR TITLE
WT-15433 In verify assert ingest on leader never returns EBUSY

### DIFF
--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -129,7 +129,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
             __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
 
         WT_ASSERT_ALWAYS(session, ingest_ret != EBUSY,
-          "Verify(layered): %s ingest table on leader cannot be verified. "
+          "Verify: %s ingest table on leader cannot be verified. "
           "Ingest contains dirty content or open cursors, which is an invalid "
           "state.",
           ingest_uri);

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -134,9 +134,9 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
           "state.",
           ingest_uri);
 
-        if (ingest_ret != 0)
-            WT_ERR_MSG(session, ingest_ret,
-              "Verify (layered): %s ingest table verification failed.", ingest_uri);
+        WT_ERR_MSG_CHK(session, ingest_ret,
+          "Verify (layered): %s ingest table verification failed. Ingest on leader must be empty.",
+          ingest_uri);
     }
 
 err:

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -128,15 +128,15 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
           ingest_ret =
             __wt_schema_worker(session, ingest_uri, file_func, name_func, cfg, open_flags));
 
-        /*
-         * FIXME-WT-15433 Add an assertion that verifying the ingest table of the leader never
-         * returns EBUSY.
-         */
+        WT_ASSERT_ALWAYS(session, ingest_ret != EBUSY,
+          "Verify(layered): %s ingest table on leader cannot be verified. "
+          "Ingest contains dirty content or open cursors, which is an invalid "
+          "state.",
+          ingest_uri);
+
         if (ingest_ret != 0)
             WT_ERR_MSG(session, ingest_ret,
-              "Verify (layered): %s ingest table verification failed. Ingest must always be empty "
-              "on leader.",
-              ingest_uri);
+              "Verify (layered): %s ingest table verification failed.", ingest_uri);
     }
 
 err:

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -136,19 +136,3 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         # The leader is still alive, verify it.
         self.verify([self.session])
-
-    def test_verify_ingest_busy_on_leader(self):
-        # Create a layered table on the leader
-        self.session.create(self.uri, self.table_cfg)
-        self.session.checkpoint()
-
-        # Open a cursor on the ingest component on leader
-        ingest_cursor = self.session.open_cursor(self.ingest_uri, None, None)
-
-        # Verify fails as the ingest table on leader has open cursors
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.verify([self.session]), '/ingest table verification failed/')
-
-        ingest_cursor.close()
-
-        self.verify([self.session])


### PR DESCRIPTION
Add an assertion to ensure that verifying the ingest constituent of layered tables on leader should never return EBUSY