### PR TITLE
WT-15409 Fix reverse compare assertion

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1540,7 +1540,8 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
         WT_ERR(version_cursor->get_key(version_cursor, tmp_key));
         WT_ERR(__wt_compare(session, CUR2BT(cbt)->collator, key, tmp_key, &cmp));
         if (cmp != 0) {
-            WT_ASSERT(session, cmp <= 0);
+            if (key->size != 0)
+                WT_ASSERT(session, cmp <= 0);
 
             if (upds != NULL) {
                 WT_WITH_DHANDLE(

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1544,8 +1544,7 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
              * Ensure keys returned are in correctly sorted order. Only perform this check when key
              * has been initialized.
              */
-            if (key->size != 0)
-                WT_ASSERT(session, cmp <= 0);
+            WT_ASSERT(session, key->size == 0 || cmp <= 0);
 
             if (upds != NULL) {
                 WT_WITH_DHANDLE(

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1540,6 +1540,10 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
         WT_ERR(version_cursor->get_key(version_cursor, tmp_key));
         WT_ERR(__wt_compare(session, CUR2BT(cbt)->collator, key, tmp_key, &cmp));
         if (cmp != 0) {
+            /*
+             * Ensure keys returned are in correctly sorted order. Only perform this check when key
+             * has been initialized.
+             */
             if (key->size != 0)
                 WT_ASSERT(session, cmp <= 0);
 


### PR DESCRIPTION
The collator and reversed table is working correctly. Because the btree is reversed and the collator is reversed the expectation is still correct around cmp <= 0. The problem is we check cmp <= 0 when the original key is not set. In the normal case this is not an issue because we expect an empty key to be less than any key. But in reverse case an empty key is greater than any key, causing the assertion failure.