### PR TITLE
WT-15461 Merge WT-14542 into develop

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1222,6 +1222,8 @@ conn_dsrc_stats = [
     CursorStat('cursor_next_skip_lt_100', 'cursor next calls that skip greater than 1 and fewer than 100 entries'),
     CursorStat('cursor_next_skip_total', 'Total number of entries skipped by cursor next calls'),
     CursorStat('cursor_open_count', 'open cursor count', 'no_clear,no_scale'),
+    CursorStat('cursor_open_time_internal_usecs', 'open cursor time internal (usecs)', 'no_clear,no_scale'),
+    CursorStat('cursor_open_time_user_usecs', 'open cursor time application (usecs)', 'no_clear,no_scale'),
     CursorStat('cursor_prev_hs_tombstone', 'cursor prev calls that skip due to a globally visible history store tombstone'),
     CursorStat('cursor_prev_skip_ge_100', 'cursor prev calls that skip greater than or equal to 100 entries'),
     CursorStat('cursor_prev_skip_lt_100', 'cursor prev calls that skip less than 100 entries'),

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1097,6 +1097,115 @@ err:
 }
 
 /*
+ * __clayered_cache --
+ *     WT_CURSOR->cache method for the layered cursor type.
+ */
+static int
+__clayered_cache(WT_CURSOR *cursor)
+{
+    WT_CURSOR_LAYERED *clayered;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+
+    clayered = (WT_CURSOR_LAYERED *)cursor;
+    session = CUR2S(cursor);
+
+    WT_TRET(__wti_cursor_cache(cursor, clayered->dhandle));
+    WT_TRET(__wt_session_release_dhandle(session));
+
+    API_RET_STAT(session, ret, cursor_cache);
+}
+
+/*
+ * __clayered_reopen_int --
+ *     Helper for __clayered_reopen, called with the session data handle set.
+ */
+static int
+__clayered_reopen_int(WT_CURSOR *cursor)
+{
+    WT_DATA_HANDLE *dhandle;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    bool is_dead;
+
+    session = CUR2S(cursor);
+    dhandle = session->dhandle;
+
+    /*
+     * Lock the handle: we're only interested in open handles, any other state disqualifies the
+     * cache.
+     */
+    ret = __wt_session_lock_dhandle(session, 0, &is_dead);
+    if (!is_dead && ret == 0 && !WT_DHANDLE_CAN_REOPEN(dhandle)) {
+        WT_RET(__wt_session_release_dhandle(session));
+        ret = __wt_set_return(session, EBUSY);
+    }
+
+    /*
+     * The data handle may not be available, fail the reopen, and flag the cursor so that the handle
+     * won't be unlocked when subsequently closed.
+     */
+    if (is_dead || ret == EBUSY) {
+        F_SET(cursor, WT_CURSTD_DEAD);
+        ret = WT_NOTFOUND;
+    }
+    __wti_cursor_reopen(cursor, dhandle);
+
+    /*
+     * The layered handle may have been reopened since we last accessed it. Reset fields in the
+     * cursor that point to memory owned by the handle.
+     */
+    if (ret == 0) {
+        WT_LAYERED_TABLE *layered = (WT_LAYERED_TABLE *)session->dhandle;
+        cursor->internal_uri = session->dhandle->name;
+        cursor->key_format = layered->key_format;
+        cursor->value_format = layered->value_format;
+
+        WT_STAT_CONN_DSRC_INCR(session, cursor_reopen);
+    }
+    return (ret);
+}
+
+/*
+ * __clayered_reopen --
+ *     WT_CURSOR->reopen method for the layered cursor type.
+ */
+static int
+__clayered_reopen(WT_CURSOR *cursor, bool sweep_check_only)
+{
+    WT_DATA_HANDLE *dhandle;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    bool can_sweep;
+
+    session = CUR2S(cursor);
+    dhandle = ((WT_CURSOR_LAYERED *)cursor)->dhandle;
+
+    if (sweep_check_only) {
+        /*
+         * The sweep check returns WT_NOTFOUND if the cursor should be swept. Generally if the
+         * associated data handle cannot be reopened it should be swept. But a handle being operated
+         * on by this thread should not be swept. The situation where a handle cannot be reopened
+         * but also cannot be swept can occur if this thread is in the middle of closing a cursor
+         * for a handle that is marked as dropped. During the close, a few iterations of the session
+         * cursor sweep are run. The sweep calls this function to see if a cursor should be swept,
+         * and it may thus be asking about the very cursor being closed.
+         */
+        can_sweep = !WT_DHANDLE_CAN_REOPEN(dhandle) && dhandle != session->dhandle;
+        return (can_sweep ? WT_NOTFOUND : 0);
+    }
+
+    /*
+     * Temporarily set the session's data handle to the data handle in the cursor. Reopen may be
+     * called either as part of an open API call, or during cursor sweep as part of a different API
+     * call, so we need to restore the original data handle that was in our session after the reopen
+     * completes.
+     */
+    WT_WITH_DHANDLE(session, dhandle, ret = __clayered_reopen_int(cursor));
+    API_RET_STAT(session, ret, cursor_reopen);
+}
+
+/*
  * __clayered_lookup_constituent --
  *     The cursor-agnostic parts of layered table lookups.
  */
@@ -1797,26 +1906,37 @@ __clayered_close_int(WT_CURSOR *cursor)
     WT_CURSOR_LAYERED *clayered;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
+    bool dead;
 
+    dead = F_ISSET(cursor, WT_CURSTD_DEAD);
     session = CUR2S(cursor);
     WT_ASSERT_ALWAYS(session, session->dhandle->type == WT_DHANDLE_TYPE_LAYERED,
       "Valid layered dhandle is required to close a cursor");
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     /*
-     * If this close is via a connection close the constituent cursors will be closed by a scan of
-     * cursors in the session. It might be better to keep them out of the session cursor list, but I
-     * don't know how to do that? Probably opening a file cursor directly instead of a table cursor?
+     * No need to close the constituent cursors if it has been already done during connection->close
+     * performing a close of all cursors in the session.
      */
-    WT_TRET(__clayered_close_cursors(clayered));
+    if (!F_ISSET(cursor, WT_CURSTD_CONSTITUENT_DEAD))
+        WT_TRET(__clayered_close_cursors(clayered));
 
     /* In case we were somehow left positioned, clear that. */
     __clayered_leave(clayered);
 
     __wt_cursor_close(cursor);
 
-    WT_TRET(__wt_session_release_dhandle(session));
+    if (session->dhandle != NULL) {
+        /* Decrement the data-source's in-use counter. */
+        __wt_cursor_dhandle_decr_use(session);
 
+        /*
+         * If the cursor was marked dead, we got here from reopening a cached cursor, which had a
+         * handle that was dead at that time, so it did not obtain a lock on the handle.
+         */
+        if (!dead)
+            WT_TRET(__wt_session_release_dhandle(session));
+    }
     return (ret);
 }
 
@@ -1838,9 +1958,36 @@ __clayered_close(WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, clayered->dhandle);
 err:
+    if (ret == 0) {
+        /*
+         * If releasing the cursor fails in any way, it will be left in a state that allows it to be
+         * normally closed.
+         */
+        bool released = false;
+        ret = __wti_cursor_cache_release(session, cursor, &released);
+
+        if (released) {
+            /*
+             * If the cursor has been cached, try to cache the constituent cursors by evoking a
+             * cursor close.
+             *
+             * Note: There no need to close the constituent cursors if it has been already done
+             * during connection->close performing a close of all cursors in the session.
+             */
+            if (!F_ISSET(cursor, WT_CURSTD_CONSTITUENT_DEAD))
+                WT_TRET(__clayered_close_cursors(clayered));
+
+            /* In case we were somehow left positioned, clear that. */
+            __clayered_leave(clayered);
+            goto done;
+        }
+    }
+    /* For cached cursors, free any extra buffers retained now. */
+    __wt_cursor_free_cached_memory(cursor);
+    cursor->internal_uri = NULL;
 
     WT_TRET(__clayered_close_int(cursor));
-
+done:
     API_END_RET(session, ret);
 }
 
@@ -1977,19 +2124,21 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
       __wti_cursor_reconfigure,                       /* reconfigure */
       __clayered_largest_key,                         /* largest_key */
       __clayered_bound,                               /* bound */
-      __wt_cursor_notsup,                             /* cache */
-      __wt_cursor_reopen_notsup,                      /* reopen */
+      __clayered_cache,                               /* cache */
+      __clayered_reopen,                              /* reopen */
       __wt_cursor_checkpoint_id,                      /* checkpoint ID */
       __clayered_close);                              /* close */
     WT_CURSOR *cursor;
     WT_CURSOR_LAYERED *clayered;
     WT_DECL_RET;
     WT_LAYERED_TABLE *layered;
+    bool cacheable;
 
     WT_VERIFY_OPAQUE_POINTER(WT_CURSOR_LAYERED);
 
     clayered = NULL;
     cursor = NULL;
+    cacheable = F_ISSET(session, WT_SESSION_CACHE_CURSORS);
 
     if (!WT_PREFIX_MATCH(uri, "layered:"))
         return (__wt_unexpected_object_type(session, uri, "layered:"));
@@ -2007,6 +2156,12 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     /* Get the layered tree, and hold a reference to it until the cursor is closed. */
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, cfg, 0));
 
+    /*
+     * Increment the data-source's in-use counter; done now because closing the cursor will
+     * decrement it, and all failure paths from here close the cursor.
+     */
+    __wt_cursor_dhandle_incr_use(session);
+
     layered = (WT_LAYERED_TABLE *)session->dhandle;
     WT_ASSERT_ALWAYS(session, layered->ingest_uri != NULL && layered->key_format != NULL,
       "Layered handle not setup");
@@ -2017,9 +2172,11 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     cursor = (WT_CURSOR *)clayered;
     *cursor = iface;
     cursor->session = (WT_SESSION *)session;
+    cursor->internal_uri = session->dhandle->name;
     cursor->key_format = layered->key_format;
     cursor->value_format = layered->value_format;
 
+    /* Try to find the cursor in the cache. */
     WT_ERR(__wt_cursor_init(cursor, uri, owner, cfg, cursorp));
 
     WT_ERR(__wt_config_gets_def(session, cfg, "next_random", 0, &cval));
@@ -2033,13 +2190,20 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
 
         WT_ERR(__wt_config_gets_def(session, cfg, "next_random_sample_size", 0, &cval));
         clayered->next_random_sample_size = (u_int)cval.val;
+        cacheable = false;
     }
+
+    if (cacheable)
+        F_SET(cursor, WT_CURSTD_CACHEABLE);
 
     /* Layered cursor is not compatible with cursor_copy config. */
     F_CLR(cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE);
 
     if (0) {
 err:
+        /* Our caller expects to release the data handles if we fail. */
+        clayered->dhandle = NULL;
+        __wt_cursor_dhandle_decr_use(session);
         if (clayered != NULL)
             WT_TRET(__clayered_close(cursor));
         WT_TRET(__wt_session_release_dhandle(session));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2176,13 +2176,6 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     cursor->key_format = layered->key_format;
     cursor->value_format = layered->value_format;
 
-    /* Set the cache flag before finding a cursor handle. */
-    if (cacheable)
-        F_SET(cursor, WT_CURSTD_CACHEABLE);
-
-    /* Try to find the cursor in the cache. */
-    WT_ERR(__wt_cursor_init(cursor, uri, owner, cfg, cursorp));
-
     WT_ERR(__wt_config_gets_def(session, cfg, "next_random", 0, &cval));
     if (cval.val != 0) {
         F_SET(clayered, WT_CLAYERED_RANDOM);
@@ -2196,6 +2189,13 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
         clayered->next_random_sample_size = (u_int)cval.val;
         cacheable = false;
     }
+
+    /* Set the cache flag before finding a cursor handle. */
+    if (cacheable)
+        F_SET(cursor, WT_CURSTD_CACHEABLE);
+
+    /* Try to find the cursor in the cache. */
+    WT_ERR(__wt_cursor_init(cursor, uri, owner, cfg, cursorp));
 
     /* Layered cursor is not compatible with cursor_copy config. */
     F_CLR(cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2176,6 +2176,10 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     cursor->key_format = layered->key_format;
     cursor->value_format = layered->value_format;
 
+    /* Set the cache flag before finding a cursor handle. */
+    if (cacheable)
+        F_SET(cursor, WT_CURSTD_CACHEABLE);
+
     /* Try to find the cursor in the cache. */
     WT_ERR(__wt_cursor_init(cursor, uri, owner, cfg, cursorp));
 
@@ -2192,9 +2196,6 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
         clayered->next_random_sample_size = (u_int)cval.val;
         cacheable = false;
     }
-
-    if (cacheable)
-        F_SET(cursor, WT_CURSTD_CACHEABLE);
 
     /* Layered cursor is not compatible with cursor_copy config. */
     F_CLR(cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE);

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -471,7 +471,8 @@ __wt_cursor_free_cached_memory(WT_CURSOR *cursor)
         __wt_buf_free(session, &cursor->value);
 
         /* Discard the underlying WT_CURSOR_BTREE buffers. */
-        __wt_btcur_free_cached_memory((WT_CURSOR_BTREE *)cursor);
+        if (!WT_PREFIX_MATCH(cursor->internal_uri, "layered:"))
+            __wt_btcur_free_cached_memory((WT_CURSOR_BTREE *)cursor);
 
         F_CLR(cursor, WT_CURSTD_CACHED_WITH_MEM);
     }

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -160,6 +160,10 @@ struct __wt_session_impl {
     u_int sweep_warning_5min;        /* Whether the session was without sweep for 5 min. */
     u_int sweep_warning_60min;       /* Whether the session was without sweep for 60 min. */
 
+#ifdef HAVE_DIAGNOSTIC
+    bool cursor_open_timer_running; /* Flag used to track timer across nested calls. */
+#endif
+
     WT_CURSOR_BACKUP *bkp_cursor; /* Hot backup cursor */
 
     WT_COMPACT_STATE *compact; /* Compaction information */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -903,6 +903,8 @@ struct __wt_connection_stats {
     int64_t cursor_update_bytes_changed;
     int64_t cursor_reopen;
     int64_t cursor_open_count;
+    int64_t cursor_open_time_user_usecs;
+    int64_t cursor_open_time_internal_usecs;
     int64_t dh_conn_handle_table_count;
     int64_t dh_conn_handle_tiered_count;
     int64_t dh_conn_handle_tiered_tree_count;
@@ -1586,6 +1588,8 @@ struct __wt_dsrc_stats {
     int64_t cursor_modify_bytes_touch;
     int64_t cursor_next;
     int64_t cursor_open_count;
+    int64_t cursor_open_time_user_usecs;
+    int64_t cursor_open_time_internal_usecs;
     int64_t cursor_restart;
     int64_t cursor_prev;
     int64_t cursor_remove;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -779,31 +779,32 @@ struct __wt_cursor {
 #define WT_CURSTD_CACHEABLE     0x000000040ull
 #define WT_CURSTD_CACHED        0x000000080ull
 #define WT_CURSTD_CACHED_WITH_MEM 0x000000100ull /* A cached cursor with allocated memory. */
-#define WT_CURSTD_DEAD          0x000000200ull
-#define WT_CURSTD_DEBUG_COPY_KEY    0x000000400ull
-#define WT_CURSTD_DEBUG_COPY_VALUE  0x000000800ull
-#define WT_CURSTD_DEBUG_RESET_EVICT 0x000001000ull
-#define WT_CURSTD_DUMP_HEX      0x000002000ull
-#define WT_CURSTD_DUMP_JSON     0x000004000ull
-#define WT_CURSTD_DUMP_PRETTY       0x000008000ull
-#define WT_CURSTD_DUMP_PRINT        0x000010000ull
-#define WT_CURSTD_DUP_NO_VALUE          0x000020000ull
-#define WT_CURSTD_EVICT_REPOSITION     0x000040000ull
-#define WT_CURSTD_HS_READ_ACROSS_BTREE 0x000080000ull
-#define WT_CURSTD_HS_READ_ALL       0x000100000ull
-#define WT_CURSTD_HS_READ_COMMITTED 0x000200000ull
-#define WT_CURSTD_IGNORE_TOMBSTONE  0x000400000ull
-#define WT_CURSTD_KEY_EXT       0x000800000ull /* Key points out of tree. */
-#define WT_CURSTD_KEY_INT       0x001000000ull /* Key points into tree. */
-#define WT_CURSTD_KEY_ONLY      0x002000000ull
-#define WT_CURSTD_META_INUSE        0x004000000ull
-#define WT_CURSTD_OPEN          0x008000000ull
-#define WT_CURSTD_OVERWRITE     0x010000000ull
-#define WT_CURSTD_RAW           0x020000000ull
-#define WT_CURSTD_RAW_SEARCH        0x040000000ull
-#define WT_CURSTD_VALUE_EXT     0x080000000ull /* Value points out of tree. */
-#define WT_CURSTD_VALUE_INT     0x100000000ull /* Value points into tree. */
-#define WT_CURSTD_VERSION_CURSOR    0x200000000ull /* Version cursor. */
+#define WT_CURSTD_CONSTITUENT_DEAD 0x000000200ull
+#define WT_CURSTD_DEAD          0x000000400ull
+#define WT_CURSTD_DEBUG_COPY_KEY    0x000000800ull
+#define WT_CURSTD_DEBUG_COPY_VALUE  0x000001000ull
+#define WT_CURSTD_DEBUG_RESET_EVICT 0x000002000ull
+#define WT_CURSTD_DUMP_HEX      0x000004000ull
+#define WT_CURSTD_DUMP_JSON     0x000008000ull
+#define WT_CURSTD_DUMP_PRETTY       0x000010000ull
+#define WT_CURSTD_DUMP_PRINT        0x000020000ull
+#define WT_CURSTD_DUP_NO_VALUE          0x000040000ull
+#define WT_CURSTD_EVICT_REPOSITION     0x000080000ull
+#define WT_CURSTD_HS_READ_ACROSS_BTREE 0x000100000ull
+#define WT_CURSTD_HS_READ_ALL       0x000200000ull
+#define WT_CURSTD_HS_READ_COMMITTED 0x000400000ull
+#define WT_CURSTD_IGNORE_TOMBSTONE  0x000800000ull
+#define WT_CURSTD_KEY_EXT       0x001000000ull /* Key points out of tree. */
+#define WT_CURSTD_KEY_INT       0x002000000ull /* Key points into tree. */
+#define WT_CURSTD_KEY_ONLY      0x004000000ull
+#define WT_CURSTD_META_INUSE        0x008000000ull
+#define WT_CURSTD_OPEN          0x010000000ull
+#define WT_CURSTD_OVERWRITE     0x020000000ull
+#define WT_CURSTD_RAW           0x040000000ull
+#define WT_CURSTD_RAW_SEARCH        0x080000000ull
+#define WT_CURSTD_VALUE_EXT     0x100000000ull /* Value points out of tree. */
+#define WT_CURSTD_VALUE_INT     0x200000000ull /* Value points into tree. */
+#define WT_CURSTD_VERSION_CURSOR    0x400000000ull /* Version cursor. */
 /* AUTOMATIC FLAG VALUE GENERATION STOP 64 */
 #define WT_CURSTD_KEY_SET   (WT_CURSTD_KEY_EXT | WT_CURSTD_KEY_INT)
 #define WT_CURSTD_VALUE_SET (WT_CURSTD_VALUE_EXT | WT_CURSTD_VALUE_INT)
@@ -7200,1119 +7201,1123 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CURSOR_REOPEN			1484
 /*! cursor: open cursor count */
 #define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1485
+/*! cursor: open cursor time application (usecs) */
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1486
+/*! cursor: open cursor time internal (usecs) */
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1487
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1486
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1488
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1487
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1489
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1488
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1490
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1489
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1491
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1490
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1492
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1491
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1493
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1492
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1494
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1493
+#define	WT_STAT_CONN_DH_SWEEP_REF			1495
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1494
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1496
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1495
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1497
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1496
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1498
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1497
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1499
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1498
+#define	WT_STAT_CONN_DH_SWEEPS				1500
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1499
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1501
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1500
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1502
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1501
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1503
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1502
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1504
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1503
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1505
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1504
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1506
 /*! layered: Layered table cursor next operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1505
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1507
 /*! layered: Layered table cursor next operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1506
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1508
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1507
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1509
 /*! layered: Layered table cursor prev operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1508
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1510
 /*! layered: Layered table cursor prev operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1509
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1511
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1510
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1512
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1511
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1513
 /*! layered: Layered table cursor search near operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1512
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1514
 /*! layered: Layered table cursor search near operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1513
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1515
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1514
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1516
 /*! layered: Layered table cursor search operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1515
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1517
 /*! layered: Layered table cursor search operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1516
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1518
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1517
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1519
 /*! layered: Layered table cursor upgrade state for ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1518
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1520
 /*! layered: Layered table cursor upgrade state for stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1519
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1521
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1520
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1522
 /*! layered: checkpoints refreshed on shared layered constituents */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_REFRESHED	1521
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_REFRESHED	1523
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1522
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1524
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1523
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1525
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1524
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1526
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1525
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1527
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1526
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1528
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1527
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1529
 /*! layered: whether the layered table manager thread has been started */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_RUNNING	1528
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_RUNNING	1530
 /*!
  * layered: whether the layered table manager thread is currently busy
  * doing work
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_ACTIVE	1529
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_ACTIVE	1531
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1530
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1532
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1531
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1533
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1532
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1534
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1533
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1535
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1534
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1536
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1535
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1537
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1536
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1538
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1537
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1539
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1538
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1540
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1539
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1541
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1540
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1542
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1541
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1543
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1542
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1544
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1543
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1545
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1544
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1546
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1545
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1547
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1546
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1548
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1547
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1549
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1548
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1550
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1549
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1551
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1550
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1552
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1551
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1553
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1552
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1554
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1553
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1555
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1554
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1556
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1555
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1557
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1556
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1558
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1557
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1559
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1558
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1560
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1559
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1561
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1560
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1562
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1561
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1563
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1562
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1564
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1563
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1565
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1564
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1566
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1565
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1567
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1566
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1568
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1567
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1569
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1568
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1570
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1569
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1571
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1570
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1572
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1571
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1573
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1572
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1574
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1573
+#define	WT_STAT_CONN_LOG_FLUSH				1575
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1574
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1576
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1575
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1577
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1576
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1578
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1577
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1579
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1578
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1580
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1579
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1581
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1580
+#define	WT_STAT_CONN_LOG_SCANS				1582
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1581
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1583
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1582
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1584
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1583
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1585
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1584
+#define	WT_STAT_CONN_LOG_SYNC				1586
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1585
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1587
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1586
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1588
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1587
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1589
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1588
+#define	WT_STAT_CONN_LOG_WRITES				1590
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1589
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1591
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1590
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1592
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1591
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1593
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1592
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1594
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1593
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1595
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1594
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1596
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1595
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1597
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1596
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1598
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1597
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1599
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1598
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1600
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1599
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1601
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1600
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1602
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1601
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1603
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1602
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1604
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1603
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1605
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1604
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1606
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1605
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1607
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1606
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1608
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1607
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1609
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1608
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1610
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1609
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1611
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1610
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1612
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1611
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1613
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1612
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1614
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1613
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1615
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1614
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1616
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1615
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1617
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1616
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1618
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1617
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1619
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1618
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1620
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1619
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1621
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1620
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1622
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1621
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1623
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1622
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1624
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1623
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1625
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1624
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1626
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1625
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1627
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1626
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1628
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1627
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1629
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1628
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1630
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1629
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1631
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1630
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1632
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1631
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1633
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1632
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1634
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1633
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1635
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1634
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1636
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1635
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1637
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1636
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1638
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1637
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1639
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1638
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1640
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1639
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1641
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1640
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1642
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1641
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1643
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1642
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1644
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1643
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1645
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1644
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1646
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1645
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1647
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1646
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1648
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1647
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1649
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1648
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1650
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1649
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1651
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1650
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1652
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1651
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1653
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1652
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1654
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1653
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1655
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1654
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1656
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1655
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1657
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1656
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1658
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1657
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1659
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1658
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1660
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1659
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1661
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1660
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1662
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1661
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1663
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1662
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1664
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1663
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1665
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1664
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1666
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1665
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1667
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1666
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1668
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1667
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1669
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1668
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1670
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1669
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1671
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1670
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1672
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1671
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1673
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1672
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1674
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1673
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1675
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1674
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1676
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1675
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1677
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1676
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1678
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1677
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1679
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1678
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1680
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1679
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1681
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1680
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1682
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1681
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1683
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1682
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1684
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1683
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1685
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1684
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1686
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1685
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1687
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1686
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1688
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1687
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1689
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1688
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1690
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1689
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1691
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1690
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1692
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1691
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1693
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1692
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1694
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1693
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1695
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1694
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1696
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1695
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1697
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1696
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1698
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1697
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1699
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1698
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1700
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1699
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1701
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1700
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1702
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1701
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1703
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1702
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1704
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1703
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1705
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1704
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1706
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1705
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1707
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1706
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1708
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1707
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1709
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1708
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1710
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1709
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1711
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1710
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1712
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1711
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1713
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1712
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1714
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1713
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1715
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1714
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1716
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1715
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1717
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1716
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1718
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1717
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1719
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1718
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1720
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1719
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1721
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1720
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1722
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1721
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1723
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1722
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1724
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1723
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1725
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1724
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1726
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1725
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1727
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1726
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1728
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1727
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1729
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1728
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1730
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1729
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1731
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1730
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1732
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1731
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1733
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1732
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1734
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1733
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1735
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1734
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1736
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1735
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1737
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1736
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1738
 /*! reconciliation: empty deltas skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_EMPTY_DELTAS		1737
+#define	WT_STAT_CONN_REC_SKIP_EMPTY_DELTAS		1739
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1738
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1740
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1739
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1741
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1740
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1742
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1741
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1743
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1742
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1744
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1743
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1745
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1744
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1746
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1745
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1747
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1746
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1748
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1747
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1749
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1748
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1750
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1749
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1751
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1750
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1752
 /*!
  * reconciliation: number of keys that are garbage collected in the
  * ingest table for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS	1751
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS	1753
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1752
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1754
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1753
+#define	WT_STAT_CONN_REC_PAGES				1755
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1754
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1756
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1755
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1757
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1756
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1758
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1757
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1759
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1758
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1760
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1759
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1761
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1760
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1762
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1761
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1763
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1762
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1764
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1763
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1765
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1764
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1766
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1765
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1767
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1766
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1768
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1767
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1769
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1768
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1770
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1769
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1771
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1770
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1772
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1771
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1773
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1772
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1774
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1773
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1775
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1774
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1776
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1775
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1777
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1776
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1778
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1777
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1779
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1778
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1780
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1779
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1781
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1780
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1782
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1781
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1783
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1782
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1784
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1783
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1785
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1784
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1786
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1785
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1787
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1786
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1788
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1787
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1789
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1788
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1790
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1789
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1791
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1790
+#define	WT_STAT_CONN_FLUSH_TIER				1792
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1791
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1793
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1792
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1794
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1793
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1795
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1794
+#define	WT_STAT_CONN_SESSION_OPEN			1796
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1795
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1797
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1796
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1798
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1797
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1799
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1798
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1800
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1799
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1801
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1800
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1802
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1801
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1803
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1802
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1804
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1803
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1805
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1804
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1806
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1805
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1807
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1806
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1808
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1807
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1809
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1808
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1810
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1809
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1811
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1810
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1812
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1811
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1813
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1812
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1814
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1813
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1815
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1814
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1816
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1815
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1817
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1816
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1818
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1817
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1819
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1818
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1820
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1819
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1821
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1820
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1822
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1821
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1823
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1822
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1824
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1823
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1825
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1824
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1826
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1825
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1827
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1826
+#define	WT_STAT_CONN_TIERED_RETENTION			1828
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1827
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1829
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1828
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1830
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1829
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1831
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1830
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1832
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1831
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1833
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1832
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1834
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1833
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1835
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1834
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1836
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1835
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1837
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1836
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1838
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1837
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1839
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1838
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1840
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1839
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1841
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1840
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1842
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1841
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1843
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1842
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1844
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1843
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1845
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1844
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1846
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1845
+#define	WT_STAT_CONN_PAGE_SLEEP				1847
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1846
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1848
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1847
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1849
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1848
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1850
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1849
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1851
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1850
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1852
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1851
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1853
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1852
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1854
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1853
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1855
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1854
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1856
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1855
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1857
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1856
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1858
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1857
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1859
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1858
+#define	WT_STAT_CONN_TXN_PREPARE			1860
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1859
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1861
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1860
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1862
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1861
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1863
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1862
+#define	WT_STAT_CONN_TXN_QUERY_TS			1864
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1863
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1865
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1864
+#define	WT_STAT_CONN_TXN_RTS				1866
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1865
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1867
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1866
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1868
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1867
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1869
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1868
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1870
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1869
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1871
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1870
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1872
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1871
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1873
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1872
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1874
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1873
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1875
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1874
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1876
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1875
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1877
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1876
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1878
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1877
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1879
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1878
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1880
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1879
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1881
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1880
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1882
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1881
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1883
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1882
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1884
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1883
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1885
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1884
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1886
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1885
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1887
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1886
+#define	WT_STAT_CONN_TXN_SET_TS				1888
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1887
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1889
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1888
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1890
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1889
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1891
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1890
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1892
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1891
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1893
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1892
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1894
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1893
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1895
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1894
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1896
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1895
+#define	WT_STAT_CONN_TXN_BEGIN				1897
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1896
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1898
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1897
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1899
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1898
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1900
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1899
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1901
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1900
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1902
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1901
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1903
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1902
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1904
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1903
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1905
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1904
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1906
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1905
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1907
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1906
+#define	WT_STAT_CONN_TXN_COMMIT				1908
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1907
+#define	WT_STAT_CONN_TXN_ROLLBACK			1909
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1908
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1910
 
 /*!
  * @}
@@ -9104,352 +9109,356 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_CURSOR_NEXT			2251
 /*! cursor: open cursor count */
 #define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2252
+/*! cursor: open cursor time application (usecs) */
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_USER_USECS	2253
+/*! cursor: open cursor time internal (usecs) */
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_INTERNAL_USECS	2254
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2253
+#define	WT_STAT_DSRC_CURSOR_RESTART			2255
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2254
+#define	WT_STAT_DSRC_CURSOR_PREV			2256
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2255
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2257
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2256
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2258
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2257
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2259
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2258
+#define	WT_STAT_DSRC_CURSOR_RESET			2260
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2259
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2261
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2260
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2262
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2261
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2263
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2262
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2264
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2263
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2265
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2264
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2266
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2265
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2267
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2266
+#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2268
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2267
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2269
 /*! layered: Layered table cursor next operations from ingest table */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2268
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2270
 /*! layered: Layered table cursor next operations from stable table */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2269
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2271
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2270
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2272
 /*! layered: Layered table cursor prev operations from ingest table */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2271
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2273
 /*! layered: Layered table cursor prev operations from stable table */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2272
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2274
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2273
+#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2275
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2274
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2276
 /*! layered: Layered table cursor search near operations from ingest table */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2275
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2277
 /*! layered: Layered table cursor search near operations from stable table */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2276
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2278
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2277
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2279
 /*! layered: Layered table cursor search operations from ingest table */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2278
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2280
 /*! layered: Layered table cursor search operations from stable table */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2279
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2281
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2280
+#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2282
 /*! layered: Layered table cursor upgrade state for ingest table */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2281
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2283
 /*! layered: Layered table cursor upgrade state for stable table */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2282
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2284
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2283
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2285
 /*! layered: checkpoints refreshed on shared layered constituents */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_REFRESHED	2284
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_REFRESHED	2286
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2285
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2287
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2286
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2288
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2287
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2289
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2288
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2290
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2289
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2291
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2290
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2292
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2291
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2293
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2292
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2294
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2293
+#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2295
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2294
+#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2296
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2295
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2297
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2296
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2298
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2297
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2299
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2298
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2300
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2299
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2301
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2300
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2302
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2301
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2303
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2302
+#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2304
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2303
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2305
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2304
+#define	WT_STAT_DSRC_REC_DICTIONARY			2306
 /*! reconciliation: empty deltas skipped in disaggregated storage */
-#define	WT_STAT_DSRC_REC_SKIP_EMPTY_DELTAS		2305
+#define	WT_STAT_DSRC_REC_SKIP_EMPTY_DELTAS		2307
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2306
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2308
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2307
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2309
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2308
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2310
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2309
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2311
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2310
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2312
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2311
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2313
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2312
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2314
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2313
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2315
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2314
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2316
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2315
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2317
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2316
+#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2318
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2317
+#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2319
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2318
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2320
 /*!
  * reconciliation: number of keys that are garbage collected in the
  * ingest table for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS	2319
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS	2321
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2320
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2322
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2321
+#define	WT_STAT_DSRC_REC_PAGES				2323
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2322
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2324
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2323
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2325
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2324
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2326
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2325
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2327
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2326
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2328
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2327
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2329
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2328
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2330
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2329
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2331
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2330
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2332
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2331
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2333
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2332
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2334
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2333
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2335
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2334
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2336
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2335
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2337
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2336
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2338
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2337
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2339
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2338
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2340
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2339
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2341
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2340
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2342
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2341
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2343
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2342
+#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2344
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2343
+#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2345
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2344
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2346
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2345
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2347
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2346
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2348
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2347
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2349
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2348
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2350
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2349
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2351
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2350
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2352
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2351
+#define	WT_STAT_DSRC_SESSION_COMPACT			2353
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2352
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2354
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2353
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2355
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2354
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2356
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2355
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2357
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2356
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2358
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2357
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2359
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2358
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2360
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2359
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2361
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2360
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2362
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2361
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2363
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2362
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2364
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2363
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2365
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2364
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2366
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2365
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2367
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2366
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2368
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2367
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2369
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2368
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2370
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2369
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2371
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2370
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2372
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2371
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2373
 
 /*!
  * @}

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -275,7 +275,7 @@ __session_close_cursors(WT_SESSION_IMPL *session, WT_CURSOR_LIST *cursors)
             WT_TRET(session->event_handler->handle_close(
               session->event_handler, &session->iface, cursor));
 
-        if (WT_PREFIX_MATCH(cursor->uri, "layered:"))
+        if (WT_PREFIX_MATCH(cursor->internal_uri, "layered:"))
             F_SET(cursor, WT_CURSTD_CONSTITUENT_DEAD);
         WT_TRET(cursor->close(cursor));
     }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -248,7 +248,6 @@ __session_clear(WT_SESSION_IMPL *session)
     __wt_atomic_store32(&session->hazards.inuse, 0);
     session->hazards.num_active = 0;
 }
-
 /*
  * __session_close_cursors --
  *     Close all cursors in a list.
@@ -276,6 +275,8 @@ __session_close_cursors(WT_SESSION_IMPL *session, WT_CURSOR_LIST *cursors)
             WT_TRET(session->event_handler->handle_close(
               session->event_handler, &session->iface, cursor));
 
+        if (WT_PREFIX_MATCH(cursor->uri, "layered:"))
+            F_SET(cursor, WT_CURSTD_CONSTITUENT_DEAD);
         WT_TRET(cursor->close(cursor));
     }
     WT_TAILQ_SAFE_REMOVE_END
@@ -730,11 +731,8 @@ __session_open_cursor_int(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *
     if (*cursorp == NULL)
         return (__wt_bad_object_type(session, uri));
 
-    if (owner != NULL) {
-        /*
-         * We support caching simple cursors that have no children. If this cursor is a child, we're
-         * not going to cache this child or its parent.
-         */
+    /* Support caching simple cursors that have no children or if the owner is a layered cursor. */
+    if (owner != NULL && !WT_PREFIX_MATCH(owner->internal_uri, "layered:")) {
         F_CLR(owner, WT_CURSTD_CACHEABLE);
         F_CLR(*cursorp, WT_CURSTD_CACHEABLE);
     }
@@ -767,6 +765,18 @@ __wt_open_cursor(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, co
     uint64_t hash_value;
 
     hash_value = 0;
+    /* Don't require a NULL input cursor */
+    *cursorp = NULL;
+
+#ifdef HAVE_DIAGNOSTIC
+    struct timespec end_time, start_time;
+    bool cursor_timing = false;
+    if (session->cursor_open_timer_running == false) {
+        session->cursor_open_timer_running = true;
+        cursor_timing = true;
+        __wt_epoch(session, &start_time);
+    }
+#endif
     WT_NOT_READ(txn_global, &S2C(session)->txn_global);
 
     /*
@@ -782,15 +792,37 @@ __wt_open_cursor(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, co
         session->hs_cursor_counter == 0 || F_ISSET(session, WT_SESSION_INTERNAL) ||
         (S2BT_SAFE(session) != NULL && F_ISSET(S2BT(session), WT_BTREE_VERIFY)));
 
-    /* We do not cache any subordinate tables/files cursors. */
-    if (owner == NULL) {
+    if (owner != NULL && !WT_PREFIX_MATCH(owner->internal_uri, "layered:")) {
+        WT_ERR(__session_open_cursor_int(session, uri, owner, NULL, cfg, hash_value, cursorp));
+    } else {
+        /* Try to find the cursor in the cache. */
         __wt_cursor_get_hash(session, uri, NULL, &hash_value);
-        if ((ret = __wt_cursor_cache_get(session, uri, hash_value, NULL, cfg, cursorp)) == 0)
-            return (0);
-        WT_RET_NOTFOUND_OK(ret);
+        WT_ERR_NOTFOUND_OK(
+          __wt_cursor_cache_get(session, uri, hash_value, NULL, cfg, cursorp), false);
+
+        /* Open a new cursor if no cached cursor was found. */
+        if (*cursorp == NULL)
+            WT_ERR(__session_open_cursor_int(session, uri, owner, NULL, cfg, hash_value, cursorp));
     }
 
-    return (__session_open_cursor_int(session, uri, owner, NULL, cfg, hash_value, cursorp));
+err:
+    /* Always close out the timing information regardless of success. */
+#ifdef HAVE_DIAGNOSTIC
+    if (cursor_timing) {
+        session->cursor_open_timer_running = false;
+        __wt_epoch(session, &end_time);
+        uint64_t time_diff_usec = WT_TIMEDIFF_US(end_time, start_time);
+        /*
+         * We may not have a valid dhandle when EBUSY is returned. In that case only increment the
+         * connection statistics
+         */
+        if (ret != EBUSY)
+            WT_STAT_CONN_DSRC_INCRV(session, cursor_open_time_internal_usecs, time_diff_usec);
+        else
+            WT_STAT_CONN_INCRV(session, cursor_open_time_internal_usecs, time_diff_usec);
+    }
+#endif
+    return (ret);
 }
 
 /*
@@ -806,12 +838,26 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
     WT_SESSION_IMPL *session;
     uint64_t hash_value;
     bool dup_backup;
+#ifdef HAVE_DIAGNOSTIC
+    struct timespec end_time, start_time;
+    bool cursor_timing;
 
+    cursor_timing = false;
+#endif
     cursor = *cursorp = NULL;
+
     hash_value = 0;
     dup_backup = false;
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL(session, ret, open_cursor, config, cfg);
+
+#ifdef HAVE_DIAGNOSTIC
+    if (session->cursor_open_timer_running == false) {
+        session->cursor_open_timer_running = true;
+        cursor_timing = true;
+        __wt_epoch(session, &start_time);
+    }
+#endif
 
     /*
      * Check for early usage of a user session to collect statistics. If the connection is not fully
@@ -864,6 +910,30 @@ err:
         if (cursor != NULL)
             WT_TRET(cursor->close(cursor));
     }
+    /* Always close out the timing information regardless of success. */
+#ifdef HAVE_DIAGNOSTIC
+    if (cursor_timing) {
+        session->cursor_open_timer_running = false;
+        __wt_epoch(session, &end_time);
+        uint64_t time_diff_usec = WT_TIMEDIFF_US(end_time, start_time);
+        /*
+         * It's considered a user open if it comes via a top-level API call. This could
+         * alternatively decide the statistic based on whether it's a user or internal session.
+         *
+         * We may not have a valid dhandle when EBUSY is returned. In that case only increment the
+         * connection statistics
+         */
+        if (ret != EBUSY)
+            if (API_USER_ENTRY(session))
+                WT_STAT_CONN_DSRC_INCRV(session, cursor_open_time_user_usecs, time_diff_usec);
+            else
+                WT_STAT_CONN_DSRC_INCRV(session, cursor_open_time_internal_usecs, time_diff_usec);
+        else if (API_USER_ENTRY(session))
+            WT_STAT_CONN_INCRV(session, cursor_open_time_user_usecs, time_diff_usec);
+        else
+            WT_STAT_CONN_INCRV(session, cursor_open_time_internal_usecs, time_diff_usec);
+    }
+#endif
     /*
      * Opening a cursor on a non-existent data source will set ret to either of ENOENT or
      * WT_NOTFOUND at this point. However, applications may reasonably do this inside a transaction

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -273,6 +273,8 @@ static const char *const __stats_dsrc_desc[] = {
   "cursor: modify value bytes modified",
   "cursor: next calls",
   "cursor: open cursor count",
+  "cursor: open cursor time application (usecs)",
+  "cursor: open cursor time internal (usecs)",
   "cursor: operation restarted",
   "cursor: prev calls",
   "cursor: remove calls",
@@ -691,6 +693,8 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->cursor_modify_bytes_touch = 0;
     stats->cursor_next = 0;
     /* not clearing cursor_open_count */
+    /* not clearing cursor_open_time_user_usecs */
+    /* not clearing cursor_open_time_internal_usecs */
     stats->cursor_restart = 0;
     stats->cursor_prev = 0;
     stats->cursor_remove = 0;
@@ -1108,6 +1112,8 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->cursor_modify_bytes_touch += from->cursor_modify_bytes_touch;
     to->cursor_next += from->cursor_next;
     to->cursor_open_count += from->cursor_open_count;
+    to->cursor_open_time_user_usecs += from->cursor_open_time_user_usecs;
+    to->cursor_open_time_internal_usecs += from->cursor_open_time_internal_usecs;
     to->cursor_restart += from->cursor_restart;
     to->cursor_prev += from->cursor_prev;
     to->cursor_remove += from->cursor_remove;
@@ -1560,6 +1566,8 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->cursor_modify_bytes_touch += WT_STAT_DSRC_READ(from, cursor_modify_bytes_touch);
     to->cursor_next += WT_STAT_DSRC_READ(from, cursor_next);
     to->cursor_open_count += WT_STAT_DSRC_READ(from, cursor_open_count);
+    to->cursor_open_time_user_usecs += WT_STAT_DSRC_READ(from, cursor_open_time_user_usecs);
+    to->cursor_open_time_internal_usecs += WT_STAT_DSRC_READ(from, cursor_open_time_internal_usecs);
     to->cursor_restart += WT_STAT_DSRC_READ(from, cursor_restart);
     to->cursor_prev += WT_STAT_DSRC_READ(from, cursor_prev);
     to->cursor_remove += WT_STAT_DSRC_READ(from, cursor_remove);
@@ -2223,6 +2231,8 @@ static const char *const __stats_connection_desc[] = {
   "cursor: cursor update value size change",
   "cursor: cursors reused from cache",
   "cursor: open cursor count",
+  "cursor: open cursor time application (usecs)",
+  "cursor: open cursor time internal (usecs)",
   "data-handle: Table connection data handles currently active",
   "data-handle: Tiered connection data handles currently active",
   "data-handle: Tiered_Tree connection data handles currently active",
@@ -3181,6 +3191,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cursor_update_bytes_changed = 0;
     stats->cursor_reopen = 0;
     /* not clearing cursor_open_count */
+    /* not clearing cursor_open_time_user_usecs */
+    /* not clearing cursor_open_time_internal_usecs */
     /* not clearing dh_conn_handle_table_count */
     /* not clearing dh_conn_handle_tiered_count */
     /* not clearing dh_conn_handle_tiered_tree_count */
@@ -4217,6 +4229,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cursor_update_bytes_changed += WT_STAT_CONN_READ(from, cursor_update_bytes_changed);
     to->cursor_reopen += WT_STAT_CONN_READ(from, cursor_reopen);
     to->cursor_open_count += WT_STAT_CONN_READ(from, cursor_open_count);
+    to->cursor_open_time_user_usecs += WT_STAT_CONN_READ(from, cursor_open_time_user_usecs);
+    to->cursor_open_time_internal_usecs += WT_STAT_CONN_READ(from, cursor_open_time_internal_usecs);
     to->dh_conn_handle_table_count += WT_STAT_CONN_READ(from, dh_conn_handle_table_count);
     to->dh_conn_handle_tiered_count += WT_STAT_CONN_READ(from, dh_conn_handle_tiered_count);
     to->dh_conn_handle_tiered_tree_count +=

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -22,7 +22,6 @@ test_cursor02.py  # FIXME: WT-15291
 test_cursor03.py
 test_cursor05.py  # FIXME: WT-15291
 test_cursor06.py  # FIXME: WT-15417
-test_cursor13.py  # FIXME: WT-15369
 test_cursor17.py  # FIXME: WT-15418
 test_cursor21.py  # FIXME: WT-15369
 test_debug_mode08.py

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -267,6 +267,11 @@ def session_create_replace(orig_session_create, session_self, uri, config):
     ret = orig_session_create(session_self, uri, config_str)
     return ret
 
+# Called to replace Session.drop
+def session_drop_replace(orig_session_drop, session_self, uri, config):
+    uri = replace_uri(uri)
+    return orig_session_drop(session_self, uri, config)
+
 # Called to replace Session.open_cursor.  We skip calls that do backup
 # as that is not yet supported in disaggregated storage.
 def session_open_cursor_replace(orig_session_open_cursor, session_self, uri, dupcursor, config):
@@ -363,6 +368,10 @@ class DisaggHookCreator(wthooks.WiredTigerHookCreator):
         orig_session_create = self.Session['create']
         self.Session['create'] =  (wthooks.HOOK_REPLACE, lambda s, uri, config=None:
           session_create_replace(orig_session_create, s, uri, config))
+
+        orig_session_drop = self.Session['drop']
+        self.Session['drop'] =  (wthooks.HOOK_REPLACE, lambda s, uri, config=None:
+          session_drop_replace(orig_session_drop, s, uri, config))
 
         orig_session_open_cursor = self.Session['open_cursor']
         self.Session['open_cursor'] = (wthooks.HOOK_REPLACE, lambda s, uri, todup=None, config=None:

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -269,8 +269,9 @@ def session_create_replace(orig_session_create, session_self, uri, config):
 
 # Called to replace Session.drop
 def session_drop_replace(orig_session_drop, session_self, uri, config):
-    uri = replace_uri(uri)
-    return orig_session_drop(session_self, uri, config)
+    # uri = replace_uri(uri)
+    # return orig_session_drop(session_self, uri, config)
+    skip_test("drop on disagg tables not yet implemented")
 
 # Called to replace Session.open_cursor.  We skip calls that do backup
 # as that is not yet supported in disaggregated storage.


### PR DESCRIPTION
The PR adds code to track how long applications and internal threads are spending opening cursors. It also enables cursor caching for layered cursors and it's constituent cursors (ingest and shared cursors).

Here are the technical change to support cursor layered cursors:
- Update the cursor->close() to accomodate for new cursor cache
- Implement cursor->reopen() and cursor->cache() functions.
- Deal with session dhandle referencing