### PR TITLE
WT-15492 Bug fix scrub eviction not setting flag correctly

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -811,8 +811,9 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
         } else if (bytes_dirty < (uint64_t)((dirty_target + dirty_trigger) * bytes_max) / 200 &&
           bytes_updates < (uint64_t)((updates_target + updates_trigger) * bytes_max) / 200) {
             LF_SET(WT_EVICT_CACHE_SCRUB);
+        } else {
+            LF_SET(WT_EVICT_CACHE_NOKEEP);
         }
-
     } else
         LF_SET(WT_EVICT_CACHE_NOKEEP);
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -801,19 +801,21 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
      *
      * There's an experimental flag WT_CACHE_EVICT_SCRUB_UNDER_TARGET that can be turned on to
      * enable scrub eviction as long as cache usage overall is under half way to the trigger limit.
+     * If the scrub under target config is set, scrub whenever we are under the clean target.
+     * Otherwise, default behavior is to scrub only if we are also under the dirty and update
+     * targets.
      */
     if (__wt_conn_is_disagg(session) && bytes_inuse < (uint64_t)(trigger * bytes_max) / 100)
         LF_SET(WT_EVICT_CACHE_SCRUB);
     else if (bytes_inuse < (uint64_t)((target + trigger) * bytes_max) / 200) {
         if (F_ISSET_ATOMIC_32(
-              &(conn->cache->cache_eviction_controls), WT_CACHE_EVICT_SCRUB_UNDER_TARGET)) {
+              &(conn->cache->cache_eviction_controls), WT_CACHE_EVICT_SCRUB_UNDER_TARGET))
             LF_SET(WT_EVICT_CACHE_SCRUB);
-        } else if (bytes_dirty < (uint64_t)((dirty_target + dirty_trigger) * bytes_max) / 200 &&
-          bytes_updates < (uint64_t)((updates_target + updates_trigger) * bytes_max) / 200) {
+        else if (bytes_dirty < (uint64_t)((dirty_target + dirty_trigger) * bytes_max) / 200 &&
+          bytes_updates < (uint64_t)((updates_target + updates_trigger) * bytes_max) / 200)
             LF_SET(WT_EVICT_CACHE_SCRUB);
-        } else {
+        else
             LF_SET(WT_EVICT_CACHE_NOKEEP);
-        }
     } else
         LF_SET(WT_EVICT_CACHE_NOKEEP);
 


### PR DESCRIPTION
There is a bug where it's possible for neither of the scrub eviction flags to be set inside a nested if. This fixes it by adding an additional else condition to make sure that either WT_EVICT_CACHE_NOKEEP or WT_EVICT_CACHE_SCRUB is always set.