### PR TITLE
WT-15464 Don't instantiate updates for read only btrees

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -566,7 +566,10 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
          */
         WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
 
-        if (__wt_txn_tw_stop_visible(session, &cbt->upd_value->tw)) {
+        WT_VISIBLE_TYPE visible_type = __wt_txn_tw_stop_visible(session, &cbt->upd_value->tw);
+        /* There is no prepared update in the history store. */
+        WT_ASSERT(session, visible_type != WT_VISIBLE_PREPARE);
+        if (visible_type == WT_VISIBLE_TRUE) {
             /*
              * If the stop time point of a record is visible to us, we won't be able to see anything
              * for this entire key.
@@ -579,7 +582,10 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
         }
 
         /* If the start time point is visible to us, let's return that record. */
-        if (__wt_txn_tw_start_visible(session, &cbt->upd_value->tw))
+        visible_type = __wt_txn_tw_start_visible(session, &cbt->upd_value->tw);
+        /* There is no prepared update in the history store. */
+        WT_ASSERT(session, visible_type != WT_VISIBLE_PREPARE);
+        if (visible_type == WT_VISIBLE_TRUE)
             break;
     }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1858,6 +1858,10 @@ static WT_INLINE WT_FILE_SYSTEM *__wt_fs_file_system(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE WT_IKEY *__wt_ref_key_instantiated(WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE WT_VISIBLE_TYPE __wt_txn_tw_start_visible(
+  WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE WT_VISIBLE_TYPE __wt_txn_tw_stop_visible(
+  WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE WT_VISIBLE_TYPE __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_block_eligible_for_sweep(WT_BM *bm, WT_BLOCK *block)
@@ -1941,11 +1945,7 @@ static WT_INLINE bool __wt_txn_timestamp_visible(WT_SESSION_IMPL *session, wt_ti
   wt_timestamp_t durable_timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_timestamp_visible_all(WT_SESSION_IMPL *session,
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_txn_tw_stop_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_tw_stop_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));


### PR DESCRIPTION
Don't instantiate updates for read only btrees. This is to prepare the future work for handling prepared updates on the layered tables.

Change the visibility check to also return prepare conflict if the onpage value is prepared for disagg.
